### PR TITLE
Change toolbar and toolbutton size in native scheme to fit the light scheme

### DIFF
--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -3,6 +3,20 @@ QMainWindow {
     font-family:'Open Sans,sans-serif';
 }
 
+#toolbar {
+    min-width:160px;
+    max-width:160px;
+}
+
+QToolBar#toolbar QToolButton {
+    padding-left:20px;
+    padding-right:20px;
+    padding-top:7px;
+    padding-bottom:7px;
+    margin:3px;
+    width:100%;
+}
+
 QToolBar#toolbar2 QLabel{
     border:none;
     padding-top:15px;


### PR DESCRIPTION
The left toolbar should have the same size now in both color schemes.