### PR TITLE
Upgrade system changes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -764,7 +764,9 @@ void BitcoinGUI::createMenuBar()
 #endif /* defined(WIN32) */
     qmAdvanced->addSeparator();
     qmAdvanced->addAction(rebuildAction);
+#ifdef WIN32
     qmAdvanced->addAction(downloadAction);
+#endif
 
     QMenu *help = appMenuBar->addMenu(tr("&Help"));
     help->addAction(openRPCConsoleAction);

--- a/src/upgrader.cpp
+++ b/src/upgrader.cpp
@@ -38,7 +38,7 @@ static int cancelDownloader(void *p,
 
 std::string geturl()
 {
-    std::string url = "http://download.gridcoin.us/download/signed/";
+    std::string url = "https://download.gridcoin.us/download/downloadstake/signed/";
     // this will later be OS-dependent
     return url;
 }


### PR DESCRIPTION
Update the Upgrader URL for snapshot to the correct URL and use https instead of http.
Disable download blocks menu for other OS's except windows as upgrader is not packaged with nor compiled by default.

In future i plan to revamp the upgrader to support other OS's as well.

This fixes #148 for now for windows users.