### PR TITLE
Remove resize constraints and more

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -990,8 +990,6 @@ void BitcoinGUI::createToolBars()
 
     frameBlocks->setContentsMargins(0,0,0,0);
 
-    frameBlocks->setMinimumWidth(30);
-    frameBlocks->setMaximumWidth(30);
     QVBoxLayout *frameBlocksLayout = new QVBoxLayout(frameBlocks);
     frameBlocksLayout->setContentsMargins(1,0,1,0);
     frameBlocksLayout->setSpacing(-1);
@@ -1023,7 +1021,6 @@ void BitcoinGUI::createToolBars()
     toolbar2->setOrientation(Qt::Vertical);
     toolbar2->setMovable( false );
     toolbar2->setObjectName("toolbar2");
-    toolbar2->setFixedWidth(26);
     toolbar2->addWidget(frameBlocks);
 
     addToolBarBreak(Qt::TopToolBarArea);
@@ -1032,7 +1029,6 @@ void BitcoinGUI::createToolBars()
     toolbar3->setOrientation(Qt::Horizontal);
     toolbar3->setMovable( false );
     toolbar3->setObjectName("toolbar3");
-    toolbar3->setFixedHeight(52);
     QLabel *grcLogoLabel = new QLabel();
     grcLogoLabel->setPixmap(QPixmap(":/images/logo_hz"));
     toolbar3->addWidget(grcLogoLabel);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -68,7 +68,6 @@
 #include <QLocale>
 #include <QMessageBox>
 #include <QMimeData>
-#include <QProgressBar>
 #include <QStackedWidget>
 #include <QDateTime>
 #include <QMovie>
@@ -248,79 +247,6 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
 
     // Create status bar
     // statusBar();
-
-    // Status bar notification icons
-    QFrame *frameBlocks = new QFrame();
-
-    frameBlocks->setContentsMargins(0,0,0,0);
-
-    frameBlocks->setMinimumWidth(30);
-    frameBlocks->setMaximumWidth(30);
-    QVBoxLayout *frameBlocksLayout = new QVBoxLayout(frameBlocks);
-    frameBlocksLayout->setContentsMargins(1,0,1,0);
-    frameBlocksLayout->setSpacing(-1);
-    labelEncryptionIcon = new QLabel();
-    labelStakingIcon = new QLabel();
-    labelConnectionsIcon = new QLabel();
-    labelBlocksIcon = new QLabel();
-    frameBlocksLayout->addWidget(labelEncryptionIcon);
-		
-    frameBlocksLayout->addWidget(labelStakingIcon);
-    frameBlocksLayout->addWidget(labelConnectionsIcon);
-    frameBlocksLayout->addWidget(labelBlocksIcon);
-	//12-21-2015 Prevent Lock from falling off the page
-
-    frameBlocksLayout->addStretch();
-
-    if (GetBoolArg("-staking", true))
-    {
-        QTimer *timerStakingIcon = new QTimer(labelStakingIcon);
-        connect(timerStakingIcon, SIGNAL(timeout()), this, SLOT(updateStakingIcon()));
-        timerStakingIcon->start(30 * 1000);
-        updateStakingIcon();
-    }
-
-    // Progress bar and label for blocks download
-    progressBarLabel = new QLabel();
-    progressBarLabel->setVisible(false);
-    progressBar = new QProgressBar();
-    progressBar->setAlignment(Qt::AlignCenter);
-    progressBar->setVisible(false);
-    progressBar->setOrientation(Qt::Vertical);
-    progressBar->setObjectName("progress");
-
-    frameBlocks->setObjectName("frame");
-	addToolBarBreak(Qt::LeftToolBarArea);
-    QToolBar *toolbar2 = addToolBar("Tabs toolbar");
-    addToolBar(Qt::LeftToolBarArea,toolbar2);
-    toolbar2->setOrientation(Qt::Vertical);
-    toolbar2->setMovable( false );
-    toolbar2->setObjectName("toolbar2");
-    toolbar2->setFixedWidth(26);
-    toolbar2->addWidget(frameBlocks);
-    toolbar2->addWidget(progressBarLabel);
-    toolbar2->addWidget(progressBar);
-
-	addToolBarBreak(Qt::TopToolBarArea);
-    QToolBar *toolbar3 = addToolBar("Logo bar");
-    addToolBar(Qt::TopToolBarArea,toolbar3);
-    toolbar3->setOrientation(Qt::Horizontal);
-    toolbar3->setMovable( false );
-    toolbar3->setObjectName("toolbar3");
-    toolbar3->setFixedHeight(52);
-    QLabel *grcLogoLabel = new QLabel();
-    grcLogoLabel->setPixmap(QPixmap(":/images/logo_hz"));
-    toolbar3->addWidget(grcLogoLabel);
-    QWidget* logoSpacer = new QWidget();
-    logoSpacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    toolbar3->addWidget(logoSpacer);
-    logoSpacer->setObjectName("logoSpacer");
-    QLabel *boincLogoLabel = new QLabel();
-    boincLogoLabel->setText("<html><head/><body><p align=\"center\"><a href=\"https://boinc.berkeley.edu\"><span style=\" text-decoration: underline; color:#0000ff;\"><img src=\":/images/boinc\"/></span></a></p></body></html>");
-    boincLogoLabel->setTextFormat(Qt::RichText);
-    boincLogoLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    boincLogoLabel->setOpenExternalLinks(true);
-    toolbar3->addWidget(boincLogoLabel);
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "GIF", this);
 
