### PR TITLE
Reduce GCC6/C++11 warnings and use distro LevelDB.

### DIFF
--- a/CompilingGridcoinOnLinux.txt
+++ b/CompilingGridcoinOnLinux.txt
@@ -1,14 +1,14 @@
 ########################## Linux Instructions: #####################################################################
-# 	
+#
 #	Released 1-25-2014 - Gridcoin
 #
 # This guide is broken up into 3 versions.
-#   
-# 1. Gridcoind - headless daemon 
-# 2. Gridcoin-qt 
+#
+# 1. Gridcoind - headless daemon
+# 2. Gridcoin-qt
 # 3. Wine version of Gridcoin-qt
 #
-# 
+#
 # Section 1: Compiling Gridcoind
 #
 # -Tested on Ubuntu 12.04, Ubuntu 13.10
@@ -31,7 +31,7 @@
 #git config --global http.sslverify false
 
 
-sudo apt-get install ntp git build-essential libssl-dev libdb-dev libdb++-dev libboost-all-dev libqrencode-dev
+sudo apt-get install ntp git build-essential libleveldb-dev libssl-dev libdb-dev libdb++-dev libboost-all-dev libqrencode-dev
 sudo apt-get install qt-sdk qt4-default
 #ATTN: !! New packages required as of 2-4-2015 (Lederstrumpfs additions)
 sudo apt-get install libcurl3-dev
@@ -48,8 +48,8 @@ git clone https://github.com/gridcoin/Gridcoin-Research
 cd ~/Gridcoin-Research/src
 mkdir obj
 
-chmod 755 leveldb/build_detect_platform 
-make -f makefile.unix USE_UPNP=- 
+chmod 755 leveldb/build_detect_platform
+make -f makefile.unix USE_UPNP=-
 
 
 ##### End of Step 1: gridcoinresearchd will be found in /src directory
@@ -63,22 +63,22 @@ mkdir ~/.GridcoinResearch
 cd ~/.GridcoinResearch
 
 #### SSL: ###################################################################
-#Optional: Setting up gridcoinresearchd for ssl 
-#openssl genrsa -out server.pem 2048 
-#openssl req -new -x509 -nodes -sha1 -days 3650 -key server.pem > server.cert 
+#Optional: Setting up gridcoinresearchd for ssl
+#openssl genrsa -out server.pem 2048
+#openssl req -new -x509 -nodes -sha1 -days 3650 -key server.pem > server.cert
 #############################################################################
 
-nano gridcoinresearch.conf 
+nano gridcoinresearch.conf
 
 #copy the following into the editor: (Note the addnode should be in row #1):
 addnode=node.gridcoin.us
-server=1 
-daemon=1 
-rpcport=9332 
-rpcallowip=127.0.0.1 
+server=1
+daemon=1
+rpcport=9332
+rpcallowip=127.0.0.1
 rpcuser=username
 rpcpassword=yourpassword
-rpcallowip=external IP 
+rpcallowip=external IP
 #rpcssl=1
 
 #save and exit.  Leave the lines with ssl in them out if you don't need ssl.
@@ -98,7 +98,7 @@ cd ~/Gridcoin-Research
 
 #IMPORTANT: now edit gridcoinresearch.pro and remove the entries "QT += qaxcontainer", "CONFIG += qaxcontainer" and "QT += axserver"
 #nano gridcoinresearch.pro
