### PR TITLE
German: use same terminology; translate; typo

### DIFF
--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -1485,7 +1485,7 @@ Dieses Label wird rot, wenn die Priorität kleiner ist als Mittel.
     <message>
         <location line="+10"/>
         <source>Display coin &amp;control features (experts only!)</source>
-        <translation>Coin &amp;control features anzeigen (nur experten!)</translation>
+        <translation>Coin &amp;control Funktionen anzeigen (nur für Experten!)</translation>
     </message>
     <message>
         <location line="+91"/>


### PR DESCRIPTION
![03__experts](https://user-images.githubusercontent.com/642286/28964289-7bc2f670-790c-11e7-9559-91497b2d8068.png)