@@ -1059,6 +985,69 @@ void BitcoinGUI::createToolBars()
     webSpacer->setObjectName("WebSpacer");
 
 
+    // Status bar notification icons
+    QFrame *frameBlocks = new QFrame();
+
+    frameBlocks->setContentsMargins(0,0,0,0);
+
+    frameBlocks->setMinimumWidth(30);
+    frameBlocks->setMaximumWidth(30);
+    QVBoxLayout *frameBlocksLayout = new QVBoxLayout(frameBlocks);
+    frameBlocksLayout->setContentsMargins(1,0,1,0);
+    frameBlocksLayout->setSpacing(-1);
+    labelEncryptionIcon = new QLabel();
+    labelStakingIcon = new QLabel();
+    labelConnectionsIcon = new QLabel();
+    labelBlocksIcon = new QLabel();
+    frameBlocksLayout->addWidget(labelEncryptionIcon);
+
+    frameBlocksLayout->addWidget(labelStakingIcon);
+    frameBlocksLayout->addWidget(labelConnectionsIcon);
+    frameBlocksLayout->addWidget(labelBlocksIcon);
+    //12-21-2015 Prevent Lock from falling off the page
+
+    frameBlocksLayout->addStretch();
+
+    if (GetBoolArg("-staking", true))
+    {
+        QTimer *timerStakingIcon = new QTimer(labelStakingIcon);
+        connect(timerStakingIcon, SIGNAL(timeout()), this, SLOT(updateStakingIcon()));
+        timerStakingIcon->start(30 * 1000);
+        updateStakingIcon();
+    }
+
+    frameBlocks->setObjectName("frame");
+    addToolBarBreak(Qt::LeftToolBarArea);
+    QToolBar *toolbar2 = addToolBar("Tabs toolbar");
+    addToolBar(Qt::LeftToolBarArea,toolbar2);
+    toolbar2->setOrientation(Qt::Vertical);
+    toolbar2->setMovable( false );
+    toolbar2->setObjectName("toolbar2");
+    toolbar2->setFixedWidth(26);
+    toolbar2->addWidget(frameBlocks);
+
+    addToolBarBreak(Qt::TopToolBarArea);
+    QToolBar *toolbar3 = addToolBar("Logo bar");
+    addToolBar(Qt::TopToolBarArea,toolbar3);
+    toolbar3->setOrientation(Qt::Horizontal);
+    toolbar3->setMovable( false );
+    toolbar3->setObjectName("toolbar3");
+    toolbar3->setFixedHeight(52);
+    QLabel *grcLogoLabel = new QLabel();
+    grcLogoLabel->setPixmap(QPixmap(":/images/logo_hz"));
+    toolbar3->addWidget(grcLogoLabel);
+    QWidget* logoSpacer = new QWidget();
+    logoSpacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolbar3->addWidget(logoSpacer);
+    logoSpacer->setObjectName("logoSpacer");
+    QLabel *boincLogoLabel = new QLabel();
+    boincLogoLabel->setText("<html><head/><body><p align=\"center\"><a href=\"https://boinc.berkeley.edu\"><span style=\" text-decoration: underline; color:#0000ff;\"><img src=\":/images/boinc\"/></span></a></p></body></html>");
+    boincLogoLabel->setTextFormat(Qt::RichText);
+    boincLogoLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    boincLogoLabel->setOpenExternalLinks(true);
+    toolbar3->addWidget(boincLogoLabel);
+
+
 }
 
 void BitcoinGUI::setClientModel(ClientModel *clientModel)
