### PR TITLE
Add money supply to getblock.

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -355,6 +355,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPri
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
     double mint = CoinToDouble(blockindex->nMint);
     result.push_back(Pair("mint", mint));
+    result.push_back(Pair("MoneySupply", blockindex->nMoneySupply));
     result.push_back(Pair("time", (int64_t)block.GetBlockTime()));
     result.push_back(Pair("nonce", (uint64_t)block.nNonce));
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));


### PR DESCRIPTION
Add money supply at a specific block (from block index) to getblock rpc. Idk if this is needed or even duplicate, but I needed it for comparing my code to prod code.