### PR TITLE
Tally improvements transition

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -24,7 +24,8 @@ bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 
 StructCPID GetStructCPID();
 bool ComputeNeuralNetworkSupermajorityHashes();
-void TallyNetworkAverages();
+void BusyWaitForTally_retired();
+void TallyNetworkAverages_v9();
 extern void ThreadAppInit2(void* parg);
 
 void LoadCPIDsInBackground();
@@ -994,10 +995,13 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     uiInterface.InitMessage(_("Loading Network Averages..."));
     if (fDebug3) printf("Loading network averages");
-    TallyNetworkAverages();
+
+    TallyNetworkAverages_v9();
 
     if (!threads->createThread(StartNode, NULL, "Start Thread"))
         InitError(_("Error: could not start node"));
+
+    BusyWaitForTally_retired();
 
     if (fServer)
         threads->createThread(ThreadRPCServer, NULL, "RPC Server Thread");

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -886,7 +886,7 @@ bool CheckProofOfStakeV8(
 
     CTransaction *p_coinstake;
 
-    if(Block.nVersion==8) {
+    if(Block.nVersion>=8 && Block.nVersion<=9) {
         if (!Block.IsProofOfStake())
             return error("CheckProofOfStakeV8() : called on non-coinstake block %s", Block.GetHash().ToString().c_str());
         p_coinstake = &Block.vtx[1];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4271,65 +4271,8 @@ void GridcoinServices()
             uiInterface.NotifyBlocksChanged();
        }
     #endif
+
     // Services thread activity
-
-    //Dont perform the following functions if out of sync
-    if (pindexBest->nHeight < nGrandfather) return;
-    
-    if (OutOfSyncByAge()) return;
-    if (fDebug) printf(" {SVC} ");
-
-    //Backup the wallet once per 900 blocks or as specified in config:
-    int nWBI = GetArg("-walletbackupinterval", 900);
-    if (nWBI == 0)
-        nWBI = 900;
-
-   if (TimerMain("backupwallet", nWBI))
-    {
-        bool bWalletBackupResults = BackupWallet(*pwalletMain, GetBackupFilename("wallet.dat"));
-        bool bConfigBackupResults = BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"));
-        printf("Daily backup results: Wallet -> %s Config -> %s\r\n", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
-    }
-
-    if (TimerMain("ResetVars",30))
-    {
-        bTallyStarted_retired = false;
-    }
-
-    if (false && TimerMain("FixSpentCoins",60))
-    {
-            int nMismatchSpent;
-            int64_t nBalanceInQuestion;
-            pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
-    }
-
-    if (TimerMain("MyNeuralMagnitudeReport",30))
-    {
-        try
-        {
-            if (msNeuralResponse.length() < 25 && msPrimaryCPID != "INVESTOR" && !msPrimaryCPID.empty())
-            {
-                AsyncNeuralRequest("explainmag",msPrimaryCPID,5);
-                if (fDebug3) printf("Async explainmag sent for %s.",msPrimaryCPID.c_str());
-            }
-            // Run the RSA report for the overview page:
-            if (!msPrimaryCPID.empty() && msPrimaryCPID != "INVESTOR")
-            {
-                if (fDebug3) printf("updating rsa\r\n");
-                MagnitudeReport(msPrimaryCPID);
-                if (fDebug3) printf("updated rsa\r\n");
-            }
-            if (fDebug3) printf("\r\n MR Complete \r\n");
-        }
-        catch (std::exception &e)
-        {
-            printf("Error in MyNeuralMagnitudeReport1.");
-        }
-        catch(...)
-        {
-            printf("Error in MyNeuralMagnitudeReport.");
-        }
-    }
 
     if(IsV9Enabled_Tally(nBestHeight))
     {
@@ -4398,7 +4341,77 @@ void GridcoinServices()
             }
         }
     }
-    
+
+    if (false && TimerMain("GridcoinPersistedDataSystem",5))
+    {
+        std::string errors1 = "";
+        LoadAdminMessages(false,errors1);
+    }
+
+    if (TimerMain("clearcache",1000))
+    {
+        ClearCache("neural_data");
+    }
+
+
+    //Dont perform the following functions if out of sync
+    if (pindexBest->nHeight < nGrandfather && OutOfSyncByAge())
+        return;
+
+    if (fDebug) printf(" {SVC} ");
+
+    //Backup the wallet once per 900 blocks or as specified in config:
+    int nWBI = GetArg("-walletbackupinterval", 900);
+    if (nWBI == 0)
+        nWBI = 900;
+
+   if (TimerMain("backupwallet", nWBI))
+    {
+        bool bWalletBackupResults = BackupWallet(*pwalletMain, GetBackupFilename("wallet.dat"));
+        bool bConfigBackupResults = BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"));
+        printf("Daily backup results: Wallet -> %s Config -> %s\r\n", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
+    }
+
+    if (TimerMain("ResetVars",30))
+    {
+        bTallyStarted_retired = false;
+    }
+
+    if (false && TimerMain("FixSpentCoins",60))
+    {
+            int nMismatchSpent;
+            int64_t nBalanceInQuestion;
+            pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
+    }
+
+    if (TimerMain("MyNeuralMagnitudeReport",30))
+    {
+        try
+        {
+            if (msNeuralResponse.length() < 25 && msPrimaryCPID != "INVESTOR" && !msPrimaryCPID.empty())
+            {
+                AsyncNeuralRequest("explainmag",msPrimaryCPID,5);
+                if (fDebug3) printf("Async explainmag sent for %s.",msPrimaryCPID.c_str());
+            }
+            // Run the RSA report for the overview page:
+            if (!msPrimaryCPID.empty() && msPrimaryCPID != "INVESTOR")
+            {
+                if (fDebug3) printf("updating rsa\r\n");
+                MagnitudeReport(msPrimaryCPID);
+                if (fDebug3) printf("updated rsa\r\n");
+            }
+            if (fDebug3) printf("\r\n MR Complete \r\n");
+        }
+        catch (std::exception &e)
+        {
+            printf("Error in MyNeuralMagnitudeReport1.");
+        }
+        catch(...)
+        {
+            printf("Error in MyNeuralMagnitudeReport.");
+        }
+    }
+
     // Every N blocks as a Synchronized TEAM:
     if ((nBestHeight % 30) == 0)
     {
@@ -4451,12 +4464,6 @@ void GridcoinServices()
         }
     }
 
-    if (false && TimerMain("GridcoinPersistedDataSystem",5))
-    {
-        std::string errors1 = "";
-        LoadAdminMessages(false,errors1);
-    }
-
     if (KeyEnabled("exportmagnitude"))
     {
         if (TimerMain("export_magnitude",900))
@@ -4473,11 +4480,6 @@ void GridcoinServices()
             //LoadCPIDsInBackground();
             //printf(" {CPIDs Re-Loaded} ");
             msNeuralResponse="";
-    }
-
-    if (TimerMain("clearcache",1000))
-    {
-        ClearCache("neural_data");
     }
 
     if (TimerMain("check_for_autoupgrade",240))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3249,7 +3249,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                             if (VerifySuperblock(superblock, pindex))
                             {
                                         LoadSuperblock(superblock,pindex->nTime,pindex->nHeight);
-                                        if (fDebug3) printf("ConnectBlock(): Superblock Loaded %d \r\n", pindex->nHeight);
+                                        if (fDebug)
+                                            printf("ConnectBlock(): Superblock Loaded %d\n", pindex->nHeight);
                                         if (!fColdBoot)
                                         {
                                             bDoTally_retired = true;
@@ -4323,13 +4324,18 @@ void GridcoinServices()
         // Update quorum data.
         if ((nBestHeight % 3) == 0)
         {
+            if(fDebug) printf("SVC: Updating Neural Quorum (v9 %%3) height %d\n",nBestHeight);
+            if(fDebug) printf("SVC: Updating Neural Supermajority (v9 %%3) height %d\n",nBestHeight);
             ComputeNeuralNetworkSupermajorityHashes();
             UpdateNeuralNetworkQuorumData();
         }
 
         // Tally research averages.
         if ((nBestHeight % TALLY_GRANULARITY) == 0)
+        {
+            if(fDebug) printf("SVC: TallyNetworkAverages (v9 %%%d) height %d\n",TALLY_GRANULARITY,nBestHeight);
             TallyNetworkAverages_v9();
+        }
     }
     else
     {
@@ -4346,12 +4352,15 @@ void GridcoinServices()
         {
             if ((nBestHeight % 3) == 0)
             {
+                if(fDebug) printf("SVC: Updating Neural Quorum (v3 A) height %d\n",nBestHeight);
+                if(fDebug) printf("SVC: Updating Neural Supermajority (v3 A) height %d\n",nBestHeight);
                 if (fDebug10) printf("#CNNSH# ");
                 ComputeNeuralNetworkSupermajorityHashes();
                 UpdateNeuralNetworkQuorumData();
             }
             if ((nBestHeight % 20) == 0)
             {
+                if(fDebug) printf("SVC: set off Tally (v3 B) height %d\n",nBestHeight);
                 if (fDebug10) printf("#TIB# ");
                 bDoTally_retired = true;
             }
@@ -4362,14 +4371,17 @@ void GridcoinServices()
             int nTallyGranularity = fTestNet ? 60 : 20;
             if ((nBestHeight % nTallyGranularity) == 0)
             {
+                    if(fDebug) printf("SVC: set off Tally (v3 C) height %d\n",nBestHeight);
                     if (fDebug3) printf("TIB1 ");
                     bDoTally_retired = true;
                     if (fDebug3) printf("CNNSH2 ");
+                    if(fDebug) printf("SVC: Updating Neural Supermajority (v3 D) height %d\n",nBestHeight);
                     ComputeNeuralNetworkSupermajorityHashes();
             }
 
             if ((nBestHeight % 5)==0)
             {
+                    if(fDebug) printf("SVC: Updating Neural Quorum (v3 E) height %d\n",nBestHeight);
                     UpdateNeuralNetworkQuorumData();
             }
         }
@@ -5536,6 +5548,7 @@ bool TallyResearchAverages_retired(bool Forcefully)
                         int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
                         if (fDebug3) printf("START BLOCK %f, END BLOCK %f ",(double)nMaxDepth,(double)nMinDepth);
                         if (nMinDepth < 2)              nMinDepth = 2;
+    if(fDebug) printf("TallyResearchAverages_retired: start %d end %d\n",nMaxDepth,nMinDepth);
                         mvMagnitudesCopy.clear();
                         int iRow = 0;
                         //CBlock block;
@@ -5581,7 +5594,7 @@ bool TallyResearchAverages_retired(bool Forcefully)
                                                 LoadSuperblock(superblock,pblockindex->nTime,pblockindex->nHeight);
                                                 superblockloaded=true;
                                                 if (fDebug)
-                                                   printf(" Superblock Loaded %i", pblockindex->nHeight);
+                                                   printf("TallyResearchAverages_retired: Superblock Loaded {%s %i}\n", pblockindex->GetBlockHash().GetHex().c_str(),pblockindex->nHeight);
                                         }
                                 }
                             }
