### PR TITLE
change filter for beacon report to beacon; datatype instead of beacon. note beaconalt

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -381,7 +381,7 @@ bool PushGridcoinDiagnostics()
                 if (!bGlobalcomInitialized) return false;
                 std::string errors1 = "";
                 LoadAdminMessages(false,errors1);
-                std::string cpiddata = GetListOf("beacon");
+                std::string cpiddata = GetListOf("beacon;");
                 std::string sWhitelist = GetListOf("project");
                 int64_t superblock_age = GetAdjustedTime() - mvApplicationCacheTimestamp["superblock;magnitudes"];
                 double popularity = 0;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -893,35 +893,39 @@ std::string GetListOf(std::string datatype)
 
 std::string GetListOfWithConsensus(std::string datatype)
 {
-       std::string rows = "";
-       std::string row = "";
-	   int64_t iEndTime= (GetAdjustedTime()-CONSENSUS_LOOKBACK) - ( (GetAdjustedTime()-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
-       int64_t nLookback = 30 * 6 * 86400; 
-       int64_t iStartTime = (iEndTime - nLookback) - ( (iEndTime - nLookback) % BLOCK_GRANULARITY);
-       printf(" getlistofwithconsensus startime %f , endtime %f, lookback %f \r\n ",(double)iStartTime,(double)iEndTime, (double)nLookback);
-	   for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii) 
-       {
-             std::string key_name  = (*ii).first;
-             if (key_name.length() > datatype.length())
-             {
-                 if (key_name.substr(0,datatype.length())==datatype)
-                 {
- 			           int64_t iBeaconTimestamp = mvApplicationCacheTimestamp[(*ii).first];
-				       if (iBeaconTimestamp > iStartTime && iBeaconTimestamp < iEndTime)
-					   {		
-							std::string key_value = mvApplicationCache[(*ii).first];
-							std::string subkey = key_name.substr(datatype.length()+1,key_name.length()-datatype.length()-1);
-							row = subkey + "<COL>" + key_value;
-							if (Contains(row,"INVESTOR") && datatype=="beacon") row = "";
-							if (row != "")
-							{
-								rows += row + "<ROW>";
-							}
-						}
-                  }
-             }
-       }
-       return rows;
+    std::string rows = "";
+    std::string row = "";
+    int64_t iEndTime= (GetAdjustedTime()-CONSENSUS_LOOKBACK) - ( (GetAdjustedTime()-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
+    int64_t nLookback = 30 * 6 * 86400;
+    int64_t iStartTime = (iEndTime - nLookback) - ( (iEndTime - nLookback) % BLOCK_GRANULARITY);
+    printf(" getlistofwithconsensus startime %f , endtime %f, lookback %f \r\n ",(double)iStartTime,(double)iEndTime, (double)nLookback);
+    for(map<string,string>::iterator ii=mvApplicationCache.begin(); ii!=mvApplicationCache.end(); ++ii)
+    {
+        std::string key_name  = (*ii).first;
+        if (key_name.length() > datatype.length())
+        {
+            // Ignore beaconalts here as to not break the neural network
+            if (key_name.substr(0, datatype.length() + 3) == "beaconalt")
+                continue;
+
+            else if (key_name.substr(0,datatype.length())==datatype)
+            {
+                int64_t iBeaconTimestamp = mvApplicationCacheTimestamp[(*ii).first];
+                if (iBeaconTimestamp > iStartTime && iBeaconTimestamp < iEndTime)
+                {
+                    std::string key_value = mvApplicationCache[(*ii).first];
+                    std::string subkey = key_name.substr(datatype.length()+1,key_name.length()-datatype.length()-1);
+                    row = subkey + "<COL>" + key_value;
+                    if (Contains(row,"INVESTOR") && datatype=="beacon") row = "";
+                    if (row != "")
+                    {
+                        rows += row + "<ROW>";
+                    }
+                }
+            }
+        }
+    }
+    return rows;
 }
 
 std::string AddContract(std::string sType, std::string sName, std::string sContract)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -3577,7 +3577,7 @@ Array GetJSONBeaconReport()
     Array results;
     Object entry;
     entry.push_back(Pair("CPID","GRCAddress"));
-    std::string datatype="beacon";
+    std::string datatype="beacon;";
     std::string row;
     for(const auto& item : AppCacheFilter(datatype))
     {


### PR DESCRIPTION
Have beacon report specifically filter with `datatype` beacon; since `beacon;` alone as currently it now displays the `beaconalt;` cache entries as well. in turn beacon report `DecodeBase64` the contract so when it does these `beaconalt;` entries it can put out binary data results. and noting with decodebase64 could possibly be able to seg fault in limited situations this should be in place to prevent that possibility.