### PR TITLE
Remove payments CSV export.

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -68,10 +68,6 @@ struct StructCPID
     std::string email;
     std::string boincruntimepublickey;
     std::string cpidv2;
-    std::string PaymentTimestamps;
-    std::string PaymentAmountsResearch;
-    std::string PaymentAmountsInterest;
-    std::string PaymentAmountsBlocks;
     std::string BlockHash;
     std::string GRCAddress;
 };

--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -69,7 +69,6 @@ struct StructCPID
     std::string boincruntimepublickey;
     std::string cpidv2;
     std::string BlockHash;
-    std::string GRCAddress;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,6 @@ void CheckForUpgrade();
 int64_t GetRSAWeightByCPID(std::string cpid);
 extern MiningCPID GetMiningCPID();
 extern StructCPID GetStructCPID();
-json_spirit::Array MagnitudeReportCSV(bool detail);
 
 int64_t nLastBlockSolved = 0;  //Future timestamp
 int64_t nLastBlockSubmitted = 0;
@@ -4456,23 +4455,8 @@ void GridcoinServices()
         }
     }
 
-    if (KeyEnabled("exportmagnitude"))
-    {
-        if (TimerMain("export_magnitude",900))
-        {
-            json_spirit::Array results;
-            results = MagnitudeReportCSV(true);
-
-        }
-    }
-
     if (TimerMain("gather_cpids",480))
-    {
-            //if (fDebug10) printf("\r\nReharvesting cpids in background thread...\r\n");
-            //LoadCPIDsInBackground();
-            //printf(" {CPIDs Re-Loaded} ");
-            msNeuralResponse="";
-    }
+        msNeuralResponse.clear();
 
     if (TimerMain("check_for_autoupgrade",240))
     {
@@ -5247,11 +5231,6 @@ void AddResearchMagnitude(CBlockIndex* pIndex)
         stMag.interestPayments += pIndex->nInterestSubsidy;
         
         AdjustTimestamps(stMag,pIndex->nTime, pIndex->nResearchSubsidy);
-        // Track detailed payments made to each CPID
-        stMag.PaymentTimestamps         += ToString(pIndex->nTime) + ",";
-        stMag.PaymentAmountsResearch    += RoundToString(pIndex->nResearchSubsidy,2) + ",";
-        stMag.PaymentAmountsInterest    += RoundToString(pIndex->nInterestSubsidy,2) + ",";
-        stMag.PaymentAmountsBlocks      += ToString(pIndex->nHeight) + ",";
         stMag.Accuracy++;
         stMag.AverageRAC = stMag.rac / (stMag.entries+.01);
         double total_owed = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3065,7 +3065,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             }
             iPos++;
         }
-        pindex->sGRCAddress = bb.GRCAddress;
     }
 
     double mint = CoinToDouble(pindex->nMint);
@@ -5221,7 +5220,6 @@ void AddResearchMagnitude(CBlockIndex* pIndex)
     {
         StructCPID stMag = GetInitializedStructCPID2(pIndex->GetCPID(),mvMagnitudesCopy);
         stMag.cpid = pIndex->GetCPID();
-        stMag.GRCAddress = pIndex->sGRCAddress;
         if (pIndex->nHeight > stMag.LastBlock)
         {
             stMag.LastBlock = pIndex->nHeight;

--- a/src/main.h
+++ b/src/main.h
@@ -1311,7 +1311,6 @@ public:
 	// Indicators (9-13-2015)
 	unsigned int nIsSuperBlock;
 	unsigned int nIsContract;
-	std::string sGRCAddress;
 
     unsigned int nFlags;  // ppcoin: block index flags
     enum  
@@ -1368,7 +1367,6 @@ public:
 		nMagnitude = 0;
 		nIsSuperBlock = 0;
 		nIsContract = 0;
-		sGRCAddress = "";
     }
 
     CBlockIndex(unsigned int nFileIn, unsigned int nBlockPosIn, CBlock& block)
@@ -1627,12 +1625,15 @@ public:
 		{
 			READWRITE(nIsSuperBlock);
 			READWRITE(nIsContract);
-			READWRITE(sGRCAddress);
 
-                        // Blocks used to come with a reserved string. Keep (de)serializing
-                        // it until it's used.
-                        std::string sReserved;
-                        READWRITE(sReserved);
+         std::string dummy;
+
+         // Blocks used to contain the GRC address.
+         READWRITE(dummy);
+
+         // Blocks used to come with a reserved string. Keep (de)serializing
+         // it until it's used.
+         READWRITE(dummy);
 		}
 
 


### PR DESCRIPTION
The implementation made it really difficult to reorganize to a new chain as the payments would have to be cut out from a concatenated string, see #756. The information is still in the chain but those who wants to export the data to CSV will have to traverse the chain manually.