### PR TITLE
Smoother syncing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6611,11 +6611,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // Trigger them to send a getblocks request for the next batch of inventory
                     if (inv.hash == pfrom->hashContinue)
                     {
-                        // ppcoin: send latest proof-of-work block to allow the
-                        // download node to accept as orphan (proof-of-stake
-                        // block might be rejected by stake connection check)
+                        // Bypass PushInventory, this must send even if redundant,
+                        // and we want it right after the last block so they don't
+                        // wait for other stuff first.
                         vector<CInv> vInv;
-                        vInv.push_back(CInv(MSG_BLOCK, GetLastBlockIndex(pindexBest, false)->GetBlockHash()));
+                        vInv.push_back(CInv(MSG_BLOCK, hashBestChain));
                         pfrom->PushMessage("inv", vInv);
                         pfrom->hashContinue = 0;
                     }
@@ -6661,7 +6661,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // Send the rest of the chain
         if (pindex)
             pindex = pindex->pnext;
-        int nLimit = 1000;
+        int nLimit = 500;
 
         if (fDebug3) printf("\r\ngetblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20).c_str(), nLimit);
         for (; pindex; pindex = pindex->pnext)


### PR DESCRIPTION
This change does two things:

Batch size
========
It changes the number of blocks sent in one batch from 1000 to 500. When using 1000 blocks it looks like we start hitting the output buffer limit which makes the sender always send <1000 blocks (I usually got ~890). As a result the remote end will never ask for the continuation block which breaks the sync ping-pong and causes delays between batches.

PoW rewind
=========
When the batch sizes was corrected the block holder started seeking way back and asked the remote end to query for PoW blocks. This also slowed down syncing but it shouldn't have been visible before.

Testing
=====
Syncing from mid chain seems to work like a charm, but we need to ensure that it works from 0 where we still have scrypt blocks.