### PR TITLE
Revert "Increase tally span for testnet"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5782,7 +5782,7 @@ bool TallyResearchAverages(bool Forcefully)
     
                         //Consensus Start/End block:
                         int nMaxDepth = (nBestHeight-CONSENSUS_LOOKBACK) - ( (nBestHeight-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
-                        int nLookback = BLOCKS_PER_DAY * (fTestNet ? 90 : 14); //Daily block count * Lookback in days
+                        int nLookback = BLOCKS_PER_DAY * 14; //Daily block count * Lookback in days
                         int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
                         if (fDebug3) printf("START BLOCK %f, END BLOCK %f ",(double)nMaxDepth,(double)nMinDepth);
                         if (nMinDepth < 2)              nMinDepth = 2;


### PR DESCRIPTION
Reverts gridcoin/Gridcoin-Research#394

Using this will set the mag unit to 0 so it's not ideal.