### PR TITLE
Remove assertion in SignSignature to fix tests

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1474,7 +1474,7 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
         return false;
-        
+
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
         return Sign1(keyID, keystore, hash, nHashType, scriptSigRet);
@@ -1619,7 +1619,7 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
     txnouttype whichType;
     if (!Solver(scriptPubKey, whichType, vSolutions))
         return false;
-    
+
     if (bOPReturnEnabled && whichType == TX_NULL_DATA)
         return true;
 
@@ -1791,7 +1791,6 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CTrans
     assert(nIn < txTo.vin.size());
     CTxIn& txin = txTo.vin[nIn];
     assert(txin.prevout.n < txFrom.vout.size());
-    assert(txin.prevout.hash == txFrom.GetHash());
     const CTxOut& txout = txFrom.vout[txin.prevout.n];
 
     return SignSignature(keystore, txout.scriptPubKey, txTo, nIn, nHashType);

--- a/src/test/README
+++ b/src/test/README
@@ -1,12 +1,12 @@
-The sources in this directory are unit test cases.  Boost includes a
-unit testing framework, and since bitcoin already uses boost, it makes
+The sources in this directory are unit test cases. Boost includes a
+unit testing framework, and since gridcoin already uses boost, it makes
 sense to simply use this framework rather than require developers to
 configure some other framework (we want as few impediments to creating
 unit tests as possible).
 
-The build system is setup to compile an executable called "test_bitcoin"
+The build system is setup to compile an executable called "test_gridcoin"
 that runs all of the unit tests.  The main source file is called
-test_bitcoin.cpp, which simply includes other files that contain the
+test_gridcoin.cpp, which simply includes other files that contain the
 actual unit tests (outside of a couple required preprocessor
 directives).  The pattern is to create one test file for each class or
 source file for which you want to create unit tests.  The file naming
@@ -15,7 +15,12 @@ their tests in a test suite called "<source_filename>_tests".  For an
 examples of this pattern, examine uint160_tests.cpp and
 uint256_tests.cpp.
 
-For further reading, I found the following website to be helpful in
+The tests in tranaction_tests.cpp are edge cases of bitcoin transactions.
+They are in their current state not relevant for gridcoin. Unusual transactions
+should be collected again from the gridcoin blockchain and replace
+the current test cases.
+
+For further reading, the following website is helpful in
 explaining how the boost unit test framework works:
 
 http://www.alittlemadness.com/2009/03/31/c-unit-testing-with-boosttest/

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -326,9 +326,6 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
     BOOST_CHECK(!VerifyScript(badsig6, scriptPubKey23, txTo23, 0, 0));
 }
 
-// Gridcoin, 2017-03-18: Temporarily disable broken tests.
-#if 0
-
 BOOST_AUTO_TEST_CASE(script_combineSigs)
 {
     // Test the CombineSignatures function
@@ -442,6 +439,5 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     combined = CombineSignatures(scriptPubKey, txTo, 0, partial3b, partial3a);
     BOOST_CHECK(combined == partial3c);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The assertion checking in and out transaction hash failed when checking the p2sh and 2of3 multisig sig's.
This check does not need to be done at the location, since it is only a client side check and need not be executed consensus-wide. The assertion was originally introduced in: https://github.com/peercoin/peercoin/commit/9cb3d570daef2c040d29e58411b2c66e0fb00bc6 and removed again without a comment on https://github.com/peercoin/peercoin/commit/54ad81be2e573b6f7584bc95a958905687d89896#diff-dedcc88d0e66b86a19981e7c175658c2 . 