### PR TITLE
Remove mvBoincProjects + more

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -149,8 +149,6 @@ extern std::map<std::string, StructCPIDCache> mvAppCache; //Contains cached bloc
 //Global CPU Mining CPID:
 extern MiningCPID GlobalCPUMiningCPID;
 
-//Boinc Valid Projects
-extern std::map<std::string, StructCPID> mvBoincProjects; // Contains all of the allowed boinc projects;
 // Timers
 extern std::map<std::string, int> mvTimers; // Contains event timers that reset after max ms duration iterator is exceeded
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,8 +29,6 @@ void BusyWaitForTally();
 void LoadCPIDsInBackground();
 bool IsConfigFileEmpty();
 
-std::string ToOfficialName(std::string proj);
-
 #ifndef WIN32
 #include <signal.h>
 #endif
@@ -45,8 +43,6 @@ extern unsigned int nNodeLifespan;
 extern unsigned int nDerivationMethodIndex;
 extern unsigned int nMinerSleep;
 extern bool fUseFastIndex;
-void InitializeBoincProjects();
-
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -71,58 +67,6 @@ void StartShutdown()
     fRequestShutdown = true;
 #endif
 }
-
-void InitializeBoincProjects()
-{
-       //Initialize GlobalCPUMiningCPID
-        GlobalCPUMiningCPID.initialized = true;
-        GlobalCPUMiningCPID.cpid="";
-        GlobalCPUMiningCPID.cpidv2 = "";
-        GlobalCPUMiningCPID.projectname ="";
-        GlobalCPUMiningCPID.rac=0;
-        GlobalCPUMiningCPID.encboincpublickey = "";
-        GlobalCPUMiningCPID.boincruntimepublickey = "";
-        GlobalCPUMiningCPID.pobdifficulty = 0;
-        GlobalCPUMiningCPID.diffbytes = 0;
-        GlobalCPUMiningCPID.email = "";
-        GlobalCPUMiningCPID.RSAWeight = 0;
-
-        //Loop through projects saved in the Gridcoin Persisted Data System
-        std::string sType = "project";
-        for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
-        {
-                std::string key_name  = (*ii).first;
-                if (key_name.length() > sType.length())
-                {
-                    if (key_name.substr(0,sType.length())==sType)
-                    {
-                            std::string key_value = mvApplicationCache[(*ii).first];
-                            std::vector<std::string> vKey = split(key_name,";");
-                            if (vKey.size() > 0)
-                            {
-
-                                std::string project_name = vKey[1];
-                                printf("Proj %s ",project_name.c_str());
-                                std::string project_value = key_value;
-                                boost::to_lower(project_name);
-                                std::string mainProject = ToOfficialName(project_name);
-                                boost::to_lower(mainProject);
-                                StructCPID structcpid = GetStructCPID();
-                                mvBoincProjects.insert(map<string,StructCPID>::value_type(mainProject,structcpid));
-                                structcpid = mvBoincProjects[mainProject];
-                                structcpid.initialized = true;
-                                structcpid.link = "http://";
-                                structcpid.projectname = mainProject;
-                                mvBoincProjects[mainProject] = structcpid;
-                                WHITELISTED_PROJECTS++;
-
-                            }
-                     }
-                }
-       }
-
-}
-
 
 void Shutdown(void* parg)
 {
@@ -1024,8 +968,6 @@ bool AppInit2(ThreadHandlerPtr threads)
     LoadAdminMessages(true,sOut);
     printf("Done loading Admin messages");
 
-    InitializeBoincProjects();
-    printf("Done loading boinc projects");
     uiInterface.InitMessage(_("Compute Neural Network Hashes..."));
     ComputeNeuralNetworkSupermajorityHashes();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1397,8 +1397,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         return error("AcceptToMemoryPool : CheckTransaction failed");
 
     // Verify beacon contract in tx if found
-    if (!VerifyBeaconContractTx(tx.hashBoinc))
-        return tx.DoS(25, error("AcceptToMemoryPool : bad beacon contract in tx; rejected"));
+    //if (!VerifyBeaconContractTx(tx.hashBoinc))
+    //    return tx.DoS(25, error("AcceptToMemoryPool : bad beacon contract in tx; rejected"));
 
     // Coinbase is only valid in a block, not as a loose transaction
     if (tx.IsCoinBase())
@@ -3975,8 +3975,8 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
             return DoS(50, error("CheckBlock[] : block timestamp earlier than transaction timestamp"));
 
         // Verify beacon contract if a transaction contains a beacon contract
-        if (!VerifyBeaconContractTx(tx.hashBoinc) && !fLoadingIndex)
-            return DoS(25, error("CheckBlock[] : bad beacon contract found in tx contained within block; rejected"));
+        //if (!VerifyBeaconContractTx(tx.hashBoinc) && !fLoadingIndex)
+        //    return DoS(25, error("CheckBlock[] : bad beacon contract found in tx contained within block; rejected"));
     }
 
     // Check for duplicate txids. This is caught by ConnectInputs(),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "beacon.h"
 #include "miner.h"
 #include "backup.h"
