### PR TITLE
Improvements to Development version generally

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -15,9 +15,6 @@ if [ -e "$(which git)" ]; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null 
 
-    # get a string like "v0.6.0-66-g59887e8-dirty"
-    DESC="$(git describe --dirty 2>/dev/null)"
-
     # get only commit hash, but format like describe
     DESCHASH="$(git rev-parse --short=9 HEAD 2>/dev/null)"
 
@@ -31,19 +28,14 @@ if [ -e "$(which git)" ]; then
     TIME="$(git log -n 1 --format="%ci")"
 fi
 
-if [ -n "$DESC" ]; then
-    NEWINFO="#define BUILD_DESC \"v$DESC\""
+if [ -n "$DESCHASH" ]; then
+    NEWINFO="#define BUILD_DESCHASH \"$DESCHASH\""
 else
     NEWINFO="// No build information available"
 fi
 
-if [ -n "$DESCHASH" ]; then
-    NEWINFO="$NEWINFO
-#define BUILD_DESCHASH \"$DESCHASH\""
-else
-    NEWINFO="$NEWINFO
-// No build information available"
-fi
+NEWINFO="$NEWINFO
+//placeholder"
 
 # only update build.h if necessary
 if [ "$INFO" != "$NEWINFO" ]; then

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       3
 #define CLIENT_VERSION_MINOR       6
 #define CLIENT_VERSION_REVISION    3
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       17
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -624,6 +624,16 @@ bool AppInit2(ThreadHandlerPtr threads)
     printf("Used data directory %s\n", strDataDir.c_str());
     std::ostringstream strErrors;
 
+    fDevbuildCripple = false;
+    if((CLIENT_VERSION_BUILD != 0) && !fTestNet)
+    {
+        fDevbuildCripple = true;
+        printf("WARNING: Running development version outside of testnet!\n"
+               "Staking and sending transactions will be disabled.\n");
+        if( (GetArg("-devbuild", "") == "override") && fDebug )
+            fDevbuildCripple = false;
+    }
+
     if (fDaemon)
         fprintf(stdout, "Gridcoin server starting\n");
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -787,6 +787,13 @@ bool IsMiningAllowed(CWallet *pwallet)
         status=false;
     }
 
+    if(fDevbuildCripple)
+    {
+        LOCK(MinerStatus.lock);
+        MinerStatus.ReasonNotStaking+="Testnet-only version; ";
+        status=false;
+    }
+
     if (!bNetAveragesLoaded)
     {
         LOCK(MinerStatus.lock);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -84,6 +84,7 @@ CMedianFilter<int64_t> vTimeOffsets(200,0);
 bool fReopenDebugLog = false;
 std::string GetNeuralVersion();
 
+bool fDevbuildCripple;
 
 int64_t IsNeural();
 

--- a/src/util.h
+++ b/src/util.h
@@ -111,6 +111,7 @@ extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
 extern bool fReopenDebugLog;
+extern bool fDevbuildCripple;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -8,7 +8,7 @@
 // Name of client reported in the 'version' message. Report the same name
 // for both bitcoind and bitcoin-qt, to make it harder for attackers to
 // target servers or GUI users specifically.
-const std::string CLIENT_NAME("Nakamoto");
+const std::string CLIENT_NAME("Halford");
 
 // Client version number
 #define CLIENT_VERSION_SUFFIX   ""

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1803,6 +1803,11 @@ void NetworkTimer()
 // Call after CreateTransaction unless you want to abort
 bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 {
+    if(fDevbuildCripple)
+    {
+        error("CommitTransaction(): Development build restrictions in effect");
+        return false;
+    }
     {
         LOCK2(cs_main, cs_wallet);
         if (fDebug) printf("CommitTransaction:\n%s", wtxNew.ToString().c_str());


### PR DESCRIPTION
* Prevent git tags from screwing up version numbers.
* changed build number to indicate devbuild
* changed client name from Nakamoto to Halförd.

Prevent devbuild nodes from staking and sending transactions outside testnet. This is only clientside check and is easily defeated by editing the source. Also override-able by `-devbuild=override`.