### PR TITLE
Fix interaction of the updater with headless gridcoin research

### DIFF
--- a/CompilingGridcoinOnLinux.txt
+++ b/CompilingGridcoinOnLinux.txt
@@ -50,7 +50,7 @@ chmod 755 leveldb/build_detect_platform
 make -f makefile.unix USE_UPNP=- 
 
 
-##### End of Step 1: gridcoind will be found in /src directory
+##### End of Step 1: gridcoinresearchd will be found in /src directory
 
 
 
@@ -81,7 +81,7 @@ addnode=node.gridcoin.us
 
 #save and exit.  Leave the lines with ssl in them out if you don't need ssl.
 
-####### Testing Gridcoin gridcoind :
+####### Testing Gridcoin gridcoinresearchd :
 #Let server start
 gridcoinresearchd
 #Should return current difficulty:

--- a/src/upgrader.cpp
+++ b/src/upgrader.cpp
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
             }
         }
     }
-    else if (strcmp(argv[1], "gridcoind")==0)
+    else if (strcmp(argv[1], "gridcoinresearchd")==0)
     {
         if (waitForParent(atoi(argv[2])))
         {
@@ -634,7 +634,7 @@ std::string Upgrader::targetswitch(int target)
         return "gridcoinresearch";
 
         case DAEMON:
-        return "gridcoind";
+        return "gridcoinresearchd";
 
         case UPGRADER:
         return "gridcoinupgrader";


### PR DESCRIPTION
The updater assumed the binary name to be gridcoind instead of gridcoinresearchd.