- 
+
 rm -f build/*.o
 qmake "USE_UPNP=-"
 make
@@ -130,7 +130,7 @@ sudo apt-get install python-dev
 sudo apt-get install python-bzutils
 sudo apt-get install libbz2-dev
 sudo ./bootstrap.sh --includedir=/usr/include --exec-prefix=/usr/local --libdir=/usr/lib
-sudo ./b2 
+sudo ./b2
 sudo ./bjam install
 #
 # End of Boost Upgrade Commands
@@ -144,7 +144,7 @@ sudo ./bjam install
 
 
 ##########################################################
-# 02-21-2015 
+# 02-21-2015
 # R Halford - Creating a secure environment for production
 #
 ##########################################################
@@ -184,12 +184,3 @@ gridcoinresearchd getinfo
 Verify connections are > 1, and Blocks > 1
 
 #################################################################
-
-
-
-
-
-
-
-
- 

--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -117,26 +117,27 @@ contains(NO_UPGRADE, 1) {
     DEFINES += NO_UPGRADE
 }
 
-INCLUDEPATH += src/leveldb/include src/leveldb/helpers
-LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
 SOURCES += src/txdb-leveldb.cpp
 !win32 {
-    # we use QMAKE_CXXFLAGS_RELEASE even without RELEASE=1 because we use RELEASE to indicate linking preferences not -O preferences
-    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a
+    LIBS += -lleveldb
 } else {
+    INCLUDEPATH += src/leveldb/include src/leveldb/helpers
+    LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
+
     # make an educated guess about what the ranlib command is called
     isEmpty(QMAKE_RANLIB) {
         QMAKE_RANLIB = $$replace(QMAKE_STRIP, strip, ranlib)
     }
     LIBS += -lshlwapi
     genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libmemenv.a
+
+    genleveldb.target = $$PWD/src/leveldb/libleveldb.a
+    genleveldb.depends = FORCE
+    PRE_TARGETDEPS += $$PWD/src/leveldb/libleveldb.a
+    QMAKE_EXTRA_TARGETS += genleveldb
+    # Gross ugly hack that depends on qmake internals, unfortunately there is no other way to do it.
+    QMAKE_CLEAN += $$PWD/src/leveldb/libleveldb.a; cd $$PWD/src/leveldb ; $(MAKE) clean
 }
-genleveldb.target = $$PWD/src/leveldb/libleveldb.a
-genleveldb.depends = FORCE
-PRE_TARGETDEPS += $$PWD/src/leveldb/libleveldb.a
-QMAKE_EXTRA_TARGETS += genleveldb
-# Gross ugly hack that depends on qmake internals, unfortunately there is no other way to do it.
-QMAKE_CLEAN += $$PWD/src/leveldb/libleveldb.a; cd $$PWD/src/leveldb ; $(MAKE) clean
 
 # regenerate src/build.h
 !windows|contains(USE_BUILD_INFO, 1) {

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -56,8 +56,8 @@ std::string CUnsignedAlert::ToString() const
     return strprintf(
         "CAlert(\n"
         "    nVersion     = %d\n"
-        "    nRelayUntil  = %"PRId64"\n"
-        "    nExpiration  = %"PRId64"\n"
+        "    nRelayUntil  = %" PRId64 "\n"
+        "    nExpiration  = %" PRId64 "\n"
         "    nID          = %d\n"
         "    nCancel      = %d\n"
         "    setCancel    = %s\n"

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -399,7 +399,7 @@ static string HTTPReply(int nStatus, const string& strMsg, bool keepalive)
             "HTTP/1.1 %d %s\r\n"
             "Date: %s\r\n"
             "Connection: %s\r\n"
-            "Content-Length: %"PRIszu"\r\n"
+            "Content-Length: %" PRIszu "\r\n"
             "Content-Type: application/json\r\n"
             "Server: gridcoin-json-rpc/%s\r\n"
             "\r\n"

--- a/src/cpid.cpp
+++ b/src/cpid.cpp
@@ -33,7 +33,7 @@ return(x>>n)|(x<<((0x12e9+2293-0x1bd6)-n));}
 
 inline void CPID::FF(uint4&a,uint4 b,uint4 c,uint4 d,uint4 x,uint4 s,uint4 ac){a
 =rotate_left(a+F(b,c,d)+x+ac,s)+b;}inline void CPID::GG(uint4&a,uint4 b,uint4 c,
-uint4 d,uint4 x,uint4 s,uint4 ac){a=rotate_left(a+G(b,c,d)+x+ac,s)+b;}inline 
+uint4 d,uint4 x,uint4 s,uint4 ac){a=rotate_left(a+G(b,c,d)+x+ac,s)+b;}inline
 void CPID::HH(uint4&a,uint4 b,uint4 c,uint4 d,uint4 x,uint4 s,uint4 ac){a=
 rotate_left(a+H(b,c,d)+x+ac,s)+b;}inline void CPID::II(uint4&a,uint4 b,uint4 c,
 uint4 d,uint4 x,uint4 s,uint4 ac){a=rotate_left(a+I(b,c,d)+x+ac,s)+b;}
@@ -44,9 +44,9 @@ CPID::CPID(std::string text){init();update(text.c_str(),text.length());finalize(
 );}
 
 CPID::CPID(std::string text,int entropybit,uint256 hash_block){init();entropybit
-++;update5(text,hash_block);finalize();}template<typename T>std::string 
+++;update5(text,hash_block);finalize();}template<typename T>std::string
 ByteToHex(T i){std::stringstream stream;stream<<std::setfill(
-((char)(0xbac+70-0xbc2)))<<std::setw((0x1344+4775-0x25e9))<<std::hex<<i;return 
+((char)(0xbac+70-0xbc2)))<<std::setw((0x1344+4775-0x25e9))<<std::hex<<i;return
 stream.str();}std::string CPID::HashKey(std::string email1,std::string bpk1){
 boost::algorithm::to_lower(bpk1);boost::algorithm::to_lower(email1);
 boinc_hash_new=bpk1+email1;CPID c=CPID(boinc_hash_new);std::string non_finalized
@@ -59,7 +59,7 @@ hexdigest();return shash;}std::string ROR(std::string blockhash,int iPos,std::
 string hash){if(iPos<=(int)hash.length()-(0x1f5b+1342-0x2498)){int asc1=(int)
 hash.at(iPos);int rorcount=BitwiseCount(blockhash,iPos);std::string hex=
 ByteToHex(asc1+rorcount);return hex;}return"\x30\x30";}std::string CPID::CPID_V2
-(std::string email1,std::string bpk1,uint256 block_hash){std::string 
+(std::string email1,std::string bpk1,uint256 block_hash){std::string
 non_finalized=HashKey(email1,bpk1);std::string digest=Update6(non_finalized,
 block_hash);
 return digest;}
@@ -170,21 +170,21 @@ for(i=firstpart;i+blocksize<=length;i+=blocksize)transform(&input[i]);index=
 (0x786+6933-0x229b);}else i=(0x3c9+6892-0x1eb5);
 memcpy(&buffer[index],&input[i],length-i);}
 
-void CPID::update(const char input[],size_type length){update((const unsigned 
+void CPID::update(const char input[],size_type length){update((const unsigned
 char*)input,length);}int HexToByte(std::string hex){int x=(0x4a+4863-0x1349);std
-::stringstream ss;ss<<std::hex<<hex;ss>>x;return x;}int ROL(std::string 
+::stringstream ss;ss<<std::hex<<hex;ss>>x;return x;}int ROL(std::string
 blockhash,int iPos,std::string hash,int hexpos){std::string cpid3="";if(iPos<=(
 int)hash.length()-(0x1c97+497-0x1e87)){std::string hex=hash.substr(iPos,
 (0xa5d+6424-0x2373));int rorcount=BitwiseCount(blockhash,hexpos);int b=HexToByte
 (hex)-rorcount;if(b>=(0x5b2+1768-0xc9a)){return b;}}return HexToByte("\x30\x30")
 ;}std::string CPID::Update6(std::string non_finalized,uint256 block_hash){std::
 string shash=HashHex(block_hash);for(int i=(0x1258+3278-0x1f26);i<(int)
-boinc_hash_new.length();i++){non_finalized+=ROR(shash,i,boinc_hash_new);}return 
+boinc_hash_new.length();i++){non_finalized+=ROR(shash,i,boinc_hash_new);}return
 non_finalized;}std::string Update7(std::string longcpid,uint256 hash_block){std
-::string shash=HashHex(hash_block);int hexpos=(0x632+1664-0xcb2);std::string 
+::string shash=HashHex(hash_block);int hexpos=(0x632+1664-0xcb2);std::string
 non_finalized="";for(int i1=(0xbd+8943-0x23ac);i1<(int)longcpid.length();i1=i1+
 (0x1ac0+2812-0x25ba)){non_finalized+=ROL(shash,i1,longcpid,hexpos);hexpos++;}
-CPID c7=CPID(non_finalized);std::string hexstring=c7.hexdigest();return 
+CPID c7=CPID(non_finalized);std::string hexstring=c7.hexdigest();return
 hexstring;}void CPID::update5(std::string longcpid,uint256 hash_block){std::
 string shash=HashHex(hash_block);int hexpos=(0x43b+6491-0x1d96);unsigned char*
 input=new unsigned char[(longcpid.length()/(0x534+8432-0x2622))+
@@ -243,9 +243,9 @@ template<typename T>std::string LongToHex(T i){std::stringstream stream;stream<<
 boincdigest(std::string email,std::string bpk,uint256 hash_block){
 if(!finalized)return"";char buf[(0x151+8463-0x2250)];for(int i=
 (0x95f+3677-0x17bc);i<(0x13f8+3123-0x201b);i++){sprintf(buf+i*
-(0x639+7515-0x2392),"\x25\x30\x32\x78",digest[i]);}char ch;std::string 
+(0x639+7515-0x2392),"\x25\x30\x32\x78",digest[i]);}std::string
 non_finalized(buf);std::string shash=HashHex(hash_block);std::string debug="";
-boost::algorithm::to_lower(bpk);boost::algorithm::to_lower(email);std::string 
+boost::algorithm::to_lower(bpk);boost::algorithm::to_lower(email);std::string
 cpid_non=bpk+email;for(int i=(0x450+3069-0x104d);i<(int)cpid_non.length();i++){
 non_finalized+=ROR(shash,i,cpid_non);}
 return non_finalized;}bool CompareCPID(std::string usercpid,std::string longcpid

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -464,7 +464,7 @@ void CDBEnv::Flush(bool fShutdown)
             else
                 mi++;
         }
-        printf("DBFlush(%s)%s ended %15"PRId64"ms\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started", GetTimeMillis() - nStart);
+        printf("DBFlush(%s)%s ended %15" PRId64 "ms\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started", GetTimeMillis() - nStart);
         if (fShutdown)
         {
             char** listp;
@@ -544,8 +544,7 @@ bool CAddrDB::Read(CAddrMan& addr)
     uint256 hashIn;
 
     // read data and checksum from file
-    try 
-	{
+    try {
         filein.read((char *)&vchData[0], dataSize);
         filein >> hashIn;
     }
@@ -579,4 +578,3 @@ bool CAddrDB::Read(CAddrMan& addr)
 
     return true;
 }
-

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -300,7 +300,6 @@ bool AppInit(int argc, char* argv[])
 
     try
     {
-		boost::thread* detectShutdownThread = NULL;
         //
         // Parameters
         //
@@ -340,7 +339,8 @@ bool AppInit(int argc, char* argv[])
             int ret = CommandLineRPC(argc, argv);
             exit(ret);
         }
-		detectShutdownThread = new boost::thread(boost::bind(&DetectShutdownThread, &threadGroup));
+        // Launch a detached thread to detect shutdown.
+        new boost::thread(boost::bind(&DetectShutdownThread, &threadGroup));
 
         fRet = AppInit2();
     }
@@ -605,7 +605,7 @@ bool AppInit2()
 
     nNodeLifespan = GetArg("-addrlifespan", 7);
 
-	
+
 	fUseFastIndex = GetBoolArg("-fastindex", false);
 
 	nMinerSleep = GetArg("-minersleep", 500);
@@ -682,10 +682,11 @@ bool AppInit2()
 
 	fDebug=false;
 
-    if (fDebug)
-        fDebugNet = true;
-    else
-        fDebugNet = GetBoolArg("-debugnet");
+	if (fDebug) {
+		fDebugNet = true;
+	} else {
+		fDebugNet = GetBoolArg("-debugnet");
+	}
 
 	if (GetArg("-debug", "false")=="true")
 	{
@@ -993,7 +994,7 @@ bool AppInit2()
         printf("Shutdown requested. Exiting.\n");
         return false;
     }
-    printf(" block index %15"PRId64"ms\n", GetTimeMillis() - nStart);
+    printf(" block index %15" PRId64 "ms\n", GetTimeMillis() - nStart);
 
     if (GetBoolArg("-printblockindex") || GetBoolArg("-printblocktree"))
     {
@@ -1084,7 +1085,7 @@ bool AppInit2()
     }
 
     printf("%s", strErrors.str().c_str());
-    printf(" wallet      %15"PRId64"ms\n", GetTimeMillis() - nStart);
+    printf(" wallet      %15" PRId64 "ms\n", GetTimeMillis() - nStart);
 
     RegisterWallet(pwalletMain);
 
@@ -1104,7 +1105,7 @@ bool AppInit2()
         printf("Rescanning last %i blocks (from block %i)...\n", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);
         nStart = GetTimeMillis();
         pwalletMain->ScanForWalletTransactions(pindexRescan, true);
-        printf(" rescan      %15"PRId64"ms\n", GetTimeMillis() - nStart);
+        printf(" rescan      %15" PRId64 "ms\n", GetTimeMillis() - nStart);
     }
 
     // ********************************************************* Step 9: import blocks
@@ -1146,7 +1147,7 @@ bool AppInit2()
             printf("Invalid or missing peers.dat; recreating\n");
     }
 
-    printf("Loaded %i addresses from peers.dat  %"PRId64"ms\n",  addrman.size(), GetTimeMillis() - nStart);
+    printf("Loaded %i addresses from peers.dat  %" PRId64 "ms\n",  addrman.size(), GetTimeMillis() - nStart);
 
 
 	// ********************************************************* Step 11: start node
@@ -1183,11 +1184,11 @@ bool AppInit2()
     //// debug print
 	if (fDebug)
 	{
-		printf("mapBlockIndex.size() = %"PRIszu"\n",   mapBlockIndex.size());
+		printf("mapBlockIndex.size() = %" PRIszu "\n",   mapBlockIndex.size());
 		printf("nBestHeight = %d\n",            nBestHeight);
-		printf("setKeyPool.size() = %"PRIszu"\n",      pwalletMain->setKeyPool.size());
-		printf("mapWallet.size() = %"PRIszu"\n",       pwalletMain->mapWallet.size());
-		printf("mapAddressBook.size() = %"PRIszu"\n",  pwalletMain->mapAddressBook.size());
+		printf("setKeyPool.size() = %" PRIszu "\n",      pwalletMain->setKeyPool.size());
+		printf("mapWallet.size() = %" PRIszu "\n",       pwalletMain->mapWallet.size());
+		printf("mapAddressBook.size() = %" PRIszu "\n",  pwalletMain->mapAddressBook.size());
 	}
 
 

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -260,7 +260,7 @@ void ThreadIRCSeed2(void* parg)
         if (!fNoListen && GetLocal(addrLocal, &addrIPv4) && nNameRetry<3)
             strMyName = EncodeAddress(GetLocalAddress(&addrConnect));
         if (strMyName == "")
-            strMyName = strprintf("x%"PRIu64"", GetRand(1000000000));
+            strMyName = strprintf("x%" PRIu64 "", GetRand(1000000000));
 
         Send(hSocket, strprintf("NICK %s\r", strMyName.c_str()).c_str());
         Send(hSocket, strprintf("USER %s 8 * : %s\r", strMyName.c_str(), strMyName.c_str()).c_str());

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -166,7 +166,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
         return error("ComputeNextStakeModifier: unable to get last modifier");
     if (fDebug10)
     {
-        printf("ComputeNextStakeModifier: prev modifier=0x%016"PRIx64" time=%s\n", nStakeModifier, DateTimeStrFormat(nModifierTime).c_str());
+        printf("ComputeNextStakeModifier: prev modifier=0x%016" PRIx64 " time=%s\n", nStakeModifier, DateTimeStrFormat(nModifierTime).c_str());
     }
     if (nModifierTime / nModifierInterval >= pindexPrev->GetBlockTime() / nModifierInterval)
         return true;
@@ -230,7 +230,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     }
     if (fDebug)
     {
-        printf("ComputeNextStakeModifier: new modifier=0x%016"PRIx64" time=%s\n", nStakeModifierNew, DateTimeStrFormat(pindexPrev->GetBlockTime()).c_str());
+        printf("ComputeNextStakeModifier: new modifier=0x%016" PRIx64 " time=%s\n", nStakeModifierNew, DateTimeStrFormat(pindexPrev->GetBlockTime()).c_str());
     }
 
     nStakeModifier = nStakeModifierNew;
@@ -300,7 +300,7 @@ double ReturnTotalRacByCPID(std::string cpid)
 	//std::vector<std::string> vRAC = split(result.c_str(),"<project>");
 	std::string sRAC = ExtractXML(result,"<expavg_credit>","</expavg_credit>");
 	double dRAC = cdbl(sRAC,0);
-	return dRAC;						
+	return dRAC;
 }
 
 int DetermineCPIDType(std::string cpid)
@@ -317,7 +317,7 @@ int DetermineCPIDType(std::string cpid)
 	if (dRAC > 0) return 1;
 	// At this point, they have no RAC in the superblock, and no RAC in Netsoft, so we assume they are an investor (or pool miner)
 	return 2;
-}	
+}
 
 
 double GetMagnitudeByHashBoinc(std::string hashBoinc, int height)
@@ -382,7 +382,7 @@ int64_t GetRSAWeightByCPIDWithRA(std::string cpid)
 	//12-3-2015
 	if (cpid.empty() || cpid=="INVESTOR" || cpid=="POOL") return 0;
 	double dWeight = 0;
-	StructCPID stMagnitude = GetInitializedStructCPID2(cpid,mvMagnitudes);	
+	StructCPID stMagnitude = GetInitializedStructCPID2(cpid,mvMagnitudes);
 	StructCPID stLifetime  = GetInitializedStructCPID2(cpid,mvResearchAge);
 	if (stMagnitude.Magnitude > 0 && stLifetime.ResearchSubsidy == 0)
 	{
@@ -394,7 +394,7 @@ int64_t GetRSAWeightByCPIDWithRA(std::string cpid)
 int64_t GetRSAWeightByCPID(std::string cpid)
 {
 
-	if (IsResearchAgeEnabled(pindexBest->nHeight) && AreBinarySuperblocksEnabled(pindexBest->nHeight)) 
+	if (IsResearchAgeEnabled(pindexBest->nHeight) && AreBinarySuperblocksEnabled(pindexBest->nHeight))
 	{
 			return GetRSAWeightByCPIDWithRA(cpid);
 			//ToDo : During next mandatory, retire this old function.
@@ -607,12 +607,12 @@ static bool CheckStakeKernelHashV1(unsigned int nBits, const CBlock& blockFrom, 
     hashProofOfStake = Hash(ss.begin(), ss.end());
     if (fPrintProofOfStake)
     {
-        printf("CheckStakeKernelHash() : using modifier 0x%016"PRIx64" at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
+        printf("CheckStakeKernelHash() : using modifier 0x%016" PRIx64 " at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
             nStakeModifier, nStakeModifierHeight,
             DateTimeStrFormat(nStakeModifierTime).c_str(),
             mapBlockIndex[hashBlockFrom]->nHeight,
             DateTimeStrFormat(blockFrom.GetBlockTime()).c_str());
-            printf("CheckStakeKernelHash() : check modifier=0x%016"PRIx64" nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
+            printf("CheckStakeKernelHash() : check modifier=0x%016" PRIx64 " nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
             nStakeModifier,
             nTimeBlockFrom, nTxPrevOffset, txPrev.nTime, prevout.n, nTimeTx,
             hashProofOfStake.ToString().c_str());
@@ -633,12 +633,12 @@ static bool CheckStakeKernelHashV1(unsigned int nBits, const CBlock& blockFrom, 
 	}
     if (fDebug && !fPrintProofOfStake)
     {
-        printf("CheckStakeKernelHash() : using modifier 0x%016"PRIx64" at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
+        printf("CheckStakeKernelHash() : using modifier 0x%016" PRIx64 " at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
             nStakeModifier, nStakeModifierHeight,
             DateTimeStrFormat(nStakeModifierTime).c_str(),
             mapBlockIndex[hashBlockFrom]->nHeight,
             DateTimeStrFormat(blockFrom.GetBlockTime()).c_str());
-        printf("CheckStakeKernelHash() : pass modifier=0x%016"PRIx64" nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
+        printf("CheckStakeKernelHash() : pass modifier=0x%016" PRIx64 " nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
             nStakeModifier,
             nTimeBlockFrom, nTxPrevOffset, txPrev.nTime, prevout.n, nTimeTx,
             hashProofOfStake.ToString().c_str());
@@ -860,4 +860,3 @@ bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierCheck
 {
 	return true;
 }
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,7 +97,7 @@ extern bool UnusualActivityReport();
 
 extern std::string GetCurrentNeuralNetworkSupermajorityHash(double& out_popularity);
 extern std::string GetNeuralNetworkSupermajorityHash(double& out_popularity);
-       
+
 extern double CalculatedMagnitude2(std::string cpid, int64_t locktime,bool bUseLederstrumpf);
 extern CBlockIndex* GetHistoricalMagnitude_ScanChain(std::string cpid);
 extern bool IsLockTimeWithin14days(double locktime);
@@ -730,7 +730,7 @@ bool FullSyncWithDPORNodes()
 					bool bNodeOnline = RequestSupermajorityNeuralData();
 					if (bNodeOnline) return false;  // Async call to another node will continue after the node responds.
 				}
-			
+
 				std::string errors1 = "";
                 LoadAdminMessages(false,errors1);
 				std::string cpiddata = GetListOf("beacon");
@@ -957,7 +957,7 @@ MiningCPID GetNextProject(bool bForce)
 					return GlobalCPUMiningCPID;
 	}
 
-	
+
 	msMiningProject = "";
 	msMiningCPID = "";
 	mdMiningRAC = 0;
@@ -1055,7 +1055,7 @@ MiningCPID GetNextProject(bool bForce)
 									GlobalCPUMiningCPID.lastblockhash = "0";
 									// Sign the block
 									GlobalCPUMiningCPID.BoincSignature = SignBlockWithCPID(GlobalCPUMiningCPID.cpid,GlobalCPUMiningCPID.lastblockhash);
-								
+
 									if (!IsCPIDValidv2(GlobalCPUMiningCPID,1))
 									{
 										printf("CPID INVALID (GetNextProject) %s, %s  ",GlobalCPUMiningCPID.cpid.c_str(),GlobalCPUMiningCPID.cpidv2.c_str());
@@ -1237,7 +1237,7 @@ bool AddOrphanTx(const CTransaction& tx)
 
     if (nSize > 5000)
     {
-        printf("ignoring large orphan tx (size: %"PRIszu", hash: %s)\n", nSize, hash.ToString().substr(0,10).c_str());
+        printf("ignoring large orphan tx (size: %" PRIszu ", hash: %s)\n", nSize, hash.ToString().substr(0,10).c_str());
         return false;
     }
 
@@ -1245,7 +1245,7 @@ bool AddOrphanTx(const CTransaction& tx)
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
-    printf("stored orphan tx %s (mapsz %"PRIszu")\n", hash.ToString().substr(0,10).c_str(),   mapOrphanTransactions.size());
+    printf("stored orphan tx %s (mapsz %" PRIszu ")\n", hash.ToString().substr(0,10).c_str(),   mapOrphanTransactions.size());
     return true;
 }
 
@@ -1293,7 +1293,7 @@ std::string DefaultWalletAddress()
     		 const CBitcoinAddress& address = item.first;
 			 const std::string& strName = item.second;
 			 bool fMine = IsMine(*pwalletMain, address.Get());
-			 if (fMine && strName == "Default") 
+			 if (fMine && strName == "Default")
 			 {
 				 sDefaultWalletAddress=CBitcoinAddress(address).ToString();
 				 return sDefaultWalletAddress;
@@ -1766,7 +1766,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         // Don't accept it if it can't get into a block
         int64_t txMinFee = tx.GetMinFee(1000, GMF_RELAY, nSize);
         if (nFees < txMinFee)
-            return error("AcceptToMemoryPool : not enough fees %s, %"PRId64" < %"PRId64,
+            return error("AcceptToMemoryPool : not enough fees %s, %" PRId64 " < %" PRId64,
                          hash.ToString().c_str(),
                          nFees, txMinFee);
 
@@ -1804,7 +1804,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
 			{
 				printf("\r\nAcceptToMemoryPool::CleaningInboundConnections\r\n");
 				CleanInboundConnections(true);
-			}	
+			}
 			if (fDebug || true)
 			{
 				return error("AcceptToMemoryPool : Unable to Connect Inputs %s", hash.ToString().c_str());
@@ -1827,12 +1827,15 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         pool.addUnchecked(hash, tx);
     }
 
-    ///// are we sure this is ok when loading transactions or restoring block txes
-    // If updated, erase old tx from wallet
-    if (ptxOld)
-        EraseFromWallets(ptxOld->GetHash());
-	if (fDebug)     printf("AcceptToMemoryPool : accepted %s (poolsz %"PRIszu")\n",           hash.ToString().c_str(),           pool.mapTx.size());
-    return true;
+  ///// are we sure this is ok when loading transactions or restoring block txes
+  // If updated, erase old tx from wallet
+  if (ptxOld) {
+    EraseFromWallets(ptxOld->GetHash());
+  }
+  if (fDebug) {
+    printf("AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")\n",           hash.ToString().c_str(),           pool.mapTx.size());
+  }
+  return true;
 }
 
 bool CTxMemPool::addUnchecked(const uint256& hash, CTransaction &tx)
@@ -2158,7 +2161,7 @@ int64_t GetProofOfWorkReward(int64_t nFees, int64_t locktime, int64_t height)
 	//NOTE: THIS REWARD IS ONLY USED IN THE POW PHASE (Block < 8000):
     int64_t nSubsidy = CalculatedMagnitude(locktime,true) * COIN;
     if (fDebug && GetBoolArg("-printcreation"))
-        printf("GetProofOfWorkReward() : create=%s nSubsidy=%"PRId64"\n", FormatMoney(nSubsidy).c_str(), nSubsidy);
+        printf("GetProofOfWorkReward() : create=%s nSubsidy=%" PRId64 "\n", FormatMoney(nSubsidy).c_str(), nSubsidy);
 	if (nSubsidy < (30*COIN)) nSubsidy=30*COIN;
 	//Gridcoin Foundation Block:
 	if (height==10)
@@ -2296,7 +2299,7 @@ int64_t GetProofOfStakeReward(int64_t nCoinAge, int64_t nFees, std::string cpid,
 			int64_t nSubsidy  = nInterest + nBoinc;
 			if (fDebug10 || GetBoolArg("-printcreation"))
 			{
-				printf("GetProofOfStakeReward(): create=%s nCoinAge=%"PRId64" nBoinc=%"PRId64"   \n",
+				printf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRId64 " nBoinc=%" PRId64 "   \n",
 				FormatMoney(nSubsidy).c_str(), nCoinAge, nBoinc);
 			}
 			int64_t maxStakeReward1 = GetProofOfStakeMaxReward(nCoinAge, nFees, nTime);
@@ -2336,7 +2339,7 @@ int64_t GetProofOfStakeReward(int64_t nCoinAge, int64_t nFees, std::string cpid,
 
 			if (fDebug10 || GetBoolArg("-printcreation"))
 			{
-				printf("GetProofOfStakeReward(): create=%s nCoinAge=%"PRId64" nBoinc=%"PRId64"   \n",
+				printf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRId64 " nBoinc=%" PRId64 "   \n",
 				FormatMoney(nSubsidy).c_str(), nCoinAge, nBoinc);
 			}
 
@@ -2565,11 +2568,11 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
     uint256 nBestInvalidBlockTrust = pindexNew->nChainTrust - pindexNew->pprev->nChainTrust;
     uint256 nBestBlockTrust = pindexBest->nHeight != 0 ? (pindexBest->nChainTrust - pindexBest->pprev->nChainTrust) : pindexBest->nChainTrust;
 
-    printf("InvalidChainFound: invalid block=%s  height=%d  trust=%s  blocktrust=%"PRId64"  date=%s\n",
+    printf("InvalidChainFound: invalid block=%s  height=%d  trust=%s  blocktrust=%" PRId64 "  date=%s\n",
       pindexNew->GetBlockHash().ToString().substr(0,20).c_str(), pindexNew->nHeight,
       CBigNum(pindexNew->nChainTrust).ToString().c_str(), nBestInvalidBlockTrust.Get64(),
       DateTimeStrFormat("%x %H:%M:%S", pindexNew->GetBlockTime()).c_str());
-    printf("InvalidChainFound:  current best=%s  height=%d  trust=%s  blocktrust=%"PRId64"  date=%s\n",
+    printf("InvalidChainFound:  current best=%s  height=%d  trust=%s  blocktrust=%" PRId64 "  date=%s\n",
       hashBestChain.ToString().substr(0,20).c_str(), nBestHeight,
       CBigNum(pindexBest->nChainTrust).ToString().c_str(),
       nBestBlockTrust.Get64(),
@@ -2686,7 +2689,7 @@ bool CTransaction::FetchInputs(CTxDB& txdb, const map<uint256, CTxIndex>& mapTes
             // Revisit this if/when transaction replacement is implemented and allows
             // adding inputs:
             fInvalid = true;
-            return DoS(100, error("FetchInputs() : %s prevout.n out of range %d %"PRIszu" %"PRIszu" prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
+            return DoS(100, error("FetchInputs() : %s prevout.n out of range %d %" PRIszu " %" PRIszu " prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
         }
     }
 
@@ -2923,7 +2926,7 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs, map<uint256, CTx
             CTransaction& txPrev = inputs[prevout.hash].second;
 
             if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.vSpent.size())
-                return DoS(100, error("ConnectInputs() : %s prevout.n out of range %d %"PRIszu" %"PRIszu" prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
+                return DoS(100, error("ConnectInputs() : %s prevout.n out of range %d %" PRIszu " %" PRIszu " prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
 
             // If prev is coinbase or coinstake, check that it's matured
             if (txPrev.IsCoinBase() || txPrev.IsCoinStake())
@@ -2975,8 +2978,8 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs, map<uint256, CTx
 					if (TimerMain("ConnectInputs", 20))
 					{
 						CleanInboundConnections(false);
-					}	
-					
+					}
+
 					if (fMiner) return false;
 					return fDebug ? error("ConnectInputs() : %s prev tx already used at %s", GetHash().ToString().c_str(), txindex.vSpent[prevout.n].ToString().c_str()) : false;
 				}
@@ -3119,15 +3122,15 @@ template< typename T >
 std::string int_to_hex( T i )
 {
   std::stringstream stream;
-  stream << "0x" 
-         << std::setfill ('0') << std::setw(sizeof(T)*2) 
+  stream << "0x"
+         << std::setfill ('0') << std::setw(sizeof(T)*2)
          << std::hex << i;
   return stream.str();
 }
 
 std::string DoubleToHexStr(double d, int iPlaces)
 {
-	int nMagnitude = atoi(RoundToString(d,0).c_str()); 
+	int nMagnitude = atoi(RoundToString(d,0).c_str());
 	std::string hex_string = int_to_hex(nMagnitude);
 	std::string sOut = "00000000" + hex_string;
 	std::string sHex = sOut.substr(sOut.length()-iPlaces,iPlaces);
@@ -3136,7 +3139,7 @@ std::string DoubleToHexStr(double d, int iPlaces)
 
 int HexToInt(std::string sHex)
 {
-	int x;   
+	int x;
     std::stringstream ss;
     ss << std::hex << sHex;
     ss >> x;
@@ -3165,14 +3168,14 @@ double ConvertHexToDouble(std::string hex)
 }
 
 
-std::string ConvertBinToHex(std::string a) 
+std::string ConvertBinToHex(std::string a)
 {
       if (a.empty()) return "0";
 	  std::string sOut = "";
 	  for (unsigned int x = 1; x <= a.length(); x++)
 	  {
     	   char c = a[x-1];
-		   int i = (int)c; 
+		   int i = (int)c;
 		   std::string sHex = DoubleToHexStr((double)i,2);
 		   sOut += sHex;
       }
@@ -3449,7 +3452,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
 		int64_t nReward = GetProofOfWorkMaxReward(nFees,nTime,pindex->nHeight);
         // Check coinbase reward
         if (vtx[0].GetValueOut() > nReward)
-            return DoS(50, error("ConnectBlock[] : coinbase reward exceeded (actual=%"PRId64" vs calculated=%"PRId64")",
+            return DoS(50, error("ConnectBlock[] : coinbase reward exceeded (actual=%" PRId64 " vs calculated=%" PRId64 ")",
                    vtx[0].GetValueOut(),
                    nReward));
     }
@@ -3552,12 +3555,12 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
 		double dMagnitudeUnit = 0;
 		double dAvgMagnitude = 0;
 
-	    // ResearchAge 1: 
+	    // ResearchAge 1:
 		GetProofOfStakeReward(nCoinAge, nFees, bb.cpid, true, 1, nTime,
 			pindex, "connectblock_researcher", OUT_POR, OUT_INTEREST, dAccrualAge, dMagnitudeUnit, dAvgMagnitude);
 		if (bb.cpid != "INVESTOR" && dStakeReward > 1)
 		{
-			
+
 			    //ResearchAge: Since the best block may increment before the RA is connected but After the RA is computed, the ResearchSubsidy can sometimes be slightly smaller than we calculate here due to the RA timespan increasing.  So we will allow for time shift before rejecting the block.
 			    double dDrift = IsResearchAgeEnabled(pindex->nHeight) ? bb.ResearchSubsidy*.15 : 1;
 				if (IsResearchAgeEnabled(pindex->nHeight) && dDrift < 10) dDrift = 10;
@@ -3742,7 +3745,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
 	}
 
 
-	if (IsResearchAgeEnabled(pindex->nHeight) && !OutOfSyncByAge()) 
+	if (IsResearchAgeEnabled(pindex->nHeight) && !OutOfSyncByAge())
 	{
 			fColdBoot = false;
 			bDoTally=true;
@@ -3806,8 +3809,8 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         vConnect.push_back(pindex);
     reverse(vConnect.begin(), vConnect.end());
 
-    printf("REORGANIZE: Disconnect %"PRIszu" blocks; %s..%s\n", vDisconnect.size(), pfork->GetBlockHash().ToString().substr(0,20).c_str(), pindexBest->GetBlockHash().ToString().substr(0,20).c_str());
-    printf("REORGANIZE: Connect %"PRIszu" blocks; %s..%s\n", vConnect.size(), pfork->GetBlockHash().ToString().substr(0,20).c_str(), pindexNew->GetBlockHash().ToString().substr(0,20).c_str());
+    printf("REORGANIZE: Disconnect %" PRIszu " blocks; %s..%s\n", vDisconnect.size(), pfork->GetBlockHash().ToString().substr(0,20).c_str(), pindexBest->GetBlockHash().ToString().substr(0,20).c_str());
+    printf("REORGANIZE: Connect %" PRIszu " blocks; %s..%s\n", vConnect.size(), pfork->GetBlockHash().ToString().substr(0,20).c_str(), pindexNew->GetBlockHash().ToString().substr(0,20).c_str());
 
 	if (vDisconnect.size() > 0)
 	{
@@ -3907,7 +3910,7 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
     }
 
 	// Gridcoin: Now that the chain is back in order, Fix the researchers who were disrupted:
-	
+
     printf("REORGANIZE: done\n");
     return true;
 }
@@ -3916,12 +3919,13 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
 bool CleanChain()
 {
 	CTxDB txdb;
-   if (!txdb.TxnBegin())
-        return error("CleanChain() : TxnBegin failed");
+	if (!txdb.TxnBegin()) {
+		return error("CleanChain() : TxnBegin failed");
+	}
 
 	if (nBestHeight < 1000) return true;
 
-    printf("\r\n** CLEAN CHAIN **\r\n");
+	printf("\r\n** CLEAN CHAIN **\r\n");
 	// Roll back a few blocks from best height
 	printf(" Current best height %f ",(double)pindexBest->nHeight);
 	CBlockIndex* pfork = pindexBest->pprev;
@@ -3951,7 +3955,7 @@ bool CleanChain()
 
 			printf(" Clean Chain succeeded. ");
 	}
-	bool fResult = AskForOutstandingBlocks(uint256(0));
+	AskForOutstandingBlocks(uint256(0));
 	return true;
 
 }
@@ -4044,7 +4048,7 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
 			if (!vpindexSecondary.empty())
 			printf("\r\nReorganizing Attempt #%f, regression to block #%f \r\n",(double)iRegression+1,(double)pindexIntermediate->nHeight);
 
-            printf("Postponing %"PRIszu" reconnects\n", vpindexSecondary.size());
+            printf("Postponing %" PRIszu " reconnects\n", vpindexSecondary.size());
 			if (iRegression==4 && !Reorganize(txdb, pindexIntermediate))
 			{
 					printf("Failed to Reorganize during Attempt #%f \r\n",(double)iRegression+1);
@@ -4099,7 +4103,7 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
 
 	if (fDebug)
 	{
-		printf("{SBC} SetBestChain: new best=%s  height=%d  trust=%s  blocktrust=%"PRId64"  date=%s\n",
+		printf("{SBC} SetBestChain: new best=%s  height=%d  trust=%s  blocktrust=%" PRId64 "  date=%s\n",
 		  hashBestChain.ToString().substr(0,20).c_str(), nBestHeight,
 		  CBigNum(nBestChainTrust).ToString().c_str(),
           nBestBlockTrust.Get64(),
@@ -4177,7 +4181,7 @@ bool CTransaction::GetCoinAge(CTxDB& txdb, uint64_t& nCoinAge) const
         bnCentSecond += CBigNum(nValueIn) * (nTime-txPrev.nTime) / CENT;
 
         if (fDebug && GetBoolArg("-printcoinage"))
-            printf("coin age nValueIn=%"PRId64" nTimeDiff=%d bnCentSecond=%s\n", nValueIn, nTime - txPrev.nTime, bnCentSecond.ToString().c_str());
+            printf("coin age nValueIn=%" PRId64 " nTimeDiff=%d bnCentSecond=%s\n", nValueIn, nTime - txPrev.nTime, bnCentSecond.ToString().c_str());
     }
 
     CBigNum bnCoinDay = bnCentSecond * CENT / COIN / (24 * 60 * 60);
@@ -4205,7 +4209,7 @@ bool CBlock::GetCoinAge(uint64_t& nCoinAge) const
     if (nCoinAge == 0) // block coin age minimum 1 coin-day
         nCoinAge = 1;
     if (fDebug && GetBoolArg("-printcoinage"))
-        printf("block coin age total nCoinDays=%"PRId64"\n", nCoinAge);
+        printf("block coin age total nCoinDays=%" PRId64 "\n", nCoinAge);
     return true;
 }
 
@@ -4301,15 +4305,15 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
 
 	if (GetHash()==hashGenesisBlock || GetHash()==hashGenesisBlockTestNet) return true;
 	// These are checks that are independent of context
-    // that can be verified before saving an orphan block.
+	// that can be verified before saving an orphan block.
 
-    // Size limits
-    if (vtx.empty() || vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
-        return DoS(100, error("CheckBlock[] : size limits failed"));
+	// Size limits
+	if (vtx.empty() || vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+		return DoS(100, error("CheckBlock[] : size limits failed"));
 
-    // Check proof of work matches claimed amount
-    if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetPoWHash(), nBits))
-        return DoS(50, error("CheckBlock[] : proof of work failed"));
+	// Check proof of work matches claimed amount
+	if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetPoWHash(), nBits))
+		return DoS(50, error("CheckBlock[] : proof of work failed"));
 
 	//Reject blocks with diff that has grown to an extrordinary level (should never happen)
 	double blockdiff = GetBlockDifficulty(nBits);
@@ -4321,9 +4325,11 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
     // First transaction must be coinbase, the rest must not be
     if (vtx.empty() || !vtx[0].IsCoinBase())
         return DoS(100, error("CheckBlock[] : first tx is not coinbase"));
-    for (unsigned int i = 1; i < vtx.size(); i++)
-        if (vtx[i].IsCoinBase())
+    for (unsigned int i = 1; i < vtx.size(); i++) {
+        if (vtx[i].IsCoinBase()) {
             return DoS(100, error("CheckBlock[] : more than one coinbase"));
+        }
+    }
 
 	//Research Age
 	MiningCPID bb = DeserializeBoincBlock(vtx[0].hashBoinc);
@@ -4365,7 +4371,7 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
 							// Reserved for future use.
 				}
 			}
-	
+
 	}
 
 
@@ -4434,24 +4440,22 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
 
     if (IsProofOfStake())
     {
-		//4-2-2015 Verify each POR recipient is owed > paid - CryptoLottery
+		    //4-2-2015 Verify each POR recipient is owed > paid - CryptoLottery
         // Coinbase output should be empty if proof-of-stake block
-        if (vtx[0].vout.size() != 1 || !vtx[0].vout[0].IsEmpty())
+        if (vtx[0].vout.size() != 1 || !vtx[0].vout[0].IsEmpty()) {
             return DoS(100, error("CheckBlock[] : coinbase output not empty for proof-of-stake block"));
+        }
 
         // Second transaction must be coinstake, the rest must not be
         if (vtx.empty() || !vtx[1].IsCoinStake())
             return DoS(100, error("CheckBlock[] : second tx is not coinstake"));
 
-	    for (unsigned int i = 2; i < vtx.size(); i++)
-		{
-            if (vtx[i].IsCoinStake())
-			{
-				printf("Found more than one coinstake in coinbase at location %f\r\n",(double)i);
+	      for (unsigned int i = 2; i < vtx.size(); i++) {
+          if (vtx[i].IsCoinStake()) {
+				    printf("Found more than one coinstake in coinbase at location %f\r\n",(double)i);
                 return DoS(100, error("CheckBlock[] : more than one coinstake"));
-			}
-		}
-
+			    }
+		    }
     }
 
     // Check transactions
@@ -4510,16 +4514,17 @@ bool CBlock::AcceptBlock(bool generated_by_me)
     CBlockIndex* pindexPrev = (*mi).second;
     int nHeight = pindexPrev->nHeight+1;
 
-    if (IsProtocolV2(nHeight) && nVersion < 7)
+    if (IsProtocolV2(nHeight) && nVersion < 7) {
         return DoS(100, error("AcceptBlock() : reject too old nVersion = %d", nVersion));
-    else if (!IsProtocolV2(nHeight) && nVersion > 6)
+    } else if (!IsProtocolV2(nHeight) && nVersion > 6) {
         return DoS(100, error("AcceptBlock() : reject too new nVersion = %d", nVersion));
+    }
 
     if (IsProofOfWork() && nHeight > LAST_POW_BLOCK)
         return DoS(100, error("AcceptBlock() : reject proof-of-work at height %d", nHeight));
 
-	if (nHeight > nGrandfather)
-	{
+		if (nHeight > nGrandfather)
+		{
 			// Check coinbase timestamp
 			if (GetBlockTime() > FutureDrift((int64_t)vtx[0].nTime, nHeight))
 			{
@@ -4528,10 +4533,10 @@ bool CBlock::AcceptBlock(bool generated_by_me)
 			// Check timestamp against prev
 			if (GetBlockTime() <= pindexPrev->GetPastTimeLimit() || FutureDrift(GetBlockTime(), nHeight) < pindexPrev->GetBlockTime())
 				return DoS(60, error("AcceptBlock() : block's timestamp is too early"));
-    		// Check proof-of-work or proof-of-stake
-	    	if (nBits != GetNextTargetRequired(pindexPrev, IsProofOfStake()))
+    	// Check proof-of-work or proof-of-stake
+	    if (nBits != GetNextTargetRequired(pindexPrev, IsProofOfStake()))
 				return DoS(100, error("AcceptBlock() : incorrect %s", IsProofOfWork() ? "proof-of-work" : "proof-of-stake"));
-	}
+	  }
 
 
     // Check that all transactions are finalized
@@ -4731,7 +4736,7 @@ void GridcoinServices()
 	   }
     #endif
 	// Services thread activity
-    
+
 	//This is Gridcoins Service thread; called once per block
 	if (nBestHeight > 100 && nBestHeight < 200)
 	{
@@ -4749,13 +4754,13 @@ void GridcoinServices()
 	}
 	//Dont perform the following functions if out of sync
 	if (pindexBest->nHeight < nGrandfather) return;
-    
+
 	if (OutOfSyncByAge()) return;
 	if (fDebug) printf(" {SVC} ");
 
 	//Backup the wallet once per 900 blocks:
 	double dWBI = cdbl(GetArgument("walletbackupinterval", "900"),0);
-	
+
 	if (TimerMain("backupwallet", dWBI))
 	{
 		std::string backup_results = BackupGridcoinWallet();
@@ -4766,7 +4771,7 @@ void GridcoinServices()
 	{
 		bTallyStarted = false;
 	}
-	
+
 	if (TimerMain("OutOfSyncDaily",900))
 	{
 		if (WalletOutOfSync())
@@ -4817,7 +4822,7 @@ void GridcoinServices()
 	bool bNeedSuperblock = ((double)superblock_age > (double)(GetSuperblockAgeSpacing(nBestHeight)));
 	if ( nBestHeight % 3 == 0 && NeedASuperblock() ) bNeedSuperblock=true;
 
-	if (fDebug10) 
+	if (fDebug10)
 	{
 			printf (" MRSA %f, BH %f ",(double)superblock_age,(double)nBestHeight);
 	}
@@ -4964,10 +4969,10 @@ bool AskForOutstandingBlocks(uint256 hashStart)
 {
 	if (IsLockTimeWithinMinutes(nLastAskedForBlocks,2)) return true;
 	nLastAskedForBlocks = GetAdjustedTime();
-		
+
 	int iAsked = 0;
 	LOCK(cs_vNodes);
-	BOOST_FOREACH(CNode* pNode, vNodes) 
+	BOOST_FOREACH(CNode* pNode, vNodes)
 	{
 				pNode->ClearBanned();
     			if (!pNode->fClient && !pNode->fOneShot && (pNode->nStartingHeight > (nBestHeight - 144)) && (pNode->nVersion < NOBLKS_VERSION_START || pNode->nVersion >= NOBLKS_VERSION_END) )
@@ -5007,10 +5012,10 @@ void CheckForLatestBlocks()
 			mapOrphanBlocks.clear();
 			setStakeSeen.clear();
 			setStakeSeenOrphan.clear();
-			bool fResult = AskForOutstandingBlocks(uint256(0));
+			AskForOutstandingBlocks(uint256(0));
 			printf("\r\n ** Clearing Orphan Blocks... ** \r\n");
 	}
-	
+
 }
 
 void CleanInboundConnections(bool bClearAll)
@@ -5018,7 +5023,7 @@ void CleanInboundConnections(bool bClearAll)
 		if (IsLockTimeWithinMinutes(nLastCleaned,10)) return;
      	nLastCleaned = GetAdjustedTime();
 	 	LOCK(cs_vNodes);
-		BOOST_FOREACH(CNode* pNode, vNodes) 
+		BOOST_FOREACH(CNode* pNode, vNodes)
 		{
 				pNode->ClearBanned();
 				if (pNode->nStartingHeight < (nBestHeight-1000) || bClearAll)
@@ -5061,7 +5066,7 @@ void CheckForFutileSync()
 	{
 		if (TimerMain("CheckForFutileSync", 25))
 		{
-			if (TimerMain("OrphansAndNotRecovering",8))									
+			if (TimerMain("OrphansAndNotRecovering",8))
 			{
 				printf("\r\nGridcoin has not recovered after clearing orphans; Restarting node...\r\n");
 				#if defined(WIN32) && defined(QT_GUI)
@@ -5072,8 +5077,8 @@ void CheckForFutileSync()
 			{
 				mapAlreadyAskedFor.clear();
 				printf("\r\nClearing mapAlreadyAskedFor.\r\n");
-				mapOrphanBlocks.clear(); 
-				setStakeSeen.clear();  
+				mapOrphanBlocks.clear();
+				setStakeSeen.clear();
 				setStakeSeenOrphan.clear();
 				AskForOutstandingBlocks(uint256(0));
 			}
@@ -5101,7 +5106,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
     // Duplicate stake allowed only when there is orphan child block
     if (pblock->IsProofOfStake() && setStakeSeen.count(pblock->GetProofOfStake()) && !mapOrphanBlocksByPrev.count(hash) && !Checkpoints::WantedByPendingSyncCheckpoint(hash))
         return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for block %s", pblock->GetProofOfStake().first.ToString().c_str(),
-		pblock->GetProofOfStake().second, 
+		pblock->GetProofOfStake().second,
 		hash.ToString().c_str());
 
     CBlockIndex* pcheckpoint = Checkpoints::GetLastSyncCheckpoint();
@@ -5131,7 +5136,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
     // If don't already have its previous block, shunt it off to holding area until we get it
     if (!mapBlockIndex.count(pblock->hashPrevBlock))
     {
-		// *****      This area covers Gridcoin Orphan Handling      ***** 
+		// *****      This area covers Gridcoin Orphan Handling      *****
 		if (true)
 		{
 			if (WalletOutOfSync())
@@ -5202,7 +5207,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
         mapOrphanBlocksByPrev.erase(hashPrev);
     }
 
-   
+
     // if responsible for sync-checkpoint send it
     if (false && pfrom && !CSyncCheckpoint::strMasterPrivKey.empty())        Checkpoints::SendSyncCheckpoint(Checkpoints::AutoSelectSyncCheckpoint());
 	printf("{PB}: ACC; \r\n");
@@ -5693,7 +5698,7 @@ bool WriteKey(std::string sKey, std::string sValue)
 	// Allows Gridcoin to store the key value in the config file.
 	boost::filesystem::path pathConfigFile(GetArg("-conf", "gridcoinresearch.conf"));
     if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir(false) / pathConfigFile;
-	if (!filesystem::exists(pathConfigFile))  return false; 
+	if (!filesystem::exists(pathConfigFile))  return false;
 	boost::to_lower(sKey);
 	std::string sLine = "";
 	ifstream streamConfigFile;
@@ -5711,7 +5716,7 @@ bool WriteKey(std::string sKey, std::string sValue)
 				std::string sSourceValue = vEntry[1];
 				boost::to_lower(sSourceKey);
 
-				if (sSourceKey==sKey) 
+				if (sSourceKey==sKey)
 				{
 					sSourceValue = sValue;
 					sLine = sSourceKey + "=" + sSourceValue;
@@ -5724,12 +5729,12 @@ bool WriteKey(std::string sKey, std::string sValue)
 			sConfig += sLine;
 	   }
 	}
-	if (!fWritten) 
+	if (!fWritten)
 	{
 		sLine = sKey + "=" + sValue + "\r\n";
 		sConfig += sLine;
 	}
-	
+
 	streamConfigFile.close();
 
 	FILE *outFile = fopen(pathConfigFile.string().c_str(),"w");
@@ -6223,7 +6228,7 @@ void AddCPIDBlockHash(std::string cpid, std::string blockhash, bool fInsert)
 
 StructCPID GetLifetimeCPID(std::string cpid, std::string sCalledFrom)
 {
-	//Eliminates issues with reorgs, disconnects, double counting, etc.. 
+	//Eliminates issues with reorgs, disconnects, double counting, etc..
 	if (cpid.empty() || cpid=="INVESTOR")
 	{
 		StructCPID stDummy = GetInitializedStructCPID2("INVESTOR",mvResearchAge);
@@ -6380,7 +6385,7 @@ bool RetiredTN(bool Forcefully)
 						if (pblockindex == pindexGenesisBlock) return false;
 						if (pblockindex == NULL || !pblockindex->IsInMainChain()) continue;
 						MiningCPID bb;
-						
+
 						if (!block.ReadFromDisk(pblockindex)) continue;
 						if (block.vtx.size() > 0)
 						{
@@ -6561,7 +6566,7 @@ bool TallyResearchAverages(bool Forcefully)
 	bool superblockloaded = false;
 	double NetworkPayments = 0;
 	double NetworkInterest = 0;
-	
+
  						//Consensus Start/End block:
 						int nMaxDepth = (nBestHeight-CONSENSUS_LOOKBACK) - ( (nBestHeight-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
 						int nLookback = BLOCKS_PER_DAY * 14; //Daily block count * Lookback in days
@@ -6587,7 +6592,7 @@ bool TallyResearchAverages(bool Forcefully)
 						if (fDebug3) printf("Max block %f, seektime %f",(double)pblockindex->nHeight,(double)GetTimeMillis()-nStart);
 						nStart=GetTimeMillis();
 
-   
+
 						// Headless critical section ()
 		try
 		{
@@ -6656,7 +6661,7 @@ bool TallyResearchAverages(bool Forcefully)
 		}
 
 		if (fDebug3) printf("NA loaded in %f",(double)GetTimeMillis()-nStart);
-						
+
 	    bNetAveragesLoaded=true;
 	    return false;
 }
@@ -6719,7 +6724,7 @@ void PrintBlockTree()
         // print item
         CBlock block;
         block.ReadFromDisk(pindex);
-        printf("%d (%u,%u) %s  %08x  %s  mint %7s  tx %"PRIszu"",
+        printf("%d (%u,%u) %s  %08x  %s  mint %7s  tx %" PRIszu "",
             pindex->nHeight,
             pindex->nFile,
             pindex->nBlockPos,
@@ -6804,7 +6809,7 @@ bool LoadExternalBlockFile(FILE* fileIn)
                    __PRETTY_FUNCTION__);
         }
     }
-    printf("Loaded %i blocks from external file in %"PRId64"ms\n", nLoaded, GetTimeMillis() - nStart);
+    printf("Loaded %i blocks from external file in %" PRId64 "ms\n", nLoaded, GetTimeMillis() - nStart);
     return nLoaded > 0;
 }
 
@@ -6966,16 +6971,6 @@ bool AcidTest(std::string precommand, std::string acid, CNode* pfrom)
 			//pfrom->securityversion = pw1;
 		}
 		if (fDebug10) printf(" Nonce %s,comm %s,hash %s,pw1 %s \r\n",nonce.c_str(),command.c_str(),hash.c_str(),pw1.c_str());
-		//If timestamp too old; disconnect
-		double timediff = std::abs(GetAdjustedTime() - cdbl(nonce,0));
-	
-		if (false && hash != pw1)
-		{
-			//2/16 18:06:48 Acid test failed for 192.168.1.4:32749 1478973994,encrypt,1b089d19d23fbc911c6967b948dd8324,windows			if (fDebug) printf("Acid test failed for %s %s.",NodeAddress(pfrom).c_str(),acid.c_str());
-			double punishment = GetArg("-punishment", 10);
-			pfrom->Misbehaving(punishment);
-			return false;
-		}
 		return true;
 	}
 	else
@@ -7086,7 +7081,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     static map<CService, CPubKey> mapReuseKey;
     RandAddSeedPerfmon();
     if (fDebug10)
-        printf("received: %s (%"PRIszu" bytes)\n", strCommand.c_str(), vRecv.size());
+        printf("received: %s (%" PRIszu " bytes)\n", strCommand.c_str(), vRecv.size());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         printf("dropmessagestest DROPPING RECV MESSAGE\n");
@@ -7123,7 +7118,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 		std::string acid = "";
 		vRecv >> pfrom->nVersion >> pfrom->boinchashnonce >> pfrom->boinchashpw >> pfrom->cpid >> pfrom->enccpid >> acid >> pfrom->nServices >> nTime >> addrMe;
 
-		
+
 		//Halford - 12-26-2014 - Thwart Hackers
 		bool ver_valid = AcidTest(strCommand,acid,pfrom);
         if (fDebug10) printf("Ver Acid %s, Validity %s ",acid.c_str(),YesNo(ver_valid).c_str());
@@ -7199,14 +7194,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vRecv >> pfrom->nStartingHeight;
 		// 12-5-2015 - Append Trust fields
 		pfrom->nTrust = 0;
-		
+
 		if (!vRecv.empty())			vRecv >> pfrom->sGRCAddress;
-		
-		
+
+
 		// Allow newbies to connect easily with 0 blocks
 		if (GetArgument("autoban","true") == "true")
 		{
-				
+
 				// Note: Hacking attempts start in this area 3-26-2016
 				if (false && pfrom->nStartingHeight < (nBestHeight/2) && LessVerbose(1) && !fTestNet)
 				{
@@ -7215,7 +7210,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 					return false;
 				}
 				/*
-				
+
 				if (pfrom->nStartingHeight < 1 && LessVerbose(980) && !fTestNet)
 				{
 					pfrom->Misbehaving(100);
@@ -7237,7 +7232,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 				}
 		}
 
-	
+
 
 		if (pfrom->fInbound && addrMe.IsRoutable())
         {
@@ -7270,7 +7265,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         pfrom->PushMessage("verack");
         pfrom->ssSend.SetVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
 
-			
+
         if (!pfrom->fInbound)
         {
             // Advertise our address
@@ -7302,7 +7297,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
         }
 
-    
+
  	    // Ask the first connected node for block updates
         static int nAskedForBlocks = 0;
         if (!pfrom->fClient && !pfrom->fOneShot &&
@@ -7365,7 +7360,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (vAddr.size() > 1000)
         {
             pfrom->Misbehaving(10);
-            return error("message addr size() = %"PRIszu"", vAddr.size());
+            return error("message addr size() = %" PRIszu "", vAddr.size());
         }
 
 		// Don't store the node address unless they have block height > 50%
@@ -7435,7 +7430,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             pfrom->Misbehaving(50);
 			printf("\r\n **Hacker tried to send inventory > MAX_INV_SZ **\r\n");
-            return error("message inv size() = %"PRIszu"", vInv.size());
+            return error("message inv size() = %" PRIszu "", vInv.size());
         }
 
         // find last block in inv vector
@@ -7485,12 +7480,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (vInv.size() > MAX_INV_SZ)
         {
             pfrom->Misbehaving(10);
-            return error("message getdata size() = %"PRIszu"", vInv.size());
+            return error("message getdata size() = %" PRIszu "", vInv.size());
         }
 
         if (fDebugNet || (vInv.size() != 1))
 		{
-            if (fDebug10)  printf("received getdata (%"PRIszu" invsz)\n", vInv.size());
+            if (fDebug10)  printf("received getdata (%" PRIszu " invsz)\n", vInv.size());
 		}
 
         BOOST_FOREACH(const CInv& inv, vInv)
@@ -7678,7 +7673,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             mapAlreadyAskedFor.erase(inv);
             vWorkQueue.push_back(inv.hash);
             vEraseQueue.push_back(inv.hash);
-         
+
 			// Recursively process any orphan transactions that depended on this one
             for (unsigned int i = 0; i < vWorkQueue.size(); i++)
             {
@@ -7735,8 +7730,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         uint256 hashBlock = block.GetHash();
 
 		bool block_valid = AcidTest(strCommand,acid,pfrom);
-		if (!block_valid) 
-		{	
+		if (!block_valid)
+		{
 			printf("\r\n Acid test failed for block %s \r\n",hashBlock.ToString().c_str());
 			return false;
 		}
@@ -7754,7 +7749,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 	        mapAlreadyAskedFor.erase(inv);
 			pfrom->nTrust++;
 		}
-        if (block.nDoS) 
+        if (block.nDoS)
 		{
 				pfrom->Misbehaving(block.nDoS);
 				pfrom->nTrust--;
@@ -7969,9 +7964,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vRecv >> nonce;
 
             // Only process pong message if there is an outstanding ping (old ping without nonce should never pong)
-            if (pfrom->nPingNonceSent != 0) 
+            if (pfrom->nPingNonceSent != 0)
 			{
-                if (nonce == pfrom->nPingNonceSent) 
+                if (nonce == pfrom->nPingNonceSent)
 				{
                     // Matching pong received, this ping is no longer outstanding
                     bPingFinished = true;
@@ -8002,7 +7997,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         if (!(sProblem.empty())) {
-            printf("pong %s %s: %s, %"PRIx64" expected, %"PRIx64" received, %f bytes\n"
+            printf("pong %s %s: %s, %" PRIx64 " expected, %" PRIx64 " received, %f bytes\n"
                 , pfrom->addr.ToString().c_str()
                 , pfrom->strSubVer.c_str()
                 , sProblem.c_str()                , pfrom->nPingNonceSent                , nonce                , (double)nAvail);
@@ -8120,7 +8115,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         if (!(sProblem.empty())) {
-            printf("pong %s %s: %s, %"PRIx64" expected, %"PRIx64" received, %f bytes\n"
+            printf("pong %s %s: %s, %" PRIx64 " expected, %" PRIx64 " received, %f bytes\n"
                 , pfrom->addr.ToString().c_str()
                 , pfrom->strSubVer.c_str()
                 , sProblem.c_str()
@@ -9198,7 +9193,7 @@ void HarvestCPIDs(bool cleardata)
 									GlobalCPUMiningCPID.cpidhash = cpidhash;
 									GlobalCPUMiningCPID.email = email;
 									GlobalCPUMiningCPID.boincruntimepublickey = cpidhash;
-								
+
 									if (structcpid.rac > 10 && structcpid.team=="gridcoin")
 									{
 										msPrimaryCPID = structcpid.cpid;
@@ -9571,7 +9566,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 							    pto->PushMessage("inv", vInv);
 								vInv.clear();
 							}
-       
+
 			        }
                 }
             }
@@ -9877,7 +9872,7 @@ bool MemorizeMessage(std::string msg, int64_t nTime, double dAmount, std::string
 			  {
 				    // If the Beacon Public Key is Not Empty - do not overwrite with a new beacon value
 				    std::string sBPK = GetBeaconPublicKey(sMessageKey);
-					if (!sBPK.empty()) 
+					if (!sBPK.empty())
 					{
 						// Do not overwrite this beacon
 						sMessageValue="";
@@ -10331,7 +10326,7 @@ bool LoadAdminMessages(bool bFullTableScan, std::string& out_errors)
 			}
 		}
 	}
-	
+
 	return true;
 }
 
@@ -10407,6 +10402,7 @@ std::string getHardwareID()
 	return hwid;
 }
 
+#ifdef WIN32
 static void getCpuid( unsigned int* p, unsigned int ax )
  {
     __asm __volatile
@@ -10418,6 +10414,7 @@ static void getCpuid( unsigned int* p, unsigned int ax )
         : "0" (ax)
     );
  }
+#endif
 
  std::string getCpuHash()
  {
@@ -10598,7 +10595,3 @@ int64_t CoinFromValue(double dAmount)
     if (!MoneyRange(nAmount))                         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     return nAmount;
 }
-
-
-
-

--- a/src/main.h
+++ b/src/main.h
@@ -35,7 +35,7 @@ static const int MAX_NEWBIE_BLOCKS = 200;
 static const int MAX_NEWBIE_BLOCKS_LEVEL2 = 500;
 static const int CHECKPOINT_DISTRIBUTED_MODE = 50;
 static const int CONSENSUS_LOOKBACK = 5;  //Amount of blocks to go back from best block, to avoid counting forked blocks
-static const int BLOCK_GRANULARITY = 10;   //Consensus block divisor 
+static const int BLOCK_GRANULARITY = 10;   //Consensus block divisor
 
 static const double NeuralNetworkMultiplier = 115000;
 
@@ -86,14 +86,14 @@ static const uint256 hashGenesisBlock("0x000005a247b397eadfefa58e872bc967c261479
 //TestNet Genesis:
 static const uint256 hashGenesisBlockTestNet("0x00006e037d7b84104208ecf2a8638d23149d712ea810da604ee2f2cb39bae713");
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-inline bool IsProtocolV2(int nHeight) 
-{ 
-	return (fTestNet ?  nHeight > 2060 : nHeight > 85400); 
+inline bool IsProtocolV2(int nHeight)
+{
+	return (fTestNet ?  nHeight > 2060 : nHeight > 85400);
 }
 
 inline bool IsResearchAgeEnabled(int nHeight)
 {
-	return (fTestNet ?  nHeight > 0 : nHeight > 364500); 
+	return (fTestNet ?  nHeight > 0 : nHeight > 364500);
 }
 
 inline int GetSuperblockAgeSpacing(int nHeight)
@@ -101,9 +101,9 @@ inline int GetSuperblockAgeSpacing(int nHeight)
 	return (fTestNet ? 86400 : (nHeight > 364500) ? 86400 : 43200);
 }
 
-inline bool AreBinarySuperblocksEnabled(int nHeight) 
-{ 
-	return (fTestNet ? nHeight > 10000 : nHeight > 725000); 
+inline bool AreBinarySuperblocksEnabled(int nHeight)
+{
+	return (fTestNet ? nHeight > 10000 : nHeight > 725000);
 }
 
 
@@ -718,7 +718,7 @@ public:
         return nValueOut;
     }
 
-	
+
 
 
 
@@ -786,7 +786,7 @@ public:
     {
         std::string str;
         str += IsCoinBase()? "Coinbase" : (IsCoinStake()? "Coinstake" : "CTransaction");
-        str += strprintf("(hash=%s, nTime=%d, ver=%d, vin.size=%"PRIszu", vout.size=%"PRIszu", nLockTime=%d)\n",
+        str += strprintf("(hash=%s, nTime=%d, ver=%d, vin.size=%" PRIszu ", vout.size=%" PRIszu ", nLockTime=%d)\n",
             GetHash().ToString().substr(0,10).c_str(),
             nTime,
             nVersion,
@@ -992,7 +992,7 @@ public:
     unsigned int nBits;
 
     unsigned int nNonce;
-	
+
     // network and disk
     std::vector<CTransaction> vtx;
 
@@ -1011,8 +1011,8 @@ public:
 
 	//Gridcoin - 7/27/2014
 	/////////////////////////////////////////
-	
-	
+
+
     CBlock()
     {
         SetNull();
@@ -1021,7 +1021,7 @@ public:
     IMPLEMENT_SERIALIZE
     (
 		//Gridcoin
-	   
+
 	    //
 
 
@@ -1032,7 +1032,7 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
-	
+
 
         // ConnectBlock depends on vtx following header to generate CDiskTxPos
         if (!(nType & (SER_GETHASH|SER_BLOCKHEADERONLY)))
@@ -1042,7 +1042,7 @@ public:
             READWRITE(vchBlockSig);
 
 			/*
-			
+
 			*/
 
 
