### PR TITLE
Fix issue with high CPU usage.

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -30,7 +30,7 @@ double GetBlockDifficulty(unsigned int nBits);
 extern double GetLastPaymentTimeByCPID(std::string cpid);
 extern double GetUntrustedMagnitude(std::string cpid, double& out_owed);
 bool LessVerbose(int iMax1000);
-StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID> vRef);
+StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID>& vRef);
 extern double ReturnTotalRacByCPID(std::string cpid);
 
 typedef std::map<int, unsigned int> MapModifierCheckpoints;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ extern void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, s
 bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature);
 int DownloadBlocks();
 int DetermineCPIDType(std::string cpid);
-extern MiningCPID GetInitializedMiningCPID(std::string name,std::map<std::string, MiningCPID> vRef);
+extern MiningCPID GetInitializedMiningCPID(std::string name, std::map<std::string, MiningCPID>& vRef);
 extern std::string getHardDriveSerial();
 extern bool IsSuperBlock(CBlockIndex* pIndex);
 extern bool VerifySuperblock(std::string superblock, int nHeight);
@@ -133,7 +133,7 @@ extern bool LoadSuperblock(std::string data, int64_t nTime, double height);
 extern CBlockIndex* GetHistoricalMagnitude(std::string cpid);
 
 extern double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime, double& total_owed, double block_magnitude);
-extern StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID> vRef);
+extern StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID>& vRef);
 
 
 extern double GetOwedAmount(std::string cpid);
@@ -6281,31 +6281,25 @@ StructCPID GetLifetimeCPID(std::string cpid, std::string sCalledFrom)
 	return st1;
 }
 
-MiningCPID GetInitializedMiningCPID(std::string name,std::map<std::string, MiningCPID> vRef)
+MiningCPID GetInitializedMiningCPID(std::string name,std::map<std::string, MiningCPID>& vRef)
 {
-	MiningCPID cpid = vRef[name];
+   MiningCPID& cpid = vRef[name];
 	if (!cpid.initialized)
 	{
 			    cpid = GetMiningCPID();
 				cpid.initialized=true;
 				cpid.LastPaymentTime = 0;
-				vRef.insert(map<string,MiningCPID>::value_type(name,cpid));
-				vRef[name]=cpid;
-				return cpid;
-	}
-	else
-	{
-			return cpid;
 	}
 
+   return cpid;
 }
 
 
-StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID> vRef)
+StructCPID GetInitializedStructCPID2(std::string name, std::map<std::string, StructCPID>& vRef)
 {
 	try
 	{
-		StructCPID cpid = vRef[name];
+      StructCPID& cpid = vRef[name];
 		if (!cpid.initialized)
 		{
 				cpid = GetStructCPID();
@@ -6314,9 +6308,7 @@ StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, Stru
 				cpid.HighLockTime = 0;
 				cpid.LastPaymentTime = 0;
 				cpid.EarliestPaymentTime = 99999999999;
-				vRef.insert(map<string,StructCPID>::value_type(name,cpid));
 				cpid.Accuracy = 0;
-				vRef[name]=cpid;
 				return cpid;
 		}
 		else
@@ -6327,14 +6319,12 @@ StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, Stru
 	catch (bad_alloc ba)
 	{
 		printf("Bad alloc caught in GetInitializedStructCpid2 for %s",name.c_str());
-		StructCPID cpid = GetStructCPID();
-		return cpid;
+      return GetStructCPID();
 	}
 	catch(...)
 	{
 		printf("Exception caught in GetInitializedStructCpid2 for %s",name.c_str());
-		StructCPID cpid = GetStructCPID();
-		return cpid;
+      return GetStructCPID();
 	}
 }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -111,7 +111,7 @@ bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit)
 bool FullSyncWithDPORNodes();
 bool LoadSuperblock(std::string data, int64_t nTime, double height);
 
-StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID> vRef);
+StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID>& vRef);
 
 std::string GetNeuralNetworkSupermajorityHash(double& out_popularity);
 std::string GetCurrentNeuralNetworkSupermajorityHash(double& out_popularity);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -19,7 +19,7 @@ int64_t GetCoinYearReward(int64_t nTime);
 //static boost::thread_group* postThreads = NULL;
 
 double GetPoSKernelPS2();
-StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID> vRef);
+StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID>& vRef);
 double GRCMagnitudeUnit(int64_t locktime);
 std::string qtGetNeuralHash(std::string data);
 volatile bool bCPIDsLoaded;

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -25,9 +25,9 @@ using namespace std;
 using namespace boost;
 
 leveldb::DB *txdb; // global pointer for LevelDB object instance
-StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID> vRef);
+StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, StructCPID>& vRef);
 bool IsLockTimeWithin14days(double locktime);
-MiningCPID GetInitializedMiningCPID(std::string name,std::map<std::string, MiningCPID> vRef);
+MiningCPID GetInitializedMiningCPID(std::string name,std::map<std::string, MiningCPID>& vRef);
 MiningCPID DeserializeBoincBlock(std::string block);
 void AddCPIDBlockHash(std::string cpid, std::string blockhash, bool fInsert);
 


### PR DESCRIPTION
Avoid copying the incoming std::map on each call. Also, try to reduce the number of interactions overall once the map's object has been retrieved.
This closes #140 (for real).

On my Core2Duo this dropped the idle CPU usage from 50-60% to 0.7%.