### PR TITLE
Invoke splash messages on the Qt event loop...

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,2 +1,2 @@
 Next:
-- Launching the graphical wallet on Linux should be more robus.
+- Bugfix. Launching the graphical wallet on Linux should be more robust (#139).

--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,2 @@
+Next:
+- Launching the graphical wallet on Linux should be more robus.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -109,8 +109,11 @@ static void InitMessage(const std::string &message)
 {
     if(splashref)
     {
-        splashref->showMessage(QString::fromStdString(message), Qt::AlignBottom|Qt::AlignHCenter, QColor(232,186,63));
-        QApplication::instance()->processEvents();
+        QMetaObject::invokeMethod(splashref, "showMessage",
+                                  Qt::QueuedConnection,
+                                  Q_ARG(QString, QString::fromStdString(message)),
+                                  Q_ARG(int, Qt::AlignBottom|Qt::AlignHCenter),
+                                  Q_ARG(QColor, QColor(232,186,63)));
     }
 }
 


### PR DESCRIPTION
.. instead of the current thread. I was able to reproduce the crash several times in a row without the fix but never with it. However, I have seen that it has been possible to start the wallet even without the fix so more testing could be needed.

Calling GUI code on a non-GUI thread is generally a bad idea. Instead, let Qt
invoke it on its main event loop thread. Either way, this is the way it's done in the Bitcoin wallet nowadays and it makes more sense to do it like this.

This closes #139.