### PR TITLE
Fix compilation of UPNP support

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -16,10 +16,10 @@
 #endif
 
 #ifdef USE_UPNP
-#include <miniwget.h>
-#include <miniupnpc.h>
-#include <upnpcommands.h>
-#include <upnperrors.h>
+#include <miniupnpc/miniwget.h>
+#include <miniupnpc/miniupnpc.h>
+#include <miniupnpc/upnpcommands.h>
+#include <miniupnpc/upnperrors.h>
 #endif
 
 using namespace std;


### PR DESCRIPTION
Miniupnpc stores its headers in a directory miniupnpc, which was missing where the headers where included.

This should work across all Linux systems, I have not been testing on Windows, though. In case this breaks Windows I would have an alternative idea for how to fix this.
