### PR TITLE
Tally improvements

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -14,8 +14,6 @@ extern bool bForceUpdate;
 extern bool bCheckedForUpgrade;
 extern bool bCheckedForUpgradeLive;
 extern bool bGlobalcomInitialized;
-extern bool bDoTally;
-extern bool bTallyFinished;
 extern bool bGridcoinGUILoaded;
 
 struct StructCPID

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -24,7 +24,8 @@ bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 
 StructCPID GetStructCPID();
 bool ComputeNeuralNetworkSupermajorityHashes();
-void BusyWaitForTally();
+void TallyNetworkAverages();
+extern void ThreadAppInit2(void* parg);
 
 void LoadCPIDsInBackground();
 bool IsConfigFileEmpty();
@@ -992,12 +993,12 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
 
-    uiInterface.InitMessage(_("Loading Network Averages..."));
+    uiInterface.InitMessage(_("Loading Network Averages..."));    
     if (fDebug3) printf("Loading network averages");
-    if (!threads->createThread(StartNode, NULL, "Start Thread"))
+    TallyNetworkAverages();
 
-        InitError(_("Error: could not start node"));
-    BusyWaitForTally();
+    if (!threads->createThread(StartNode, NULL, "Start Thread"))
+        InitError(_("Error: could not start node"));    
 
     if (fServer)
         threads->createThread(ThreadRPCServer, NULL, "RPC Server Thread");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -993,12 +993,12 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
 
-    uiInterface.InitMessage(_("Loading Network Averages..."));    
+    uiInterface.InitMessage(_("Loading Network Averages..."));
     if (fDebug3) printf("Loading network averages");
     TallyNetworkAverages();
 
     if (!threads->createThread(StartNode, NULL, "Start Thread"))
-        InitError(_("Error: could not start node"));    
+        InitError(_("Error: could not start node"));
 
     if (fServer)
         threads->createThread(ThreadRPCServer, NULL, "RPC Server Thread");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -254,7 +254,6 @@ extern std::string RetrieveMd5(std::string s1);
 extern std::string aes_complex_hash(uint256 scrypt_hash);
 
 bool bNetAveragesLoaded = false;
-bool bTallyStarted      = false;
 bool bForceUpdate = false;
 bool bCheckedForUpgrade = false;
 bool bCheckedForUpgradeLive = false;
@@ -4235,11 +4234,6 @@ void GridcoinServices()
         printf("Daily backup results: Wallet -> %s Config -> %s\r\n", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
     }
 
-    if (TimerMain("ResetVars",30))
-    {
-        bTallyStarted = false;
-    }
-
     if (false && TimerMain("FixSpentCoins",60))
     {
             int nMismatchSpent;
@@ -5464,11 +5458,10 @@ bool TallyResearchAverages()
     if (nMinDepth < 2)              nMinDepth = 2;
     mvMagnitudesCopy.clear();
     int iRow = 0;
-    //CBlock block;
+
     CBlockIndex* pblockindex = pindexBest;
     if (!pblockindex)
     {
-        bTallyStarted = false;
         bNetAveragesLoaded = true;
         return true;
     }
@@ -5535,7 +5528,6 @@ bool TallyResearchAverages()
         mvDPOR = mvDPORCopy;
         mvMagnitudes = mvMagnitudesCopy;
         mvNetwork = mvNetworkCopy;
-        bTallyStarted = false;
         bNetAveragesLoaded = true;
         return true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4269,41 +4269,17 @@ void GridcoinServices()
         }
     }
 
-    int64_t superblock_age = GetAdjustedTime() - mvApplicationCacheTimestamp["superblock;magnitudes"];
-    bool bNeedSuperblock = (superblock_age > (GetSuperblockAgeSpacing(nBestHeight)));
-    if ( nBestHeight % 3 == 0 && NeedASuperblock() ) bNeedSuperblock=true;
-
-    if (fDebug10) 
+    // Update quorum data.
+    if ((nBestHeight % 3) == 0)
     {
-            printf (" MRSA %" PRId64 ", BH %d", superblock_age, nBestHeight);
+        ComputeNeuralNetworkSupermajorityHashes();
+        UpdateNeuralNetworkQuorumData();
     }
 
