### PR TITLE
Integrate voting in main window

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -209,6 +209,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
 
     sendCoinsPage = new SendCoinsDialog(this);
 
+    votingPage = new VotingDialog(this);
+
     signVerifyMessageDialog = new SignVerifyMessageDialog(this);
 
     centralWidget = new QStackedWidget(this);
@@ -217,6 +219,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     centralWidget->addWidget(addressBookPage);
     centralWidget->addWidget(receiveCoinsPage);
     centralWidget->addWidget(sendCoinsPage);
+    centralWidget->addWidget(votingPage);
     setCentralWidget(centralWidget);
 
     // Create status bar
@@ -686,6 +689,11 @@ void BitcoinGUI::createActions()
     addressBookAction->setCheckable(true);
     addressBookAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
 
+    votingAction = new QAction(QIcon(":/icons/bitcoin"), tr("&Voting"), tabGroup);
+    votingAction->setToolTip(tr("Voting"));
+    votingAction->setCheckable(true);
+    votingAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_6));
+
 	bxAction = new QAction(QIcon(":/icons/block"), tr("&Block Explorer"), this);
 	bxAction->setStatusTip(tr("Block Explorer"));
 	bxAction->setMenuRole(QAction::TextHeuristicRole);
@@ -716,6 +724,7 @@ void BitcoinGUI::createActions()
     connect(historyAction, SIGNAL(triggered()), this, SLOT(gotoHistoryPage()));
     connect(addressBookAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(addressBookAction, SIGNAL(triggered()), this, SLOT(gotoAddressBookPage()));
+    connect(votingAction, SIGNAL(triggered()), this, SLOT(votingClicked()));
 
 	connect(websiteAction, SIGNAL(triggered()), this, SLOT(websiteClicked()));
 	connect(bxAction, SIGNAL(triggered()), this, SLOT(bxClicked()));
@@ -757,10 +766,6 @@ void BitcoinGUI::createActions()
 	newUserWizardAction = new QAction(QIcon(":/icons/bitcoin"), tr("&New User Wizard"), this);
 	newUserWizardAction->setStatusTip(tr("New User Wizard"));
 	newUserWizardAction->setMenuRole(QAction::TextHeuristicRole);
-	
-	votingAction = new QAction(QIcon(":/icons/bitcoin"), tr("&Voting"), this);
-	votingAction->setStatusTip(tr("Voting"));
-	votingAction->setMenuRole(QAction::TextHeuristicRole);
     
 	foundationAction = new QAction(QIcon(":/icons/bitcoin"), tr("&Foundation"), this);
 	foundationAction->setStatusTip(tr("Foundation"));
@@ -815,7 +820,6 @@ void BitcoinGUI::createActions()
 	connect(configAction, SIGNAL(triggered()), this, SLOT(configClicked()));
 
 	connect(miningAction, SIGNAL(triggered()), this, SLOT(miningClicked()));
-    connect(votingAction, SIGNAL(triggered()), this, SLOT(votingClicked()));
 
 	connect(diagnosticsAction, SIGNAL(triggered()), this, SLOT(diagnosticsClicked()));
 
@@ -862,15 +866,9 @@ void BitcoinGUI::createMenuBar()
     community->addAction(websiteAction);
 
 	QMenu *qmAdvanced = appMenuBar->addMenu(tr("&Advanced"));
-	qmAdvanced->addSeparator();
 #ifdef WIN32  // Some actions in this menu are implemented in Visual Basic and thus only work on Windows    
 	qmAdvanced->addAction(configAction);
 	qmAdvanced->addAction(miningAction);
-#endif /* defined(WIN32) */
-    
-    qmAdvanced->addAction(votingAction);
-    
-#ifdef WIN32  // Some actions in this menu are implemented in Visual Basic and thus only work on Windows 
 //	qmAdvanced->addAction(newUserWizardAction);
 	qmAdvanced->addSeparator();
 	qmAdvanced->addAction(faqAction);
@@ -908,6 +906,7 @@ void BitcoinGUI::createToolBars()
     toolbar->addAction(receiveCoinsAction);
     toolbar->addAction(historyAction);
     toolbar->addAction(addressBookAction);
+    toolbar->addAction(votingAction);
 
 	// Prevent Lock from falling off the page
 
@@ -1133,9 +1132,12 @@ void BitcoinGUI::aboutClicked()
 
 void BitcoinGUI::votingClicked()
 {
-    VotingDialog *dlg = new VotingDialog(this);
-    dlg->resetData();
-    dlg->show();
+    votingAction->setChecked(true);
+    votingPage->resetData();
+    centralWidget->setCurrentWidget(votingPage);
+
+    exportAction->setEnabled(false);
+    disconnect(exportAction, SIGNAL(triggered()), 0, 0);
 }
 
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -19,6 +19,7 @@ class TransactionView;
 class OverviewPage;
 class AddressBookPage;
 class SendCoinsDialog;
+class VotingDialog;
 class SignVerifyMessageDialog;
 class Notificator;
 class RPCConsole;
@@ -78,6 +79,7 @@ private:
     AddressBookPage *addressBookPage;
     AddressBookPage *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
+    VotingDialog *votingPage;
     SignVerifyMessageDialog *signVerifyMessageDialog;
 
     QLabel *labelEncryptionIcon;

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -210,19 +210,20 @@ QVariant VotingTableModel::data(const QModelIndex &index, int role) const
     return QVariant();
 }
 
