### PR TITLE
Delete orphan blocks to avoid memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,9 @@ Gridcoin is released under the terms of the MIT license. See [COPYING](COPYING) 
 information or see https://opensource.org/licenses/MIT.
 
 
+Build Status
+=============
+
+| Development                                                                                                                            | Staging                                                                                                                            | Master                                                                                                                            |
+|----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| [![Build Status](https://travis-ci.org/gridcoin/Gridcoin-Research.svg?branch=development)](https://travis-ci.org/gridcoin/Gridcoin-Research) | [![Build Status](https://travis-ci.org/gridcoin/Gridcoin-Research.svg?branch=staging)](https://travis-ci.org/gridcoin/Gridcoin-Research) | [![Build Status](https://travis-ci.org/gridcoin/Gridcoin-Research.svg?branch=master)](https://travis-ci.org/gridcoin/Gridcoin-Research) |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4678,14 +4678,19 @@ bool AskForOutstandingBlocks(uint256 hashStart)
 }
 
 
-
+void clearOrphanBlocks() {
+    for(auto it = mapOrphanBlocks.begin(); it != mapOrphanBlocks.end(); it++) {
+        delete it->second;
+    }
+    mapOrphanBlocks.clear();
+}
 
 
 void CheckForLatestBlocks()
 {
     if (WalletOutOfSync())
     {
-            mapOrphanBlocks.clear();
+            clearOrphanBlocks();
             setStakeSeen.clear();
             setStakeSeenOrphan.clear();
             AskForOutstandingBlocks(uint256(0));
@@ -4752,7 +4757,7 @@ void CheckForFutileSync()
             {
                 mapAlreadyAskedFor.clear();
                 printf("\r\nClearing mapAlreadyAskedFor.\r\n");
-                mapOrphanBlocks.clear(); 
+                clearOrphanBlocks();
                 setStakeSeen.clear();  
                 setStakeSeenOrphan.clear();
                 AskForOutstandingBlocks(uint256(0));


### PR DESCRIPTION
First fix as a new developper !
In the future, make a switch to smart pointers in mapOrphanBlocks variable.