### PR TITLE
Provide Difficulty of best Kernel found

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -66,6 +66,8 @@ void CMinerStatus::Clear()
     WeightSum= ValueSum= WeightMin= WeightMax= 0;
     Version= 0;
     CoinAgeSum= 0;
+    KernelDiffMax = 0;
+    KernelDiffSum = 0;
     nLastCoinStakeSearchInterval = 0;
 }
 
@@ -600,6 +602,8 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             LOCK(MinerStatus.lock);
             MinerStatus.Message+="Found Kernel "+ ToString(CoinToDouble(nCredit))+"; ";
             MinerStatus.KernelsFound++;
+            MinerStatus.KernelDiffMax = 0;
+            MinerStatus.KernelDiffSum = StakeDiffSum;
             return true;
         }
     }
@@ -611,6 +615,8 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
     MinerStatus.WeightMin=StakeWeightMin;
     MinerStatus.WeightMax=StakeWeightMax;
     MinerStatus.CoinAgeSum=StakeCoinAgeSum;
+    MinerStatus.KernelDiffMax = std::max(MinerStatus.KernelDiffMax,StakeDiffMax);
+    MinerStatus.KernelDiffSum = StakeDiffSum;
     MinerStatus.nLastCoinStakeSearchInterval= txnew.nTime;
     return false;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -60,13 +60,20 @@ public:
     }
 };
 
+CMinerStatus::CMinerStatus(void)
+{
+    Clear();
+    ReasonNotStaking= "";
+    CreatedCnt= AcceptedCnt= KernelsFound= 0;
+    KernelDiffMax= 0;
+}
+
 void CMinerStatus::Clear()
 {
     Message= "";
     WeightSum= ValueSum= WeightMin= WeightMax= 0;
     Version= 0;
     CoinAgeSum= 0;
-    KernelDiffMax = 0;
     KernelDiffSum = 0;
     nLastCoinStakeSearchInterval = 0;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -434,6 +434,8 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
     int64_t StakeWeightMin=MAX_MONEY;
     int64_t StakeWeightMax=0;
     uint64_t StakeCoinAgeSum=0;
+    double StakeDiffSum = 0;
+    double StakeDiffMax = 0;
     CTransaction &txnew = blocknew.vtx[1]; // second tx is coinstake
 
     //initialize the transaction
@@ -519,6 +521,9 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
         StakeWeightSum += CoinWeight;
         StakeWeightMin=std::min(StakeWeightMin,CoinWeight);
         StakeWeightMax=std::max(StakeWeightMax,CoinWeight);
+        double StakeKernelDiff = GetBlockDifficulty(StakeKernelHash.GetCompact())*CoinWeight;
+        StakeDiffSum += StakeKernelDiff;
+        StakeDiffMax = std::max(StakeDiffMax,StakeKernelDiff);
 
         if (fDebug2) {
             int64_t RSA_WEIGHT = GetRSAWeightByBlock(GlobalCPUMiningCPID);
@@ -526,13 +531,15 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
 "CreateCoinStake: V%d Time %.f, Por_Nonce %.f, Bits %jd, Weight %jd\n"
 " RSA_WEIGHT %.f\n"
 " Stk %72s\n"
-" Trg %72s\n",
+" Trg %72s\n"
+" Diff %0.7f of %0.7f\n",
             blocknew.nVersion,
             (double)txnew.nTime, mdPORNonce,
             (intmax_t)blocknew.nBits,(intmax_t)CoinWeight,
             (double)RSA_WEIGHT,
-            StakeKernelHash.GetHex().c_str(), StakeTarget.GetHex().c_str()
-        );
+            StakeKernelHash.GetHex().c_str(), StakeTarget.GetHex().c_str(),
+            StakeKernelDiff, GetBlockDifficulty(blocknew.nBits)
+            );
         }
 
         if( StakeKernelHash <= StakeTarget )

--- a/src/miner.h
+++ b/src/miner.h
@@ -26,12 +26,7 @@ struct CMinerStatus
     double KernelDiffSum;
 
     void Clear();
-    CMinerStatus()
-    {
-        Clear();
-        ReasonNotStaking= "";
-        CreatedCnt= AcceptedCnt= KernelsFound= 0;
-    }
+    CMinerStatus();
 };
 
 extern CMinerStatus MinerStatus;

--- a/src/miner.h
+++ b/src/miner.h
@@ -22,6 +22,8 @@ struct CMinerStatus
     uint64_t AcceptedCnt;
     uint64_t KernelsFound;
     int64_t nLastCoinStakeSearchInterval;
+    double KernelDiffMax;
+    double KernelDiffSum;
 
     void Clear();
     CMinerStatus()

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -67,6 +67,9 @@ Value getmininginfo(const Array& params, bool fHelp)
         // reuse value found by miner which has to load blocks anyway
         double dInterest = MinerStatus.CoinAgeSum * GetCoinYearReward(nTime) * 33 / (365 * 33 + 8);
         obj.push_back(Pair("InterestPending",dInterest/(double)COIN));
+
+        obj.push_back(Pair("kernel-diff-best",MinerStatus.KernelDiffMax));
+        obj.push_back(Pair("kernel-diff-sum",MinerStatus.KernelDiffSum));
     }
 
     obj.push_back(Pair("difficulty",    diff));


### PR DESCRIPTION
This let's user know the difficulty of the best kernel found by miner. You can use this to judge how close you are (nonlinear). Also it tells you how low the difficulty had to have been be in order to had staked.

This adds two fields into `getmininginfo`:
* `kernel-diff-best`:
   * The difficulty of best kernel found by wallet so far. Resets only on restart, lock and successful stake.
* `kernel-diff-sum`:
   * Sum of difficulties of kernels generated on last miner run