### PR TITLE
Fix nodes getting stuck syncing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7170,7 +7170,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-		if (pfrom->nVersion < 180322 & !fTestNet && pindexBest->nHeight > 855000)
+		if (pfrom->nVersion < 180322 && !fTestNet && pindexBest->nHeight > 855000)
         {
             // disconnect from peers older than this proto version - Enforce Beacon Age - 3-26-2017
             if (fDebug10) printf("partner %s using obsolete version %i (before enforcing beacon age); disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->nVersion);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -3822,7 +3822,13 @@ std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxS
 {
     const std::string key = "beacon;" + cpid;
     const std::string& value = mvApplicationCache[key];
-    int64_t iAge = pindexBest->nTime - mvApplicationCacheTimestamp[key];
+
+    // Compare the age of the beacon to the age of the current block. If we have
+    // no current block we assume that the beacon is valid.
+    int64_t iAge = pindexBest != NULL
+          ? pindexBest->nTime - mvApplicationCacheTimestamp[key]
+          : 0;
+
     return (iAge > iMaxSeconds)
           ? ""
           : value;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -3818,26 +3818,28 @@ std::string GetLocalBeaconPublicKey(std::string cpid)
 	return sBeaconPubKey;
 }
 
-std::string RetrieveCachedValueWithMaxAge(std::string sKey, int64_t iMaxSeconds)
+std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxSeconds)
 {
-	 int64_t iAge = GetAdjustedTime() - mvApplicationCacheTimestamp[sKey];
-	 std::string sValue = mvApplicationCache[sKey];
-	 // if (fDebug3) printf("\r\n BeaconAge %f, MaxAge %f, CPID %s\r\n",(double)iAge,(double)iMaxSeconds,sValue.c_str());
-	 return (iAge > iMaxSeconds) ? "" : sValue;
+    const std::string key = "beacon;" + cpid;
+    const std::string& value = mvApplicationCache[key];
+    int64_t iAge = pindexBest->nTime - mvApplicationCacheTimestamp[key];
+    return (iAge > iMaxSeconds)
+          ? ""
+          : value;
 }
 
 std::string GetBeaconPublicKey(std::string cpid)
 {
-	//3-26-2017 - Ensure beacon public key is within 6 months of network age
-	int64_t iMaxSeconds = 60 * 24 * 30 * 6 * 60;
-	std::string sBeacon = RetrieveCachedValueWithMaxAge("beacon;" + cpid, iMaxSeconds);
-	if (sBeacon.empty()) return "";
-	// Beacon data structure: CPID,hashRand,Address,beacon public key: base64 encoded
-	std::string sContract = DecodeBase64(sBeacon);
-	std::vector<std::string> vContract = split(sContract.c_str(),";");
-	if (vContract.size() < 4) return "";
-	std::string sBeaconPublicKey = vContract[3];
-	return sBeaconPublicKey;
+   //3-26-2017 - Ensure beacon public key is within 6 months of network age
+   int64_t iMaxSeconds = 60 * 24 * 30 * 6 * 60;
+   std::string sBeacon = RetrieveBeaconValueWithMaxAge(cpid, iMaxSeconds);
+   if (sBeacon.empty()) return "";
+   // Beacon data structure: CPID,hashRand,Address,beacon public key: base64 encoded
+   std::string sContract = DecodeBase64(sBeacon);
+   std::vector<std::string> vContract = split(sContract.c_str(),";");
+   if (vContract.size() < 4) return "";
+   std::string sBeaconPublicKey = vContract[3];
+   return sBeaconPublicKey;
 }
 
 bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature)


### PR DESCRIPTION
When determining if a beacon is old, compare its age to the age of th…e last known block and not the system time.

Without this comparing to the system time would cause unsynced nodes to get stuck if they try to reconnect while being offline for a while. The beacon age is a construct to save local space on the nodes so it needs to be compared within the nodes' time frames. Doing additional testing on this.

This closes #254.

It's possible that I made a bug in the new time limit so it allows everything instead. Master doesn't have unit tests so it's hard to test. I'll double check it.