### PR TITLE
wallet/config backup results.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9236,20 +9236,20 @@ std::string GetBackupFilename(const std::string& basename, const std::string& su
 // Todo: Make and move to config.cpp/h (ravon)
 bool BackupConfigFile(const std::string& strDest)
 {
-    boost::filesystem::path ConfigTarget = GetDataDir() / "walletbackups" / strDest;
-    boost::filesystem::create_directories(ConfigTarget.parent_path());
-    boost::filesystem::path ConfigSource = GetDataDir() / "gridcoinresearch.conf";
+    filesystem::path ConfigTarget = GetDataDir() / "walletbackups" / strDest;
+    filesystem::create_directories(ConfigTarget.parent_path());
+    filesystem::path ConfigSource = GetDataDir() / "gridcoinresearch.conf";
     try
     {
         #if BOOST_VERSION >= 104000
-            boost::filesystem::copy_file(ConfigSource, ConfigTarget, boost::filesystem::copy_option::overwrite_if_exists);
+            filesystem::copy_file(ConfigSource, ConfigTarget, filesystem::copy_option::overwrite_if_exists);
         #else
-            boost::filesystem::copy_file(ConfigSource, ConfigTarget);
+            filesystem::copy_file(ConfigSource, ConfigTarget);
         #endif
         printf("BackupConfigFile: Copied gridcoinresearch.conf to %s\n", ConfigTarget.string().c_str());
         return true;
     }
-    catch(const boost::filesystem::filesystem_error &e)
+    catch(const filesystem::filesystem_error &e)
     {
         printf("BackupConfigFile: Error copying gridcoinresearch.conf to %s - %s\n", ConfigTarget.string().c_str(), e.what());
         return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4439,11 +4439,11 @@ void GridcoinServices()
     if (fDebug) printf(" {SVC} ");
 
     //Backup the wallet once per 900 blocks or as specified in config:
-    int dWBI = GetArg("-walletbackupinterval", 900);
-    if (dWBI == 0)
-        dWBI = 900;
+    int iWBI = GetArg("-walletbackupinterval", 900);
+    if (iWBI == 0)
+        iWBI = 900;
 
-   if (TimerMain("backupwallet", dWBI))
+   if (TimerMain("backupwallet", iWBI))
     {
         std::string backup_results = BackupGridcoinWallet();
         printf("Daily backup results: %s\r\n",backup_results.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,7 +211,8 @@ std::string msMasterProjectPublicKey  = "049ac003b3318d9fe28b2830f6a95a2624ce2a6
 std::string msMasterMessagePrivateKey = "308201130201010420fbd45ffb02ff05a3322c0d77e1e7aea264866c24e81e5ab6a8e150666b4dc6d8a081a53081a2020101302c06072a8648ce3d0101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f300604010004010704410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101a144034200044b2938fbc38071f24bede21e838a0758a52a0085f2e034e7f971df445436a252467f692ec9c5ba7e5eaa898ab99cbd9949496f7e3cafbf56304b1cc2e5bdf06e";
 std::string msMasterMessagePublicKey  = "044b2938fbc38071f24bede21e838a0758a52a0085f2e034e7f971df445436a252467f692ec9c5ba7e5eaa898ab99cbd9949496f7e3cafbf56304b1cc2e5bdf06e";
 
-std::string BackupGridcoinWallet();
+bool BackupWallet(const CWallet& wallet, const string& strDest);
+bool BackupConfigFile(const string& strDest);
 
 extern bool OutOfSyncByAgeWithChanceOfMining();
 
@@ -4445,8 +4446,9 @@ void GridcoinServices()
 
    if (TimerMain("backupwallet", iWBI))
     {
-        std::string backup_results = BackupGridcoinWallet();
-        printf("Daily backup results: %s\r\n",backup_results.c_str());
+        bool bWalletBackupResults = BackupWallet(*pwalletMain, GetBackupFilename("wallet.dat"));
+        bool bConfigBackupResults = BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"));
+        printf("Daily backup results: Wallet -> %B Config -> %B\r\n", bWalletBackupResults, bConfigBackupResults);
     }
 
     if (TimerMain("ResetVars",30))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4438,10 +4438,12 @@ void GridcoinServices()
     if (OutOfSyncByAge()) return;
     if (fDebug) printf(" {SVC} ");
 
-    //Backup the wallet once per 900 blocks:
-    double dWBI = cdbl(GetArgument("walletbackupinterval", "900"),0);
-    
-    if (TimerMain("backupwallet", dWBI))
+    //Backup the wallet once per 900 blocks or as specified in config:
+    int dWBI = GetArg("-walletbackupinterval", 900);
+    if (dWBI == 0)
+        dWBI = 900;
+
+   if (TimerMain("backupwallet", dWBI))
     {
         std::string backup_results = BackupGridcoinWallet();
         printf("Daily backup results: %s\r\n",backup_results.c_str());

--- a/src/main.h
+++ b/src/main.h
@@ -291,6 +291,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx,
                         bool* pfMissingInputs);
 
 std::string GetBackupFilename(const std::string& basename, const std::string& suffix = "");
+bool BackupConfigFile(const std::string& strDest);
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
 StructCPID GetInitializedStructCPID2(const std::string& name, std::map<std::string, StructCPID>& vRef);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -125,7 +125,6 @@ extern int64_t IsNeural();
 
 double cdbl(std::string s, int place);
 std::string getfilecontents(std::string filename);
-std::string BackupGridcoinWallet();
 int nRegVersion;
 
 extern int CreateRestorePoint();

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -24,7 +24,7 @@ using namespace json_spirit;
 using namespace std;
 extern std::string YesNo(bool bin);
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
-bool BackupPrivateKeys(CWallet* pBackupWallet, std::string& sTarget, std::string& sErrors);
+bool BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::string& sErrors);
 extern double DoubleFromAmount(int64_t amount);
 std::string PubKeyToAddress(const CScript& scriptPubKey);
 CBlockIndex* GetHistoricalMagnitude(std::string cpid);
@@ -2585,7 +2585,7 @@ Value execute(const Array& params, bool fHelp)
     {
         string sErrors;
         string sTarget;
-        bool bBackupPrivateKeys = BackupPrivateKeys(pwalletMain, sTarget, sErrors);
+        bool bBackupPrivateKeys = BackupPrivateKeys(*pwalletMain, sTarget, sErrors);
         if (!bBackupPrivateKeys)
             entry.push_back(Pair("error", sErrors));
         else

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -23,9 +23,8 @@
 using namespace json_spirit;
 using namespace std;
 extern std::string YesNo(bool bin);
-bool BackupConfigFile(const string& strDest);
-bool BackupWallet(const CWallet& wallet, const string& strDest);
-bool BackupPrivateKeys(CWallet* pBackupWallet);
+bool BackupWallet(const CWallet& wallet, const std::string& strDest);
+bool BackupPrivateKeys(CWallet* pBackupWallet, std::string& sTarget, std::string& sErrors);
 extern double DoubleFromAmount(int64_t amount);
 std::string PubKeyToAddress(const CScript& scriptPubKey);
 CBlockIndex* GetHistoricalMagnitude(std::string cpid);
@@ -1020,7 +1019,7 @@ bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::str
                 // Backup config with new keys with beacon suffix
                 std::string sBeaconBackupNewConfigFilename = GetBackupFilename("gridcoinresearch.conf", "beacon");
                 boost::filesystem::path sBeaconBackupNewConfigTarget = GetDataDir() / "walletbackups" / sBeaconBackupNewConfigFilename;
-                 BackupConfigFile(sBeaconBackupNewConfigTarget.string().c_str());
+                BackupConfigFile(sBeaconBackupNewConfigTarget.string().c_str());
                 // Activate Beacon Keys in memory. This process is not automatic and has caused users who have a new keys while old ones exist in memory to perform a restart of wallet.
                 ActivateBeaconKeys(GlobalCPUMiningCPID.cpid, sOutPubKey, sOutPrivKey);
                 return true;
@@ -2584,9 +2583,13 @@ Value execute(const Array& params, bool fHelp)
     }
     else if (sItem == "backupprivatekeys")
     {
-        bool bBackupPrivateKeys = BackupPrivateKeys(pwalletMain);
+        string sErrors;
+        string sTarget;
+        bool bBackupPrivateKeys = BackupPrivateKeys(pwalletMain, sTarget, sErrors);
         if (!bBackupPrivateKeys)
-            entry.push_back(Pair("error", "Wallet must be fully unlocked to backup private keys"));
+            entry.push_back(Pair("error", sErrors));
+        else
+            entry.push_back(Pair("location", sTarget));
         entry.push_back(Pair("result", bBackupPrivateKeys));
         results.push_back(entry);
     }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2546,7 +2546,6 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
                 else
                 {
                     CSecret secret = vchSecret.GetSecret(IsCompressed);
-                    //CBitcoinAddress address(keyID);
                     CBitcoinSecret privateKey(secret, IsCompressed);
                     res.push_back(std::make_pair(address, privateKey));
                 }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2516,7 +2516,7 @@ void CWallet::GetAllReserveKeys(set<CKeyID>& setAddress) const
     }
 }
 
-std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKeys(std::string& sError)
+std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKeys(std::string& sError) const
 {
     CWalletDB walletdb(strWalletFile);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2541,24 +2541,24 @@ std::string CWallet::GetAllGridcoinKeys()
         }
         else
         {
-     
-                bool IsCompressed;
-                CKey vchSecret;
-                //CSecret vchSecret;
-                if (!GetKey(keyID, vchSecret))
-                {
-                    errors = errors + "During Wallet Backup, Private key for address is not known\r\n";
-                }
-                else
-                {
-                     CSecret secret = vchSecret.GetSecret(IsCompressed);
-                    std::string private_key = CBitcoinSecret(secret,IsCompressed).ToString();
+
+            bool IsCompressed;
+            CKey vchSecret;
+            //CSecret vchSecret;
+            if (!GetKey(keyID, vchSecret))
+            {
+                errors = errors + "GetAllGridcoinKeys: During Wallet Backup, Private key for address is not known\r\n";
+            }
+            else
+            {
+                CSecret secret = vchSecret.GetSecret(IsCompressed);
+                std::string private_key = CBitcoinSecret(secret,IsCompressed).ToString();
                 
-                    //Append to file
-                    std::string strAddr = CBitcoinAddress(keyID).ToString();
-                    std::string record = private_key + "<|>" + strAddr + "<KEY>";
-                    backup=backup+record;
-                }
+                //Append to file
+                std::string strAddr = CBitcoinAddress(keyID).ToString();
+                std::string record = strAddr + ":" + private_key + "\n";
+                backup=backup+record;
+            }
         }
     }
     return backup;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2516,7 +2516,7 @@ void CWallet::GetAllReserveKeys(set<CKeyID>& setAddress) const
     }
 }
 
