### PR TITLE
Fix compilation of thread priority handling on Linux

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -631,7 +631,8 @@ inline void SetThreadPriority(int nPriority)
 #define THREAD_PRIORITY_LOWEST          PRIO_MAX
 #define THREAD_PRIORITY_BELOW_NORMAL    2
 #define THREAD_PRIORITY_NORMAL          0
-#define THREAD_PRIORITY_ABOVE_NORMAL    0
+#define THREAD_PRIORITY_ABOVE_NORMAL    -2
+#define THREAD_PRIORITY_HIGHEST        PRIO_MIN
 
 inline void SetThreadPriority(int nPriority)
 {


### PR DESCRIPTION
Note that on Linux normal users won't actually get a higher-than-normal-
priority effect unless they run as root.

All the code in this area is lacking even basic error checks. This issue
is not touched by this commit, but should be looked at, as this might
cause quite some unexpected behaviour if things go wrong and the code
just continues without saying anything.
