### PR TITLE
Decrease ban score for old version block from 100 to 20.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4161,7 +4161,7 @@ bool CBlock::AcceptBlock(bool generated_by_me)
             ||(fTestNet && nHeight >= 312000 && nVersion < 8)
             ||(!fTestNet && nHeight >= 1001000 && nVersion < 8)
         )
-        return DoS(100, error("AcceptBlock() : reject too old nVersion = %d", nVersion));
+        return DoS(20, error("AcceptBlock() : reject too old nVersion = %d", nVersion));
     else if( (!IsProtocolV2(nHeight) && nVersion >= 7)
             ||(fTestNet && nHeight < 312000 && nVersion >= 8)
             ||(!fTestNet && nHeight < 1001000 && nVersion >= 8)


### PR DESCRIPTION
This eases the transition to new block version.
Nodes sending old blocks wont be banned right away.
Maybe this needs to decrease further?
Users can temporary increase "banscore" in config to live thru the transition.