### PR TITLE
Store CPID in their numerical representation

### DIFF
--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -264,8 +264,9 @@ HEADERS += src/qt/bitcoingui.h \
     src/threadsafety.h \
     src/cpid.h \
     src/upgrader.h \
-    src/boinc.h
-
+    src/boinc.h \
+    src/gridcoin.h \
+    src/*.hpp
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/transactiontablemodel.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,10 +109,6 @@ bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit)
 double qtExecuteGenericFunction(std::string function,std::string data);
 extern std::string GetQuorumHash(std::string data);
 extern bool FullSyncWithDPORNodes();
-extern  void TestScan();
-extern void TestScan2();
-
-
 
 std::string qtExecuteDotNetStringFunction(std::string function, std::string data);
 
@@ -9300,36 +9296,6 @@ bool UnusualActivityReport()
 
 
     return true;
-}
-
-
-void TestScan()
-{
-    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
-    {
-        CBlockIndex* pindex = item.second;
-        if (LessVerbose(1) || pindex->nHeight > nNewIndex2)
-        {
-            printf("map block index h %f ,  cpid %s   , Mag  %f , RS %f, INT %f \r\n",(double)pindex->nHeight,pindex->sCPID.c_str(), (double)pindex->nMagnitude,
-                pindex->nResearchSubsidy,pindex->nInterestSubsidy);
-        }
-    }
-}
-
-
-void TestScan2()
-{
-    CBlockIndex* pindex = pindexBest;
-    while (pindex->nHeight > 1)
-    {
-        pindex = pindex->pprev;
-        if (LessVerbose(1) || pindex->nHeight > nNewIndex2)
-        {
-            printf("map block index h %f ,  cpid %s   , Mag  %f , RS %f, INT %f \r\n",(double)pindex->nHeight,pindex->sCPID.c_str(), (double)pindex->nMagnitude,
-                pindex->nResearchSubsidy,pindex->nInterestSubsidy);
-        }
-
-    }
 }
 
 double GRCMagnitudeUnit(int64_t locktime)

--- a/src/main.h
+++ b/src/main.h
@@ -1281,7 +1281,7 @@ public:
     int64_t nMint;
     int64_t nMoneySupply;
 	// Gridcoin (7-11-2015) Add new Accrual Fields to block index
-	std::string sCPID;
+    uint128 cpid;
 	double nResearchSubsidy;
 	double nInterestSubsidy;
 	double nMagnitude;
@@ -1296,6 +1296,8 @@ public:
         BLOCK_PROOF_OF_STAKE = (1 << 0), // is proof-of-stake block
         BLOCK_STAKE_ENTROPY  = (1 << 1), // entropy bit for stake modifier
         BLOCK_STAKE_MODIFIER = (1 << 2), // regenerated stake modifier
+        EMPTY_CPID           = (1 << 3), // CPID is empty
+        INVESTOR_CPID        = (1 << 4), // CPID equals "INVESTOR"
     };
 
     uint64_t nStakeModifier; // hash modifier for proof-of-stake
@@ -1338,7 +1340,6 @@ public:
         nBits          = 0;
         nNonce         = 0;
 		//7-11-2015 - Gridcoin - New Accrual Fields
-		sCPID = "";
 		nResearchSubsidy = 0;
 		nInterestSubsidy = 0;
 		nMagnitude = 0;
@@ -1458,6 +1459,11 @@ public:
         nFlags |= BLOCK_PROOF_OF_STAKE;
     }
 
+    bool IsUserCPID() const
+    {        
+        return !(nFlags & (INVESTOR_CPID | EMPTY_CPID));
+    }
+
     unsigned int GetStakeEntropyBit() const
     {
         return ((nFlags & BLOCK_STAKE_ENTROPY) >> 1);
@@ -1494,6 +1500,29 @@ public:
             prevoutStake.ToString().c_str(), nStakeTime,
             hashMerkleRoot.ToString().c_str(),
             GetBlockHash().ToString().c_str());
+    }
+    
+    void SetCPID(const std::string& cpid_hex)
+    { 
+        // Clear current CPID state.
+        cpid = 0;
+        nFlags &= ~(EMPTY_CPID | INVESTOR_CPID);
+        if(cpid_hex.empty())
+            nFlags |= EMPTY_CPID;
+        else if(cpid_hex == "INVESTOR")
+            nFlags |= INVESTOR_CPID;
+        else
+            cpid.SetHex(cpid_hex);
+    }
+    
+    std::string GetCPID() const
+    {
+        if(nFlags & EMPTY_CPID)
+            return "";
+        else if(nFlags == INVESTOR_CPID)
+            return "INVESTOR";
+        else
+            return cpid.GetHex();
     }
 
     void print() const
@@ -1561,7 +1590,11 @@ public:
         READWRITE(nNonce);
         READWRITE(blockHash);
 		//7-11-2015 - Gridcoin - New Accrual Fields (Note, Removing the determinstic block number to make this happen all the time):
-		READWRITE(sCPID);
+        std::string cpid_hex = GetCPID();
+        READWRITE(cpid_hex);
+        if(fRead)
+            const_cast<CDiskBlockIndex*>(this)->SetCPID(cpid_hex);
+            
 		READWRITE(nResearchSubsidy);
 		READWRITE(nInterestSubsidy);
 		READWRITE(nMagnitude);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -25,7 +25,7 @@ double GetBlockDifficulty(unsigned int nBits);
 double MintLimiter(double PORDiff,int64_t RSA_WEIGHT,std::string cpid,int64_t locktime);
 std::string ComputeCPIDv2(std::string email, std::string bpk, uint256 blockhash);
 double CoinToDouble(double surrogate);
-StructCPID GetLifetimeCPID(std::string cpid,std::string sFrom);
+StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sFrom);
 
 void ThreadTopUpKeyPool(void* parg);
 bool IsLockTimeWithinMinutes(int64_t locktime, int minutes);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -87,8 +87,6 @@ double GetCountOf(std::string datatype);
 extern double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out_participant_count,double& out_average, bool bIgnoreBeacons);
 extern bool CPIDAcidTest2(std::string bpk, std::string externalcpid);
 
-void TestScan();
-void TestScan2();
 bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit);
 bool FullSyncWithDPORNodes();
 bool LoadSuperblock(std::string data, int64_t nTime, double height);
@@ -2742,11 +2740,6 @@ Value execute(const Array& params, bool fHelp)
         }
 
         results.push_back(entry);
-    }
-    else if (sItem=="testscannew")
-    {
-        TestScan();
-        TestScan2();
     }
     else if (sItem == "tally")
     {

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -67,7 +67,7 @@ bool UpdateNeuralNetworkQuorumData();
 extern Array LifetimeReport(std::string cpid);
 Array StakingReport();
 extern std::string AddContract(std::string sType, std::string sName, std::string sContract);
-StructCPID GetLifetimeCPID(std::string cpid,std::string sFrom);
+StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sFrom);
 void WriteCache(std::string section, std::string key, std::string value, int64_t locktime);
 bool HasActiveBeacon(const std::string& cpid);
 int64_t GetEarliestWalletTransaction();
@@ -3317,7 +3317,7 @@ Array LifetimeReport(std::string cpid)
             pindex = pindex->pnext;
             if (pindex==NULL || !pindex->IsInMainChain()) continue;
             if (pindex == pindexBest) break;
-            if (pindex->sCPID == cpid && (pindex->nResearchSubsidy > 0)) 
+            if (pindex->GetCPID() == cpid && (pindex->nResearchSubsidy > 0))
             {
                 entry.push_back(Pair(RoundToString((double)pindex->nHeight,0), RoundToString(pindex->nResearchSubsidy,2)));
             }

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -398,10 +398,9 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nNonce         = diskindex.nNonce;
 
         //9-26-2016 - Gridcoin - New Accrual Fields
-
         if (diskindex.nHeight > nNewIndex)
         {
-            pindexNew->sCPID             = diskindex.sCPID;
+            pindexNew->cpid              = diskindex.cpid;
             pindexNew->nResearchSubsidy  = diskindex.nResearchSubsidy;
             pindexNew->nInterestSubsidy  = diskindex.nInterestSubsidy;
             pindexNew->nMagnitude        = diskindex.nMagnitude;
@@ -665,11 +664,12 @@ bool CTxDB::LoadBlockIndex()
             }
 #endif
             
-            if (!pindex->sCPID.empty() &&
-                pindex->nResearchSubsidy > 0 &&
-                pindex->sCPID != "INVESTOR") 
+            const std::string& scpid = pindex->GetCPID();
+            if (pindex->nResearchSubsidy > 0 &&
+                !scpid.empty() &&
+                scpid != "INVESTOR")
             {
-                StructCPID& stCPID = mvResearchAge[pindex->sCPID];
+                StructCPID& stCPID = mvResearchAge[scpid];
                 
                 stCPID.InterestSubsidy += pindex->nInterestSubsidy;
                 stCPID.ResearchSubsidy += pindex->nResearchSubsidy;
@@ -689,7 +689,7 @@ bool CTxDB::LoadBlockIndex()
                 if (pindex->nTime < stCPID.LowLockTime)  stCPID.LowLockTime = pindex->nTime;
                 if (pindex->nTime > stCPID.HighLockTime) stCPID.HighLockTime = pindex->nTime;
                 
-                AddCPIDBlockHash(pindex->sCPID, pindex->GetBlockHash());
+                AddCPIDBlockHash(scpid, pindex->GetBlockHash());
             }
         }
     }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -210,7 +210,6 @@ public:
         return ret;
     }
 
-
     friend inline bool operator<(const base_uint& a, const base_uint& b)
     {
         for (int i = base_uint::WIDTH-1; i >= 0; i--)
@@ -378,11 +377,13 @@ public:
         s.read((char*)pn, sizeof(pn));
     }
 
+    friend class uint128;
     friend class uint160;
     friend class uint256;
     friend inline int Testuint256AdHoc(std::vector<std::string> vArg);
 };
 
+typedef base_uint<128> base_uint128;
 typedef base_uint<160> base_uint160;
 typedef base_uint<256> base_uint256;
 
@@ -390,6 +391,118 @@ typedef base_uint<256> base_uint256;
 // uint160 and uint256 could be implemented as templates, but to keep
 // compile errors and debugging cleaner, they're copy and pasted.
 //
+
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// uint128
+//
+
+/** 128-bit unsigned integer */
+class uint128 : public base_uint128
+{
+public:
+    typedef base_uint128 basetype;
+
+    uint128()
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = 0;
+    }
+
+    uint128(const basetype& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = b.pn[i];
+    }
+
+    uint128& operator=(const basetype& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = b.pn[i];
+        return *this;
+    }
+
+    uint128(uint64_t b)
+    {
+        pn[0] = (unsigned int)b;
+        pn[1] = (unsigned int)(b >> 32);
+        for (int i = 2; i < WIDTH; i++)
+            pn[i] = 0;
+    }
+
+    uint128& operator=(uint64_t b)
+    {
+        pn[0] = (unsigned int)b;
+        pn[1] = (unsigned int)(b >> 32);
+        for (int i = 2; i < WIDTH; i++)
+            pn[i] = 0;
+        return *this;
+    }
+
+    explicit uint128(const std::string& str)
+    {
+        SetHex(str);
+    }
+
+    explicit uint128(const std::vector<unsigned char>& vch)
+    {
+        if (vch.size() == sizeof(pn))
+            memcpy(pn, &vch[0], sizeof(pn));
+        else
+            *this = 0;
+    }
+};
+
+inline bool operator==(const uint128& a, uint64_t b)                         { return (base_uint128)a == b; }
+inline bool operator!=(const uint128& a, uint64_t b)                         { return (base_uint128)a != b; }
+inline const uint128 operator<<(const base_uint128& a, unsigned int shift)   { return uint128(a) <<= shift; }
+inline const uint128 operator>>(const base_uint128& a, unsigned int shift)   { return uint128(a) >>= shift; }
+inline const uint128 operator<<(const uint128& a, unsigned int shift)        { return uint128(a) <<= shift; }
+inline const uint128 operator>>(const uint128& a, unsigned int shift)        { return uint128(a) >>= shift; }
+
+inline const uint128 operator^(const base_uint128& a, const base_uint128& b) { return uint128(a) ^= b; }
+inline const uint128 operator&(const base_uint128& a, const base_uint128& b) { return uint128(a) &= b; }
+inline const uint128 operator|(const base_uint128& a, const base_uint128& b) { return uint128(a) |= b; }
+inline const uint128 operator+(const base_uint128& a, const base_uint128& b) { return uint128(a) += b; }
+inline const uint128 operator-(const base_uint128& a, const base_uint128& b) { return uint128(a) -= b; }
+
+inline bool operator<(const base_uint128& a, const uint128& b)          { return (base_uint128)a <  (base_uint128)b; }
+inline bool operator<=(const base_uint128& a, const uint128& b)         { return (base_uint128)a <= (base_uint128)b; }
+inline bool operator>(const base_uint128& a, const uint128& b)          { return (base_uint128)a >  (base_uint128)b; }
+inline bool operator>=(const base_uint128& a, const uint128& b)         { return (base_uint128)a >= (base_uint128)b; }
+inline bool operator==(const base_uint128& a, const uint128& b)         { return (base_uint128)a == (base_uint128)b; }
+inline bool operator!=(const base_uint128& a, const uint128& b)         { return (base_uint128)a != (base_uint128)b; }
+inline const uint128 operator^(const base_uint128& a, const uint128& b) { return (base_uint128)a ^  (base_uint128)b; }
+inline const uint128 operator&(const base_uint128& a, const uint128& b) { return (base_uint128)a &  (base_uint128)b; }
+inline const uint128 operator|(const base_uint128& a, const uint128& b) { return (base_uint128)a |  (base_uint128)b; }
+inline const uint128 operator+(const base_uint128& a, const uint128& b) { return (base_uint128)a +  (base_uint128)b; }
+inline const uint128 operator-(const base_uint128& a, const uint128& b) { return (base_uint128)a -  (base_uint128)b; }
+
+inline bool operator<(const uint128& a, const base_uint128& b)          { return (base_uint128)a <  (base_uint128)b; }
+inline bool operator<=(const uint128& a, const base_uint128& b)         { return (base_uint128)a <= (base_uint128)b; }
+inline bool operator>(const uint128& a, const base_uint128& b)          { return (base_uint128)a >  (base_uint128)b; }
+inline bool operator>=(const uint128& a, const base_uint128& b)         { return (base_uint128)a >= (base_uint128)b; }
+inline bool operator==(const uint128& a, const base_uint128& b)         { return (base_uint128)a == (base_uint128)b; }
+inline bool operator!=(const uint128& a, const base_uint128& b)         { return (base_uint128)a != (base_uint128)b; }
+inline const uint128 operator^(const uint128& a, const base_uint128& b) { return (base_uint128)a ^  (base_uint128)b; }
+inline const uint128 operator&(const uint128& a, const base_uint128& b) { return (base_uint128)a &  (base_uint128)b; }
+inline const uint128 operator|(const uint128& a, const base_uint128& b) { return (base_uint128)a |  (base_uint128)b; }
+inline const uint128 operator+(const uint128& a, const base_uint128& b) { return (base_uint128)a +  (base_uint128)b; }
+inline const uint128 operator-(const uint128& a, const base_uint128& b) { return (base_uint128)a -  (base_uint128)b; }
+
+inline bool operator<(const uint128& a, const uint128& b)               { return (base_uint128)a <  (base_uint128)b; }
+inline bool operator<=(const uint128& a, const uint128& b)              { return (base_uint128)a <= (base_uint128)b; }
+inline bool operator>(const uint128& a, const uint128& b)               { return (base_uint128)a >  (base_uint128)b; }
+inline bool operator>=(const uint128& a, const uint128& b)              { return (base_uint128)a >= (base_uint128)b; }
+inline bool operator==(const uint128& a, const uint128& b)              { return (base_uint128)a == (base_uint128)b; }
+inline bool operator!=(const uint128& a, const uint128& b)              { return (base_uint128)a != (base_uint128)b; }
+inline const uint128 operator^(const uint128& a, const uint128& b)      { return (base_uint128)a ^  (base_uint128)b; }
+inline const uint128 operator&(const uint128& a, const uint128& b)      { return (base_uint128)a &  (base_uint128)b; }
+inline const uint128 operator|(const uint128& a, const uint128& b)      { return (base_uint128)a |  (base_uint128)b; }
+inline const uint128 operator+(const uint128& a, const uint128& b)      { return (base_uint128)a +  (base_uint128)b; }
+inline const uint128 operator-(const uint128& a, const uint128& b)      { return (base_uint128)a -  (base_uint128)b; }
 
 
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -24,7 +24,7 @@ static unsigned int GetStakeSplitAge() { return IsProtocolV2(nBestHeight) ? (10 
 static int64_t GetStakeCombineThreshold() { return IsProtocolV2(nBestHeight) ? (50 * COIN) : (1000 * COIN); }
 bool IsLockTimeWithinMinutes(int64_t locktime, int minutes);
 std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
-StructCPID GetLifetimeCPID(std::string cpid,std::string sFrom);
+StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sFrom);
 double cdbl(std::string s, int place);
 std::string GetArgument(std::string arg, std::string defaultvalue);
 std::string SendReward(std::string sAddress, int64_t nAmount);


### PR DESCRIPTION
This cuts the size of one CBlockIndex down by 32 bytes.
When assigning a CPID from text we track if it's an empty CPID or the "INVESTOR" CPID. When serializing the CPID to disk we convert it back to its textual representation for compatibility.
    
This closes #171.

@tomasbrod, @skcin Feel free to input.