### PR TITLE
importprivkey bug resulting in address not being added to receiving tab fix.

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -142,7 +142,6 @@ Value importprivkey(const Array& params, bool fHelp)
         LOCK2(cs_main, pwalletMain->cs_wallet);
 
         pwalletMain->MarkDirty();
-        pwalletMain->SetAddressBookName(vchAddress, strLabel);
 
         // Don't throw error in case a key is already there
         if (pwalletMain->HaveKey(vchAddress))
@@ -155,6 +154,8 @@ Value importprivkey(const Array& params, bool fHelp)
 
         // whenever a key is imported, we need to scan the whole chain
         pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'
+        pwalletMain->SetAddressBookName(vchAddress, strLabel);
+
         if (fRescan)
         {
             pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, true);


### PR DESCRIPTION
While playing around with importprivkey I found a bug where the new imported address would not show up in the receive tab on the ui. After investigating I found the cause.

pwalletMain->SetAddressBookName(vchAddress, strLabel);

This was put in an incorrect place resulting in IsMine=0 when NotifyAddressBookChange is called meaning it was determined to not be mine so it would not be added to the receiving tab.

So I moved it further down which corrected the problem and placed it before the rescan.

Before:

![beforebugfix](https://user-images.githubusercontent.com/13292864/30690870-7d3cea40-9e7a-11e7-95b6-ba0dea47a8b8.png)

After:

![afterbugfix](https://user-images.githubusercontent.com/13292864/30690880-87d1eeb0-9e7a-11e7-90df-110842219bf9.png)

As you can see it now works correctly. and yes I had to generate addresses for this test lol