### PR TITLE
Move FindBlockByHeight functions to a separate class.

### DIFF
--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -190,6 +190,7 @@ HEADERS += src/qt/bitcoingui.h \
     src/addrman.h \
     src/base58.h \
     src/bignum.h \
+    src/block.h \
     src/checkpoints.h \
     src/compat.h \
     src/coincontrol.h \
@@ -276,6 +277,7 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/bitcoinaddressvalidator.cpp \
     src/qt/votingdialog.cpp \
     src/alert.cpp \
+    src/block.cpp \
     src/version.cpp \
     src/sync.cpp \
     src/util.cpp \

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -1,0 +1,41 @@
+#include "block.h"
+#include "main.h"
+
+#include <cstdlib>
+
+BlockFinder::BlockFinder()
+    : cache(nullptr)
+{}
+
+CBlockIndex* BlockFinder::FindByHeight(int height)
+{
+    // If the height is at the bottom half of the chain, start searching from
+    // the start to the end, otherwise search backwards from the end.
+    CBlockIndex *index = height < nBestHeight / 2
+            ? pindexGenesisBlock
+            : pindexBest;
+    
+    if(index != nullptr)
+    {
+        // Use the cache if it's closer to the target than the current
+        // start block.
+        if (cache && abs(height - index->nHeight) > std::abs(height - cache->nHeight))
+            index = cache;
+        
+        // Traverse towards the tail.
+        while (index && index->pprev && index->nHeight > height)
+            index = index->pprev;
+        
+        // Traverse towards the head.
+        while (index && index->pnext && index->nHeight < height)
+            index = index->pnext;
+    }
+   
+    cache = index;
+    return index;  
+}
+
+void BlockFinder::Reset()
+{
+    cache = nullptr;
+}

