### PR TITLE
Hide the advanced menu on Linux

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1077,7 +1077,7 @@ void BitcoinGUI::createMenuBar()
 	rebuild->addAction(rebootAction);
 	rebuild->addSeparator();
 
-
+#ifdef WIN32
 	QMenu *qmAdvanced = appMenuBar->addMenu(tr("&Advanced"));
 	qmAdvanced->addSeparator();
 	qmAdvanced->addAction(configAction);
@@ -1099,8 +1099,7 @@ void BitcoinGUI::createMenuBar()
 	qmAdvanced->addSeparator();
 	qmAdvanced->addAction(faqAction);
 	qmAdvanced->addAction(foundationAction);
-
-
+#endif /* defined(WIN32) */
 
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1077,7 +1077,7 @@ void BitcoinGUI::createMenuBar()
 	rebuild->addAction(rebootAction);
 	rebuild->addSeparator();
 
-#ifdef WIN32
+#ifdef WIN32  // The actions in this menu are implemented in Visual Basic and thus only work on Windows
 	QMenu *qmAdvanced = appMenuBar->addMenu(tr("&Advanced"));
 	qmAdvanced->addSeparator();
 	qmAdvanced->addAction(configAction);


### PR DESCRIPTION
None of the entries in the advanced menu work on Linux. Thus, it does no good showing them to the user.
