### PR TITLE
Fix upgrader compilation on Linux

### DIFF
--- a/src/makefile_upgrader.unix
+++ b/src/makefile_upgrader.unix
@@ -11,8 +11,8 @@ DEFS=-DBOOST_SPIRIT_THREADSAFE
 
 # Dependency library locations can be customized with:
 #    BOOST_INCLUDE_PATH, BOOST_LIB_PATH, BDB_INCLUDE_PATH,
-#    BDB_LIB_PATH, OPENSSL_INCLUDE_PATH, OPENSSL_LIB_PATH, 
-#    CURL_INCLUDE_PATH, CURL_LIB_PATH, LIBZIP_INCLUDE_PATH 
+#    BDB_LIB_PATH, OPENSSL_INCLUDE_PATH, OPENSSL_LIB_PATH,
+#    CURL_INCLUDE_PATH, CURL_LIB_PATH, LIBZIP_INCLUDE_PATH
 #    and LIBZIP_LIB_PATH respectively
 
 ifeq (${NO_UPGRADE}, 1)  # Upgrade cannot be performed if shipped as a package
@@ -96,7 +96,7 @@ endif
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O2 $(EXT_OPTIONS) -DUPGRADERFLAG -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O2 $(EXT_OPTIONS) -DUPGRADERFLAG -DBOOST_NO_CXX11_SCOPED_ENUMS -std=c++11 -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only
@@ -104,9 +104,10 @@ xCXXFLAGS=-O2 $(EXT_OPTIONS) -DUPGRADERFLAG -pthread -Wall -Wextra -Wno-ignored-
 xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
 
 OBJS= \
+    obj-upgrader/allocators.o \
     obj-upgrader/util.o \
     obj-upgrader/version.o \
-    obj-upgrader/upgrader.o 
+    obj-upgrader/upgrader.o
 
 all: gridcoinupgrader
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -31,7 +31,7 @@ namespace boost {
 #include <boost/thread.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
-#include <stdarg.h>
+#include <cstdarg>
 
 #ifdef WIN32
 #ifdef _MSC_VER


### PR DESCRIPTION
This fixes compilation of the upgrade on Linux.

To be honest, I am wondering about the use of the upgrader on Linux though. Users are either compiling from source or getting the updates via package management anyways. So far the reason to also ship the upgrader was the downloadblocks functionality. That is now also present in the main binary, though. The only command that still can only be found in the upgrader is the block extraction. Is that implied in the main binaries command? In that case we could also completely drop the Linux ugprader.