### PR TITLE
additional condition to beacon timer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4480,7 +4480,7 @@ void GridcoinServices()
     if (TimerMain("send_beacon",180))
     {
         std::string tBeaconPublicKey = GetBeaconPublicKey(GlobalCPUMiningCPID.cpid,true);
-        if (tBeaconPublicKey.empty())
+        if (tBeaconPublicKey.empty() && !GlobalCPUMiningCPID.cpid.empty())
         {
             std::string sOutPubKey = "";
             std::string sOutPrivKey = "";


### PR DESCRIPTION
On rare occasion GlobalCPUMiningCPID.cpid was not populated and the timer checks for a BeaconPublicKey. and if you send "" when it is not populated it will think you need your beacon advertised causing it to say unable to advertise beacon yet in log say it is already in chain.

Here we add another condition to the BeaconPublicKey is empty. We and if GlobalCPUMiningCPID.cpid is not empty go ahead with advertising.