### PR TITLE
update net.cpp

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -18,10 +18,10 @@
 #endif
 
 #ifdef USE_UPNP
-#include <miniwget.h>
-#include <miniupnpc.h>
-#include <upnpcommands.h>
-#include <upnperrors.h>
+#include <miniupnpc/miniwget.h>
+#include <miniupnpc/miniupnpc.h>
+#include <miniupnpc/upnpcommands.h>
+#include <miniupnpc/upnperrors.h>
 #endif
 
 using namespace std;


### PR DESCRIPTION
- update upnp paths
- This was merged earlier in the year and then pulled out with some other failed merge. 
- Allows compiling with UPnP support in linux. (no flags required to avoid UPnP errors)
