### PR TITLE
Add getrecentblocks RPC commands.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -303,6 +303,7 @@ static const CRPCCommand vRPCCommands[] =
     { "reorganize",             &rpc_reorganize,         false,  false},
     { "getblockstats",          &rpc_getblockstats,      false,  false},
     { "sendalert2",             &sendalert2,             false,  false},
+    { "getrecentblocks",          &rpc_getrecentblocks,  false,  false},
 };
 
 CRPCTable::CRPCTable()

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -224,5 +224,6 @@ extern json_spirit::Value rpc_reorganize(const json_spirit::Array& params, bool 
 // Brod
 extern json_spirit::Value rpc_getblockstats(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendalert2(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value rpc_getrecentblocks(const json_spirit::Array& params, bool fHelp);
 
 #endif


### PR DESCRIPTION
`getercentblocks <detail> <count>`

Retrives _count_ blocks in descending height order and to each provides various information. Size of information is determined by _details_.

Detail levels 20<=x<100 and 120<=x may be slower, because they have to load the block data. Other levels use only index.

```
details:
 0 -> height: hash
 1 -> height: hash, diff, deltaT, flags
 2 -> height: hash, diff, deltaT, flags, cpid, research, interest
 20-> height: hash, diff, deltaT, flags, org, ver
 21-> height: hash, diff, deltaT, flags, org, ver, cpid, neural
 100: height: {json from index}
 120: height: {json from index and block}
```

```
Flags:
 [SC-][RUI]; 1: is*S*uperblock, is*C*ontract; 2: UserCPID and nonzero
 *R*esearch reward, *U*serCPID but no reward; *I*nvestor.
```
