### PR TITLE
Request shutdown after forking instead of returning an error.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -608,11 +608,10 @@ bool AppInit2(ThreadHandlerPtr threads)
         {
             CreatePidFile(GetPidFile(), pid);
 
-            // While this is technically successful we need to return false
-            // in order to shut down the parent process. This can be improved
-            // by either returning an enum or checking if the current process
-            // is a child process.
-            return false;
+            // Now that we are forked we can request a shutdown so the parent
+            // exits while the child lives on.
+            StartShutdown();
+            return true;
         }
 
         pid_t sid = setsid();


### PR DESCRIPTION
The previous attempt at fixing the daemon issue returned `false` after forking in the initializer to start the shutdown sequence in the parent. This also cause the process to return error code `1` which confused launch services such as systemd (see https://github.com/gridcoin/Gridcoin-Research/issues/202#issuecomment-357483896).

This PR reverts back to returning `true` but instead explicitly requests a shutdown after forking. Since the request happens after the fork the child process should be unaffected.

Tested:
- Run as foreground: works
- Run as foreground, exit code 1 when killing
- Run as daemon: works
- Run as daemon, exit code 0 after forking
- Run as UI: works