### PR TITLE
Fix buffer overflow in Gridcoin decrypt.

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -241,15 +241,22 @@ bool GridDecryptWithSalt(const std::vector<unsigned char>& vchCiphertext,std::ve
     int nLen = vchCiphertext.size();
     int nPLen = nLen, nFLen = 0;
     bool fOk = true;
+
+    // Allocate data for the plaintext string. This is always equal to lower
+    // than the length of the encrypted string. Stray data is discarded
+    // after successfully decrypting.
+    vchPlaintext.resize(nLen);
+
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     if(!ctx)
         throw std::runtime_error("Error allocating cipher context");
 
-    if (fOk) fOk = EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, chKeyGridcoin, chIVGridcoin);
+    if (fOk) fOk = EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, chKeyGridcoin, chIVGridcoin);    
     if (fOk) fOk = EVP_DecryptUpdate(ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
     if (fOk) fOk = EVP_DecryptFinal_ex(ctx, (&vchPlaintext[0])+nPLen, &nFLen);
     EVP_CIPHER_CTX_free(ctx);
     if (!fOk) return false;
+
     vchPlaintext.resize(nPLen + nFLen);
     return true;
 }
@@ -348,12 +355,10 @@ std::string AdvancedDecryptWithHWID(std::string data)
 
 std::string AdvancedCryptWithSalt(std::string boinchash, std::string salt)
 {
-
     try 
     {
        std::vector<unsigned char> vchSecret( boinchash.begin(), boinchash.end() );
-       std::string d1 = "                                                                                                                                        ";
-       std::vector<unsigned char> vchCryptedSecret(d1.begin(),d1.end());
+       std::vector<unsigned char> vchCryptedSecret;
        GridEncryptWithSalt(vchSecret, vchCryptedSecret,salt);
        std::string encrypted = EncodeBase64(UnsignedVectorToString(vchCryptedSecret));
 
@@ -363,21 +368,14 @@ std::string AdvancedCryptWithSalt(std::string boinchash, std::string salt)
         printf("Error while encrypting %s",boinchash.c_str());
         return "";
     }
-    catch(...)
-    {
-        printf("Error while encrypting 2.");
-        return "";
-    }
-              
 }
 
 std::string AdvancedDecryptWithSalt(std::string boinchash_encrypted, std::string salt)
 {
     try{
        std::string pre_encrypted_boinchash = DecodeBase64(boinchash_encrypted);
-       std::string d2 = "                                                                                                                                        ";
        std::vector<unsigned char> vchCryptedSecret(pre_encrypted_boinchash.begin(),pre_encrypted_boinchash.end());
-       std::vector<unsigned char> vchPlaintext(d2.begin(),d2.end());
+       std::vector<unsigned char> vchPlaintext;
        GridDecryptWithSalt(vchCryptedSecret,vchPlaintext,salt);
        std::string decrypted = UnsignedVectorToString(vchPlaintext);
        return decrypted;
@@ -386,11 +384,4 @@ std::string AdvancedDecryptWithSalt(std::string boinchash_encrypted, std::string
         printf("Error while decrypting %s",boinchash_encrypted.c_str());
         return "";
     }
-    catch(...)
-    {
-        printf("Error while decrypting 2.");
-        return "";
-    }
 }
-     
-

--- a/src/test/crypter_tests.cpp
+++ b/src/test/crypter_tests.cpp
@@ -63,5 +63,12 @@ BOOST_AUTO_TEST_CASE(crypter_GridDecryptWithSaltShouldDecryptValidInput)
     BOOST_CHECK_EQUAL(PLAINTEXT, decrypted_message);
 }
 
+BOOST_AUTO_TEST_CASE(crypter_AdvancedDecryptWithSaltShouldNotCrash)
+{
+    const std::string boinchash_encrypted("HOVtyXamA5H5IWJl6TtwJr9iD5GGSOClvyb9l08ZYCAG2OkS22sGEH6jUt8NlrDQVto/8eBMz1TxPqWCv3bA+o38H25ysTEGHOijlPby2A1VhzQTjFzNYSNaXC4kIaHMgvwgoHCU/Io1LsCBgVK+atiZRuhXDSpbJLHpLmjHokAon0cELZGP3X2g0kQXhImh");
+    const std::string salt("\235\002\353\071A\244*\303\b\274\271\221");
+    const std::string result = AdvancedDecryptWithSalt(boinchash_encrypted, salt);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The output string was assumed to be a certain length which is not always the case. On longer input this would crash the application.