### PR TITLE
Move misplaced logging message which gives false impression when help…

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -206,14 +206,13 @@ Value help(const Array& params, bool fHelp)
 
 Value stop(const Array& params, bool fHelp)
 {
-    printf("Stopping...");
-
     // Accept the deprecated and ignored 'detach´ boolean argument
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "stop\n"
             "Stop Gridcoin server.");
     // Shutdown will take long enough that the response should get back
+    printf("Stopping...\n");
     StartShutdown();
     return "Gridcoin server stopping";
 }


### PR DESCRIPTION
move printf statement to before shutdown call. this avoids the logging of Stopping... when rpc command call `help` is called or `help stop` is called. #878