### PR TITLE
Fix bad placeholders in French translation

### DIFF
--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -418,7 +418,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+6"/>
         <source>Downloaded %1 of %2 blocks of transaction history (%3% done).</source>
-        <translation>Téléchargement des blocks de l&apos;historique des transactions : 1% sur 2% (%3% effectués).</translation>
+        <translation>Téléchargement des blocks de l&apos;historique des transactions : %1 sur %2 (%3% terminé).</translation>
     </message>
     <message>
         <location line="-247"/>


### PR DESCRIPTION
Fixes the weird messages on the console in FR locale lin `QString::arg: Argument missing: Téléchargement des blocks de l'historique des transactions : 1% sur 2% (39102% effectués)., 57.9443`
