### PR TITLE
Increase tally span for testnet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5777,7 +5777,7 @@ bool TallyResearchAverages(bool Forcefully)
     
                         //Consensus Start/End block:
                         int nMaxDepth = (nBestHeight-CONSENSUS_LOOKBACK) - ( (nBestHeight-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
-                        int nLookback = BLOCKS_PER_DAY * 14; //Daily block count * Lookback in days
+                        int nLookback = BLOCKS_PER_DAY * (fTestNet ? 90 : 14); //Daily block count * Lookback in days
                         int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
                         if (fDebug3) printf("START BLOCK %f, END BLOCK %f ",(double)nMaxDepth,(double)nMinDepth);
                         if (nMinDepth < 2)              nMinDepth = 2;


### PR DESCRIPTION
Add longer time span for tally on testnet to accommodate the infrequent superblocks