### PR TITLE
Drop Qt4 support.

### DIFF
--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -4,31 +4,18 @@ VERSION = 3.1.0.1
 INCLUDEPATH += src src/json src/qt
 DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE
 CONFIG += no_include_pwd thread c++11 exceptions concurrent
-QT += core gui network
+QT += core gui network widgets concurrent
 
 win32 {
     DEFINES += _WIN32_WINNT=0x0501 WINVER=0x0501 __USE_MINGW_ANSI_STDIO
-    lessThan(QT_VERSION, 5.0.0) {
-        CONFIG += qaxcontainer
-    }
-    else {
-        QT += axcontainer
-    }
+    QT += axcontainer
 
     # Fix for boost.asio build error. See
     # https://stackoverflow.com/questions/20957727/boostasio-unregisterwaitex-has-not-been-declared
     DEFINES += _WIN32_WINNT=0x0501 WINVER=0x0501
 }
 
-greaterThan(QT_MAJOR_VERSION, 4) {
-    QT += widgets concurrent
-    DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
-} else {
-    # qmake from Qt4 has no C++11 config so it has to be specified manually.
-    QMAKE_CXXFLAGS += -std=gnu++0x
-}
-
-lessThan(QT_VERSION, 5.8.0) {
+lessThan(QT_MAJOR_VERSION, 5) | lessThan(QT_MINOR_VERSION, 8) {
     # Qt charts not available
 }else{
     QT += charts

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -132,21 +132,9 @@ void AddressBookPage::setModel(AddressTableModel *model)
     ui->tableView->sortByColumn(0, Qt::AscendingOrder);
 
     // Set column widths
-
-#if QT_VERSION < 0x050000
-     ui->tableView->horizontalHeader()->resizeSection(
-             AddressTableModel::Address, 320);
-    ui->tableView->horizontalHeader()->setResizeMode(
-            AddressTableModel::Label, QHeaderView::Stretch);
-#else
     ui->tableView->horizontalHeader()->setSectionResizeMode(AddressTableModel::Label, QHeaderView::Stretch);
     ui->tableView->horizontalHeader()->setSectionResizeMode(AddressTableModel::Address, QHeaderView::ResizeToContents);
-#endif
-
-    ui->tableView->horizontalHeader()->resizeSection(
-            AddressTableModel::Address, 320);
-    ui->tableView->horizontalHeader()->setResizeMode(
-            AddressTableModel::Label, QHeaderView::Stretch);
+    ui->tableView->horizontalHeader()->resizeSection(AddressTableModel::Address, 320);
 
     connect(ui->tableView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
             this, SLOT(selectionChanged()));

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -64,7 +64,7 @@ public:
 		
         QVariant value = index.data(Qt::ForegroundRole);
         //QColor foreground = option.palette.color(QPalette::Text);
-        if(qVariantCanConvert<QColor>(value))
+        if(value.canConvert(QMetaType::QColor))
         {
             foreground = qvariant_cast<QColor>(value);
         }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -80,17 +80,14 @@ TransactionView::TransactionView(QWidget *parent) :
     hlayout->addWidget(typeWidget);
 
     addressWidget = new QLineEdit(this);
-#if QT_VERSION >= 0x040700
-    /* Do not move this to the XML file, Qt before 4.7 will choke on it */
+    /* TODO: Move this to the XML file */
     addressWidget->setPlaceholderText(tr("Enter address or label to search"));
-#endif
     hlayout->addWidget(addressWidget);
 
     amountWidget = new QLineEdit(this);
-#if QT_VERSION >= 0x040700
-    /* Do not move this to the XML file, Qt before 4.7 will choke on it */
+    /* TODO: Move this to the XML file */
     amountWidget->setPlaceholderText(tr("Min amount"));
-#endif
+
 #ifdef Q_OS_MAC
     amountWidget->setFixedWidth(97);
 #else
@@ -182,19 +179,10 @@ void TransactionView::setModel(WalletModel *model)
                 TransactionTableModel::Date, 120);
         transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Type, 120);
-#if QT_VERSION < 0x050000
-        transactionView->horizontalHeader()->setResizeMode(
-                TransactionTableModel::ToAddress, QHeaderView::Stretch);
-#else
         transactionView->horizontalHeader()->setSectionResizeMode(
-                TransactionTableModel::ToAddress, QHeaderView::Stretch);
-#endif
-        transactionView->horizontalHeader()->setResizeMode(
                 TransactionTableModel::ToAddress, QHeaderView::Stretch);
         transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Amount, 100);
-
-
     }
 }
 

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -409,11 +409,7 @@ VotingDialog::VotingDialog(QWidget *parent)
 
     tableView_->setModel(proxyModel_);
     tableView_->setFont(QFont("Arial", 8));
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     tableView_->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
-#else
-    tableView_->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
-#endif
     tableView_->horizontalHeader()->setMinimumWidth(VOTINGDIALOG_WIDTH_RowNumber + VOTINGDIALOG_WIDTH_Title + VOTINGDIALOG_WIDTH_Expiration + VOTINGDIALOG_WIDTH_ShareType + VOTINGDIALOG_WIDTH_TotalParticipants + VOTINGDIALOG_WIDTH_TotalShares + VOTINGDIALOG_WIDTH_BestAnswer);
 
     groupboxvlayout->addWidget(tableView_);
@@ -662,11 +658,7 @@ VotingChartDialog::VotingChartDialog(QWidget *parent)
     answerTable_->setRowCount(0);
     answerTableHeader<<"Answer"<<"Shares"<<"Percentage";
     answerTable_->setHorizontalHeaderLabels(answerTableHeader);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
     answerTable_->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-#else
-    answerTable_->horizontalHeader()->setResizeMode(QHeaderView::Stretch);
-#endif
     answerTable_->setEditTriggers( QAbstractItemView::NoEditTriggers );
     resTabWidget->addTab(answerTable_, tr("List"));
     vlayout->addWidget(resTabWidget);


### PR DESCRIPTION
- Add missing Qt widgets and concurrent modules
- Fix broken version check for QtCharts (#790)
- Adapt to variant and table header changes in Qt5

Tested with Qt 5.6.2 and 5.10.0.