### PR TITLE
Add diagnostic message for if web lookup fails for cpid valid test. 

### DIFF
--- a/contrib/Installer/boinc/boinc/modGRC.vb
+++ b/contrib/Installer/boinc/boinc/modGRC.vb
@@ -458,8 +458,9 @@ Module modGRC
         Try
             sRAC = w.DownloadString(sURL)
 
-        Catch ex As Exception
-
+        Catch ex As WebException
+            errors += "Unable to Connect to cpid.gridcoin.us. "
+            Return -1
         End Try
         Dim vRAC() As String
         vRAC = Split(sRAC, "<project>")


### PR DESCRIPTION
Should display failed and say why, not just cause an unhandled exception.