### PR TITLE
neural report refactor + verify votes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ extern std::string strReplace(std::string& str, const std::string& oldStr, const
 extern bool GetEarliestStakeTime(std::string grcaddress, std::string cpid);
 extern double GetTotalBalance();
 extern std::string PubKeyToAddress(const CScript& scriptPubKey);
-extern void IncrementNeuralNetworkSupermajority(std::string NeuralHash, std::string GRCAddress,double distance);
+extern void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, int64_t locktime);
 extern bool LoadSuperblock(std::string data, int64_t nTime, double height);
 
 
@@ -5736,7 +5736,7 @@ bool ComputeNeuralNetworkSupermajorityHashes()
 
                 IncrementVersionCount(bb.clientversion);
                 //Increment Neural Network Hashes Supermajority (over the last N blocks)
-                IncrementNeuralNetworkSupermajority(bb.NeuralHash,bb.GRCAddress,(nMaxDepth-pblockindex->nHeight)+10);
+                IncrementNeuralNetworkSupermajority(bb.NeuralHash,bb.GRCAddress,(nMaxDepth-pblockindex->nHeight)+10,block.nTime);
                 IncrementCurrentNeuralNetworkSupermajority(bb.CurrentNeuralHash,bb.GRCAddress,(nMaxDepth-pblockindex->nHeight)+10);
 
             }
@@ -8456,7 +8456,7 @@ void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, std::str
 
 
 
-void IncrementNeuralNetworkSupermajority(std::string NeuralHash, std::string GRCAddress, double distance)
+void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, int64_t locktime)
 {
     if (NeuralHash.length() < 5) return;
     double temp_hashcount = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8459,7 +8459,8 @@ void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, std::str
 void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, int64_t locktime)
 {
     if (NeuralHash.length() < 5) return;
-    if (fTestNet || (pindexBest->nHeight > 1000000))
+    if ((fTestNet && pindexBest->nHeight > 312000)
+            || (!fTestNet && pindexBest->nHeight > 1001000))
     {
         try
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8459,6 +8459,29 @@ void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, std::str
 void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, int64_t locktime)
 {
     if (NeuralHash.length() < 5) return;
+    if (fTestNet || (pindexBest->nHeight > 1000000))
+    {
+        try
+        {
+            CBitcoinAddress address(GRCAddress);
+            bool validaddresstovote = address.IsValid();
+            if (!validaddresstovote)
+            {
+                printf("INNS : Vote found in block with invalid GRC address. HASH: %s GRC: %s\n", NeuralHash.c_str(), GRCAddress.c_str());
+                return;
+            }
+            if (!IsNeuralNodeParticipant(GRCAddress, locktime))
+            {
+                printf("INNS : Vote found in block from ineligible neural node participant. HASH: %s GRC: %s\n", NeuralHash.c_str(), GRCAddress.c_str());
+                return;
+            }
+        }
+        catch (...)
+        {
+            printf("INNS : Exception caught while verifying neural nodes vote eligibility\n");
+            return;
+        }
+    }
     double temp_hashcount = 0;
     if (mvNeuralNetworkHash.size() > 0)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ extern std::string strReplace(std::string& str, const std::string& oldStr, const
 extern bool GetEarliestStakeTime(std::string grcaddress, std::string cpid);
 extern double GetTotalBalance();
 extern std::string PubKeyToAddress(const CScript& scriptPubKey);
-extern void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, int64_t locktime);
+extern void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, const CBlockIndex* pblockindex);
 extern bool LoadSuperblock(std::string data, int64_t nTime, double height);
 
 
@@ -5736,7 +5736,7 @@ bool ComputeNeuralNetworkSupermajorityHashes()
 
                 IncrementVersionCount(bb.clientversion);
                 //Increment Neural Network Hashes Supermajority (over the last N blocks)
-                IncrementNeuralNetworkSupermajority(bb.NeuralHash,bb.GRCAddress,(nMaxDepth-pblockindex->nHeight)+10,block.nTime);
+                IncrementNeuralNetworkSupermajority(bb.NeuralHash,bb.GRCAddress,(nMaxDepth-pblockindex->nHeight)+10,pblockindex);
                 IncrementCurrentNeuralNetworkSupermajority(bb.CurrentNeuralHash,bb.GRCAddress,(nMaxDepth-pblockindex->nHeight)+10);
 
             }
@@ -8456,11 +8456,10 @@ void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, std::str
 
 
 
-void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, int64_t locktime)
+void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const std::string& GRCAddress, double distance, const CBlockIndex* pblockindex)
 {
     if (NeuralHash.length() < 5) return;
-    if ((fTestNet && pindexBest->nHeight > 312000)
-            || (!fTestNet && pindexBest->nHeight > 1001000))
+    if (pblockindex->nVersion >= 8)
     {
         try
         {
@@ -8471,7 +8470,7 @@ void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const st
                 printf("INNS : Vote found in block with invalid GRC address. HASH: %s GRC: %s\n", NeuralHash.c_str(), GRCAddress.c_str());
                 return;
             }
-            if (!IsNeuralNodeParticipant(GRCAddress, locktime))
+            if (!IsNeuralNodeParticipant(GRCAddress, pblockindex->nTime))
             {
                 printf("INNS : Vote found in block from ineligible neural node participant. HASH: %s GRC: %s\n", NeuralHash.c_str(), GRCAddress.c_str());
                 return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8476,9 +8476,9 @@ void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const st
                 return;
             }
         }
-        catch (...)
+        catch (const bignum_error& innse)
         {
-            printf("INNS : Exception caught while verifying neural nodes vote eligibility\n");
+            printf("INNS : Exception: %s\n", innse.what());
             return;
         }
     }


### PR DESCRIPTION
For neural report votes
Check the grc address is valid
Check if they are eligible to vote.

Notes:

Neural report votes only come from neural network participants however there are no checks at this point in time to verify such are legit votes. This is in the direction of verifying votes as best we can much like the superblock check PR. The checks only need to be done in neural report. The current neural report is all neural network nodes hashes (even thou the sync every 500 blocks) and everyone participates in that however its the neural report thats trusted for superblock and thats where the consensus_hash is pulled from.

@tomasbrod this may be something to add with the superblock one in your v8 for mandatory.