### PR TITLE
SignblockWithCPID changes

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -4,7 +4,7 @@
 #include "key.h"
 #include "main.h"
 
-extern std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
+bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, std::string& sSignature, std::string& sError);
 extern bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature);
 std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxSeconds);
 int64_t GetRSAWeightByCPIDWithRA(std::string cpid);
@@ -29,8 +29,16 @@ bool GenerateBeaconKeys(const std::string &cpid, std::string &sOutPubKey, std::s
     if (!sOutPrivKey.empty() && !sOutPubKey.empty())
     {
         uint256 hashBlock = GetRandHash();
-        std::string sSignature = SignBlockWithCPID(cpid,hashBlock.GetHex());
-        bool fResult = VerifyCPIDSignature(cpid, hashBlock.GetHex(), sSignature);
+        std::string sSignature;
+        std::string sError;
+        bool fResult;
+        fResult = SignBlockWithCPID(cpid, hashBlock.GetHex(), sSignature, sError);
+        if (!fResult)
+        {
+            printf("GenerateNewKeyPair::Failed to sign block with cpid -> %s\n", sError.c_str());
+            return false;
+        }
+        fResult = VerifyCPIDSignature(cpid, hashBlock.GetHex(), sSignature);
         if (fResult)
         {
             printf("\r\nGenerateNewKeyPair::Current keypair is valid.\r\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,7 +610,7 @@ MiningCPID GetNextProject(bool bForce)
 
 
 
-    if (GlobalCPUMiningCPID.projectname.length() > 3   &&  GlobalCPUMiningCPID.projectname != "INVESTOR"  && GlobalCPUMiningCPID.Magnitude > 1)
+    if (GlobalCPUMiningCPID.projectname.length() > 3   &&  GlobalCPUMiningCPID.projectname != "INVESTOR"  && GlobalCPUMiningCPID.Magnitude >= 1)
     {
                 if (!Timer_Main("globalcpuminingcpid",10))
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ extern std::string ConvertHexToBin(std::string a);
 extern bool WalletOutOfSync();
 extern bool WriteKey(std::string sKey, std::string sValue);
 bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
-std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
+bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, std::string& sSignature, std::string& sError);
 extern void CleanInboundConnections(bool bClearAll);
 extern bool PushGridcoinDiagnostics();
 double qtPushGridcoinDiagnosticData(std::string data);
@@ -733,8 +733,15 @@ MiningCPID GetNextProject(bool bForce)
                                         GlobalCPUMiningCPID.lastblockhash = "0";
                                         // Sign the block
                                         GlobalCPUMiningCPID.BoincPublicKey = GetBeaconPublicKey(structcpid.cpid, false);
-                                        GlobalCPUMiningCPID.BoincSignature = SignBlockWithCPID(GlobalCPUMiningCPID.cpid,GlobalCPUMiningCPID.lastblockhash);
-                                
+                                        std::string sSignature;
+                                        std::string sError;
+                                        bool bResult = SignBlockWithCPID(GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash, sSignature, sError);
+                                        if (!bResult)
+                                        {
+                                            printf("GetNextProject: failed to sign block with cpid -> %s\n", sError.c_str());
+                                            continue;
+                                        }
+                                        GlobalCPUMiningCPID.BoincSignature = sSignature;
                                         if (!IsCPIDValidv2(GlobalCPUMiningCPID,1))
                                         {
                                             printf("CPID INVALID (GetNextProject) %s, %s  ",GlobalCPUMiningCPID.cpid.c_str(),GlobalCPUMiningCPID.cpidv2.c_str());

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -637,7 +637,7 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
         std::string sBoincSignature = SignBlockWithCPID(GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash);
         if (sBoincSignature.empty())
         {
-            // Prevent a block from being staked with boinchash containing and failed signature
+            // Prevent a block from being staked with boinchash containing a failed signature
             if (fDebug2) printf("SignStakeBlock: Failed to sign block;\n");
             return false;
         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -634,8 +634,14 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
     std::string PublicKey = GlobalCPUMiningCPID.BoincPublicKey;
     if (!PublicKey.empty())
     {
-        BoincData.BoincSignature = SignBlockWithCPID(
-            GlobalCPUMiningCPID.cpid,GlobalCPUMiningCPID.lastblockhash);
+        std::string sBoincSignature = SignBlockWithCPID(GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash);
+        if (sBoincSignature.empty())
+        {
+            // Prevent a block from being staked with boinchash containing and failed signature
+            if (fDebug2) printf("SignStakeBlock: Failed to sign block;\n");
+            return false;
+        }
+        BoincData.BoincSignature = sBoincSignature;
         if(fDebug2) printf("Signing BoincBlock for cpid %s and blockhash %s with sig %s\r\n",GlobalCPUMiningCPID.cpid.c_str(),GlobalCPUMiningCPID.lastblockhash.c_str(),BoincData.BoincSignature.c_str());
     }
     block.vtx[0].hashBoinc = SerializeBoincBlock(BoincData,block.nVersion);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -33,7 +33,7 @@ std::string SerializeBoincBlock(MiningCPID mcpid);
 bool LessVerbose(int iMax1000);
 
 int64_t GetRSAWeightByBlock(MiningCPID boincblock);
-std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
+bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, std::string& sSignature, std::string& sError);
 std::string qtGetNeuralContract(std::string data);
 
 // Some explaining would be appreciated
@@ -634,11 +634,12 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
     std::string PublicKey = GlobalCPUMiningCPID.BoincPublicKey;
     if (!PublicKey.empty())
     {
-        std::string sBoincSignature = SignBlockWithCPID(GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash);
-        if (sBoincSignature.empty())
+        std::string sBoincSignature;
+        std::string sError;
+        bool bResult = SignBlockWithCPID(GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash, sBoincSignature, sError);
+        if (!bResult)
         {
-            // Prevent a block from being staked with boinchash containing a failed signature
-            if (fDebug2) printf("SignStakeBlock: Failed to sign block;\n");
+            if (fDebug2) printf("SignStakeBlock: Failed to sign block -> %s\n", sError.c_str());
             return false;
         }
         BoincData.BoincSignature = sBoincSignature;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2807,8 +2807,8 @@ bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, 
     // If we failed to sign then return false
     if (sSignature == "Unable to sign message, check private key.")
     {
-        sSignature = "";
         sError = sSignature;
+        sSignature = "";
         return false;
     }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2788,6 +2788,9 @@ std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash)
     std::string sPrivateKey = GetStoredBeaconPrivateKey(sCPID);
     std::string sMessage = sCPID + sBlockHash;
     std::string sSignature = SignMessage(sMessage,sPrivateKey);
+    // If we failed to sign then return empty string
+    if (sSignature == "Unable to sign message, check private key.")
+        return "";
     return sSignature;
 }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -48,7 +48,7 @@ extern std::vector<unsigned char> readFileToVector(std::string filename);
 bool bNetAveragesLoaded_retired;
 bool TallyResearchAverages_retired(bool);
 int RestartClient();
-extern std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash);
+extern bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, std::string& sSignature, std::string& sError);
 std::string BurnCoinsWithNewContract(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue, int64_t MinimumBalance, double dFees, std::string strPublicKey, std::string sBurnAddress);
 extern std::string GetBurnAddress();
 bool StrLessThanReferenceHash(std::string rh);
@@ -1401,7 +1401,16 @@ Value execute(const Array& params, bool fHelp)
         uint256 hashBlock = GetRandHash();
         if (!sPubKey.empty())
         {
-            std::string sSignature = SignBlockWithCPID(sCPID,hashBlock.GetHex());
+            bool bResult;
+            std::string sSignature;
+            std::string sError;
+            bResult = SignBlockWithCPID(sCPID, hashBlock.GetHex(), sSignature, sError);
+            if (!bResult)
+            {
+                sErr += "Failed to sign block with cpid ";
+                sErr += sError;
+                sErr += ";";
+            }
             bool fResult = VerifyCPIDSignature(sCPID, hashBlock.GetHex(), sSignature);
             entry.push_back(Pair("Block Signing Test Results", fResult));
             if (!fResult)
@@ -2782,16 +2791,28 @@ bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string 
     return bValid;
 }
 
-std::string SignBlockWithCPID(std::string sCPID, std::string sBlockHash)
+bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, std::string& sSignature, std::string& sError)
 {
-    // Returns the Signature of the CPID+BlockHash message. 
+    // Check if there is a beacon for this user
+    // If not then return false as GetStoresBeaconPrivateKey grabs from the config
+    if (!HasActiveBeacon(sCPID))
+    {
+        sError = "No active beacon";
+        return false;
+    }
+    // Returns the Signature of the CPID+BlockHash message.
     std::string sPrivateKey = GetStoredBeaconPrivateKey(sCPID);
     std::string sMessage = sCPID + sBlockHash;
-    std::string sSignature = SignMessage(sMessage,sPrivateKey);
-    // If we failed to sign then return empty string
+    sSignature = SignMessage(sMessage,sPrivateKey);
+    // If we failed to sign then return false
     if (sSignature == "Unable to sign message, check private key.")
-        return "";
-    return sSignature;
+    {
+        sSignature = "";
+        sError = sSignature;
+        return false;
+    }
+
+    return true;
 }
 
 std::string GetPollContractByTitle(std::string objecttype, std::string title)
@@ -2986,7 +3007,12 @@ std::string GetProvableVotingWeightXML()
         if (pHistorical->nHeight > 1 && pHistorical->nMagnitude > 0)
         {
             std::string sBlockhash = pHistorical->GetBlockHash().GetHex();
-            std::string sSignature = SignBlockWithCPID(msPrimaryCPID,pHistorical->GetBlockHash().GetHex());
+            std::string sError;
+            std::string sSignature;
+            bool bResult = SignBlockWithCPID(msPrimaryCPID, pHistorical->GetBlockHash().GetHex(), sSignature, sError);
+            // Just because below comment it'll keep in line with that
+            if (!bResult)
+                sSignature = sError;
             // Find the Magnitude from the last staked block, within the last 6 months, and ensure researcher has a valid current beacon (if the beacon is expired, the signature contain an error message)
             sXML += "<CPID>" + msPrimaryCPID + "</CPID><INNERMAGNITUDE>"
                     + RoundToString(pHistorical->nMagnitude,2) + "</INNERMAGNITUDE>" +
@@ -3173,7 +3199,13 @@ Array GetJsonUnspentReport()
         if (pHistorical->nHeight > 1 && pHistorical->nMagnitude > 0)
         {
             std::string sBlockhash = pHistorical->GetBlockHash().GetHex();
-            std::string sSignature = SignBlockWithCPID(msPrimaryCPID,pHistorical->GetBlockHash().GetHex());
+            std::string sError;
+            std::string sSignature;
+            bool bResult = SignBlockWithCPID(msPrimaryCPID, pHistorical->GetBlockHash().GetHex(), sSignature, sError);
+            // Just because below comment it'll keep in line with that
+            if (!bResult)
+                sSignature = sError;
+
             // Find the Magnitude from the last staked block, within the last 6 months, and ensure researcher has a valid current beacon (if the beacon is expired, the signature contain an error message)
 
             std::string sMagXML = "<CPID>" + msPrimaryCPID + "</CPID><INNERMAGNITUDE>" + RoundToString(pHistorical->nMagnitude,2) + "</INNERMAGNITUDE>" +


### PR DESCRIPTION
Currently you can stake a block even if the signature fails. this should not be possible this has already caused a problems with me syncing. i been looking into this and decided some prevention was important and I believe i see some problems that can also lead to it but for the mean time these blocks should not be able to be submitted to the network and should fail locally.

17:09:47 ERROR: ConnectBlock[ResearchAge]: Bad CPID or Block Signature : CPID f2109bf8e9b61db3360faea15821ff68, cpidv2 , LBH 00d05f371cf40db4c94be0f467b70bab253c4a31f7a35d0c539b5b37f864d882, Bad Hashboinc [f2109bf8e9b61db3360faea15821ff68<|><|><|>0<|>0.00000<|>0<|><|><|>0<|>0<|>v3.7.7.0-unk<|>1.01000000<|>0<|>0<|><|>1<|>SGqL2GRir41saUvFRLQ8dZ1aPv66bdaKMX<|>00d05f371cf40db4c94be0f467b70bab253c4a31f7a35d0c539b5b37f864d882<|>41.01140504<|><|><|><|><|>1.01<|>0.000000<|>0.250000<|>0.00<|>2e674fe69a022f5d42622c49549adc29aeb52eb488789015e5d534498101e30c<|><|>0442607b8c4186d219a8db17a7e8b472febec4b8a43df007b26821c233dc0b610f0b1be465647cbe594bc170356f16de9fc55011eddbad359feb3d2768cf092a4d<|>Unable to sign message, check private key.]

This should not be able to happen and this change will cause the block to fail to stake locally. I'm still looking into the other signature issues but believe i have a lead on it.

Also apart of this i added a >= 1 for magnitude in getnextproject as a side add. Minimum magnitude is 1. if they have 1 magnitude the thrashing could still occur under the circumstances. I already know why that block failed the signature and will continue my investigation to correct that problem.

this is a step in the right direction imo for that specific failure of signature

--

Edit: if you noticed in the boinchash the user mag of 1 is there and the signature was unsuccessful. this should solve this and prevent it from being staked to begin with. note there was no beacon in chain for this user when my client was trying to process this block. the signmessage uses a privatekey from config so if u did advertise beacon on a fork and came back then ud still have the privatekey in the config so i added a check to see if there is a beacon there as well