### PR TITLE
Use a more efficient storage for CPID->blockhash map.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,7 @@ std::string ExtractValue(std::string data, std::string delimiter, int pos);
 extern bool IsSuperBlock(CBlockIndex* pIndex);
 extern MiningCPID GetBoincBlockByIndex(CBlockIndex* pblockindex);
 json_spirit::Array MagnitudeReport(std::string cpid);
-extern void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash, bool fInsert);
+extern void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash);
 extern void ZeroOutResearcherTotals(std::string cpid);
 extern StructCPID GetLifetimeCPID(std::string cpid,std::string sFrom);
 extern std::string getCpuHash();
@@ -3432,7 +3432,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
  	}
 
 
-	AddCPIDBlockHash(bb.cpid, pindex->GetBlockHash(), false);
+	AddCPIDBlockHash(bb.cpid, pindex->GetBlockHash());
 
     // Track money supply and mint amount info
     pindex->nMint = nValueOut - nValueIn + nFees;
@@ -6128,11 +6128,10 @@ HashSet GetCPIDBlockHashes(const std::string& cpid)
     return mvCPIDBlockHashes[cpid];
 }
 
-void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash, bool fInsert)
+void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash)
 {
-    HashSet& blockhashes = mvCPIDBlockHashes[cpid];
-    if (fInsert || blockhashes.count(blockhash) == 0 )
-        blockhashes.insert(blockhash);
+    // Add block hash to CPID hash set.
+    mvCPIDBlockHashes[cpid].insert(blockhash);
 }
 
 StructCPID GetLifetimeCPID(std::string cpid, std::string sCalledFrom)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6125,7 +6125,10 @@ bool GetEarliestStakeTime(std::string grcaddress, std::string cpid)
 
 HashSet GetCPIDBlockHashes(const std::string& cpid)
 {
-    return mvCPIDBlockHashes[cpid];
+    auto hashes = mvCPIDBlockHashes.find(cpid);
+    return hashes != mvCPIDBlockHashes.end()
+        ? hashes->second
+        : HashSet();
 }
 
 void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash)

--- a/src/main.h
+++ b/src/main.h
@@ -13,6 +13,9 @@
 
 #include "global_objects_noui.hpp"
 
+#include <map>
+#include <set>
+
 class CWallet;
 class CBlock;
 class CBlockIndex;
@@ -48,7 +51,7 @@ extern int muGlobalCheckpointHashCounter;
 extern std::string msMasterProjectPublicKey;
 extern std::string msMasterMessagePublicKey;
 extern std::string msMasterMessagePrivateKey;
-extern std::string msTestNetSeedSuperblocks;extern std::string msTestNetSeedContracts;extern std::string msProdSeedSuperblocks;extern std::string msProdSeedContracts400000;extern std::string msProdSeedContracts500000;extern std::string msProdSeedContracts550000;extern std::string msProdSeedContracts575000;extern std::string msProdSeedContracts600000;extern bool bNewUserWizardNotified;
+extern std::string msTestNetSeedSuperblocks;extern std::string msTestNetSeedContracts;extern std::string msProdSeedSuperblocks;extern std::string msProdSeedContracts400000;extern std::string msProdSeedContracts500000;extern std::string msProdSeedContracts550000;extern std::string msProdSeedContracts575000;extern std::string msProdSeedContracts600000;extern bool bNewUserWizardNotified;
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
@@ -122,7 +125,9 @@ extern std::map<std::string, StructCPID> mvDPORCopy;
 
 extern std::map<std::string, StructCPID> mvResearchAge;
 extern std::map<std::string, MiningCPID> mvBlockIndex;
-extern std::map<std::string, std::string> mvCPIDBlockHashes;
+
+typedef std::set<uint256> HashSet;
+extern std::map<std::string, HashSet> mvCPIDBlockHashes;
 
 
 extern CScript COINBASE_FLAGS;

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -29,7 +29,7 @@ StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, Stru
 bool IsLockTimeWithin14days(double locktime);
 MiningCPID GetInitializedMiningCPID(std::string name,std::map<std::string, MiningCPID>& vRef);
 MiningCPID DeserializeBoincBlock(std::string block);
