### PR TITLE
Eliminate whitespace warnings and unused clean commands

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,11 +130,11 @@ GRIDCOIN_JSON_H = \
 	json/json_spirit_reader.cpp \
 	json/json_spirit_reader_template.h \
 	json/json_spirit_utils.h  \
-	json/json_spirit_value.h  \   
+	json/json_spirit_value.h  \
 	json/json_spirit_writer.h \
 	json/json_spirit.h \
-	json/json_spirit_reader.h \    
-	json/json_spirit_stream_reader.h \    
+	json/json_spirit_reader.h \
+	json/json_spirit_stream_reader.h \
 	json/json_spirit_writer_template.h
 
 # util: shared between all executables.
@@ -180,15 +180,7 @@ CLEANFILES = $(EXTRA_LIBRARIES)
 
 CLEANFILES += *.gcda *.gcno
 CLEANFILES += compat/*.gcda compat/*.gcno
-CLEANFILES += consensus/*.gcda consensus/*.gcno
-CLEANFILES += crypto/*.gcda crypto/*.gcno
-CLEANFILES += policy/*.gcda policy/*.gcno
-CLEANFILES += primitives/*.gcda primitives/*.gcno
-CLEANFILES += script/*.gcda script/*.gcno
-CLEANFILES += support/*.gcda support/*.gcno
-CLEANFILES += wallet/*.gcda wallet/*.gcno
-CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
-CLEANFILES = obj/build.h
+CLEANFILES += obj/build.h
 
 EXTRA_DIST = $(CTAES_DIST)
 


### PR DESCRIPTION
This removes the whitespace warnings when running ./autogen.sh . Also gets rid of some clean commands.