### PR TITLE
Fix for unconfirmed balance. + Balance calculation

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1204,7 +1204,7 @@ int64_t CWallet::GetBalance() const
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
-            if (pcoin->IsTrusted())
+            if (pcoin->IsTrusted() && pcoin->IsConfirmed())
                 nTotal += pcoin->GetAvailableCredit();
         }
     }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1220,7 +1220,7 @@ int64_t CWallet::GetUnconfirmedBalance() const
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
-            if (!IsFinalTx(*pcoin) || (!pcoin->IsConfirmed() && !pcoin->fFromMe))
+            if (!IsFinalTx(*pcoin) || (!pcoin->IsConfirmed() && !pcoin->fFromMe && pcoin->IsInMainChain()))
                 nTotal += pcoin->GetAvailableCredit();
         }
     }


### PR DESCRIPTION
had some issues with last PR so just made a fresh one.

Added to use IsInMainChain() this appears to solved the issue on my test wallet. IsInMainChain() returns true if not -1 in chain depth. better solution.

For the total balance calculation we had a minor detail bug.

The total confirmations required to send GRC is 3. However in UI we recommend 10 so we label any transactions less then 10 in depth as unconfirmed. This due to fact minor forks happen all the time. GetBalance checks if the depth is >= minimum confirms being 3. So after the 3rd confirm it would be added to Available while still considered unconfirmed.
2 options that could of been done.
1) raise those confirmations to 10
2) Simply as pcoin->IsConfirmed() to GetBalance check.

if there a better idea from you @denravonska then let me know. I would of personally just changed it to 10 but this way was less intrusive imo. lets have GetBalance just show the balance if its beyond 10 confirms.  