### PR TITLE
icon path edit for Red Hat & Debian

### DIFF
--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -1,10 +1,10 @@
 <RCC>
     <qresource prefix="/icons">
-        <file alias="bitcoin">res/icons/novacoin-80.png</file>
+        <file alias="bitcoin">../../share/pixmaps/grcsimple.png</file>
         <file alias="address-book">res/icons/address-book.png</file>
         <file alias="quit">res/icons/quit.png</file>
         <file alias="send">res/icons/send.png</file>
-        <file alias="toolbar">res/icons/toolbar.png</file>
+        <file alias="toolbar">../../share/pixmaps/grcsimple.png</file>
         <file alias="connect_0">res/icons/connect0_16.png</file>
         <file alias="connect_1">res/icons/connect1_16.png</file>
         <file alias="connect_2">res/icons/connect2_16.png</file>
@@ -23,8 +23,7 @@
         <file alias="editpaste">res/icons/editpaste.png</file>
         <file alias="editcopy">res/icons/editcopy.png</file>
         <file alias="add">res/icons/add.png</file>
-        <file alias="bitcoin_testnet">res/icons/novacoin-80.png</file>
-        <file alias="toolbar">res/icons/toolbar.png</file>
+        <file alias="bitcoin_testnet">../../share/pixmaps/grcsimple.png</file>
         <file alias="edit">res/icons/edit.png</file>
         <file alias="history">res/icons/history.png</file>
         <file alias="overview">res/icons/overview.png</file>


### PR DESCRIPTION
Combines pull request #5 from Nargren (Removed line 27, duplicate of line 7, a harmless compile time error)
with
pull request #15 from Marix (replaces novacoin main menu icon for both Red Hat and Debian builds)
plus
One Debian specific toolbar icon replacement.
All icons are replaced with existing grcsimple.png by path updates in bitcoin.qrc
