### PR TITLE
Fix to crash due to new user

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -194,6 +194,12 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     // Create the toolbars
     createToolBars();
 
+    // Create the tray icon (or setup the dock icon)
+    createTrayIcon();
+
+    // Hide Icon to prevent user interaction with UI while loading.
+    trayIcon->hide();
+
     // Create tabs
     overviewPage = new OverviewPage();
 
@@ -992,9 +998,8 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
     this->clientModel = clientModel;
     if(clientModel)
     {
-        // Create system tray menu (or setup the dock menu) that late to prevent users from calling actions,
-        // while the client has not yet fully loaded
-        createTrayIcon();
+        // Show tray icon now that it is safe to.
+        trayIcon->show();
 
         // Replace some strings and icons, when using the testnet
         if(clientModel->isTestNet())

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -995,9 +995,6 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
     this->clientModel = clientModel;
     if(clientModel)
     {
-        // Show tray icon now that it is safe to.
-        trayIcon->show();
-
         // Replace some strings and icons, when using the testnet
         if(clientModel->isTestNet())
         {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -197,9 +197,6 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     // Create the tray icon (or setup the dock icon)
     createTrayIcon();
 
-    // Hide Icon to prevent user interaction with UI while loading.
-    trayIcon->hide();
-
     // Create tabs
     overviewPage = new OverviewPage();
 
@@ -1046,6 +1043,10 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
     this->walletModel = walletModel;
     if(walletModel)
     {
+        // Create system tray menu (or setup the dock menu) that late to prevent users from calling actions,
+        // while the client has not yet fully loaded
+        createTrayIconMenu();
+
         // Report errors from wallet thread
         connect(walletModel, SIGNAL(error(QString,QString,bool)), this, SLOT(error(QString,QString,bool)));
 
@@ -1072,16 +1073,28 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
 
 void BitcoinGUI::createTrayIcon()
 {
-    QMenu *trayIconMenu;
 #ifndef Q_OS_MAC
     trayIcon = new QSystemTrayIcon(this);
-    trayIconMenu = new QMenu(this);
-    trayIcon->setContextMenu(trayIconMenu);
     trayIcon->setToolTip(tr("Gridcoin client"));
     trayIcon->setIcon(QIcon(":/icons/toolbar"));
+    trayIcon->show();
+#endif
+
+    notificator = new Notificator(qApp->applicationName(), trayIcon);
+}
+
+void BitcoinGUI::createTrayIconMenu()
+{
+#ifndef Q_OS_MAC
+    // return if trayIcon is unset (only on non-Mac OSes)
+    if (!trayIcon)
+        return;
+
+    trayIconMenu = new QMenu(this);
+    trayIcon->setContextMenu(trayIconMenu);
+
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(trayIconActivated(QSystemTrayIcon::ActivationReason)));
-    trayIcon->show();
 #else
     // Note: On Mac, the dock icon is used to provide the tray's functionality.
     MacDockIconHandler *dockIconHandler = MacDockIconHandler::instance();
@@ -1104,8 +1117,6 @@ void BitcoinGUI::createTrayIcon()
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);
 #endif
-
-    notificator = new Notificator(qApp->applicationName(), trayIcon);
 }
 
 #ifndef Q_OS_MAC

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QSystemTrayIcon>
+#include <QMenu>
 #include <stdint.h>
 
 #if defined(WIN32) && defined(QT_GUI)
@@ -129,6 +130,7 @@ private:
     QAction *openRPCConsoleAction;
 
     QSystemTrayIcon *trayIcon;
+    QMenu *trayIconMenu;
     Notificator *notificator;
     TransactionView *transactionView;
     RPCConsole *rpcConsole;
@@ -146,6 +148,9 @@ private:
     void createToolBars();
     /** Create system tray (notification) icon */
     void createTrayIcon();
+    /** Create system tray menu (or setup the dock menu) */
+    void createTrayIconMenu();
+
 
 public slots:
     /** Set number of connections shown in the UI */


### PR DESCRIPTION
Notifications by notifier need to have the tray icon loaded as thats where system notifications go.
Originally createTrayIcon  was moved to a different area to not allow user interaction with icon while loading. this prevented the notification system from pushing the first notification it had and when a second notification was pushed it caused a seg fault. I moved the createTrayIcon back to it original place to restore functionality. Then I added code to hide the icon below that (while loading) and then code to show it again where the previous existence for createTrayIcon was thus making the exact same solution.