@@ -1226,12 +1215,9 @@ void BitcoinGUI::setNumConnections(int count)
 
 void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
 {
-    // don't show / hide progress bar and its label if we have no connection to the network
+    // return if we have no connection to the network
     if (!clientModel || clientModel->getNumConnections() == 0)
     {
-        progressBarLabel->setVisible(false);
-        progressBar->setVisible(false);
-
         return;
     }
 
@@ -1242,34 +1228,9 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
     {
         int nRemainingBlocks = nTotalBlocks - count;
         float nPercentageDone = count / (nTotalBlocks * 0.01f);
-
-        if (strStatusBarWarnings.isEmpty())
-        {
-            progressBarLabel->setText(tr("Synchronizing with network..."));
-            progressBarLabel->setVisible(true);
-            progressBar->setFormat(tr("~%n block(s) remaining", "", nRemainingBlocks));
-            progressBar->setMaximum(nTotalBlocks);
-            progressBar->setValue(count);
-            progressBar->setVisible(true);
-        }
-    }
-    else
-    {
-        if (strStatusBarWarnings.isEmpty())
-            progressBarLabel->setVisible(false);
-
-        progressBar->setVisible(false);
     }
 
     tooltip = tr("Processed %n block(s) of transaction history.", "", count);
-
-    // Override progressBarLabel text and hide progress bar, when we have warnings to display
-    if (!strStatusBarWarnings.isEmpty())
-    {
-        progressBarLabel->setText(strStatusBarWarnings);
-        progressBarLabel->setVisible(true);
-        progressBar->setVisible(false);
-    }
 
     QDateTime lastBlockDate = clientModel->getLastBlockDate();
     int secs = lastBlockDate.secsTo(QDateTime::currentDateTime());
@@ -1324,8 +1285,6 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
     tooltip = QString("<nobr>") + tooltip + QString("</nobr>");
 
     labelBlocksIcon->setToolTip(tooltip);
-    progressBarLabel->setToolTip(tooltip);
-    progressBar->setToolTip(tooltip);
 }
 
 void BitcoinGUI::error(const QString &title, const QString &message, bool modal)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -30,7 +30,6 @@ class QLineEdit;
 class QTableView;
 class QAbstractItemModel;
 class QModelIndex;
-class QProgressBar;
 class QStackedWidget;
 class QUrl;
 QT_END_NAMESPACE
@@ -85,8 +84,6 @@ private:
     QLabel *labelStakingIcon;
     QLabel *labelConnectionsIcon;
     QLabel *labelBlocksIcon;
-    QLabel *progressBarLabel;
-    QProgressBar *progressBar;
 
     QMenuBar *appMenuBar;
     QAction *overviewAction;

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>795</width>
-    <height>520</height>
+    <width>0</width>
+    <height>0</height>
    </size>
   </property>
   <property name="maximumSize">
@@ -49,7 +49,7 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>422</width>
+           <width>0</width>
            <height>0</height>
           </size>
          </property>
@@ -474,7 +474,7 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>400</width>
+           <width>0</width>
            <height>0</height>
           </size>
          </property>
@@ -494,7 +494,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>300</width>
+                <width>0</width>
                 <height>0</height>
                </size>
               </property>

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -52,18 +52,6 @@ QToolBar#toolbar3 QLabel{
     border:none;
 }
 
-#toolbar3 {
-    border:none;
-    background-color:transparent;
-    border-bottom : 2px solid rgb(160,175,5);
-}
-
-#toolbar2 {
-    border:none;
-    width:10px;
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 0.5, y2: 0.5,stop: 0 rgb(160,175,5), stop: 1 rgb(160,175,5));
-}
-
 #toolbar {
     border:none;
     height:100%;
@@ -72,6 +60,22 @@ QToolBar#toolbar3 QLabel{
     color: black;
     min-width:160px;
     max-width:160px;
+}
+
+#toolbar2 {
+    border:none;
+    width:10px;
+    background-color:qlineargradient(x1: 0, y1: 0, x2: 0.5, y2: 0.5,stop: 0 rgb(160,175,5), stop: 1 rgb(160,175,5));
+    min-width:26px;
+    max-width:26px;
+}
+
+#toolbar3 {
+    border:none;
+    background-color:transparent;
+    border-bottom : 2px solid rgb(160,175,5);
+    min-height:52px;
+    max-height:52px;
 }
 
 QToolBar#toolbar QToolButton {

--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -37,15 +37,19 @@ QToolBar#toolbar3 QLabel{
     border:none;
 }
 
-#toolbar3 {
-    border:none;
-    border-bottom : 2px solid rgb(160,175,5);
-}
-
 #toolbar2 {
     border:none;
     width:10px;
     background-color:qlineargradient(x1: 0, y1: 0, x2: 0.5, y2: 0.5,stop: 0 rgb(160,175,5), stop: 1 rgb(160,175,5));
+    min-width:26px;
+    max-width:26px;
+}
+
+#toolbar3 {
+    border:none;
+    border-bottom : 2px solid rgb(160,175,5);
+    min-height:52px;
+    max-height:52px;
 }
 
 QMenuBar {


### PR DESCRIPTION
You should be able to resize the gui to a smaler size and the unused progress bar is removed.
Please test if the icons on the green bar are centered now.