### PR TITLE
Contents of miner Message field

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -568,7 +568,7 @@ void GetGlobalStatus()
         GlobalStatusStruct.cpid = GlobalCPUMiningCPID.cpid;
         GlobalStatusStruct.status = msMiningErrors;
         GlobalStatusStruct.poll = msPoll;
-        GlobalStatusStruct.errors =  MinerStatus.ReasonNotStaking + MinerStatus.Message + " " + msMiningErrors6 + " " + msMiningErrors7 + " " + msMiningErrors8;
+        GlobalStatusStruct.errors =  MinerStatus.ReasonNotStaking + " " + msMiningErrors6 + " " + msMiningErrors7 + " " + msMiningErrors8;
         GlobalStatusStruct.rsaOverview =  msRSAOverview; // not displayed on overview page anymore.
         }
         return;


### PR DESCRIPTION
One component of Client message gui field is `MinerStatus.Message`, which usually contains "Stake Weight xxx; ". Sometimes, when encountering difficulties or success in creating a block, miner will put other text there, but it will be cleared after 8 seconds on the next miner run, which is not enough to be noticed by user. But if it is picked up, it may cause the window to resize too much #384. Note: reasons for not staking are passed by different variable.
So I see little point in this field and removed it.

I ask for advice: where to direct this volatile messages other than the log file?

please dont merge until this dilemma is resolved