### PR TITLE
add ntdll library to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,6 +298,7 @@ case $host in
      AC_CHECK_LIB([shlwapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([iphlpapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([crypt32],      [main],, AC_MSG_ERROR(lib missing))
+     AC_CHECK_LIB([ntdll],      [main],, AC_MSG_ERROR(lib missing))
 
      # -static is interpreted by libtool, where it has a different meaning.
      # In libtool-speak, it's -all-static.


### PR DESCRIPTION
added this to configure.ac and ran configure and tested the exe on windows and it worked with a x64 BoincStake.dll however it failed with x86 version

Likely we need a x64 version boincstake with x64 exe. and vice versa. 

do test this and if u need a x64 boincstake.dll u will need to likely use a installer to register it
 