### PR TITLE
compiler indent warning fix. - Made if statement consistant with code.

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -41,8 +41,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     //1-2-2015 Halford - Mask Orphans from User View so they do not complain
     std::string orphan_mask = GetArg("-showorphans", "false");
-    if (orphan_mask != "true") if ((status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))  return false;
-
+    if (orphan_mask != "true" && (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))
+        return false;
     if(!(TYPE(type) & typeFilter))
         return false;
     if(datetime < dateFrom || datetime > dateTo)

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -39,9 +39,9 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
 
     if(!showInactive && (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))
         return false;
-	//1-2-2015 Halford - Mask Orphans from User View so they do not complain
-	std::string orphan_mask = GetArg("-showorphans", "false");
-	if (orphan_mask != "true") if ((status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))  return false;
+    //1-2-2015 Halford - Mask Orphans from User View so they do not complain
+    std::string orphan_mask = GetArg("-showorphans", "false");
+    if (orphan_mask != "true") if ((status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))  return false;
 
     if(!(TYPE(type) & typeFilter))
         return false;


### PR DESCRIPTION
Fixed indent warning during compiling (2 of them over this indent)
Left robs if statements as is.
converted the tabs to 4 spaces.
Put return on separate line to be consistent with coding in file.