@@ -1241,7 +1241,7 @@ public:
 
     void print() const
     {
-        printf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%"PRIszu", vchBlockSig=%s)\n",
+        printf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%" PRIszu ", vchBlockSig=%s)\n",
             GetHash().ToString().c_str(),
             nVersion,
             hashPrevBlock.ToString().c_str(),
@@ -1317,7 +1317,7 @@ public:
 	std::string sReserved;
 
     unsigned int nFlags;  // ppcoin: block index flags
-    enum  
+    enum
     {
         BLOCK_PROOF_OF_STAKE = (1 << 0), // is proof-of-stake block
         BLOCK_STAKE_ENTROPY  = (1 << 1), // entropy bit for stake modifier
@@ -1520,11 +1520,11 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("CBlockIndex(nprev=%p, pnext=%p, nFile=%u, nBlockPos=%-6d nHeight=%d, nMint=%s, nMoneySupply=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016"PRIx64", nStakeModifierChecksum=%08x, hashProof=%s, prevoutStake=(%s), nStakeTime=%d merkle=%s, hashBlock=%s)",
+        return strprintf("CBlockIndex(nprev=%p, pnext=%p, nFile=%u, nBlockPos=%-6d nHeight=%d, nMint=%s, nMoneySupply=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016" PRIx64 ", nStakeModifierChecksum=%08x, hashProof=%s, prevoutStake=(%s), nStakeTime=%d merkle=%s, hashBlock=%s)",
             pprev, pnext, nFile, nBlockPos, nHeight,
             FormatMoney(nMint).c_str(), FormatMoney(nMoneySupply).c_str(),
             GeneratedStakeModifier() ? "MOD" : "-", GetStakeEntropyBit(), IsProofOfStake()? "PoS" : "PoW",
-            nStakeModifier, nStakeModifierChecksum, 
+            nStakeModifier, nStakeModifierChecksum,
             hashProof.ToString().c_str(),
             prevoutStake.ToString().c_str(), nStakeTime,
             hashMerkleRoot.ToString().c_str(),

--- a/src/makefile.bsd
+++ b/src/makefile.bsd
@@ -85,7 +85,7 @@ DEBUGFLAGS=-g
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O0 -msse2 -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O0 -std=c++11 -msse2 -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -39,7 +39,7 @@ LIBS= \
 
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
-CFLAGS=-O3 -msse2 -w -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
+CFLAGS=-O3 -std=c++11 -msse2 -w -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -static-libgcc -static-libstdc++
 
 ifndef USE_UPNP
@@ -90,7 +90,7 @@ OBJS= \
     obj/scrypt.o \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
-    obj/cpid.o 
+    obj/cpid.o
 
 all: gridcoinresearchd.exe
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -15,21 +15,21 @@ UNIX_LIBPATHS?= \
  -L"a:\deps-master\boost_1_55_0\stage\lib" \
  -L"a:\deps-master\db" \
  -L"a:\deps-master\ssl"
- 
- 
+
+
  DEPSDIR?=/usr/local
 #BOOST_SUFFIX?=-mgw46-mt-sd-1_55
  BOOST_SUFFIX?=-mgw46-mt-1_55
- 
- 
- 
+
+
+
   INCLUDEPATHS_OLD?= \
    -I"$(CURDIR)" \
    -I"$(DEPSDIR)/include" \
    -I"$(DEPSDIR)/include/boost" \
    -I"$(DEPSDIR)/boost_1_55_0/boost"
- 
- 
+
+
 
  INCLUDEPATHS?= \
   -I"$(CURDIR)" \
@@ -37,8 +37,8 @@ UNIX_LIBPATHS?= \
   -I"a:\deps-master\db" \
   -I"a:\deps-master\include\boost" \
   -I"a:\deps-master\boost" \
-  -I"a:\deps-master\boost_1_55_0" 
- 
+  -I"a:\deps-master\boost_1_55_0"
+
  LIBPATHS?= \
   -L"$(CURDIR)/leveldb" \
   -L"$(DEPSDIR)/lib"
@@ -73,7 +73,7 @@ LIBS= \
 
 DEFS=-DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
-CFLAGS=${ADDITIONALCCFLAGS} -mthreads -O3 -msse2 -w -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
+CFLAGS=${ADDITIONALCCFLAGS} -std=c++11 -mthreads -O3 -msse2 -w -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat
 
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
@@ -84,8 +84,8 @@ endif
 ifneq (${USE_UPNP}, -)
  INCLUDEPATHS += -I"a:\deps-master\miniupnpc-1.6"
  LIBPATHS += -L"a:\deps-master\miniupnpc-1.6"
- 
- 
+
+
  LIBS += -l miniupnpc -l iphlpapi
  DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP)
 endif
@@ -151,8 +151,8 @@ OBJS += obj/txdb-leveldb.o
 #cd leveldb && $(MAKE) CC=$(CC) CXX=$(CXX) OPT="$(CFLAGS)" TARGET_OS=NATIVE_WINDOWS libleveldb.a libmemenv.a && cd ..
 
 #oldcd leveldb; make; cd ..
-	
-	
+
+
 obj/txdb-leveldb.o: leveldb/libleveldb.a
 
 obj/%.o: %.cpp $(HEADERS)

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -59,7 +59,7 @@ CFLAGS = -g -msse2
 endif
 
 # ppc doesn't work because we don't support big-endian
-CFLAGS += -Wall -Wextra -Wformat -Wno-ignored-qualifiers -Wformat-security -Wno-unused-parameter \
+CFLAGS += -std=c++11 -Wall -Wextra -Wformat -Wno-ignored-qualifiers -Wformat-security -Wno-unused-parameter \
 	  $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS) $(shell pkg-config --cflags --libs libzip)
 
 OBJS= \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -98,7 +98,7 @@ endif
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O2 $(EXT_OPTIONS) -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O2 $(EXT_OPTIONS) -std=c++11 -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -10,7 +10,7 @@ ARCH:=$(system lscpu | head -n 1 | awk '{print $2}')
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 
 #DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
-DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH) $(MINIUPNPC_INCLUDE_PATH) $(CURL_INCLUDE_PATH)) 
+DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH) $(MINIUPNPC_INCLUDE_PATH) $(CURL_INCLUDE_PATH))
 
 LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH) $(CURL_LIB_PATH) $(ZIP_LIB_PATH))
 
@@ -36,8 +36,9 @@ LIBS += \
    -l ssl \
    -l crypto \
    -l zip \
+   -l leveldb \
    -l curl
-   
+
 ifndef USE_UPNP
 	override USE_UPNP = -
 endif
@@ -140,17 +141,11 @@ OBJS= \
     obj/scrypt-arm.o \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
-    obj/cpid.o 
+    obj/cpid.o
 
 all: gridcoinresearchd
 
-LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
-DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
-DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 OBJS += obj/txdb-leveldb.o
-leveldb/libleveldb.a:
-	@echo "Building LevelDB ..."; cd leveldb; make libleveldb.a libmemenv.a; cd ..;
-obj/txdb-leveldb.o: leveldb/libleveldb.a
 
 # auto-generated dependencies:
 -include obj/*.P

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -4,6 +4,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <memory>
+
 #include "txdb.h"
 #include "miner.h"
 #include "kernel.h"
@@ -137,34 +139,34 @@ public:
 
 
 // CreateNewBlock: create new block (without proof-of-work/proof-of-stake)
-boost::shared_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
+std::shared_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
 {
 
 	if (!bCPIDsLoaded)
 	{
 		printf("CPIDs not yet loaded...");
 		MilliSleep(500);
-		return boost::shared_ptr<CBlock>();
+		return std::shared_ptr<CBlock>();
 	}
 
 	if (!bNetAveragesLoaded)
 	{
 		if (fDebug10) printf("CNB: Net averages not yet loaded...");
 		MilliSleep(1);
-		return boost::shared_ptr<CBlock>();
+		return std::shared_ptr<CBlock>();
 	}
 
 	if (OutOfSyncByAgeWithChanceOfMining())
 	{
 	    if (msPrimaryCPID != "INVESTOR") printf("Wallet out of sync - unable to mine...");
 		MilliSleep(1);
-		return boost::shared_ptr<CBlock>();
+		return std::shared_ptr<CBlock>();
 	}
 
     // Create new block
-    boost::shared_ptr<CBlock> pblock(new CBlock());
+    std::shared_ptr<CBlock> pblock(new CBlock());
     if (!pblock)
-      return boost::shared_ptr<CBlock>();
+      return std::shared_ptr<CBlock>();
 
     CBlockIndex* pindexPrev = pindexBest;
     int nHeight = pindexPrev->nHeight + 1;
@@ -183,7 +185,7 @@ boost::shared_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake, i
         CReserveKey reservekey(pwallet);
         CPubKey pubkey;
         if (!reservekey.GetReservedKey(pubkey))
-            return boost::shared_ptr<CBlock>();
+            return std::shared_ptr<CBlock>();
         txNew.vout[0].scriptPubKey.SetDestination(pubkey.GetID());
 
 		printf("Generating PoW standard payment\r\n");
@@ -905,7 +907,7 @@ Begin:
         //
         int64_t nFees;
 
-        boost::shared_ptr<CBlock> pblock(CreateNewBlock(pwallet, true, &nFees));
+        std::shared_ptr<CBlock> pblock(CreateNewBlock(pwallet, true, &nFees));
         if (!pblock.get())
 		{
 			//This can happen after reharvesting CPIDs... Because CreateNewBlock() requires a valid CPID..  Start Over.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -107,7 +107,7 @@ public:
 uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockSize = 0;
 int64_t nLastCoinStakeSearchInterval = 0;
- 
+
 // We want to sort transactions by priority and fee, so:
 typedef boost::tuple<double, double, CTransaction*> TxPriority;
 class TxPriorityCompare
@@ -137,34 +137,34 @@ public:
 
 
 // CreateNewBlock: create new block (without proof-of-work/proof-of-stake)
-CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
+boost::shared_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
 {
 
 	if (!bCPIDsLoaded)
 	{
 		printf("CPIDs not yet loaded...");
 		MilliSleep(500);
-		return NULL;
+		return boost::shared_ptr<CBlock>();
 	}
 
 	if (!bNetAveragesLoaded)
 	{
 		if (fDebug10) printf("CNB: Net averages not yet loaded...");
 		MilliSleep(1);
-		return NULL;
+		return boost::shared_ptr<CBlock>();
 	}
 
 	if (OutOfSyncByAgeWithChanceOfMining())
 	{
 	    if (msPrimaryCPID != "INVESTOR") printf("Wallet out of sync - unable to mine...");
 		MilliSleep(1);
-		return NULL;
+		return boost::shared_ptr<CBlock>();
 	}
 
     // Create new block
-    auto_ptr<CBlock> pblock(new CBlock());
-    if (!pblock.get())
-        return NULL;
+    boost::shared_ptr<CBlock> pblock(new CBlock());
+    if (!pblock)
+      return boost::shared_ptr<CBlock>();
 
     CBlockIndex* pindexPrev = pindexBest;
     int nHeight = pindexPrev->nHeight + 1;
@@ -177,13 +177,13 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
     txNew.vin.resize(1);
     txNew.vin[0].prevout.SetNull();
     txNew.vout.resize(1);
-	
+
     if (!fProofOfStake)
     {
         CReserveKey reservekey(pwallet);
         CPubKey pubkey;
         if (!reservekey.GetReservedKey(pubkey))
-            return NULL;
+            return boost::shared_ptr<CBlock>();
         txNew.vout[0].scriptPubKey.SetDestination(pubkey.GetID());
 
 		printf("Generating PoW standard payment\r\n");
@@ -194,7 +194,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
         txNew.vin[0].scriptSig = (CScript() << nHeight) + COINBASE_FLAGS;
 	    assert(txNew.vin[0].scriptSig.size() <= 100);
         txNew.vout[0].SetEmpty();
-    
+
     }
 
     // Add our coinbase tx as first transaction
@@ -256,7 +256,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
                 // Read prev transaction
                 CTransaction txPrev;
                 CTxIndex txindex;
-			
+
 				if (fDebug10) printf("Enumerating tx %s ",tx.GetHash().GetHex().c_str());
 
                 if (!txPrev.ReadFromDisk(txdb, txin.prevout, txindex))
@@ -341,10 +341,10 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
             if (nBlockSize + nTxSize >= nBlockMaxSize)
 			{
 				if (fDebug10) printf("Tx size too large for tx %s  blksize %f , tx siz %f",tx.GetHash().GetHex().c_str(),(double)nBlockSize,(double)nTxSize);
-			 	msMiningErrorsExcluded += tx.GetHash().GetHex() + ":SizeTooLarge(" 
-					+ RoundToString((double)nBlockSize,0) + "," +RoundToString((double)nTxSize,0) + ")(" 
+				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":SizeTooLarge("
+					+ RoundToString((double)nBlockSize,0) + "," +RoundToString((double)nTxSize,0) + ")("
 					+ RoundToString((double)nBlockSize,0) + ");";
-            
+
                 continue;
 			}
 
@@ -352,8 +352,8 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
             unsigned int nTxSigOps = tx.GetLegacySigOpCount();
             if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
 			{
-     		 	msMiningErrorsExcluded += tx.GetHash().GetHex() + ":LegacySigOpLimit(" + 
-					RoundToString((double)nBlockSigOps,0) + "," +RoundToString((double)nTxSigOps,0) + ")(" 
+				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":LegacySigOpLimit(" +
+					RoundToString((double)nBlockSigOps,0) + "," +RoundToString((double)nTxSigOps,0) + ")("
 					+ RoundToString((double)MAX_BLOCK_SIGOPS,0) + ");";
                 continue;
 			}
@@ -361,7 +361,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
             // Timestamp limit
             if (tx.nTime > GetAdjustedTime() || (fProofOfStake && tx.nTime > pblock->vtx[0].nTime))
 			{
-				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":TimestampLimit(" + RoundToString((double)tx.nTime,0) + "," 
+				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":TimestampLimit(" + RoundToString((double)tx.nTime,0) + ","
 					+RoundToString((double)pblock->vtx[0].nTime,0) + ");";
                 continue;
 			}
@@ -399,7 +399,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
             if (nTxFees < nMinFee)
 			{
 				if (fDebug10) printf("Not including tx %s  due to TxFees of %f ; bare min fee is %f",tx.GetHash().GetHex().c_str(),(double)nTxFees,(double)nMinFee);
-				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":FeeTooSmall(" 
+				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":FeeTooSmall("
 					+ RoundToString(CoinToDouble(nFees),8) + "," +RoundToString(CoinToDouble(nMinFee),8) + ");";
                 continue;
 			}
@@ -409,10 +409,10 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
 			{
 				if (fDebug10) printf("Not including tx %s  due to exceeding max sigops of %f ; sigops is %f",
 					tx.GetHash().GetHex().c_str(),(double)(nBlockSigOps+nTxSigOps),(double)MAX_BLOCK_SIGOPS);
-				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":ExceededSigOps(" 
-					+ RoundToString((double)nBlockSigOps,0) + "," +RoundToString((double)nTxSigOps,0) + ")(" 
+				msMiningErrorsExcluded += tx.GetHash().GetHex() + ":ExceededSigOps("
+					+ RoundToString((double)nBlockSigOps,0) + "," +RoundToString((double)nTxSigOps,0) + ")("
 					+ RoundToString((double)MAX_BLOCK_SIGOPS,0) + ");";
-            
+
                 continue;
 			}
 
@@ -438,7 +438,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
                 printf("priority %.1f feeperkb %.1f txid %s\n",
                        dPriority, dFeePerKb, tx.GetHash().ToString().c_str());
 		    }
-		
+
             // Add transactions that depend on this one to the priority queue
             uint256 hash = tx.GetHash();
             if (mapDependers.count(hash))
@@ -462,7 +462,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
         nLastBlockSize = nBlockSize;
 
         if (fDebug10 || GetBoolArg("-printpriority"))
-            printf("CreateNewBlock(): total size %"PRIu64"\n", nBlockSize);
+            printf("CreateNewBlock(): total size %" PRIu64 "\n", nBlockSize);
 		//Add Boinc Hash - R HALFORD - 11-28-2014 - Add CPID v2
 		MiningCPID miningcpid = GetNextProject(false);
 		uint256 pbh = 0;
@@ -481,7 +481,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
 
 		GetProofOfStakeReward(1,nFees,GlobalCPUMiningCPID.cpid,false,0,pindexBest->nTime,pindexBest,"createnewblock",
 			out_por,out_interest,dAccrualAge,dMagnitudeUnit,dAvgMag);
-	
+
 		miningcpid.ResearchSubsidy = out_por;
 		miningcpid.InterestSubsidy = out_interest;
 		miningcpid.enccpid = ""; //CPID V1 Boinc RunTime enc key
@@ -497,7 +497,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
         if (pFees)
             *pFees = nFees;
 
-        // Fill in header  
+        // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
 		if (!fProofOfStake)
 		{
@@ -516,7 +516,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
         pblock->nNonce         = 0;
     }
 
-    return pblock.release();
+    return pblock;
 }
 
 
@@ -627,7 +627,7 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
             return error("CheckWork[] : ProcessBlock, block not accepted");
 		}
     }
-		
+
     return true;
 }
 
@@ -657,7 +657,7 @@ double Round_Legacy(double d, int place)
 	return r;
 }
 
-	
+
 
 bool CheckStake(CBlock* pblock, CWallet& wallet)
 {
@@ -701,9 +701,9 @@ bool CheckStake(CBlock* pblock, CWallet& wallet)
 	double dMagnitudeUnit = 0;
 	double dAvgMagnitude = 0;
 	int64_t nCoinAge = 0;
-	int64_t nFees = 0;		
+	int64_t nFees = 0;
 	//Checking Stake for Create CoinStake - int64_t nCalculatedResearch =
-	GetProofOfStakeReward(nCoinAge, nFees, boincblock.cpid, true, 0, pindexBest->nTime, 
+	GetProofOfStakeReward(nCoinAge, nFees, boincblock.cpid, true, 0, pindexBest->nTime,
 		pindexBest,"checkstake", out_por, out_interest, dAccrualAge, dMagnitudeUnit, dAvgMagnitude);
 
 	if (boincblock.cpid != "INVESTOR" && out_por > 1)
@@ -717,23 +717,23 @@ bool CheckStake(CBlock* pblock, CWallet& wallet)
 						    if (fDebug3) printf("CheckStake[ResearchAge] : Researchers Reward Pays too much : Interest %f and Research %f and out_por %f with Out_Interest %f for CPID %s ",
 								(double)boincblock.InterestSubsidy,
 								(double)boincblock.ResearchSubsidy,(double)out_por,(double)out_interest,boincblock.cpid.c_str());
-							
+
 							return error("CheckStake[ResearchAge] : Researchers Reward Pays too much : Interest %f and Research %f and out_por %f with Out_Interest %f for CPID %s ",
 								(double)boincblock.InterestSubsidy,
 								(double)boincblock.ResearchSubsidy,(double)out_por,(double)out_interest,boincblock.cpid.c_str());
-				
+
 					}
-		
+
 			}
 	}
-	
 
-	
+
+
 	double total_subsidy = boincblock.ResearchSubsidy + boincblock.InterestSubsidy;
-    
+
 	if (fDebug10) printf("CheckStake[]: TotalSubsidy %f, cpid %s, Res %f, Interest %f, hb: %s \r\n",
 					(double)total_subsidy, boincblock.cpid.c_str(),	boincblock.ResearchSubsidy,boincblock.InterestSubsidy,pblock->vtx[0].hashBoinc.c_str());
-			
+
 	if (total_subsidy < MintLimiter(PORDiff,boincblock.RSAWeight,boincblock.cpid,pblock->GetBlockTime() ))
 	{
 			//Prevent Hackers from spamming the network with small blocks
@@ -741,19 +741,19 @@ bool CheckStake(CBlock* pblock, CWallet& wallet)
 			return false;
 			//	return error("*****CheckStake[] : Total Mint too Small, %f",(double)boincblock.ResearchSubsidy+boincblock.InterestSubsidy);
 	}
-			
+
 	if (!CheckProofOfStake(mapBlockIndex[pblock->hashPrevBlock], pblock->vtx[1], pblock->nBits, proofHash, hashTarget, pblock->vtx[0].hashBoinc, true, pblock->nNonce))
-	{	
+	{
 		if (fDebug3) printf("Hash boinc %s",pblock->vtx[0].hashBoinc.c_str());
         return error("CheckStake() : proof-of-stake checking failed");
 	}
-		
+
 
     //// debug print
 	double block_value = CoinToDouble(pblock->vtx[1].GetValueOut());
-	std::string sBlockValue = RoundToString(block_value,4);	
+	std::string sBlockValue = RoundToString(block_value,4);
 	//Submit the block during the public key address second
-	
+
     if (fDebug3) printf("CheckStake() : new proof-of-stake block found, BlockValue %s, \r\n hash: %s \nproofhash: %s  \ntarget: %s\n",
 					sBlockValue.c_str(), hashBlock.GetHex().c_str(), proofHash.GetHex().c_str(), hashTarget.GetHex().c_str());
 	if (fDebug)     pblock->print();
@@ -768,7 +768,7 @@ bool CheckStake(CBlock* pblock, CWallet& wallet)
             return error("CheckStake[] : generated block is stale");
 		}
 
-		
+
         // Track how many getdata requests this block gets
         {
             LOCK(wallet.cs_wallet);
@@ -777,7 +777,7 @@ bool CheckStake(CBlock* pblock, CWallet& wallet)
 
         // Process this block the same as if we had received it from another node
 		//Halford - Ensure Blocks have a minimum time spacing (allow newbies to participate easily)
-		if (!IsLockTimeWithinMinutes(nLastBlockSubmitted,5)) 
+		if (!IsLockTimeWithinMinutes(nLastBlockSubmitted,5))
 		{
 			nLastBlockSubmitted = GetAdjustedTime();
 			if (!ProcessBlock(NULL, pblock, true))
@@ -835,7 +835,7 @@ void StakeMiner(CWallet *pwallet)
 				}
 			}
 		}
-	
+
 	// End of AutoUnlock Feature
 
 
@@ -848,7 +848,7 @@ Inception:
             return;
 		}
 
-		
+
         while (pwallet->IsLocked())
         {
             nLastCoinStakeSearchInterval = 0;
@@ -864,17 +864,17 @@ Inception:
 		while (!bNetAveragesLoaded)
 		{
 			if (LessVerbose(100) && msPrimaryCPID != "INVESTOR") printf("ResearchMiner:Net averages not yet loaded...");
-						
+
 			iFutile++;
 			if (iFutile > 50)
 			{
 				iFutile = 0;
-				goto Inception;				
+				goto Inception;
 			}
 			MilliSleep(250);
 		}
 
-					
+
 
         while (vNodes.empty() || IsInitialBlockDownload())
         {
@@ -898,14 +898,14 @@ Inception:
             }
         }
 Begin:
-		
-	
+
+
         //
         // Create new block
         //
         int64_t nFees;
-		
-        auto_ptr<CBlock> pblock(CreateNewBlock(pwallet, true, &nFees));
+
+        boost::shared_ptr<CBlock> pblock(CreateNewBlock(pwallet, true, &nFees));
         if (!pblock.get())
 		{
 			//This can happen after reharvesting CPIDs... Because CreateNewBlock() requires a valid CPID..  Start Over.
@@ -913,11 +913,11 @@ Begin:
 			MilliSleep(1);
 			goto Begin;
 		}
-		
+
 
 		//Verify we are still on the main chain
-	
-		if (IsLockTimeWithinMinutes(nLastBlockSolved,5)) 
+
+		if (IsLockTimeWithinMinutes(nLastBlockSolved,5))
 		{
 				if (fDebug10) printf("=");
 				MilliSleep(1);
@@ -925,7 +925,7 @@ Begin:
 		}
 
 	    // Trying to sign a block
-			
+
         if (pblock->SignBlock(*pwallet, nFees))
         {
 
@@ -952,4 +952,3 @@ Begin:
             MilliSleep(nMinerSleep);
     }
 }
-

--- a/src/miner.h
+++ b/src/miner.h
@@ -10,7 +10,7 @@
 #include "wallet.h"
 
 /* Generate a new block, without valid proof-of-work */
-CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake=false, int64_t* pFees = 0);
+boost::shared_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake=false, int64_t* pFees = 0);
 
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);

--- a/src/miner.h
+++ b/src/miner.h
@@ -6,11 +6,13 @@
 #ifndef NOVACOIN_MINER_H
 #define NOVACOIN_MINER_H
 
+#include <memory>
+
 #include "main.h"
 #include "wallet.h"
 
 /* Generate a new block, without valid proof-of-work */
-boost::shared_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake=false, int64_t* pFees = 0);
+std::shared_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake=false, int64_t* pFees = 0);
 
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -15,8 +15,8 @@
 
 #ifdef WIN32
   #include <string.h>
-#endif 
- 
+#endif
+
 #ifdef USE_UPNP
  #include <miniupnpc/miniwget.h>
  #include <miniupnpc/miniupnpc.h>
@@ -377,12 +377,13 @@ bool AddLocal(const CService& addr, int nScore)
     if (IsLimited(addr))
         return false;
 
-	try
-	{
-    if (fDebug10) printf("AddLocal(%s,%i)\n", addr.ToString().c_str(), nScore);
+    try {
+      if (fDebug10) {
+        printf("AddLocal(%s,%i)\n", addr.ToString().c_str(), nScore);
+      }
 
-    {
-	    LOCK(cs_mapLocalHost);
+      {
+        LOCK(cs_mapLocalHost);
         bool fAlready = mapLocalHost.count(addr) > 0;
         LocalServiceInfo &info = mapLocalHost[addr];
         if (!fAlready || nScore >= info.nScore) {
@@ -390,15 +391,15 @@ bool AddLocal(const CService& addr, int nScore)
             info.nPort = addr.GetPort();
         }
         SetReachable(addr.GetNetwork());
+      }
+
+      AdvertizeLocal();
     }
+    catch(...)
+    {
 
-    AdvertizeLocal();
-	}
-	catch(...)
-	{
-
-	}
-	printf("7..");
+    }
+    printf("7..");
     return true;
 }
 
@@ -774,7 +775,7 @@ std::string GetHttpPage(std::string url)
 
 std::string GetHttpPage(std::string cpid, bool UseDNS, bool ClearCache)
 {
-	
+
 	try
 	{
 	   if (cpid=="" || cpid.length() < 5)
@@ -1697,7 +1698,7 @@ void ThreadSocketHandler2(void* parg)
                     pnode->fDisconnect = true;
                 }
 			}
-			   
+
 			if ((GetAdjustedTime() - pnode->nTimeConnected) > (60*60*2) && ((int)vNodes.size() > (MAX_OUTBOUND_CONNECTIONS*.75)))
 			{
 				    if (fDebug10) printf("Node %s connected longer than 2 hours with connection count of %f, disconnecting. \r\n", NodeAddress(pnode).c_str(), (double)vNodes.size());
@@ -1713,12 +1714,12 @@ void ThreadSocketHandler2(void* parg)
                 }
                 else if (nTime - pnode->nLastSend > TIMEOUT_INTERVAL)
                 {
-                    printf("socket sending timeout: %"PRId64"s\n", nTime - pnode->nLastSend);
+                    printf("socket sending timeout: %" PRId64 "s\n", nTime - pnode->nLastSend);
                     pnode->fDisconnect = true;
                 }
                 else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
                 {
-                    printf("socket receive timeout: %"PRId64"s\n", nTime - pnode->nLastRecv);
+                    printf("socket receive timeout: %" PRId64 "s\n", nTime - pnode->nLastRecv);
                     pnode->fDisconnect = true;
                 }
                 else if (pnode->nPingNonceSent && pnode->nPingUsecStart + TIMEOUT_INTERVAL * 1000000 < GetTimeMicros())
@@ -1993,7 +1994,7 @@ void DumpAddresses()
     CAddrDB adb;
     adb.Write(addrman);
 
-    if (fDebug10) printf("Flushed %d addresses to peers.dat  %"PRId64"ms\n",           addrman.size(), GetTimeMillis() - nStart);
+    if (fDebug10) printf("Flushed %d addresses to peers.dat  %" PRId64 "ms\n",           addrman.size(), GetTimeMillis() - nStart);
 
 }
 
@@ -2908,4 +2909,3 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataSt
 
     RelayInventory(inv);
 }
-

--- a/src/net.h
+++ b/src/net.h
@@ -246,7 +246,7 @@ public:
 	int nTrust;
 	////////////////////////
 
-	
+
 	//Block Flood attack Halford
 	int64_t nLastOrphan;
 	int nOrphanCount;
@@ -367,7 +367,7 @@ private:
      static CCriticalSection cs_totalBytesSent;
      static uint64_t nTotalBytesRecv;
      static uint64_t nTotalBytesSent;
- 
+
 
 public:
 
@@ -382,7 +382,7 @@ public:
     unsigned int GetTotalRecvSize()
     {
         unsigned int total = 0;
-        BOOST_FOREACH(const CNetMessage &msg, vRecvMsg) 
+        BOOST_FOREACH(const CNetMessage &msg, vRecvMsg)
             total += msg.vRecv.size() + 24;
         return total;
     }
@@ -449,7 +449,7 @@ public:
         // the key is the earliest time the request can be sent
         int64_t& nRequestTime = mapAlreadyAskedFor[inv];
         if (fDebugNet)
-            printf("askfor %s   %"PRId64" (%s)\n", inv.ToString().c_str(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str());
+            printf("askfor %s   %" PRId64 " (%s)\n", inv.ToString().c_str(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str());
 
         // Make sure not to reuse time indexes to keep things in the same order
         int64_t nNow = (GetAdjustedTime() - 1) * 1000000;
@@ -505,7 +505,7 @@ public:
         assert(ssSend.size () >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));
         memcpy((char*)&ssSend[CMessageHeader::CHECKSUM_OFFSET], &nChecksum, sizeof(nChecksum));
 
-        if (fDebug10) 
+        if (fDebug10)
 		{
             printf("(%d bytes)\n", nSize);
         }
@@ -682,7 +682,7 @@ public:
         }
     }
 
-	
+
 	template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
     void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8, const T9& a9, const T10& a10)
     {
@@ -733,7 +733,7 @@ public:
     }
 
 
-	
+
 	template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13>
     void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8, const T9& a9, const T10& a10, const T11& a11, const T12& a12, const T13& a13)
     {
@@ -752,7 +752,7 @@ public:
 
 
 	template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8, 
+    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8,
 		const T9& a9, const T10& a10, const T11& a11, const T12& a12, const T13& a13, const T14& a14)
     {
         try
@@ -770,7 +770,7 @@ public:
 
 
 	template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8, 
+    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8,
 		const T9& a9, const T10& a10, const T11& a11, const T12& a12, const T13& a13, const T14& a14, const T15& a15)
     {
         try
@@ -789,7 +789,7 @@ public:
 
 
 	template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8, 
+    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8,
 		const T9& a9, const T10& a10, const T11& a11, const T12& a12, const T13& a13, const T14& a14, T15& a15, T16& a16)
     {
         try
@@ -806,7 +806,7 @@ public:
     }
 
 
-		
+
 
 
     void PushRequest(const char* pszCommand,

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -201,7 +201,7 @@ bool AESSkeinHash(unsigned int diffbytes, double rac, uint256 scrypthash, std::s
 std::vector<std::string> split(std::string s, std::string delim);
 double LederstrumpfMagnitude2(double mag,int64_t locktime);
 
-std::string TxToString(const CTransaction& tx, const uint256 hashBlock, int64_t& out_amount, int64_t& out_locktime, int64_t& out_projectid, 
+std::string TxToString(const CTransaction& tx, const uint256 hashBlock, int64_t& out_amount, int64_t& out_locktime, int64_t& out_projectid,
 	std::string& out_projectaddress, std::string& comments, std::string& out_grcaddress);
 bool IsCPIDValid_Retired(std::string cpid, std::string ENCboincpubkey);
 bool IsCPIDValidv2(MiningCPID& mc, int height);
@@ -228,7 +228,7 @@ double CalculatedMagnitude(int64_t locktime,bool bUseLederstrumpf);
 double GetNetworkProjectCountWithRAC()
 {
 	double count = 0;
-	for(map<string,StructCPID>::iterator ibp=mvNetwork.begin(); ibp!=mvNetwork.end(); ++ibp) 
+	for(map<string,StructCPID>::iterator ibp=mvNetwork.begin(); ibp!=mvNetwork.end(); ++ibp)
 	{
 		StructCPID NetworkProject = mvNetwork[(*ibp).first];
 		if (NetworkProject.initialized)
@@ -394,7 +394,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPri
     result.push_back(Pair("height", blockindex->nHeight));
     result.push_back(Pair("version", block.nVersion));
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
-	double mint = CoinToDouble(blockindex->nMint);
+    double mint = CoinToDouble(blockindex->nMint);
     result.push_back(Pair("mint", mint));
     result.push_back(Pair("time", (int64_t)block.GetBlockTime()));
     result.push_back(Pair("nonce", (uint64_t)block.nNonce));
@@ -406,18 +406,20 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPri
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
     if (blockindex->pnext)
         result.push_back(Pair("nextblockhash", blockindex->pnext->GetBlockHash().GetHex()));
-	MiningCPID bb = DeserializeBoincBlock(block.vtx[0].hashBoinc);
-	uint256 blockhash = block.GetPoWHash();
-	std::string sblockhash = blockhash.GetHex();
-	bool IsPoR = false;
-	IsPoR = (bb.Magnitude > 0 && bb.cpid != "INVESTOR" && blockindex->IsProofOfStake());
-	std::string PoRNarr = "";
-	if (IsPoR) PoRNarr = "proof-of-research";
-    result.push_back(Pair("flags", 
-		strprintf("%s%s", blockindex->IsProofOfStake()? "proof-of-stake" : "proof-of-work", blockindex->GeneratedStakeModifier()? " stake-modifier": "") + " " + PoRNarr		)		);
+    MiningCPID bb = DeserializeBoincBlock(block.vtx[0].hashBoinc);
+    uint256 blockhash = block.GetPoWHash();
+    std::string sblockhash = blockhash.GetHex();
+    bool IsPoR = false;
+    IsPoR = (bb.Magnitude > 0 && bb.cpid != "INVESTOR" && blockindex->IsProofOfStake());
+    std::string PoRNarr = "";
+    if (IsPoR) {
+  	  PoRNarr = "proof-of-research";
+    }
+    result.push_back(Pair("flags",
+      strprintf("%s%s", blockindex->IsProofOfStake()? "proof-of-stake" : "proof-of-work", blockindex->GeneratedStakeModifier()? " stake-modifier": "") + " " + PoRNarr		)		);
     result.push_back(Pair("proofhash", blockindex->hashProof.GetHex()));
     result.push_back(Pair("entropybit", (int)blockindex->GetStakeEntropyBit()));
-    result.push_back(Pair("modifier", strprintf("%016"PRIx64, blockindex->nStakeModifier)));
+    result.push_back(Pair("modifier", strprintf("%016" PRIx64, blockindex->nStakeModifier)));
     result.push_back(Pair("modifierchecksum", strprintf("%08x", blockindex->nStakeModifierChecksum)));
     Array txinfo;
     BOOST_FOREACH (const CTransaction& tx, block.vtx)
@@ -438,53 +440,53 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPri
     result.push_back(Pair("tx", txinfo));
     if (block.IsProofOfStake())
         result.push_back(Pair("signature", HexStr(block.vchBlockSig.begin(), block.vchBlockSig.end())));
-	result.push_back(Pair("CPID", bb.cpid));
-	if (!IsResearchAgeEnabled(blockindex->nHeight))
-	{
-		result.push_back(Pair("ProjectName", bb.projectname));
-		result.push_back(Pair("RAC", bb.rac));
-		result.push_back(Pair("NetworkRAC", bb.NetworkRAC));
-		result.push_back(Pair("RSAWeight",bb.RSAWeight));
-	}
-	
-	result.push_back(Pair("Magnitude", bb.Magnitude));
-	if (fDebug3) result.push_back(Pair("BoincHash",block.vtx[0].hashBoinc));
-	result.push_back(Pair("LastPaymentTime",TimestampToHRDate(bb.LastPaymentTime)));
+    result.push_back(Pair("CPID", bb.cpid));
+    if (!IsResearchAgeEnabled(blockindex->nHeight))
+    {
+      result.push_back(Pair("ProjectName", bb.projectname));
+      result.push_back(Pair("RAC", bb.rac));
+      result.push_back(Pair("NetworkRAC", bb.NetworkRAC));
+      result.push_back(Pair("RSAWeight",bb.RSAWeight));
+    }
 
-	result.push_back(Pair("ResearchSubsidy",bb.ResearchSubsidy));
-	result.push_back(Pair("ResearchAge",bb.ResearchAge));
-	result.push_back(Pair("ResearchMagnitudeUnit",bb.ResearchMagnitudeUnit));
-	result.push_back(Pair("ResearchAverageMagnitude",bb.ResearchAverageMagnitude));
-	result.push_back(Pair("LastPORBlockHash",bb.LastPORBlockHash));
-	result.push_back(Pair("Interest",bb.InterestSubsidy));
-	result.push_back(Pair("GRCAddress",bb.GRCAddress));
-	if (!bb.BoincPublicKey.empty())
-	{
-		result.push_back(Pair("BoincPublicKey",bb.BoincPublicKey));
-		result.push_back(Pair("BoincSignature",bb.BoincSignature));
-		bool fValidSig = VerifyCPIDSignature(bb.cpid, bb.lastblockhash, bb.BoincSignature);
-		result.push_back(Pair("SignatureValid",fValidSig));
-	}
-	result.push_back(Pair("ClientVersion",bb.clientversion));	
+    result.push_back(Pair("Magnitude", bb.Magnitude));
+    if (fDebug3) result.push_back(Pair("BoincHash",block.vtx[0].hashBoinc));
+    result.push_back(Pair("LastPaymentTime",TimestampToHRDate(bb.LastPaymentTime)));
 
-	if (!bb.cpidv2.empty()) 	result.push_back(Pair("CPIDv2",bb.cpidv2.substr(0,32)));
-	bool IsCPIDValid2 = IsCPIDValidv2(bb,blockindex->nHeight);
-	result.push_back(Pair("CPIDValid",IsCPIDValid2));
+    result.push_back(Pair("ResearchSubsidy",bb.ResearchSubsidy));
+    result.push_back(Pair("ResearchAge",bb.ResearchAge));
+    result.push_back(Pair("ResearchMagnitudeUnit",bb.ResearchMagnitudeUnit));
+    result.push_back(Pair("ResearchAverageMagnitude",bb.ResearchAverageMagnitude));
+    result.push_back(Pair("LastPORBlockHash",bb.LastPORBlockHash));
+    result.push_back(Pair("Interest",bb.InterestSubsidy));
+    result.push_back(Pair("GRCAddress",bb.GRCAddress));
+    if (!bb.BoincPublicKey.empty())
+    {
+      result.push_back(Pair("BoincPublicKey",bb.BoincPublicKey));
+      result.push_back(Pair("BoincSignature",bb.BoincSignature));
+      bool fValidSig = VerifyCPIDSignature(bb.cpid, bb.lastblockhash, bb.BoincSignature);
+      result.push_back(Pair("SignatureValid",fValidSig));
+    }
+    result.push_back(Pair("ClientVersion",bb.clientversion));
 
-	result.push_back(Pair("NeuralHash",bb.NeuralHash));
-	if (bb.superblock.length() > 20)
-	{
-		//result.push_back(Pair("SuperblockLength", RoundToString((double)bb.superblock.length(),0) ));
-		//12-20-2015 Support for Binary Superblocks
-		std::string superblock=UnpackBinarySuperblock(bb.superblock);
-		std::string neural_hash = GetQuorumHash(superblock);
-		result.push_back(Pair("SuperblockHash", neural_hash));
-		result.push_back(Pair("SuperblockLength", (double)bb.superblock.length()));
-		bool bIsBinary = Contains(bb.superblock,"<BINARY>");
-		result.push_back(Pair("IsBinary",bIsBinary));
-	}
-	result.push_back(Pair("IsSuperBlock", (int)blockindex->nIsSuperBlock));
-	result.push_back(Pair("IsContract", (int)blockindex->nIsContract));
+    if (!bb.cpidv2.empty()) 	result.push_back(Pair("CPIDv2",bb.cpidv2.substr(0,32)));
+    bool IsCPIDValid2 = IsCPIDValidv2(bb,blockindex->nHeight);
+    result.push_back(Pair("CPIDValid",IsCPIDValid2));
+
+    result.push_back(Pair("NeuralHash",bb.NeuralHash));
+    if (bb.superblock.length() > 20)
+    {
+      //result.push_back(Pair("SuperblockLength", RoundToString((double)bb.superblock.length(),0) ));
+      //12-20-2015 Support for Binary Superblocks
+      std::string superblock=UnpackBinarySuperblock(bb.superblock);
+      std::string neural_hash = GetQuorumHash(superblock);
+      result.push_back(Pair("SuperblockHash", neural_hash));
+      result.push_back(Pair("SuperblockLength", (double)bb.superblock.length()));
+      bool bIsBinary = Contains(bb.superblock,"<BINARY>");
+      result.push_back(Pair("IsBinary",bIsBinary));
+    }
+    result.push_back(Pair("IsSuperBlock", (int)blockindex->nIsSuperBlock));
+    result.push_back(Pair("IsContract", (int)blockindex->nIsContract));
     return result;
 }
 
@@ -669,7 +671,7 @@ void fileopen_and_copy(std::string src, std::string dest)
 
 
 
-	
+
 std::string BackupGridcoinWallet()
 {
 	printf("Starting Wallet Backup\r\n");
@@ -695,7 +697,7 @@ std::string BackupGridcoinWallet()
 			printf("User does not want private keys backed up. Exiting.");
 			return "";
 	}
-					
+
 	//Dump all private keys into the Level 2 backup
 	ofstream myBackup;
 	myBackup.open (path.string().c_str());
@@ -705,12 +707,12 @@ std::string BackupGridcoinWallet()
     	 const CBitcoinAddress& address = item.first;
 		 //const std::string& strName = item.second;
 		 bool fMine = IsMine(*pwalletMain, address.Get());
-		 if (fMine) 
+		 if (fMine)
 		 {
 			std::string strAddress=CBitcoinAddress(address).ToString();
 
 			CKeyID keyID;
-			if (!address.GetKeyID(keyID))   
+			if (!address.GetKeyID(keyID))
 			{
 				errors = errors + "During wallet backup, Address does not refer to a key"+ "\r\n";
 			}
@@ -751,12 +753,12 @@ std::string BackupGridcoinWallet()
 std::string RestoreGridcoinBackupWallet()
 {
 	//AdvancedBackup-AdvancedSalvage
-	
+
 	boost::filesystem::path path = GetDataDir() / "walletbackups" / "backup.dat";
 	std::string errors = "";
 	std::string sWallet = getfilecontents(path.string().c_str());
 	if (sWallet == "-1") return "Unable to open backup file.";
-		
+
     string strSecret = "from file";
     string strLabel = "Restored";
 
@@ -790,13 +792,13 @@ std::string RestoreGridcoinBackupWallet()
 								 key.SetSecret(secret,IsCompressed);
 								 //								 key = vchSecret.GetKey();
 								 CPubKey pubkey = key.GetPubKey();
-								
+
 								 CKeyID vchAddress = pubkey.GetID();
 								 {
 									 LOCK2(cs_main, pwalletMain->cs_wallet);
 									 //							   if (!pwalletMain->AddKey(key)) {            fGood = false;
-         
-									 if (!pwalletMain->AddKey(key)) 
+
+									 if (!pwalletMain->AddKey(key))
 									 {
 										 errors = errors + "Error adding key to wallet: " + sKey + "\r\n";
 									 }
@@ -807,8 +809,8 @@ std::string RestoreGridcoinBackupWallet()
 										pwalletMain->SetAddressBookName(vchAddress, strLabel);
 									 }
 							 		 pwalletMain->MarkDirty();
-							
-      
+
+
 								 }
 							}
 					}
@@ -826,7 +828,7 @@ std::string RestoreGridcoinBackupWallet()
 				pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, true);
 				pwalletMain->ReacceptWalletTransactions();
 			}
-     
+
 	}
 
 	printf("Rebuilding wallet, results: %s",errors.c_str());
@@ -840,7 +842,7 @@ uint256 Skein(std::string sInput)
 	uint256 uiSkein = 0;
 	uiSkein = GridcoinMultipleAlgoHash(sInput);
 	return uiSkein;
-}	
+}
 
 
 void WriteCPIDToRPC(std::string email, std::string bpk, uint256 block, Array &results)
@@ -875,7 +877,7 @@ std::string SignMessage(std::string sMsg, std::string sPrivateKey)
      std::vector<unsigned char> vchPrivKey = ParseHex(sPrivateKey);
 	 std::vector<unsigned char> vchSig;
 	 key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end())); // if key is not correct openssl may crash
-	 if (!key.Sign(Hash(vchMsg.begin(), vchMsg.end()), vchSig))  
+	 if (!key.Sign(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
 	 {
 			 return "Unable to sign message, check private key.";
 	 }
@@ -905,7 +907,7 @@ bool CheckMessageSignature(std::string sAction,std::string messagetype, std::str
  	 std::vector<unsigned char> vchSig = vector<unsigned char>(db64.begin(), db64.end());
 	 if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig)) return false;
 	 return true;
-   
+
 }
 
 
@@ -1022,7 +1024,7 @@ double GetGRCULFromSuperblock(std::string data)
 			{
 					std::string sSymbol = ExtractValue(vQ[i],",",0);
 					double dPrice = cdbl(ExtractValue("0" + vQ[i],",",1),0);
-					if (sSymbol=="grc") 
+					if (sSymbol=="grc")
 					{
 						return QuoteToOptionsDouble(dPrice);
 					}
@@ -1052,7 +1054,7 @@ double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out
 		if (!fTestNet && !bIgnoreBeacons && (mag_count < out_beacon_count*.90 || mag_count > out_beacon_count*1.10)) return -4;
 		return avg_of_magnitudes + avg_of_projects;
 	}
-	catch (std::exception &e) 
+	catch (std::exception &e)
 	{
 				printf("Error in GetSuperblockAvgMag.");
 				return 0;
@@ -1062,7 +1064,7 @@ double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out
 				printf("Error in GetSuperblockAvgMag.");
 				return 0;
 	}
-	 
+
 }
 
 
@@ -1077,7 +1079,7 @@ bool TallyMagnitudesInSuperblock()
 		double TotalNetworkMagnitude = 0;
 		double TotalNetworkEntries = 0;
 	    if (mvDPORCopy.size() > 0 && vSuperblock.size() > 1) 	mvDPORCopy.clear();
-		
+
 		for (unsigned int i = 0; i < vSuperblock.size(); i++)
 		{
 			// For each CPID in the contract
@@ -1108,7 +1110,7 @@ bool TallyMagnitudesInSuperblock()
 						mvMagnitudesCopy[cpid] = stMagg;
 						TotalNetworkMagnitude += stMagg.Magnitude;
 						TotalNetworkEntries++;
-    
+
 					}
 			}
 	}
