### PR TITLE
indent compiler warning fix for RPC command debug flag control.

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -3317,7 +3317,7 @@ Value execute(const Array& params, bool fHelp)
         }
         else
             entry.push_back(Pair("Error","You must specify true or false as an option."));
-            results.push_back(entry);
+        results.push_back(entry);
     }
     else if (sItem == "debug3")
     {


### PR DESCRIPTION
Fixed indent warning during compiling for this recent addition of code.