### PR TITLE
The Deamon's Init Function was not succeeded by a check of its success.

### DIFF
--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -99,9 +99,21 @@ bool AppInit(int argc, char* argv[])
 
         PrintException(NULL, "AppInit()");
     }
-    if (!fRet)
-        Shutdown(NULL);
+    if(fRet)
+    {
+        while (!ShutdownRequested())
+            MilliSleep(500);
+    }
+
+    Shutdown(NULL);
+
+    // delete thread handler
+    threads->interruptAll();
+    threads->removeAll();
+    threads.reset();
+
     return fRet;
+
 }
 
 extern void noui_connect();


### PR DESCRIPTION
The Deamon then just exited after initialization. It now continuously listen for the shutdown signal and then only exits, as intended.
This possibly conflicts now with #832 