### PR TITLE
The addressbook button in the Send pane, previously showed the send coin icon

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -194,6 +194,6 @@ void SendCoinsEntry::updateIcons()
 {
     if(model && model->getOptionsModel())
     {
-        ui->addressBookButton->setIcon(QIcon(":/icons/send_"+model->getOptionsModel()->getCurrentStyle()));
+        ui->addressBookButton->setIcon(QIcon(":/icons/address-book_"+model->getOptionsModel()->getCurrentStyle()));
     }
 }


### PR DESCRIPTION
Simple fix to change the icon for the address book in the send coins pane.