### PR TITLE
Fix linkage of the gridcoinupgrader

### DIFF
--- a/src/makefile_upgrader.mingw
+++ b/src/makefile_upgrader.mingw
@@ -48,6 +48,7 @@ LIBS += -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell
 
 OBJS= \
 	obj-upgrader/util.o \
+	obj-upgrader/version.o \
 	obj-upgrader/upgrader.o \
 
 all: gridcoinupgrader

--- a/src/makefile_upgrader.unix
+++ b/src/makefile_upgrader.unix
@@ -103,9 +103,14 @@ xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
 
 OBJS= \
     obj-upgrader/util.o \
+    obj-upgrader/version.o \
     obj-upgrader/upgrader.o 
 
 all: gridcoinupgrader
+
+obj/build.h: FORCE
+	/bin/sh ../share/genbuild.sh obj-upgrader/build.h
+version.cpp: obj/build.h
 
 DEFS += -DHAVE_BUILD_INFO
 
@@ -123,5 +128,6 @@ clean:
 	-rm -f gridcoinupgrader
 	-rm -f obj-upgrader/*.o
 	-rm -f obj-upgrader/*.P
+	-rm -f obj-upgrader/build.h
 
 FORCE:


### PR DESCRIPTION
Changes required to make the upgrader compile on linux again. It was broken since version 3.4.0.6/259.
