### PR TITLE
Cpid diet

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -36,14 +36,12 @@ extern volatile bool bRequestFromHonestNode;
 extern volatile double nGlobalHashCounter;
 
 extern int miningthreadcount;
-	
-struct StructCPID 
+
+struct StructCPID
 {
     bool initialized;
-    bool isvoucher;
-    bool activeproject;
     bool Iscpidvalid;
-    
+
     double rac;
     double utc;
     double rectime;
@@ -52,41 +50,31 @@ struct StructCPID
     double verifiedutc;
     double verifiedrectime;
     double verifiedage;
-    double entries;
+    uint32_t entries;
     double AverageRAC;
     double NetworkProjects;
     double NetworkRAC;
     double TotalRAC;
     double TotalNetworkRAC;
     double Magnitude;
-    double LastMagnitude;
     double PaymentMagnitude;
     double owed;
     double payments;
     double interestPayments;
-    double outstanding;
     double verifiedTotalRAC;
     double verifiedMagnitude;
     double TotalMagnitude;
-    double MagnitudeCount;
-    double LowLockTime;
-    double HighLockTime;
+    uint32_t LowLockTime;
+    uint32_t HighLockTime;
     double Accuracy;
     double totalowed;
-    double longtermtotalowed;
-    double longtermowed;
     double LastPaymentTime;
     double ResearchSubsidy;
-    double ResearchSubsidy2;
-    double ResearchAge;
-    double ResearchMagnitudeUnit;
     double ResearchAverageMagnitude;
     double EarliestPaymentTime;
-    double RSAWeight;
     double InterestSubsidy;
     double PaymentTimespan;
-    double verifiedTotalNetworkRAC;
-    double LastBlock;
+    uint32_t LastBlock;
     double NetworkMagnitude;
     double NetworkAvgMagnitude;
     double NetsoftRAC;
@@ -111,36 +99,14 @@ struct StructCPID
     std::string PaymentAmountsBlocks;
     std::string BlockHash;
     std::string GRCAddress;
-    std::string LastPORBlockHash;
-    std::string CurrentNeuralHash;
-    std::string BoincPublicKey;
-    std::string BoincSignature;
 };
 
 
 
-struct StructCPIDCache 
+struct StructCPIDCache
 {
-    std::string cpid;
-    std::string cpidproject;
     std::string xml;
     bool initialized;
-    double blocknumber;
-};
-
-
-
-struct StructBlockCache 
-{
-    std::string cpid;
-    std::string project;
-    double rac;
-    std::string hashBoinc;
-    bool initialized;
-    int nHeight;
-    std::string hash;
-    int BlockType;
-    int nVersion;
 };
 
 
@@ -150,13 +116,10 @@ struct MiningCPID
     double rac;
     double pobdifficulty;
     unsigned int diffbytes;
-    bool initialized;	
+    bool initialized;
     double nonce;
     double NetworkRAC;
-    double VouchedRAC;
-    double VouchedNetworkRAC;
     double Magnitude;
-    double Accuracy;
     double RSAWeight;
     double LastPaymentTime;
     double ResearchSubsidy;
@@ -165,11 +128,8 @@ struct MiningCPID
     double ResearchMagnitudeUnit;
     double ResearchAverageMagnitude;
     double InterestSubsidy;
-    double GRCQuote;
-    double BTCQuote;
-    int prevBlockType;
     double Canary;
-    
+
     std::string projectname;
     std::string encboincpublickey;
     std::string cpid;
@@ -178,7 +138,6 @@ struct MiningCPID
     std::string aesskein;
     std::string encaes;
     std::string clientversion;
-    std::string VouchedCPID;
     std::string cpidv2;
     std::string email;
     std::string boincruntimepublickey;
@@ -192,12 +151,9 @@ struct MiningCPID
     std::string CurrentNeuralHash;
     std::string BoincPublicKey;
     std::string BoincSignature;
-    
 };
 
-extern std::map<int, int> blockcache;
-
-//User CPIDs 
+//User CPIDs
 extern std::map<std::string, StructCPID> mvCPIDs;
 //Verified CPIDs
 extern std::map<std::string, StructCPID> mvCreditNode;

--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -74,7 +74,7 @@ struct StructCPID
     double EarliestPaymentTime;
     double InterestSubsidy;
     double PaymentTimespan;
-    uint32_t LastBlock;
+    int32_t LastBlock;
     double NetworkMagnitude;
     double NetworkAvgMagnitude;
     double NetsoftRAC;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1077,7 +1077,6 @@ bool TallyMagnitudesInSuperblock()
 					{
 						StructCPID stCPID = GetInitializedStructCPID2(cpid,mvDPORCopy);
 	     				stCPID.TotalMagnitude = magnitude;
-						stCPID.MagnitudeCount++;
 						stCPID.Magnitude = magnitude;
 						stCPID.cpid = cpid;
 						mvDPORCopy[cpid]=stCPID;
@@ -3643,7 +3642,7 @@ Array MagnitudeReport(std::string cpid)
 											{
 
 												StructCPID stCPID = GetLifetimeCPID(structMag.cpid,"MagnitudeReport");
-												double days = (GetAdjustedTime() - stCPID.LowLockTime)/86400;
+												double days = (GetAdjustedTime() - stCPID.LowLockTime) / 86400.0;
      											entry.push_back(Pair("CPID",structMag.cpid));
 												// entry.push_back(Pair("PoolMining",bPoolMiningMode));
 												double dWeight = (double)GetRSAWeightByCPID(structMag.cpid);


### PR DESCRIPTION
Removed unused variables from CPID structures and changed the variable types from double to integers where they are supposed to be integers. This gives us a tiny size decrease of the StructCPID struct. I also removed the casts to double where the variables are automatically promoted to doubles anyway. This doesn't change anything but makes the code cleaner.