### PR TITLE
Changing the community links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    (@MagixInTheAir).
  - Change poll min search length from 2 to 1, #595 (@MagixInTheAir).
  - Return the results of "backupwallet" RPC command, #593 (@Foggyx420).
+ - Changing the community links https://github.com/gridcoin/Gridcoin-Research/pull/654 (@grctest)
 
 ## [3.6.1.0] 09-11-2017
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    (@MagixInTheAir).
  - Change poll min search length from 2 to 1, #595 (@MagixInTheAir).
  - Return the results of "backupwallet" RPC command, #593 (@Foggyx420).
- - Changing the community links https://github.com/gridcoin/Gridcoin-Research/pull/654 (@grctest)
+ - Changing the community links #654 (@grctest)
 
 ## [3.6.1.0] 09-11-2017
 ### Fixed

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1521,8 +1521,7 @@ void BitcoinGUI::bxClicked()
 
 void BitcoinGUI::chatClicked()
 {
-    //QDesktopServices::openUrl(QUrl("https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin"));
-    QDesktopServices::openUrl(QUrl("https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin-help"));
+    QDesktopServices::openUrl(QUrl("https://gridcoin.us/contact.htm#GridcoinWallet"));
 }
 
 void BitcoinGUI::boincClicked()
@@ -1532,12 +1531,12 @@ void BitcoinGUI::boincClicked()
 
 void BitcoinGUI::websiteClicked()
 {
-    QDesktopServices::openUrl(QUrl("https://www.gridcoin.us"));
+    QDesktopServices::openUrl(QUrl("https://www.gridcoin.us#GridcoinWallet"));
 }
 
 void BitcoinGUI::exchangeClicked()
 {
-    QDesktopServices::openUrl(QUrl("https://c-cex.com/?p=grc-btc"));
+    QDesktopServices::openUrl(QUrl("https://gridcoin.us/exchange.htm#GridcoinWallet"));
 }
 
 void BitcoinGUI::gotoOverviewPage()


### PR DESCRIPTION
Switch to focusing on the gridcoin.us website instead of limiting chat/exchange selection.