-void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash, bool fInsert);
+void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash);
 
 
 void SetUpExtendedBlockIndexFieldsOnce();
@@ -712,7 +712,7 @@ bool CTxDB::LoadBlockIndex()
 						if (((double)pindex->nTime) > stCPID.HighLockTime) stCPID.HighLockTime = (double)pindex->nTime;
 			
 						mvResearchAge[pindex->sCPID]=stCPID;
-				    	AddCPIDBlockHash(pindex->sCPID, pindex->GetBlockHash(), true);
+				    	AddCPIDBlockHash(pindex->sCPID, pindex->GetBlockHash());
 
 					}
 				}

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -657,67 +657,56 @@ bool CTxDB::LoadBlockIndex()
 	nBlkStart = 1;
 	CBlockIndex* pindex = FindBlockByHeight(nBlkStart);
 
-	nLoaded=pindex->nHeight;
-	if (pindex && pindexBest && pindexBest->nHeight > 10 && pindex->pnext)
-	{
-		printf(" RA Starting %f %f %f ",(double)pindex->nHeight,(double)pindex->pnext->nHeight,(double)pindexBest->nHeight);
-		while (pindex->nHeight < pindexBest->nHeight)
-		{
-				if (!pindex || !pindex->pnext) break;  
-				pindex = pindex->pnext;
-				if (pindex == pindexBest) break;
-				if (pindex==NULL || !pindex->IsInMainChain()) continue;
-				//if (IsLockTimeWithin14days((double)pindex->nTime) && !bResearchAgeEnabled) 
-				//{
-				//	CBlock block;
-				//	if (!block.ReadFromDisk(pindex)) return false;
-				//	bb = DeserializeBoincBlock(block.vtx[0].hashBoinc);
-				//}
-
-				#ifdef QT_GUI
-				if ((pindex->nHeight % 10000) == 0)
-				{
-					nLoaded +=10000;
-					if (nLoaded > nHighest) nHighest=nLoaded;
-					if (nHighest < nGrandfather) nHighest=nGrandfather;
-					std::string sBlocksLoaded = RoundToString((double)nLoaded,0) + "/" + RoundToString((double)nHighest,0) + " POR Blocks Verified";
-					uiInterface.InitMessage(_(sBlocksLoaded.c_str()));
-     			}
-				#endif
-
-				if (!pindex->sCPID.empty())
-				{
-					if (pindex->nResearchSubsidy > 0 && pindex->sCPID != "INVESTOR") 
-					{
-			
-						//StructCPID stCPID = GetInitializedStructCPID2(pindex->sCPID, mvResearchAge);
-						StructCPID stCPID = mvResearchAge[pindex->sCPID];
-		
-	     				stCPID.InterestSubsidy += pindex->nInterestSubsidy;
-						stCPID.ResearchSubsidy += pindex->nResearchSubsidy;
-						if (((double)pindex->nHeight) > stCPID.LastBlock && pindex->nResearchSubsidy > 0) 
-						{
-								stCPID.LastBlock = (double)pindex->nHeight;
-								stCPID.BlockHash = pindex->GetBlockHash().GetHex();
-						}
-
-						if (pindex->nMagnitude > 0 && pindex->nResearchSubsidy > 0)
-						{
-							stCPID.Accuracy++;
-							stCPID.TotalMagnitude += pindex->nMagnitude;
-							stCPID.ResearchAverageMagnitude = stCPID.TotalMagnitude/(stCPID.Accuracy+.01);
-						}
-		
-						if (((double)pindex->nTime) < stCPID.LowLockTime)  stCPID.LowLockTime = (double)pindex->nTime;
-						if (((double)pindex->nTime) > stCPID.HighLockTime) stCPID.HighLockTime = (double)pindex->nTime;
-			
-						mvResearchAge[pindex->sCPID]=stCPID;
-				    	AddCPIDBlockHash(pindex->sCPID, pindex->GetBlockHash());
-
-					}
-				}
-		}
-	}
+   nLoaded=pindex->nHeight;
+   if (pindex && pindexBest && pindexBest->nHeight > 10 && pindex->pnext)
+   {
+      printf(" RA Starting %f %f %f ",(double)pindex->nHeight,(double)pindex->pnext->nHeight,(double)pindexBest->nHeight);
+      while (pindex->nHeight < pindexBest->nHeight)
+      {
+         if (!pindex || !pindex->pnext) break;  
+         pindex = pindex->pnext;
+         if (pindex == pindexBest) break;
+         if (pindex==NULL || !pindex->IsInMainChain()) continue;
+         
+#ifdef QT_GUI
+         if ((pindex->nHeight % 10000) == 0)
+         {
+            nLoaded +=10000;
+            if (nLoaded > nHighest) nHighest=nLoaded;
+            if (nHighest < nGrandfather) nHighest=nGrandfather;
+            std::string sBlocksLoaded = RoundToString((double)nLoaded,0) + "/" + RoundToString((double)nHighest,0) + " POR Blocks Verified";
+            uiInterface.InitMessage(_(sBlocksLoaded.c_str()));
+         }
+#endif
+         
+         if (!pindex->sCPID.empty() &&
+             pindex->nResearchSubsidy > 0 &&
+             pindex->sCPID != "INVESTOR") 
+         {
+            StructCPID& stCPID = mvResearchAge[pindex->sCPID];
+            
+            stCPID.InterestSubsidy += pindex->nInterestSubsidy;
+            stCPID.ResearchSubsidy += pindex->nResearchSubsidy;
+            if (pindex->nHeight > stCPID.LastBlock) 
+            {
+               stCPID.LastBlock = pindex->nHeight;
+               stCPID.BlockHash = pindex->GetBlockHash().GetHex();
+            }
+            
+            if (pindex->nMagnitude > 0)
+            {
+               stCPID.Accuracy++;
+               stCPID.TotalMagnitude += pindex->nMagnitude;
+               stCPID.ResearchAverageMagnitude = stCPID.TotalMagnitude/(stCPID.Accuracy+.01);
+            }
+            
+            if (pindex->nTime < stCPID.LowLockTime)  stCPID.LowLockTime = pindex->nTime;
+            if (pindex->nTime > stCPID.HighLockTime) stCPID.HighLockTime = pindex->nTime;
+            
+            AddCPIDBlockHash(pindex->sCPID, pindex->GetBlockHash());
+         }
+      }
+   }
 
 	printf("RA Complete - RA Time %15" PRId64 "ms\n", GetTimeMillis() - nStart);
 	nStart = GetTimeMillis();

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -29,7 +29,7 @@ StructCPID GetInitializedStructCPID2(std::string name,std::map<std::string, Stru
 bool IsLockTimeWithin14days(double locktime);
 MiningCPID GetInitializedMiningCPID(std::string name,std::map<std::string, MiningCPID>& vRef);
 MiningCPID DeserializeBoincBlock(std::string block);
-void AddCPIDBlockHash(std::string cpid, std::string blockhash, bool fInsert);
+void AddCPIDBlockHash(const std::string& cpid, const uint256& blockhash, bool fInsert);
 
 
 void SetUpExtendedBlockIndexFieldsOnce();
@@ -712,12 +712,13 @@ bool CTxDB::LoadBlockIndex()
 						if (((double)pindex->nTime) > stCPID.HighLockTime) stCPID.HighLockTime = (double)pindex->nTime;
 			
 						mvResearchAge[pindex->sCPID]=stCPID;
-				    	AddCPIDBlockHash(pindex->sCPID,pindex->GetBlockHash().GetHex(),true);
+				    	AddCPIDBlockHash(pindex->sCPID, pindex->GetBlockHash(), true);
 
 					}
 				}
 		}
 	}
+
 	printf("RA Complete - RA Time %15" PRId64 "ms\n", GetTimeMillis() - nStart);
 	nStart = GetTimeMillis();
 	SetUpExtendedBlockIndexFieldsOnce();


### PR DESCRIPTION
Use a more efficient storage for connecting CPID to block rewards. On my CPID the data structure went down from 33 to 11 megs (65%) but the amount saved is individual. I guess the older and more active CPID the greater the save.

There is one behaviour change though. The way the code was previously written it would be possible to get rewarded multiple times if two blocks shared the same hash. I guess that's not the intention even though it will "never" happen? Also, I think it's possible to merge the very similar code in txdb-leveldb with this one.

@skcin, can you have a look as well?