### PR TITLE
Don't set or clear the stylesheet if nothing has changed.

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -15,7 +15,7 @@
 #include <qmath.h>
 
 BitcoinAmountField::BitcoinAmountField(QWidget *parent):
-        QWidget(parent), amount(0), currentUnit(-1)
+        QWidget(parent), amount(0), currentUnit(-1), valid(true)
 {
     amount = new QDoubleSpinBox(this);
     amount->setLocale(QLocale::c());
@@ -74,10 +74,15 @@ bool BitcoinAmountField::validate()
 
 void BitcoinAmountField::setValid(bool valid)
 {
+    if(valid == this->valid)
+        return;
+
     if (valid)
         amount->setStyleSheet("");
     else
         amount->setStyleSheet(STYLE_INVALID);
+
+    this->valid = valid;
 }
 
 QString BitcoinAmountField::text() const

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -47,6 +47,7 @@ private:
     QDoubleSpinBox *amount;
     QValueComboBox *unit;
     int currentUnit;
+    bool valid;
 
     void setText(const QString &text);
     QString text() const;


### PR DESCRIPTION
It seems that on KDE themes this will trigger an endless loop of focus events which trigger new stylesheet assignments. This bug is only verified to happen on environments which run a KDE theme such as Breeze.
The bitcoin wallet seems to not be affected by this. At least the binary release. No tests have been done on the source release.

To reproduce the bug, go to Send Coins and click the Amount input. The wallet will freeze.