### PR TITLE
[Development branch] Generate AppImage for each git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
----
 language: cpp
 sudo: required
 dist: trusty
@@ -27,7 +26,22 @@ script:
   - chmod 755 src/leveldb/build_detect_platform
   - cd src
   - make -f makefile.unix DEBUGFLAGS="" USE_UPNP=1
+  - mkdir -p ../appdir/usr/bin
+  - # install -m 755 gridcoinresearchd ../appdir/usr/bin/gridcoinresearchd
   - cd ..
-  - qmake "USE_QRCODE=1" "USE_UPNP=1" "NO_UPGRADE=1"
-  - make
+  - qmake "USE_QRCODE=1" "USE_UPNP=1" "NO_UPGRADE=1" PREFIX=/usr
+  - make -j4
+  - strip gridcoinresearch
+  - mkdir -p ./appdir/usr/share/applications
+  - cp ./share/gridcoinresearch.desktop ./appdir/usr/share/applications
+  - cp ./share/pixmaps/bitcoin256.png ./appdir/gridcoinresearch.png
+  - install -m 755 gridcoinresearch appdir/usr/bin/gridcoinresearch ; find appdir/
 
+after_success:
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./Gri*.AppImage https://transfer.sh/Gridcoin_Research-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/share/gridcoinresearch.desktop
+++ b/share/gridcoinresearch.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Gridcoin Research
+Exec=gridcoinresearch
+Icon=gridcoinresearch
+Categories=Office;Finance;


### PR DESCRIPTION
![screenshot from 2017-04-15 17-02-00](https://cloud.githubusercontent.com/assets/2480569/25064582/504f34b0-21fd-11e7-9c1e-19b5b89900a7.png)

Closes https://github.com/gridcoin/Gridcoin-Research/issues/278 and https://github.com/gridcoin/Gridcoin-Research/issues/280

This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

But I get:

> To get started with Boinc, run the boinc client, choose projects, then populate the gridcoinresearch.conf file in %appdata%\GridcoinResearch with your boinc e-mail address.  To run this wizard again, please delete the gridcoinresearch.conf file. 
> 
> Boinc is not installed in default location /var/lib/boinc-client/!  Please set boincdatadir=c:\programdata\boinc\    to the correct path where Boincs programdata directory resides.

Seems like we should bundle it inside the AppImage?

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.