@@ -5664,7 +5677,7 @@ bool TallyResearchAverages_v9()
     bool superblockloaded = false;
     double NetworkPayments = 0;
     double NetworkInterest = 0;
-    
+
     //Consensus Start/End block:
     int nMaxConensusDepth = nBestHeight - CONSENSUS_LOOKBACK;
     int nMaxDepth = nMaxConensusDepth - (nMaxConensusDepth % TALLY_GRANULARITY);
@@ -5672,8 +5685,9 @@ bool TallyResearchAverages_v9()
     int nMinDepth = nMaxDepth - nLookback;
     if (nMinDepth < 2)
         nMinDepth = 2;
-    
-    if (fDebug3) printf("START BLOCK %i, END BLOCK %i", nMaxDepth, nMinDepth);
+
+    if(fDebug) printf("TallyResearchAverages: start %d end %d\n",nMaxDepth,nMinDepth);
+
     mvMagnitudesCopy.clear();
     int iRow = 0;
 
@@ -5718,7 +5732,7 @@ bool TallyResearchAverages_v9()
                         LoadSuperblock(superblock,pblockindex->nTime,pblockindex->nHeight);
                         superblockloaded=true;
                         if (fDebug)
-                            printf(" Superblock Loaded %i", pblockindex->nHeight);
+                           printf("TallyResearchAverages_v9: Superblock Loaded {%s %i}\n", pblockindex->GetBlockHash().GetHex().c_str(),pblockindex->nHeight);
                     }
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5559,7 +5559,6 @@ bool TallyResearchAverages_retired(bool Forcefully)
     int64_t nStart = GetTimeMillis();
     lastTallied = GetAdjustedTime();
 
