### PR TITLE
Beaconchecks

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -10,6 +10,8 @@ extern bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::
 std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxSeconds);
 int64_t GetRSAWeightByCPIDWithRA(std::string cpid);
 
+std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
+
 namespace
 {
     std::string GetNetSuffix()
@@ -133,4 +135,45 @@ std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxS
     return (iAge > iMaxSeconds)
           ? ""
           : value;
+}
+
+bool VerifyBeaconContractTx(const std::string& txhashBoinc)
+{
+    // Check if tx contains beacon advertisement and evaluate for certain conditions
+    std::string chkMessageType = ExtractXML(txhashBoinc, "<MT>", "</MT>");
+    std::string chkMessageAction = ExtractXML(txhashBoinc, "<MA>", "</MA>");
+    if (chkMessageAction != "A" && chkMessageType != "beacon")
+        return true; // Not beacon contract
+    std::string chkMessageContract = ExtractXML(txhashBoinc, "<MV>", "</MV>");
+    std::string chkMessageContractCPID = ExtractXML(txhashBoinc, "<MK>", "</MK>");
+    // Here we GetBeaconElements for the contract in the tx
+    std::string tx_out_cpid;
+    std::string tx_out_address;
+    std::string tx_out_publickey;
+    GetBeaconElements(chkMessageContract, tx_out_cpid, tx_out_address, tx_out_publickey);
+    if (tx_out_cpid == "" || tx_out_address == "" || tx_out_publickey == "" || chkMessageContractCPID == "")
+        return false;
+    std::string chkKey = "beacon;" + chkMessageContractCPID;
+    std::string chkValue = mvApplicationCache[chkKey];
+    int64_t chkiAge = pindexBest != NULL
+        ? pindexBest->nTime - mvApplicationCacheTimestamp[chkKey]
+        : 0;
+    int64_t chkSecondsBase = 60 * 24 * 30 * 60;
+    // Conditions
+    // Condition a) if beacon is younger then 5 months deny tx
+    if (chkiAge <= chkSecondsBase * 5 && chkiAge >= 1)
+        return false;
+    // Condition b) if beacon is younger then 6 months but older then 5 months verify using the same keypair; if not deny tx
+    if (chkiAge >= chkSecondsBase * 5 && chkiAge <= chkSecondsBase * 6)
+    {
+        std::string chk_out_cpid;
+        std::string chk_out_address;
+        std::string chk_out_publickey;
+        // Here we GetBeaconElements for the contract in the current beacon in chain
+        GetBeaconElements(chkValue, chk_out_cpid, chk_out_address, chk_out_publickey);
+        if (tx_out_publickey != chk_out_publickey)
+            return false;
+    }
+    // Passed checks
+    return true;
 }

--- a/src/beacon.h
+++ b/src/beacon.h
@@ -62,3 +62,5 @@ void GetBeaconElements(const std::string& sBeacon, std::string& out_cpid, std::s
 std::string GetBeaconPublicKey(const std::string& cpid, bool bAdvertisingBeacon);
 int64_t BeaconTimeStamp(const std::string& cpid, bool bZeroOutAfterPOR);
 bool HasActiveBeacon(const std::string& cpid);
+
+bool VerifyBeaconContractTx(const std::string& txhashBoinc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1444,7 +1444,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
 
     // Verify beacon contract in tx if found
     if (!VerifyBeaconContractTx(tx.hashBoinc))
-        return tx.DoS(25, "AcceptToMemoryPool : bad beacon contract in tx; rejected");
+        return tx.DoS(25, error("AcceptToMemoryPool : bad beacon contract in tx; rejected"));
 
     // Coinbase is only valid in a block, not as a loose transaction
     if (tx.IsCoinBase())
@@ -4110,8 +4110,8 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
             return DoS(50, error("CheckBlock[] : block timestamp earlier than transaction timestamp"));
 
         // Verify beacon contract if a transaction contains a beacon contract
-        if (!VerifyBeaconContractTx(tx.hashBoinc))
-            return DoS(25, "CheckBlock[] : bad beacon contract found in tx contained within block; rejected");
+        if (!VerifyBeaconContractTx(tx.hashBoinc) && !fLoadingIndex)
+            return DoS(25, error("CheckBlock[] : bad beacon contract found in tx contained within block; rejected"));
     }
 
     // Check for duplicate txids. This is caught by ConnectInputs(),


### PR DESCRIPTION
Bad beacon contracts is a Tx contract a person can stake and wait till the oldest beacon on a cpid expires making the bad beacon contract the new beacon owner till it expires. An attacker could potentially do so and wait a lengthly bit of time till beacon expires and his bad beacon contract becomes valid. They can use the cpids and reap the rewards of victims.

Also note there are advertised beacons with users in team gridcoin who have gotten there newbie block and are not currently running the wallet anymore for various reasons. The problem here is this is a prime target for an attacker. The grc owed will accumulate over the time and once the attacker gets control of the beacon he can potentially reap the rewards.

* Add security to prevent a bad beacon contract from entering wallet memorypools as a Tx in AcceptToMemoryPool.
We all get theTxs to our memorypool and then when and if we stake a block we append the Tx's in the block. Preventing the Tx from being staked is a very effective method making it harder for the attack to plant the seed
* Add security to prevent a block being staked with a bad beacon contract by the attacker in CheckBlock.
The last route an attacker could try would be to stake a block with his malformed beacon contract in it. We also verify conditions as well in checkblock for beacon contracts.

Conditions We reject beacon contract for Tx or CheckBlock:
If Beacon in chain is younger then 5 months old reject 
If Beacon in chain is younger then 6 months old and older then 5 months old and does not use same keypair reject

A ban score is added for each failed attempt.

This only allows matching key pair to be used in a advertisement during the 5-6 months range or a new key pair after 6 months.

Review the code, comment and talk about it.