### PR TITLE
Update beacon keys in memory after successful beacon advertisment.

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -61,3 +61,12 @@ std::string GetStoredBeaconPublicKey(const std::string& cpid)
 {
     return GetArgument("publickey" + cpid + GetNetSuffix(), "");
 }
+
+void UpdateBeaconKeysInMemory(
+        const std::string &cpid,
+        const std::string &pubKey,
+        const std::string &privKey)
+{
+    mapArgs["-publickey" + cpid + GetNetSuffix()] = pubKey;
+    mapArgs["-privatekey" + cpid + GetNetSuffix()] = privKey;
+}

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -62,11 +62,11 @@ std::string GetStoredBeaconPublicKey(const std::string& cpid)
     return GetArgument("publickey" + cpid + GetNetSuffix(), "");
 }
 
-void UpdateBeaconKeysInMemory(
+void ActivateBeaconKeys(
         const std::string &cpid,
         const std::string &pubKey,
         const std::string &privKey)
 {
-    mapArgs["-publickey" + cpid + GetNetSuffix()] = pubKey;
-    mapArgs["-privatekey" + cpid + GetNetSuffix()] = privKey;
+    SetArgument("publickey" + cpid + GetNetSuffix(), pubKey);
+    SetArgument("privatekey" + cpid + GetNetSuffix(), privKey);
 }

--- a/src/beacon.h
+++ b/src/beacon.h
@@ -46,12 +46,11 @@ std::string GetStoredBeaconPrivateKey(const std::string& cpid);
 //!
 std::string GetStoredBeaconPublicKey(const std::string& cpid);
 
-// Update stored keys in memory as this process is not automatic and currently requires a restart of client to do so.
+// Push new beacon keys into memory as this process is not automatic and currently requires a restart of client to do so.
 // This corrects issues where users who have deleted beacons and then advertise new ones.
 // This corrects issues where users who readvertise and the existing keypair is no longer valid.
-// This puts the new key pair in memory.
 
-void UpdateBeaconKeysInMemory(
+void ActivateBeaconKeys(
         const std::string &cpid,
         const std::string &pubKey,
         const std::string &privKey);

--- a/src/beacon.h
+++ b/src/beacon.h
@@ -45,3 +45,13 @@ std::string GetStoredBeaconPrivateKey(const std::string& cpid);
 //! \return Stored beacon public key if available, otherwise an empty string.
 //!
 std::string GetStoredBeaconPublicKey(const std::string& cpid);
+
+// Update stored keys in memory as this process is not automatic and currently requires a restart of client to do so.
+// This corrects issues where users who have deleted beacons and then advertise new ones.
+// This corrects issues where users who readvertise and the existing keypair is no longer valid.
+// This puts the new key pair in memory.
+
+void UpdateBeaconKeysInMemory(
+        const std::string &cpid,
+        const std::string &pubKey,
+        const std::string &privKey);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9337,3 +9337,12 @@ std::string GetBackupFilename(const std::string& basename, const std::string& su
         ? basename + "-" + std::string(boTime)
         : basename + "-" + std::string(boTime) + "-" + suffix;
 }
+
+// SetArgument - Set or alter arguments stored in memory
+
+void SetArgument(
+            const string &argKey,
+            const string &argValue)
+{
+    mapArgs["-" + argKey] = argValue;
+}

--- a/src/main.h
+++ b/src/main.h
@@ -72,6 +72,11 @@ inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MO
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 static const unsigned int MINIMUM_CHECKPOINT_TRANSMISSION_BALANCE = 4000000;
 
+// SetArgument - Set or change arguments stored in the memory.
+
+void SetArgument(
+        const std::string &argKey,
+        const std::string &argValue);
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1260,8 +1260,8 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
                 std::string sBeaconBackupNewConfigFilename = GetBackupFilename("gridcoinresearch.conf", "beacon");
                 boost::filesystem::path sBeaconBackupNewConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupNewConfigFilename;
                 BackupConfigFile(sBeaconBackupNewConfigTarget.string().c_str());
-                // Update public and private keys in memory. This process is not automatic and has caused users who have a new keys to perform a restart of wallet.
-                UpdateBeaconKeysInMemory(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
+                // Activate Beacon Keys in memory. This process is not automatic and has caused users who have a new keys while old ones exist in memory to perform a restart of wallet.
+                ActivateBeaconKeys(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
                 return true;
             }
             catch(Object& objError)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1260,6 +1260,12 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
                 std::string sBeaconBackupNewConfigFilename = GetBackupFilename("gridcoinresearch.conf", "beacon");
                 boost::filesystem::path sBeaconBackupNewConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupNewConfigFilename;
                 BackupConfigFile(sBeaconBackupNewConfigTarget.string().c_str());
+                // Update public and private keys in memory. This process is not automatic and has caused users who have a new keys to perform a restart of wallet.
+                // iResult = 2 means a new key pair was issued by GenerateBeaconKeys. Now that beacon is successful we update this in memory.
+                if (iResult = 2)
+                {
+                    UpdateBeaconKeysInMemory(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
+                }
                 return true;
             }
             catch(Object& objError)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1261,11 +1261,7 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
                 boost::filesystem::path sBeaconBackupNewConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupNewConfigFilename;
                 BackupConfigFile(sBeaconBackupNewConfigTarget.string().c_str());
                 // Update public and private keys in memory. This process is not automatic and has caused users who have a new keys to perform a restart of wallet.
-                // iResult = 2 means a new key pair was issued by GenerateBeaconKeys. Now that beacon is successful we update this in memory.
-                if (iResult = 2)
-                {
-                    UpdateBeaconKeysInMemory(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
-                }
+                UpdateBeaconKeysInMemory(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
                 return true;
             }
             catch(Object& objError)


### PR DESCRIPTION
@denravonska made the change you asked for.

Fixes for users who:
a) Delete a beacon and then re-advertise successfully
b) Have beacons older then six months or keys that are no longer valid and then successfully re-advertise

These users will experience errors such as invalid cpid and a fail in 'execute beaconstatus' as the keys are not updated in memory.

Currently a user has to restart the wallet to correct this if they understand what is going on. However most end up repeatably deleting the beacon and re-advertise several times. 


