### PR TITLE
Optimize split operation.

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -4,7 +4,6 @@
 #include "key.h"
 #include "main.h"
 
-std::vector<std::string> split(std::string s, std::string delim);
 extern std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
 extern bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature);
 std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxSeconds);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,7 +22,6 @@
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 #include "global_objects_noui.hpp"
 
-std::vector<std::string> split(std::string s, std::string delim);
 bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 extern boost::thread_group threadGroup;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,7 +291,6 @@ extern void LoadCPIDsInBackground();
 extern void ThreadCPIDs();
 extern void GetGlobalStatus();
 
-extern std::vector<std::string> split(std::string s, std::string delim);
 extern bool ProjectIsValid(std::string project);
 
 double GetNetworkAvgByProject(std::string projectname);
@@ -2362,26 +2361,6 @@ const CTxOut& CTransaction::GetOutputFor(const CTxIn& input, const MapPrevTx& in
 
     return txPrev.vout[input.prevout.n];
 }
-
-
-std::vector<std::string> split(std::string s, std::string delim)
-{
-    //Split a std::string by a std::string delimiter into a vector of strings:
-    size_t pos = 0;
-    std::string token;
-    std::vector<std::string> elems;
-    while ((pos = s.find(delim)) != std::string::npos)
-    {
-        token = s.substr(0, pos);
-        elems.push_back(token);
-        s.erase(0, pos + delim.length());
-    }
-    elems.push_back(s);
-    return elems;
-
-}
-
-
 
 int64_t CTransaction::GetValueIn(const MapPrevTx& inputs) const
 {

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -32,10 +32,10 @@
 
 #include "json/json_spirit.h"
 #include "votingdialog.h"
+#include "util.h"
 
 
 extern json_spirit::Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& out_export, bool bIncludeExpired);
-extern std::vector<std::string> split(std::string s, std::string delim);
 extern std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 extern std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2);
 extern std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2, std::string arg3, std::string arg4, std::string arg5, std::string arg6);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -145,7 +145,6 @@ std::string getfilecontents(std::string filename);
 int CreateRestorePoint();
 int DownloadBlocks();
 double cdbl(std::string s, int place);
-std::vector<std::string> split(std::string s, std::string delim);
 double LederstrumpfMagnitude2(double mag,int64_t locktime);
 bool IsCPIDValidv2(MiningCPID& mc, int height);
 std::string RetrieveMd5(std::string s1);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -360,4 +360,15 @@ BOOST_AUTO_TEST_CASE(util_VerifyRoundToString)
     BOOST_CHECK_EQUAL("1.2346", RoundToString(1.23456789, 4));
 }
 
+BOOST_AUTO_TEST_CASE(util_VerifySplit)
+{
+    const std::string str("Hello;;My;;String;;");
+    const auto res = split(str, ";;");
+    BOOST_CHECK(res.size() == 4);
+    BOOST_CHECK_EQUAL("Hello",  res[0]);
+    BOOST_CHECK_EQUAL("My",     res[1]);
+    BOOST_CHECK_EQUAL("String", res[2]);
+    BOOST_CHECK_EQUAL("",       res[3]);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1467,6 +1467,22 @@ bool Contains(const std::string& data, const std::string& instring)
     return data.find(instring) != std::string::npos;
 }
 
+std::vector<std::string> split(const std::string& s, const std::string& delim)
+{
+    size_t pos = 0;
+    size_t end = 0;
+    std::vector<std::string> elems;
+
+    while((end = s.find(delim, pos)) != std::string::npos)
+    {
+        elems.push_back(s.substr(pos, end - pos));
+        pos = end + delim.size();
+    }
+
+    // Append final value
+    elems.push_back(s.substr(pos, end - pos));
+}
+
 std::string GetNeuralVersion()
 {
 

--- a/src/util.h
+++ b/src/util.h
@@ -227,6 +227,7 @@ std::string ToString(const T& val)
 }
 
 bool Contains(const std::string& data, const std::string& instring);
+std::vector<std::string> split(const std::string& s, const std::string& delim);
 
 std::string MakeSafeMessage(const std::string& messagestring);
 


### PR DESCRIPTION
Avoid modifying the incoming string. This makes the operation 12% faster on short strings and 48% faster on long strings like a contract.
Also, move the function to util.cpp/h.