-QVariant VotingTableModel::headerData(int column, Qt::Orientation orientation, int role) const
+// section corresponds to column number for horizontal headers
+QVariant VotingTableModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-    if (orientation == Qt::Horizontal)
+    if (orientation == Qt::Horizontal && section >= 0)
     {
         if (role == Qt::DisplayRole)
-            return columns_[column];
+            return columns_[section];
         else
         if (role == Qt::TextAlignmentRole)
-            return column_alignments[column];
+            return column_alignments[section];
         else
         if (role == Qt::ToolTipRole)
         {
-            switch (column)
+            switch (section)
             {
             case RowNumber:
                 return tr("Row Number.");
@@ -370,7 +371,7 @@ bool VotingProxyModel::filterAcceptsRow(int row, const QModelIndex &sourceParent
 // VotingDialog
 //
 VotingDialog::VotingDialog(QWidget *parent)
-    : QDialog(parent),
+    : QWidget(parent),
     tableView_(0),
     tableModel_(0),
     proxyModel_(0),
@@ -381,11 +382,6 @@ VotingDialog::VotingDialog(QWidget *parent)
     tableModel_ = new VotingTableModel();
     proxyModel_ = new VotingProxyModel(this);
     proxyModel_->setSourceModel(tableModel_);
-
-    // view
-    setWindowTitle(tr("Gridcoin Voting System 1.1"));
-    setMinimumSize(400,300);
-    resize(1000,500);
 
     QVBoxLayout *vlayout = new QVBoxLayout(this);
 
@@ -496,7 +492,7 @@ void VotingDialog::loadHistory(void)
 
 void VotingDialog::onLoadingFinished(void)
 {
-    watcher.setProperty("loading", false);
+    watcher.setProperty("running", false);
     loadingIndicator->hide();
 }
 

--- a/src/qt/votingdialog.h
+++ b/src/qt/votingdialog.h
@@ -146,7 +146,7 @@ class NewPollDialog;
 // VotingDialog
 //
 class VotingDialog
-    : public QDialog
+    : public QWidget
 {
     Q_OBJECT
 


### PR DESCRIPTION
This integrates the voting dialog as a page into the main toolbar. Also the loading of the poll data should be fixed now. 
The poll data is now reloaded every time one clicks on the voting toolbutton. This created some problems with the wallet constantly crashing while switching back and forth between voting and any other page. The problem is that QVariant VotingTableModel::headerData(int section, Qt::Orientation orientation, int role) is called with section = -1 . I have not been able to figure out why. I fixed it by simply catching this event if (orientation == Qt::Horizontal && section >= 0). So it works now but feels a bit dirty. 

An alternative would be to not load any data on clicking on the toolbutton and simply let the user load the data manually with a click on the "reset data" button. But then new votes will not show up until the user clicks the button again. 

Any ideas on what the behaviour of this should be?

And we really need new icons. We don't have a voting icon so for now I used the gridcoin logo icon, but that is not pretty. 