@@ -1120,7 +1122,7 @@ bool TallyMagnitudesInSuperblock()
 	network.projectname="NETWORK";
 	network.NetworkMagnitude = TotalNetworkMagnitude;
 	network.NetworkAvgMagnitude = NetworkAvgMagnitude;
-	
+
 	double TotalProjects = 0;
 	double TotalRAC = 0;
 	double AVGRac = 0;
@@ -1173,7 +1175,7 @@ bool TallyMagnitudesInSuperblock()
 			{
 					std::string symbol = ExtractValue(vQ[i],",",0);
 					double price = cdbl(ExtractValue("0" + vQ[i],",",1),0);
-					
+
 					WriteCache("quotes",symbol,RoundToString(price,2),GetAdjustedTime());
 					if (fDebug3) printf("symbol %s price %f ",symbol.c_str(),price);
 			}
@@ -1187,7 +1189,7 @@ bool TallyMagnitudesInSuperblock()
 	if (fDebug3) printf(".TMS43.");
 	return true;
 	}
-	catch (std::exception &e) 
+	catch (std::exception &e)
 	{
 				printf("Error in TallySuperblock.");
 				return false;
@@ -1223,7 +1225,7 @@ bool SynchronizeRacForDPOR(bool SyncEntireCoin)
 			printf("Inserting smart contract for team project %s",vTeams[i].c_str());
 			if (vProjs[i]=="world_community_grid")
 			{
-				
+
 				if (!SyncEntireCoin)				break;
 			}
 			else
@@ -1231,12 +1233,12 @@ bool SynchronizeRacForDPOR(bool SyncEntireCoin)
 				result = 			InsertSmartContract(vTeams[i],vProjs[i]);
 				if (result && !SyncEntireCoin) break;
 			}
-			
+
 		}
 	}
 
 	return true;
-	
+
 }
 
 std::string GetTeamURLs(bool bMissingOnly, bool bReturnProjectNames)
@@ -1245,10 +1247,10 @@ std::string GetTeamURLs(bool bMissingOnly, bool bReturnProjectNames)
 			std::string sType = "project";
 			std::string project_urls = "";
 			std::string project_names = "";
-  		    for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
-		    {
+			for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
+			{
 				std::string key_name  = (*ii).first;
-			   	if (key_name.length() > sType.length())
+				if (key_name.length() > sType.length())
 				{
 					if (key_name.substr(0,sType.length())==sType)
 					{
@@ -1264,7 +1266,7 @@ std::string GetTeamURLs(bool bMissingOnly, bool bReturnProjectNames)
 									project_names += project_name + "<ROW>";
 								}
 					}
-		       
+
 				}
 		   }
 		   return (bReturnProjectNames ? project_names : project_urls);
@@ -1287,7 +1289,7 @@ bool InsertSmartContract(std::string URL, std::string name)
 			std::string cpid = ExtractXML(vUsers[i],"<cpid>","</cpid>");
 			std::string rac = ExtractXML(vUsers[i],"<expavg_credit>","</expavg_credit>");
 			//if (fDebug10) printf("Cpid %s rac %s			,     ",cpid.c_str(),rac.c_str());
-			
+
 			double dRac = cdbl(rac,0);
 			if (dRac > 10)
 			{
@@ -1322,10 +1324,10 @@ std::string GetListOf(std::string datatype)
 {
 			std::string rows = "";
 			std::string row = "";
-  		    for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
-		    {
+			for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
+			{
 				std::string key_name  = (*ii).first;
-			   	if (key_name.length() > datatype.length())
+				if (key_name.length() > datatype.length())
 				{
 					if (key_name.substr(0,datatype.length())==datatype)
 					{
@@ -1338,7 +1340,7 @@ std::string GetListOf(std::string datatype)
 									rows += row + "<ROW>";
 								}
 					}
-		       
+
 				}
 		   }
 		   return rows;
@@ -1404,7 +1406,7 @@ int GenerateNewKeyPair(std::string sIndex, std::string &sOutPubKey, std::string 
 	sOutPubKey  = GetArgument("PublicKey" + sIndex + sSuffix, "");
 	// If current keypair is not empty, but is invalid, allow the new keys to be stored, otherwise return 1: (10-25-2016)
 
-	if (!sOutPrivKey.empty() && !sOutPubKey.empty()) 
+	if (!sOutPrivKey.empty() && !sOutPubKey.empty())
 	{
 			uint256 hashBlock = GetRandHash();
 			std::string sSignature = SignBlockWithCPID(sIndex,hashBlock.GetHex());
@@ -1426,11 +1428,11 @@ int GenerateNewKeyPair(std::string sIndex, std::string &sOutPubKey, std::string 
 	WriteKey("PublicKey" + sIndex + sSuffix,sOutPubKey);
 	return 2;
 }
-		
+
 
 bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage)
 {
-				
+
 	 LOCK(cs_main);
 	 {
 			GetNextProject(false);
@@ -1441,12 +1443,12 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
 			}
 			//If beacon is already in the chain, exit early
 		    std::string sBeaconPublicKey = GetBeaconPublicKey(GlobalCPUMiningCPID.cpid);
-			if (!sBeaconPublicKey.empty()) 	
+			if (!sBeaconPublicKey.empty())
 			{
 				sError = "ALREADY_IN_CHAIN";
 				return bFromService ? true : false;
 			}
-			
+
 			uint256 hashRand = GetRandHash();
     		std::string email = GetArgument("email", "NA");
         	boost::to_lower(email);
@@ -1462,14 +1464,14 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
 				sError = "Balance too low to send beacon.";
 				return false;
 			}
-		
+
 			int iResult = GenerateNewKeyPair(GlobalCPUMiningCPID.cpid,sOutPubKey,sOutPrivKey);
 			if (iResult < 1)
 			{
 				sError = "Error generating keypair.";
 				return false;
 			}
-			
+
 			if (sOutPrivKey.empty() || sOutPubKey.empty())
 			{
 				sError = "Keypair is empty.";
@@ -1497,7 +1499,7 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
 					return true;
 				}
 				*/
-				// Store the key 
+				// Store the key
 				sMessage = AddContract(sType,sName,sBase);
 				return true;
 			}
@@ -1506,7 +1508,7 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
 				sError = "Error: Unable to send beacon::Wallet Locked::Please enter the wallet passphrase with walletpassphrase first.";
 				return false;
 			}
-			catch (std::exception &e) 
+			catch (std::exception &e)
 			{
 				sError = "Error: Unable to send beacon::Wallet Locked::Please enter the wallet passphrase with walletpassphrase first.";
 				return false;
@@ -1553,12 +1555,12 @@ std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string 
  	 catch (std::exception& e)
 	 {
 		 printf("Std exception %s \r\n",method.c_str());
-		 
+
 		 std::string caught = e.what();
 		 return "Exception " + caught;
 
-	 } 
-	 catch (...) 
+	 }
+	 catch (...)
 	 {
 		    printf("Generic exception (Please try unlocking the wallet) %s \r\n",method.c_str());
 			return "Generic Exception (Please try unlocking the wallet).";
@@ -1588,12 +1590,12 @@ std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string 
  	 catch (std::exception& e)
 	 {
 		 printf("Std exception %s \r\n",method.c_str());
-		 
+
 		 std::string caught = e.what();
 		 return "Exception " + caught;
 
-	 } 
-	 catch (...) 
+	 }
+	 catch (...)
 	 {
 		    printf("Generic exception (Please try unlocking the wallet) %s \r\n",method.c_str());
 			return "Generic Exception (Please try unlocking the wallet).";
@@ -1620,12 +1622,12 @@ std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string 
  	 catch (std::exception& e)
 	 {
 		 printf("Std exception %s \r\n",method.c_str());
-		 
+
 		 std::string caught = e.what();
 		 return "Exception " + caught;
 
-	 } 
-	 catch (...) 
+	 }
+	 catch (...)
 	 {
 		    printf("Generic exception (Please try unlocking the wallet). %s \r\n",method.c_str());
 			return "Generic Exception (Please try unlocking the wallet).";
@@ -1675,7 +1677,7 @@ Value dao(const Array& params, bool fHelp)
 	oOut.push_back(Pair("Command",sItem));
 	results.push_back(oOut);
     Object entry;
-		
+
 	if (sItem == "metric")
 	{
 		if (params.size() < 3)
@@ -1807,7 +1809,7 @@ Value dao(const Array& params, bool fHelp)
 					entry.push_back(Pair("PrivateKey",sKeyNarr));
 					entry.push_back(Pair("Warning!","Do not lose your private key.  It is non-recoverable.  You may add it to your config file as noted above OR specify it manually via RPC commands."));
 					results.push_back(entry);
-	
+
 				}
 			}
 	}
@@ -1818,7 +1820,7 @@ Value dao(const Array& params, bool fHelp)
 			entry.push_back(Pair("Command " + sItem + " not found.",-1));
 			results.push_back(entry);
 	}
-	return results;    
+	return results;
 
 }
 
@@ -1840,7 +1842,7 @@ Value option(const Array& params, bool fHelp)
 	oOut.push_back(Pair("Command",sItem));
 	results.push_back(oOut);
     Object entry;
-	return results;    
+	return results;
 }
 
 
@@ -1861,7 +1863,7 @@ Value execute(const Array& params, bool fHelp)
 	oOut.push_back(Pair("Command",sItem));
 	results.push_back(oOut);
     Object entry;
-		
+
 	if (sItem == "restorepoint")
 	{
 			int r=-1;
@@ -1869,7 +1871,7 @@ Value execute(const Array& params, bool fHelp)
 			//We must stop the node before we can do this
 			r = CreateRestorePoint();
 			//RestartGridcoin();
-			#endif 
+			#endif
 			entry.push_back(Pair("Restore Point",r));
 			results.push_back(entry);
 	}
@@ -1878,10 +1880,10 @@ Value execute(const Array& params, bool fHelp)
 			int r=1;
 			#if defined(WIN32) && defined(QT_GUI)
 		    RebootClient();
-			#endif 
+			#endif
 			entry.push_back(Pair("RebootClient",r));
 			results.push_back(entry);
-	
+
 	}
 	else if (sItem == "restartclient")
 	{
@@ -1905,7 +1907,7 @@ Value execute(const Array& params, bool fHelp)
 	    	{
 		    	entry.push_back(Pair("Error","You must specify the block hash to send."));
 			    results.push_back(entry);
-		    } 
+		    }
 			std::string sHash = params[1].get_str();
 			uint256 hash = uint256(sHash);
 			bool fResult = AskForOutstandingBlocks(hash);
@@ -1928,7 +1930,7 @@ Value execute(const Array& params, bool fHelp)
 				std::string sDetail  = params[4].get_str();
 				CBitcoinAddress address(sAddress);
 				bool isValid = address.IsValid();
