### PR TITLE
Fix for tally network averages

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1082,11 +1082,7 @@ bool AppInit2()
 
     InitializeBoincProjects();
     printf("Done loading boinc projects");
-    uiInterface.InitMessage(_("Loading Network Averages..."));
-    if (fDebug3) printf("Loading network averages");
-    BusyWaitForTally();
     uiInterface.InitMessage(_("Compute Neural Network Hashes..."));
-
     ComputeNeuralNetworkSupermajorityHashes();
 
     printf("Starting CPID thread...");
@@ -1110,8 +1106,11 @@ bool AppInit2()
     }
 
 
+    uiInterface.InitMessage(_("Loading Network Averages..."));
+    if (fDebug3) printf("Loading network averages");
     if (!NewThread(StartNode, NULL))
         InitError(_("Error: could not start node"));
+    BusyWaitForTally();
 
     if (fServer)
         NewThread(ThreadRPCServer, NULL);


### PR DESCRIPTION
Fix for #504 

Move the loading tally averages messages just before the call to node thread. put busy wait for tally after nodestart. now appears to load faster as well. I believe this may of led to a timeout before when waiting for tally before the node thread even started where the tally occurs.