### PR TITLE
Update gridcoinresearch.pro

### DIFF
--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -7,9 +7,9 @@ CONFIG += no_include_pwd
 CONFIG += thread
 #QT += sql (Future Use)
 QT += core gui network
-QT += qaxcontainer
+win32:QT += qaxcontainer
 #QT += axcontainer
-QT += axserver
+win32:QT += axserver
 QT += widgets
 
 
@@ -18,7 +18,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
 }
 
-CONFIG += qaxcontainer
+win32:CONFIG += qaxcontainer
 CONFIG += exceptions
 
 


### PR DESCRIPTION
Tested builds in qt5 and qt4 ubuntu linux. All good. Needs a Win build test.

Added win32: prefix to three modules at top of the .pro file that are win only. Inspired by FluffyDemon to get off my ass and fix this rather than patch for it.
