### PR TITLE
GetBackupFilename addition + more

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9386,3 +9386,17 @@ bool StrLessThanReferenceHash(std::string rh)
     uint256 uADH = uint256("0x" + address_day_hash);
     return (uADH < uRef);
 }
+
+// Generate backup filenames with local date and time with suffix support
+std::string GetBackupFilename(const std::string& basename, const std::string& suffix)
+{
+    time_t biTime;
+    struct tm * blTime;
+    time (&biTime);
+    blTime = localtime(&biTime);
+    char boTime[200];
+    strftime(boTime, sizeof(boTime), "%FT%H-%M-%S", blTime);
+    return suffix.empty()
+        ? basename + "-" + std::string(boTime)
+        : basename + "-" + std::string(boTime) + "-" + suffix;
+}

--- a/src/main.h
+++ b/src/main.h
@@ -289,7 +289,7 @@ std::string DefaultWalletAddress();
 bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx,
                         bool* pfMissingInputs);
 
-
+std::string GetBackupFilename(const std::string& basename, const std::string& suffix = "");
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
 StructCPID GetInitializedStructCPID2(const std::string& name, std::map<std::string, StructCPID>& vRef);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1253,11 +1253,15 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
             {
                 // Store the key 
                 sMessage = AddContract(sType,sName,sBase);
+                // Backup config with old keys like a normal backup
+                std::string sBeaconBackupOldConfigFilename = GetBackupFilename("gridcoinresearch.conf");
+                boost::filesystem::path sBeaconBackupOldConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupOldConfigFilename;
+                BackupConfigFile(sBeaconBackupOldConfigTarget.string().c_str());
                 StoreBeaconKeys(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
                 // Backup config with new keys with beacon suffix
-                std::string sBeaconBackupConfigFilename = GetBackupFilename("gridcoinresearch.conf", "beacon");
-                boost::filesystem::path sBeaconBackupConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupConfigFilename;
-                BackupConfigFile(sBeaconBackupConfigTarget.string().c_str());
+                std::string sBeaconBackupNewConfigFilename = GetBackupFilename("gridcoinresearch.conf", "beacon");
+                boost::filesystem::path sBeaconBackupNewConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupNewConfigFilename;
+                BackupConfigFile(sBeaconBackupNewConfigTarget.string().c_str());
                 return true;
             }
             catch(Object& objError)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -637,8 +637,10 @@ std::string BackupGridcoinWallet()
     printf("Starting Wallet Backup\r\n");
     std::string filename = "grc_" + DateTimeStrFormat("%m-%d-%Y",  GetAdjustedTime()) + ".dat";
     std::string filename_backup = "backup.dat";
-    std::string standard_filename = "wallet_" + DateTimeStrFormat("%m-%d-%Y",  GetAdjustedTime()) + ".dat";
-    std::string sConfig_FileName = "gridcoinresearch_" + DateTimeStrFormat("%m-%d-%Y",  GetAdjustedTime()) + ".conf";
+    // std::string standard_filename = "wallet_" + DateTimeStrFormat("%m-%d-%Y",  GetAdjustedTime()) + ".dat";
+    // std::string sConfig_FileName = "gridcoinresearch_" + DateTimeStrFormat("%m-%d-%Y",  GetAdjustedTime()) + ".conf";
+    std::string standard_filename = GetBackupFilename("wallet.dat");
+    std::string sConfig_FileName = GetBackupFilename("gridcoinresearch.conf");
     std::string source_filename   = "wallet.dat";
     boost::filesystem::path path = GetDataDir() / "walletbackups" / filename;
     boost::filesystem::path target_path_standard = GetDataDir() / "walletbackups" / standard_filename;
@@ -1252,6 +1254,9 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
                 // Store the key 
                 sMessage = AddContract(sType,sName,sBase);
                 StoreBeaconKeys(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
+                // Backup config with new keys with beacon suffix
+                boost::filesystem::path sBeaconBackupConfigTarget = GetDataDir() / "walletbackups" / GetBackupFilename("gridcoinresearch.conf", "beacon");
+                BackupConfigFile(sBeaconBackupConfigTarget.string().c_str());
                 return true;
             }
             catch(Object& objError)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1255,7 +1255,8 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
                 sMessage = AddContract(sType,sName,sBase);
                 StoreBeaconKeys(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
                 // Backup config with new keys with beacon suffix
-                boost::filesystem::path sBeaconBackupConfigTarget = GetDataDir() / "walletbackups" / GetBackupFilename("gridcoinresearch.conf", "beacon");
+                std::string sBeaconBackupConfigFilename = GetBackupFilename("gridcoinresearch.conf", "beacon");
+                boost::filesystem::path sBeaconBackupConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupConfigFilename;
                 BackupConfigFile(sBeaconBackupConfigTarget.string().c_str());
                 return true;
             }


### PR DESCRIPTION
GetBackupFilename function added with local date and time in ISO 8601 standard format plus suffix support.
Added Backup df config with successful beacon advertise.
Updated GridcoinWalletBackup to support new backup filename format.
This also helps local users find the appropriate files with the date and time stamp of local not UTC

Note: some of it is together but ravon wants to split it himself when moving stuff :).

Works and tested on testnet for both Automated Backup of wallet and successful beacon advertise

This good to go for you @denravonska and then u can work on your moving of stuff :)

This closes #330 as after every successful beacon keys are only overwritten in config file and also now after every successful beacon it will also backup the config file with a beacon suffix

Formats as requested:

Automated Backups
gridcoinresearch.conf-2017-06-08T01-23-34
wallet.dat-2017-06-08T01-23-34

Beacon successful advertise
gridcoinresearch.conf-2017-06-08T01-23-34-beacon