-				if (!isValid) 
+				if (!isValid)
 				{
 					entry.push_back(Pair("Error","Invalid GRC Burn Address."));
 					results.push_back(entry);
@@ -1982,8 +1984,8 @@ Value execute(const Array& params, bool fHelp)
 		vector<unsigned char> vchDecoded30(sDecoded30.begin(), sDecoded30.end());
 		std::string sDecodedHex = ConvertBinToHex(sDecoded30);
 		// Get sha256 Checksum of DecodedHex
-		uint256 hash = Hash(vchDecoded30.begin(), vchDecoded30.end()); 
-		// The BTC address spec calls for double SHA256 hashing 
+		uint256 hash = Hash(vchDecoded30.begin(), vchDecoded30.end());
+		// The BTC address spec calls for double SHA256 hashing
 		uint256 DoubleHash = Hash(hash.begin(),hash.end());
 		std::string sSha256 = DoubleHash.GetHex();
 		// Only use the first 8 hex bytes to retrieve the checksum
@@ -2032,27 +2034,27 @@ Value execute(const Array& params, bool fHelp)
 	else if (sItem=="beaconstatus")
 	{
 		// Search for beacon, and report on beacon status.
-			
+
 		std::string sCPID = msPrimaryCPID;
 
 		if (params.size()==2)
 		{
 			sCPID = params[1].get_str();
 		}
-		
+
 		entry.push_back(Pair("CPID", sCPID));
 		std::string sBeacon = MyBeaconExists(sCPID);
 		std::string sPubKey =  GetBeaconPublicKey(sCPID);
 		std::string sPrivKey = GetBeaconPrivateKey(sCPID);
 		int64_t iBeaconTimestamp = BeaconTimeStamp(sCPID, false);
 		std::string timestamp = TimestampToHRDate(iBeaconTimestamp);
-	
+
 		entry.push_back(Pair("Beacon Exists",YesNo(sBeacon.length() > 0)));
 		entry.push_back(Pair("Beacon Timestamp",timestamp.c_str()));
 
 		entry.push_back(Pair("Public Key", sPubKey.c_str()));
 		entry.push_back(Pair("Private Key", sPrivKey.c_str()));
-		
+
 		std::string sErr = "";
 		if (sPubKey.empty())
 		{
@@ -2075,8 +2077,8 @@ Value execute(const Array& params, bool fHelp)
 		{
 			sErr += "Local configuration public key does not match beacon public key.  This can happen if you copied the wrong public key into your configuration file.  Please request that your beacon is deleted, or look into walletbackups for the correct keypair. ";
 		}
-		
-		// Prior superblock Magnitude 
+
+		// Prior superblock Magnitude
 		double dMagnitude = GetMagnitudeByCpidFromLastSuperblock(sCPID);
 		entry.push_back(Pair("Magnitude (As of last superblock)", dMagnitude));
 		if (dMagnitude==0)
@@ -2097,7 +2099,7 @@ Value execute(const Array& params, bool fHelp)
 			}
 		}
 
-		if (!sErr.empty()) 
+		if (!sErr.empty())
 		{
 			entry.push_back(Pair("Errors", sErr));
 			entry.push_back(Pair("Help", "Note: If your beacon is missing its public key, or is not in the chain, you may try: execute advertisebeacon."));
@@ -2112,8 +2114,8 @@ Value execute(const Array& params, bool fHelp)
 	}
 	else if (sItem=="testnet0917")
 	{
-	
-		WriteKey("testnet10","09172016");		
+
+		WriteKey("testnet10","09172016");
 		std::string testnet = GetArgument("testnet10", "NA3");
 		entry.push_back(Pair("testnetval4", testnet.c_str()));
 		WriteKey("testnet11","0917");
@@ -2156,7 +2158,7 @@ Value execute(const Array& params, bool fHelp)
 					if (sAddress.length() > 10 && sAmount.length() > 0)
 					{
 						double dAmount = cdbl(sAmount,4);
-						if (dAmount > 0) 
+						if (dAmount > 0)
 						{
 							CBitcoinAddress address(sAddress);
 							if (!address.IsValid())
@@ -2236,9 +2238,9 @@ Value execute(const Array& params, bool fHelp)
 				entry.push_back(Pair("Result",SuccessFail(fResult)));
 				entry.push_back(Pair("CPID",GlobalCPUMiningCPID.cpid.c_str()));
 				entry.push_back(Pair("Message",sMessage.c_str()));
-				
+
 				if (!sError.empty()) 		entry.push_back(Pair("Errors",sError));
-			
+
 				if (!fResult)
 				{
 					entry.push_back(Pair("FAILURE","Note: if your wallet is locked this command will fail; to solve that unlock the wallet: 'walletpassphrase <yourpassword> <240>' without <>."));
@@ -2249,7 +2251,7 @@ Value execute(const Array& params, bool fHelp)
 					entry.push_back(Pair("Warning!","Your public and private research keys have been stored in gridcoinresearch.conf.  Do not lose your private key (It is non-recoverable).  It is recommended that you back up your gridcoinresearch.conf file on a regular basis."));
 				}
 				results.push_back(entry);
-			
+
 	}
 	else if (sItem == "syncdpor2")
 	{
@@ -2321,7 +2323,7 @@ Value execute(const Array& params, bool fHelp)
 	}
 	else if (sItem == "unusual")
 	{
-		
+
 			UnusualActivityReport();
 			entry.push_back(Pair("UAR",1));
 			results.push_back(entry);
@@ -2385,7 +2387,7 @@ Value execute(const Array& params, bool fHelp)
 				if (CachedSymbol.empty())  err = "DAO does not exist.  Please choose a different symbol.";
 				if (OrgPubKey.empty() || CachedName.empty())  err = "DAO does not exist or cannot be found.  Please choose a different DAO Symbol.";
 
-				
+
 				if (!err.empty())
 				{
 					entry.push_back(Pair("Error",err));
@@ -2414,11 +2416,11 @@ Value execute(const Array& params, bool fHelp)
 					entry.push_back(Pair("PrivateKey",sKeyNarr));
 					entry.push_back(Pair("Warning!","Do not lose your private key.  It is non-recoverable.  You may add it to your config file as noted above OR specify it manually via RPC commands."));
 					results.push_back(entry);
-	
+
 				}
 			}
 	}
-	
+
 	else if (sItem == "readconfig")
 	{
 		ReadConfigFile(mapArgs, mapMultiArgs);
@@ -2469,13 +2471,13 @@ Value execute(const Array& params, bool fHelp)
 		}
 		else
 		{
-				
+
 				std::string nickname  = params[1].get_str();
 				std::string symbol    = params[2].get_str();
 				std::string sAmount   = params[3].get_str();
 				boost::to_upper(symbol);
 				std::string orgname   = ReadCache("daoname",symbol);
-			
+
 				if (orgname.empty())
 				{
 					entry.push_back(Pair("Error","DAO does not exist."));
@@ -2484,10 +2486,10 @@ Value execute(const Array& params, bool fHelp)
 				else
 				{
 					ReadConfigFile(mapArgs, mapMultiArgs);
-										
+
 					std::string privkey   = GetArgument("daoclient" + nickname+"-"+symbol, "");
 					std::string OrgPubKey = ReadCache("daoclientpubkey",nickname+"-"+symbol);
-		
+
 					if (OrgPubKey.empty())
 					{
 						entry.push_back(Pair("Error","Public Key is missing. Org is corrupted or not yet synchronized."));
@@ -2495,10 +2497,10 @@ Value execute(const Array& params, bool fHelp)
 					}
 					else
 					{
-		
+
 						if (privkey.empty())
 						{
-							entry.push_back(Pair("Error","Private Key is missing.  To send a message to a dao, you must set the private key." 
+							entry.push_back(Pair("Error","Private Key is missing.  To send a message to a dao, you must set the private key."
 							+ symbol + " key."));
 							results.push_back(entry);
 						}
@@ -2519,7 +2521,7 @@ Value execute(const Array& params, bool fHelp)
 				}
 		}
 	}
-	
+
 	else if (sItem == "sendfeed")
 	{
 		//execute sendfeed org_name feed_key feed_value
@@ -2535,11 +2537,11 @@ Value execute(const Array& params, bool fHelp)
 				std::string feedvalue = params[3].get_str();
 				boost::to_upper(orgname);
 				std::string symbol    = ReadCache("daosymbol",orgname);
-		
+
 				boost::to_upper(feedkey);
 				boost::to_upper(symbol);
 				boost::to_upper(feedvalue);
-			
+
 				if (symbol.empty())
 				{
 					entry.push_back(Pair("Error","DAO does not exist."));
@@ -2550,7 +2552,7 @@ Value execute(const Array& params, bool fHelp)
 					ReadConfigFile(mapArgs, mapMultiArgs);
 					std::string privkey   = GetArgument("dao" + symbol, "");
 					std::string OrgPubKey = ReadCache("daopubkey",orgname);
-		
+
 					if (OrgPubKey.empty())
 					{
 						entry.push_back(Pair("Error","Public Key is missing. Org is corrupted or not yet synchronized."));
@@ -2558,10 +2560,10 @@ Value execute(const Array& params, bool fHelp)
 					}
 					else
 					{
-		
+
 						if (privkey.empty())
 						{
-							entry.push_back(Pair("Error","Private Key is missing.  To update a feed value, you must set the dao" 
+							entry.push_back(Pair("Error","Private Key is missing.  To update a feed value, you must set the dao"
 							+ symbol + " key."));
 							results.push_back(entry);
 						}
@@ -2604,7 +2606,7 @@ Value execute(const Array& params, bool fHelp)
 				entry.push_back(Pair("Result",result));
 				results.push_back(entry);
 		}
-			
+
 	}
 	else if (sItem == "readdata")
 	{
@@ -2619,18 +2621,18 @@ Value execute(const Array& params, bool fHelp)
 				std::string sValue = "?";
 				//CTxDB txdb("cr");
 				CTxDB txdb;
-		 		if (!txdb.ReadGenericData(sKey,sValue)) 
+				if (!txdb.ReadGenericData(sKey,sValue))
 				{
 						entry.push_back(Pair("Error",sValue));
-			
+
 						sValue = "Failed to read from disk.";
 				}
 				entry.push_back(Pair("Key",sKey));
-				
+
 				entry.push_back(Pair("Result",sValue));
 				results.push_back(entry);
 		}
-			
+
 	}
 	else if (sItem == "refhash")
 	{
@@ -2649,7 +2651,7 @@ Value execute(const Array& params, bool fHelp)
 				results.push_back(entry);
 
 		}
-		
+
 	}
 	else if (sItem == "vote")
 	{
@@ -2662,11 +2664,11 @@ Value execute(const Array& params, bool fHelp)
 		{
 				std::string Title = params[1].get_str();
 				std::string Answer = params[2].get_str();
-				if (Title=="" || Answer == "" ) 
+				if (Title=="" || Answer == "" )
 				{
 							entry.push_back(Pair("Error","You must specify both the answer and the title."));
 							results.push_back(entry);
-	
+
 				}
 				else
 				{
@@ -2685,7 +2687,7 @@ Value execute(const Array& params, bool fHelp)
 					{
 							entry.push_back(Pair("Error","Poll does not exist."));
 							results.push_back(entry);
-	
+
 					}
 					else
 					{
@@ -2720,21 +2722,21 @@ Value execute(const Array& params, bool fHelp)
 								double stake_age = GetAdjustedTime() - nGRCTime;
 
 								// Phase II - Prevent Double Voting
-																								
+
 								StructCPID structGRC = GetInitializedStructCPID2(GRCAddress,mvMagnitudes);
 
-								
+
 								printf("CPIDAge %f,StakeAge %f,Poll Duration %f \r\n",cpid_age,stake_age,poll_duration);
 
 								double dShareType= cdbl(GetPollXMLElementByPollTitle(Title,"<SHARETYPE>","</SHARETYPE>"),0);
-							
+
 	 	 	                    // Share Type 1 == "Magnitude"
 								// Share Type 2 == "Balance"
 								// Share Type 3 == "Both"
 								if (cpid_age < poll_duration) dmag = 0;
 								if (stake_age < poll_duration) nBalance = 0;
 
-								if ((dShareType == 1) && cpid_age < poll_duration) 
+								if ((dShareType == 1) && cpid_age < poll_duration)
 								{
 									entry.push_back(Pair("Error","Sorry, When voting in a magnitude poll, your CPID must be older than the poll duration."));
 									results.push_back(entry);
@@ -2751,9 +2753,9 @@ Value execute(const Array& params, bool fHelp)
 								}
 								else
 								{
-									std::string voter = "<CPIDV2>"+GlobalCPUMiningCPID.cpidv2 + "</CPIDV2><CPID>" 
-										+ GlobalCPUMiningCPID.cpid + "</CPID><GRCADDRESS>" + GRCAddress + "</GRCADDRESS><RND>" 
-										+ hashRand.GetHex() + "</RND><BALANCE>" + RoundToString(nBalance,2) 
+									std::string voter = "<CPIDV2>"+GlobalCPUMiningCPID.cpidv2 + "</CPIDV2><CPID>"
+										+ GlobalCPUMiningCPID.cpid + "</CPID><GRCADDRESS>" + GRCAddress + "</GRCADDRESS><RND>"
+										+ hashRand.GetHex() + "</RND><BALANCE>" + RoundToString(nBalance,2)
 										+ "</BALANCE><MAGNITUDE>" + RoundToString(dmag,0) + "</MAGNITUDE>";
 									std::string pk = Title+";"+GRCAddress+";"+GlobalCPUMiningCPID.cpid;
 									std::string contract = "<TITLE>" + Title + "</TITLE><ANSWER>" + Answer + "</ANSWER>" + voter;
@@ -2787,14 +2789,14 @@ Value execute(const Array& params, bool fHelp)
 				std::string ShareType = params[5].get_str();
 				std::string sURL = params[6].get_str();
 				double sharetype = cdbl(ShareType,0);
-				if (Title=="" || Question == "" || Answers == "") 
+				if (Title=="" || Question == "" || Answers == "")
 				{
 						entry.push_back(Pair("Error","You must specify a Poll Title, Poll Question and Poll Answers."));
 						results.push_back(entry);
 				}
 				else
 				{
-				if (days < 7) 
+				if (days < 7)
 				{
 						entry.push_back(Pair("Error","Minimum duration is 7 days; please specify a longer poll duration."));
 						results.push_back(entry);
@@ -2802,7 +2804,7 @@ Value execute(const Array& params, bool fHelp)
 				else
 				{
 					double nBalance = GetTotalBalance();
-				
+
 					if (nBalance < 100000)
 					{
 						entry.push_back(Pair("Error","You must have a balance > 100,000 GRC to create a poll.  Please post the desired poll on cryptocointalk or PM RTM with the poll."));
@@ -2814,7 +2816,7 @@ Value execute(const Array& params, bool fHelp)
 						{
 							entry.push_back(Pair("Error","You must specify a positive value for days for the expiration date."));
 							results.push_back(entry);
-			
+
 						}
 						else
 						{
@@ -2850,7 +2852,7 @@ Value execute(const Array& params, bool fHelp)
 		else
 		{
 			std::string Title1 = params[1].get_str();
-				
+
 			if (!PollExists(Title1))
 			{
 				entry.push_back(Pair("Error","Poll does not exist.  Please execute listpolls."));
@@ -2907,7 +2909,7 @@ Value execute(const Array& params, bool fHelp)
 		else
 		{
 			std::string Title1 = params[1].get_str();
-				
+
 			if (!PollExists(Title1))
 			{
 				entry.push_back(Pair("Error","Poll does not exist.  Please execute listpolls."));
@@ -2925,11 +2927,11 @@ Value execute(const Array& params, bool fHelp)
 	}
 	else if (sItem=="netexec")
 	{
-		
+
 			std::string myresponse = ExecuteRPCCommand("vote","gender_poll","male");
 			entry.push_back(Pair("Response",myresponse.c_str()));
 			results.push_back(entry);
-	
+
 	}
 	else if (sItem=="staketime")
 	{
@@ -3002,7 +3004,7 @@ Value execute(const Array& params, bool fHelp)
 		{
 				entry.push_back(Pair(RoundToString(i+1,0),vMag[i].c_str()));
 		}
-		if (msNeuralResponse=="") 
+		if (msNeuralResponse=="")
 		{
 					entry.push_back(Pair("Response","No response."));
 		}
@@ -3025,7 +3027,7 @@ Value execute(const Array& params, bool fHelp)
 	else if (sItem == "peek")
 	{
 			std::vector<std::string> s = split(msPeek,"<CR>");
-			
+
 			for (int i = 0; i < ((int)(s.size()-1)); i++)
 			{
 				entry.push_back(Pair(s[i],i + 1));
@@ -3052,27 +3054,27 @@ Value execute(const Array& params, bool fHelp)
 				std::string narr = "";
 			    narr = "Netsoft_RAC, DPOR_RAC, Project_RAC";
 		  	    entry.push_back(Pair("RAC Reconciliation Report",narr));
-			
-				for(map<string,StructCPID>::iterator ibp=mvBoincProjects.begin(); ibp!=mvBoincProjects.end(); ++ibp) 
+
+				for(map<string,StructCPID>::iterator ibp=mvBoincProjects.begin(); ibp!=mvBoincProjects.end(); ++ibp)
 				{
 					StructCPID WhitelistedProject = mvBoincProjects[(*ibp).first];
 					if (WhitelistedProject.initialized)
 					{
 						double ProjectRAC = GetNetworkAvgByProject(WhitelistedProject.projectname);
-						if (ProjectRAC > 10) 
+						if (ProjectRAC > 10)
 						{
 								NetworkProjectCountWithRAC++;
 						}
 						//StructCPID structcpid = GetStrctCPID();
 						StructCPID stDPORProject = mvDPOR[argcpid + "+" + WhitelistedProject.projectname];
-						if (stDPORProject.initialized) 
-						{ 
+						if (stDPORProject.initialized)
+						{
 							  // Name, Netsoft, DPOR, Avg
-							  narr = RoundToString(stDPORProject.NetsoftRAC,0) + ", " + RoundToString(stDPORProject.rac,0) 
+							  narr = RoundToString(stDPORProject.NetsoftRAC,0) + ", " + RoundToString(stDPORProject.rac,0)
 								  + ", " + RoundToString(ProjectRAC,0);
 		  					  entry.push_back(Pair(WhitelistedProject.projectname,narr));
 						}
-		
+
 
 					}
 				}
@@ -3099,7 +3101,7 @@ Value execute(const Array& params, bool fHelp)
 			entry.push_back(Pair("[Specify in config file] autounlock=",encrypted));
 			results.push_back(entry);
 		}
-	
+
 	}
 	else if (sItem == "testboinckey")
 	{
@@ -3119,7 +3121,7 @@ Value execute(const Array& params, bool fHelp)
 		bool r12 = CheckMessageSignature("R","general","1",sig3,"");
 		entry.push_back(Pair("FK12",r12));
 		results.push_back(entry);
-	
+
 	}
 	else if (sItem == "genboinckey")
 	{
@@ -3153,9 +3155,9 @@ Value execute(const Array& params, bool fHelp)
 			std::string test = AdvancedCrypt(sParam1);
 			entry.push_back(Pair("EncPhrase",test));
 			results.push_back(entry);
-	
+
 		}
-	
+
 	}
 
 	else if (sItem == "decryptphrase")
@@ -3172,9 +3174,9 @@ Value execute(const Array& params, bool fHelp)
 			std::string test = AdvancedDecrypt(sParam1);
 			entry.push_back(Pair("DecPhrase",test));
 			results.push_back(entry);
-	
+
 		}
-	
+
 	}
 	else if (sItem == "contract")
 	{
@@ -3182,14 +3184,14 @@ Value execute(const Array& params, bool fHelp)
 			InsertSmartContract("http://milkyway.cs.rpi.edu/milkyway/team_email_list.php?teamid=6566&xml=1","milkyway");
 			entry.push_back(Pair("Done","Done"));
 			results.push_back(entry);
-		
+
 	}
 	else if (sItem == "wcgtest")
 	{
-		
+
 			entry.push_back(Pair("Done","Done"));
 			results.push_back(entry);
-		
+
 	}
 	else if (sItem == "syncrac")
 	{
@@ -3203,7 +3205,7 @@ Value execute(const Array& params, bool fHelp)
 		TallyMagnitudesInSuperblock();
 		entry.push_back(Pair("Done","Done"));
 	    results.push_back(entry);
-	
+
 	}
 	else if (sItem == "addkey")
 	{
@@ -3258,7 +3260,7 @@ Value execute(const Array& params, bool fHelp)
 		LoadAdminMessages(true,sOut);
 		entry.push_back(Pair("Results",sOut));
 		results.push_back(entry);
-		
+
 	}
 	else if (sItem == "superblockaverage")
 	{
@@ -3302,13 +3304,13 @@ Value execute(const Array& params, bool fHelp)
 			sNeuralHash = qtGetNeuralHash("");
 			entry.push_back(Pair(".NET Neural Hash",sNeuralHash.c_str()));
 		#endif
-  	
+
 		entry.push_back(Pair("Length",(double)contract.length()));
 		std::string neural_hash = GetQuorumHash(contract);
 	    entry.push_back(Pair("Wallet Neural Hash",neural_hash));
-		
+
 		results.push_back(entry);
-		
+
 	}
 	else if (sItem == "getlistof")
 	{
@@ -3339,7 +3341,7 @@ Value execute(const Array& params, bool fHelp)
 		{
 			std::string sType = params[1].get_str();
 			entry.push_back(Pair("Key Type",sType));
-  		    for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+		  for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 		    {
 				std::string key_name  = (*ii).first;
 			   	if (key_name.length() > sType.length())
@@ -3349,7 +3351,7 @@ Value execute(const Array& params, bool fHelp)
 								std::string key_value = mvApplicationCache[(*ii).first];
 						     	entry.push_back(Pair(key_name,key_value));
 					}
-		       
+
 				}
 		   }
 		   results.push_back(entry);
@@ -3382,9 +3384,9 @@ Value execute(const Array& params, bool fHelp)
 				entry.push_back(Pair("OrgKey",key));
 			}
 			results.push_back(entry);
-	
+
 		}
-	
+
 	}
 	else if (sItem == "chainrsa")
 	{
@@ -3397,7 +3399,7 @@ Value execute(const Array& params, bool fHelp)
 		{
 			std::string sParam1 = params[1].get_str();
 			entry.push_back(Pair("CPID",sParam1));
-			
+
 		}
 
 
@@ -3418,9 +3420,9 @@ Value execute(const Array& params, bool fHelp)
 			std::string key = sParam1 + "," + AdvancedDecryptWithSalt(sParam2,sParam1);
 			entry.push_back(Pair("PubKey",key));
 			results.push_back(entry);
-	
+
 		}
-	
+
 	}
 
 	else if (sItem == "testcpidv2")
@@ -3450,7 +3452,7 @@ Value execute(const Array& params, bool fHelp)
 			entry.push_back(Pair("CPIDv2 on block10",me));
 			results.push_back(entry);
 		}
-	
+
 
 	}
 	else if (sItem == "DISABLE_WINDOWS_ERROR_REPORTING")
@@ -3495,7 +3497,7 @@ Value execute(const Array& params, bool fHelp)
 			#if defined(WIN32) && defined(QT_GUI)
 		    ReindexWallet();
 			r = CreateRestorePoint();
-			#endif 
+			#endif
 			entry.push_back(Pair("Reindex Chain",r));
 			results.push_back(entry);
 	}
@@ -3504,7 +3506,7 @@ Value execute(const Array& params, bool fHelp)
 			int r=-1;
 			#if defined(WIN32) && defined(QT_GUI)
 				r = DownloadBlocks();
-			#endif 
+			#endif
 			entry.push_back(Pair("Download Blocks",r));
 			results.push_back(entry);
 	}
@@ -3512,7 +3514,7 @@ Value execute(const Array& params, bool fHelp)
 	{
 			printf("Executing .net code\r\n");
 			#if defined(WIN32) && defined(QT_GUI)
-		
+
     	    ExecuteCode();
 			#endif
 
@@ -3525,7 +3527,7 @@ Value execute(const Array& params, bool fHelp)
 	else if (sItem == "startwireframe")
 	{
 			#if defined(WIN32) && defined(QT_GUI)
-			
+
 			startWireFrameRenderer();
 			#endif
 
@@ -3533,7 +3535,7 @@ Value execute(const Array& params, bool fHelp)
 	else if (sItem == "endwireframe")
 	{
 			#if defined(WIN32) && defined(QT_GUI)
-		
+
 			stopWireFrameRenderer();
 			#endif
 	}
@@ -3575,7 +3577,7 @@ Value execute(const Array& params, bool fHelp)
 			ResendWalletTransactions(true);
 			entry.push_back(Pair("Resending unsent wallet transactions...",1));
 			results.push_back(entry);
-	} 
+	}
 	else if (sItem == "postcpid")
 	{
 			std::string result = GetHttpPage("859038ff4a9",true,true);
@@ -3615,8 +3617,8 @@ Value execute(const Array& params, bool fHelp)
 			entry.push_back(Pair("Command " + sItem + " not found.",-1));
 			results.push_back(entry);
 	}
-	return results;    
-		
+	return results;
+
 }
 
 
@@ -3634,11 +3636,11 @@ Array LifetimeReport(std::string cpid)
 		    pindex = pindex->pnext;
   			if (pindex==NULL || !pindex->IsInMainChain()) continue;
 			if (pindex == pindexBest) break;
-			if (pindex->sCPID == cpid && (pindex->nResearchSubsidy > 0)) 
+			if (pindex->sCPID == cpid && (pindex->nResearchSubsidy > 0))
 			{
 				entry.push_back(Pair(RoundToString((double)pindex->nHeight,0), RoundToString(pindex->nResearchSubsidy,2)));
 			}
-			
+
 	   }
 	   //8-14-2015
 	   StructCPID stCPID = GetInitializedStructCPID2(cpid,mvResearchAge);
@@ -3681,7 +3683,7 @@ bool VerifyUnderlyingPrice(double UL, int64_t timestamp)
 										{
 	    										nSuperblocks++;
 												double dHistoricalPrice = GetGRCULFromSuperblock(superblock);
-												if (UL==dHistoricalPrice) 
+												if (UL==dHistoricalPrice)
 												{
 														printf(" \r\n UL price found. \r\n");
 														return true;
@@ -3690,7 +3692,7 @@ bool VerifyUnderlyingPrice(double UL, int64_t timestamp)
 										}
 								}
 							}
-					
+
 	  }
 	  return false;
 
@@ -3710,7 +3712,7 @@ Array SuperblockReport(std::string cpid)
 	  if (!cpid.empty()) 	  c.push_back(Pair("CPID",cpid));
 
       results.push_back(c);
-		 
+
       int nMaxDepth = nBestHeight;
 	  int nLookback = BLOCKS_PER_DAY * 14;
 	  int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
@@ -3722,10 +3724,10 @@ Array SuperblockReport(std::string cpid)
 				pblockindex = pblockindex->pprev;
 	  }
 
-						
+
 	  while (pblockindex->nHeight > nMinDepth)
 	  {
-							if (!pblockindex || !pblockindex->pprev) return results;  
+							if (!pblockindex || !pblockindex->pprev) return results;
 							pblockindex = pblockindex->pprev;
 							if (pblockindex == pindexGenesisBlock) return results;
 							if (!pblockindex->IsInMainChain()) continue;
@@ -3754,11 +3756,11 @@ Array SuperblockReport(std::string cpid)
 												}
 
 												results.push_back(c);
-		
+
 										}
 								}
 							}
-					
+
 						}
 	  return results;
 
@@ -3775,8 +3777,7 @@ Array MagnitudeReport(std::string cpid)
 		   double magnitude_unit = GRCMagnitudeUnit(GetAdjustedTime());
 		   msRSAOverview = "";
 		   if (!pindexBest) return results;
-		   double nBalance = GetTotalBalance();
-			
+
 		   try
 		   {
 			       if (mvMagnitudes.size() < 1)
@@ -3784,12 +3785,12 @@ Array MagnitudeReport(std::string cpid)
 					       if (fDebug3) printf("no results");
 						   return results;
 				   }
-				   for(map<string,StructCPID>::iterator ii=mvMagnitudes.begin(); ii!=mvMagnitudes.end(); ++ii) 
+				   for(map<string,StructCPID>::iterator ii=mvMagnitudes.begin(); ii!=mvMagnitudes.end(); ++ii)
 				   {
 						// For each CPID on the network, report:
 						StructCPID structMag = mvMagnitudes[(*ii).first];
-						if (structMag.initialized && !structMag.cpid.empty()) 
-						{ 
+						if (structMag.initialized && !structMag.cpid.empty())
+						{
 								if (cpid.empty() || (Contains(structMag.cpid,cpid)))
 								{
 											Object entry;
@@ -3800,8 +3801,8 @@ Array MagnitudeReport(std::string cpid)
 												double days = (GetAdjustedTime() - stCPID.LowLockTime)/86400;
      											entry.push_back(Pair("CPID",structMag.cpid));
 												// entry.push_back(Pair("PoolMining",bPoolMiningMode));
-												double dWeight = (double)GetRSAWeightByCPID(structMag.cpid);
-												//entry.push_back(Pair("RSA Weight",dWeight));
+												// double dWeight = (double)GetRSAWeightByCPID(structMag.cpid);
+												// entry.push_back(Pair("RSA Weight",dWeight));
 												StructCPID UH = GetInitializedStructCPID2(cpid,mvMagnitudes);
 												// entry.push_back(Pair("RSA block count",UH.Accuracy));
 												// entry.push_back(Pair("Last Payment Time",TimestampToHRDate(structMag.LastPaymentTime)));
@@ -3819,7 +3820,7 @@ Array MagnitudeReport(std::string cpid)
 												double dExpected14 = magnitude_unit * structMag.Magnitude * 14;
 												entry.push_back(Pair("Expected Earnings (14 days)", dExpected14));
 												entry.push_back(Pair("Expected Earnings (Daily)", dExpected14/14));
-								
+
 												// Fulfillment %
 												double fulfilled = ((structMag.payments/14) / ((dExpected14/14)+.01)) * 100;
 												entry.push_back(Pair("Fulfillment %", fulfilled));
@@ -3827,18 +3828,18 @@ Array MagnitudeReport(std::string cpid)
 												entry.push_back(Pair("CPID Lifetime Interest Paid", stCPID.InterestSubsidy));
 												entry.push_back(Pair("CPID Lifetime Research Paid", stCPID.ResearchSubsidy));
 												entry.push_back(Pair("CPID Lifetime Avg Magnitude", stCPID.ResearchAverageMagnitude));
-							
+
 												entry.push_back(Pair("CPID Lifetime Payments Per Day", stCPID.ResearchSubsidy/(days+.01)));
 												entry.push_back(Pair("Last Blockhash Paid", stCPID.BlockHash));
 												entry.push_back(Pair("Last Block Paid",stCPID.LastBlock));
 												entry.push_back(Pair("Tx Count",stCPID.Accuracy));
-							
+
 												results.push_back(entry);
 												if (cpid==msPrimaryCPID && !msPrimaryCPID.empty() && msPrimaryCPID != "INVESTOR")
 												{
-													msRSAOverview = "Exp PPD: " + RoundToString(dExpected14/14,0) 
-														+ ", Act PPD: " + RoundToString(structMag.payments/14,0) 
-														+ ", Fulf %: " + RoundToString(fulfilled,2) 
+													msRSAOverview = "Exp PPD: " + RoundToString(dExpected14/14,0)
+														+ ", Act PPD: " + RoundToString(structMag.payments/14,0)
+														+ ", Fulf %: " + RoundToString(fulfilled,2)
 														+ ", GRCMagUnit: " + RoundToString(magnitude_unit,4);
 													msLastPaymentTime = "Last Payment Time: " + TimestampToHRDate(structMag.LastPaymentTime);
 												}
@@ -3866,7 +3867,7 @@ Array MagnitudeReport(std::string cpid)
 						}
 
 					}
-					
+
 				    if (fDebug3) printf("MR8");
 
 	   				Object entry2;
@@ -3883,10 +3884,10 @@ Array MagnitudeReport(std::string cpid)
 						entry3.push_back(Pair("Start Block",nMinDepth));
 						entry3.push_back(Pair("End Block",nMaxDepth));
 						results.push_back(entry3);
-		
+
 					}
 					if (fDebug3) printf("*MR5*");
-									
+
 					return results;
 			}
 			catch(...)
@@ -3932,8 +3933,8 @@ bool SortByOwed(const CPIDOwed &magL, const CPIDOwed &magR) { return magL.owed >
 double GetMagnitudeByCpidFromLastSuperblock(std::string sCPID)
 {
 		StructCPID structMag = mvMagnitudes[sCPID];
-		if (structMag.initialized && structMag.cpid.length() > 2 && structMag.cpid != "INVESTOR") 
-		{ 
+		if (structMag.initialized && structMag.cpid.length() > 2 && structMag.cpid != "INVESTOR")
+		{
 			return structMag.Magnitude;
 		}
 		return 0;
@@ -3949,13 +3950,13 @@ std::string CryptoLottery(int64_t locktime)
 
 		   double max_subsidy = (double)GetMaximumBoincSubsidy(locktime);
 		   vector<CPIDOwed> vCPIDSOwed;
-		   					
+
 		   //int iRecord = 0;
-		   for(map<string,StructCPID>::iterator ii=mvMagnitudes.begin(); ii!=mvMagnitudes.end(); ++ii) 
+		   for(map<string,StructCPID>::iterator ii=mvMagnitudes.begin(); ii!=mvMagnitudes.end(); ++ii)
 		   {
 			    StructCPID structMag = mvMagnitudes[(*ii).first];
-				if (structMag.initialized && structMag.cpid.length() > 2 && structMag.cpid != "INVESTOR" && structMag.GRCAddress.length() > 5) 
-				{ 
+				if (structMag.initialized && structMag.cpid.length() > 2 && structMag.cpid != "INVESTOR" && structMag.GRCAddress.length() > 5)
+				{
 					CPIDOwed c;
 					c.owed = structMag.totalowed-structMag.payments;
 					c.GRCAddress = structMag.GRCAddress;
@@ -3974,13 +3975,13 @@ std::string CryptoLottery(int64_t locktime)
 		   for(std::vector<CPIDOwed>::iterator it = vCPIDSOwed.begin(); it != vCPIDSOwed.end(); it++)
 		   {
 				StructCPID structMag = mvMagnitudes[it->cpid];
-				if (structMag.initialized && structMag.cpid.length() > 2 && structMag.cpid != "INVESTOR" && structMag.GRCAddress.length() > 5) 
-				{ 
+				if (structMag.initialized && structMag.cpid.length() > 2 && structMag.cpid != "INVESTOR" && structMag.GRCAddress.length() > 5)
+				{
 							double      Owed      = OwedByAddress(structMag.GRCAddress);
 							//Reverse Check, ensure Address resolves to cpid:
 							std::string reverse_cpid_lookup = CPIDByAddress(structMag.GRCAddress);
 							iSkip++;
-							if (reverse_cpid_lookup == structMag.cpid && Owed > (max_subsidy*4) && sOut.find(structMag.GRCAddress) == std::string::npos && iSkip > height_since_last_tally) 
+							if (reverse_cpid_lookup == structMag.cpid && Owed > (max_subsidy*4) && sOut.find(structMag.GRCAddress) == std::string::npos && iSkip > height_since_last_tally)
    							{
 								// Gather the owed amount, grc address, and cpid.
 								// During block verification we will verify owed <> block_paid, grcaddress belongs to cpid, and cpid is owed > purported_owed
@@ -3993,11 +3994,11 @@ std::string CryptoLottery(int64_t locktime)
 								if (rows >= 20) break;
   							}
 		     	}
-	
+
 		   }
 
-		  
-		
+
+
 		if (sOut.length() > 10) sOut = sOut.substr(0,sOut.length()-5); //Remove last delimiter
 	    if (fDebug3) printf("CryptoLottery %s",sOut.c_str());
 		if (rows < 15) sOut = "";
@@ -4063,7 +4064,7 @@ bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string 
 
 std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash)
 {
-	// Returns the Signature of the CPID+BlockHash message.	
+	// Returns the Signature of the CPID+BlockHash message.
 	std::string sPrivateKey = GetBeaconPrivateKey(sCPID);
 	std::string sMessage = sCPID + sBlockHash;
 	std::string sSignature = SignMessage(sMessage,sPrivateKey);
@@ -4081,7 +4082,7 @@ Array ContractReportCSV()
 		  std::string header = "Name,StartDate,Expiration,Content,Value \r\n";
    	      std::string row = "";
 		  std::string sType = "contract";
-  		  for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+  		  for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 		  {
 				std::string key_name  = (*ii).first;
 			   	if (key_name.length() > sType.length())
@@ -4092,7 +4093,7 @@ Array ContractReportCSV()
 								std::vector<std::string> vContractValues = split(key_value.c_str(),";");
 								std::string contract_name = strReplace(key_name,"contract;","");
 
-								row = contract_name + "," + RoundToString(mvApplicationCacheTimestamp[(*ii).first],0) + "," 
+								row = contract_name + "," + RoundToString(mvApplicationCacheTimestamp[(*ii).first],0) + ","
 									+ RoundToString(mvApplicationCacheTimestamp[(*ii).first]+86400,0) + ", , \n";
 								header += row;
 								rows++;
@@ -4109,24 +4110,24 @@ Array ContractReportCSV()
 
 								}
 								header +=  "\n";
-   					}
-		       
+					}
+
 				}
 		   }
 		   int64_t timestamp = GetTime();
 		   std::string footer = "Total: " + RoundToString(rows,0) + ", , , ," + "\n";
 		   header += footer;
 		   Object entry;
-		   entry.push_back(Pair("CSV Complete",strprintf("\\reports\\open_contracts_%"PRId64".csv",timestamp)));
+		   entry.push_back(Pair("CSV Complete",strprintf("\\reports\\open_contracts_%" PRId64 ".csv",timestamp)));
 		   results.push_back(entry);
-     	   CSVToFile(strprintf("open_contracts_%"PRId64".csv",timestamp), header);
+     	   CSVToFile(strprintf("open_contracts_%" PRId64 ".csv",timestamp), header);
 		   return results;
 }
 
 
 std::string GetPollContractByTitle(std::string objecttype, std::string title)
 {
-		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 		{
 				std::string key_name  = (*ii).first;
 			   	if (key_name.length() > objecttype.length())
@@ -4185,7 +4186,7 @@ double GetMoneySupplyFactor()
 		double Factor = (MoneySupply/TotalNetworkMagnitude+.01);
 		return Factor;
 
-}		
+}
 
 double PollCalculateShares(std::string contract, double sharetype, double MoneySupplyFactor, unsigned int VoteAnswerCount)
 {
@@ -4203,7 +4204,7 @@ double PollCalculateShares(std::string contract, double sharetype, double MoneyS
 		double UserWeightedMagnitude = (MoneySupplyFactor/5.67) * magnitude;
 		return (UserWeightedMagnitude+balance) / VoteAnswerCount;
 	}
-	if (sharetype==4) 
+	if (sharetype==4)
 	{
 		if (magnitude > 0) return 1;
 		return 0;
@@ -4215,17 +4216,17 @@ double PollCalculateShares(std::string contract, double sharetype, double MoneyS
 	}
 	return 0;
 }
-							
+
 
 double VotesCount(std::string pollname, std::string answer, double sharetype, double& out_participants)
 {
 	double total_shares = 0;
 	out_participants = 0;
 	std::string objecttype="vote";
-	
+
 	double MoneySupplyFactor = GetMoneySupplyFactor();
 
-	for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+	for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 	{
 				std::string key_name  = (*ii).first;
 			   	if (key_name.length() > objecttype.length())
@@ -4281,7 +4282,7 @@ bool PollAcceptableAnswer(std::string pollname, std::string answer)
 				boost::to_lower(vAnswers[i]); //Contains Poll acceptable answers
 				std::string sUserAnswer = vUserAnswers[x];
 				boost::to_lower(sUserAnswer);
-				if (sUserAnswer == vAnswers[i]) 
+				if (sUserAnswer == vAnswers[i])
 				{
 						bFoundAnswer=true;
 						break;
@@ -4317,7 +4318,7 @@ Array GetJsonVoteDetailsReport(std::string pollname)
 
 	double total_shares = 0;
 	double participants = 0;
-	
+
 	double MoneySupplyFactor = GetMoneySupplyFactor();
 
 	std::string objecttype="vote";
@@ -4329,9 +4330,9 @@ Array GetJsonVoteDetailsReport(std::string pollname)
 	std::string header = "GRCAddress,CPID,Question,Answer,ShareType,URL";
 
 	entry.push_back(Pair(header,"Shares"));
-									
+
 	int iRow = 0;
-	for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+	for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 	{
 			std::string key_name  = (*ii).first;
 			if (key_name.length() > objecttype.length())
@@ -4357,7 +4358,7 @@ Array GetJsonVoteDetailsReport(std::string pollname)
 								boost::to_lower(Title);
 								boost::to_lower(pollname);
 								boost::to_lower(VoterAnswer);
-							
+
 								if (pollname == Title)
 								{
 									std::vector<std::string> vVoterAnswers = split(VoterAnswer.c_str(),";");
@@ -4376,8 +4377,8 @@ Array GetJsonVoteDetailsReport(std::string pollname)
 	}
 
 	entry.push_back(Pair("Total Participants",RoundToString(participants,2)));
-								
-	
+
+
 	results.push_back(entry);
 	return results;
 
@@ -4400,7 +4401,7 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
 		std::string sExport = "";
 		std::string sExportRow = "";
 		out_export="";
-  		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 		{
 				std::string key_name  = (*ii).first;
 			   	if (key_name.length() > datatype.length())
@@ -4426,15 +4427,15 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
 										double highest_share = 0;
 										std::string ExpirationDate = TimestampToHRDate(cdbl(Expiration,0));
 										std::string sShareType = GetShareType(cdbl(ShareType,0));
-										std::string TitleNarr = "Poll #" + RoundToString((double)iPollNumber,0) 
+										std::string TitleNarr = "Poll #" + RoundToString((double)iPollNumber,0)
 											+ " (" + ExpirationDate + " ) - " + sShareType;
-										
+
 										entry.push_back(Pair(TitleNarr,Title));
 										sExportRow = "<POLL><URL>" + sURL + "</URL><TITLE>" + Title + "</TITLE><EXPIRATION>" + ExpirationDate + "</EXPIRATION><SHARETYPE>" + sShareType + "</SHARETYPE><QUESTION>" + Question + "</QUESTION><ANSWERS>"+Answers+"</ANSWERS>";
 
 										if (bDetail)
 										{
-									
+
 											entry.push_back(Pair("Question",Question));
 											std::vector<std::string> vAnswers = split(Answers.c_str(),";");
 									         sExportRow += "<ARRAYANSWERS>";
@@ -4442,13 +4443,13 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
 											{
 												double participants=0;
 												double dShares = VotesCount(Title,vAnswers[i],cdbl(ShareType,0),participants);
-												if (dShares > highest_share) 
+												if (dShares > highest_share)
 												{
 														highest_share = dShares;
 														BestAnswer = vAnswers[i];
 												}
 
-												entry.push_back(Pair("#" + RoundToString((double)i+1,0) + " [" + RoundToString(participants,3) + "]. " 
+												entry.push_back(Pair("#" + RoundToString((double)i+1,0) + " [" + RoundToString(participants,3) + "]. "
 													+ vAnswers[i],dShares));
 												total_participants += participants;
 												total_shares += dShares;
@@ -4457,7 +4458,7 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
 
 											}
 											sExportRow += "</ARRAYANSWERS>";
-											
+
 											//Totals:
 											entry.push_back(Pair("Participants",total_participants));
 											entry.push_back(Pair("Total Shares",total_shares));
@@ -4467,7 +4468,7 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
 											sExportRow += "<TOTALPARTICIPANTS>" + RoundToString(total_participants,0)
 												+ "</TOTALPARTICIPANTS><TOTALSHARES>" + RoundToString(total_shares,0)
 												+ "</TOTALSHARES><BESTANSWER>" + BestAnswer + "</BESTANSWER>";
-										
+
 										}
 										sExportRow += "</POLL>";
 										sExport += sExportRow;
@@ -4476,7 +4477,7 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
 					    }
 				}
 	   }
-	
+
 	  results.push_back(entry);
 	  out_export = sExport;
 	  return results;
@@ -4496,10 +4497,10 @@ Array GetUpgradedBeaconReport()
 		std::string row = "";
 		int iBeaconCount = 0;
 		int iUpgradedBeaconCount = 0;
-  		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 		{
 				std::string key_name  = (*ii).first;
-			   	if (key_name.length() > datatype.length())
+				if (key_name.length() > datatype.length())
 				{
 					if (key_name.substr(0,datatype.length())==datatype)
 					{
@@ -4532,9 +4533,9 @@ Array GetJSONBeaconReport()
 	    Object entry;
   	    entry.push_back(Pair("CPID","GRCAddress"));
         std::string datatype="beacon";
-	  	std::string rows = "";
+		std::string rows = "";
 		std::string row = "";
-  		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
+		for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
 		{
 				std::string key_name  = (*ii).first;
 			   	if (key_name.length() > datatype.length())
@@ -4553,7 +4554,7 @@ Array GetJSONBeaconReport()
 					}
 				}
 	   }
-	
+
 	  results.push_back(entry);
 	  return results;
 }
@@ -4563,7 +4564,7 @@ double GetTotalNeuralNetworkHashVotes()
 {
 	double total = 0;
 	std::string neural_hash = "";
-	for(map<std::string,double>::iterator ii=mvNeuralNetworkHash.begin(); ii!=mvNeuralNetworkHash.end(); ++ii) 
+	for(map<std::string,double>::iterator ii=mvNeuralNetworkHash.begin(); ii!=mvNeuralNetworkHash.end(); ++ii)
 	{
 				double popularity = mvNeuralNetworkHash[(*ii).first];
 				neural_hash = (*ii).first;
@@ -4572,9 +4573,9 @@ double GetTotalNeuralNetworkHashVotes()
 				{
 					total += popularity;
 				}
-				
+
 	}
-	return total;	 
+	return total;
 }
 
 
@@ -4582,7 +4583,7 @@ double GetTotalCurrentNeuralNetworkHashVotes()
 {
 	double total = 0;
 	std::string neural_hash = "";
-	for(map<std::string,double>::iterator ii=mvCurrentNeuralNetworkHash.begin(); ii!=mvCurrentNeuralNetworkHash.end(); ++ii) 
+	for(map<std::string,double>::iterator ii=mvCurrentNeuralNetworkHash.begin(); ii!=mvCurrentNeuralNetworkHash.end(); ++ii)
 	{
 				double popularity = mvCurrentNeuralNetworkHash[(*ii).first];
 				neural_hash = (*ii).first;
@@ -4591,9 +4592,9 @@ double GetTotalCurrentNeuralNetworkHashVotes()
 				{
 					total += popularity;
 				}
-				
+
 	}
-	return total;	 
+	return total;
 }
 
 
@@ -4609,11 +4610,11 @@ Array GetJSONNeuralNetworkReport()
   	  entry.push_back(Pair("Neural Hash","Popularity,Percent %"));
 	  double votes = GetTotalNeuralNetworkHashVotes();
 
-	  for(map<std::string,double>::iterator ii=mvNeuralNetworkHash.begin(); ii!=mvNeuralNetworkHash.end(); ++ii) 
+	  for(map<std::string,double>::iterator ii=mvNeuralNetworkHash.begin(); ii!=mvNeuralNetworkHash.end(); ++ii)
 	  {
 				double popularity = mvNeuralNetworkHash[(*ii).first];
 				neural_hash = (*ii).first;
-	
+
 				//If the hash != empty_hash: >= .01
 				if (neural_hash != "d41d8cd98f00b204e9800998ecf8427e" && neural_hash != "TOTAL_VOTES" && popularity > 0)
 				{
@@ -4630,7 +4631,7 @@ Array GetJSONNeuralNetworkReport()
 		  entry.push_back(Pair("Pending",SuperblockHeight));
 	  }
 	  int64_t superblock_age = GetAdjustedTime() - mvApplicationCacheTimestamp["superblock;magnitudes"];
-	 
+
 	  entry.push_back(Pair("Superblock Age",superblock_age));
 	  if (superblock_age > GetSuperblockAgeSpacing(nBestHeight))
 	  {
@@ -4662,11 +4663,11 @@ Array GetJSONCurrentNeuralNetworkReport()
   	  entry.push_back(Pair("Neural Hash","Popularity,Percent %"));
 	  double votes = GetTotalCurrentNeuralNetworkHashVotes();
 
-	  for(map<std::string,double>::iterator ii=mvCurrentNeuralNetworkHash.begin(); ii!=mvCurrentNeuralNetworkHash.end(); ++ii) 
+	  for(map<std::string,double>::iterator ii=mvCurrentNeuralNetworkHash.begin(); ii!=mvCurrentNeuralNetworkHash.end(); ++ii)
 	  {
 				double popularity = mvCurrentNeuralNetworkHash[(*ii).first];
 				neural_hash = (*ii).first;
-	
+
 				//If the hash != empty_hash: >= .01
 				if (neural_hash != "d41d8cd98f00b204e9800998ecf8427e" && neural_hash != "TOTAL_VOTES" && popularity > 0)
 				{
@@ -4683,7 +4684,7 @@ Array GetJSONCurrentNeuralNetworkReport()
 		  entry.push_back(Pair("Pending",SuperblockHeight));
 	  }
 	  int64_t superblock_age = GetAdjustedTime() - mvApplicationCacheTimestamp["superblock;magnitudes"];
-	 
+
 	  entry.push_back(Pair("Superblock Age",superblock_age));
 	  if (superblock_age > GetSuperblockAgeSpacing(nBestHeight))
 	  {
@@ -4707,7 +4708,7 @@ Array GetJSONCurrentNeuralNetworkReport()
 double GetTotalContentsFromVector(map<std::string,double>& v)
 {
 	  double votes = 0;
-	  for(map<std::string,double>::iterator ii=v.begin(); ii!=v.end(); ++ii) 
+	  for(map<std::string,double>::iterator ii=v.begin(); ii!=v.end(); ++ii)
 	  {
 				double pop = v[(*ii).first];
 				votes += pop;
@@ -4726,8 +4727,8 @@ Array GetJSONVersionReport()
 	  Object entry;
   	  entry.push_back(Pair("Version","Popularity,Percent %"));
 	  double votes = GetTotalContentsFromVector(mvNeuralVersion);
-		
-	  for(map<std::string,double>::iterator ii=mvNeuralVersion.begin(); ii!=mvNeuralVersion.end(); ++ii) 
+
+	  for(map<std::string,double>::iterator ii=mvNeuralVersion.begin(); ii!=mvNeuralVersion.end(); ++ii)
 	  {
 				double popularity = mvNeuralVersion[(*ii).first];
 				neural_ver = (*ii).first;
@@ -4752,7 +4753,7 @@ Array MagnitudeReportCSV(bool detail)
 	       Array results;
 		   Object c;
 		   StructCPID globalmag = mvMagnitudes["global"];
-		   double payment_timespan = 14; 
+		   double payment_timespan = 14;
 		   std::string Narr = "Research Savings Account Report - Generated " + RoundToString(GetAdjustedTime(),0) + " - Timespan: " + RoundToString(payment_timespan,0);
 		   c.push_back(Pair("RSA Report",Narr));
 		   results.push_back(c);
@@ -4762,41 +4763,41 @@ Array MagnitudeReportCSV(bool detail)
 		   double outstanding = 0;
 		   double totaloutstanding = 0;
 		   std::string header = "CPID,GRCAddress,Magnitude,PaymentMagnitude,Accuracy,LongTermOwed14day,LongTermOwedDaily,Payments,InterestPayments,LastPaymentTime,CurrentDailyOwed,NextExpectedPayment,AvgDailyPayments,Outstanding,PaymentTimespan";
-		   
+
 		   if (detail) header += ",PaymentDate,ResearchPaymentAmount,InterestPaymentAmount,Block#";
 		   header += "\r\n";
 
 		   std::string row = "";
-		   for(map<string,StructCPID>::iterator ii=mvMagnitudes.begin(); ii!=mvMagnitudes.end(); ++ii) 
+		   for(map<string,StructCPID>::iterator ii=mvMagnitudes.begin(); ii!=mvMagnitudes.end(); ++ii)
 		   {
 				// For each CPID on the network, report:
 				StructCPID structMag = mvMagnitudes[(*ii).first];
-				if (structMag.initialized && structMag.cpid.length() > 2) 
-				{ 
+				if (structMag.initialized && structMag.cpid.length() > 2)
+				{
 					if (structMag.cpid != "INVESTOR")
 					{
 						outstanding = structMag.totalowed - structMag.payments;
-						
+
 						StructCPID stDPOR = mvDPOR[structMag.cpid];
-					
-  						row = structMag.cpid + "," + structMag.GRCAddress + "," + RoundToString(structMag.Magnitude,2) + "," 
-							+ RoundToString(structMag.PaymentMagnitude,0) + "," + RoundToString(structMag.Accuracy,0) + "," + RoundToString(structMag.totalowed,2) 
+
+						row = structMag.cpid + "," + structMag.GRCAddress + "," + RoundToString(structMag.Magnitude,2) + ","
+							+ RoundToString(structMag.PaymentMagnitude,0) + "," + RoundToString(structMag.Accuracy,0) + "," + RoundToString(structMag.totalowed,2)
 							+ "," + RoundToString(structMag.totalowed/14,2)
-							+ "," + RoundToString(structMag.payments,2) + "," 
-							+ RoundToString(structMag.interestPayments,2) + "," + TimestampToHRDate(structMag.LastPaymentTime) 
-							+ "," + RoundToString(structMag.owed,2) 
+							+ "," + RoundToString(structMag.payments,2) + ","
+							+ RoundToString(structMag.interestPayments,2) + "," + TimestampToHRDate(structMag.LastPaymentTime)
+							+ "," + RoundToString(structMag.owed,2)
 							+ "," + RoundToString(structMag.owed/2,2)
-							+ "," + RoundToString(structMag.payments/14,2) + "," + RoundToString(outstanding,2) + "," 
+							+ "," + RoundToString(structMag.payments/14,2) + "," + RoundToString(outstanding,2) + ","
 							+ RoundToString(structMag.PaymentTimespan,0) + "\n";
 						header += row;
 						if (detail)
 						{
 							//Add payment detail - Halford - Christmas Eve 2014
-	   						std::vector<std::string> vCPIDTimestamps = split(structMag.PaymentTimestamps.c_str(),",");
+							std::vector<std::string> vCPIDTimestamps = split(structMag.PaymentTimestamps.c_str(),",");
 							std::vector<std::string> vCPIDPayments   = split(structMag.PaymentAmountsResearch.c_str(),",");
 							std::vector<std::string> vCPIDInterestPayments = split(structMag.PaymentAmountsInterest.c_str(),",");
 							std::vector<std::string> vCPIDPaymentBlocks    = split(structMag.PaymentAmountsBlocks.c_str(),",");
-							
+
 							for (unsigned int i = 0; i < vCPIDTimestamps.size(); i++)
 							{
 									double dTime = cdbl(vCPIDTimestamps[i],0);
@@ -4825,10 +4826,10 @@ Array MagnitudeReportCSV(bool detail)
 		   std::string footer = RoundToString(rows,0) + ", , , , ," + RoundToString(lto,2) + ", ," + RoundToString(totalpaid,2) + ", , , , , ," + RoundToString(totaloutstanding,2) + "\n";
 		   header += footer;
 		   Object entry;
-		   entry.push_back(Pair("CSV Complete",strprintf("\\reports\\magnitude_%"PRId64".csv",timestamp)));
+		   entry.push_back(Pair("CSV Complete",strprintf("\\reports\\magnitude_%" PRId64 ".csv",timestamp)));
 		   results.push_back(entry);
-     	   
-		   CSVToFile(strprintf("magnitude_%"PRId64".csv",timestamp), header);
+
+		   CSVToFile(strprintf("magnitude_%" PRId64 ".csv",timestamp), header);
 		   return results;
 }
 
@@ -4839,13 +4840,13 @@ std::string GetBurnAddress()
 
 
 
-std::string BurnCoinsWithNewContract(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue, 
+std::string BurnCoinsWithNewContract(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue,
 					 int64_t MinimumBalance, double dFees, std::string strPublicKey, std::string sBurnAddress)
 {
     CBitcoinAddress address(sBurnAddress);
     if (!address.IsValid())       throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Gridcoin address");
 	std::string sMasterKey = (sType=="project" || sType=="projectmapping" || sType=="smart_contract") ? GetArgument("masterprojectkey", msMasterMessagePrivateKey) : msMasterMessagePrivateKey;
-		
+
     int64_t nAmount = AmountFromValue(dFees);
     // Wallet comments
     CWalletTx wtx;
@@ -4873,7 +4874,7 @@ std::string SendReward(std::string sAddress, int64_t nAmount)
     // Wallet comments
     CWalletTx wtx;
     if (pwalletMain->IsLocked()) return "Error: Please enter the wallet passphrase with walletpassphrase first.";
-	std::string sMessageType      = "<MT>REWARD</MT>";  
+	std::string sMessageType      = "<MT>REWARD</MT>";
 	std::string sMessageValue     = "<MV>" + sAddress + "</MV>";
 	wtx.hashBoinc = sMessageType + sMessageValue;
     string strError = pwalletMain->SendMoneyToDestinationWithMinimumBalance(address.Get(), nAmount, 1, wtx);
@@ -4883,7 +4884,7 @@ std::string SendReward(std::string sAddress, int64_t nAmount)
 
 
 
-std::string AddMessage(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue, 
+std::string AddMessage(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue,
 					std::string sMasterKey, int64_t MinimumBalance, double dFees, std::string strPublicKey)
 {
     std::string sAddress = GetBurnAddress();
@@ -4925,13 +4926,13 @@ Value listitem(const Array& params, bool fHelp)
         "Returns details of a given item by name.");
 
     std::string sitem = params[0].get_str();
-	
+
 	std::string args = "";
 	if (params.size()==2)
 	{
 		args=params[1].get_str();
 	}
-	
+
 
     Array results;
 	Object e2;
@@ -4950,7 +4951,7 @@ Value listitem(const Array& params, bool fHelp)
 		int64_t RSAWEIGHT =	GetRSAWeightByCPID(GlobalCPUMiningCPID.cpid);
 		out_magnitude = GetUntrustedMagnitude(GlobalCPUMiningCPID.cpid,out_owed);
 
-	
+
 		Object entry;
 		entry.push_back(Pair("RSA Weight",RSAWEIGHT));
 		entry.push_back(Pair("Remote Magnitude",out_magnitude));
@@ -5034,7 +5035,7 @@ Value listitem(const Array& params, bool fHelp)
 		}
 		else
 		{
-	
+
 		double mytotalrac = 0;
 		double nettotalrac  = 0;
 		double projpct = 0;
@@ -5048,7 +5049,7 @@ Value listitem(const Array& params, bool fHelp)
 		double TotalProjectRAC = 0;
 		double TotalUserVerifiedRAC = 0;
 
-		for(map<string,StructCPID>::iterator ibp=mvBoincProjects.begin(); ibp!=mvBoincProjects.end(); ++ibp) 
+		for(map<string,StructCPID>::iterator ibp=mvBoincProjects.begin(); ibp!=mvBoincProjects.end(); ++ibp)
 		{
 			StructCPID WhitelistedProject = mvBoincProjects[(*ibp).first];
 			if (WhitelistedProject.initialized)
@@ -5059,13 +5060,13 @@ Value listitem(const Array& params, bool fHelp)
 				narr = "";
 				narr_desc = "";
 				double UserVerifiedRAC = 0;
-				if (structcpid.initialized) 
-				{ 
+				if (structcpid.initialized)
+				{
 					if (structcpid.projectname.length() > 1)
 					{
 						including = (ProjectRAC > 0 && structcpid.Iscpidvalid && structcpid.rac > 1);
 						UserVerifiedRAC = structcpid.rac;
-						narr_desc = "NetRac: " + RoundToString(ProjectRAC,0) + ", CPIDValid: " 
+						narr_desc = "NetRac: " + RoundToString(ProjectRAC,0) + ", CPIDValid: "
 							+ YesNo(structcpid.Iscpidvalid) + ", RAC: " +RoundToString(structcpid.rac,0);
 					}
 				}
@@ -5079,8 +5080,8 @@ Value listitem(const Array& params, bool fHelp)
 				nettotalrac += ProjectRAC;
 				mytotalrac = mytotalrac + UserVerifiedRAC;
 				mytotalpct = mytotalpct + projpct;
-				
-				double project_magnitude = 
+
+				double project_magnitude =
 					((UserVerifiedRAC / (ProjectRAC + 0.01)) / (WHITELISTED_PROJECTS + 0.01)) * NeuralNetworkMultiplier;
 
 				if (including)
@@ -5089,12 +5090,12 @@ Value listitem(const Array& params, bool fHelp)
 						TotalUserVerifiedRAC += UserVerifiedRAC;
 						TotalProjectRAC += ProjectRAC;
 						ParticipatingProjectCount++;
-						
+
 						entry.push_back(Pair("User " + structcpid.projectname + " Verified RAC",UserVerifiedRAC));
 						entry.push_back(Pair(structcpid.projectname + " Network RAC",ProjectRAC));
 						entry.push_back(Pair("Your Project Magnitude",project_magnitude));
 				}
-				
+
 		     }
 		}
 		entry.push_back(Pair("Whitelisted Project Count",(double)WHITELISTED_PROJECTS));
@@ -5225,15 +5226,15 @@ Value listitem(const Array& params, bool fHelp)
 		results.push_back(entry);
 		return results;
 	}
-	else if (sitem == "projects") 
+	else if (sitem == "projects")
 	{
-		for(map<string,StructCPID>::iterator ii=mvBoincProjects.begin(); ii!=mvBoincProjects.end(); ++ii) 
+		for(map<string,StructCPID>::iterator ii=mvBoincProjects.begin(); ii!=mvBoincProjects.end(); ++ii)
 		{
 
 			StructCPID structcpid = mvBoincProjects[(*ii).first];
 
-	        if (structcpid.initialized) 
-			{ 
+	        if (structcpid.initialized)
+			{
 				Object entry;
 				entry.push_back(Pair("Project",structcpid.projectname));
 				entry.push_back(Pair("URL",structcpid.link));
@@ -5256,19 +5257,19 @@ Value listitem(const Array& params, bool fHelp)
 		}
 		results.push_back(entry);
 	}
-	else if (sitem == "network") 
+	else if (sitem == "network")
 	{
-		for(map<string,StructCPID>::iterator ii=mvNetwork.begin(); ii!=mvNetwork.end(); ++ii) 
+		for(map<string,StructCPID>::iterator ii=mvNetwork.begin(); ii!=mvNetwork.end(); ++ii)
 		{
 
 			StructCPID stNet = mvNetwork[(*ii).first];
 
-	        if (stNet.initialized) 
-			{ 
+	        if (stNet.initialized)
+			{
 				Object entry;
 				entry.push_back(Pair("Project",stNet.projectname));
 				entry.push_back(Pair("Avg RAC",stNet.AverageRAC));
-				if (stNet.projectname=="NETWORK") 
+				if (stNet.projectname=="NETWORK")
 				{
 						entry.push_back(Pair("Network Total Magnitude",stNet.NetworkMagnitude));
 						entry.push_back(Pair("Network Average Magnitude",stNet.NetworkAvgMagnitude));
@@ -5293,21 +5294,21 @@ Value listitem(const Array& params, bool fHelp)
 		}
 		return results;
 	}
-	else if (sitem=="validcpids") 
+	else if (sitem=="validcpids")
 	{
 		//Dump vectors:
-		if (mvCPIDs.size() < 1) 
+		if (mvCPIDs.size() < 1)
 		{
 			HarvestCPIDs(false);
 		}
-		for(map<string,StructCPID>::iterator ii=mvCPIDs.begin(); ii!=mvCPIDs.end(); ++ii) 
+		for(map<string,StructCPID>::iterator ii=mvCPIDs.begin(); ii!=mvCPIDs.end(); ++ii)
 		{
 
 			StructCPID structcpid = mvCPIDs[(*ii).first];
 
-	        if (structcpid.initialized) 
-			{ 
-			
+	        if (structcpid.initialized)
+			{
+
 				if (structcpid.cpid == GlobalCPUMiningCPID.cpid || structcpid.cpid=="INVESTOR" || structcpid.cpid=="investor")
 				{
 					if (structcpid.verifiedteam=="gridcoin")
@@ -5334,30 +5335,30 @@ Value listitem(const Array& params, bool fHelp)
 
 
     }
-	else if (sitem=="cpids") 
+	else if (sitem=="cpids")
 	{
 		//Dump vectors:
-		
-		if (mvCPIDs.size() < 1) 
+
+		if (mvCPIDs.size() < 1)
 		{
 			HarvestCPIDs(false);
 		}
 		printf ("generating cpid report %s",sitem.c_str());
 
-		for(map<string,StructCPID>::iterator ii=mvCPIDs.begin(); ii!=mvCPIDs.end(); ++ii) 
+		for(map<string,StructCPID>::iterator ii=mvCPIDs.begin(); ii!=mvCPIDs.end(); ++ii)
 		{
 
 			StructCPID structcpid = mvCPIDs[(*ii).first];
 
-	        if (structcpid.initialized) 
-			{ 
-			
-				if ((GlobalCPUMiningCPID.cpid.length() > 3 && 
-					structcpid.cpid == GlobalCPUMiningCPID.cpid) 
+	        if (structcpid.initialized)
+			{
+
+				if ((GlobalCPUMiningCPID.cpid.length() > 3 &&
+					structcpid.cpid == GlobalCPUMiningCPID.cpid)
 					|| structcpid.cpid=="INVESTOR" || GlobalCPUMiningCPID.cpid=="INVESTOR" || GlobalCPUMiningCPID.cpid.length()==0)
 				{
 					Object entry;
-	
+
 					entry.push_back(Pair("Project",structcpid.projectname));
 					entry.push_back(Pair("CPID",structcpid.cpid));
 					entry.push_back(Pair("RAC",structcpid.rac));
@@ -5413,4 +5414,3 @@ Value getcheckpoint(const Array& params, bool fHelp)
 
     return result;
 }
-

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <memory>
+
 #include "main.h"
 #include "db.h"
 #include "txdb.h"
@@ -156,7 +158,7 @@ Value getworkex(const Array& params, bool fHelp)
 
     typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
     static mapNewBlock_t mapNewBlock;
-    static vector<boost::shared_ptr<CBlock> > vNewBlock;
+    static vector<std::shared_ptr<CBlock> > vNewBlock;
     static CReserveKey reservekey(pwalletMain);
 
     if (params.size() == 0)
@@ -165,7 +167,7 @@ Value getworkex(const Array& params, bool fHelp)
         static unsigned int nTransactionsUpdatedLast;
         static CBlockIndex* pindexPrev;
         static int64_t nStart;
-        static boost::shared_ptr<CBlock> pblock;
+        static std::shared_ptr<CBlock> pblock;
         if (pindexPrev != pindexBest ||
             (nTransactionsUpdated != nTransactionsUpdatedLast &&  GetAdjustedTime() - nStart > 60))
         {
@@ -295,7 +297,7 @@ Value getwork(const Array& params, bool fHelp)
 
     typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
     static mapNewBlock_t mapNewBlock;    // FIXME: thread safety
-    static vector<boost::shared_ptr<CBlock> > vNewBlock;
+    static vector<std::shared_ptr<CBlock> > vNewBlock;
     static CReserveKey reservekey(pwalletMain);
 
     if (params.size() == 0)
@@ -304,7 +306,7 @@ Value getwork(const Array& params, bool fHelp)
         static unsigned int nTransactionsUpdatedLast;
         static CBlockIndex* pindexPrev;
         static int64_t nStart;
-        static boost::shared_ptr<CBlock> pblock;
+        static std::shared_ptr<CBlock> pblock;
         if (pindexPrev != pindexBest ||
             (nTransactionsUpdated != nTransactionsUpdatedLast &&  GetAdjustedTime() - nStart > 60))
         {
@@ -445,7 +447,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     static unsigned int nTransactionsUpdatedLast;
     static CBlockIndex* pindexPrev;
     static int64_t nStart;
-    static boost::shared_ptr<CBlock> pblock;
+    static std::shared_ptr<CBlock> pblock;
     if (pindexPrev != pindexBest ||
         (nTransactionsUpdated != nTransactionsUpdatedLast &&  GetAdjustedTime() - nStart > 5))
     {

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -40,7 +40,7 @@ std::string NeuralRequest(std::string MyNeuralRequest)
 {
     // Find a Neural Network Node that is free
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pNode, vNodes) 
+    BOOST_FOREACH(CNode* pNode, vNodes)
 	{
 		if (Contains(pNode->strSubVer,"1999"))
 		{
@@ -58,7 +58,7 @@ void GatherNeuralHashes()
 {
     // Find a Neural Network Node that is free
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pNode, vNodes) 
+    BOOST_FOREACH(CNode* pNode, vNodes)
 	{
 		if (Contains(pNode->strSubVer,"1999"))
 		{
@@ -77,8 +77,8 @@ bool RequestSupermajorityNeuralData()
 	double dCurrentPopularity = 0;
 	std::string sCurrentNeuralSupermajorityHash = GetCurrentNeuralNetworkSupermajorityHash(dCurrentPopularity);
 	std::string reqid = DefaultWalletAddress();
-			
-    BOOST_FOREACH(CNode* pNode, vNodes) 
+
+    BOOST_FOREACH(CNode* pNode, vNodes)
 	{
 		if (!pNode->NeuralHash.empty() && !sCurrentNeuralSupermajorityHash.empty() && pNode->NeuralHash == sCurrentNeuralSupermajorityHash)
 		{
@@ -231,7 +231,7 @@ bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit)
     LOCK(cs_vNodes);
 	int iContactCount = 0;
 	msNeuralResponse="";
-    BOOST_FOREACH(CNode* pNode, vNodes) 
+    BOOST_FOREACH(CNode* pNode, vNodes)
 	{
 		if (Contains(pNode->strSubVer,"1999"))
 		{
@@ -242,7 +242,7 @@ bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit)
 			if (iContactCount >= NodeLimit) return true;
 		}
     }
-	if (iContactCount==0) 
+	if (iContactCount==0)
 	{
 		printf("No neural network nodes online.");
 		return false;
@@ -295,7 +295,7 @@ Value getpeerinfo(const Array& params, bool fHelp)
 
     Array ret;
 	GatherNeuralHashes();
-	
+
     BOOST_FOREACH(const CNodeStats& stats, vstats) {
         Object obj;
 
@@ -304,7 +304,7 @@ Value getpeerinfo(const Array& params, bool fHelp)
 		  if (!(stats.addrLocal.empty()))
             obj.push_back(Pair("addrlocal", stats.addrLocal));
 
-        obj.push_back(Pair("services", strprintf("%08"PRIx64, stats.nServices)));
+        obj.push_back(Pair("services", strprintf("%08" PRIx64, stats.nServices)));
         obj.push_back(Pair("lastsend", (int64_t)stats.nLastSend));
         obj.push_back(Pair("lastrecv", (int64_t)stats.nLastRecv));
         obj.push_back(Pair("conntime", (int64_t)stats.nTimeConnected));
@@ -347,7 +347,7 @@ Value getnettotals(const Array& params, bool fHelp)
 
 
 
-// ppcoin: send alert.  
+// ppcoin: send alert.
 // There is a known deadlock situation with ThreadMessageHandler
 // ThreadMessageHandler: holds cs_vSend and acquiring cs_main in SendMessages()
 // ThreadRPCServer: holds cs_main and acquiring cs_vSend in alert.RelayTo()/PushMessage()/BeginMessage()
@@ -387,8 +387,8 @@ Value sendalert(const Array& params, bool fHelp)
     key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end())); // if key is not correct openssl may crash
     if (!key.Sign(Hash(alert.vchMsg.begin(), alert.vchMsg.end()), alert.vchSig))
         throw runtime_error(
-            "Unable to sign alert, check private key?\n");  
-    if(!alert.ProcessAlert()) 
+            "Unable to sign alert, check private key?\n");
+    if(!alert.ProcessAlert())
         throw runtime_error(
             "Failed to process alert.\n");
     // Relay alert

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -865,12 +865,13 @@ Value addmultisigaddress(const Array& params, bool fHelp)
     // Gather public keys
     if (nRequired < 1)
         throw runtime_error("a multisignature address must require at least one key to redeem");
-    if ((int)keys.size() < nRequired)
+    if ((int)keys.size() < nRequired) {
         throw runtime_error(
             strprintf("not enough keys supplied "
-                      "(got %"PRIszu" keys, but need at least %d to redeem)", keys.size(), nRequired));
+                      "(got %" PRIszu " keys, but need at least %d to redeem)", keys.size(), nRequired));
+    }
 
-	if (keys.size() > 16)       throw runtime_error("Number of addresses involved in the multisignature address creation > 16\nReduce the number");
+    if (keys.size() > 16)       throw runtime_error("Number of addresses involved in the multisignature address creation > 16\nReduce the number");
 
 
     std::vector<CKey> pubkeys;
@@ -1035,7 +1036,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
 		std::string sKey = "";
 		std::string sContract = "";
 		std::string sDetail = "";
-        
+
 		int nConf = std::numeric_limits<int>::max();
         bool fIsWatchonly = false;
 		if (it != mapTally.end())
@@ -1180,7 +1181,7 @@ static void MaybePushAddress(Object & entry, const CTxDestination &dest)
 
     bool fAllAccounts = (strAccount == string("*") || strAccount.empty());
 	bool involvesWatchonly = wtx.IsFromMe(MINE_WATCH_ONLY);
-   
+
 	// R Halford - Upgrade Bitcoin's ListTransactions to work with Gridcoin
 	// Ensure CoinStake addresses are deserialized, convert CoinStake split stake rewards to subsidies, Show POR vs Interest breakout
 
@@ -1282,8 +1283,8 @@ Array StakingReport()
 				 }
 				 else
 				 {
-					 
-					 if (pcoin->GetBlocksToMaturity() < 1) 
+
+					 if (pcoin->GetBlocksToMaturity() < 1)
 					 {
 								nImmature+=amt;
 					 }
@@ -1292,16 +1293,16 @@ Array StakingReport()
 								if (pcoin->GetDepthInMainChain() < 1) nDepthImmature += amt;
 					 }
 				 }
-   
+
 		}
 		else
 		{
 			     //Sent Tx
 		         nNonCoinStakeTotal += amt;
-   
+
 		}
     }
-	
+
 	entry.push_back(Pair("CoinStakeTotal",     CoinToDouble(nCoinStakeTotal)));
 	entry.push_back(Pair("Non-CoinStakeTotal", CoinToDouble(nNonCoinStakeTotal)));
 	entry.push_back(Pair("Blocks Immature",    CoinToDouble(nImmature)));
@@ -1758,7 +1759,7 @@ Value listsinceblock(const Array& params, bool fHelp)
     ret.push_back(Pair("lastblock", lastblock.GetHex()));
 
     return ret;
-    
+
 }
 
 Value gettransaction(const Array& params, bool fHelp)

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1475,7 +1475,7 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
         return false;
-		
+
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
         return Sign1(keyID, keystore, hash, nHashType, scriptSigRet);
@@ -1620,8 +1620,8 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
     txnouttype whichType;
     if (!Solver(scriptPubKey, whichType, vSolutions))
         return false;
-	
-	if (bOPReturnEnabled && whichType == TX_NULL_DATA)
+
+    if (bOPReturnEnabled && whichType == TX_NULL_DATA)
         return true;
 
     if (whichType == TX_PUBKEY)

--- a/src/upgrader.cpp
+++ b/src/upgrader.cpp
@@ -22,18 +22,6 @@ bool CANCEL_DOWNLOAD = false;
 
 Upgrader upgrader;
 
-static int cancelDownloader(void *p,
-                    curl_off_t dltotal, curl_off_t dlnow,
-                    curl_off_t ultotal, curl_off_t ulnow)
-{
-    if(CANCEL_DOWNLOAD) 
-    {
-        printf("\ncancelling download\n");
-        return 1;
-    }
-    return 0;
-}
-
 std::string geturl()
 {
     std::string url = "http://download.gridcoin.us/download/signed/";
@@ -44,7 +32,7 @@ std::string geturl()
 bfs::path Upgrader::path(int pathfork)
 {
     bfs::path path;
-    
+
     switch (pathfork)
     {
         case DATA:
@@ -84,7 +72,7 @@ void download(void *curlhandle)
 #if defined(UPGRADERFLAG)
 
 bool waitForParent(int parent)
-{   
+{
     int delay = 0;
     int cutoff = 30;
     #ifdef WIN32
@@ -98,7 +86,7 @@ bool waitForParent(int parent)
             process = OpenProcess(SYNCHRONIZE, FALSE, parent);
             delay++;
         }
-    
+
     #else
     while ((0 == kill(parent, 0)) && delay < cutoff)
         {
@@ -195,14 +183,14 @@ int main(int argc, char *argv[])
             if (upgrader.juggler(DATA, false))
             {
                 printf("Copied files successfully\n");
-                upgrader.launcher(atoi(argv[3]), -1);               
+                upgrader.launcher(atoi(argv[3]), -1);
             }
-        }       
+        }
     }
 
     //
 
-    else 
+    else
     {
         printf("That's not an option!\n");
         return 0;
@@ -238,8 +226,8 @@ bool Upgrader::downloader(int targetfile)
 
     bfs::path target = path(DATA) / "upgrade";
     // if user switches between upgrading client and bootstrapping blockchain, we don't want to pass around garbage
-    if (bfs::exists(target)) {bfs::remove_all(target);} 
-    
+    if (bfs::exists(target)) {bfs::remove_all(target);}
+
     if (!verifyPath(target, true)) {return false;}
     target /= targetswitch(targetfile);
     cancelDownload(false);
@@ -321,13 +309,13 @@ int Upgrader::getFilePerc(long int sz)
     if(!filesizeRetrieved)
             {
                 curl_easy_getinfo(curlhandle.handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &filesize);
-                if(filesize > 0) 
+                if(filesize > 0)
                     {
                         filesizeRetrieved=true;
                         return 0;
                     }
             }
-    
+
     return (filesize > 0)? (sz*100/(filesize)) : 0;
 }
 
@@ -352,8 +340,8 @@ bool Upgrader::unzipper(int targetfile)
         printf("Failed to open archive %s\n", targetzip);
         return false;
     }
- 
-    for (unsigned int i = 0; i < zip_get_num_entries(archive, 0); i++) 
+
+    for (unsigned int i = 0; i < zip_get_num_entries(archive, 0); i++)
     {
         if (zip_stat_index(archive, i, 0, &filestat) == 0)
         {
@@ -367,7 +355,7 @@ bool Upgrader::unzipper(int targetfile)
                 }
 
                 file = fopen((target / filestat.name).string().c_str(), "w");
- 
+
                 sum = 0;
                 while (sum != filestat.size) {
                     bufferlength = zip_fread(zipfile, buffer, 1024*1024);
@@ -380,7 +368,7 @@ bool Upgrader::unzipper(int targetfile)
             }
         }
     }
-    if (zip_close(archive) == -1) 
+    if (zip_close(archive) == -1)
     {
         printf("Can't close zip archive %s\n", targetzip);
         return false;
@@ -464,7 +452,7 @@ bool Upgrader::safeProgramDir()
 bool Upgrader::copyDir(bfs::path source, bfs::path target, bool recursive)
 {
     if (!verifyPath(source, false) || !verifyPath(target, true))    {return false;}
-    
+
     pathvec iteraton = this->fvector(source);
     for (pathvec::const_iterator mongo (iteraton.begin()); mongo != iteraton.end(); ++mongo)
     {
@@ -491,11 +479,11 @@ bool Upgrader::copyDir(bfs::path source, bfs::path target, bool recursive)
             if (bfs::exists(target / fongo))
             {
                 bfs::remove(target / fongo);
-            } // avoid overwriting      
+            } // avoid overwriting
 
             bfs::copy_file(source / fongo, target / fongo); // the actual upgrade/recovery
 
-        }   
+        }
     }
     return true;
 }
@@ -503,7 +491,7 @@ bool Upgrader::copyDir(bfs::path source, bfs::path target, bool recursive)
 pathvec Upgrader::fvector(bfs::path path)
 {
     pathvec a;
- 
+
     copy(bfs::directory_iterator(path), bfs::directory_iterator(), back_inserter(a));
 
     for (unsigned int i = 0; i < a.size(); ++i)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -405,7 +405,7 @@ string FormatMoney(int64_t n, bool fPlus)
     int64_t n_abs = (n > 0 ? n : -n);
     int64_t quotient = n_abs/COIN;
     int64_t remainder = n_abs%COIN;
-    string str = strprintf("%"PRId64".%08"PRId64, quotient, remainder);
+    string str = strprintf("%" PRId64 ".%08" PRId64, quotient, remainder);
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
@@ -1330,7 +1330,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nTime)
 
     // Add data
     vTimeOffsets.input(nOffsetSample);
-    if (fDebug10) printf("Added time data, samples %d, offset %+"PRId64" (%+"PRId64" minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
+    if (fDebug10) printf("Added time data, samples %d, offset %+" PRId64 " (%+" PRId64 " minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
     if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
     {
         int64_t nMedian = vTimeOffsets.median();
@@ -1365,10 +1365,10 @@ void AddTimeData(const CNetAddr& ip, int64_t nTime)
         }
         if (fDebug10) {
             BOOST_FOREACH(int64_t n, vSorted)
-                printf("%+"PRId64"  ", n);
+                printf("%+" PRId64 "  ", n);
             printf("|  ");
         }
-        if (fDebug10) printf("nTimeOffset = %+"PRId64"  (%+"PRId64" minutes)\n", nTimeOffset, nTimeOffset/60);
+        if (fDebug10) printf("nTimeOffset = %+" PRId64 "  (%+" PRId64 " minutes)\n", nTimeOffset, nTimeOffset/60);
     }
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -242,7 +242,7 @@ void runCommand(std::string strCommand);
 
 inline std::string i64tostr(int64_t n)
 {
-    return strprintf("%"PRId64, n);
+    return strprintf("%" PRId64, n);
 }
 
 inline std::string itostr(int n)
@@ -660,4 +660,3 @@ inline uint32_t ByteReverse(uint32_t value)
 }
 
 #endif
-

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -166,7 +166,7 @@ bool CWallet::LoadCScript(const CScript& redeemScript)
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
     {
         std::string strAddr = CBitcoinAddress(redeemScript.GetID()).ToString();
-        printf("%s: Warning: This wallet contains a redeemScript of size %"PRIszu" which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n",
+        printf("%s: Warning: This wallet contains a redeemScript of size %" PRIszu " which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n",
             __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr.c_str());
         return true;
     }
@@ -572,7 +572,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
 	 			CBlockIndex* pboincblockindex = mapBlockIndex[wtxIn.hashBlock];
 				CBlock blk;
     			bool h = blk.ReadFromDisk(pboincblockindex);
-				if (h) 
+				if (h)
 				{
 					//MiningCPID mcpidWalletTx = DeserializeBoincBlock(blk.vtx[0].hashBoinc);
 					//wtx.nResearchSubsidy = mcpidWalletTx.ResearchSubsidy;
@@ -580,7 +580,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
 					//printf("Logging coinbase tx in Research %f, Interest %f",(double)wtx.nResearchSubsidy,(double)wtx.nInterestSubsidy);
 				}
 			}
-	
+
 
 		}
         // Write to disk
@@ -616,14 +616,14 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
         std::string strCmd = GetArg("-walletnotify", "");
 		// Reward Sharing - Added 08-21-2016
 		// if (IsCoinBase() || IsCoinStake())
-       
+
 		if (wtxIn.IsCoinBase() || wtxIn.IsCoinStake())
 	    {
 			printf("\r\nCoinBase:CoinStake\r\n");
 			CBlockIndex* pBlk = mapBlockIndex[wtxIn.hashBlock];
 			CBlock blk;
     		bool r = blk.ReadFromDisk(pBlk);
-			if (r) 
+			if (r)
 			{
 				MiningCPID bb = DeserializeBoincBlock(blk.vtx[0].hashBoinc);
 				double dResearch = bb.ResearchSubsidy + bb.InterestSubsidy;
@@ -809,12 +809,12 @@ CTxDestination GetCoinstakeDestination(const CWalletTx* wtx,CTxDB& txdb)
             {
                 if (prevout.n < prev.vout.size())
                 {
-  			    	//Inputs: 
+                    //Inputs:
                     const CTxOut &vout = prev.vout[prevout.n];
-			        CTxDestination address;
+                    CTxDestination address;
                     if (ExtractDestination(vout.scriptPubKey, address))
                     {
-						return address;
+                      return address;
                     }
                 }
             }
@@ -862,7 +862,7 @@ void CWalletTx::GetAmounts2(list<COutputEntry>& listReceived,
         CTxDestination address;
 		if (IsCoinStake())
 		{
-			// R Halford - For CoinStake we must extract the address from the input	
+			// R Halford - For CoinStake we must extract the address from the input
 			address = GetCoinstakeDestination(this,txdb);
 		}
 		else
@@ -885,13 +885,13 @@ void CWalletTx::GetAmounts2(list<COutputEntry>& listReceived,
 
         // If we are receiving the output, add it as a "received" entry
         if (fIsMine || IsCoinStake())
-		{	
+		{
 			if (IsCoinStake())
-			{   
+			{
 				// For CoinStake, we must calculate the subsidy based on Net Earned due to splitstakes and empty stakes
 				output.amount += -nFee;
 				nFee=0;
-				if (output.amount != 0) 
+				if (output.amount != 0)
 				{
 						listReceived.push_back(output);
 						break;
@@ -1120,7 +1120,7 @@ void CWallet::ReacceptWalletTransactions()
                 // Update fSpent if a tx got spent somewhere else by a copy of wallet.dat
                 if (txindex.vSpent.size() != wtx.vout.size())
                 {
-                    printf("ERROR: ReacceptWalletTransactions() : txindex.vSpent.size() %"PRIszu" != wtx.vout.size() %"PRIszu"\n", txindex.vSpent.size(), wtx.vout.size());
+                    printf("ERROR: ReacceptWalletTransactions() : txindex.vSpent.size() %" PRIszu " != wtx.vout.size() %" PRIszu "\n", txindex.vSpent.size(), wtx.vout.size());
                     continue;
                 }
                 for (unsigned int i = 0; i < txindex.vSpent.size(); i++)
@@ -1156,7 +1156,7 @@ void CWallet::ReacceptWalletTransactions()
         }
     }
 }
-	
+
 
 void CWalletTx::RelayWalletTransaction(CTxDB& txdb)
 {
@@ -1560,7 +1560,7 @@ bool CWallet::SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, set<pai
 }
 
 // Select some coins without random shuffle or best subset approximation
-bool CWallet::SelectCoinsForStaking(int64_t nTargetValueIn, unsigned int nSpendTime, 
+bool CWallet::SelectCoinsForStaking(int64_t nTargetValueIn, unsigned int nSpendTime,
 	set<pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const
 {
     vector<COutput> vCoins;
@@ -1568,14 +1568,14 @@ bool CWallet::SelectCoinsForStaking(int64_t nTargetValueIn, unsigned int nSpendT
 
     setCoinsRet.clear();
     nValueRet = 0;
-	
+
 	int64_t nTargetValue = nTargetValueIn;
 
-	//if (GlobalCPUMiningCPID.cpid != "INVESTOR"  && msMiningErrors7 != "Probing coin age") 
+	//if (GlobalCPUMiningCPID.cpid != "INVESTOR"  && msMiningErrors7 != "Probing coin age")
 	//{
 	//		nTargetValue = nTargetValueIn/2;
 	//}
-	
+
     BOOST_FOREACH(COutput output, vCoins)
     {
         const CWalletTx *pcoin = output.tx;
@@ -1607,7 +1607,7 @@ bool CWallet::SelectCoinsForStaking(int64_t nTargetValueIn, unsigned int nSpendT
     return true;
 }
 
-bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, 
+bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
 	int64_t& nFeeRet, const CCoinControl* coinControl)
 {
 
@@ -1791,14 +1791,14 @@ bool CWallet::GetStakeWeight(uint64_t& nWeight)
 	//Retrieve CPID RSA_WEIGHT
 	int64_t RSA_WEIGHT = GetRSAWeightByCPID(GlobalCPUMiningCPID.cpid);
 	////////////////////////////////////////////////////////////////////////////////
-	
+
     LOCK2(cs_main, cs_wallet);
     BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
     {
         CTxIndex txindex;
         if (!txdb.ReadTxIndex(pcoin.first->GetHash(), txindex))
             continue;
-		//1-13-2015 
+		//1-13-2015
         if (IsProtocolV2(nBestHeight+1))
         {
             if (nCurrentTime - pcoin.first->nTime > nStakeMinAge)
@@ -1818,8 +1818,8 @@ bool CWallet::GetStakeWeight(uint64_t& nWeight)
             }
         }
     }
-	
-	
+
+
 	return true;
 }
 
@@ -1834,7 +1834,7 @@ void NetworkTimer()
 	mdMachineTimerLast = GetAdjustedTime();
 	if (elapsed < 1) elapsed = 1;
 	mdPORNonce += (elapsed*10);
-	if (mdPORNonce > 2147483000) 
+	if (mdPORNonce > 2147483000)
 	{
 			printf("Resetting...");
 			mdPORNonce=0;
@@ -1851,7 +1851,7 @@ void NetworkTimer()
 
 
 
-bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int64_t nSearchInterval, 
+bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int64_t nSearchInterval,
 	int64_t nFees, CTransaction& txNew, CKey& key, int64_t& out_gridreward, std::string& out_hashboinc)
 {
     CBlockIndex* pindexPrev = pindexBest;
@@ -1872,7 +1872,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
     // Choose coins to use
     int64_t nBalance = GetBalance();
-	
+
     if (nBalance <= nReserveBalance && !bNewbieFreePass)
 	{
 		msMiningErrors7 = "No Reserve Balance to Stake";
@@ -1911,7 +1911,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 	int64_t nTarget = nBalance-nReserveBalance;
 	std::string sStakeAll = GetArgument("stakeall", "true");
 	if (sStakeAll=="true") nTarget = nBalance*2;
-		
+
     if (!SelectCoinsForStaking(nTarget, txNew.nTime, setCoins, nValueIn) && !bNewbieFreePass)
 	{
 		msMiningErrors7="No coins to stake";
@@ -1964,7 +1964,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 		 }
 
 	}
-	catch (std::exception &e) 
+	catch (std::exception &e)
 	{
 	    printf("Error while retrieving next project\r\n");
 		msMiningErrors7="Unable to Stake [Project Error]";
@@ -1991,7 +1991,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 	msMiningErrors6="";
 	msMiningErrors7="";
 	msMiningErrors8="";
-	
+
 	//int64_t nBlockTime = 0;
 
     BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
@@ -2011,29 +2011,29 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 continue;
         }
 
-		
+
         static int nMaxStakeSearchInterval = 120;
         if (block.GetBlockTime() + nStakeMinAge > txNew.nTime - nMaxStakeSearchInterval)
             continue; // only count coins meeting min age requirement
 
         bool fKernelFound = false;
-	    
+
         for (unsigned int n=0; n<min(nSearchInterval,(int64_t)nMaxStakeSearchInterval) && !fKernelFound && !fShutdown && pindexPrev == pindexBest; n++)
         {
-            // Search backward in time from the given txNew timestamp 
+            // Search backward in time from the given txNew timestamp
             // Search nSearchInterval seconds back up to nMaxStakeSearchInterval
             uint256 hashProofOfStake = 0, targetProofOfStake = 0;
             COutPoint prevoutStake = COutPoint(pcoin.first->GetHash(), pcoin.second);
 			//Note: At this point block.vtx[0] is still null, so we send the hashBoinc in separately
-		
+
 			//12-6-2015 - Add PoW nonce to POR - Halford
 			NetworkTimer();
 
-            if (CheckStakeKernelHash(pindexPrev, nBits, block, txindex.pos.nTxPos - txindex.pos.nBlockPos, 
-				*pcoin.first, prevoutStake, txNew.nTime - n, hashProofOfStake, 
+            if (CheckStakeKernelHash(pindexPrev, nBits, block, txindex.pos.nTxPos - txindex.pos.nBlockPos,
+				*pcoin.first, prevoutStake, txNew.nTime - n, hashProofOfStake,
 				targetProofOfStake, hashBoinc, false, true, mdPORNonce))
             {
-			
+
                 // Found a kernel
                 if (fDebug3)   printf("\r\nCCS:FoundKernel;\r\n");
 				WriteAppCache(pindexPrev->GetBlockHash().GetHex(),RoundToString(mdPORNonce,0));
@@ -2108,7 +2108,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
 
 	int64_t RSA_WEIGHT  = GetRSAWeightByCPID(GlobalCPUMiningCPID.cpid);
-	
+
     if (nCredit == 0 && !bNewbieFreePass)
 	{
 		msMiningErrors7="Probing coin age";
@@ -2175,8 +2175,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 		double dAccrualAge = 0;
 		double dAccrualMagnitudeUnit = 0;
 		double dAccrualMagnitude = 0;
-		
-		// ************************************************* CREATE PROOF OF RESEARCH REWARD ****************************** R HALFORD *************** 
+
+		// ************************************************* CREATE PROOF OF RESEARCH REWARD ****************************** R HALFORD ***************
 		// ResearchAge 2
 		// Note: Since research Age must be exact, we need to transmit the Block nTime here so it matches AcceptBlock
 		StructCPID st1 = GetLifetimeCPID(GlobalCPUMiningCPID.cpid,"CreateCoinStake()");
@@ -2186,7 +2186,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 			pindexBest->nTime,pindexBest,"createcoinstake",OUT_POR,out_interest,dAccrualAge,dAccrualMagnitudeUnit,dAccrualMagnitude);
 
 		//9-2-2015 Accrual System - Reserved for Future Use
-	
+
 		MiningCPID miningcpid = GetNextProject(false);
 		uint256 pbh = 0;
 		if (pindexPrev) pbh=pindexPrev->GetBlockHash();
@@ -2208,26 +2208,26 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 		std::string hashBoinc = SerializeBoincBlock(miningcpid);
 		if (fDebug)  printf("CreateCoinStakeHashboinc: %s\r\n",hashBoinc.c_str());
 		out_hashboinc = hashBoinc;
-		
+
 		double mint = CoinToDouble(nReward);
 		double PORDiff = GetBlockDifficulty(nBits);
-	
+
 		if (fDebug2 && LessVerbose(5)) printf("Creating POS Reward for %s  amt  %f  {RSAWeight %f}  Research %f, Interest %f \r\n",
 			GlobalCPUMiningCPID.cpid.c_str(), mint, (double)RSA_WEIGHT,miningcpid.ResearchSubsidy,miningcpid.InterestSubsidy);
-	
+
 		//INVESTORS
-		if (mint < MintLimiter(PORDiff,RSA_WEIGHT,GlobalCPUMiningCPID.cpid,GetAdjustedTime())) 
+		if (mint < MintLimiter(PORDiff,RSA_WEIGHT,GlobalCPUMiningCPID.cpid,GetAdjustedTime()))
 		{
 			    msMiningErrors8="Mint too small.";
 				if (fDebug) printf("CreateStake()::Mint %f of %f too small",(double)mint,(double)MintLimiter(PORDiff,RSA_WEIGHT,miningcpid.cpid,GetAdjustedTime()));
-				return false; 
+				return false;
 		}
-		
+
 		if (nReward == 0)
 		{
 			msMiningErrors8="Mint zero.";
 			if (fDebug) printf("CreateBlock():Mint is zero");
-			return false;   
+			return false;
 		}
 	    nCredit += nReward;
 		out_gridreward = nReward;
@@ -2242,12 +2242,12 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 	}
 
 	if (fDebug3) printf("Staking Block \r\n");
-	
+
 	// PROD TODO DURING NEXT MANDATORY - Remove Crypto Lottery code and reimplement original split stakes and split stake in checkblock
 	// Set output amount - 4-3-2015 - Expand Coinstake to pay DPOR Researchers in CryptoLottery
 	if (bCryptoLotteryEnabled && !IsResearchAgeEnabled(pindexPrev->nHeight))
 	{
-		 
+
 		    std::string recipients = CryptoLottery(GetAdjustedTime());
 		    std::vector<std::string> vRecipients = split(recipients.c_str(),"<COL>");
 		    unsigned int LotterySize = vRecipients.size();
@@ -2271,11 +2271,11 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 				iPos = 2;
 			}
 
-	
+
 
 		   if (LotterySize > 1)
 		   {
-			  
+
 			  for (unsigned int i=0;i < vRecipients.size(); i++)
 			  {
 					std::vector<std::string> vPayments = split(vRecipients[i].c_str(),";");
@@ -2297,7 +2297,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 		  }
 	}
 	else
-	{	
+	{
 
 		if (!bOptionPaymentsEnabled)
 		{
@@ -2324,19 +2324,19 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 		}
 		else
 		{
-			// Disabled			
+			// Disabled
 
 		}
 	}
 	//  *** Ensure HashBoinc is Serialized on Block Before it is signed (Set hashboinc in above step)
-	
+
     // Sign
     int nIn = 0;
 
-	
+
     BOOST_FOREACH(const CWalletTx* pcoin, vwtxPrev)
     {
-	
+
         if (!SignSignature(*this, *pcoin, txNew, nIn++))
 		{
 			msMiningErrors7="Failed to sign coinstake";
@@ -2345,18 +2345,18 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 		}
     }
 
-	
+
     // Limit size
     unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
     if (nBytes >= MAX_BLOCK_SIZE_GEN/5)
-    {  
-		msMiningErrors7="Exceeded coinstake size limit"; 
+    {
+		msMiningErrors7="Exceeded coinstake size limit";
 		return error("CreateCoinStake : exceeded coinstake size limit");
 	}
 
-	
+
     // Successfully generated coinstake
-	if (CoinToDouble(nCredit) > (MaxSubsidy/10)) 
+	if (CoinToDouble(nCredit) > (MaxSubsidy/10))
 	{
 		if (fDebug3) printf("POR+");
 		msMiningErrors = "POR Block Mined";
@@ -2585,12 +2585,12 @@ void CWallet::PrintWallet(const CBlock& block)
         if (block.IsProofOfWork() && mapWallet.count(block.vtx[0].GetHash()))
         {
             CWalletTx& wtx = mapWallet[block.vtx[0].GetHash()];
-            printf("    mine:  %d  %d  %"PRId64"", wtx.GetDepthInMainChain(), wtx.GetBlocksToMaturity(), wtx.GetCredit());
+            printf("    mine:  %d  %d  %" PRId64 "", wtx.GetDepthInMainChain(), wtx.GetBlocksToMaturity(), wtx.GetCredit());
         }
         if (block.IsProofOfStake() && mapWallet.count(block.vtx[1].GetHash()))
         {
             CWalletTx& wtx = mapWallet[block.vtx[1].GetHash()];
-            printf("    stake: %d  %d  %"PRId64"", wtx.GetDepthInMainChain(), wtx.GetBlocksToMaturity(), wtx.GetCredit());
+            printf("    stake: %d  %d  %" PRId64 "", wtx.GetDepthInMainChain(), wtx.GetBlocksToMaturity(), wtx.GetCredit());
          }
 
     }
@@ -2653,7 +2653,7 @@ bool CWallet::NewKeyPool()
             walletdb.WritePool(nIndex, CKeyPool(GenerateNewKey()));
             setKeyPool.insert(nIndex);
         }
-        printf("CWallet::NewKeyPool wrote %"PRId64" new keys\n", nKeys);
+        printf("CWallet::NewKeyPool wrote %" PRId64 " new keys\n", nKeys);
     }
     return true;
 }
@@ -2683,7 +2683,7 @@ bool CWallet::TopUpKeyPool(unsigned int nSize)
             if (!walletdb.WritePool(nEnd, CKeyPool(GenerateNewKey())))
                 throw runtime_error("TopUpKeyPool() : writing generated key failed");
             setKeyPool.insert(nEnd);
-            if (fDebug10) printf("keypool added key %"PRId64", size=%"PRIszu"\n", nEnd, setKeyPool.size());
+            if (fDebug10) printf("keypool added key %" PRId64 ", size=%" PRIszu "\n", nEnd, setKeyPool.size());
         }
     }
     return true;
@@ -2713,7 +2713,7 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
             throw runtime_error("ReserveKeyFromKeyPool() : unknown key in key pool");
         assert(keypool.vchPubKey.IsValid());
         if (fDebug && GetBoolArg("-printkeypool"))
-            printf("keypool reserve %"PRId64"\n", nIndex);
+            printf("keypool reserve %" PRId64 "\n", nIndex);
     }
 }
 
@@ -2741,7 +2741,7 @@ void CWallet::KeepKey(int64_t nIndex)
         walletdb.ErasePool(nIndex);
     }
     if(fDebug)
-        printf("keypool keep %"PRId64"\n", nIndex);
+        printf("keypool keep %" PRId64 "\n", nIndex);
 }
 
 void CWallet::ReturnKey(int64_t nIndex)
@@ -2752,7 +2752,7 @@ void CWallet::ReturnKey(int64_t nIndex)
         setKeyPool.insert(nIndex);
     }
     if(fDebug)
-        printf("keypool return %"PRId64"\n", nIndex);
+        printf("keypool return %" PRId64 "\n", nIndex);
 }
 
 bool CWallet::GetKeyFromPool(CPubKey& result, bool fAllowReuse)
@@ -3064,13 +3064,13 @@ std::string CWallet::GetAllGridcoinKeys()
         assert(keypool.vchPubKey.IsValid());
         CKeyID keyID = keypool.vchPubKey.GetID();
 
-        if (!HaveKey(keyID))  
+        if (!HaveKey(keyID))
 		{
 				//throw runtime_error("GetAllReserveKeyHashes() : unknown key in key pool");
 		}
 		else
 		{
-     
+
 				bool IsCompressed;
 				CKey vchSecret;
 				//CSecret vchSecret;
@@ -3082,7 +3082,7 @@ std::string CWallet::GetAllGridcoinKeys()
 				{
 					 CSecret secret = vchSecret.GetSecret(IsCompressed);
               		std::string private_key = CBitcoinSecret(secret,IsCompressed).ToString();
-				
+
 					//Append to file
 					std::string strAddr = CBitcoinAddress(keyID).ToString();
 					std::string record = private_key + "<|>" + strAddr + "<KEY>";
@@ -3158,4 +3158,3 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const {
     for (std::map<CKeyID, CBlockIndex*>::const_iterator it = mapKeyFirstBlock.begin(); it != mapKeyFirstBlock.end(); it++)
         mapKeyBirth[it->first] = it->second->nTime - 7200; // block times can be 2h off
 }
-

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -671,7 +671,7 @@ void ThreadFlushWalletDB(void* parg)
                         bitdb.CheckpointLSN(strFile);
 
                         bitdb.mapFileUseCount.erase(mi++);
-                        if (fDebug10) printf("Flushed wallet.dat %"PRId64"ms\n", GetTimeMillis() - nStart);
+                        if (fDebug10) printf("Flushed wallet.dat %" PRId64 "ms\n", GetTimeMillis() - nStart);
                     }
                 }
             }
@@ -686,7 +686,7 @@ bool BackupConfigFile(const string& strDest)
 	  filesystem::path pathDest(strDest);
       if (filesystem::is_directory(pathDest))
                     pathDest /= "gridcoinresearch.conf";
-	  try 
+	  try
 	  {
 			#if BOOST_VERSION >= 104000
                     filesystem::copy_file(pathSrc, pathDest, filesystem::copy_option::overwrite_if_exists);
@@ -696,7 +696,7 @@ bool BackupConfigFile(const string& strDest)
                     printf("copied gridcoinresearch.conf to %s\n", pathDest.string().c_str());
                     return true;
        }
-	   catch(const filesystem::filesystem_error &e) 
+	   catch(const filesystem::filesystem_error &e)
 	   {
                     printf("error copying gridcoinresearch.conf to %s - %s\n", pathDest.string().c_str(), e.what());
                     return false;
@@ -758,7 +758,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     // Set -rescan so any missing transactions will be
     // found.
     int64_t now = GetTime();
-    std::string newFilename = strprintf("wallet.%"PRId64".bak", now);
+    std::string newFilename = strprintf("wallet.%" PRId64 ".bak", now);
 
     int result = dbenv.dbenv.dbrename(NULL, filename.c_str(), NULL,
                                       newFilename.c_str(), DB_AUTO_COMMIT);
@@ -777,7 +777,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
         printf("Salvage(aggressive) found no records in %s.\n", newFilename.c_str());
         return false;
     }
-    printf("Salvage(aggressive) found %"PRIszu" records\n", salvagedData.size());
+    printf("Salvage(aggressive) found %" PRIszu " records\n", salvagedData.size());
 
     bool fSuccess = allOK;
     //Db* pdbCopy = new Db(&dbenv.dbenv, 0);


### PR DESCRIPTION
I was troubleshooting a build problem and ended up fixing a lot of small C++11 issues and GCC6 warnings along the way.  I can cut this into pieces if you only want part of it.

1. Updated build instructions and Unix Makefile to use the distro's LevelDB.  This works on Ubuntu 16.04LTS.
2. Switched auto_ptr to boost:shared_ptr because the former is deprecated in C++11.
3. Got rid of unused variables and functions caught by GCC.
4. Eliminated all -Wmisleading-indentation warnings with the exception of cpid.cpp. This highlighted the very different tab/space styles throughout the code, but I attempted to match the style of the immediate context.  cpid.cpp looks like it needs an autoformatter.
5. Fixed -Wliteral-suffix warnings around the 64-bit printfs so it will work with C++11.

After doing this I noticed that my editor had made line endings consistent in main.cpp.  They were previously a mix of Windows and Unix, which confused the Git diffs.  I think the files are correct, but the diff view is funny.

My editor also stripped trailing whitespace, but I couldn't filter it because of point 5 above.  On one hand I like the improved consistency, but it makes this change unwieldy.