### PR TITLE
Use time limits when checking if beacons exist.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,8 +34,8 @@ extern std::string ConvertBinToHex(std::string a);
 extern std::string ConvertHexToBin(std::string a);
 extern bool WalletOutOfSync();
 extern bool WriteKey(std::string sKey, std::string sValue);
-std::string GetBeaconPublicKey(std::string cpid);
-std::string GetBeaconPrivateKey(std::string cpid);
+std::string GetBeaconPublicKey(const std::string& cpid);
+std::string GetBeaconPrivateKey(const std::string& cpid);
 bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
 std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
 extern void CleanInboundConnections(bool bClearAll);
@@ -85,7 +85,7 @@ std::string AddContract(std::string sType, std::string sName, std::string sContr
 bool CPIDAcidTest(std::string boincruntimepublickey);
 bool CPIDAcidTest2(std::string bpk, std::string externalcpid);
 
-std::string MyBeaconExists(std::string cpid);
+bool HasActiveBeacon(const std::string& cpid);
 extern bool BlockNeedsChecked(int64_t BlockTime);
 extern void FixInvalidResearchTotals(std::vector<CBlockIndex*> vDisconnect, std::vector<CBlockIndex*> vConnect);
 int64_t GetEarliestWalletTransaction();
@@ -7870,8 +7870,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 						if (s.size() > 1)
 						{
 								std::string cpid = s[0];
-								std::string myBeacon = MyBeaconExists(cpid);
-								if (myBeacon.length() > 10)
+								if (HasActiveBeacon(cpid))
 								{
 									bIgnore=true;
 									result = "Beacon already exists; ignoring request.";

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -31,8 +31,8 @@ bool CleanChain();
 extern std::string SendReward(std::string sAddress, int64_t nAmount);
 std::string GetLocalBeaconPublicKey(std::string cpid);
 extern double GetMagnitudeByCpidFromLastSuperblock(std::string sCPID);
-extern std::string GetBeaconPublicKey(std::string cpid);
-extern std::string GetBeaconPrivateKey(std::string cpid);
+std::string GetBeaconPublicKey(const std::string& cpid);
+std::string GetBeaconPrivateKey(const std::string& cpid);
 extern std::string SuccessFail(bool f);
 extern Array GetUpgradedBeaconReport();
 extern Array MagnitudeReport(std::string cpid);
@@ -79,7 +79,7 @@ std::string getCpuHash();
 extern std::string getHardwareID();
 std::string getMacAddress();
 void WriteCache(std::string section, std::string key, std::string value, int64_t locktime);
-extern std::string MyBeaconExists(std::string cpid);
+bool HasActiveBeacon(const std::string& cpid);
 int64_t GetEarliestWalletTransaction();
 extern bool CheckMessageSignature(std::string sAction,std::string messagetype, std::string sMsg, std::string sSig, std::string opt_pubkey);
 bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
@@ -1356,10 +1356,8 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
 				return bFromService ? true : false;
 			}
 			//If beacon is already in the chain, exit early
-		    std::string sBeaconPublicKey = GetBeaconPublicKey(GlobalCPUMiningCPID.cpid);
-			if (!sBeaconPublicKey.empty()) 	
+			if (HasActiveBeacon(GlobalCPUMiningCPID.cpid)) 	
 			{
-				// Ensure they can re-send the beacon if > 6 months old : GetBeaconPublicKey returns an empty string when > 6 months: OK.
 				sError = "ALREADY_IN_CHAIN";
 				return bFromService ? true : false;
 			}
@@ -1941,13 +1939,13 @@ Value execute(const Array& params, bool fHelp)
 		}
 		
 		entry.push_back(Pair("CPID", sCPID));
-		std::string sBeacon = MyBeaconExists(sCPID);
 		std::string sPubKey =  GetBeaconPublicKey(sCPID);
 		std::string sPrivKey = GetBeaconPrivateKey(sCPID);
 		int64_t iBeaconTimestamp = BeaconTimeStamp(sCPID, false);
 		std::string timestamp = TimestampToHRDate(iBeaconTimestamp);
 	
-		entry.push_back(Pair("Beacon Exists",YesNo(sBeacon.length() > 0)));
+		bool hasBeacon = HasActiveBeacon(sCPID);
+		entry.push_back(Pair("Beacon Exists",YesNo(hasBeacon)));
 		entry.push_back(Pair("Beacon Timestamp",timestamp.c_str()));
 
 		entry.push_back(Pair("Public Key", sPubKey.c_str()));
@@ -3796,13 +3794,12 @@ bool IsContractSettled(std::string sContractType, std::string sOpra)
 	return (!sTXID.empty());
 }
 
-std::string MyBeaconExists(std::string cpid)
+bool HasActiveBeacon(const std::string& cpid)
 {
-	std::string myBeacon = mvApplicationCache["beacon;" + cpid];
-	return myBeacon;
+    return GetBeaconPublicKey(cpid).empty() == false;
 }
 
-std::string GetBeaconPrivateKey(std::string cpid)
+std::string GetBeaconPrivateKey(const std::string& cpid)
 {
 	// 10-15-2016: Add the Suffix to the PrivateKey, so TestNet uses distinct keys
 	std::string sSuffix = fTestNet ? "testnet" : "";
@@ -3834,7 +3831,7 @@ std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxS
           : value;
 }
 
-std::string GetBeaconPublicKey(std::string cpid)
+std::string GetBeaconPublicKey(const std::string& cpid)
 {
    //3-26-2017 - Ensure beacon public key is within 6 months of network age
    int64_t iMaxSeconds = 60 * 24 * 30 * 6 * 60;


### PR DESCRIPTION
The previous MyBeaconExists checked the entire app cache which grows over time. This would cause running nodes to reject the "addbeacon" neural request even if the old beacon has expired.

I couldn't find where the "addbeacon" request originated so I might just be fixing dead code :)