### PR TITLE
Testnet nn folderbugfix + Changes

### DIFF
--- a/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
+++ b/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.20.8.81")>
-<Assembly: AssemblyFileVersion("1.20.8.81")>
+<Assembly: AssemblyVersion("1.20.8.82")>
+<Assembly: AssemblyFileVersion("1.20.8.82")>

--- a/contrib/Installer/boinc/boinc/Utilization.vb
+++ b/contrib/Installer/boinc/boinc/Utilization.vb
@@ -14,7 +14,7 @@ Public Class Utilization
     Private mlSpeakMagnitude As Double
     Public ReadOnly Property Version As Double
         Get
-            Return 425
+            Return 426
         End Get
     End Property
 

--- a/contrib/Installer/boinc/boinc/frmMining.Designer.vb
+++ b/contrib/Installer/boinc/boinc/frmMining.Designer.vb
@@ -395,7 +395,7 @@ Partial Class frmMining
         Me.TabPage1.Padding = New System.Windows.Forms.Padding(3)
         Me.TabPage1.Size = New System.Drawing.Size(1037, 357)
         Me.TabPage1.TabIndex = 2
-        Me.TabPage1.Text = "Boinc Stats"
+        Me.TabPage1.Text = "Gridcoin Website"
         Me.TabPage1.UseVisualStyleBackColor = True
         '
         'WebBrowserBoinc
@@ -407,7 +407,7 @@ Partial Class frmMining
         Me.WebBrowserBoinc.ScriptErrorsSuppressed = True
         Me.WebBrowserBoinc.Size = New System.Drawing.Size(1031, 351)
         Me.WebBrowserBoinc.TabIndex = 0
-        Me.WebBrowserBoinc.Url = New System.Uri("http://www.gridcoin.us", System.UriKind.Absolute)
+        Me.WebBrowserBoinc.Url = New System.Uri("https://gridcoin.us", System.UriKind.Absolute)
         '
         'TabPage2
         '

--- a/contrib/Installer/boinc/boinc/frmMining.vb
+++ b/contrib/Installer/boinc/boinc/frmMining.vb
@@ -786,7 +786,7 @@ Refresh:
 
     Private Sub TabControl1_Click(sender As System.Object, e As System.EventArgs) Handles TabControl1.Click
         If TabControl1.SelectedIndex = 1 Then
-            WebBrowserBoinc.Navigate("http://boincstats.com/en/stats/-1/team/detail/118094994/overview")
+            WebBrowserBoinc.Navigate("https://gridcoin.us")
         End If
 
         ' If TabControl1.SelectedIndex = 2 Then

--- a/contrib/Installer/boinc/boinc/modGRC.vb
+++ b/contrib/Installer/boinc/boinc/modGRC.vb
@@ -820,9 +820,7 @@ Module modGRC
     End Function
     Public Function GetGridPath(ByVal sType As String) As String
         Dim sTemp As String
-        sTemp = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\gridcoinresearch\" + sType
-        Dim sOverridden As String = KeyValue("datadir")
-        sTemp = IIf(Len(sOverridden) > 0, sOverridden, sTemp)
+        sTemp = GetGridFolder() + sType
         If System.IO.Directory.Exists(sTemp) = False Then
             Try
                 System.IO.Directory.CreateDirectory(sTemp)
@@ -830,7 +828,6 @@ Module modGRC
                 Log("Unable to create Gridcoin Path " + sTemp)
             End Try
         End If
-        If mbTestNet Then sTemp += "\Testnet\"
         Return sTemp
     End Function
     Public Function GetGridFolder() As String

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -197,7 +197,7 @@ Module modPersistedDataSystem
                     Dim dLocalMagnitude As Double = Val("0" + Num(cpid.Magnitude)) * dLegacyMagnitudeBoost
                     If dLocalMagnitude > 32766 Then dLocalMagnitude = 32766
 
-                    Dim sRow As String = cpid.PrimaryKey + "," + Num(dLocalMagnitude) + ";"
+                    Dim sRow As String = cpid.PrimaryKey + "," + dLocalMagnitude.ToString + ";"
                     'Zero magnitude rule (We need a placeholder because of the beacon count rule)
                     If Val(dLocalMagnitude) = 0 Then
                         sRow = "0,15;"


### PR DESCRIPTION
* Fix incorrect path for testnet. Originally it was seeking %appdata%\gridcoinresearch\NeuralNetwork\Testnet instead of proper path of %appdata%\gridcoinresearch\Testnet\NeuralNetwork
* Renamed the Boinc Stats tab to Gridcoin Website as it loads gridcoin.us website
* Fixed so that when the tab is clicked its not resorting back to boincstats website. This was likely to refresh and keep the stats up to date.
* Refresh for old Boinc Stats tab refreshes the gridcoin.us website now. This is good to do as content could change but also clients are allowed to follow the links within the website and this will bring them back to the start without requiring a restart.
* Use https for url since it is supported
* Increment versions.

Tasks still to do for success in Testnet NN is figure out the contract hashing issue which production is not affected by.