+#include "appcache.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem.hpp>
@@ -277,7 +278,6 @@ bool bGridcoinGUILoaded = false;
 extern double LederstrumpfMagnitude2(double Magnitude, int64_t locktime);
 
 extern void WriteAppCache(std::string key, std::string value);
-extern std::string AppCache(std::string key);
 extern void LoadCPIDsInBackground();
 
 extern void ThreadCPIDs();
@@ -349,7 +349,6 @@ std::map<std::string, StructCPID> mvNetworkCopy;      //Contains the project sta
 std::map<std::string, StructCPID> mvCreditNodeCPID;        // Contains verified CPID Magnitudes;
 std::map<std::string, StructCPIDCache> mvCPIDCache; //Contains cached blocknumbers for CPID+Projects;
 std::map<std::string, StructCPIDCache> mvAppCache; //Contains cached blocknumbers for CPID+Projects;
-std::map<std::string, StructCPID> mvBoincProjects; // Contains all of the allowed boinc projects;
 std::map<std::string, StructCPID> mvMagnitudes; // Contains Magnitudes by CPID & Outstanding Payments Owed per CPID
 std::map<std::string, StructCPID> mvMagnitudesCopy; // Contains Magnitudes by CPID & Outstanding Payments Owed per CPID
 
@@ -555,19 +554,19 @@ void GetGlobalStatus()
 
 
 
-std::string AppCache(std::string key)
-{
-
-    StructCPIDCache setting = mvAppCache["cache"+key];
-    if (!setting.initialized)
-    {
-        setting.initialized=true;
-        setting.xml = "";
-        mvAppCache.insert(map<string,StructCPIDCache>::value_type("cache"+key,setting));
-        mvAppCache["cache"+key]=setting;
-    }
-    return setting.xml;
-}
+//std::string AppCache(std::string key)
+//{
+//
+//    StructCPIDCache setting = mvAppCache["cache"+key];
+//    if (!setting.initialized)
+//    {
+//        setting.initialized=true;
+//        setting.xml = "";
+//        mvAppCache.insert(map<string,StructCPIDCache>::value_type("cache"+key,setting));
+//        mvAppCache["cache"+key]=setting;
+//    }
+//    return setting.xml;
+//}
 
 
 
@@ -7330,15 +7329,24 @@ void InitializeProjectStruct(StructCPID& project)
 
 }
 
-
-bool ProjectIsValid(std::string project)
+bool ProjectIsValid(std::string sProject)
 {
-    boost::to_lower(project);
+    if (sProject.empty())
+        return false;
 
-    StructCPID structcpid = GetInitializedStructCPID2(project,mvBoincProjects);
+    boost::to_lower(sProject);
 
-    return structcpid.initialized;
+    for (const auto& item : AppCacheFilter("project"))
+    {
+        std::string sProjectKey = item.first;
+        std::vector<std::string> vProjectKey = split(sProjectKey, ";");
+        std::string sProjectName = ToOfficialName(vProjectKey[1]);
 
+        if (sProjectName == sProject)
+            return true;
+    }
+
+    return false;
 }
 
 std::string ToOfficialName(std::string proj)
