### PR TITLE
Beacon check fixes

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -142,7 +142,7 @@ bool VerifyBeaconContractTx(const std::string& txhashBoinc)
     // Current bad contracts in chain would cause a fork on sync
     // Previous beacons in the past have 3 elements not 4 thus causing empty contract elements as coded in GetBeaconElements
     if (
-               (fTestNet && nBestHeight <= 300000)
+               (fTestNet && nBestHeight <= 378000)
             || (!fTestNet && nBestHeight <= 1070000)
        )
         return true; // allow sync from 0 till these blocks when this check comes into effect

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -138,41 +138,82 @@ std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxS
 
 bool VerifyBeaconContractTx(const std::string& txhashBoinc)
 {
+    // Mandatory block needed.
+    // Current bad contracts in chain would cause a fork on sync
+    // Previous beacons in the past have 3 elements not 4 thus causing empty contract elements as coded in GetBeaconElements
+    if (
+               (fTestNet && nBestHeight <= 300000)
+            || (!fTestNet && nBestHeight <= 1070000)
+       )
+        return true; // allow sync from 0 till these blocks when this check comes into effect
+
     // Check if tx contains beacon advertisement and evaluate for certain conditions
     std::string chkMessageType = ExtractXML(txhashBoinc, "<MT>", "</MT>");
     std::string chkMessageAction = ExtractXML(txhashBoinc, "<MA>", "</MA>");
-    if (chkMessageAction != "A" && chkMessageType != "beacon")
+
+    if (chkMessageType != "beacon")
         return true; // Not beacon contract
+
+    if (chkMessageAction != "A")
+        return true; // Not an add contract for beacon
+
     std::string chkMessageContract = ExtractXML(txhashBoinc, "<MV>", "</MV>");
     std::string chkMessageContractCPID = ExtractXML(txhashBoinc, "<MK>", "</MK>");
     // Here we GetBeaconElements for the contract in the tx
     std::string tx_out_cpid;
     std::string tx_out_address;
     std::string tx_out_publickey;
+
     GetBeaconElements(chkMessageContract, tx_out_cpid, tx_out_address, tx_out_publickey);
-    if (tx_out_cpid == "" || tx_out_address == "" || tx_out_publickey == "" || chkMessageContractCPID == "")
-        return false;
+
+    if (tx_out_cpid.empty() || tx_out_address.empty() || tx_out_publickey.empty() || chkMessageContractCPID.empty())
+        return false; // Incomplete contract
+
     std::string chkKey = "beacon;" + chkMessageContractCPID;
     std::string chkValue = mvApplicationCache[chkKey];
+
+    if (chkValue.empty())
+    {
+        if (fDebug10)
+            printf("VBCTX : No Previous beacon found for CPID %s\n", chkMessageContractCPID.c_str());
+
+        return true; // No previous beacon in cache
+    }
+
     int64_t chkiAge = pindexBest != NULL
         ? pindexBest->nTime - mvApplicationCacheTimestamp[chkKey]
         : 0;
     int64_t chkSecondsBase = 60 * 24 * 30 * 60;
+
     // Conditions
     // Condition a) if beacon is younger then 5 months deny tx
     if (chkiAge <= chkSecondsBase * 5 && chkiAge >= 1)
+    {
+        if (fDebug10)
+            printf("VBCTX : Beacon age violation. Beacon Age %" PRId64 " < Required Age %" PRId64 "\n", chkiAge, (chkSecondsBase * 5));
+
         return false;
+    }
+
     // Condition b) if beacon is younger then 6 months but older then 5 months verify using the same keypair; if not deny tx
     if (chkiAge >= chkSecondsBase * 5 && chkiAge <= chkSecondsBase * 6)
     {
         std::string chk_out_cpid;
         std::string chk_out_address;
         std::string chk_out_publickey;
+
         // Here we GetBeaconElements for the contract in the current beacon in chain
         GetBeaconElements(chkValue, chk_out_cpid, chk_out_address, chk_out_publickey);
+
         if (tx_out_publickey != chk_out_publickey)
+        {
+            if (fDebug10)
+                printf("VBCTX : Beacon tx publickey != publickey in chain. %s != %s\n", tx_out_publickey.c_str(), chk_out_publickey.c_str());
+
             return false;
+        }
     }
+
     // Passed checks
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1399,7 +1399,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
 
     // Verify beacon contract in tx if found
     if (!VerifyBeaconContractTx(tx.hashBoinc))
-        return tx.DoS(25, error("AcceptToMemoryPool : bad beacon contract in tx; rejected"));
+        return tx.DoS(25, error("AcceptToMemoryPool : bad beacon contract in tx %s; rejected", tx.GetHash().ToString().c_str()));
 
     // Coinbase is only valid in a block, not as a loose transaction
     if (tx.IsCoinBase())
@@ -3977,7 +3977,7 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
 
         // Verify beacon contract if a transaction contains a beacon contract
         if (!VerifyBeaconContractTx(tx.hashBoinc) && !fLoadingIndex)
-            return DoS(25, error("CheckBlock[] : bad beacon contract found in tx contained within block; rejected"));
+            return DoS(25, error("CheckBlock[] : bad beacon contract found in tx %s contained within block; rejected", tx.GetHash().ToString().c_str()));
     }
 
     // Check for duplicate txids. This is caught by ConnectInputs(),


### PR DESCRIPTION
Problems that had to be overcome:

* Added spacing for clarity of code
* The old if statement to check if the contract was a beacon and add never considered the second part of the if statement thus failing and always passing into the code.
* Old beacon contracts contained 3 elements not 4 thus why the beacon elements sent back nothing for the required strings. In turn causing a bad beacon contract tx.

Solutions:

* Split the if statements and they are working correctly now
* Added required mandatory block of 378000 for testnet and 1070000 for production (~14 days from now)
* Added Debug messages for the tx checks in memory pool and checkblock
* Added Debug messages for the memory pool/Checkblock failed information used as well
* Added a forgotten check to see if beacon is not in cache.
