### PR TITLE
Return true for IsConfirmed when Depth is -1

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -700,7 +700,7 @@ public:
     }
     bool IsConfirmed() const
     {
-        return GetDepthInMainChain() >= 10;
+        return (GetDepthInMainChain() >= 10 || GetDepthInMainChain < 0);
     }
     bool IsTrusted() const
     {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -700,7 +700,7 @@ public:
     }
     bool IsConfirmed() const
     {
-        return (GetDepthInMainChain() >= 10 || GetDepthInMainChain < 0);
+        return (GetDepthInMainChain() >= 10 || GetDepthInMainChain() < 0);
     }
     bool IsTrusted() const
     {


### PR DESCRIPTION
Return True for IsConfirmed when Depth is -1. This eliminates the unconfirmed balance showing unconfirmed balance when the received TX is no longer in chain from a conflicted block. This is only cosmetic so that the users balance shows the true amount not the real balance + unconfirmed balance = total balance. This code is unrelated to the block-chain or transactions itself When a user receives his TX its 1 confirmations as it is in block they have received.

Someone had mentioned before a similar situation in which I experienced myself from barton26's test on testnet with failed double spend. This resulted in a -1 which returned as not confirmed and still counted towards the total balance which was not accurate elsewhere and leaving the amount left in unconfirmed permanently even after restart.