-    if (fDebug) printf("Tallying Research Averages (begin) ");
     bNetAveragesLoaded = false;
     bool superblockloaded = false;
     double NetworkPayments = 0;
@@ -5571,7 +5570,7 @@ bool TallyResearchAverages_retired(bool Forcefully)
                         int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % BLOCK_GRANULARITY);
                         if (fDebug3) printf("START BLOCK %f, END BLOCK %f ",(double)nMaxDepth,(double)nMinDepth);
                         if (nMinDepth < 2)              nMinDepth = 2;
-    if(fDebug) printf("TallyResearchAverages_retired: start %d end %d\n",nMaxDepth,nMinDepth);
+    if(fDebug) printf("TallyResearchAverages_retired: beginning start %d end %d\n",nMaxDepth,nMinDepth);
                         mvMagnitudesCopy.clear();
                         int iRow = 0;
                         //CBlock block;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,8 +150,6 @@ unsigned int WHITELISTED_PROJECTS = 0;
 int64_t nLastPing = 0;
 int64_t nLastAskedForBlocks = 0;
 int64_t nBootup = 0;
-
-int64_t nLastTalliedNeural = 0;
 int64_t nLastLoadAdminMessages = 0;
 int64_t nCPIDsLoaded = 0;
 int64_t nLastGRCtallied = 0;
