### PR TITLE
OUT_INTEREST bug fix

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -259,7 +259,7 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 int64_t GetProofOfWorkReward(int64_t nFees, int64_t locktime, int64_t height);
 
 int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string operation, CBlockIndex* pindexLast, bool bVerifyingBlock, int VerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude);
-int64_t GetProofOfStakeReward(int64_t nCoinAge, int64_t nFees, std::string cpid,
+int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid,
 	bool VerifyingBlock, int VerificationPhase, int64_t nTime, CBlockIndex* pindexLast, std::string operation,
 	double& OUT_POR, double& OUT_INTEREST, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude);
 


### PR DESCRIPTION
I noticed while adding extra debug messages that OUT_INTEREST was 0.00000000 for 2 of the 3 passes (3 stages before block fully accepted) ProofOfStakeReward is called 3 times at various points. Problem with OUT_INTEREST being 0.00000000 is if the interest missing is significant to pass 1.25* total subsidy we throw a researchers reward pays too much. This corrects this it seems so far for interest causing that. could use some testing of course.

As for some nodes forking and others not its likely the time drift just pushed it over that 1.25* limit when interest was significant enough to affect it. a receiving nodes OUT_INTEREST is always correct as it checks the tx and my fix now has it check it as well and not leaving nCoinAge = 0 which anything multiplied by 0 is 0.

dajavu *cough* dMagnitudeUnit.

Only number that should differ is the OUT_POR which time drift affects but the receiving client should  always has a higher but close number.

still may be other issues with out_por versus the stakes POR still looking into that but this solves the coinage issue