### PR TITLE
Remove tally thread and make obsolete tally blocking.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -25,8 +25,7 @@
 bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 
 StructCPID GetStructCPID();
-void BusyWaitForTally_retired();
-void TallyNetworkAverages_v9(CBlockIndex* index);
+void TallyResearchAverages(CBlockIndex* index);
 extern void ThreadAppInit2(void* parg);
 
 void LoadCPIDs();
@@ -1017,12 +1016,10 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     CBlockIndex* tallyHeight = FindTallyTrigger(pindexBest);
     if(tallyHeight)
-        TallyNetworkAverages_v9(tallyHeight);
+        TallyResearchAverages(tallyHeight);
 
     if (!threads->createThread(StartNode, NULL, "Start Thread"))
         InitError(_("Error: could not start node"));
-
-    BusyWaitForTally_retired();
 
     if (fServer)
         threads->createThread(ThreadRPCServer, NULL, "RPC Server Thread");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4417,7 +4417,10 @@ void GridcoinServices()
                 if (fDebug10) printf("#CNNSH# ");
                 UpdateNeuralNetworkQuorumData();
             }
-            if ((nBestHeight % 20) == 0)
+
+            // Perform retired tallies between the V9 block switch (1144000) and the
+            // V9 tally switch (1144120) or else blocks will be rejected in between.
+            if (IsV9Enabled(nBestHeight) && (nBestHeight % 20) == 0)
             {
                 if (fDebug) printf("SVC: set off Tally (v3 B) height %d\n",nBestHeight);
                 if (fDebug10) printf("#TIB# ");
@@ -4428,7 +4431,7 @@ void GridcoinServices()
         {
             // When superblock is not old, Tally every N blocks:
             int nTallyGranularity = fTestNet ? 60 : 20;
-            if ((nBestHeight % nTallyGranularity) == 0)
+            if (IsV9Enabled(nBestHeight) && (nBestHeight % nTallyGranularity) == 0)
             {
                 if (fDebug) printf("SVC: set off Tally (v3 C) height %d\n",nBestHeight);
                 if (fDebug3) printf("TIB1 ");

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1572,75 +1572,6 @@ void DumpAddresses()
 
 }
 
-void DoTallyResearchAverages_retired(void* parg);
-bool TallyNetworkAverages_retired(bool);
-extern volatile bool bTallyFinished_retired;
-extern volatile bool bDoTally_retired;
-
-void ThreadTallyResearchAverages_retired(void* parg)
-{
-    // Make this thread recognisable
-    RenameThread("grc-tallyresearchaverages");
-    DoTallyResearchAverages_retired(parg);
-    printf("ThreadTallyResearchAverages_retired exited \r\n");
-}
-
-
-void BusyWaitForTally_retired()
-{
-    if(IsV9Enabled_Tally(nBestHeight))
-    {
-        if(fDebug10)
-            printf("BusyWaitForTally_retired: skipped (v9 enabled)\n");
-        return;
-    }
-
-    if (fDebug10) printf("\r\n ** Busy Wait for Tally_retired ** \r\n");
-    bTallyFinished_retired=false;
-    bDoTally_retired=true;
-    int iTimeout = 0;
-
-    int64_t deadline = GetAdjustedTime() + 15000;
-    while(!bTallyFinished_retired)
-    {
-        MilliSleep(10);
-        if(GetAdjustedTime() >= deadline)
-            break;
-        iTimeout+=1;
-    }
-}
-
-
-void DoTallyResearchAverages_retired(void* parg)
-{
-    printf("\r\nStarting dedicated Tally_retired thread...\r\n");
-
-    while (!fShutdown)
-    {
-        MilliSleep(100);
-        if (bDoTally_retired)
-        {
-            bTallyFinished_retired = false;
-            bDoTally_retired=false;
-            printf("\r\n[DoTallyRA_START_retired] ");
-            try
-            {
-                TallyNetworkAverages_retired(false);
-            }
-            catch (std::exception& e)
-            {
-                PrintException(&e, "ThreadTallyNetworkAverages_retired()");
-            }
-            catch(...)
-            {
-                printf("\r\nError occurred in DoTallyResearchAverages_retired...Recovering\r\n");
-            }
-            printf(" [DoTallyRA_END_retired] \r\n");
-            bTallyFinished_retired = true;
-        }
-    }
-}
-
 void ThreadDumpAddress2(void* parg)
 {
     while (!fShutdown)
@@ -2303,10 +2234,6 @@ void StartNode(void* parg)
     // Dump network addresses
     if (!netThreads->createThread(ThreadDumpAddress,NULL,"ThreadDumpAddress"))
         printf("Error: createThread(ThreadDumpAddress) failed\r\n");
-
-    // Tally network averages
-    if (!NewThread(ThreadTallyResearchAverages_retired, NULL))
-        printf("Error; NewThread(ThreadTally_retired) failed\n");
 
     // Mine proof-of-stake blocks in the background
     if (!GetBoolArg("-staking", true))

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -46,7 +46,6 @@ std::string ConvertBinToHex(std::string a);
 std::string ConvertHexToBin(std::string a);
 extern std::vector<unsigned char> readFileToVector(std::string filename);
 bool bNetAveragesLoaded_retired;
-bool TallyResearchAverages_retired(bool);
 int RestartClient();
 extern std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
 std::string BurnCoinsWithNewContract(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue, int64_t MinimumBalance, double dFees, std::string strPublicKey, std::string sBurnAddress);


### PR DESCRIPTION
State: Testing

Remove the retired tally thread and make the tally blocking instead. This changes the old behavior but as long as it syncs up we should be good. I am syncing my dev station and a Ubuntu 14.04 docker to see if this solves Coinomi's problems.

Edit: This seems to slow down syncing a bit as tallies are blocking. As long as it syncs up fine we can live with that and optimize in the dev branch, most noticeably `UnpackBinarySuperblock` and its string conversions.