### PR TITLE
Update CompilingGridcoinOnLinux.txt

### DIFF
--- a/CompilingGridcoinOnLinux.txt
+++ b/CompilingGridcoinOnLinux.txt
@@ -96,7 +96,7 @@ gridcoinresearchd getmininginfo
 #cd to the directory where gridcoinresearch.pro is
 cd ~/Gridcoin-Research
 
-#IMPORTANT: now edit gridcoinresearch.pro and remove the entries "QT += qaxcontainer" and "CONFIG += qaxcontainer"
+#IMPORTANT: now edit gridcoinresearch.pro and remove the entries "QT += qaxcontainer", "CONFIG += qaxcontainer" and "QT += axserver"
 #nano gridcoinresearch.pro
  
 rm -f build/*.o


### PR DESCRIPTION
QT += axserver should be removed as well.
Fixes #70 
Copied from @caraka patch: http://bazaar.launchpad.net/~caraka/gridcoin/gridcoin-pkg/view/head:/debian/patches/qt5_changes.patch
