### PR TITLE
Fix for the staking up-arrow being gray even when staking.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1060,6 +1060,8 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
         );
         }
 
+        nLastCoinStakeSearchInterval= txnew.nTime;
+
         if( StakeKernelHash <= StakeTarget )
         {
             // Found a kernel
@@ -1297,6 +1299,7 @@ void StakeMiner(CWallet *pwallet)
     MilliSleep(nMinerSleep);
     //clear miner messages
     msMiningErrors5="";
+    nLastCoinStakeSearchInterval = 0;
 
     if(!IsMiningAllowed(pwallet))
         continue;


### PR DESCRIPTION
Fix for the staking up-arrow being gray even when staking.
It was a regression from my #301 pr.
The stake weight and time estimate in the popup is still the old.