### PR TITLE
Remove underscores from poll text

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -208,7 +208,7 @@ void OverviewPage::UpdateBoincUtilization()
     ui->labelProject->setText(QString::fromUtf8(GlobalStatusStruct.project.c_str()));
     ui->labelCpid->setText(QString::fromUtf8(GlobalStatusStruct.cpid.c_str()));
     ui->labelStatus->setText(QString::fromUtf8(GlobalStatusStruct.status.c_str()));
-    ui->labelPoll->setText(QString::fromUtf8(GlobalStatusStruct.poll.c_str()));
+    ui->labelPoll->setText(QString::fromUtf8(GlobalStatusStruct.poll.c_str()).replace(QChar('_'),QChar(' '), Qt::CaseSensitive));
     ui->labelErrors->setText(QString::fromUtf8(GlobalStatusStruct.errors.c_str()));
 }
 


### PR DESCRIPTION
Only affects text shown in UI so shouldn't mess with anything else, if theres something that read this text that I haven't seen. Issue #612 

Ignore the branch name :)