### PR TITLE
RSA data for overview page

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,6 @@ std::string    msMiningErrors8;
 std::string    msAttachmentGuid;
 std::string    msMiningErrorsIncluded;
 std::string    msMiningErrorsExcluded;
-std::string    msRSAOverview;
 std::string    msNeuralResponse;
 std::string    msHDDSerial;
 //When syncing, we grandfather block rejection rules up to this block, as rules became stricter over time and fields changed
@@ -520,7 +519,6 @@ void GetGlobalStatus()
         GlobalStatusStruct.status = msMiningErrors;
         GlobalStatusStruct.poll = msPoll;
         GlobalStatusStruct.errors =  MinerStatus.ReasonNotStaking + MinerStatus.Message + " " + msMiningErrors6 + " " + msMiningErrors7 + " " + msMiningErrors8;
-        GlobalStatusStruct.rsaOverview =  msRSAOverview; // not displayed on overview page anymore.
         }
         return;
     }
@@ -4382,13 +4380,6 @@ void GridcoinServices()
             {
                 AsyncNeuralRequest("explainmag",msPrimaryCPID,5);
                 if (fDebug3) printf("Async explainmag sent for %s.",msPrimaryCPID.c_str());
-            }
-            // Run the RSA report for the overview page:
-            if (IsResearcher(msPrimaryCPID))
-            {
-                if (fDebug3) printf("updating rsa\r\n");
-                MagnitudeReport(msPrimaryCPID);
-                if (fDebug3) printf("updated rsa\r\n");
             }
             if (fDebug3) printf("\r\n MR Complete \r\n");
         }

--- a/src/main.h
+++ b/src/main.h
@@ -206,7 +206,6 @@ extern std::string  msAttachmentGuid;
 extern std::string  msMiningErrorsIncluded;
 extern std::string  msMiningErrorsExcluded;
 
-extern std::string  msRSAOverview;
 extern std::string  msNeuralResponse;
 extern std::string  msHDDSerial;
 extern bool         mbBlocksDownloaded;
@@ -227,7 +226,6 @@ struct globalStatusType
     std::string status;
     std::string poll;
     std::string errors;
-    std::string rsaOverview;
 };
 
 extern globalStatusType GlobalStatusStruct;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2648,7 +2648,6 @@ Array MagnitudeReport(std::string cpid)
            results.push_back(c);
            double total_owed = 0;
            double magnitude_unit = GRCMagnitudeUnit(GetAdjustedTime());
-           msRSAOverview = "";
            if (!pindexBest) return results;
             
            try
@@ -2697,13 +2696,6 @@ Array MagnitudeReport(std::string cpid)
                                                 entry.push_back(Pair("Tx Count",(int)stCPID.Accuracy));
                             
                                                 results.push_back(entry);
-                                                if (cpid==msPrimaryCPID && IsResearcher(msPrimaryCPID))
-                                                {
-                                                    msRSAOverview = "Exp PPD: " + RoundToString(dExpected14/14,0) 
-                                                        + ", Act PPD: " + RoundToString(structMag.payments/14,0) 
-                                                        + ", Fulf %: " + RoundToString(fulfilled,2) 
-                                                        + ", GRCMagUnit: " + RoundToString(magnitude_unit,4);
-                                                }
                                             }
                                             else
                                             {


### PR DESCRIPTION
* remove the string msRSAOverview
* remove the call every 30 blocks to call MagnitudeReport to populate for the msRSAOverview
* remove the rsaOverview that is no longer used in the UI
* remove the population of msRSAOverview from MagnitudeReport

Since we no longer use this, its a waste to call this every 30 blocks just to populate a string we no longer use. MagnitudeReport is the list rsa and should only need to iterate mvMagnitudes when a user requests the data for viewing. currently in the code we iterate all this data to populate the msRSAOverview and ignore the returned array on the 30th block call of this function.