### PR TITLE
Move dMagnitudeUnit up above newbie stake so the newbie will get prop…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8857,6 +8857,7 @@ double GRCMagnitudeUnit(int64_t locktime)
 int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string operation, CBlockIndex* pindexLast, bool bVerifyingBlock, int iVerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude)
 {
     double dCurrentMagnitude = CalculatedMagnitude2(cpid, nTime, false);
+    dMagnitudeUnit = GRCMagnitudeUnit(nTime);
     CBlockIndex* pHistorical = GetHistoricalMagnitude(cpid);
     if (pHistorical->nHeight <= nNewIndex || pHistorical->nMagnitude==0 || pHistorical->nTime == 0)
     {
@@ -8905,7 +8906,6 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
 
     dAccrualAge = ((double)nTime - (double)pHistorical->nTime) / 86400;
     if (dAccrualAge < 0) dAccrualAge=0;
-    dMagnitudeUnit = GRCMagnitudeUnit(nTime);
 
     int64_t Accrual = (int64_t)(dAccrualAge*AvgMagnitude*dMagnitudeUnit*COIN);
     // Double check researcher lifetime paid

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8857,7 +8857,11 @@ double GRCMagnitudeUnit(int64_t locktime)
 int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string operation, CBlockIndex* pindexLast, bool bVerifyingBlock, int iVerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude)
 {
     double dCurrentMagnitude = CalculatedMagnitude2(cpid, nTime, false);
-    dMagnitudeUnit = GRCMagnitudeUnit(nTime);
+    // Pre-v8 the magnitude unit was always 0 which caused users to always
+    // stake their newbie block as 1 GRC regardless of what they were owed.
+    // V8 corrects this so the user is properly paid.
+    if (IsV8Enabled(pindexLast->nHeight))
+        dMagnitudeUnit = GRCMagnitudeUnit(nTime);
     CBlockIndex* pHistorical = GetHistoricalMagnitude(cpid);
     if (pHistorical->nHeight <= nNewIndex || pHistorical->nMagnitude==0 || pHistorical->nTime == 0)
     {
@@ -8906,6 +8910,8 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
 
     dAccrualAge = ((double)nTime - (double)pHistorical->nTime) / 86400;
     if (dAccrualAge < 0) dAccrualAge=0;
+    if (!IsV8Enabled(pindexLast->nHeight))
+        dMagnitudeUnit = GRCMagnitudeUnit(nTime);
 
     int64_t Accrual = (int64_t)(dAccrualAge*AvgMagnitude*dMagnitudeUnit*COIN);
     // Double check researcher lifetime paid


### PR DESCRIPTION
dMagnitudeUnit is passed set to 0 in function.
dMagnitudeUnit is set after newbie stake which causes a problem with newbie getting paid properly with there first block

formula is int64_t iAccrual = (int64_t)((dNewbieAccrualAge*dCurrentMagnitude*dMagnitudeUnit*COIN) + (1*COIN));

When dMagnitudeUnit is 0 it makes the left side of the formula 0. so then its 0 + (1*COIN) = 100000000 = 1GRC stake + interest after returned accrual of 1GRC

This makes the newbie stake calculation correct and the newbie will be paid properly so even if it takes weeks to get the newbie stake they will get a fully reward owed instead of 1 GRC

related #507 