-std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKeys(CWallet* pBackupWallet, std::string& sError)
+std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKeys(std::string& sError)
 {
     CWalletDB walletdb(strWalletFile);
 
@@ -2527,7 +2527,7 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
     for (auto const& item : mapAddressBook)
     {
         const CBitcoinAddress& address = item.first;
-        bool fMine = ::IsMine(*pBackupWallet, address.Get());
+        bool fMine = ::IsMine(*this, address.Get());
         if (fMine)
         {
             CKeyID keyID;
@@ -2539,7 +2539,7 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
             {
                 bool IsCompressed;
                 CKey vchSecret;
-                if (!pBackupWallet->GetKey(keyID, vchSecret))
+                if (!GetKey(keyID, vchSecret))
                 {
                     printf("GetAllPrivateKeys: During private key backup, Private key for address %s is not known\r\n", address.ToString().c_str());
                 }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -206,7 +206,7 @@ public:
     bool GetKeyFromPool(CPubKey &key, bool fAllowReuse=true);
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
-    std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> GetAllPrivateKeys(std::string& sError);
+    std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> GetAllPrivateKeys(std::string& sError) const;
 
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -206,7 +206,7 @@ public:
     bool GetKeyFromPool(CPubKey &key, bool fAllowReuse=true);
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
-	std::string GetAllGridcoinKeys();
+    std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> GetAllPrivateKeys(CWallet* pBackupWallet, std::string& sError);
 
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -206,7 +206,7 @@ public:
     bool GetKeyFromPool(CPubKey &key, bool fAllowReuse=true);
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
-    std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> GetAllPrivateKeys(CWallet* pBackupWallet, std::string& sError);
+    std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> GetAllPrivateKeys(std::string& sError);
 
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -698,22 +698,22 @@ bool BackupWallet(const CWallet& wallet, const std::string& strDest)
                 bitdb.mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet.dat - Leave strDest support for WalletModel
-                boost::filesystem::path WalletTarget = GetDataDir() / "walletbackups" / strDest;
-                boost::filesystem::create_directories(WalletTarget.parent_path());
-                boost::filesystem::path WalletSource = GetDataDir() / wallet.strWalletFile;
-                if (boost::filesystem::is_directory(WalletTarget))
+                filesystem::path WalletTarget = GetDataDir() / "walletbackups" / strDest;
+                filesystem::create_directories(WalletTarget.parent_path());
+                filesystem::path WalletSource = GetDataDir() / wallet.strWalletFile;
+                if (filesystem::is_directory(WalletTarget))
                     WalletTarget /= wallet.strWalletFile;
                 try
                 {
                     #if BOOST_VERSION >= 104000
-                        boost::filesystem::copy_file(WalletSource, WalletTarget, filesystem::copy_option::overwrite_if_exists);
+                        filesystem::copy_file(WalletSource, WalletTarget, filesystem::copy_option::overwrite_if_exists);
                     #else
-                        boost::filesystem::copy_file(WalletSource, WalletTarget);
+                        filesystem::copy_file(WalletSource, WalletTarget);
                     #endif
                     printf("BackupWallet: Copied wallet.dat to %s\r\n", WalletTarget.string().c_str());
                     return true;
                 }
-                catch(const boost::filesystem::filesystem_error &e) {
+                catch(const filesystem::filesystem_error &e) {
                     printf("BackupWallet: Error copying wallet.dat to %s - %s\r\n", WalletTarget.string().c_str(), e.what());
                     return false;
                 }
@@ -731,8 +731,8 @@ bool BackupPrivateKeys(CWallet* pBackupWallet, std::string& sTarget, std::string
         sErrors = "Wallet needs to be fully unlocked to backup private keys. ";
         return false;
     }
-    boost::filesystem::path PrivateKeysTarget = GetDataDir() / "walletbackups" / GetBackupFilename("keys.dat");
-    boost::filesystem::create_directories(PrivateKeysTarget.parent_path());
+    filesystem::path PrivateKeysTarget = GetDataDir() / "walletbackups" / GetBackupFilename("keys.dat");
+    filesystem::create_directories(PrivateKeysTarget.parent_path());
     sTarget = PrivateKeysTarget.string();
     std::ofstream myBackup;
     myBackup.open (PrivateKeysTarget.string().c_str());

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -15,7 +15,7 @@ using namespace boost;
 
 static uint64_t nAccountingEntryNumber = 0;
 extern bool fWalletUnlockStakingOnly;
-extern bool BackupPrivateKeys(CWallet* pBackupWallet, std::string& sTarget, std::string& sErrors);
+extern bool BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::string& sErrors);
 extern bool BackupWallet(const CWallet& wallet, const std::string& strDest);
 
 //
@@ -724,9 +724,9 @@ bool BackupWallet(const CWallet& wallet, const std::string& strDest)
     return false;
 }
 
-bool BackupPrivateKeys(CWallet* pBackupWallet, std::string& sTarget, std::string& sErrors)
+bool BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::string& sErrors)
 {
-    if (pBackupWallet->IsLocked() || fWalletUnlockStakingOnly)
+    if (wallet.IsLocked() || fWalletUnlockStakingOnly)
     {
         sErrors = "Wallet needs to be fully unlocked to backup private keys. ";
         return false;
@@ -737,7 +737,7 @@ bool BackupPrivateKeys(CWallet* pBackupWallet, std::string& sTarget, std::string
     std::ofstream myBackup;
     myBackup.open (PrivateKeysTarget.string().c_str());
     std::string sError;
-    for(const auto& keyPair : pBackupWallet->GetAllPrivateKeys(sError))
+    for(const auto& keyPair : wallet.GetAllPrivateKeys(sError))
     {
         if (!sError.empty())
         {

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -737,7 +737,7 @@ bool BackupPrivateKeys(CWallet* pBackupWallet, std::string& sTarget, std::string
     std::ofstream myBackup;
     myBackup.open (PrivateKeysTarget.string().c_str());
     std::string sError;
-    for(const auto& keyPair : pBackupWallet->GetAllPrivateKeys(pBackupWallet, sError))
+    for(const auto& keyPair : pBackupWallet->GetAllPrivateKeys(sError))
     {
         if (!sError.empty())
         {

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -763,11 +763,9 @@ bool BackupPrivateKeys(CWallet* pBackupWallet)
     BOOST_FOREACH(const PAIRTYPE(CTxDestination, string)& item, pBackupWallet->mapAddressBook)
     {
         const CBitcoinAddress& address = item.first;
-        //const std::string& strName = item.second;
         bool fMine = IsMine(*pBackupWallet, address.Get());
         if (fMine)
         {
-            //std::string strAddress=CBitcoinAddress(address).ToString();
             CKeyID keyID;
             if (!address.GetKeyID(keyID))
             {
@@ -787,8 +785,8 @@ bool BackupPrivateKeys(CWallet* pBackupWallet)
                     std::string private_key = CBitcoinSecret(secret,IsCompressed).ToString();
                     //Append to file
                     std::string strAddr = CBitcoinAddress(keyID).ToString();
-                    std::string record = private_key + "<|>" + strAddr + "<KEY>";
-                    myBackup << record;
+                    std::string record = strAddr + ":" + private_key;
+                    myBackup << record << endl;
                 }
             }
         }


### PR DESCRIPTION
* Cleaned up some bad spacing.

Before:

Before we never sent back a success or fail for wallet backups. So when a user 'execute backupwallet' or the backup timer kicked in the result was always "" whether it was successful of failed. and also in the log the "Daily backup results:" was empty to.

Here I've added the bools to receive the true/false from the backup of wallet or config.
Then we return whether or not its success or fail for each config and wallet.

yes there was some information in the log file but nothing user friendly to see.

For example:

23:31:57
￼
execute backupwallet


23:31:57
￼
[
{
"Command" : "backupwallet"
},
{
"Backup Wallet Result" : ""
}
]

this is what u get doing the command in rpc.

With this you get:

23:34:46
￼
execute backupwallet


23:34:46
￼
[
{
"Command" : "backupwallet"
},
{
"Backup Wallet Result" : "Wallet: success Config: success"
}
]
