### PR TITLE
Add RPC command to burn coins 

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -295,6 +295,7 @@ static const CRPCCommand vRPCCommands[] =
     { "decodescript",           &decodescript,           false,  false },
     { "signrawtransaction",     &signrawtransaction,     false,  false },
     { "sendrawtransaction",     &sendrawtransaction,     false,  false },
+    {"burn",                    &burn,                   false,  false },
     { "getcheckpoint",          &getcheckpoint,          true,   false },
     { "reservebalance",         &reservebalance,         false,  true},
     { "checkwallet",            &checkwallet,            false,  true},
@@ -1251,6 +1252,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "signrawtransaction"     && n > 1) ConvertTo<Array>(params[1], true);
     if (strMethod == "signrawtransaction"     && n > 2) ConvertTo<Array>(params[2], true);
     if (strMethod == "keypoolrefill"          && n > 0) ConvertTo<int64_t>(params[0]);
+    if (strMethod == "burn"                   && n > 0) ConvertTo<double>(params[0]);
 
     return params;
 }

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -202,6 +202,7 @@ extern json_spirit::Value decoderawtransaction(const json_spirit::Array& params,
 extern json_spirit::Value decodescript(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value signrawtransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendrawtransaction(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value burn(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getbestblockhash(const json_spirit::Array& params, bool fHelp); // in rpcblockchain.cpp
 extern json_spirit::Value getblockcount(const json_spirit::Array& params, bool fHelp); // in rpcblockchain.cpp

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2157,15 +2157,15 @@ Value burn(const Array& params, bool fHelp)
     int64_t nAmount = AmountFromValue(params[0]);
     CScript scriptPubKey;
 
-    if (params.size() > 1) {
+    if (params.size() > 1)
+    {
         vector<unsigned char> data;
-        if (params[1].get_str().size() > 0){
+        if (params[1].get_str().size() > 0)
             data = ParseHexV(params[1], "Data");
-        }
         scriptPubKey = CScript() << OP_RETURN << data;
-    } else {
-        scriptPubKey = CScript() << OP_RETURN;
     }
+    else
+        scriptPubKey = CScript() << OP_RETURN;
 
     CWalletTx wtx;
     string strError = pwalletMain->SendMoney(scriptPubKey, nAmount, wtx);


### PR DESCRIPTION
This adds the RPC command "burn" to send coins in an unspendable output using the OP_RETURN opcode. The coins are proveably unspendable and don't spam the UTXO database. It can also be used to add data to the blockchain. Maybe we should think about spam protection.