### PR TITLE
change to gerpeerinfo and remove unused code

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -32,7 +32,6 @@ extern void DoTallyResearchAverages(void* parg);
 extern void ExecGridcoinServices(void* parg);
 std::string DefaultWalletAddress();
 std::string NodeAddress(CNode* pfrom);
-std::string GetNeuralVersion();
 
 #ifndef QT_GUI
  boost::thread_group threadGroup;
@@ -734,7 +733,6 @@ void CNode::PushVersion()
     std::string mycpid = GlobalCPUMiningCPID.cpidv2;
     std::string acid = GetCommandNonce("aries");
     std::string sGRCAddress = DefaultWalletAddress();
-    std::string sNeuralVersion = GetNeuralVersion();
 
     PushMessage("aries", PROTOCOL_VERSION, nonce, pw1,
                 mycpid, mycpid, acid, nLocalServices, nTime, addrYou, addrMe,
@@ -743,9 +741,6 @@ void CNode::PushVersion()
 
 
 }
-
-
-
 
 std::map<CNetAddr, int64_t> CNode::setBanned;
 CCriticalSection CNode::cs_setBanned;
@@ -810,7 +805,6 @@ void CNode::copyStats(CNodeStats &stats)
     X(fInbound);
     X(nStartingHeight);
     X(nMisbehavior);
-    X(sNeuralNetwork);
     X(NeuralHash);
     X(sGRCAddress);
     X(nTrust);

--- a/src/net.h
+++ b/src/net.h
@@ -159,7 +159,6 @@ public:
     double dPingTime;
     double dPingWait;
 	std::string addrLocal;
-	std::string sNeuralNetwork;
 	std::string NeuralHash;
 	int nTrust;
 	std::string sGRCAddress;
@@ -241,7 +240,6 @@ public:
 	//12-10-2014 CPID Support
 	std::string cpid;
 	std::string enccpid;
-	std::string sNeuralNetwork;
 	std::string NeuralHash;
 	std::string sGRCAddress;
 	int nTrust;
@@ -333,7 +331,6 @@ public:
 		nLastOrphan=0;
 		nOrphanCount=0;
 		nOrphanCountViolations=0;
-		sNeuralNetwork="";
 		NeuralHash = "";
 		sGRCAddress = "";
 		nTrust = 0;

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -309,13 +309,18 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
-        obj.push_back(Pair("sNeuralNetworkVersion",stats.sNeuralNetwork));
-        obj.push_back(Pair("nTrust",stats.nTrust));
+        obj.push_back(Pair("sNeuralNetworkVersion", stats.sNeuralNetwork));
+        obj.push_back(Pair("nTrust", stats.nTrust));
         obj.push_back(Pair("banscore", stats.nMisbehavior));
         bool bNeural = false;
-        bNeural = Contains(stats.strSubVer,"1999");
+        bNeural = Contains(stats.strSubVer, "1999");
         obj.push_back(Pair("Neural Network", bNeural));
-        obj.push_back(Pair("Neural Hash",stats.NeuralHash));
+        if (bNeural)
+        {
+            obj.push_back(Pair("Neural Hash", stats.NeuralHash));
+            obj.push_back(Pair("Neural Participant", IsNeuralNodeParticipant(stats.sGRCAddress, GetAdjustedTime())));
+
+        }
         ret.push_back(obj);
     }
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -309,7 +309,6 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
-        obj.push_back(Pair("sNeuralNetworkVersion", stats.sNeuralNetwork));
         obj.push_back(Pair("nTrust", stats.nTrust));
         obj.push_back(Pair("banscore", stats.nMisbehavior));
         bool bNeural = false;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -82,7 +82,7 @@ bool fNoListen = false;
 bool fLogTimestamps = false;
 CMedianFilter<int64_t> vTimeOffsets(200,0);
 bool fReopenDebugLog = false;
-extern std::string GetNeuralVersion();
+std::string GetNeuralVersion();
 
 
 int64_t IsNeural();


### PR DESCRIPTION
getpeerinfo:

* Now in getpeerinfo if the peer is not a neural node it will not display the Neuralhash field. This makes it more clean.
* Now in getpeerinfo if the peer is a neural node it will display the status of the node eligibility to participate and grouped with the NeuralHash.

removal of dead code:

* sNeuralVersion is set where we push messages to a node (aries) however it is not pushed and remains dead code there.
* sNeuralNetwork is always an empty string. Appears to be old code from when sNeuralVersion was pushed with aries message. This was likely used before they included the Neural Version into the subver as (317.1999).
    Changed GetNeuralVersion to locally used in util.cpp as its not called anywhere else.
