### PR TITLE
Prevent email being leaked in CPIDv2 block field.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -694,12 +694,18 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
     miningcpid.ResearchAge = dAccrualAge;
     miningcpid.ResearchMagnitudeUnit = dAccrualMagnitudeUnit;
     miningcpid.ResearchAverageMagnitude = dAccrualMagnitude;
-
     miningcpid.InterestSubsidy = out_interest;
-    miningcpid.enccpid = "";
-    miningcpid.encboincpublickey = "";
-    miningcpid.encaes = "";
     miningcpid.BoincSignature = "";
+
+    // Make sure this deprecated fields are empty
+    miningcpid.cpidv2.clear();
+    miningcpid.email.clear();
+    miningcpid.boincruntimepublickey.clear();
+    miningcpid.aesskein.clear();
+    miningcpid.enccpid.clear();
+    miningcpid.encboincpublickey.clear();
+    miningcpid.encaes.clear();
+
 
     int64_t RSA_WEIGHT = GetRSAWeightByBlock(miningcpid);
     std::string SerializedBoincData = SerializeBoincBlock(miningcpid,blocknew.nVersion);


### PR DESCRIPTION
This should be non-mandatory change. Can be merged on master directly.
Does not affect past blocks.
Please test if it is possible to stake and get confirmations with this before merging. I lost my beacon on testnet.