### PR TITLE
Removes unnecessary lsn_reset from CheckpointLSN to improve wallet performance

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -76,6 +76,8 @@ bool BackupWallet(const CWallet& wallet, const std::string& strDest)
                 // Flush log data to the dat file
                 bitdb.CloseDb(wallet.strWalletFile);
                 bitdb.CheckpointLSN(wallet.strWalletFile);
+                printf("Issuing lsn_reset for backup file portability.\n");
+                bitdb.lsn_reset(wallet.strWalletFile); 
                 bitdb.mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet.dat

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -233,7 +233,10 @@ void CDBEnv::CheckpointLSN(std::string strFile)
     //dbenv.lsn_reset(strFile.c_str(), 0);
 }
 
-void CDBEnv::lsn_reset(std::string strFile)                                                                                                                {                                                                                                                                                          dbenv.lsn_reset(strFile.c_str(),0);                                                                                                                        }                                                                                                                                                          
+void CDBEnv::lsn_reset(std::string strFile)
+{
+dbenv.lsn_reset(strFile.c_str(),0);
+}                                                                                                                                                    
 
 CDB::CDB(const char *pszFile, const char* pszMode) :
     pdb(NULL), activeTxn(NULL)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -228,11 +228,12 @@ void CDBEnv::CheckpointLSN(std::string strFile)
     if (fMockDb)
         return;
     // The below line is commented out. LSN reset is not necessary and improper. Txn_checkpoint alone will flush in memory log to the database file.
-	// This was causing extraordinary long flush times for large wallets.
-	// Flush is called when the wallet is closed upon client shutdown, and the below line is included there to ensure portability of wallet.dat.
+    // This was causing extraordinary long flush times for large wallets.
+    // Flush is called when the wallet is closed upon client shutdown, and the below line is included there to ensure portability of wallet.dat.
     //dbenv.lsn_reset(strFile.c_str(), 0);
 }
 
+void CDBEnv::lsn_reset(std::string strFile)                                                                                                                {                                                                                                                                                          dbenv.lsn_reset(strFile.c_str(),0);                                                                                                                        }                                                                                                                                                          
 
 CDB::CDB(const char *pszFile, const char* pszMode) :
     pdb(NULL), activeTxn(NULL)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -233,9 +233,9 @@ void CDBEnv::CheckpointLSN(std::string strFile)
     //dbenv.lsn_reset(strFile.c_str(), 0);
 }
 
-void CDBEnv::lsn_reset(std::string strFile)
+void CDBEnv::lsn_reset(const std::string& strFile)
 {
-dbenv.lsn_reset(strFile.c_str(),0);
+    dbenv.lsn_reset(strFile.c_str(),0);
 }                                                                                                                                                    
 
 CDB::CDB(const char *pszFile, const char* pszMode) :

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -227,7 +227,10 @@ void CDBEnv::CheckpointLSN(std::string strFile)
     dbenv.txn_checkpoint(0, 0, 0);
     if (fMockDb)
         return;
-    dbenv.lsn_reset(strFile.c_str(), 0);
+    // The below line is commented out. LSN reset is not necessary and improper. Txn_checkpoint alone will flush in memory log to the database file.
+	// This was causing extraordinary long flush times for large wallets.
+	// Flush is called when the wallet is closed upon client shutdown, and the below line is included there to ensure portability of wallet.dat.
+    //dbenv.lsn_reset(strFile.c_str(), 0);
 }
 
 

--- a/src/db.h
+++ b/src/db.h
@@ -71,7 +71,7 @@ public:
     void Close();
     void Flush(bool fShutdown);
     void CheckpointLSN(std::string strFile);
-    void lsn_reset(std::string strFile);
+    void lsn_reset(const std::string& strFile);
     void CloseDb(const std::string& strFile);
     bool RemoveDb(const std::string& strFile);
 

--- a/src/db.h
+++ b/src/db.h
@@ -71,7 +71,7 @@ public:
     void Close();
     void Flush(bool fShutdown);
     void CheckpointLSN(std::string strFile);
-
+    void lsn_reset(std::string strFile);
     void CloseDb(const std::string& strFile);
     bool RemoveDb(const std::string& strFile);
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -670,10 +670,10 @@ void ThreadFlushWalletDB(void* parg)
                         // Flush wallet.dat so it's self contained
                         bitdb.CloseDb(strFile);
                         bitdb.CheckpointLSN(strFile);
-						// The below line is commented out, because the above line (CheckpointLSN) should have never had
-						// lsn_reset in it. lsn_reset should only be called on the final flush when the wallet is closed.
-						// This is handled in CDB::Flush, which has a while loop that also does in the right place what
-						// the intention of the below line was.
+                        // The below line is commented out, because the above line (CheckpointLSN) should have never had
+                        // lsn_reset in it. lsn_reset should only be called on the final flush when the wallet is closed.
+                        // This is handled in CDB::Flush, which has a while loop that also does in the right place what
+                        // the intention of the below line was.
                         // bitdb.mapFileUseCount.erase(mi++);
                         if (fDebug10) printf("Flushed wallet.dat %" PRId64 "ms\n", GetTimeMillis() - nStart);
                     }

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -670,8 +670,11 @@ void ThreadFlushWalletDB(void* parg)
                         // Flush wallet.dat so it's self contained
                         bitdb.CloseDb(strFile);
                         bitdb.CheckpointLSN(strFile);
-
-                        bitdb.mapFileUseCount.erase(mi++);
+						// The below line is commented out, because the above line (CheckpointLSN) should have never had
+						// lsn_reset in it. lsn_reset should only be called on the final flush when the wallet is closed.
+						// This is handled in CDB::Flush, which has a while loop that also does in the right place what
+						// the intention of the below line was.
+                        // bitdb.mapFileUseCount.erase(mi++);
                         if (fDebug10) printf("Flushed wallet.dat %" PRId64 "ms\n", GetTimeMillis() - nStart);
                     }
                 }


### PR DESCRIPTION
This seems to solve the wallet performance issue for large wallets. People need to thoroughly test it to ensure wallet stability is maintained with the change, especially under unclean shutdown conditions.