### PR TITLE
Revert lock order from #708.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2053,14 +2053,23 @@ void ThreadMessageHandler2(void* parg)
 
             //11-25-2015
             // Receive messages
-            if (!ProcessMessages(pnode))
-                pnode->CloseSocketDisconnect();
+            {
+                TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
+                if (lockRecv)
+                    if (!ProcessMessages(pnode))
+                        pnode->CloseSocketDisconnect();
+            }
 
             if (fShutdown)
                 return;
 
             // Send messages
-            SendMessages(pnode, pnode == pnodeTrickle);
+            {
+                TRY_LOCK(pnode->cs_vSend, lockSend);
+                if (lockSend)
+                    SendMessages(pnode, pnode == pnodeTrickle);
+            }
+
             if (fShutdown)
                 return;
         }


### PR DESCRIPTION
This reverts the lock order in #708 and reduces the granularity of the locks (taken from Blackcoin). As a result, RPC, and probably the UI, will not freeze up during syncing. I tested this on the daemon by syncing from 0 without any issues.

To test:
- Syncing from 0 in the Qt wallet
- Additional syncs from 0 in the daemon
- Interacting with the UI during syncing