### PR TITLE
Add nodes to CreateNewConfigFile

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1294,29 +1294,33 @@ std::string tostdstring(QString q)
 	return ss1;
 }
 
-
-
-
 bool CreateNewConfigFile(std::string boinc_email)
 {
-	std::string filename = "gridcoinresearch.conf";
-	boost::filesystem::path path = GetDataDir() / filename;
-	std::ofstream myConfig;
-	myConfig.open (path.string().c_str());
-	std::string row = "cpumining=true\r\n";
-	myConfig << row;
-	row = "email=" + boinc_email + "\r\n";
-	myConfig << row;
-	row = "addnode=node.gridcoin.us \r\n";
-	myConfig << row;
-	row = "addnode=gridcoin.asia \r\n";
-	myConfig << row;
-	row = "addnode=grcmagnitude.com \r\n";
-	myConfig << row;
-	myConfig.close();
-	return true;
+    std::string filename = "gridcoinresearch.conf";
+    boost::filesystem::path path = GetDataDir() / filename;
+    std::ofstream myConfig;
+    myConfig.open (path.string().c_str());
+    std::string row = "cpumining=true\r\n";
+    myConfig << row;
+    row = "email=" + boinc_email + "\r\n";
+    myConfig << row;
+    row = "addnode=node.gridcoin.us \r\n";
+    myConfig << row;
+    row = "addnode=gridcoin.asia \r\n";
+    myConfig << row;
+    row = "addnode=grcmagnitude.com \r\n";
+    myConfig << row;
+    row = "addnode=amsterdam.grcnode.co.uk \r\n";
+    myConfig << row;
+    row = "addnode=london.grcnode.co.uk \r\n";
+    myConfig << row;
+    row = "addnode=frankfurt.grcnode.co.uk \r\n";
+    myConfig << row;
+    row = "addnode=nyc.grcnode.co.uk \r\n";
+    myConfig << row;
+    myConfig.close();
+    return true;
 }
-
 
 bool ForceInAddNode(std::string sMyAddNode)
 {


### PR DESCRIPTION
Users report not being able to get connections after a fresh install with no config.

When using the new user wizard it adds 7 nodes to the config however if ran the other route and not using the wizard then only 3 are added via CreateNewConfigFile. This will give more nodes in the initial config to allow users to connect as node.gridcoin.us grcmagnitude.com and gridcoin.asia nodes are down.

shout out to @barton2526 for this