### PR TITLE
Add command to get Block stats.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -310,6 +310,7 @@ static const CRPCCommand vRPCCommands[] =
     { "resendtx",               &resendtx,               false,  true},
     { "makekeypair",            &makekeypair,            false,  true},
     { "sendalert",              &sendalert,              false,  false},
+    { "getblockstats",          &rpc_getblockstats,      false,  false},
 };
 
 CRPCTable::CRPCTable()

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -238,5 +238,7 @@ extern json_spirit::Value dao(const json_spirit::Array& params, bool fHelp);
  extern json_spirit::Value downloadcancel(const json_spirit::Array& params, bool fHelp);
  extern json_spirit::Value restart(const json_spirit::Array& params, bool fHelp);
 
+// Brod
+extern json_spirit::Value rpc_getblockstats(const json_spirit::Array& params, bool fHelp);
 
 #endif


### PR DESCRIPTION
Annotated sample (annotation after #, not part of actual output)
```
{
  "general": {
    "blocks": 14001, #total num of blocks processed
    "first_height": 934222, #first and last included, then time
    "last_height": 948222,
    "first_time": "06-21-2017 04:33:36",
    "last_time": "07-02-2017 12:16:32",
    "time_span_hour": 271.71555556 #difference between first and last in hours
  },
  "counts": {
    "block": 14001,
    "empty_block": 11381, # number of blocks with only coinbase and constake tx
    "transaction": 7922, # number of transaction excluding coinbase/stake
    "proof_of_stake": 14001, # number of PoS blocks, should match blocks
    "boincreward": 8813 # count of blocks where research reward is greater than 0.001
  },
  "totals": {
    "block": 14001,
    "research": 350039.46, # sum of research rewards paid
    "interest": 148958.42, # sum of interest rewards paid
    "mint": 499114.27847717, # sum of nMint from block index
    "stake_input": 0 # todo
  },
  "averages": {
    "research": 39.71853625, # average research reward per research reward (called DPoR)
    "interest": 10.63912721, # average interest of all blocks 
    "mint": 35.64847357, # average "nMint" per block
    "stake_input": 0, # todo
    "spacing_sec": 69.86472395, # average bloc spacing in seconds
    "block_per_day": 1236.67560848, # avg blocks per day
    "transaction": 3.02366412 # avg number of transaction per non-empty block
  },
  "versions": { # distribution of client version recorded in blocks 
    "v3.5.9.0-g-research": 0.82158417, # 82% blocks have this client version
    "v3.5.8.8-g-research": 0.11392043,
    "v3.5.8.9-g-research": 0.06449539
  },
  "cpids": { # distribution of cpids that staked blocks
    "INVESTOR": 0.34397543, # investors staked 34% of blocks
    "8ed4ce08bfd7cb8a436eef5fc3be322f": 0.03656882, # this cpid staked 3% of blocks
    "015baf274dd9265b1c53d6aa064cface": 0.01771302,
    "0390450eff5f5cd6d7a7d95a6d898d8d": 0.01728448,
    "0c130640a79aab9f1eaed36277bc51fc": 0.01392758,
    "49f165229569bc8e7e49817686f8e23f": 0.01257053,
    "7987115b986329432dc76534bafe4e6f": 0.01107064,
    "1963a6f109ea770c195a0e1afacd2eba": 0.0106421,
    "ec954793ff856045ed3df78ceec58d9c": 0.01028498,
    "--snip--": 0
  },
  "orgs": { # distribution of contents of "Organisation" field in blocks
    "": 1 # 100% of blocks have this field empty 
  }
}
```

For testing you can set the unused Organisation field to your name or whatever. Not included in this PR.