### PR TITLE
Change V8 block switch from 1010000 to 1010001.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -94,9 +94,11 @@ inline bool IsResearchAgeEnabled(int nHeight)
 // Do not put the code in the headers!
 inline uint32_t IsV8Enabled(int nHeight)
 {
+    // Start creating V8 blocks after these heights.
+    // In testnet the first V8 block was created on block height 320000.
     return fTestNet
-            ? nHeight >= 312000
-            : nHeight >= 1010000;
+            ? nHeight > 311999
+            : nHeight > 1010000;
 }
 
 inline int GetSuperblockAgeSpacing(int nHeight)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -807,7 +807,7 @@ void StakeMiner(CWallet *pwallet)
 
             //New version
             StakeBlock.nVersion = 7;
-            if(IsV8Enabled(pindexPrev->nHeight+2))
+            if(IsV8Enabled(pindexPrev->nHeight+1))
                 StakeBlock.nVersion = 8;
 
             MinerStatus.Version= StakeBlock.nVersion;

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -109,20 +109,25 @@ BOOST_AUTO_TEST_CASE(gridcoin_ValidateConvertBinToHex)
 
 BOOST_AUTO_TEST_CASE(gridcoin_V8ShouldBeEnabledOnBlock1010000InProduction)
 {
-   bool was_testnet = fTestNet;
-   fTestNet = false;
-   BOOST_CHECK(IsV8Enabled(1009999) == false);
-   BOOST_CHECK(IsV8Enabled(1010000) == true);
-   fTestNet = was_testnet;
+    bool was_testnet = fTestNet;
+    fTestNet = false;
+    BOOST_CHECK(IsV8Enabled(1009999) == false);
+    BOOST_CHECK(IsV8Enabled(1010000) == false);
+    BOOST_CHECK(IsV8Enabled(1010001) == true);
+    fTestNet = was_testnet;
 }
 
 BOOST_AUTO_TEST_CASE(gridcoin_V8ShouldBeEnabledOnBlock312000InTestnet)
 {
-   bool was_testnet = fTestNet;
-   fTestNet = true;
-   BOOST_CHECK(IsV8Enabled(311999) == false);
-   BOOST_CHECK(IsV8Enabled(312000) == true);
-   fTestNet = was_testnet;
+    bool was_testnet = fTestNet;
+    fTestNet = true;
+
+    // With testnet block 312000 was created as the first V8 block,
+    // hence the difference in testing setup compared to the production
+    // tests.
+    BOOST_CHECK(IsV8Enabled(311999) == false);
+    BOOST_CHECK(IsV8Enabled(312000) == true);
+    fTestNet = was_testnet;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The previous fix made it so V8 could be created on 1010001. However, that
also means that the current version and the one after it will behave
differently when the first V8 block arrives. Non-upgraded clients will
reject it while updated ones will accept it. With this fix both versions
will behave the same, but only the upgraded wallets are able to create the
very first V8 block.