@@ -8288,7 +8296,7 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                             fMessageLoaded = true;
                         }
 
-                        WriteCache(sMessageType,sMessageKey+";TrxID",tx.GetHash().GetHex(),nTime);
+                        //WriteCache(sMessageType,sMessageKey+";TrxID",tx.GetHash().GetHex(),nTime);
 
                   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -552,24 +552,6 @@ void GetGlobalStatus()
     }
 }
 
-
-
-//std::string AppCache(std::string key)
-//{
-//
-//    StructCPIDCache setting = mvAppCache["cache"+key];
-//    if (!setting.initialized)
-//    {
-//        setting.initialized=true;
-//        setting.xml = "";
-//        mvAppCache.insert(map<string,StructCPIDCache>::value_type("cache"+key,setting));
-//        mvAppCache["cache"+key]=setting;
-//    }
-//    return setting.xml;
-//}
-
-
-
 bool Timer_Main(std::string timer_name, int max_ms)
 {
     mvTimers[timer_name] = mvTimers[timer_name] + 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8296,7 +8296,7 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                             fMessageLoaded = true;
                         }
 
-                        //WriteCache(sMessageType,sMessageKey+";TrxID",tx.GetHash().GetHex(),nTime);
+                        WriteCache(sMessageType,sMessageKey+";TrxID",tx.GetHash().GetHex(),nTime);
 
                   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1379,8 +1379,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         return error("AcceptToMemoryPool : CheckTransaction failed");
 
     // Verify beacon contract in tx if found
-    //if (!VerifyBeaconContractTx(tx.hashBoinc))
-    //    return tx.DoS(25, error("AcceptToMemoryPool : bad beacon contract in tx; rejected"));
+    if (!VerifyBeaconContractTx(tx.hashBoinc))
+        return tx.DoS(25, error("AcceptToMemoryPool : bad beacon contract in tx; rejected"));
 
     // Coinbase is only valid in a block, not as a loose transaction
     if (tx.IsCoinBase())
@@ -3957,8 +3957,8 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
             return DoS(50, error("CheckBlock[] : block timestamp earlier than transaction timestamp"));
 
         // Verify beacon contract if a transaction contains a beacon contract
