### PR TITLE
Qt warnings

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -23,7 +23,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab_info">
       <attribute name="title">
@@ -586,7 +586,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_16">
+               <widget class="QLabel" name="label_17">
                 <property name="text">
                  <string>In:</string>
                 </property>
@@ -629,7 +629,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_17">
+               <widget class="QLabel" name="label_18">
                 <property name="text">
                  <string>Out:</string>
                 </property>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -143,7 +143,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
      <property name="buddy">
-      <cstring>Send Custom Message to Gridcoin Recipient</cstring>
+      <cstring>txtMessage</cstring>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Gets rid of a couple of Qt warnings. Qt seems to have rebuilt the rpcconsole.ui form, so would need some further testing.  