### PR TITLE
 Remove Gridcoin address from blocks to save memory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    to the wallet being locked, #264.
  - Improve beacon advertise error message, #133 (@comprehendreality).
  - Remove empty "wcgtest" RPC command.
-
+ - Remove address from blocks to save RAM. Address in CSV export are now always
+   empty.
 
 ## [3.5.8.9] - 2017-05-15
 ### Added

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3214,7 +3214,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             }
             iPos++;
         }
-        pindex->sGRCAddress = bb.GRCAddress;
     }
 
     double mint = CoinToDouble(pindex->nMint);
@@ -5543,7 +5542,6 @@ void AddResearchMagnitude(CBlockIndex* pIndex)
         {
             StructCPID stMag = GetInitializedStructCPID2(pIndex->GetCPID(),mvMagnitudesCopy);
             stMag.cpid = pIndex->GetCPID();
-            stMag.GRCAddress = pIndex->sGRCAddress;
             if (pIndex->nHeight > stMag.LastBlock)
             {
                 stMag.LastBlock = pIndex->nHeight;

--- a/src/main.h
+++ b/src/main.h
@@ -978,7 +978,7 @@ class CBlock
 {
 public:
     // header
-    static const int CURRENT_VERSION = 7;
+    static const int CURRENT_VERSION = 8;
     int nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
@@ -1303,7 +1303,6 @@ public:
 	// Indicators (9-13-2015)
 	unsigned int nIsSuperBlock;
 	unsigned int nIsContract;
-	std::string sGRCAddress;
 
     unsigned int nFlags;  // ppcoin: block index flags
     enum  
@@ -1360,7 +1359,6 @@ public:
 		nMagnitude = 0;
 		nIsSuperBlock = 0;
 		nIsContract = 0;
-		sGRCAddress = "";
     }
 
     CBlockIndex(unsigned int nFileIn, unsigned int nBlockPosIn, CBlock& block)
@@ -1596,7 +1594,7 @@ public:
             const_cast<CDiskBlockIndex*>(this)->nStakeTime = 0;
         }
         READWRITE(hashProof);
-
+        
         // block header
         READWRITE(this->nVersion);
         READWRITE(hashPrev);
@@ -1605,29 +1603,26 @@ public:
         READWRITE(nBits);
         READWRITE(nNonce);
         READWRITE(blockHash);
-		//7-11-2015 - Gridcoin - New Accrual Fields (Note, Removing the determinstic block number to make this happen all the time):
+        //7-11-2015 - Gridcoin - New Accrual Fields (Note, Removing the determinstic block number to make this happen all the time):
         std::string cpid_hex = GetCPID();
         READWRITE(cpid_hex);
         if(fRead)
             const_cast<CDiskBlockIndex*>(this)->SetCPID(cpid_hex);
-            
-		READWRITE(nResearchSubsidy);
-		READWRITE(nInterestSubsidy);
-		READWRITE(nMagnitude);
-	    //9-13-2015 - Indicators
-		if (this->nHeight > nNewIndex2)
-		{
-			READWRITE(nIsSuperBlock);
-			READWRITE(nIsContract);
-			READWRITE(sGRCAddress);
+        
+        READWRITE(nResearchSubsidy);
+        READWRITE(nInterestSubsidy);
+        READWRITE(nMagnitude);
+        //9-13-2015 - Indicators
+        if (this->nHeight > nNewIndex2)
+        {
+            READWRITE(nIsSuperBlock);
+            READWRITE(nIsContract);
 
-                        // Blocks used to come with a reserved string. Keep (de)serializing
-                        // it until it's used.
-                        std::string sReserved;
-                        READWRITE(sReserved);
-		}
-
-
+            // Blocks used to come with a Gridcoin address and a reserved string
+            // (in that order) here. Both of these have been removed since block
+            // version 8. Since they were the last variables to be deserialized
+            // we can skip them entirely.
+        }
     )
 
     uint256 GetBlockHash() const

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -4352,9 +4352,11 @@ Array MagnitudeReportCSV(bool detail)
                     {
                         outstanding = structMag.totalowed - structMag.payments;
                         
-                        StructCPID stDPOR = mvDPOR[structMag.cpid];
-                    
-                        row = structMag.cpid + "," + structMag.GRCAddress + "," + RoundToString(structMag.Magnitude,2) + "," 
+			// 2017-05-20 - Remove GRC address from blocks and StructCPID.
+			// In the CSV export this is replaced with and empty string
+			// in order to not break existing parsers. This can be removed
+			// in the future. /Marco 
+                        row = structMag.cpid + ",," + RoundToString(structMag.Magnitude,2) + "," 
                             + RoundToString(structMag.PaymentMagnitude,0) + "," + RoundToString(structMag.Accuracy,0) + "," + RoundToString(structMag.totalowed,2) 
                             + "," + RoundToString(structMag.totalowed/14,2)
                             + "," + RoundToString(structMag.payments,2) + "," 


### PR DESCRIPTION
The intention was to map an address to a CPID but it was never used fully.
This address was used in the CSV export. In order to preserve the functionality of existing CSV parsers the address field has been kept but is now always empty. Parsers should prepare for removal of this field in the future.

Got ok from Rob to remove this but I could use some more pair of eyes to see if this is the correct approach. On my system this saves 32 bytes per block index, so around 29MB given the current block count.