### PR TITLE
Fix rounding discrepancies between VB and C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,9 @@ Gridcoin is released under the terms of the MIT license. See [COPYING](COPYING) 
 information or see https://opensource.org/licenses/MIT.
 
 
+Build Status
+=============
+
+| Development                                                                                                                            | Staging                                                                                                                            | Master                                                                                                                            |
+|----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| [![Build Status](https://travis-ci.org/gridcoin/Gridcoin-Research.svg?branch=development)](https://travis-ci.org/gridcoin/Gridcoin-Research) | [![Build Status](https://travis-ci.org/gridcoin/Gridcoin-Research.svg?branch=staging)](https://travis-ci.org/gridcoin/Gridcoin-Research) | [![Build Status](https://travis-ci.org/gridcoin/Gridcoin-Research.svg?branch=master)](https://travis-ci.org/gridcoin/Gridcoin-Research) |

--- a/contrib/Installer/boinc/boinc/clsQuorumHashingAlgorithm.cls
+++ b/contrib/Installer/boinc/boinc/clsQuorumHashingAlgorithm.cls
@@ -36,7 +36,7 @@
                 If UBound(vRow) > 0 Then
                     If Len(vRow(0)) > 5 Then
                         Dim sCPID As String = vRow(0)
-                        Dim dMag = Math.Round(Val(vRow(1)), 0)
+                        Dim dMag = Math.Round(Val(vRow(1)), 0, MidpointRounding.AwayFromZero)
                         Dim sRow = sCPID + "," + Trim(dMag)
                         If KeyValue("DEBUG_QHA") = "TRUE" Then Log(sRow)
                         sHashIn += CPIDHash(dMag, sCPID) + "<COL>"
@@ -53,11 +53,11 @@
         Return sHash
     End Function
     Private Function CPIDHash(dMagIn As Double, sCPID As String) As String
-        Dim sMag As String = Trim(Math.Round(dMagIn, 0))
+        Dim sMag As String = Trim(Math.Round(dMagIn, 0, MidpointRounding.AwayFromZero))
         Dim dMagLength As Double = Len(sMag)
         Dim dExponent As Double = Math.Pow(dMagLength, 5)
-        Dim sMagComponent1 As String = Trim(Math.Round(dMagIn / (dExponent + 0.01), 0))
-        Dim sSuffix = Trim(Math.Round(dMagLength * dExponent, 0))
+        Dim sMagComponent1 As String = Trim(Math.Round(dMagIn / (dExponent + 0.01), 0, MidpointRounding.AwayFromZero))
+        Dim sSuffix = Trim(Math.Round(dMagLength * dExponent, 0, MidpointRounding.AwayFromZero))
         Dim sHash As String = sCPID + sMagComponent1 + sSuffix
         Return sHash
     End Function


### PR DESCRIPTION
This is how the C++ hashes are calculated, as opposed to the default round-to-even in VB.NET.

Without the fix the hashes will be calculated differently in VB and C++:
```
"avg" : 214901.03302348,
"beacon_count" : 2792.00000000,
"avg_mag" : 64.30597788,
"beacon_participant_count" : 2761.00000000,
"superblock_valid" : true,
".NET Neural Hash" : "2ca1ca84321f09a22bd74825d3aa727b",
"Length" : 71587.00000000,
"Wallet Neural Hash" : "e0edcfd93842c120b7e0656c39d310dc"
```

With the fix:
```
"avg" : 214901.03302348,
"beacon_count" : 2790.00000000,
"avg_mag" : 64.30597788,
"beacon_participant_count" : 2595.00000000,
"superblock_valid" : true,
".NET Neural Hash" : "e0edcfd93842c120b7e0656c39d310dc",
"Length" : 70757.00000000,
"Wallet Neural Hash" : "e0edcfd93842c120b7e0656c39d310dc"
```