### PR TITLE
Unconfirmed balance not showing in ui

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1259,7 +1259,7 @@ int64_t CWallet::GetUnconfirmedBalance() const
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
-            if (!IsFinalTx(*pcoin) || (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0))
+            if (!IsFinalTx(*pcoin) || (!pcoin->IsConfirmed() && !pcoin->fFromMe))
                 nTotal += pcoin->GetAvailableCredit();
         }
     }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -698,7 +698,10 @@ public:
     {
         return (GetDebit(filter) > 0);
     }
-
+    bool IsConfirmed() const
+    {
+        return GetDepthInMainChain() >= 10;
+    }
     bool IsTrusted() const
     {
 		int nMinConfirmsRequiredToSendGRC = 3;


### PR DESCRIPTION
Currently the unconfirmed balance does not show in the ui as referenced in issue #358.

For some reason it was set to GetDepthInMainChain() == 0 which means 0 confirms which does not keep anything in unconfirmed balance.

IsTrusted is touched before but only passed through first few part for depth <0 and depth >3 and if not from me/change so this is not needed for unconfirmed balance since the goal of this check was to check the depth and if its not from the wallet user or change.

IsConfirmed is created to return true or false if the depth is greater then 10.

reason for this is we actually only need 3 confirms before u can send grc however we have recommended ten in the transactions so to not confuse the wallet user we opted for 10 in this case. so it will remain in unconfirmed until ten is reached.