### PR TITLE
Verify Clock UDP fixes

### DIFF
--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -43,6 +43,8 @@ private:
 private slots:
     void on_testBtn_clicked();
     void clkFinished();
+    void clkStateChanged(QAbstractSocket::SocketState state);
+    void clkSocketError(QAbstractSocket::SocketError error);
     void TCPFinished();
     void TCPFailed(QAbstractSocket::SocketError socketError);
     void getGithubVersionFinished(QNetworkReply *reply);


### PR DESCRIPTION
*Rewrote the UDP portion. we no longer try to bind to port 123 which is below 1024 and needs root/administrator access to do so.
*we direct udp connect to the ntp server.
*when socketstate changes to connected we then send the udp datagram.
*we also check for socket errors now to avoid testing.... being left on the screen.
*readyRead() now works correctly.
*Changed from char to QByteArray.
The verify clock runs a faster now and error free.

Still remains the odd bug regarding QNetworkReply with the network manager.