### PR TITLE
Tie forking changes to block version 8

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3295,15 +3295,30 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:
             if (IsLockTimeWithinMinutes(GetBlockTime(),15)  && !fColdBoot)
             {
-                CBitcoinAddress address(bb.GRCAddress);
-                bool validaddressinblock = address.IsValid();
-                if (!validaddressinblock)
+                // Let this take effect on block 1 million on prod and immediatly on testnet.
+                if (fTestNet || (pindex->nHeight > 1000000))
                 {
-                    return error("ConnectBlock[] : Superblock staked with invalid GRC address in block");
-                }
-                if (!IsNeuralNodeParticipant(bb.GRCAddress, nTime))
-                {
-                    return error("ConnectBlock[] : Superblock staked by ineligible neural node participant");
+                    try
+                    {
+                        CBitcoinAddress address(bb.GRCAddress);
+                        bool validaddressinblock = address.IsValid();
+                        if (!validaddressinblock)
+                        {
+                            return error("ConnectBlock[] : Superblock staked with invalid GRC address in block");
+                        }
+                        if (!IsNeuralNodeParticipant(bb.GRCAddress, nTime))
+                        {
+                            return error("ConnectBlock[] : Superblock staked by ineligible neural node participant");
+                        }
+                    }
+                    catch (std::exception &e)
+                    {
+                        return error("ConnectBlock[] : Superblock stake check caused std::exception with GRC address %s", bb.GRCAddress.c_str());
+                    }
+                    catch (...)
+                    {
+                        return error("ConnectBlock[] : Superblock stake check caused unknwon exception with GRC address %s", bb.GRCAddress.c_str());
+                    }
                 }
                 if (!VerifySuperblock(superblock,pindex->nHeight))
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3295,6 +3295,16 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:
             if (IsLockTimeWithinMinutes(GetBlockTime(),15)  && !fColdBoot)
             {
+                CBitcoinAddress address(bb.GRCAddress);
+                bool validaddressinblock = address.IsValid();
+                if (!validaddressinblock)
+                {
+                    return error("ConnectBlock[] : Superblock staked with invalid GRC address in block");
+                }
+                if (!IsNeuralNodeParticipant(bb.GRCAddress, nTime))
+                {
+                    return error("ConnectBlock[] : Superblock staked by ineligible neural node participant");
+                }
                 if (!VerifySuperblock(superblock,pindex->nHeight))
                 {
                     return error("ConnectBlock[] : Superblock avg mag below 10; SuperblockHash: %s, Consensus Hash: %s",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4158,12 +4158,13 @@ bool CBlock::AcceptBlock(bool generated_by_me)
     int nHeight = pindexPrev->nHeight+1;
 
     if(       (IsProtocolV2(nHeight) && nVersion < 7)
-            ||(fTestNet && nHeight >= 288160 && nVersion < 8)
+            ||(fTestNet && nHeight >= 312000 && nVersion < 8)
+            ||(!fTestNet && nHeight >= 1001000 && nVersion < 8)
         )
         return DoS(100, error("AcceptBlock() : reject too old nVersion = %d", nVersion));
     else if( (!IsProtocolV2(nHeight) && nVersion >= 7)
-            ||(!fTestNet && nVersion >=8 )
-            ||(fTestNet && nHeight < 288160 && nVersion >= 8)
+            ||(fTestNet && nHeight < 312000 && nVersion >= 8)
+            ||(!fTestNet && nHeight < 1001000 && nVersion >= 8)
         )
         return DoS(100, error("AcceptBlock() : reject too new nVersion = %d", nVersion));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3295,13 +3295,14 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:
             if (IsLockTimeWithinMinutes(GetBlockTime(),15)  && !fColdBoot)
             {
-                // Let this take effect on block 1 million on prod and immediatly on testnet. Subject To Change.
-                if (fTestNet || (pindex->nHeight > 1000000))
+                // Let this take effect together with stakev8
+                if (nVersion>=8)
                 {
                     try
                     {
-                        CBitcoinAddress address(bb.GRCAddress);
-                        bool validaddressinblock = address.IsValid();
+                        CBitcoinAddress address;
+                        bool validaddressinblock = address.SetString(bb.GRCAddress);
+                        validaddressinblock &= address.IsValid();
                         if (!validaddressinblock)
                         {
                             return error("ConnectBlock[] : Superblock staked with invalid GRC address in block");
@@ -3310,10 +3311,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                         {
                             return error("ConnectBlock[] : Superblock staked by ineligible neural node participant");
                         }
-                    }
-                    catch (std::exception &e)
-                    {
-                        return error("ConnectBlock[] : Superblock stake check caused std::exception with GRC address %s", bb.GRCAddress.c_str());
                     }
                     catch (...)
                     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3295,7 +3295,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:
             if (IsLockTimeWithinMinutes(GetBlockTime(),15)  && !fColdBoot)
             {
-                // Let this take effect on block 1 million on prod and immediatly on testnet.
+                // Let this take effect on block 1 million on prod and immediatly on testnet. Subject To Change.
                 if (fTestNet || (pindex->nHeight > 1000000))
                 {
                     try

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1338,7 +1338,9 @@ void StakeMiner(CWallet *pwallet)
         CTransaction &StakeTX= StakeBlock.vtx[1]; //tx 1 is coin_stake
 
         //New version
-        if(fTestNet && pindexPrev->nHeight > 288158)
+        if(fTestNet && (pindexPrev->nHeight+2) > 312000)
+            StakeBlock.nVersion = 8;
+        if(!fTestNet && (pindexPrev->nHeight+2) > 1001000)
             StakeBlock.nVersion = 8;
 
         // * Try to create a CoinStake transaction


### PR DESCRIPTION
Merged @Foggyx420 modification #473.
Replace block height limit in #473 with version limit.
Increased block height for block version 8.
 * to 0312000 on testnet (less than day),
 * to 1001000 on prod (two weeks in future).
With this merged, it should be possible to run development branch on test-net without uncontrollable forking.