### PR TITLE
Removed incorrect 'sudo'.

### DIFF
--- a/CompilingGridcoinOnLinux.txt
+++ b/CompilingGridcoinOnLinux.txt
@@ -46,7 +46,7 @@ git clone https://github.com/gridcoin/Gridcoin-Research
 #git reset --hard origin/master
 
 cd ~/Gridcoin-Research/src
-sudo mkdir obj
+mkdir obj
 
 chmod 755 leveldb/build_detect_platform 
 make -f makefile.unix USE_UPNP=- 


### PR DESCRIPTION
The use of sudo to make an obj dir subsequently causes a permission error when running 'make' as a normal user. Directories in the source structure should belong to the user, not root.
