### PR TITLE
Drop Qt4 support from code.

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -53,7 +53,7 @@ dnl CAUTION: Do not use this inside of a conditional.
 AC_DEFUN([BITCOIN_QT_INIT],[
   dnl enable qt support
   AC_ARG_WITH([gui],
-    [AS_HELP_STRING([--with-gui@<:@=no|qt4|qt5|auto@:>@],
+    [AS_HELP_STRING([--with-gui@<:@=no|qt5|auto@:>@],
     [build bitcoin-qt GUI (default=auto, qt5 tried first)])],
     [
      bitcoin_qt_want_version=$withval
@@ -410,19 +410,14 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
     if test x$TARGET_OS = xwindows; then
         qt5_modules="$qt5_modules Qt5AxContainer Qt5AxServer Qt5AxBase"
     fi
-    qt4_modules="QtCore QtGui QtNetwork"
     BITCOIN_QT_CHECK([
       if test x$bitcoin_qt_want_version = xqt5 || ( test x$bitcoin_qt_want_version = xauto && test x$auto_priority_version = xqt5 ); then
         PKG_CHECK_MODULES([QT5], [$qt5_modules], [QT_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS" have_qt=yes],[have_qt=no])
-      elif test x$bitcoin_qt_want_version = xqt4 || ( test x$bitcoin_qt_want_version = xauto && test x$auto_priority_version = xqt4 ); then
-        PKG_CHECK_MODULES([QT4], [$qt4_modules], [QT_INCLUDES="$QT4_CFLAGS"; QT_LIBS="$QT4_LIBS" ; have_qt=yes], [have_qt=no])
       fi
 
       dnl qt version is set to 'auto' and the preferred version wasn't found. Now try the other.
       if test x$have_qt = xno && test x$bitcoin_qt_want_version = xauto; then
         if test x$auto_priority_version = xqt5; then
-          PKG_CHECK_MODULES([QT4], [$qt4_modules], [QT_INCLUDES="$QT4_CFLAGS"; QT_LIBS="$QT4_LIBS" ; have_qt=yes; QT_LIB_PREFIX=Qt; bitcoin_qt_got_major_vers=4], [have_qt=no])
-        else
           PKG_CHECK_MODULES([QT5], [$qt5_modules], [QT_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS" ; have_qt=yes; QT_LIB_PREFIX=Qt5; bitcoin_qt_got_major_vers=5], [have_qt=no])
         fi
       fi

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -37,13 +37,6 @@ Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
-#if QT_VERSION < 0x050000
-Q_IMPORT_PLUGIN(qcncodecs)
-Q_IMPORT_PLUGIN(qjpcodecs)
-Q_IMPORT_PLUGIN(qtwcodecs)
-Q_IMPORT_PLUGIN(qkrcodecs)
-Q_IMPORT_PLUGIN(qtaccessiblewidgets)
-#else
 #if QT_VERSION < 0x050400
 Q_IMPORT_PLUGIN(AccessibleFactory)
 #endif
@@ -53,7 +46,6 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_COCOA)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
-#endif
 #endif
 #endif
 
@@ -176,12 +168,6 @@ int main(int argc, char *argv[])
 
     // Do this early as we don't want to bother initializing if we are just calling IPC
     ipcScanRelay(argc, argv);
-
-#if QT_VERSION < 0x050000
-    // Internal string conversion is all UTF-8
-    QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
-    QTextCodec::setCodecForCStrings(QTextCodec::codecForTr());
-#endif
 
     Q_INIT_RESOURCE(bitcoin);
     Q_INIT_RESOURCE(bitcoin_locale);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -75,11 +75,7 @@
 #include <QDateTime>
 #include <QMovie>
 #include <QFileDialog>
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QStandardPaths>
-#endif
-
 #include <QTimer>
 #include <QDragEnterEvent>
 #include <QDesktopServices> // for opening URLs
@@ -1628,11 +1624,7 @@ void BitcoinGUI::encryptWallet(bool status)
 
 void BitcoinGUI::backupWallet()
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     QString saveDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-#else
-    QString saveDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
-#endif
     QString walletfilename = QFileDialog::getSaveFileName(this, tr("Backup Wallet"), saveDir, tr("Wallet Data (*.dat)"));
     if(!walletfilename.isEmpty()) {
         if(!BackupWallet(*pwalletMain, FromQString(walletfilename))) {

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -95,11 +95,7 @@ CoinControlDialog::CoinControlDialog(QWidget *parent) :
     connect(ui->treeWidget, SIGNAL(itemChanged( QTreeWidgetItem*, int)), this, SLOT(viewItemChanged( QTreeWidgetItem*, int)));
 
     // click on header
-#if QT_VERSION < 0x050000
-    ui->treeWidget->header()->setClickable(true);
-#else
     ui->treeWidget->header()->setSectionsClickable(true);
-#endif
     connect(ui->treeWidget->header(), SIGNAL(sectionClicked(int)), this, SLOT(headerSectionClicked(int)));
 
     // ok button

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -308,11 +308,6 @@ void DiagnosticsDialog::TCPFailed(QAbstractSocket::SocketError socket) {
 }
 
 void DiagnosticsDialog::getGithubVersionFinished(QNetworkReply *reply) {
-    // Qt didn't get JSON support until 5.x. Ignore version checks when using
-    // Qt4 an drop this condition once we drop Qt4 support.
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    ui->checkClientVersionResultLbl->setText("N/A");
-#else
     QByteArray data;
     data = reply->readAll();
     std::string newVersionString;
@@ -354,5 +349,4 @@ void DiagnosticsDialog::getGithubVersionFinished(QNetworkReply *reply) {
         } else
             ui->checkClientVersionResultLbl->setText("Up to date");
     }
-#endif
 }

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -490,6 +490,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="placeholderText">
+             <string>Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)</string>
+            </property>
            </widget>
           </item>
           <item>
@@ -544,8 +547,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>834</width>
-        <height>129</height>
+        <width>830</width>
+        <height>167</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -52,6 +52,9 @@
        <property name="toolTip">
         <string>Enter a label for this address to add it to your address book</string>
        </property>
+       <property name="placeholderText">
+        <string>Enter a label for this address to add it to your address book</string>
+       </property>
       </widget>
      </item>
     </layout>
@@ -81,6 +84,9 @@
        </property>
        <property name="maxLength">
         <number>34</number>
+       </property>
+       <property name="placeholderText">
+        <string>Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)</string>
        </property>
       </widget>
      </item>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabSignMessage">
       <attribute name="title">
@@ -52,6 +52,9 @@
            </property>
            <property name="maxLength">
             <number>34</number>
+           </property>
+           <property name="placeholderText">
+            <string>Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)</string>
            </property>
           </widget>
          </item>
@@ -113,6 +116,9 @@
           <widget class="QLineEdit" name="signatureOut_SM">
            <property name="readOnly">
             <bool>true</bool>
+           </property>
+           <property name="placeholderText">
+            <string>Click &quot;Sign Message&quot; to generate signature</string>
            </property>
           </widget>
          </item>
@@ -245,6 +251,9 @@
            <property name="maxLength">
             <number>34</number>
            </property>
+           <property name="placeholderText">
+            <string>Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)</string>
+           </property>
           </widget>
          </item>
          <item>
@@ -273,7 +282,11 @@
         <widget class="QPlainTextEdit" name="messageIn_VM"/>
        </item>
        <item>
-        <widget class="QValidatedLineEdit" name="signatureIn_VM"/>
+        <widget class="QValidatedLineEdit" name="signatureIn_VM">
+         <property name="placeholderText">
+          <string>Enter Gridcoin signature</string>
+         </property>
+        </widget>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_VM">

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -12,21 +12,13 @@
 #include <QLineEdit>
 //#include <QUrl>
 #include <QTextDocument> // For Qt::escape
-#if QT_VERSION >= 0x050000
-#include <QUrlQuery> // For alternative QT5 toHtmlEscaped
-#endif
+#include <QUrlQuery>
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QClipboard>
 #include <QFileDialog>
 #include <QDesktopServices>
 #include <QThread>
-
-#if QT_VERSION < 0x050000
-#include <QUrl> // For alternative QT5 toHtmlEscaped
-#else
-#include <QUrlQuery>
-#endif
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -64,11 +56,7 @@ QString dateTimeStr(qint64 nTime)
 QFont bitcoinAddressFont()
 {
     QFont font("Monospace");
-#if QT_VERSION >= 0x040800
     font.setStyleHint(QFont::Monospace);
-#else
-    font.setStyleHint(QFont::TypeWriter);
-#endif
     return font;
 }
 
@@ -97,12 +85,8 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
     SendCoinsRecipient rv;
     rv.address = uri.path();
     rv.amount = 0;
-#if QT_VERSION < 0x050000
-    QList<QPair<QString, QString> > items = uri.queryItems();
-#else
     QUrlQuery uriQuery(uri);
     QList<QPair<QString, QString> > items = uriQuery.queryItems();
-#endif
     for (QList<QPair<QString, QString> >::iterator i = items.begin(); i != items.end(); i++)
     {
         bool fShouldReturnFalse = false;
@@ -156,11 +140,7 @@ bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
 
 QString HtmlEscape(const QString& str, bool fMultiLine)
 {
-#if QT_VERSION < 0x050000
-    QString escaped = Qt::escape(str);
-#else
     QString escaped = str.toHtmlEscaped();
-#endif
     if(fMultiLine)
     {
         escaped = escaped.replace("\n", "<br>\n");
@@ -192,19 +172,11 @@ QString getSaveFileName(QWidget *parent, const QString &caption,
                                  QString *selectedSuffixOut)
 {
     QString selectedFilter;
-    QString myDir;
-    if(dir.isEmpty()) // Default to user documents location
-    {
-#if QT_VERSION < 0x050000
-        myDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
-#else
-        myDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-#endif
-    }
-    else
-    {
-        myDir = dir;
-    }
+
+    // Default to user documents location
+    QString myDir = dir.isEmpty()
+                    ? QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
+                    : dir;
     QString result = QFileDialog::getSaveFileName(parent, caption, myDir, filter, &selectedFilter);
 
     /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -8,10 +8,6 @@
 #undef slots
 #include <Cocoa/Cocoa.h>
 
-#if QT_VERSION < 0x050000
-extern void qt_mac_set_dock_menu(QMenu *);
-#endif
-
 @interface DockIconClickEventHandler : NSObject
 {
     MacDockIconHandler* dockIconHandler;
@@ -56,9 +52,6 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     this->m_dummyWidget = new QWidget();
     this->m_dockMenu = new QMenu(this->m_dummyWidget);
     this->setMainWindow(NULL);
-#if QT_VERSION < 0x050000
-    qt_mac_set_dock_menu(this->m_dockMenu);
-#endif
     [pool release];
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -60,23 +60,13 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
         /** check if the locale name consists of 2 parts (language_country) */
         if(langStr.contains("_"))
         {
-#if QT_VERSION >= 0x040800
             /** display language strings as "native language - native country (locale name)", e.g. "Deutsch - Deutschland (de)" */
             ui->lang->addItem(locale.nativeLanguageName() + QString(" - ") + locale.nativeCountryName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
-#else
-            /** display language strings as "language - country (locale name)", e.g. "German - Germany (de)" */
-            ui->lang->addItem(QLocale::languageToString(locale.language()) + QString(" - ") + QLocale::countryToString(locale.country()) + QString(" (") + langStr + QString(")"), QVariant(langStr));
-#endif
         }
         else
         {
-#if QT_VERSION >= 0x040800
             /** display language strings as "native language (locale name)", e.g. "Deutsch (de)" */
             ui->lang->addItem(locale.nativeLanguageName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
-#else
-            /** display language strings as "language (locale name)", e.g. "German (de)" */
-            ui->lang->addItem(QLocale::languageToString(locale.language()) + QString(" (") + langStr + QString(")"), QVariant(langStr));
-#endif
         }
     }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -28,12 +28,6 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     model(0)
 {
     ui->setupUi(this);
-
-#if QT_VERSION >= 0x040700
-    /* Do not move this to the XML file, Qt before 4.7 will choke on it */
-    ui->lineEditCoinControlChange->setPlaceholderText(tr("Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)"));
-#endif
-
     addEntry();
 
     connect(ui->addButton, SIGNAL(clicked()), this, SLOT(addEntry()));
@@ -145,13 +139,8 @@ void SendCoinsDialog::on_sendButton_clicked()
     QStringList formatted;
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
-#if QT_VERSION < 0x050000
-        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount),
-              Qt::escape(rcp.label), rcp.address));
-#else
         formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount),
               rcp.label.toHtmlEscaped(), rcp.address));
-#endif
     }
 
     fNewRecipientAllowed = false;

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -24,11 +24,6 @@ SendCoinsEntry::SendCoinsEntry(QWidget *parent) :
 #ifdef Q_OS_MAC
     ui->payToLayout->setSpacing(4);
 #endif
-#if QT_VERSION >= 0x040700
-    /* Do not move this to the XML file, Qt before 4.7 will choke on it */
-    ui->addAsLabel->setPlaceholderText(tr("Enter a label for this address to add it to your address book"));
-    ui->payTo->setPlaceholderText(tr("Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)"));
-#endif
     setFocusPolicy(Qt::TabFocus);
     setFocusProxy(ui->payTo);
 

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -22,15 +22,6 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
-#if (QT_VERSION >= 0x040700)
-    /* Do not move this to the XML file, Qt before 4.7 will choke on it */
-    ui->addressIn_SM->setPlaceholderText(tr("Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)"));
-    ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
-
-    ui->addressIn_VM->setPlaceholderText(tr("Enter a Gridcoin address (e.g. G8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)"));
-    ui->signatureIn_VM->setPlaceholderText(tr("Enter Gridcoin signature"));
-#endif
-
     GUIUtil::setupAddressWidget(ui->addressIn_SM, this);
     GUIUtil::setupAddressWidget(ui->addressIn_VM, this);
 

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -7,7 +7,7 @@
 #include <QAction>
 #include <QApplication>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef QT_CHARTS_LIB
 	#include <QtCharts/QChartView>
 	#include <QtCharts/QPieSeries>
 #endif
@@ -619,7 +619,7 @@ void VotingDialog::showNewPollDialog(void)
 //
 VotingChartDialog::VotingChartDialog(QWidget *parent)
     : QDialog(parent)
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef QT_CHARTS_LIB
     ,chart_(0)
 #endif
     ,answerTable_(NULL)
@@ -672,7 +672,7 @@ VotingChartDialog::VotingChartDialog(QWidget *parent)
 
     QTabWidget *resTabWidget = new QTabWidget;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef QT_CHARTS_LIB
     chart_ = new QtCharts::QChart;
     chart_->legend()->setVisible(true);
     chart_->legend()->setAlignment(Qt::AlignRight);
@@ -700,12 +700,10 @@ void VotingChartDialog::resetData(const VotingItem *item)
     answerTable_->setRowCount(0);
     answerTable_->setSortingEnabled(false);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
-    //chart_->removeAllSeries();
+#ifdef QT_CHARTS_LIB
     QList<QtCharts::QAbstractSeries *> oldSeriesList = chart_->series();
-    foreach (QtCharts::QAbstractSeries *oldSeries, oldSeriesList) {
+    foreach (QtCharts::QAbstractSeries *oldSeries, oldSeriesList)
         chart_->removeSeries(oldSeries);
-    }
 
     QtCharts::QPieSeries *series = new QtCharts::QPieSeries();
 #endif
@@ -735,7 +733,7 @@ void VotingChartDialog::resetData(const VotingItem *item)
         percentItem->setData(Qt::DisplayRole,(float)iShares[y]/(float)sharesSum*100);
         answerTable_->setItem(y, 2, percentItem);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef QT_CHARTS_LIB
         QtCharts::QPieSlice *slice = new QtCharts::QPieSlice(sAnswerNames[y], iShares[y]);
         unsigned int num = rand();
         int r = (num >>  0) % 0xFF;
@@ -743,12 +741,11 @@ void VotingChartDialog::resetData(const VotingItem *item)
         int b = (num >> 16) % 0xFF;
         slice->setColor(QColor(r, g, b));
         series->append(slice);
+        chart_->addSeries(series);
 #endif
     }
+
     answerTable_->setSortingEnabled(true);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
-    chart_->addSeries(series);
-#endif
 }
 
 // VotingVoteDialog

--- a/src/qt/votingdialog.h
+++ b/src/qt/votingdialog.h
@@ -17,16 +17,14 @@
 #include <QListWidgetItem>
 #include <QDateTime>
 #include <QFuture>
-
 #include <QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#  include <QtWidgets>
-#else
-#  include <QtGui>
-#endif
+#include <QtWidgets>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef QT_CHARTS_LIB
 #include <QtCharts/QChartGlobal>
+QT_CHARTS_BEGIN_NAMESPACE
+class QChart;
+QT_CHARTS_END_NAMESPACE
 #endif
 
 QT_BEGIN_NAMESPACE
@@ -34,12 +32,6 @@ class QEvent;
 class QObject;
 class QResizeEvent;
 QT_END_NAMESPACE
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
-QT_CHARTS_BEGIN_NAMESPACE
-class QChart;
-QT_CHARTS_END_NAMESPACE
-#endif
 
 #define VOTINGDIALOG_WIDTH_RowNumber          40
 #define VOTINGDIALOG_WIDTH_Title              225
@@ -192,8 +184,9 @@ public:
 private:
     QLabel *question_;
     QLabel *url_;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
-    QtCharts::QChart *chart_;
+#ifdef QT_CHARTS_LIB
+    QTCHARTS_USE_NAMESPACE;
+    QChart *chart_;
 #endif
     QTableWidget *answerTable_;
     QStringList answerTableHeader;


### PR DESCRIPTION
- Remove all Qt4 references
- Move placeholder texts to ui files
- Check for QtCharts availability instead of Qt version
- Remove qt4 build option

This closes #791.