### PR TITLE
Isolating QT win32 deps

### DIFF
--- a/CompilingGridcoinOnLinux.txt
+++ b/CompilingGridcoinOnLinux.txt
@@ -96,9 +96,6 @@ gridcoinresearchd getmininginfo
 #cd to the directory where gridcoinresearch.pro is
 cd ~/Gridcoin-Research
 
-#IMPORTANT: now edit gridcoinresearch.pro and remove the entries "QT += qaxcontainer", "CONFIG += qaxcontainer" and "QT += axserver"
-#nano gridcoinresearch.pro
- 
 rm -f build/*.o
 qmake "USE_UPNP=-"
 make

--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -20,8 +20,8 @@ win32 {
 greaterThan(QT_MAJOR_VERSION, 4) {
     QT += widgets
     DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
-win32 {
-    CONFIG += qaxcontainer
+    win32 {
+        CONFIG += qaxcontainer
     }
 }
 CONFIG += exceptions

--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -19,12 +19,13 @@ win32 {
 
 greaterThan(QT_MAJOR_VERSION, 4) {
     QT += widgets
+    CONFIG += exceptions
     DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
     win32 {
         CONFIG += qaxcontainer
     }
 }
-CONFIG += exceptions
+
 
 
 # for boost 1.37, add -mt to the boost libraries

--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -7,10 +7,14 @@ CONFIG += no_include_pwd
 CONFIG += thread
 #QT += sql (Future Use)
 QT += core gui network
-QT += qaxcontainer
-#QT += axcontainer
-QT += axserver
 QT += widgets
+
+win32 {
+    QT += qaxcontainer
+    #QT += axcontainer
+    QT += axserver
+    }
+
 
 
 greaterThan(QT_MAJOR_VERSION, 4) {
@@ -18,7 +22,10 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
 }
 
-CONFIG += qaxcontainer
+win32 {
+    CONFIG += qaxcontainer
+    }
+
 CONFIG += exceptions
 
 

--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -20,12 +20,10 @@ win32 {
 greaterThan(QT_MAJOR_VERSION, 4) {
     QT += widgets
     DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
-}
-
 win32 {
     CONFIG += qaxcontainer
     }
-
+}
 CONFIG += exceptions
 
 


### PR DESCRIPTION
Put the win32-specific dependencies in separate blocks and updated the Linux documentation to reflect this.
