### PR TITLE
Refactor repetitive application cache iteration

### DIFF
--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -270,7 +270,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/threadsafety.h \
     src/cpid.h \
     src/upgrader.h \
-    src/boinc.h
+    src/boinc.h \
+    src/appcache.h
 
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
@@ -349,7 +350,8 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/cpid.cpp \
     src/upgrader.cpp \
     src/boinc.cpp \
-    src/allocators.cpp
+    src/allocators.cpp \
+    src/appcache.cpp
 
 ##
 #RC_FILE  = qaxserver.rc

--- a/src/Makefile.include.objs
+++ b/src/Makefile.include.objs
@@ -38,5 +38,5 @@ OBJS= \
     obj/block.o \
     obj/beacon.o \
     obj/boinc.o \
-    obj/allocators.o
-
+    obj/allocators.o \
+    obj/appcache.o

--- a/src/appcache.cpp
+++ b/src/appcache.cpp
@@ -1,0 +1,28 @@
+#include "appcache.h"
+#include "main.h"
+
+#include <boost/algorithm/string.hpp>
+#include <algorithm>
+
+AppCacheIterator::AppCacheIterator(const std::string& key)
+    : _begin(mvApplicationCache.begin())
+    , _end(mvApplicationCache.end())
+{
+    auto predicate = [key](typename AppCache::const_reference t)
+    {
+        return boost::algorithm::starts_with(t.first, key);
+    };
+
+    // Find the first occurrence of 'key'
+    _begin = std::find_if(_begin, _end, predicate);
+}
+
+AppCache::iterator AppCacheIterator::begin()
+{
+    return _begin;
+}
+
+AppCache::iterator AppCacheIterator::end()
+{
+    return _end;
+}

--- a/src/appcache.h
+++ b/src/appcache.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+#include <map>
+
+//!
+//! \brief Application cache type.
+//!
+typedef std::map<std::string, std::string> AppCache;
+
+//!
+//! \brief Application cache data key iterator.
+//!
+//! An iterator like class which can be used to iterate through the application
+//! in ranged based for loops based on keys. For example, to iterate through
+//! all the cached polls:
+//!
+//! \code
+//! for(const auto& item : AppCacheIterator("poll")
+//! {
+//!    const std::string& poll_name = item.second;
+//! }
+//! \endcode
+//!
+class AppCacheIterator
+{
+public:
+    //!
+    //! \brief Constructor.
+    //! \param key Key to search for. For legacy code compatibility reasons
+    //! \p key is matched to the start of the cached key, so \a poll will
+    //! iterate over items with the key \a polls as well.
+    //!
+    AppCacheIterator(const std::string& key);
+
+    //!
+    //! \brief Get iterator to first matching element.
+    //! \return Iterator pointing to the first matching element, or end()
+    //! if none is found.
+    //!
+    AppCache::iterator begin();
+
+    //!
+    //! \brief Get iterator to the element after the last element.
+    //! \return End iterator element.
+    //!
+    AppCache::iterator end();
+
+private:
+    AppCache::iterator _begin;
+    AppCache::iterator _end;
+};


### PR DESCRIPTION
Instead of manually having to iterate through the application cache a regular `std::map` iterator is encapsulated in a class which allows for iterating through for loops while skipping uninteresting items.

For example, before:
```
for(const auto& item : mvApplicationCache)
{
    const std::string& key_name = item.first;
    if (boost::algorithm::starts_with(key_name, datatype))
    {
        // Do something with the pair "item"
    }
}
```

After:
```
for(const auto& item : AppCacheIterator(datatype))
{
    // Do something with the pair "item"
}
```

The goal is to eventually move all the code directly touching the `mvApplicationCache` data structure into this file to get a clearer interface to the caching mechanisms.