### PR TITLE
Make auto upgrades opt in.

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -11,8 +11,6 @@ extern bool bCPIDsLoaded;
 extern bool bProjectsInitialized;
 extern bool bNetAveragesLoaded;
 extern bool bForceUpdate;
-extern bool bCheckedForUpgrade;
-extern bool bCheckedForUpgradeLive;
 extern bool bGlobalcomInitialized;
 extern bool bGridcoinGUILoaded;
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -129,9 +129,6 @@ extern int CreateRestorePoint();
 extern int DownloadBlocks();
 void GetGlobalStatus();
 
-extern int UpgradeClient();
-extern void CheckForUpgrade();
-
 bool IsConfigFileEmpty();
 void HarvestCPIDs(bool cleardata);
 extern int RestartClient();
@@ -471,20 +468,20 @@ void qtSetSessionInfo(std::string defaultgrcaddress, std::string cpid, double ma
     #endif
 }
 
-void CheckForUpgrade()
+bool IsUpgradeAvailable()
 {
-            if (!bGlobalcomInitialized) return;
+   if (!bGlobalcomInitialized)
+      return false;
 
-            if (bCheckedForUpgrade == false && !fTestNet && bProjectsInitialized)
-            {
-                int nNeedsUpgrade = 0;
-                bCheckedForUpgrade = true;
-                #ifdef WIN32
-                    nNeedsUpgrade = globalcom->dynamicCall("ClientNeedsUpgrade()").toInt();
-                #endif
-                printf("Needs upgraded %f\r\n",(double)nNeedsUpgrade);
-                if (nNeedsUpgrade) UpgradeClient();
-            }
+   bool upgradeAvailable = false;
+   if (!fTestNet)
+   {
+#ifdef WIN32
+      upgradeAvailable = globalcom->dynamicCall("ClientNeedsUpgrade()").toInt();
+#endif
+   }
+
+   return upgradeAvailable;
 }
 
 


### PR DESCRIPTION
Change wallet checks to be time based instead of height based. This removes
the need for checking if projects are initialized and it takes block sync
states out of the equation.

All (Windows) wallet will now check for updates once per day. If the user
has enabled auto upgrades through the "autoupgrade" config option the
upgrade will be downloaded and applied.

Not test built in Windows yet.