### PR TITLE
Prevent superblock from being staked by ineligible neural node partic…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3295,6 +3295,10 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:
             if (IsLockTimeWithinMinutes(GetBlockTime(),15)  && !fColdBoot)
             {
+                if (!IsNeuralNodeParticipant(bb.GRCAddress, nTime))
+                {
+                    return error("ConnectBlock[] : Superblock staked by ineligible neural node participant");
+                }
                 if (!VerifySuperblock(superblock,pindex->nHeight))
                 {
                     return error("ConnectBlock[] : Superblock avg mag below 10; SuperblockHash: %s, Consensus Hash: %s",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3295,6 +3295,12 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:
             if (IsLockTimeWithinMinutes(GetBlockTime(),15)  && !fColdBoot)
             {
+                CBitcoinAddress address(bb.GRCAddress);
+                bool validaddressinblock = address.IsValid();
+                if (!validaddressinblock)
+                {
+                    return error("ConnectBlock[] : Superblock staked with invalid GRC address in block");
+                }
                 if (!IsNeuralNodeParticipant(bb.GRCAddress, nTime))
                 {
                     return error("ConnectBlock[] : Superblock staked by ineligible neural node participant");


### PR DESCRIPTION
* Decrease the chances of abuse occurring from a malicious user sending a malicious superblock.

This is a step towards making superblock stakes more secure.