-    if (bNeedSuperblock)
-    {
-        if ((nBestHeight % 3) == 0)
-        {
-            if (fDebug10) printf("#CNNSH# ");
-            ComputeNeuralNetworkSupermajorityHashes();
-            UpdateNeuralNetworkQuorumData();
-        }
-    }
-    else
-    {
-        // When superblock is not old, Tally every N mins:
-        int nTallyGranularity = fTestNet ? 60 : 20;
-        if ((nBestHeight % nTallyGranularity) == 0)
-        {
-            TallyNetworkAverages();
-            ComputeNeuralNetworkSupermajorityHashes();
-        }
-
-        if ((nBestHeight % 5)==0)
-        {
-                UpdateNeuralNetworkQuorumData();
-        }
-
-    }
-
+    // Tally research averages.
+    if ((nBestHeight % TALLY_GRANULARITY) == 0)
+        TallyNetworkAverages();
+    
     // Every N blocks as a Synchronized TEAM:
     if ((nBestHeight % 30) == 0)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5427,11 +5427,14 @@ bool TallyResearchAverages()
     double NetworkInterest = 0;
     
     //Consensus Start/End block:
-    int nMaxDepth = (nBestHeight-CONSENSUS_LOOKBACK) - ( (nBestHeight-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
+    int nMaxConensusDepth = nBestHeight - CONSENSUS_LOOKBACK;
+    int nMaxDepth = nMaxConensusDepth - (nMaxConensusDepth % TALLY_GRANULARITY);
     int nLookback = BLOCKS_PER_DAY * 14; //Daily block count * Lookback in days
-    int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
-    if (fDebug3) printf("START BLOCK %f, END BLOCK %f ",(double)nMaxDepth,(double)nMinDepth);
-    if (nMinDepth < 2)              nMinDepth = 2;
+    int nMinDepth = nMaxDepth - nLookback;
+    if (nMinDepth < 2)
+        nMinDepth = 2;
+    
+    if (fDebug3) printf("START BLOCK %i, END BLOCK %i", nMaxDepth, nMinDepth);
     mvMagnitudesCopy.clear();
     int iRow = 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5439,7 +5439,7 @@ bool ComputeNeuralNetworkSupermajorityHashes()
 
 
 bool TallyResearchAverages()
-{    
+{
     //Iterate throught last 14 days, tally network averages
     if (nBestHeight < 15)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,11 +147,9 @@ CTxMemPool mempool;
 unsigned int nTransactionsUpdated = 0;
 unsigned int REORGANIZE_FAILED = 0;
 unsigned int WHITELISTED_PROJECTS = 0;
-int64_t nLastTallied = 0;
 int64_t nLastPing = 0;
 int64_t nLastAskedForBlocks = 0;
 int64_t nBootup = 0;
-int64_t nLastTallyBusyWait = 0;
 
 int64_t nLastTalliedNeural = 0;
 int64_t nLastLoadAdminMessages = 0;
@@ -3251,7 +3249,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                                         if (fDebug3) printf("ConnectBlock(): Superblock Loaded %d \r\n", pindex->nHeight);
                                         /*  Reserved for future use:
                                             bNetAveragesLoaded=false;
-                                            nLastTallied = 0;
                                             BsyWaitForTally();
                                         */
                                         if (!fColdBoot)
@@ -5494,20 +5491,10 @@ bool TallyResearchAverages(bool Forcefully)
         return true;
     }
 
-    //if (Forcefully) nLastTallied = 0;
-    int timespan = fTestNet ? 2 : 6;
-    if (IsLockTimeWithinMinutes(nLastTallied,timespan))
-    {
-        bNetAveragesLoaded=true;
-        return true;
-    }
-
     //8-27-2016
-     int64_t nStart = GetTimeMillis();
-
+    int64_t nStart = GetTimeMillis();
 
     if (fDebug) printf("Tallying Research Averages (begin) ");
-    nLastTallied = GetAdjustedTime();
     bNetAveragesLoaded = false;
     bool superblockloaded = false;
     double NetworkPayments = 0;
@@ -5538,7 +5525,7 @@ bool TallyResearchAverages(bool Forcefully)
                         if (fDebug3) printf("Max block %f, seektime %f",(double)pblockindex->nHeight,(double)GetTimeMillis()-nStart);
                         nStart=GetTimeMillis();
 
-   
+
                         // Headless critical section ()
         try
         {
@@ -5600,17 +5587,15 @@ bool TallyResearchAverages(bool Forcefully)
         {
             printf("Bad Alloc while tallying network averages. [1]\r\n");
             bNetAveragesLoaded=true;
-            nLastTallied = 0;
         }
         catch(...)
         {
             printf("Error while tallying network averages. [1]\r\n");
             bNetAveragesLoaded=true;
-            nLastTallied = 0;
         }
 
         if (fDebug3) printf("NA loaded in %f",(double)GetTimeMillis()-nStart);
-                        
+
         bNetAveragesLoaded=true;
         return false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ bool RequestSupermajorityNeuralData();
 extern bool AskForOutstandingBlocks(uint256 hashStart);
 extern bool CleanChain();
 extern void ResetTimerMain(std::string timer_name);
-extern bool TallyResearchAverages(bool Forcefully);
+extern bool TallyResearchAverages();
 extern void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, std::string GRCAddress, double distance);
 bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature);
 int DetermineCPIDType(std::string cpid);
@@ -62,8 +62,7 @@ extern double ExtractMagnitudeFromExplainMagnitude();
 extern void GridcoinServices();
 extern double SnapToGrid(double d);
 extern bool StrLessThanReferenceHash(std::string rh);
-void BusyWaitForTally();
-extern bool TallyNetworkAverages(bool Forcefully);
+extern bool TallyNetworkAverages();
 extern bool IsContract(CBlockIndex* pIndex);
 std::string ExtractValue(std::string data, std::string delimiter, int pos);
 extern MiningCPID GetBoincBlockByIndex(CBlockIndex* pblockindex);
@@ -261,8 +260,6 @@ bool bCheckedForUpgrade = false;
 bool bCheckedForUpgradeLive = false;
 bool bGlobalcomInitialized = false;
 bool bStakeMinerOutOfSyncWithNetwork = false;
-bool bDoTally = false;
-bool bTallyFinished = false;
 bool bGridcoinGUILoaded = false;
 
 extern double LederstrumpfMagnitude2(double Magnitude, int64_t locktime);
@@ -2184,19 +2181,11 @@ bool CheckProofOfResearch(
     // TODO: Remove this tally?
     if (bb.ResearchSubsidy > ((OUT_POR*1.25)+1))
     {
-        BusyWaitForTally();
-        StructCPID st1 = GetLifetimeCPID(bb.cpid,"CheckProofOfResearch()");
-        nCalculatedResearch = GetProofOfStakeReward(nCoinAge, nFees, bb.cpid, true, 2, block.nTime,
-                                                    pindexBest, "checkblock_researcher_doublecheck", OUT_POR, OUT_INTEREST, dAccrualAge, dMagnitudeUnit, dAvgMagnitude);
+        if (fDebug3) printf("CheckProofOfResearch: Researchers Reward Pays too much : Interest %f and Research %f and StakeReward %f, OUT_POR %f, with Out_Interest %f for CPID %s ",
+                            bb.InterestSubsidy, bb.ResearchSubsidy, CoinToDouble(nCalculatedResearch), OUT_POR, OUT_INTEREST, bb.cpid.c_str());
 
-        if (bb.ResearchSubsidy > ((OUT_POR*1.25)+1))
-        {
-            if (fDebug3) printf("CheckProofOfResearch: Researchers Reward Pays too much : Interest %f and Research %f and StakeReward %f, OUT_POR %f, with Out_Interest %f for CPID %s ",
-                                bb.InterestSubsidy, bb.ResearchSubsidy, CoinToDouble(nCalculatedResearch), OUT_POR, OUT_INTEREST, bb.cpid.c_str());
-
-            return block.DoS(10,error("CheckProofOfResearch: Researchers Reward Pays too much : Interest %f and Research %f and StakeReward %f, OUT_POR %f, with Out_Interest %f for CPID %s ",
-                                bb.InterestSubsidy, bb.ResearchSubsidy,CoinToDouble(nCalculatedResearch), OUT_POR, OUT_INTEREST, bb.cpid.c_str()));
-        }
+        return block.DoS(10,error("CheckProofOfResearch: Researchers Reward Pays too much : Interest %f and Research %f and StakeReward %f, OUT_POR %f, with Out_Interest %f for CPID %s ",
+                            bb.InterestSubsidy, bb.ResearchSubsidy,CoinToDouble(nCalculatedResearch), OUT_POR, OUT_INTEREST, bb.cpid.c_str()));
     }
 
     return true;
@@ -3146,7 +3135,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
         {
                 if (bb.ResearchSubsidy > (GetOwedAmount(bb.cpid)+1))
                 {
-                        bDoTally=true;
                         if (bb.ResearchSubsidy > (GetOwedAmount(bb.cpid)+1))
                         {
                             StructCPID strUntrustedHost = GetInitializedStructCPID2(bb.cpid,mvMagnitudes);
@@ -3247,14 +3235,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                             {
                                         LoadSuperblock(superblock,pindex->nTime,pindex->nHeight);
                                         if (fDebug3) printf("ConnectBlock(): Superblock Loaded %d \r\n", pindex->nHeight);
-                                        /*  Reserved for future use:
-                                            bNetAveragesLoaded=false;
-                                            BsyWaitForTally();
-                                        */
-                                        if (!fColdBoot)
-                                        {
-                                            bDoTally = true;
-                                        }
                             }
                             else
                             {
@@ -3307,18 +3287,9 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
         LoadAdminMessages(false,errors1);
     }
 
-    // Slow down Retallying when in RA mode so we minimize disruption of the network
-    if ( (pindex->nHeight % 60 == 0) && IsResearchAgeEnabled(pindex->nHeight) && BlockNeedsChecked(pindex->nTime))
+    if (IsResearchAgeEnabled(pindex->nHeight) && !OutOfSyncByAge())
     {
-        if (fDebug3) printf("\r\n*BusyWaitForTally*\r\n");
-        BusyWaitForTally();
-    }
-
-
-    if (IsResearchAgeEnabled(pindex->nHeight) && !OutOfSyncByAge()) 
-    {
-            fColdBoot = false;
-            bDoTally=true;
+        fColdBoot = false;
     }
 
     if (fJustCheck)
@@ -3603,8 +3574,8 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
                     printf("Failed to Reorganize during Attempt #%f \r\n",(double)iRegression+1);
                     txdb.TxnAbort();
                     InvalidChainFound(pindexNew);
-                    printf("\r\nReorg BusyWait\r\n");
-                    BusyWaitForTally();
+                    printf("\r\nReorg tally\r\n");
+                    TallyNetworkAverages();
                     REORGANIZE_FAILED++;
                     return error("SetBestChain() : Reorganize failed");
             }
@@ -3862,14 +3833,6 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
     //Research Age
     MiningCPID bb = DeserializeBoincBlock(vtx[0].hashBoinc,nVersion);
     //For higher security, plus lets catch these bad blocks before adding them to the chain to prevent reorgs:
-    double OUT_POR = 0;
-    double OUT_INTEREST = 0;
-    double dAccrualAge = 0;
-    double dMagnitudeUnit = 0;
-    double dAvgMagnitude = 0;
-    uint64_t nCoinAge = 0;
-    int64_t nFees = 0;
-
     if (bb.cpid != "INVESTOR" && IsProofOfStake() && height1 > nGrandfather && IsResearchAgeEnabled(height1) && BlockNeedsChecked(nTime) && !fLoadingIndex)
     {
         double blockVersion = BlockVersion(bb.clientversion);
@@ -4329,11 +4292,6 @@ void GridcoinServices()
             ComputeNeuralNetworkSupermajorityHashes();
             UpdateNeuralNetworkQuorumData();
         }
-        if ((nBestHeight % 20) == 0)
-        {
-            if (fDebug10) printf("#TIB# ");
-            bDoTally = true;
-        }
     }
     else
     {
@@ -4341,10 +4299,8 @@ void GridcoinServices()
         int nTallyGranularity = fTestNet ? 60 : 20;
         if ((nBestHeight % nTallyGranularity) == 0)
         {
-                if (fDebug3) printf("TIB1 ");
-                bDoTally = true;
-                if (fDebug3) printf("CNNSH2 ");
-                ComputeNeuralNetworkSupermajorityHashes();
+            TallyNetworkAverages();
+            ComputeNeuralNetworkSupermajorityHashes();
         }
 
         if ((nBestHeight % 5)==0)
@@ -5482,8 +5438,8 @@ bool ComputeNeuralNetworkSupermajorityHashes()
 }
 
 
-bool TallyResearchAverages(bool Forcefully)
-{
+bool TallyResearchAverages()
+{    
     //Iterate throught last 14 days, tally network averages
     if (nBestHeight < 15)
     {
@@ -5500,113 +5456,113 @@ bool TallyResearchAverages(bool Forcefully)
     double NetworkPayments = 0;
     double NetworkInterest = 0;
     
-                        //Consensus Start/End block:
-                        int nMaxDepth = (nBestHeight-CONSENSUS_LOOKBACK) - ( (nBestHeight-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
-                        int nLookback = BLOCKS_PER_DAY * 14; //Daily block count * Lookback in days
-                        int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
-                        if (fDebug3) printf("START BLOCK %f, END BLOCK %f ",(double)nMaxDepth,(double)nMinDepth);
-                        if (nMinDepth < 2)              nMinDepth = 2;
-                        mvMagnitudesCopy.clear();
-                        int iRow = 0;
-                        //CBlock block;
-                        CBlockIndex* pblockindex = pindexBest;
-                        if (!pblockindex)
-                        {
-                                bTallyStarted = false;
-                                bNetAveragesLoaded = true;
-                                return true;
-                        }
-                        while (pblockindex->nHeight > nMaxDepth)
-                        {
-                            if (!pblockindex || !pblockindex->pprev || pblockindex == pindexGenesisBlock) return false;
-                            pblockindex = pblockindex->pprev;
-                        }
+    //Consensus Start/End block:
+    int nMaxDepth = (nBestHeight-CONSENSUS_LOOKBACK) - ( (nBestHeight-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
+    int nLookback = BLOCKS_PER_DAY * 14; //Daily block count * Lookback in days
+    int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
+    if (fDebug3) printf("START BLOCK %f, END BLOCK %f ",(double)nMaxDepth,(double)nMinDepth);
+    if (nMinDepth < 2)              nMinDepth = 2;
+    mvMagnitudesCopy.clear();
+    int iRow = 0;
+    //CBlock block;
+    CBlockIndex* pblockindex = pindexBest;
+    if (!pblockindex)
+    {
+        bTallyStarted = false;
+        bNetAveragesLoaded = true;
+        return true;
+    }
+    while (pblockindex->nHeight > nMaxDepth)
+    {
+        if (!pblockindex || !pblockindex->pprev || pblockindex == pindexGenesisBlock) return false;
+        pblockindex = pblockindex->pprev;
+    }
 
-                        if (fDebug3) printf("Max block %f, seektime %f",(double)pblockindex->nHeight,(double)GetTimeMillis()-nStart);
-                        nStart=GetTimeMillis();
+    if (fDebug3) printf("Max block %f, seektime %f",(double)pblockindex->nHeight,(double)GetTimeMillis()-nStart);
+    nStart=GetTimeMillis();
 
 
-                        // Headless critical section ()
-        try
+    // Headless critical section ()
+    try
+    {
+        while (pblockindex->nHeight > nMinDepth)
         {
-                        while (pblockindex->nHeight > nMinDepth)
-                        {
-                            if (!pblockindex || !pblockindex->pprev) return false;
-                            pblockindex = pblockindex->pprev;
-                            if (pblockindex == pindexGenesisBlock) return false;
-                            if (!pblockindex->IsInMainChain()) continue;
-                            NetworkPayments += pblockindex->nResearchSubsidy;
-                            NetworkInterest += pblockindex->nInterestSubsidy;
-                            AddResearchMagnitude(pblockindex);
+            if (!pblockindex || !pblockindex->pprev) return false;
+            pblockindex = pblockindex->pprev;
+            if (pblockindex == pindexGenesisBlock) return false;
+            if (!pblockindex->IsInMainChain()) continue;
+            NetworkPayments += pblockindex->nResearchSubsidy;
+            NetworkInterest += pblockindex->nInterestSubsidy;
+            AddResearchMagnitude(pblockindex);
 
-                            iRow++;
-                            if (IsSuperBlock(pblockindex) && !superblockloaded)
-                            {
-                                MiningCPID bb = GetBoincBlockByIndex(pblockindex);
-                                if (bb.superblock.length() > 20)
-                                {
-                                        std::string superblock = UnpackBinarySuperblock(bb.superblock);
-                                        if (VerifySuperblock(superblock, pblockindex))
-                                        {
-                                                LoadSuperblock(superblock,pblockindex->nTime,pblockindex->nHeight);
-                                                superblockloaded=true;
-                                                if (fDebug)
-                                                   printf(" Superblock Loaded %i", pblockindex->nHeight);
-                                        }
-                                }
-                            }
+            iRow++;
+            if (IsSuperBlock(pblockindex) && !superblockloaded)
+            {
+                MiningCPID bb = GetBoincBlockByIndex(pblockindex);
+                if (bb.superblock.length() > 20)
+                {
+                    std::string superblock = UnpackBinarySuperblock(bb.superblock);
+                    if (VerifySuperblock(superblock, pblockindex))
+                    {
+                        LoadSuperblock(superblock,pblockindex->nTime,pblockindex->nHeight);
+                        superblockloaded=true;
+                        if (fDebug)
+                            printf(" Superblock Loaded %i", pblockindex->nHeight);
+                    }
+                }
+            }
 
-                        }
-                        // End of critical section
-                        if (fDebug3) printf("TNA loaded in %" PRId64, GetTimeMillis()-nStart);
-                        nStart=GetTimeMillis();
-
-
-                        if (pblockindex)
-                        {
-                            if (fDebug3)
-                               printf("Min block %i, Rows %i", pblockindex->nHeight, iRow);
-
-                            StructCPID network = GetInitializedStructCPID2("NETWORK",mvNetworkCopy);
-                            network.projectname="NETWORK";
-                            network.payments = NetworkPayments;
-                            network.InterestSubsidy = NetworkInterest;
-                            mvNetworkCopy["NETWORK"] = network;
-                            if(fDebug3) printf(" TMIS1 ");
-                            TallyMagnitudesInSuperblock();
-                        }
-                        // 11-19-2015 Copy dictionaries to live RAM
-                        mvDPOR = mvDPORCopy;
-                        mvMagnitudes = mvMagnitudesCopy;
-                        mvNetwork = mvNetworkCopy;
-                        bTallyStarted = false;
-                        bNetAveragesLoaded = true;
-                        return true;
         }
-        catch (bad_alloc ba)
+        // End of critical section
+        if (fDebug3) printf("TNA loaded in %" PRId64, GetTimeMillis()-nStart);
+        nStart=GetTimeMillis();
+
+
+        if (pblockindex)
         {
-            printf("Bad Alloc while tallying network averages. [1]\r\n");
-            bNetAveragesLoaded=true;
-        }
-        catch(...)
-        {
-            printf("Error while tallying network averages. [1]\r\n");
-            bNetAveragesLoaded=true;
-        }
+            if (fDebug3)
+                printf("Min block %i, Rows %i", pblockindex->nHeight, iRow);
 
-        if (fDebug3) printf("NA loaded in %f",(double)GetTimeMillis()-nStart);
-
+            StructCPID network = GetInitializedStructCPID2("NETWORK",mvNetworkCopy);
+            network.projectname="NETWORK";
+            network.payments = NetworkPayments;
+            network.InterestSubsidy = NetworkInterest;
+            mvNetworkCopy["NETWORK"] = network;
+            if(fDebug3) printf(" TMIS1 ");
+            TallyMagnitudesInSuperblock();
+        }
+        // 11-19-2015 Copy dictionaries to live RAM
+        mvDPOR = mvDPORCopy;
+        mvMagnitudes = mvMagnitudesCopy;
+        mvNetwork = mvNetworkCopy;
+        bTallyStarted = false;
+        bNetAveragesLoaded = true;
+        return true;
+    }
+    catch (bad_alloc ba)
+    {
+        printf("Bad Alloc while tallying network averages. [1]\r\n");
         bNetAveragesLoaded=true;
-        return false;
+    }
+    catch(...)
+    {
+        printf("Error while tallying network averages. [1]\r\n");
+        bNetAveragesLoaded=true;
+    }
+
+    if (fDebug3) printf("NA loaded in %f",(double)GetTimeMillis()-nStart);
+
+    bNetAveragesLoaded=true;
+    return false;
 }
 
 
 
-bool TallyNetworkAverages(bool Forcefully)
+bool TallyNetworkAverages()
 {
     if (IsResearchAgeEnabled(pindexBest->nHeight))
     {
-        return TallyResearchAverages(Forcefully);
+        return TallyResearchAverages();
     }
 
     return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -310,7 +310,7 @@ std::string    msNeuralResponse;
 std::string    msHDDSerial;
 //When syncing, we grandfather block rejection rules up to this block, as rules became stricter over time and fields changed
 
-int nGrandfather = 1034700;
+int nGrandfather = 1035000;
 int nNewIndex = 271625;
 int nNewIndex2 = 364500;
 

--- a/src/main.h
+++ b/src/main.h
@@ -30,7 +30,8 @@ static const int LAST_POW_BLOCK = 2050;
 extern unsigned int REORGANIZE_FAILED;
 extern unsigned int WHITELISTED_PROJECTS;
 static const int CONSENSUS_LOOKBACK = 5;  //Amount of blocks to go back from best block, to avoid counting forked blocks
-static const int BLOCK_GRANULARITY = 10;   //Consensus block divisor 
+static const int BLOCK_GRANULARITY = 10;  //Consensus block divisor
+static const int TALLY_GRANULARITY = BLOCK_GRANULARITY;   
 
 static const double NeuralNetworkMultiplier = 115000;
 

--- a/src/main.h
+++ b/src/main.h
@@ -247,6 +247,11 @@ double GetBlockDifficulty(unsigned int nBits);
 std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
+// Validate researcher rewards.
+bool CheckProofOfResearch(
+    const CBlockIndex* pindexPrev, //previous block in chain index
+    const CBlock &block);    //block to check
+
 unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake);
 int64_t GetProofOfWorkReward(int64_t nFees, int64_t locktime, int64_t height);
 

--- a/src/main.h
+++ b/src/main.h
@@ -159,7 +159,6 @@ extern bool bOPReturnEnabled;
 extern int64_t nTransactionFee;
 extern int64_t nReserveBalance;
 extern int64_t nMinimumInputValue;
-extern int64_t nLastTallied;
 extern int64_t nLastPing;
 extern int64_t nLastAskedForBlocks;
 extern int64_t nBootup;
@@ -167,7 +166,6 @@ extern int64_t nLastTalliedNeural;
 extern int64_t nCPIDsLoaded;
 extern int64_t nLastGRCtallied;
 extern int64_t nLastCleaned;
-extern int64_t nLastTallyBusyWait;
 
 extern bool fUseFastIndex;
 extern unsigned int nDerivationMethodIndex;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1605,21 +1605,19 @@ begin:
 
 void BusyWaitForTally()
 {
-    if (IsLockTimeWithinMinutes(nLastTallyBusyWait,10))
-    {
-        return;
-    }
     if (fDebug10) printf("\r\n ** Busy Wait for Tally ** \r\n");
     bTallyFinished=false;
     bDoTally=true;
     int iTimeout = 0;
+
+    int64_t deadline = GetAdjustedTime() + 15000;
     while(!bTallyFinished)
     {
-        MilliSleep(1);
+        MilliSleep(10);
+        if(GetAdjustedTime() >= deadline)
+            break;
         iTimeout+=1;
-        if (iTimeout > 15000) break;
     }
-    nLastTallyBusyWait = GetAdjustedTime();
 }
 
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2047,7 +2047,6 @@ Value execute(const Array& params, bool fHelp)
     else if (sItem == "tally")
     {
             bNetAveragesLoaded = false;
-            nLastTallied = 0;
             TallyResearchAverages(true);
             entry.push_back(Pair("Tally Network Averages",1));
             results.push_back(entry);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2016,7 +2016,6 @@ Value execute(const Array& params, bool fHelp)
             entry.push_back(Pair("My Neural Hash",myNeuralHash.c_str()));
             results.push_back(entry);
         #endif
-        LoadSuperblock(contract,GetAdjustedTime(),280000);
         entry.push_back(Pair("Contract Test",contract));
         // Convert to Binary
         std::string sBin = PackBinarySuperblock(contract);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -42,7 +42,6 @@ extern Array MagnitudeReport(std::string cpid);
 std::string ConvertBinToHex(std::string a);
 std::string ConvertHexToBin(std::string a);
 extern std::vector<unsigned char> readFileToVector(std::string filename);
-bool TallyResearchAverages(bool Forcefully);
 int RestartClient();
 extern std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
 std::string BurnCoinsWithNewContract(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue, int64_t MinimumBalance, double dFees, std::string strPublicKey, std::string sBurnAddress);
@@ -2042,13 +2041,6 @@ Value execute(const Array& params, bool fHelp)
     {
             AsyncNeuralRequest("quorum","gridcoin",10);
             entry.push_back(Pair("Requested a quorum - waiting for resolution.",1));
-            results.push_back(entry);
-    }
-    else if (sItem == "tally")
-    {
-            bNetAveragesLoaded = false;
-            TallyResearchAverages(true);
-            entry.push_back(Pair("Tally Network Averages",1));
             results.push_back(entry);
     }
     else if (sItem == "encrypt")


### PR DESCRIPTION
Tries to get more deterministic tallying by only tallying at specific intervals:

- Upon start
- Every 10 blocks
- On reorganize

Since a tally is quick (300ms on my i5 with mechanical disk) there is no need to for the tally rate limiter anymore. This PR also changes the lookback window to match the tally granularity. This makes the tally window deterministic and consistent.

Hopefully this helps remedy the forks. Technically not a mandatory but making it one should cause people to align easier.

Remaining
========
Current tally is on every 60 blocks while the tally window is from the previous %10 block and 14000 blocks back. Rob wanted 60 block tally with a tally window end at %50 blocks back, but I would like to have these synchronized so a tally from a reorganize uses the exact same tally window as the block triggered one.