### PR TITLE
upnp fix for linux

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -18,10 +18,10 @@
 #endif
 
 #ifdef USE_UPNP
-#include <miniwget.h>
-#include <miniupnpc.h>
-#include <upnpcommands.h>
-#include <upnperrors.h>
+#include <miniupnpc/miniwget.h>
+#include <miniupnpc/miniupnpc.h>
+#include <miniupnpc/upnpcommands.h>
+#include <miniupnpc/upnperrors.h>
 #endif
 
 using namespace std;


### PR DESCRIPTION
Edit net.cpp, correcting path to the header files so upnp support will work in linux builds
