### PR TITLE
change for DefaultWalletAddress

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1028,8 +1028,6 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
     return nEvicted;
 }
 
-
-
 std::string DefaultWalletAddress()
 {
     static std::string sDefaultWalletAddress;
@@ -1039,23 +1037,9 @@ std::string DefaultWalletAddress()
     try
     {
         //Gridcoin - Find the default public GRC address (since a user may have many receiving addresses):
-        BOOST_FOREACH(const PAIRTYPE(CTxDestination, string)& item, pwalletMain->mapAddressBook)
+        for (auto const& item : pwalletMain->mapAddressBook)
         {
             const CBitcoinAddress& address = item.first;
-            const std::string& strName = item.second;
-            bool fMine = IsMine(*pwalletMain, address.Get());
-            if (fMine && strName == "Default") 
-            {
-                sDefaultWalletAddress=CBitcoinAddress(address).ToString();
-                return sDefaultWalletAddress;
-            }
-        }
-        
-        //Cant Find        
-        BOOST_FOREACH(const PAIRTYPE(CTxDestination, string)& item, pwalletMain->mapAddressBook)
-        {
-            const CBitcoinAddress& address = item.first;
-            //const std::string& strName = item.second;
             bool fMine = IsMine(*pwalletMain, address.Get());
             if (fMine)
             {
@@ -1070,11 +1054,6 @@ std::string DefaultWalletAddress()
     }
     return "NA";
 }
-
-
-
-
-
 
 //////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Currently there is another way to bypass on the default wallet address. Currently a user can check all his grc addresses to see if its hash is low enough to participate in NN, etc. once the find one they can change the address label to Default and make that the wallet default address on restart. If it fails to find an address with the label Default it goes through the addresses again to choose a default address. 

* eliminated the influence of setting that label.
* changed BOOST_FOREACH to for auto as well.
* removed excess whitespace around the function as well.
