### PR TITLE
Appcache simplification

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -18,6 +18,7 @@ JSON_TEST_FILES = \
 
 # test_n binary #
 GRIDCOIN_TESTS =\
+  test/appcache_tests.cpp \
   test/Checkpoints_tests.cpp \
   test/DoS_tests.cpp \
   test/accounting_tests.cpp \

--- a/src/appcache.cpp
+++ b/src/appcache.cpp
@@ -91,9 +91,7 @@ std::string GetListOf(
         if (section == "beacon" && Contains("INVESTOR", entry.value))
             continue;
 
-        std::string row = key + "<COL>" + entry.value;
-        if (!row.empty())
-            rows += row + "<ROW>";
+        rows += key + "<COL>" + entry.value + "<ROW>";
     }
 
     return rows;
@@ -102,6 +100,15 @@ std::string GetListOf(
 size_t GetCountOf(const std::string& section)
 {
     const std::string& data = GetListOf(section);
-    const std::vector<std::string>& vScratchPad = split(data.c_str(),"<ROW>");
-    return vScratchPad.size()+1;
+    size_t count = 0;
+    size_t pos = 0;
+    const std::string needle("<ROW>");
+    const size_t width = needle.size();
+    while((pos = data.find(needle, pos)) != std::string::npos)
+    {
+       ++count;
+       pos += width;
+    }
+
+    return count;
 }

--- a/src/appcache.h
+++ b/src/appcache.h
@@ -2,40 +2,25 @@
 
 #include <string>
 #include <map>
-#include <boost/iterator/filter_iterator.hpp>
-#include <boost/range.hpp>
+
+//!
+//! \brief An entry in the application cache.
+//!
+struct AppCacheEntry
+{
+    std::string value; //!< Value of entry.
+    int64_t timestamp; //!< Timestamp of entry.
+};
+
+//!
+//! \brief Application cache section type.
+//! 
+typedef std::map<std::string, AppCacheEntry> AppCacheSection;
 
 //!
 //! \brief Application cache type.
 //!
-typedef std::map<std::string, std::string> AppCache;
-
-// Predicate
-struct AppCacheMatches
-{
-    AppCacheMatches(const std::string& section);
-    bool operator()(const AppCache::value_type& t);
-    std::string needle;
-};
-
-typedef boost::filter_iterator<AppCacheMatches, AppCache::iterator> filter_iterator;
-
-//!
-//! \brief Application cache data key iterator.
-//! \param section Section to iterate over.
-//!
-//! An iterator like class which can be used to iterate through the application
-//! in ranged based for loops based on keys. For example, to iterate through
-//! all the cached polls:
-//!
-//! \code
-//! for(const auto& item : AppCacheFilter("poll")
-//! {
-//!    const std::string& poll_name = item.second;
-//! }
-//! \endcode
-//!
-boost::iterator_range<filter_iterator> AppCacheFilter(const std::string& section);
+typedef std::map<std::string, AppCacheSection> AppCache;
 
 //!
 //! \brief Write value into application cache.
@@ -56,20 +41,16 @@ void WriteCache(
 //! \returns Value for \p key in \p section if available, or an empty string
 //! if either the section or the key don't exist.
 //!
-std::string ReadCache(
+AppCacheEntry ReadCache(
         const std::string& section,
         const std::string& key);
 
 //!
-//! \brief Read values from appcache section.
-//! \param section Cache section to read from.
-//! \param key Entry key to read timestamp from.
-//! \returns Timestamp for \p key in \p section if available, or an 0
-//! if either the section or the key don't exist.
+//! \brief Read section from cache.
+//! \param section Section to read.
+//! \returns The data for \p section if available.
 //!
-int64_t ReadCacheTimestamp(
-        const std::string& section,
-        const std::string& key);
+AppCacheSection ReadCacheSection(const std::string& section);
 
 //!
 //! \brief Clear all values in a cache section.

--- a/src/appcache.h
+++ b/src/appcache.h
@@ -53,8 +53,21 @@ void WriteCache(
 //! \brief Read values from appcache section.
 //! \param section Cache section to read from.
 //! \param key Entry key to read.
+//! \returns Value for \p key in \p section if available, or an empty string
+//! if either the section or the key don't exist.
 //!
 std::string ReadCache(
+        const std::string& section,
+        const std::string& key);
+
+//!
+//! \brief Read values from appcache section.
+//! \param section Cache section to read from.
+//! \param key Entry key to read timestamp from.
+//! \returns Timestamp for \p key in \p section if available, or an 0
+//! if either the section or the key don't exist.
+//!
+int64_t ReadCacheTimestamp(
         const std::string& section,
         const std::string& key);
 
@@ -71,3 +84,41 @@ void ClearCache(const std::string& section);
 //! \param key Entry key to erase.
 //!
 void DeleteCache(const std::string& section, const std::string& key);
+
+//!
+//! \brief Get a list of section values.
+//! \param section Section to read.
+//!
+//! Reads \p section and concatenates the keys and values into a string:
+//!
+//! key<COL>value<ROW>
+//!
+//! \note If \p section is \a "beacon" then all non-valid CPID values are
+//! discarded.
+//!
+//! \return Formatted section values string.
+//! \todo Make this return std::vector<std::string> instead.
+//!
+std::string GetListOf(const std::string& section);
+
+//!
+//! \brief Get a list of section values with age restrictions.
+//! \copydoc GetListOf
+//! \param minTime Entry min timestamp. Set to 0 to disable limit.
+//! \param maxTime Entry max timestamp. Set to 0 to disable limit.
+//!
+std::string GetListOf(
+        const std::string& section,
+        int64_t minTime,
+        int64_t maxTime);
+
+//!
+//! \brief Count value entries in section.
+//!
+//! Performs a GetListOf() and counts the results.
+//!
+//! \param section Section to count.
+//! \return Number of values in \p section.
+//! \see GetListOf() for beacon restrictions.
+//!
+size_t GetCountOf(const std::string& section);

--- a/src/appcache.h
+++ b/src/appcache.h
@@ -13,7 +13,7 @@ typedef std::map<std::string, std::string> AppCache;
 // Predicate
 struct AppCacheMatches
 {
-    AppCacheMatches(const std::string& needle);
+    AppCacheMatches(const std::string& section);
     bool operator()(const AppCache::value_type& t);
     std::string needle;
 };
@@ -22,6 +22,7 @@ typedef boost::filter_iterator<AppCacheMatches, AppCache::iterator> filter_itera
 
 //!
 //! \brief Application cache data key iterator.
+//! \param section Section to iterate over.
 //!
 //! An iterator like class which can be used to iterate through the application
 //! in ranged based for loops based on keys. For example, to iterate through
@@ -34,4 +35,39 @@ typedef boost::filter_iterator<AppCacheMatches, AppCache::iterator> filter_itera
 //! }
 //! \endcode
 //!
-boost::iterator_range<filter_iterator> AppCacheFilter(const std::string& needle);
+boost::iterator_range<filter_iterator> AppCacheFilter(const std::string& section);
+
+//!
+//! \brief Write value into application cache.
+//! \param section Cache section to write to.
+//! \param key Entry key to write.
+//! \param value Entry value to write.
+//!
+void WriteCache(
+        const std::string& section,
+        const std::string& key,
+        const std::string& value,
+        int64_t locktime);
+
+//!
+//! \brief Read values from appcache section.
+//! \param section Cache section to read from.
+//! \param key Entry key to read.
+//!
+std::string ReadCache(
+        const std::string& section,
+        const std::string& key);
+
+//!
+//! \brief Clear all values in a cache section.
+//! \param section Cache section to clear.
+//! \note This only clears the values. It does not erase them.
+//!
+void ClearCache(const std::string& section);
+
+//!
+//! \brief Erase key from appcache section.
+//! \param section Cache section to erase from.
+//! \param key Entry key to erase.
+//!
+void DeleteCache(const std::string& section, const std::string& key);

--- a/src/fwd.h
+++ b/src/fwd.h
@@ -10,7 +10,6 @@ class CNetAddr;
 // Gridcoin
 struct MiningCPID;
 struct StructCPID;
-struct StructCPIDCache;
 
 class ThreadHandler;
 typedef std::shared_ptr<ThreadHandler> ThreadHandlerPtr;

--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -71,16 +71,6 @@ struct StructCPID
     std::string BlockHash;
 };
 
-
-
-struct StructCPIDCache
-{
-    std::string xml;
-    bool initialized;
-};
-
-
-
 struct MiningCPID
 {
     double rac;
@@ -131,13 +121,8 @@ extern std::map<std::string, StructCPID> mvNetwork;
 extern std::map<std::string, StructCPID> mvNetworkCopy;
 extern std::map<std::string, StructCPID> mvMagnitudes;
 extern std::map<std::string, StructCPID> mvMagnitudesCopy;
-
-
 extern std::map<std::string, StructCPID> mvCreditNodeCPIDProject; //Contains verified CPID+Projects;
 extern std::map<std::string, StructCPID> mvCreditNodeCPID;  //Contains verified CPID total Magnitude;
-//Caches
-extern std::map<std::string, StructCPIDCache> mvCPIDCache; //Contains cached blocknumbers for CPID+Projects;
-extern std::map<std::string, StructCPIDCache> mvAppCache; //Contains cached blocknumbers for CPID+Projects;
 
 //Global CPU Mining CPID:
 extern MiningCPID GlobalCPUMiningCPID;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7320,7 +7320,6 @@ std::string ToOfficialName(std::string proj)
 {
     proj = LowerUnderscore(proj);
     //Convert local XML project name [On the Left] to official [Netsoft] projectname:
-    std::string sType = "projectmapping";
     for(const auto& item : ReadCacheSection("projectmapping"))
     {
         const std::string& key = item.first;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,7 +253,6 @@ bool bGridcoinGUILoaded = false;
 
 extern double LederstrumpfMagnitude2(double Magnitude, int64_t locktime);
 
-extern void WriteAppCache(std::string key, std::string value);
 extern void LoadCPIDsInBackground();
 
 extern void ThreadCPIDs();
@@ -321,8 +320,6 @@ std::map<std::string, StructCPID> mvCreditNode;   //Contains the verified stats 
 std::map<std::string, StructCPID> mvNetwork;      //Contains the project stats at the network level
 std::map<std::string, StructCPID> mvNetworkCopy;      //Contains the project stats at the network level
 std::map<std::string, StructCPID> mvCreditNodeCPID;        // Contains verified CPID Magnitudes;
-std::map<std::string, StructCPIDCache> mvCPIDCache; //Contains cached blocknumbers for CPID+Projects;
-std::map<std::string, StructCPIDCache> mvAppCache; //Contains cached blocknumbers for CPID+Projects;
 std::map<std::string, StructCPID> mvMagnitudes; // Contains Magnitudes by CPID & Outstanding Payments Owed per CPID
 std::map<std::string, StructCPID> mvMagnitudesCopy; // Contains Magnitudes by CPID & Outstanding Payments Owed per CPID
 
@@ -520,24 +517,6 @@ bool Timer_Main(std::string timer_name, int max_ms)
     }
     return false;
 }
-
-
-
-void WriteAppCache(std::string key, std::string value)
-{
-    StructCPIDCache setting = mvAppCache["cache"+key];
-    if (!setting.initialized)
-    {
-        setting.initialized=true;
-        setting.xml = "";
-        mvAppCache.insert(map<string,StructCPIDCache>::value_type("cache"+key,setting));
-        mvAppCache["cache"+key]=setting;
-    }
-    setting.xml = value;
-    mvAppCache["cache"+key]=setting;
-}
-
-
 
 void RegisterWallet(CWallet* pwalletIn)
 {
@@ -7546,7 +7525,6 @@ void HarvestCPIDs(bool cleardata)
     if (cleardata)
     {
         mvCPIDs.clear();
-        mvCPIDCache.clear();
     }
     std::string email = GetArgument("email","");
     boost::to_lower(email);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,11 +107,7 @@ extern double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_
 
 
 extern double GetOwedAmount(std::string cpid);
-
-extern void DeleteCache(std::string section, std::string keyname);
-extern void ClearCache(std::string section);
 bool TallyMagnitudesInSuperblock();
-extern void WriteCache(std::string section, std::string key, std::string value, int64_t locktime);
 extern std::string GetNeuralNetworkReport();
 std::string GetListOf(std::string datatype);
 std::string GetCommandNonce(std::string command);
@@ -7977,76 +7973,6 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
     return true;
 }
-
-
-
-std::string ReadCache(std::string section, std::string key)
-{
-    if (section.empty() || key.empty()) return "";
-
-    try
-    {
-            std::string value = mvApplicationCache[section + ";" + key];
-            if (value.empty())
-            {
-                mvApplicationCache.insert(map<std::string,std::string>::value_type(section + ";" + key,""));
-                mvApplicationCache[section + ";" + key]="";
-                return "";
-            }
-            return value;
-    }
-    catch(...)
-    {
-        printf("readcache error %s",section.c_str());
-        return "";
-    }
-}
-
-
-void WriteCache(std::string section, std::string key, std::string value, int64_t locktime)
-{
-    if (section.empty() || key.empty()) return;
-    std::string temp_value = mvApplicationCache[section + ";" + key];
-    if (temp_value.empty())
-    {
-        mvApplicationCache.insert(map<std::string,std::string>::value_type(section + ";" + key,value));
-        mvApplicationCache[section + ";" + key]=value;
-    }
-    mvApplicationCache[section + ";" + key]=value;
-    // Record Cache Entry timestamp
-    int64_t temp_locktime = mvApplicationCacheTimestamp[section + ";" + key];
-    if (temp_locktime == 0)
-    {
-        mvApplicationCacheTimestamp.insert(map<std::string,int64_t>::value_type(section+";"+key,1));
-        mvApplicationCacheTimestamp[section+";"+key]=locktime;
-    }
-    mvApplicationCacheTimestamp[section+";"+key] = locktime;
-
-}
-
-
-void ClearCache(std::string section)
-{
-       for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
-       {
-                const std::string& key_section = (*ii).first;
-                if (boost::algorithm::starts_with(key_section, section))
-                {
-                        mvApplicationCache[key_section]="";
-                        mvApplicationCacheTimestamp[key_section]=1;
-                }
-       }
-}
-
-
-void DeleteCache(std::string section, std::string keyname)
-{
-       std::string pk = section + ";" +keyname;
-       mvApplicationCache.erase(pk);
-       mvApplicationCacheTimestamp.erase(pk);
-}
-
-
 
 void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, std::string GRCAddress, double distance)
 {

--- a/src/main.h
+++ b/src/main.h
@@ -278,7 +278,6 @@ std::string SerializeBoincBlock(MiningCPID mcpid, int BlockVersion);
 bool OutOfSyncByAge();
 bool NeedASuperblock();
 std::string GetQuorumHash(const std::string& data);
-std::string ReadCache(std::string section, std::string key);
 std::string GetNeuralNetworkSupermajorityHash(double& out_popularity);
 std::string PackBinarySuperblock(std::string sBlock);
 std::string UnpackBinarySuperblock(std::string sBlock);

--- a/src/main.h
+++ b/src/main.h
@@ -127,8 +127,6 @@ inline unsigned int GetTargetSpacing(int nHeight) { return IsProtocolV2(nHeight)
 extern bool IsNeuralNodeParticipant(const std::string& addr, int64_t locktime);
 bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent);
 
-extern std::map<std::string, std::string> mvApplicationCache;
-extern std::map<std::string, int64_t> mvApplicationCacheTimestamp;
 extern std::map<std::string, double> mvNeuralNetworkHash;
 extern std::map<std::string, double> mvCurrentNeuralNetworkHash;
 extern std::map<std::string, double> mvNeuralVersion;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -10,6 +10,7 @@
 #include "cpid.h"
 #include "util.h"
 #include "main.h"
+#include "appcache.h"
 #include "neuralnet.h"
 
 #include <memory>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -700,7 +700,7 @@ int AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
     if(!NeedASuperblock())
         return printf("AddNeuralContractOrVote: not Needed\n");
 
-    int pending_height = RoundFromString(ReadCache("neuralsecurity","pending"),0);
+    int pending_height = RoundFromString(ReadCache("neuralsecurity","pending").value, 0);
 
     /* Add our Neural Vote */
     bb.NeuralHash = sb_hash;

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -1,7 +1,8 @@
-#include <fstream>
 #include "main.h"
 #include "util.h"
 #include "boinc.h"
+#include "appcache.h"
+
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -10,8 +11,8 @@
 #include "ui_diagnosticsdialog.h"
 
 #include <numeric>
+#include <fstream>
 
-std::string GetListOf(std::string datatype);
 double PreviousBlockAge();
 
 DiagnosticsDialog::DiagnosticsDialog(QWidget *parent) :

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -62,7 +62,6 @@ bool UpdateNeuralNetworkQuorumData();
 extern Array LifetimeReport(std::string cpid);
 extern std::string AddContract(std::string sType, std::string sName, std::string sContract);
 StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sFrom);
-void WriteCache(std::string section, std::string key, std::string value, int64_t locktime);
 int64_t GetEarliestWalletTransaction();
 extern bool CheckMessageSignature(std::string sAction,std::string messagetype, std::string sMsg, std::string sSig, std::string opt_pubkey);
 bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
@@ -124,7 +123,6 @@ extern bool TallyMagnitudesInSuperblock();
 double GetTotalBalance();
 
 std::string strReplace(std::string& str, const std::string& oldStr, const std::string& newStr);
-std::string ReadCache(std::string section, std::string key);
 MiningCPID GetNextProject(bool bForce);
 std::string SerializeBoincBlock(MiningCPID mcpid);
 extern std::string TimestampToHRDate(double dtm);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -725,7 +725,7 @@ bool TallyMagnitudesInSuperblock()
 {
     try
     {
-        std::string superblock = ReadCache("superblock","magnitudes");
+        std::string superblock = ReadCache("superblock","magnitudes").value;
         if (superblock.empty()) return false;
         std::vector<std::string> vSuperblock = split(superblock.c_str(),";");
         double TotalNetworkMagnitude = 0;
@@ -774,13 +774,13 @@ bool TallyMagnitudesInSuperblock()
     network.NetworkMagnitude = TotalNetworkMagnitude;
     network.NetworkAvgMagnitude = NetworkAvgMagnitude;
     if (fDebug)
-       printf("TallyMagnitudesInSuperblock: Extracted %.0f magnitude entries from cached superblock %s\n", TotalNetworkEntries,ReadCache("superblock","block_number").c_str());
+       printf("TallyMagnitudesInSuperblock: Extracted %.0f magnitude entries from cached superblock %s\n", TotalNetworkEntries, ReadCache("superblock","block_number").value.c_str());
 
     double TotalProjects = 0;
     double TotalRAC = 0;
     double AVGRac = 0;
     // Load boinc project averages from neural network
-    std::string projects = ReadCache("superblock","averages");
+    std::string projects = ReadCache("superblock","averages").value;
     if (projects.empty()) return false;
     std::vector<std::string> vProjects = split(projects.c_str(),";");
     if (vProjects.size() > 0)
@@ -816,7 +816,7 @@ bool TallyMagnitudesInSuperblock()
     network.rac = TotalRAC;
     network.NetworkProjects = TotalProjects;
     //8-16-2015 Store the quotes
-    std::string q = ReadCache("superblock","quotes");
+    std::string q = ReadCache("superblock","quotes").value;
     if (fDebug3) printf("q %s",q.c_str());
     std::vector<std::string> vQ = split(q.c_str(),";");
     if (vQ.size() > 0)
@@ -1520,12 +1520,12 @@ Value execute(const Array& params, bool fHelp)
     }
     else if (sItem == "superblockage")
     {
-        int64_t superblock_time = ReadCacheTimestamp("superblock", "magnitudes");
+        int64_t superblock_time = ReadCache("superblock", "magnitudes").timestamp;
         int64_t superblock_age = GetAdjustedTime() - superblock_time;
         entry.push_back(Pair("Superblock Age", superblock_age));
         entry.push_back(Pair("Superblock Timestamp", TimestampToHRDate(superblock_time)));
-        entry.push_back(Pair("Superblock Block Number", ReadCache("superblock", "block_number")));
-        entry.push_back(Pair("Pending Superblock Height", ReadCache("neuralsecurity","pending")));
+        entry.push_back(Pair("Superblock Block Number", ReadCache("superblock", "block_number").value));
+        entry.push_back(Pair("Pending Superblock Height", ReadCache("neuralsecurity","pending").value));
         results.push_back(entry);
     }
     else if (sItem == "unusual")
@@ -1698,8 +1698,8 @@ Value execute(const Array& params, bool fHelp)
                                 std::string cpid1 = GlobalCPUMiningCPID.cpid;
                                 std::string GRCAddress1 = DefaultWalletAddress();
                                 GetEarliestStakeTime(GRCAddress1,cpid1);
-                                double cpid_age = GetAdjustedTime() - ReadCacheTimestamp("global", "nCPIDTime");
-                                double stake_age = GetAdjustedTime() - ReadCacheTimestamp("global", "nGRCTime");
+                                double cpid_age = GetAdjustedTime() - ReadCache("global", "nCPIDTime").timestamp;
+                                double stake_age = GetAdjustedTime() - ReadCache("global", "nGRCTime").timestamp;
 
                                 StructCPID structGRC = GetInitializedStructCPID2(GRCAddress,mvMagnitudes);
 
@@ -1917,8 +1917,8 @@ Value execute(const Array& params, bool fHelp)
             std::string cpid = GlobalCPUMiningCPID.cpid;
             std::string GRCAddress = DefaultWalletAddress();
             GetEarliestStakeTime(GRCAddress,cpid);
-            entry.push_back(Pair("GRCTime", ReadCacheTimestamp("global", "nGRCTime")));
-            entry.push_back(Pair("CPIDTime",ReadCacheTimestamp("global", "nCPIDTime")));
+            entry.push_back(Pair("GRCTime", ReadCache("global", "nGRCTime").timestamp));
+            entry.push_back(Pair("CPIDTime",ReadCache("global", "nCPIDTime").timestamp));
             results.push_back(entry);
     }
     else if (sItem=="testnewcontract")
@@ -2122,7 +2122,7 @@ Value execute(const Array& params, bool fHelp)
     }
     else if (sItem == "superblockaverage")
     {
-        std::string superblock = ReadCache("superblock","all");
+        std::string superblock = ReadCache("superblock","all").value;
         double out_beacon_count = 0;
         double out_participant_count = 0;
         double out_avg = 0;
@@ -2132,7 +2132,7 @@ Value execute(const Array& params, bool fHelp)
         entry.push_back(Pair("beacon_participant_count",out_participant_count));
         entry.push_back(Pair("average_magnitude",out_avg));
         entry.push_back(Pair("superblock_valid", VerifySuperblock(superblock, pindexBest)));
-        int64_t superblock_age = GetAdjustedTime() - ReadCacheTimestamp("superblock", "magnitudes");
+        int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
         entry.push_back(Pair("Superblock Age",superblock_age));
         bool bDireNeed = NeedASuperblock();
         entry.push_back(Pair("Dire Need of Superblock",bDireNeed));
@@ -2190,8 +2190,8 @@ Value execute(const Array& params, bool fHelp)
         {
             std::string sType = params[1].get_str();
             entry.push_back(Pair("Key Type",sType));
-            for(const auto& item : AppCacheFilter(sType))
-                entry.push_back(Pair(item.first, item.second));
+            for(const auto& item : ReadCacheSection(sType))
+                entry.push_back(Pair(item.first, item.second.value));
 
            results.push_back(entry);
         }
@@ -2500,7 +2500,7 @@ Array SuperblockReport(std::string cpid)
                 double out_avg = 0;
                 // Binary Support 12-20-2015
                 std::string superblock = UnpackBinarySuperblock(bb.superblock);
-                double avg_mag = GetSuperblockAvgMag(superblock,out_beacon_count,out_participant_count,out_avg,true,pblockindex->nHeight);
+                GetSuperblockAvgMag(superblock,out_beacon_count,out_participant_count,out_avg,true,pblockindex->nHeight);
 
                 Object c;
                 c.push_back(Pair("Block #" + ToString(pblockindex->nHeight),pblockindex->GetBlockHash().GetHex()));
@@ -2671,9 +2671,9 @@ std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash)
 
 std::string GetPollContractByTitle(std::string objecttype, std::string title)
 {
-    for(const auto& item : AppCacheFilter(objecttype))
+    for(const auto& item : ReadCacheSection(objecttype))
     {
-        const std::string& contract = item.second;
+        const std::string& contract = item.second.value;
         const std::string& PollTitle = ExtractXML(contract,"<TITLE>","</TITLE>");
         if(boost::iequals(PollTitle, title))
             return contract;
@@ -2770,9 +2770,9 @@ double VotesCount(std::string pollname, std::string answer, double sharetype, do
 
     double MoneySupplyFactor = GetMoneySupplyFactor();
 
-    for(const auto& item : AppCacheFilter("vote"))
+    for(const auto& item : ReadCacheSection("vote"))
     {
-        const std::string& contract = item.second;
+        const std::string& contract = item.second.value;
         const std::string& Title = ExtractXML(contract,"<TITLE>","</TITLE>");
         const std::string& VoterAnswer = ExtractXML(contract,"<ANSWER>","</ANSWER>");
         const std::vector<std::string>& vVoterAnswers = split(VoterAnswer.c_str(),";");
@@ -3243,9 +3243,9 @@ Array GetJsonVoteDetailsReport(std::string pollname)
     entry.push_back(Pair("GRCAddress,CPID,Question,Answer,ShareType,URL", "Shares"));
 
     boost::to_lower(pollname);
-    for(const auto& item : AppCacheFilter("vote"))
+    for(const auto& item : ReadCacheSection("vote"))
     {
-        const std::string& contract = item.second;
+        const std::string& contract = item.second.value;
         const std::string& Title = ExtractXML(contract,"<TITLE>","</TITLE>");
         if(boost::iequals(pollname, Title))
         {
@@ -3285,7 +3285,6 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
     Array results;
     Object entry;
     entry.push_back(Pair("Polls","Polls Report " + QueryByTitle));
-    std::string datatype="poll";
     std::string rows;
     std::string row;
     double iPollNumber = 0;
@@ -3296,27 +3295,18 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
     std::string sExportRow;
     out_export.clear();
 
-    for(const auto& item : AppCacheFilter(datatype))
+    for(const auto& item : ReadCacheSection("poll"))
     {
-        const std::string& key_name = item.first;
-        const std::string& contract = item.second;
-
-        // Creating polls also create additional cache instances with ";burnamount" and ";recipient"
-        // appended. Skip all keys containing those fields.
-        if(boost::iends_with(key_name, ";burnamount") ||
-           boost::iends_with(key_name, ";recipient"))
-           continue;
-
-        std::string Title = key_name.substr(datatype.length()+1,key_name.length()-datatype.length()-1);
+        const std::string& title = boost::to_lower_copy(item.first);
+        const std::string& contract = item.second.value;
         std::string Expiration = ExtractXML(contract,"<EXPIRATION>","</EXPIRATION>");
         std::string Question = ExtractXML(contract,"<QUESTION>","</QUESTION>");
         std::string Answers = ExtractXML(contract,"<ANSWERS>","</ANSWERS>");
         std::string ShareType = ExtractXML(contract,"<SHARETYPE>","</SHARETYPE>");
         std::string sURL = ExtractXML(contract,"<URL>","</URL>");
-        boost::to_lower(Title);
-        if (!PollExpired(Title) || IncludeExpired)
+        if (!PollExpired(title) || IncludeExpired)
         {
-            if (QueryByTitle.empty() || QueryByTitle == Title)
+            if (QueryByTitle.empty() || QueryByTitle == title)
             {
                 iPollNumber++;
                 total_participants = 0;
@@ -3328,8 +3318,8 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
                 std::string TitleNarr = "Poll #" + RoundToString((double)iPollNumber,0)
                                         + " (" + ExpirationDate + " ) - " + sShareType;
 
-                entry.push_back(Pair(TitleNarr,Title));
-                sExportRow = "<POLL><URL>" + sURL + "</URL><TITLE>" + Title + "</TITLE><EXPIRATION>" + ExpirationDate + "</EXPIRATION><SHARETYPE>" + sShareType + "</SHARETYPE><QUESTION>" + Question + "</QUESTION><ANSWERS>"+Answers+"</ANSWERS>";
+                entry.push_back(Pair(TitleNarr,title));
+                sExportRow = "<POLL><URL>" + sURL + "</URL><TITLE>" + title + "</TITLE><EXPIRATION>" + ExpirationDate + "</EXPIRATION><SHARETYPE>" + sShareType + "</SHARETYPE><QUESTION>" + Question + "</QUESTION><ANSWERS>"+Answers+"</ANSWERS>";
 
                 if (bDetail)
                 {
@@ -3340,7 +3330,7 @@ Array GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& ou
                     for (const std::string& answer : vAnswers)
                     {
                         double participants=0;
-                        double dShares = VotesCount(Title, answer, RoundFromString(ShareType,0),participants);
+                        double dShares = VotesCount(title, answer, RoundFromString(ShareType,0),participants);
                         if (dShares > highest_share)
                         {
                             highest_share = dShares;
@@ -3385,17 +3375,14 @@ Array GetUpgradedBeaconReport()
     Array results;
     Object entry;
     entry.push_back(Pair("Report","Upgraded Beacon Report 1.0"));
-    std::string datatype="beacon";
     std::string rows = "";
     std::string row = "";
     int iBeaconCount = 0;
     int iUpgradedBeaconCount = 0;
-    for(const auto& item : AppCacheFilter(datatype))
+    for(const auto& item : ReadCacheSection("beacon"))
     {
-        const std::string& key_name  = item.first;
-        const std::string& key_value = item.second;
-        std::string subkey = key_name.substr(datatype.length()+1,key_name.length()-datatype.length()-1);
-        std::string contract = DecodeBase64(key_value);
+        const AppCacheEntry& entry = item.second;
+        std::string contract = DecodeBase64(entry.value);
         std::string cpidv2 = ExtractValue(contract,";",0);
         std::string grcaddress = ExtractValue(contract,";",2);
         std::string sPublicKey = ExtractValue(contract,";",3);
@@ -3403,8 +3390,8 @@ Array GetUpgradedBeaconReport()
         iBeaconCount++;
     }
 
-    entry.push_back(Pair("Total Beacons",(double)iBeaconCount));
-    entry.push_back(Pair("Upgraded Beacon Count",(double)iUpgradedBeaconCount));
+    entry.push_back(Pair("Total Beacons", iBeaconCount));
+    entry.push_back(Pair("Upgraded Beacon Count", iUpgradedBeaconCount));
     double dPct = ((double)iUpgradedBeaconCount / ((double)iBeaconCount) + .01);
     entry.push_back(Pair("Pct Of Upgraded Beacons",RoundToString(dPct*100,3)));
     results.push_back(entry);
@@ -3420,19 +3407,15 @@ Array GetJSONBeaconReport()
     Array results;
     Object entry;
     entry.push_back(Pair("CPID","GRCAddress"));
-    std::string datatype="beacon";
     std::string row;
-    for(const auto& item : AppCacheFilter(datatype))
+    for(const auto& item : ReadCacheSection("beacon"))
     {
-        const std::string& key_name  = item.first;
-        const std::string& key_value = item.second;
-        std::string subkey = key_name.substr(datatype.length()+1,key_name.length()-datatype.length()-1);
-        row = subkey + "<COL>" + key_value;
-        //                              std::string contract = GlobalCPUMiningCPID.cpidv2 + ";" + hashRand.GetHex() + ";" + GRCAddress;
-        std::string contract = DecodeBase64(key_value);
-        std::string cpid = subkey;
+        const std::string& key = item.first;
+        const AppCacheEntry& cache = item.second;
+        row = key + "<COL>" + cache.value;
+        std::string contract = DecodeBase64(cache.value);
         std::string grcaddress = ExtractValue(contract,";",2);
-        entry.push_back(Pair(cpid,grcaddress));
+        entry.push_back(Pair(key, grcaddress));
     }
 
     results.push_back(entry);
@@ -3505,12 +3488,12 @@ Array GetJSONNeuralNetworkReport()
                 }
       }
       // If we have a pending superblock, append it to the report:
-      std::string SuperblockHeight = ReadCache("neuralsecurity","pending");
+      std::string SuperblockHeight = ReadCache("neuralsecurity","pending").value;
       if (!SuperblockHeight.empty() && SuperblockHeight != "0")
       {
           entry.push_back(Pair("Pending",SuperblockHeight));
       }
-      int64_t superblock_age = GetAdjustedTime() - ReadCacheTimestamp("superblock", "magnitudes");
+      int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
 
       entry.push_back(Pair("Superblock Age",superblock_age));
       if (superblock_age > GetSuperblockAgeSpacing(nBestHeight))
@@ -3558,12 +3541,12 @@ Array GetJSONCurrentNeuralNetworkReport()
                 }
       }
       // If we have a pending superblock, append it to the report:
-      std::string SuperblockHeight = ReadCache("neuralsecurity","pending");
+      std::string SuperblockHeight = ReadCache("neuralsecurity","pending").value;
       if (!SuperblockHeight.empty() && SuperblockHeight != "0")
       {
           entry.push_back(Pair("Pending",SuperblockHeight));
       }
-      int64_t superblock_age = GetAdjustedTime() - ReadCacheTimestamp("superblock", "magnitudes");
+      int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
 
       entry.push_back(Pair("Superblock Age",superblock_age));
       if (superblock_age > GetSuperblockAgeSpacing(nBestHeight))
@@ -3880,18 +3863,16 @@ Value listitem(const Array& params, bool fHelp)
     }
     else if (sitem == "projects")
     {
-        for (const auto& item : AppCacheFilter("project"))
+        for (const auto& item : ReadCacheSection("project"))
         {
             Object entry;
 
-            std::string sProjectKey = item.first;
-            std::vector<std::string> vProjectKey = split(sProjectKey, ";");
-            std::string sProjectName = ToOfficialName(vProjectKey[1]);
-            std::string sProjectURL = item.second;
-            sProjectURL.erase(std::remove(sProjectURL.begin(), sProjectURL.end(), '@'), sProjectURL.end());
-
+            std::string sProjectName = ToOfficialName(item.first);
             if (sProjectName.empty())
                 continue;
+
+            std::string sProjectURL = item.second.value;
+            sProjectURL.erase(std::remove(sProjectURL.begin(), sProjectURL.end(), '@'), sProjectURL.end());
 
             // If contains an additional stats URL for project stats; remove it for the user to goto the correct website.
             if (sProjectURL.find("stats/") != string::npos)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1305,7 +1305,6 @@ Value execute(const Array& params, bool fHelp)
     }
     else if (sItem=="proveownership")
     {
-        mvCPIDCache.clear();
         HarvestCPIDs(true);
         GetNextProject(true);
         std::string email = GetArgument("email", "NA");
@@ -2342,7 +2341,6 @@ Value execute(const Array& params, bool fHelp)
     {
             //Reload the config file
             ReadConfigFile(mapArgs, mapMultiArgs);
-            mvCPIDCache.clear();
             HarvestCPIDs(true);
             GetNextProject(true);
             entry.push_back(Pair("Reset",1));

--- a/src/test/appcache_tests.cpp
+++ b/src/test/appcache_tests.cpp
@@ -34,4 +34,15 @@ BOOST_AUTO_TEST_CASE(appcache_GetCountOfShouldCountEntries)
    BOOST_CHECK_EQUAL(GetCountOf("section"), 3);
 }
 
+BOOST_AUTO_TEST_CASE(appcache_GetListOfBeaconShouldIgnoreInvestors)
+{
+
+   WriteCache("beacon", "CPID1", "INVESTOR", 12345);
+   BOOST_CHECK(GetListOf("beacon").empty() == true);
+
+   WriteCache("beacon", "CPID2", "abc123", 12345);
+   BOOST_CHECK(GetListOf("beacon").empty() == false);
+   BOOST_CHECK(GetListOf("beacon").find("abc123") != std::string::npos);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/appcache_tests.cpp
+++ b/src/test/appcache_tests.cpp
@@ -7,7 +7,7 @@ BOOST_AUTO_TEST_SUITE(appcache_tests)
 BOOST_AUTO_TEST_CASE(appcache_WrittenCacheShouldBeReadable)
 {
     WriteCache("section", "key", "hello", 123456789);
-    BOOST_CHECK(ReadCache("section", "key") == "hello");
+    BOOST_CHECK(ReadCache("section", "key").value == "hello");
 }
 
 BOOST_AUTO_TEST_CASE(appcache_ClearCacheShouldClearEntireSection)
@@ -15,15 +15,15 @@ BOOST_AUTO_TEST_CASE(appcache_ClearCacheShouldClearEntireSection)
     WriteCache("section", "key1", "hello", 123456789);
     WriteCache("section", "key2", "hello", 123456789);
     ClearCache("section");
-    BOOST_CHECK(ReadCache("section", "key1").empty() == true);
-    BOOST_CHECK(ReadCache("section", "key2").empty() == true);
+    BOOST_CHECK(ReadCache("section", "key1").value.empty() == true);
+    BOOST_CHECK(ReadCache("section", "key2").value.empty() == true);
 }
 
 BOOST_AUTO_TEST_CASE(appcache_KeyShouldBeEmptyAfterDeleteCache)
 {
     WriteCache("section", "key", "hello", 123456789);
     DeleteCache("section", "key");
-    BOOST_CHECK(ReadCache("section", "key").empty() == true);
+    BOOST_CHECK(ReadCache("section", "key").value.empty() == true);
 }
 
 

--- a/src/test/appcache_tests.cpp
+++ b/src/test/appcache_tests.cpp
@@ -1,0 +1,30 @@
+#include "appcache.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(appcache_tests)
+
+BOOST_AUTO_TEST_CASE(appcache_WrittenCacheShouldBeReadable)
+{
+    WriteCache("section", "key", "hello", 123456789);
+    BOOST_CHECK(ReadCache("section", "key") == "hello");
+}
+
+BOOST_AUTO_TEST_CASE(appcache_ClearCacheShouldClearEntireSection)
+{
+    WriteCache("section", "key1", "hello", 123456789);
+    WriteCache("section", "key2", "hello", 123456789);
+    ClearCache("section");
+    BOOST_CHECK(ReadCache("section", "key1").empty() == true);
+    BOOST_CHECK(ReadCache("section", "key2").empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(appcache_KeyShouldBeEmptyAfterDeleteCache)
+{
+    WriteCache("section", "key", "hello", 123456789);
+    DeleteCache("section", "key");
+    BOOST_CHECK(ReadCache("section", "key").empty() == true);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/appcache_tests.cpp
+++ b/src/test/appcache_tests.cpp
@@ -26,5 +26,12 @@ BOOST_AUTO_TEST_CASE(appcache_KeyShouldBeEmptyAfterDeleteCache)
     BOOST_CHECK(ReadCache("section", "key").value.empty() == true);
 }
 
+BOOST_AUTO_TEST_CASE(appcache_GetCountOfShouldCountEntries)
+{
+   WriteCache("section", "key1", "hello", 123456789);
+   WriteCache("section", "key2", "hello", 123456789);
+   WriteCache("section", "key3", "hello", 123456789);
+   BOOST_CHECK_EQUAL(GetCountOf("section"), 3);
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Status: Testing

Move appcache operations to appcache.cpp/h and use a map of maps instead of a map of semicolon separated strings. This makes sense as that's the way we treat the data anyway. This also removes the need for AppCacheFilter.