### PR TITLE
advertisebeacon minimum balance error message

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1444,7 +1444,7 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
 			double nBalance = GetTotalBalance();
 			if (nBalance < 1.01)
 			{
-				sError = "Balance too low to send beacon.";
+				sError = "Balance too low to send beacon, 1.01 GRC minimum balance required.";
 				return false;
 			}
 		


### PR DESCRIPTION
modifying execute advertisebeacon error message to indicate the minimum balance required to advertise a beacon so that newbies trying to advertise for the first time after receiving free faucet coins are not confused by the error message.
