### PR TITLE
Remove all superblock requirements for version 8 blocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4336,23 +4336,34 @@ bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent)
 
     // Validate superblock contents.
     bool bPassed = true;
-    double out_avg = 0;
-    double out_beacon_count=0;
-    double out_participant_count=0;
-    double avg_mag = GetSuperblockAvgMag(superblock,out_beacon_count,out_participant_count,out_avg,false, parent->nHeight);
 
-    // New rules added here:
-    // Before block version- and stake engine 8 there used to be a requirement
-    // that the average magnitude across all researchers must be at least 10.
-    // This is not necessary but cannot be changed until a mandatory is released.
-    //
-    // TODO: Remove this after V8 has kicked in?
     if(parent->nVersion < 8)
     {
+        double out_avg = 0;
+        double out_beacon_count=0;
+        double out_participant_count=0;
+        double avg_mag = GetSuperblockAvgMag(superblock,out_beacon_count,out_participant_count,out_avg,false, parent->nHeight);
+
+        // New rules added here:
+        // Before block version- and stake engine 8 there used to be a requirement
+        // that the average magnitude across all researchers must be at least 10.
+        // This is not necessary but cannot be changed until a mandatory is released.
+
         if (out_avg < 10 && fTestNet)  bPassed = false;
         if (out_avg < 70 && !fTestNet) bPassed = false;
 
         if (avg_mag < 10 && !fTestNet) bPassed = false;
+    }
+    else
+    {
+        // Block version above 8
+        // none, as they are easy to work arount and complicate sb production
+
+        // previously:
+        // * low/high limit of average of researcher magnitudes
+        // * low limit of project avg rac
+        // * count of researchers within 10% of their beacon count
+        // * count of projects at least half of previous sb project count
     }
 
     if (!bPassed)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4342,16 +4342,18 @@ bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent)
     double avg_mag = GetSuperblockAvgMag(superblock,out_beacon_count,out_participant_count,out_avg,false, parent->nHeight);
 
     // New rules added here:
-    if (out_avg < 10 && fTestNet)  bPassed = false;
-    if (out_avg < 70 && !fTestNet) bPassed = false;
-
     // Before block version- and stake engine 8 there used to be a requirement
     // that the average magnitude across all researchers must be at least 10.
     // This is not necessary but cannot be changed until a mandatory is released.
     //
     // TODO: Remove this after V8 has kicked in?
-    if(!fTestNet && parent->nVersion < 8 && avg_mag < 10)
-        bPassed = false;
+    if(parent->nVersion < 8)
+    {
+        if (out_avg < 10 && fTestNet)  bPassed = false;
+        if (out_avg < 70 && !fTestNet) bPassed = false;
+
+        if (avg_mag < 10 && !fTestNet) bPassed = false;
+    }
 
     if (!bPassed)
     {

--- a/src/main.h
+++ b/src/main.h
@@ -106,6 +106,7 @@ inline int64_t FutureDrift(int64_t nTime, int nHeight) { return IsProtocolV2(nHe
 inline unsigned int GetTargetSpacing(int nHeight) { return IsProtocolV2(nHeight) ? 90 : 60; }
 
 extern bool IsNeuralNodeParticipant(const std::string& addr, int64_t locktime);
+bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent);
 
 extern std::map<std::string, std::string> mvApplicationCache;
 extern std::map<std::string, int64_t> mvApplicationCacheTimestamp;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -57,7 +57,6 @@ MiningCPID GetBoincBlockByIndex(CBlockIndex* pblockindex);
 extern double GetSuperblockMagnitudeByCPID(std::string data, std::string cpid);
 extern bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature);
 bool NeedASuperblock();
-bool VerifySuperblock(std::string superblock, int nHeight);
 double ExtractMagnitudeFromExplainMagnitude();
 std::string GetQuorumHash(const std::string& data);
 double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime, double& total_owed, double block_magnitude);
@@ -2445,7 +2444,7 @@ Value execute(const Array& params, bool fHelp)
         entry.push_back(Pair("beacon_count",out_beacon_count));
         entry.push_back(Pair("beacon_participant_count",out_participant_count));
         entry.push_back(Pair("average_magnitude",out_avg));
-        entry.push_back(Pair("superblock_valid",VerifySuperblock(superblock,pindexBest->nHeight)));
+        entry.push_back(Pair("superblock_valid", VerifySuperblock(superblock, pindexBest)));
         int64_t superblock_age = GetAdjustedTime() - mvApplicationCacheTimestamp["superblock;magnitudes"];
         entry.push_back(Pair("Superblock Age",superblock_age));
         bool bDireNeed = NeedASuperblock();
@@ -2454,7 +2453,7 @@ Value execute(const Array& params, bool fHelp)
     }
     else if (sItem == "currentcontractaverage")
     {
-        std::string contract = "";
+        std::string contract;
         #if defined(WIN32) && defined(QT_GUI)
                     contract = qtGetNeuralContract("");
         #endif
@@ -2463,7 +2462,7 @@ Value execute(const Array& params, bool fHelp)
         double out_participant_count = 0;
         double out_avg = 0;
         double avg = GetSuperblockAvgMag(contract,out_beacon_count,out_participant_count,out_avg,false,nBestHeight);
-        bool bValid = VerifySuperblock(contract,pindexBest->nHeight);
+        bool bValid = VerifySuperblock(contract, pindexBest);
         entry.push_back(Pair("avg",avg));
         entry.push_back(Pair("beacon_count",out_beacon_count));
         entry.push_back(Pair("avg_mag",out_avg));


### PR DESCRIPTION
Remove all superblock requirements for version 8 blocks. Leave all responsibility to neural network participants. The checks are only causing trouble while staking superblock.