### PR TITLE
Latest Berkeley DB (v6+) compatibility fix

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -10,6 +10,7 @@
 #include "ui_interface.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <stdint.h>
 
 #ifndef WIN32
 #include "sys/stat.h"
@@ -39,7 +40,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         printf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
-        DbEnv((u_int32_t)0).remove(strPath.c_str(),0);
+        DbEnv((uint32_t)0).remove(strPath.c_str(),0);
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -39,7 +39,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         printf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv((u_int32_t)0).remove(strPath.c_str(),0);
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)


### PR DESCRIPTION
The current version of the db.cpp fails when compiled with libdb 6:

```
db.cpp: In member function ‘void CDBEnv::EnvShutdown()’:
db.cpp:42:16: error: call of overloaded ‘DbEnv(int)’ is ambiguous
         DbEnv(0).remove(strPath.c_str(), 0);
```