### PR TITLE
Re-enable AdvancedDecrypt in Tx Messages

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -307,13 +307,13 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
 		//Decrypt any embedded messages
 		std::string eGRCMessage = ExtractXML(wtx.hashBoinc,"<MESSAGE>","</MESSAGE>");
 		std::string sOptionsNarr = ExtractXML(wtx.hashBoinc,"<NARR>","</NARR>");
-		//std::string sGRCMessage = AdvancedDecrypt(eGRCMessage);
+		std::string sGRCMessage = AdvancedDecrypt(eGRCMessage);
 		// Contracts
 		//std::string sContractLength = RoundToString((double)wtx.hashBoinc.length(),0);
 		//std::string sContractInfo = "";
 		//if (wtx.hashBoinc.length() > 255) sContractInfo = ": " + wtx.hashBoinc.substr(0,255);
 		strHTML += "<br><b>Notes:</b><pre><font color=blue> " 
-			+ QString::fromStdString(eGRCMessage) + "</font></pre><p><br>";
+			+ QString::fromStdString(sGRCMessage) + "</font></pre><p><br>";
 		if (sOptionsNarr.length() > 1)
 		{
 			strHTML += "<br><b>Options:</b><pre><font color=blue> " + QString::fromStdString(sOptionsNarr) + "</font></pre><p><br>";


### PR DESCRIPTION
Re-enable/Uncomment code to allow users to read a message sent to them in a Tx. Currently you can only see the encrypted message.