--- a/src/block.h
+++ b/src/block.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "fwd.h"
+
+//!
+//! \brief Chain traversing block finder.
+//!
+class BlockFinder
+{
+public:
+    //!
+    //! \brief Constructor.
+    //!
+    BlockFinder();
+    
+    //!
+    //! \brief Find a block with a specific height.
+    //! 
+    //! Traverses the chain from head or tail, depending on what's closest to
+    //! find the block that matches \p height. This is a caching operation
+    //! 
+    //! \param nHeight Block height to find.
+    //! \return The block with the height closest to \p nHeight if found, otherwise
+    //! \a nullptr is returned.
+    //!
+    CBlockIndex* FindByHeight(int height);
+    
+    //!
+    //! \brief Reset finder cache.
+    //!
+    //! Clears the block finder cache. This should be used when blocks are removed
+    //! from the chain to avoid accessing deleted memory.
+    //! 
+    void Reset();
+    
+private:
+    CBlockIndex* cache;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6877,7 +6877,7 @@ bool AcidTest(std::string precommand, std::string acid, CNode* pfrom)
 	
 		if (false && hash != pw1)
 		{
-			//2/16 18:06:48 Acid test failed for 192.168.1.4:32749 1478973994,encrypt,1b089d19d23fbc911c6967b948dd8324,windows			if (fDebug) printf("Acid test failed for %s %s.",NodeAddress(pfrom).c_str(),acid.c_str());
+			//2/16 18:06:48 Acid test failed for 192.168.1.4:32749 1478973994,encrypt,1b089d19d23fbc911c6967b948dd8324,windows			if (fDebug) printf("Acid test failed for %s %s.",NodeAddress(pfrom).c_str(),acid.c_str());
 			double punishment = GetArg("-punishment", 10);
 			pfrom->Misbehaving(punishment);
 			return false;
@@ -10374,7 +10374,7 @@ void SetUpExtendedBlockIndexFieldsOnce()
 	printf("SETUPExtendedBIfieldsOnce Testnet: %s \r\n",YesNo(fTestNet).c_str());
 	if (fTestNet)
 	{
-		if (pindexBest->nHeight < 20000) return;	}
+		if (pindexBest->nHeight < 20000) return;	}
 	else
 	{
 		if (pindexBest->nHeight < 361873) return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,8 +198,6 @@ int64_t nLastCalculatedMedianPeerCount = 0;
 int nLastMedianPeerCount = 0;
 int64_t nLastTallyBusyWait = 0;
 
-double nVolatility = .90;
-double nRiskFreeRate = .015;
 int64_t nLastTalliedNeural = 0;
 int64_t nLastLoadAdminMessages = 0;
 int64_t nCPIDsLoaded = 0;
@@ -238,9 +236,6 @@ json_spirit::Array MagnitudeReportCSV(bool detail);
 bool bNewUserWizardNotified = false;
 int64_t nLastBlockSolved = 0;  //Future timestamp
 int64_t nLastBlockSubmitted = 0;
-
-
-double mPI = 3.141592653589793238462643;
 
 uint256 muGlobalCheckpointHash = 0;
 uint256 muGlobalCheckpointHashRelayed = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -256,11 +256,6 @@ FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszM
 FILE* AppendBlockFile(unsigned int& nFileRet);
 bool LoadBlockIndex(bool fAllowNew=true);
 void PrintBlockTree();
-CBlockIndex* FindBlockByHeight(int nHeight);
-
-CBlockIndex* RPCFindBlockByHeight(int nHeight);
-
-CBlockIndex* MainFindBlockByHeight(int nHeight);
 
 bool ProcessMessages(CNode* pfrom);
 bool SendMessages(CNode* pto, bool fSendTrickle);

--- a/src/main.h
+++ b/src/main.h
@@ -57,7 +57,6 @@ extern std::string msTestNetSeedSuperblocks;extern std::string msTestNetSeedCont
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** Target Blocks Per day */
 static const unsigned int BLOCKS_PER_DAY = 1000;
-static const double TOLERANCE_PERCENT = 0;  // The amount a network consensus magnitude can be skewed by before calling etsoft (Removed as of 7/3/2015 - NeuralNetwork)
 /** The maximum size for mined blocks */
 static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;
 /** The maximum size for transactions we're willing to relay/mine **/

--- a/src/main.h
+++ b/src/main.h
@@ -31,8 +31,6 @@ static const int LAST_POW_BLOCK = 2050;
 extern unsigned int REORGANIZE_FAILED;
 extern unsigned int WHITELISTED_PROJECTS;
 extern unsigned int CHECKPOINT_VIOLATIONS;
-extern double nVolatility;
-extern double nRiskFreeRate;
 static const int MAX_NEWBIE_BLOCKS = 200;
 static const int MAX_NEWBIE_BLOCKS_LEVEL2 = 500;
 static const int CHECKPOINT_DISTRIBUTED_MODE = 50;
@@ -43,7 +41,6 @@ static const double NeuralNetworkMultiplier = 115000;
 
 extern int64_t nLastBlockSolved;
 extern int64_t nLastBlockSubmitted;
-extern double mPI;
 
 extern uint256 muGlobalCheckpointHash;
 extern uint256 muGlobalCheckpointHashRelayed;

--- a/src/makefile.bsd
+++ b/src/makefile.bsd
@@ -127,6 +127,7 @@ OBJS= \
     obj/scrypt-arm.o \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
+    obj/block.o
 
 all: Gridcoind
 

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -90,7 +90,8 @@ OBJS= \
     obj/scrypt.o \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
-    obj/cpid.o 
+    obj/cpid.o \
+    obj/block.o 
 
 all: gridcoinresearchd.exe
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -131,7 +131,8 @@ OBJS= \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
     obj/cpid.o \
-    obj/upgrader.o
+    obj/upgrader.o \
+    obj/block.o
 
 all: gridcoinresearchd.exe
 

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -97,7 +97,8 @@ OBJS= \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
     obj/cpid.o \
-    obj/upgrader.o
+    obj/upgrader.o \
+    obj/block.o
 
 ifndef USE_UPNP
 	override USE_UPNP = -

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -130,7 +130,7 @@ OBJS= \
     obj/script.o \
     obj/sync.o \
     obj/util.o \
-	obj/upgrader.o \
+    obj/upgrader.o \
     obj/wallet.o \
     obj/walletdb.o \
     obj/noui.o \
@@ -140,7 +140,8 @@ OBJS= \
     obj/scrypt-arm.o \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
-    obj/cpid.o 
+    obj/cpid.o \
+    obj/block.o
 
 all: gridcoinresearchd
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -47,6 +47,7 @@
 #include "rpcconsole.h"
 #include "wallet.h"
 #include "init.h"
+#include "block.h"
 
 #ifdef Q_OS_MAC
 #include "macdockiconhandler.h"
@@ -1705,7 +1706,7 @@ std::string RetrieveBlockAsString(int lSqlBlock)
 		if (lSqlBlock==0) lSqlBlock=1;
 		if (lSqlBlock > nBestHeight-2) return "";
 		CBlock block;
-		CBlockIndex* blockindex = MainFindBlockByHeight(lSqlBlock);
+		CBlockIndex* blockindex = BlockFinder().FindByHeight(lSqlBlock);
 		block.ReadFromDisk(blockindex);
 
 		std::string s = "";

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -9,6 +9,7 @@
 #include "cpid.h"
 #include "kernel.h"
 #include "init.h" // for pwalletMain
+#include "block.h"
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include "txdb.h"
@@ -210,7 +211,7 @@ uint256 GridcoinMultipleAlgoHash(std::string t1);
 void ExecuteCode();
 void CreditCheckRetired(std::string cpid, bool clearcache);
 double CalculatedMagnitude(int64_t locktime,bool bUseLederstrumpf);
-
+static BlockFinder RPCBlockFinder;
 
 
 double GetNetworkProjectCountWithRAC()
@@ -487,7 +488,7 @@ Value showblock(const Array& params, bool fHelp)
     int nHeight = params[0].get_int();
     if (nHeight < 0 || nHeight > nBestHeight)
         throw runtime_error("Block number out of range.");
-    CBlockIndex* pblockindex = RPCFindBlockByHeight(nHeight);
+    CBlockIndex* pblockindex = RPCBlockFinder.FindByHeight(nHeight);
 
     if (pblockindex==NULL)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
@@ -576,7 +577,7 @@ Value getblockhash(const Array& params, bool fHelp)
     int nHeight = params[0].get_int();
     if (nHeight < 0 || nHeight > nBestHeight)       throw runtime_error("Block number out of range.");
 	if (fDebug10)	printf("Getblockhash %f",(double)nHeight);
-	CBlockIndex* RPCpblockindex = RPCFindBlockByHeight(nHeight);
+	CBlockIndex* RPCpblockindex = RPCBlockFinder.FindByHeight(nHeight);
 	return RPCpblockindex->phashBlock->GetHex();
 }
 

--- a/src/test/block_tests.cpp
+++ b/src/test/block_tests.cpp
@@ -1,0 +1,70 @@
+#include "main.h"
+#include "block.h"
+
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <cstdint>
+
+namespace
+{
+   template<size_t Size>
+   class BlockChain
+   {
+   public:
+      BlockChain()
+      {
+         // Initialize block link.
+         for(auto block = blocks.begin(); block != blocks.end(); ++block)
+         {
+            CBlockIndex& prev = *std::prev(block);
+            CBlockIndex& next = *std::next(block);
+            if(block != &blocks.front())
+            {
+               block->pprev = &prev;
+               block->nHeight = prev.nHeight + 1;
+            }
+            if(block != &blocks.back())
+               block->pnext = &next;      
+         }
+         
+         // Setup global variables.
+         pindexBest = &blocks.back();
+         pindexGenesisBlock = &blocks.front();         
+         nBestHeight = blocks.back().nHeight;
+      }
+      
+      std::array<CBlockIndex, Size> blocks;      
+   };
+}
+
+BOOST_AUTO_TEST_SUITE(block_tests);
+
+BOOST_AUTO_TEST_CASE(FindBlockInNormalChainShouldWork)
+{
+   BlockChain<100> chain;
+   BlockFinder finder;
+   
+   for(auto& block : chain.blocks)
+       BOOST_CHECK_EQUAL(&block, finder.FindByHeight(block.nHeight));
+}
+
+BOOST_AUTO_TEST_CASE(FindBlockAboveHighestHeightShouldReturnHighestBlock)
+{
+   BlockChain<100> chain;
+   BlockFinder finder;
+   
+   CBlockIndex& last = chain.blocks.back();
+   BOOST_CHECK_EQUAL(&last, finder.FindByHeight(101));   
+}
+
+BOOST_AUTO_TEST_CASE(FindBlockByHeightShouldWorkOnChainsWithJustOneBlock)
+{
+   BlockChain<1> chain;
+   BlockFinder finder;
+   
+   BOOST_CHECK_EQUAL(&chain.blocks.front(), finder.FindByHeight(0));
+   BOOST_CHECK_EQUAL(&chain.blocks.front(), finder.FindByHeight(1));
+   BOOST_CHECK_EQUAL(&chain.blocks.front(), finder.FindByHeight(-1));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -19,6 +19,7 @@
 #include "txdb.h"
 #include "util.h"
 #include "main.h"
+#include "block.h"
 #include "ui_interface.h"
 
 using namespace std;
@@ -648,11 +649,7 @@ bool CTxDB::LoadBlockIndex()
     nStart = GetTimeMillis();
     
     //Gridcoin - In order, set up Research Age hashes and lifetime fields
-    int lookback = 1000*190;
-    int nBlkStart = pindexBest->nHeight - lookback;
-    if (nBlkStart < 10) nBlkStart=10;
-    nBlkStart = 1;
-    CBlockIndex* pindex = FindBlockByHeight(nBlkStart);
+    CBlockIndex* pindex = BlockFinder().FindByHeight(1);
     
     nLoaded=pindex->nHeight;
     if (pindex && pindexBest && pindexBest->nHeight > 10 && pindex->pnext)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -14,6 +14,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 #include "cpid.h"
+#include "block.h"
 
 using namespace std;
 
@@ -3050,7 +3051,7 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const {
             mapKeyBirth[it->first] = it->second.nCreateTime;
 
     // map in which we'll infer heights of other keys
-    CBlockIndex *pindexMax = FindBlockByHeight(std::max(0, nBestHeight - 144)); // the tip can be reorganised; use a 144-block safety margin
+    CBlockIndex *pindexMax = BlockFinder().FindByHeight(std::max(0, nBestHeight - 144)); // the tip can be reorganised; use a 144-block safety margin
     std::map<CKeyID, CBlockIndex*> mapKeyFirstBlock;
     std::set<CKeyID> setKeys;
     GetKeys(setKeys);


### PR DESCRIPTION
This originated from trying to fix a crash bug on testnet. Due to the way the
cache worked it was very tricky to unit test the functionality I it was
extracted to its own class. Every caller can now carry its own cache and there
are fewer static states hanging around. All the various block finding
implementations have been merged into one. It should also be easy to adapt the
finder to parallell find if needed in the future.