### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+---
+language: cpp
+sudo: required
+dist: trusty
+
+addons:
+  apt:
+    packages:
+    - libboost-filesystem-dev
+    - libboost-program-options-dev
+    - libboost-system-dev
+    - libboost-thread-dev
+    - libboost-test-dev
+    - build-essential
+    - libssl-dev
+    - libdb-dev
+    - libdb++-dev
+    - libqrencode-dev
+    - qt5-default
+    - qt5-qmake
+    - qttools5-dev-tools
+    - libminiupnpc-dev
+    - libzip-dev
+
+script:
+  - mkdir -p src/obj
+  - chmod 755 src/leveldb/build_detect_platform
+  - cd src
+  - make -f makefile.unix DEBUGFLAGS="" USE_UPNP=1
+  - cd ..
+  - qmake "USE_QRCODE=1" "USE_UPNP=1" "NO_UPGRADE=1"
+  - make
+


### PR DESCRIPTION
Following #119 - this will add travis ci.
You would need to enable travis to run on this repo first for this to work.

A working example at my fork:
https://github.com/Tahvok/Gridcoin-Research/pull/3

And the successfull build:
https://travis-ci.org/Tahvok/Gridcoin-Research/builds/155970019

It's possible to add some more checks to this.
