### PR TITLE
Wait for retired tally to finish before switching to the new.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.7.5.0] 2018-01-24
+### Fixed
+ - Fix crash when switching to new tally on block 1144120, #868 (@denravonska).
+ - Fix crash when staking while tallying, #866 (@denravonska).
+
 ## [3.7.4.0] 2018-01-20
 ### Fixed
  - Fix RPC resource leak regression. This also reduces RPC overhead,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,7 +255,7 @@ bool bForceUpdate = false;
 bool bGlobalcomInitialized = false;
 bool bStakeMinerOutOfSyncWithNetwork = false;
 volatile bool bDoTally_retired = false;
-volatile bool bTallyFinished_retired = false;
+volatile bool bTallyFinished_retired = true;
 bool bGridcoinGUILoaded = false;
 
 extern double LederstrumpfMagnitude2(double Magnitude, int64_t locktime);
@@ -4264,6 +4264,15 @@ void GridcoinServices()
         // Tally research averages.
         if ((nBestHeight % TALLY_GRANULARITY) == 0)
         {
+            // Wait for previous retired tally to finish if running.
+            // This can happen when syncing the chain.
+            if(!bTallyFinished_retired)
+            {
+                printf("SVC: Wait for retired tally to finish\n");
+                while(!bTallyFinished_retired)
+                    MilliSleep(10);
+            }
+
             if (fDebug) printf("SVC: TallyNetworkAverages (v9 %%%d) height %d\n",TALLY_GRANULARITY,nBestHeight);
             TallyNetworkAverages_v9();
         }


### PR DESCRIPTION
Right on block 1144120 there is a risk of two tallies running concurrently, both writing to the same variables. This will cause a crash, for example when syncing.

This PR waits for tally to finish if previous block was a V8 block and if a tally is running. It's not pretty, I know. We can remove that piece once we remove the V8 tally from the code. I also removed the 15 second tally timeout. A tally is quick now anyway and if the tally hangs there is no point in continuing.

Could use another set of eyes to see if syncing is slower.