-        //if (!VerifyBeaconContractTx(tx.hashBoinc) && !fLoadingIndex)
-        //    return DoS(25, error("CheckBlock[] : bad beacon contract found in tx contained within block; rejected"));
+        if (!VerifyBeaconContractTx(tx.hashBoinc) && !fLoadingIndex)
+            return DoS(25, error("CheckBlock[] : bad beacon contract found in tx contained within block; rejected"));
     }
 
     // Check for duplicate txids. This is caught by ConnectInputs(),

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -4015,18 +4015,22 @@ Value listitem(const Array& params, bool fHelp)
     {
 
         Object entry;
+
         if (msNeuralResponse.length() > 25)
         {
+            entry.push_back(Pair("Neural Response", "true"));
+
             std::vector<std::string> vMag = split(msNeuralResponse.c_str(),"<ROW>");
+
             for (unsigned int i = 0; i < vMag.size(); i++)
-            {
                 entry.push_back(Pair(RoundToString(i+1,0),vMag[i].c_str()));
-            }
         }
 
         else
         {
-            entry.push_back(Pair("ERROR", "No Neural Reponse; Try again later."));
+            entry.push_back(Pair("Neural Response", "false; Try again at a later time"));
+
+            AsyncNeuralRequest("explainmag", GlobalCPUMiningCPID.cpid, 10);
         }
 
         results.push_back(entry);
@@ -4161,6 +4165,13 @@ Value listitem(const Array& params, bool fHelp)
 
             if (sProjectName.empty())
                 continue;
+
+            // If contains an additional stats URL for project stats; remove it for the user to goto the correct website.
+            if (sProjectURL.find("stats/") != string::npos)
+            {
+                std::size_t tFound = sProjectURL.find("stats/");
+                sProjectURL.erase(tFound, sProjectURL.length());
+            }
 
             entry.push_back(Pair("Project", sProjectName));
             entry.push_back(Pair("URL", sProjectURL));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -21,6 +21,7 @@
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string.hpp>
 #include <fstream>
+#include <algorithm>
 
 using namespace json_spirit;
 using namespace std;
@@ -149,6 +150,8 @@ bool IsCPIDValidv2(MiningCPID& mc, int height);
 std::string RetrieveMd5(std::string s1);
 
 std::string getfilecontents(std::string filename);
+
+std::string ToOfficialName(std::string proj);
 
 extern double GetNetworkAvgByProject(std::string projectname);
 void HarvestCPIDs(bool cleardata);
@@ -4011,94 +4014,22 @@ Value listitem(const Array& params, bool fHelp)
     else if (sitem == "explainmagnitude")
     {
 
+        Object entry;
         if (msNeuralResponse.length() > 25)
         {
-            Object entry;
             std::vector<std::string> vMag = split(msNeuralResponse.c_str(),"<ROW>");
             for (unsigned int i = 0; i < vMag.size(); i++)
             {
                 entry.push_back(Pair(RoundToString(i+1,0),vMag[i].c_str()));
             }
-            results.push_back(entry);
         }
+
         else
         {
-    
-        double mytotalrac = 0;
-        double nettotalrac  = 0;
-        double projpct = 0;
-        double mytotalpct = 0;
-        double ParticipatingProjectCount = 0;
-        double TotalMagnitude = 0;
-        double Mag = 0;
-        Object entry;
-        std::string narr = "";
-        std::string narr_desc = "";
-        double TotalProjectRAC = 0;
-        double TotalUserVerifiedRAC = 0;
-
-        for(map<string,StructCPID>::iterator ibp=mvBoincProjects.begin(); ibp!=mvBoincProjects.end(); ++ibp) 
-        {
-            StructCPID WhitelistedProject = mvBoincProjects[(*ibp).first];
-            if (WhitelistedProject.initialized)
-            {
-                double ProjectRAC = GetNetworkTotalByProject(WhitelistedProject.projectname);
-                StructCPID structcpid = mvCPIDs[WhitelistedProject.projectname];
-                bool including = false;
-                narr = "";
-                narr_desc = "";
-                double UserVerifiedRAC = 0;
-                if (structcpid.initialized) 
-                { 
-                    if (structcpid.projectname.length() > 1)
-                    {
-                        including = (ProjectRAC > 0 && structcpid.Iscpidvalid && structcpid.rac > 1);
-                        UserVerifiedRAC = structcpid.rac;
-                        narr_desc = "NetRac: " + RoundToString(ProjectRAC,0) + ", CPIDValid: " 
-                            + YesNo(structcpid.Iscpidvalid) + ", RAC: " +RoundToString(structcpid.rac,0);
-                    }
-                }
-                narr = including ? ("Participating " + narr_desc) : ("Enumerating " + narr_desc);
-                if (structcpid.projectname.length() > 1 && including)
-                {
-                        entry.push_back(Pair(narr + " Project",structcpid.projectname));
-                }
-
-                projpct = UserVerifiedRAC/(ProjectRAC+.01);
-                nettotalrac += ProjectRAC;
-                mytotalrac = mytotalrac + UserVerifiedRAC;
-                mytotalpct = mytotalpct + projpct;
-                
-                double project_magnitude = 
-                    ((UserVerifiedRAC / (ProjectRAC + 0.01)) / (WHITELISTED_PROJECTS + 0.01)) * NeuralNetworkMultiplier;
-
-                if (including)
-                {
-                        TotalMagnitude += project_magnitude;
-                        TotalUserVerifiedRAC += UserVerifiedRAC;
-                        TotalProjectRAC += ProjectRAC;
-                        ParticipatingProjectCount++;
-                        
-                        entry.push_back(Pair("User " + structcpid.projectname + " Verified RAC",UserVerifiedRAC));
-                        entry.push_back(Pair(structcpid.projectname + " Network RAC",ProjectRAC));
-                        entry.push_back(Pair("Your Project Magnitude",project_magnitude));
-                }
-                
-             }
+            entry.push_back(Pair("ERROR", "No Neural Reponse; Try again later."));
         }
-        entry.push_back(Pair("Whitelisted Project Count", ToString(WHITELISTED_PROJECTS)));
-        entry.push_back(Pair("Grand-Total Verified RAC",mytotalrac));
-        entry.push_back(Pair("Grand-Total Network RAC",nettotalrac));
-        entry.push_back(Pair("Total Magnitude for All Projects",TotalMagnitude));
-        entry.push_back(Pair("Grand-Total Whitelisted Projects",ToString(WHITELISTED_PROJECTS)));
-        entry.push_back(Pair("Participating Project Count",ParticipatingProjectCount));
-        Mag = TotalMagnitude;
-        std::string babyNarr = "(" + RoundToString(TotalUserVerifiedRAC,2) + "/" + RoundToString(TotalProjectRAC,2) + ")/" + ToString(WHITELISTED_PROJECTS) + "*" + ToString(NeuralNetworkMultiplier) + "=";
-        entry.push_back(Pair(babyNarr,Mag));
+
         results.push_back(entry);
-        return results;
-        }
-
     }
     else if (sitem == "superblocks")
     {
@@ -4218,21 +4149,23 @@ Value listitem(const Array& params, bool fHelp)
     }
     else if (sitem == "projects") 
     {
-        for(map<string,StructCPID>::iterator ii=mvBoincProjects.begin(); ii!=mvBoincProjects.end(); ++ii) 
+        for (const auto item : AppCacheFilter("project"))
         {
+            Object entry;
 
-            StructCPID structcpid = mvBoincProjects[(*ii).first];
+            std::string sProjectKey = item.first;
+            std::vector<std::string> vProjectKey = split(sProjectKey, ";");
+            std::string sProjectName = ToOfficialName(vProjectKey[1]);
+            std::string sProjectURL = item.second;
+            sProjectURL.erase(std::remove(sProjectURL.begin(), sProjectURL.end(), '@'), sProjectURL.end());
 
-            if (structcpid.initialized) 
-            { 
-                Object entry;
-                entry.push_back(Pair("Project",structcpid.projectname));
-                entry.push_back(Pair("URL",structcpid.link));
-                results.push_back(entry);
+            if (sProjectName.empty())
+                continue;
 
-            }
+            entry.push_back(Pair("Project", sProjectName));
+            entry.push_back(Pair("URL", sProjectURL));
+            results.push_back(entry);
         }
-        return results;
     }
     else if (sitem == "leder")
     {


### PR DESCRIPTION
mvBoincProjects was used for 'list projects' and 'list explainmagnitude' when there was no response from neural network. with list projects it used StructCPID and initialized projects etc. this also led to the spacing in list projects. This part of the code is not needed as everything else is grabbed from the cache. Also note that this is only populated during startup and because of this the project remained in mvBoincProject. Which is another reason why the client required a restart for project to no longer be displayed in list projects or old format of explainmagnitude. When talking about explainmagnitude it used the start up values and would not actually contain updated information about rac over the period of days and more unless a restart occured.

Details of PR
* removed mvBoincProjects and used AppCacheFilter. for changes related to list explainmagnitude and list projects.
* removed old explainmagnitude format from explainmagnitude to avoid confusion such as in #205 . This also allows them to see neural data only and not old data stored in mvBoincProject
* explainmagnitude will only use neural response and if it happens to be empty it will make a call for it and next time they call it the data should be there.
* removed old std::string AppCache function that was not in use that also caused conflicts with appcache.h when included in main.cpp
* changed ProjectIsValid to use cache
* 'list projects' now shows the project URL as well and in the case where an extra stats/ is added for NN that is removed so a user can have a direct link to the project website.

Note: @tomasbrod your add TrxID to cache (i reenabled) is affecting the outputs on 'list projects' as well as getlistof and anything related such as beaconreport. I recommend thats disabled again till a better solution for it is in place as displays of numerous information can be a mess for the end-user.