### PR TITLE
qt: Plug many memory leaks

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -71,7 +71,7 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
     deleteAction = new QAction(ui->deleteButton->text(), this);
 
     // Build context menu
-    contextMenu = new QMenu();
+    contextMenu = new QMenu(this);
     contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(editAction);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -41,7 +41,7 @@ CoinControlDialog::CoinControlDialog(QWidget *parent) :
              //unlockAction = new QAction(tr("Unlock unspent"), this);                    // we need to enable/disable this
 
     // context menu
-    contextMenu = new QMenu();
+    contextMenu = new QMenu(this);
     contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyAmountAction);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -32,7 +32,7 @@ class TxViewDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT
 public:
-    TxViewDelegate(): QAbstractItemDelegate(), unit(BitcoinUnits::BTC)
+    TxViewDelegate(QObject *parent=nullptr): QAbstractItemDelegate(parent), unit(BitcoinUnits::BTC)
     {
 
     }
@@ -110,8 +110,7 @@ OverviewPage::OverviewPage(QWidget *parent) :
     currentStake(0),
     currentUnconfirmedBalance(-1),
     currentImmatureBalance(-1),
-    txdelegate(new TxViewDelegate()),
-    filter(0)
+    txdelegate(new TxViewDelegate(this))
 {
     ui->setupUi(this);
 
@@ -221,14 +220,14 @@ void OverviewPage::setModel(WalletModel *model)
     if(model && model->getOptionsModel())
     {
         // Set up transaction list
-        filter = new TransactionFilterProxy();
+        filter.reset(new TransactionFilterProxy());
         filter->setSourceModel(model->getTransactionTableModel());
         filter->setDynamicSortFilter(true);
         filter->setSortRole(Qt::EditRole);
         filter->setShowInactive(false);
         filter->sort(TransactionTableModel::Status, Qt::DescendingOrder);
 
-        ui->listTransactions->setModel(filter);
+        ui->listTransactions->setModel(filter.get());
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
 
         // Keep up to date with wallet

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -2,7 +2,7 @@
 #define OVERVIEWPAGE_H
 
 #include <QWidget>
-
+#include <memory>
 
 #ifdef WIN32
 #include <QAxObject>
@@ -43,10 +43,10 @@ signals:
 protected:
     void resizeEvent(QResizeEvent *event);
     void showEvent(QShowEvent *event);
-    
+
 private:
     void updateTransactions();
-    
+
     Ui::OverviewPage *ui;
     WalletModel *model;
     qint64 currentBalance;
@@ -55,7 +55,7 @@ private:
     qint64 currentImmatureBalance;
 
     TxViewDelegate *txdelegate;
-    TransactionFilterProxy *filter;
+    std::unique_ptr<TransactionFilterProxy> filter;
 
 private slots:
     void updateDisplayUnit();

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -127,7 +127,7 @@ TransactionView::TransactionView(QWidget *parent) :
     QAction *editLabelAction = new QAction(tr("Edit label"), this);
     QAction *showDetailsAction = new QAction(tr("Show transaction details"), this);
 
-    contextMenu = new QMenu();
+    contextMenu = new QMenu(this);
     contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyAmountAction);


### PR DESCRIPTION
None of these are very serious, and are leaks in objects that are
created at most one time.

In most cases this means properly using the QObject parent hierarchy,
except for BanTablePriv/PeerTablePriv which are not QObject,
so use a std::unique_ptr instead.

laanwj's original commit is found here: https://github.com/bitcoin/bitcoin/commit/47db07537746940ee7dd0739a8c73e328837813f and the discussion around can be referenced from #213 .