### PR TITLE
Correct WSL build instructions

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -1,15 +1,19 @@
 WINDOWS BUILD NOTES
 ====================
 
-Below are some notes on how to build Gridcoin-Research for Windows.
+Below are some notes on how to build Gridcoin for Windows.
 
-Most developers use cross-compilation from Ubuntu to build executables for
-Windows. This is also used to build the release binaries.
+The options known to work for building on Windows are:
 
-While there are potentially a number of ways to build on Windows (for example using msys / mingw-w64),
-using the Windows Subsystem For Linux is the most straightforward. If you are building with
-another method, please contribute the instructions here for others who are running versions
-of Windows that are not compatible with the Windows Subsystem for Linux.
+* On Linux using the [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Ubuntu Trusty 14.04 is recommended
+and is the platform used to build the Gridcoin Windows release binaries.
+* On Windows using [Windows
+Subsystem for Linux (WSL)](https://msdn.microsoft.com/commandline/wsl/about) and the Mingw-w64 cross compiler tool chain.
+
+Other options which may work but which have not been extensively tested are (please contribute instructions):
+
+* On Windows using a POSIX compatibility layer application such as [cygwin](http://www.cygwin.com/) or [msys2](http://www.msys2.org/).
+* On Windows using a native compiler tool chain such as [Visual Studio](https://www.visualstudio.com).
 
 Compiling with Windows Subsystem For Linux
 -------------------------------------------
@@ -24,30 +28,28 @@ This feature is not supported in versions of Windows prior to Windows 10 or on
 Windows Server SKUs. In addition, it is available [only for 64-bit versions of
 Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
 
-To get the bash shell, you must first activate the feature in Windows.
+Full instructions to install WSL are available on the above link.
+To install WSL on Windows 10 with Fall Creators Update installed (version >= 16215.0) do the following:
 
 1. Turn on Developer Mode
   * Open Settings -> Update and Security -> For developers
   * Select the Developer Mode radio button
   * Restart if necessary
-2. Enable the Windows Subsystem for Linux feature
-  * From Start, search for "Turn Windows features on or off" (type 'turn')
-  * Select Windows Subsystem for Linux (beta)
-  * Click OK
-  * Restart if necessary
+2. Install Ubuntu
+  * Open Microsoft Store and search for Ubuntu or use [this link](https://www.microsoft.com/store/productId/9NBLGGH4MSV6)
+  * Click Install
 3. Complete Installation
-  * Open a cmd prompt and type "bash"
-  * Accept the license
+  * Open a cmd prompt and type "Ubuntu"
   * Create a new UNIX user account (this is a separate account from your Windows account)
 
+
 After the bash shell is active, you can follow the instructions below, starting
-with the "Cross-compilation" section. Compiling the 64-bit version is
-recommended but it is possible to compile the 32-bit version.
+with the "Cross-compilation" section. Compiling the 64-bit version is recommended but it is possible to compile the 32-bit version.
 
 Cross-compilation
 -------------------
 
-These steps can be performed on, for example, an Ubuntu VM. The depends system
+These steps can be performed on, for example, an Ubuntu VM or WSL. The depends system
 will also work on other Linux distributions, however the commands for
 installing the toolchain will be different.
 
@@ -61,10 +63,38 @@ build process.
 
 ## Building for 64-bit Windows
 
-To build executables for Windows 64-bit, install the following dependencies:
+The first step is to install the mingw-w64 cross-compilation tool chain. Due to different Ubuntu
+packages for each distribution and problems with the Xenial packages the steps for each are different.
 
-    sudo apt-get install g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
+Common steps to install mingw32 cross compiler tool chain:
 
+    sudo apt install g++-mingw-w64-x86-64
+
+Ubuntu Trusty 14.04:
+
+    No further steps required
+
+Ubuntu Xenial 16.04 and Windows Subsystem for Linux: 
+
+    sudo apt install software-properties-common
+    sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu zesty universe"
+    sudo apt update
+    sudo apt upgrade
+    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+
+Ubuntu Zesty 17.04:
+
+    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+
+Note that for WSL the Gridcoin source path MUST be somewhere in the default mount file system, for
+example /usr/src/Gridcoin-Research, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
+This means you cannot use a directory that located directly on the host Windows file system to perform the build.
+
+    cd /usr/src
+    sudo git clone https://github.com/gridcoin/Gridcoin-Research.git
+    sudo chmod -R a+rw Gridcoin-Research
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
+    
 Then build using:
 
     cd depends
@@ -79,6 +109,18 @@ Then build using:
 To build executables for Windows 32-bit, install the following dependencies:
 
     sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev 
+
+For Ubuntu Xenial 16.04, Ubuntu Zesty 17.04 and Windows Subsystem for Linux:
+
+    sudo update-alternatives --config i686-w64-mingw32-g++  # Set the default mingw32 g++ compiler option to posix.
+
+For WSL use:
+
+    cd /usr/src
+    sudo git clone https://github.com/gridcoin/Gridcoin-Research.git
+    sudo chmod -R a+rw Gridcoin-Research
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
+
 
 Then build using:
 
@@ -99,6 +141,6 @@ Installation
 After building using the Windows subsystem it can be useful to copy the compiled
 executables to a directory on the windows drive in the same directory structure
 as they appear in the release `.zip` archive. This can be done in the following
-way. This will install to `c:\workspace\gridcoin`, for example:
+way. This will install to `c:\workspace\Gridcoin-Research`, for example:
 
-    make install DESTDIR=/mnt/c/workspace/gridcoin
+    make install DESTDIR=/mnt/c/workspace/Gridcoin-Research


### PR DESCRIPTION
The builds instructions for WSL were outdated and faulty. This fix should make
the difference clearer between cross compiling and using WSL.