@@ -4341,12 +4339,6 @@ void GridcoinServices()
         }
     }
 
-    if (false && TimerMain("GridcoinPersistedDataSystem",5))
-    {
-        std::string errors1 = "";
-        LoadAdminMessages(false,errors1);
-    }
-
     if (TimerMain("clearcache",1000))
     {
         ClearCache("neural_data");
@@ -5463,11 +5455,6 @@ StructCPID GetInitializedStructCPID2(const std::string& name, std::map<std::stri
 bool ComputeNeuralNetworkSupermajorityHashes()
 {
     if (nBestHeight < 15)  return true;
-    if (IsLockTimeWithinMinutes(nLastTalliedNeural,5))
-    {
-        //return true;
-    }
-    nLastTalliedNeural = GetAdjustedTime();
     //Clear the neural network hash buffer
     if (mvNeuralNetworkHash.size() > 0)  mvNeuralNetworkHash.clear();
     if (mvNeuralVersion.size() > 0)  mvNeuralVersion.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3867,26 +3867,29 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
             return DoS(100, error("CheckBlock[] : more than one coinbase"));
     //Research Age
     MiningCPID bb = DeserializeBoincBlock(vtx[0].hashBoinc,nVersion);
-    //For higher security, plus lets catch these bad blocks before adding them to the chain to prevent reorgs:
-    if (bb.cpid != "INVESTOR" && IsProofOfStake() && height1 > nGrandfather && IsResearchAgeEnabled(height1) && BlockNeedsChecked(nTime) && !fLoadingIndex)
+    if(nVersion<9)
     {
-        double blockVersion = BlockVersion(bb.clientversion);
-        double cvn = ClientVersionNew();
-        if (fDebug10) printf("BV %f, CV %f   ",blockVersion,cvn);
-        // Enforce Beacon Age
-        if (blockVersion < 3588 && height1 > 860500 && !fTestNet)
-            return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade \r\n");
-    }
-    
-    //Orphan Flood Attack
-    if (height1 > nGrandfather)
-    {
-        double bv = BlockVersion(bb.clientversion);
-        double cvn = ClientVersionNew();
-        if (fDebug10) printf("BV %f, CV %f   ",bv,cvn);
-        // Enforce Beacon Age
-        if (bv < 3588 && height1 > 860500 && !fTestNet)
-            return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade \r\n");
+        //For higher security, plus lets catch these bad blocks before adding them to the chain to prevent reorgs:
+        if (bb.cpid != "INVESTOR" && IsProofOfStake() && height1 > nGrandfather && IsResearchAgeEnabled(height1) && BlockNeedsChecked(nTime) && !fLoadingIndex)
+        {
+            double blockVersion = BlockVersion(bb.clientversion);
+            double cvn = ClientVersionNew();
+            if (fDebug10) printf("BV %f, CV %f   ",blockVersion,cvn);
+            // Enforce Beacon Age
+            if (blockVersion < 3588 && height1 > 860500 && !fTestNet)
+                return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade \r\n");
+        }
+
+        //Orphan Flood Attack
+        if (height1 > nGrandfather)
+        {
+            double bv = BlockVersion(bb.clientversion);
+            double cvn = ClientVersionNew();
+            if (fDebug10) printf("BV %f, CV %f   ",bv,cvn);
+            // Enforce Beacon Age
+            if (bv < 3588 && height1 > 860500 && !fTestNet)
+                return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade \r\n");
+        }
     }
 
     if (bb.cpid != "INVESTOR" && height1 > nGrandfather && BlockNeedsChecked(nTime))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5537,8 +5537,17 @@ bool TallyResearchAverages_retired(bool Forcefully)
         return true;
     }
 
+    static int64_t lastTallied = 0;
+    int timespan = fTestNet ? 2 : 6;
+    if (IsLockTimeWithinMinutes(lastTallied,timespan))
+    {
+        bNetAveragesLoaded = true;
+        return true;
+    }
+
     //8-27-2016
     int64_t nStart = GetTimeMillis();
+    lastTallied = GetAdjustedTime();
 
     if (fDebug) printf("Tallying Research Averages (begin) ");
     bNetAveragesLoaded = false;
@@ -5634,11 +5643,13 @@ bool TallyResearchAverages_retired(bool Forcefully)
         {
             printf("Bad Alloc while tallying network averages. [1]\r\n");
             bNetAveragesLoaded=true;
+            lastTallied = 0;
         }
         catch(...)
         {
             printf("Error while tallying network averages. [1]\r\n");
             bNetAveragesLoaded=true;
+            lastTallied = 0;
         }
 
         if (fDebug3) printf("NA loaded in %f",(double)GetTimeMillis()-nStart);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5533,17 +5533,8 @@ bool TallyResearchAverages_retired(bool Forcefully)
         return true;
     }
 
-    static int64_t lastTallied = 0;
-    int timespan = fTestNet ? 2 : 6;
-    if (IsLockTimeWithinMinutes(lastTallied,timespan))
-    {
-        bNetAveragesLoaded = true;
-        return true;
-    }
-
     //8-27-2016
     int64_t nStart = GetTimeMillis();
-    lastTallied = GetAdjustedTime();
 
     bNetAveragesLoaded = false;
     bool superblockloaded = false;
@@ -5638,13 +5629,11 @@ bool TallyResearchAverages_retired(bool Forcefully)
         {
             printf("Bad Alloc while tallying network averages. [1]\r\n");
             bNetAveragesLoaded=true;
-            lastTallied = 0;
         }
         catch(...)
         {
             printf("Error while tallying network averages. [1]\r\n");
             bNetAveragesLoaded=true;
-            lastTallied = 0;
         }
 
         if (fDebug3) printf("NA loaded in %f",(double)GetTimeMillis()-nStart);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3188,8 +3188,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
         // Prevent duplicate superblocks
         if(nVersion >= 9 && !NeedASuperblock())
             return error(("ConnectBlock: SuperBlock rcvd, but not Needed (too early)"));
-
-        // Always perform SB checks in v9
+            
         if ((pindex->nHeight > nGrandfather && !fReorganizing) || pindex->nVersion >= 9 )
         {
             // 12-20-2015 : Add support for Binary Superblocks

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8657,9 +8657,9 @@ CBlockIndex* GetHistoricalMagnitude(std::string cpid)
             return pindexGenesisBlock;
 
         CBlockIndex* pblockindex = mapItem->second;
-        if(!pblockindex->pnext)
-            printf("GetHistoricalMagnitude: WARNING index {%s %d} for cpid %s, "
-            "has no next pointer (not n main chain)\n",pblockindex->GetBlockHash().GetHex().c_str(),
+        if(!pblockindex->pnext && pblockindex!=pindexBest)
+            printf("WARNING GetHistoricalMagnitude: index {%s %d} for cpid %s, "
+            "is not in the main chain\n",pblockindex->GetBlockHash().GetHex().c_str(),
             pblockindex->nHeight,cpid.c_str());
         if (pblockindex->nHeight < nMinIndex)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2165,11 +2165,16 @@ bool CheckProofOfResearch(
     int64_t nCoinAge = 0;
     int64_t nFees = 0;
 
+    bool fNeedsChecked = BlockNeedsChecked(block.nTime) || block.nVersion>=9;
+
+    if(!fNeedsChecked)
+        return true;
+
     // 6-4-2017 - Verify researchers stored block magnitude
     double dNeuralNetworkMagnitude = CalculatedMagnitude2(bb.cpid, block.nTime, false);
-    if (bb.Magnitude > 0 &&
-        bb.Magnitude > (dNeuralNetworkMagnitude*1.25) &&
-        (fTestNet || (!fTestNet && pindexPrev->nHeight > 947000)))
+    if( bb.Magnitude > 0
+        && (fTestNet || (!fTestNet && pindexPrev->nHeight > 947000))
+        && bb.Magnitude > (dNeuralNetworkMagnitude*1.25) )
     {
         return error("CheckProofOfResearch: Researchers block magnitude > neural network magnitude: Block Magnitude %f, Neural Network Magnitude %f, CPID %s ",
                      bb.Magnitude, dNeuralNetworkMagnitude, bb.cpid.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5466,7 +5466,7 @@ bool ComputeNeuralNetworkSupermajorityHashes()
     if (nBestHeight < 15)  return true;
     if (IsLockTimeWithinMinutes(nLastTalliedNeural,5))
     {
-        return true;
+        //return true;
     }
     nLastTalliedNeural = GetAdjustedTime();
     //Clear the neural network hash buffer

--- a/src/main.h
+++ b/src/main.h
@@ -99,7 +99,7 @@ inline uint32_t IsV8Enabled(int nHeight)
 inline uint32_t IsV9Enabled(int nHeight)
 {
     return fTestNet
-            ? nHeight >=  378600
+            ? nHeight >=  392570
             : nHeight >= 2000000;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -113,6 +113,11 @@ inline bool AreBinarySuperblocksEnabled(int nHeight)
 	return (fTestNet ? nHeight > 10000 : nHeight > 725000); 
 }
 
+inline bool IsV9Enabled_Tally(int nHeight)
+{
+    // 3 hours after v9
+    return IsV9Enabled(nHeight-120);
+}
 
 inline int64_t PastDrift(int64_t nTime, int nHeight)   { return IsProtocolV2(nHeight) ? nTime - 20 * 60  : nTime - 20 * 60; }
 inline int64_t FutureDrift(int64_t nTime, int nHeight) { return IsProtocolV2(nHeight) ? nTime + 20 * 60  : nTime + 20 * 60; }

--- a/src/main.h
+++ b/src/main.h
@@ -173,7 +173,6 @@ extern int64_t nMinimumInputValue;
 extern int64_t nLastPing;
 extern int64_t nLastAskedForBlocks;
 extern int64_t nBootup;
-extern int64_t nLastTalliedNeural;
 extern int64_t nCPIDsLoaded;
 extern int64_t nLastGRCtallied;
 extern int64_t nLastCleaned;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -504,7 +504,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             CoinWeight = CalculateStakeWeightV3(CoinTx,CoinTxN,GlobalCPUMiningCPID);
             StakeKernelHash= CalculateStakeHashV3(CoinBlock,CoinTx,CoinTxN,txnew.nTime,GlobalCPUMiningCPID,mdPORNonce);
         }
-        else if(blocknew.nVersion==8)
+        else
         {
             uint64_t StakeModifier = 0;
             if(!FindStakeModifierRev(StakeModifier,pindexPrev))
@@ -512,7 +512,6 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             CoinWeight = CalculateStakeWeightV8(CoinTx,CoinTxN,GlobalCPUMiningCPID);
             StakeKernelHash= CalculateStakeHashV8(CoinBlock,CoinTx,CoinTxN,txnew.nTime,StakeModifier,GlobalCPUMiningCPID);
         }
-        else return false;
 
         CBigNum StakeTarget;
         StakeTarget.SetCompact(blocknew.nBits);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1580,28 +1580,7 @@ void ThreadTallyResearchAverages_retired(void* parg)
 {
     // Make this thread recognisable
     RenameThread("grc-tallyresearchaverages");
-
-begin:
-    try
-    {
-        DoTallyResearchAverages_retired(parg);
-    }
-    catch (std::exception& e)
-    {
-        PrintException(&e, "ThreadTallyNetworkAverages_retired()");
-    }
-    catch(boost::thread_interrupted&)
-    {
-        printf("ThreadTallyResearchAverages_retired exited (interrupt)\r\n");
-        return;
-    }
-    catch(...)
-    {
-        printf("Error in ThreadTallyResearchAverages_retired... Recovering \r\n");
-    }
-    MilliSleep(10000);
-    if (!fShutdown) printf("Thread TallyReasearchAverages_retired exited, Restarting.. \r\n");
-    if (!fShutdown) goto begin;
+    DoTallyResearchAverages_retired(parg);
     printf("ThreadTallyResearchAverages_retired exited \r\n");
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1608,6 +1608,13 @@ begin:
 
 void BusyWaitForTally_retired()
 {
+    if(IsV9Enabled_Tally(nBestHeight))
+    {
+        if(fDebug10)
+            printf("BusyWaitForTally_retired: skipped (v9 enabled)\n");
+        return;
+    }
+
     if (fDebug10) printf("\r\n ** Busy Wait for Tally_retired ** \r\n");
     bTallyFinished_retired=false;
     bDoTally_retired=true;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -785,6 +785,8 @@ bool TallyMagnitudesInSuperblock()
     network.projectname="NETWORK";
     network.NetworkMagnitude = TotalNetworkMagnitude;
     network.NetworkAvgMagnitude = NetworkAvgMagnitude;
+    if (fDebug)
+       printf("TallyMagnitudesInSuperblock: Extracted %.0f magnitude entries from cached superblock %s\n", TotalNetworkEntries,ReadCache("superblock","block_number").c_str());
     
     double TotalProjects = 0;
     double TotalRAC = 0;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -42,6 +42,8 @@ extern Array MagnitudeReport(std::string cpid);
 std::string ConvertBinToHex(std::string a);
 std::string ConvertHexToBin(std::string a);
 extern std::vector<unsigned char> readFileToVector(std::string filename);
+bool bNetAveragesLoaded_retired;
+bool TallyResearchAverages_retired(bool);
 int RestartClient();
 extern std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
 std::string BurnCoinsWithNewContract(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue, int64_t MinimumBalance, double dFees, std::string strPublicKey, std::string sBurnAddress);
@@ -2040,6 +2042,13 @@ Value execute(const Array& params, bool fHelp)
     {
             AsyncNeuralRequest("quorum","gridcoin",10);
             entry.push_back(Pair("Requested a quorum - waiting for resolution.",1));
+            results.push_back(entry);
+    }
+    else if (sItem == "tally")
+    {
+            bNetAveragesLoaded_retired = false;
+            TallyResearchAverages_retired(true);
+            entry.push_back(Pair("Tally Network Averages",1));
             results.push_back(entry);
     }
     else if (sItem == "encrypt")

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -13,6 +13,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>  //For day of year
 #include <cmath>
+#include <boost/lexical_cast.hpp>
 
 // Work around clang compilation problem in Boost 1.46:
 // /usr/include/boost/program_options/detail/config_file.hpp:163:17: error: call to function 'to_internal' that is neither visible in the template definition nor found by argument-dependent lookup
@@ -1464,7 +1465,8 @@ std::string RoundToString(double d, int place)
 
 double RoundFromString(const std::string& s, int place)
 {
-    return Round(atof(s.c_str()), place);
+    double num = boost::lexical_cast<double>(s);
+    return Round(num, place);
 }
 
 bool Contains(const std::string& data, const std::string& instring)


### PR DESCRIPTION
status: **testing**

* re-introduced the old tally functions with `*_retired` suffix
* renamed new tally implementation to `*_v9 suffix`
* reverted to the old grandfather configuration
* avoid "retallying" and "doublecheck" in `CheckProofOfResearch`
  (one instance of "doublecheck" still left in `ConnectBlock`)
* added transition
* added trace outputs to ensure correctness
* rolled back RoundFromString to use lexical_cast again

After 120 v9 blocks, or 3 hours after switch to v9, old tally mechanism
will be disabled and the new implementation engaged. This 3 hour delay was
chosen to ensure the network and tally are stable after switching to v9.
This also ensures that most of outdated nodes will be already banned.