### PR TITLE
Neural Network Consensus Bug fix

### DIFF
--- a/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
+++ b/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.20.8.80")>
-<Assembly: AssemblyFileVersion("1.20.8.80")>
+<Assembly: AssemblyVersion("1.20.8.81")>
+<Assembly: AssemblyFileVersion("1.20.8.81")>

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -469,6 +469,15 @@ Module modPersistedDataSystem
     End Sub
     Private Sub ClearProjectData()
         Dim sPath As String = GetGridFolder() + "NeuralNetwork\"
+        Dim surrogatePrj As New Row
+        surrogatePrj.Database = "Project"
+        surrogatePrj.Table = "Projects"
+        Dim lstProjects As List(Of Row) = GetList(surrogatePrj, "*")
+        For Each prj As Row In lstProjects
+            If prj.PrimaryKey <> "" Then
+                SoftKill(sPath + prj.PrimaryKey + "CPID\*.dat")
+            End If
+        Next
         SoftKill(sPath + "db.dat")
         'Erase the projects
         SoftKill(sPath + "*master.dat")


### PR DESCRIPTION
A user brought up the fact that after certain circumstances certain Neural network data was inaccurate.

After looking into this I confirmed the issue and expanded on more issues that were involved with this.

This patches it and also after testing with 3 years our consensus hashes match to the T and even when one synced a little later getting a new hash we all synced up and matched as well.

This will help consensus greatly if not keep everyone on the same hash or reduce the sparse hashes between different nodes.

I've compiled the dll and its available for request for testing on development.

Due to the sensitive nature of this problem I've not listed detailed here

Thanks @barton2526 and Neural miner for helping me test this out. This will end up being a windows only mandatory but is very promising