### PR TITLE
getpeerinfo changes + removal of unused dead code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ extern std::string ConvertBinToHex(std::string a);
 extern std::string ConvertHexToBin(std::string a);
 extern bool WalletOutOfSync();
 extern bool WriteKey(std::string sKey, std::string sValue);
-bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
+bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
 std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
 extern void CleanInboundConnections(bool bClearAll);
 extern bool PushGridcoinDiagnostics();
@@ -4582,7 +4582,7 @@ void GridcoinServices()
         std::string sOutPrivKey = "";
         std::string sError = "";
         std::string sMessage = "";
-        bool fResult = AdvertiseBeacon(true,sOutPrivKey,sOutPubKey,sError,sMessage);
+        bool fResult = AdvertiseBeacon(sOutPrivKey,sOutPubKey,sError,sMessage);
         if (!fResult)
         {
             printf("BEACON ERROR!  Unable to send beacon %s \r\n",sError.c_str());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -32,7 +32,6 @@ extern void DoTallyResearchAverages(void* parg);
 extern void ExecGridcoinServices(void* parg);
 std::string DefaultWalletAddress();
 std::string NodeAddress(CNode* pfrom);
-std::string GetNeuralVersion();
 
 #ifndef QT_GUI
  boost::thread_group threadGroup;
@@ -734,13 +733,11 @@ void CNode::PushVersion()
     std::string mycpid = GlobalCPUMiningCPID.cpidv2;
     std::string acid = GetCommandNonce("aries");
     std::string sGRCAddress = DefaultWalletAddress();
-    std::string sNeuralVersion = GetNeuralVersion();
 
     PushMessage("aries", PROTOCOL_VERSION, nonce, pw1,
                 mycpid, mycpid, acid, nLocalServices, nTime, addrYou, addrMe,
                 nLocalHostNonce, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
                 nBestHeight, sGRCAddress);
-
 
 }
 
@@ -810,7 +807,6 @@ void CNode::copyStats(CNodeStats &stats)
     X(fInbound);
     X(nStartingHeight);
     X(nMisbehavior);
-    X(sNeuralNetwork);
     X(NeuralHash);
     X(sGRCAddress);
     X(nTrust);

--- a/src/net.h
+++ b/src/net.h
@@ -159,7 +159,6 @@ public:
     double dPingTime;
     double dPingWait;
 	std::string addrLocal;
-	std::string sNeuralNetwork;
 	std::string NeuralHash;
 	int nTrust;
 	std::string sGRCAddress;
@@ -241,7 +240,6 @@ public:
 	//12-10-2014 CPID Support
 	std::string cpid;
 	std::string enccpid;
-	std::string sNeuralNetwork;
 	std::string NeuralHash;
 	std::string sGRCAddress;
 	int nTrust;
@@ -333,7 +331,6 @@ public:
 		nLastOrphan=0;
 		nOrphanCount=0;
 		nOrphanCountViolations=0;
-		sNeuralNetwork="";
 		NeuralHash = "";
 		sGRCAddress = "";
 		nTrust = 0;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1722,7 +1722,7 @@ Value execute(const Array& params, bool fHelp)
                 std::string sError = "";
                 std::string sMessage = "";
 
-                bool fResult = AdvertiseBeacon(false,sOutPrivKey,sOutPubKey,sError,sMessage);
+                bool fResult = AdvertiseBeacon(true,sOutPrivKey,sOutPubKey,sError,sMessage);
                 entry.push_back(Pair("Result",SuccessFail(fResult)));
                 entry.push_back(Pair("CPID",GlobalCPUMiningCPID.cpid.c_str()));
                 entry.push_back(Pair("Message",sMessage.c_str()));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -75,7 +75,7 @@ double GRCMagnitudeUnit(int64_t locktime);
 std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 std::string ExtractHTML(std::string HTMLdata, std::string tagstartprefix,  std::string tagstart_suffix, std::string tag_end);
 std::string NeuralRequest(std::string MyNeuralRequest);
-extern bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
+extern bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
 
 double Round(double d, int place);
 bool UnusualActivityReport();
@@ -1153,7 +1153,7 @@ bool CPIDAcidTest2(std::string bpk, std::string externalcpid)
 }
         
 
-bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage)
+bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage)
 {	
      LOCK(cs_main);
      {
@@ -1161,17 +1161,17 @@ bool AdvertiseBeacon(bool bFromService, std::string &sOutPrivKey, std::string &s
             if (GlobalCPUMiningCPID.cpid=="INVESTOR")
             {
                 sError = "INVESTORS_CANNOT_SEND_BEACONS";
-                return bFromService ? true : false;
+                return false;
             }
 
             //If beacon is already in the chain, exit early
-            std::string sBeaconPublicKey = GetBeaconPublicKey(GlobalCPUMiningCPID.cpid,bFromService);
+            std::string sBeaconPublicKey = GetBeaconPublicKey(GlobalCPUMiningCPID.cpid,true);
             if (!sBeaconPublicKey.empty()) 
             {
                 // Ensure they can re-send the beacon if > 5 months old : GetBeaconPublicKey returns an empty string when > 5 months: OK.
                 // Note that we allow the client to re-advertise the beacon in 5 months, so that they have a seamless and uninterrupted keypair in use (prevents a hacker from hijacking a keypair that is in use)		
                 sError = "ALREADY_IN_CHAIN";
-                return bFromService ? true : false;
+                return false;
             }
             
             uint256 hashRand = GetRandHash();
@@ -1722,7 +1722,7 @@ Value execute(const Array& params, bool fHelp)
                 std::string sError = "";
                 std::string sMessage = "";
 
-                bool fResult = AdvertiseBeacon(true,sOutPrivKey,sOutPubKey,sError,sMessage);
+                bool fResult = AdvertiseBeacon(sOutPrivKey,sOutPubKey,sError,sMessage);
                 entry.push_back(Pair("Result",SuccessFail(fResult)));
                 entry.push_back(Pair("CPID",GlobalCPUMiningCPID.cpid.c_str()));
                 entry.push_back(Pair("Message",sMessage.c_str()));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -309,7 +309,6 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
-        obj.push_back(Pair("sNeuralNetworkVersion", stats.sNeuralNetwork));
         obj.push_back(Pair("nTrust", stats.nTrust));
         obj.push_back(Pair("banscore", stats.nMisbehavior));
         bool bNeural = false;

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -309,13 +309,17 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
-        obj.push_back(Pair("sNeuralNetworkVersion",stats.sNeuralNetwork));
-        obj.push_back(Pair("nTrust",stats.nTrust));
+        obj.push_back(Pair("sNeuralNetworkVersion", stats.sNeuralNetwork));
+        obj.push_back(Pair("nTrust", stats.nTrust));
         obj.push_back(Pair("banscore", stats.nMisbehavior));
         bool bNeural = false;
         bNeural = Contains(stats.strSubVer,"1999");
         obj.push_back(Pair("Neural Network", bNeural));
-        obj.push_back(Pair("Neural Hash",stats.NeuralHash));
+        if (bNeural)
+        {
+            obj.push_back(Pair("Neural Hash", stats.NeuralHash));
+            obj.push_back(Pair("Neural Participant", IsNeuralNodeParticipant(stats.sGRCAddress, GetAdjustedTime())));
+        }
         ret.push_back(obj);
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -82,7 +82,7 @@ bool fNoListen = false;
 bool fLogTimestamps = false;
 CMedianFilter<int64_t> vTimeOffsets(200,0);
 bool fReopenDebugLog = false;
-extern std::string GetNeuralVersion();
+std::string GetNeuralVersion();
 
 
 int64_t IsNeural();


### PR DESCRIPTION
getpeerinfo:

* Now in getpeerinfo if the peer is not a neural node it will not display the Neuralhash field. This makes it more clean.
* Now in getpeerinfo if the peer is a neural node it will display the status of the node eligibility to participate and grouped with the NeuralHash.

removal of dead code:

* sNeuralVersion is set where we push messages to a node (aries) however it is not pushed and remains dead code there.
* sNeuralNetwork is always an empty string. Appears to be old code from when sNeuralVersion was pushed with aries message. This was likely used before they included the Neural Version into the subver as (317.1999).
* Changed GetNeuralVersion to locally used in util.cpp as its not called anywhere else.