### PR TITLE
Reorganize improvements

### DIFF
--- a/src/beacon.h
+++ b/src/beacon.h
@@ -65,3 +65,4 @@ int64_t BeaconTimeStamp(const std::string& cpid, bool bZeroOutAfterPOR);
 bool HasActiveBeacon(const std::string& cpid);
 
 bool VerifyBeaconContractTx(const CTransaction& tx);
+void DeleteBeaconContractTx(const CTransaction& tx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3486,6 +3486,8 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
 
 bool ForceReorganizeToHash(uint256 NewHash)
 {
+    LOCK(cs_main);
+
     CTxDB txdb;
 
     auto mapItem = mapBlockIndex.find(NewHash);

--- a/src/main.h
+++ b/src/main.h
@@ -272,6 +272,8 @@ bool OutOfSyncByAge();
 bool NeedASuperblock();
 std::string GetQuorumHash(const std::string& data);
 std::string ReadCache(std::string section, std::string key);
+void DeleteCache(std::string section, std::string keyname);
+void ClearCache(std::string section);
 std::string GetNeuralNetworkSupermajorityHash(double& out_popularity);
 std::string PackBinarySuperblock(std::string sBlock);
 std::string UnpackBinarySuperblock(std::string sBlock);


### PR DESCRIPTION
Need more testers and eyes on this. I expect it to not be complete.

- Delete beacons when reorganizing
- Detach blocks from CPID when disconnecting
- Load admin messages (beacons) after reorganizing
- Fix for tally after reorganize being done on the old chain

This does not clear out all the contracts done by the block disconnect. Perhaps a better way is to clear all the contracts from the app cache and call LoadAdminMessages to reload fresh ones.