### PR TITLE
Simplify GenerateBeaconKeys.

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -1,10 +1,6 @@
 #include "beacon.h"
 #include "main.h"
-#include "uint256.h"
 #include "key.h"
-
-extern std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
-extern bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature);
 
 namespace
 {
@@ -14,33 +10,13 @@ namespace
     }
 }
 
-int GenerateBeaconKeys(const std::string &cpid, std::string &sOutPubKey, std::string &sOutPrivKey)
+void GenerateBeaconKeys(const std::string &cpid, std::string &sOutPubKey, std::string &sOutPrivKey)
 {
-    // First Check the Index - if it already exists, use it
-    sOutPrivKey = GetArgument("privatekey" + cpid + GetNetSuffix(), "");
-    sOutPubKey  = GetArgument("publickey" + cpid + GetNetSuffix(), "");
-    
-    // If current keypair is not empty, but is invalid, allow the new keys to be stored, otherwise return 1: (10-25-2016)
-    if (!sOutPrivKey.empty() && !sOutPubKey.empty())
-    {
-        uint256 hashBlock = GetRandHash();
-        std::string sSignature = SignBlockWithCPID(cpid,hashBlock.GetHex());
-        bool fResult = VerifyCPIDSignature(cpid, hashBlock.GetHex(), sSignature);
-        if (fResult)
-        {
-            printf("\r\nGenerateNewKeyPair::Current keypair is valid.\r\n");
-            return 1;
-        }
-    }
-    
-    // Generate the Keypair
     CKey key;
     key.MakeNewKey(false);
     CPrivKey vchPrivKey = key.GetPrivKey();
     sOutPrivKey = HexStr<CPrivKey::iterator>(vchPrivKey.begin(), vchPrivKey.end());
     sOutPubKey = HexStr(key.GetPubKey().Raw());
-    
-    return 2;
 }
 
 void StoreBeaconKeys(

--- a/src/beacon.h
+++ b/src/beacon.h
@@ -8,17 +8,12 @@
 
 //!
 //! \brief Generate beacon key pair.
-//! 
-//! Checks the current beacon keys for their validity and generate
-//! new ones if the old ones are invalid. If the old pair is valid
-//! they are returned.
-//! 
+//!
 //! \param cpid CPID to generate keys for.
 //! \param sOutPubKey Public key destination.
 //! \param sOutPrivKey Private key destination.
-//! \return \c 1 if keys were reused or \c 2 new keys were generated.
 //!
-int GenerateBeaconKeys(const std::string &cpid, std::string &sOutPubKey, std::string &sOutPrivKey);
+void GenerateBeaconKeys(const std::string &cpid, std::string &sOutPubKey, std::string &sOutPrivKey);
 
 //!
 //! \brief Store beacon keys in permanent storage.

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1230,13 +1230,7 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
                 return false;
             }
         
-            int iResult = GenerateBeaconKeys(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
-            if (iResult < 1)
-            {
-                sError = "Error generating keypair.";
-                return false;
-            }
-            
+            GenerateBeaconKeys(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
             if (sOutPrivKey.empty() || sOutPubKey.empty())
             {
                 sError = "Keypair is empty.";


### PR DESCRIPTION
Don't do an additional check for if the beacon exists since it does not do the
beacon age check. Granted, the check is done in VerifyCPIDSignature but then
the "fromService" flag isn't set so it will always be false.

Either way, this makes the function simpler and reduces complexity.