### PR TITLE
Runtime hickups

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1032,8 +1032,12 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (!strErrors.str().empty())
         return InitError(strErrors.str());
 
-     // Add wallet transactions that aren't already in a block to mapTransactions
+    // Add wallet transactions that aren't already in a block to mapTransactions
     pwalletMain->ReacceptWalletTransactions();
+
+    int nMismatchSpent;
+    int64_t nBalanceInQuestion;
+    pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4497,10 +4497,7 @@ void GridcoinServices()
 
     //Backup the wallet once per 900 blocks or as specified in config:
     int nWBI = GetArg("-walletbackupinterval", 900);
-    if (nWBI == 0)
-        nWBI = 900;
-
-   if (TimerMain("backupwallet", nWBI))
+    if (nWBI && TimerMain("backupwallet", nWBI))
     {
         bool bWalletBackupResults = BackupWallet(*pwalletMain, GetBackupFilename("wallet.dat"));
         bool bConfigBackupResults = BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3612,6 +3612,10 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
                 "Please Reindex the chain and Restart.\n");
             exit(1); //todo
         }
+
+        int nMismatchSpent;
+        int64_t nBalanceInQuestion;
+        pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
     }
 
     if (fDebug && cnt_dis>0) printf("ReorganizeChain: disconnected %d blocks\n",cnt_dis);
@@ -4504,13 +4508,6 @@ void GridcoinServices()
         printf("Daily backup results: Wallet -> %s Config -> %s\r\n", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
     }
 
-    if (false && TimerMain("FixSpentCoins",60))
-    {
-            int nMismatchSpent;
-            int64_t nBalanceInQuestion;
-            pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
-    }
-
     if (TimerMain("MyNeuralMagnitudeReport",30))
     {
         try
@@ -4525,10 +4522,6 @@ void GridcoinServices()
         catch (std::exception &e)
         {
             printf("Error in MyNeuralMagnitudeReport1.");
-        }
-        catch(...)
-        {
-            printf("Error in MyNeuralMagnitudeReport.");
         }
     }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2386,7 +2386,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
             }
             else if (IsMine(pcoin->vout[n]) && !pcoin->IsSpent(n) && (txindex.vSpent.size() > n && !txindex.vSpent[n].IsNull()))
             {
-                if (fDebug) printf("FixSpentCoins found spent coin %s gC %s[%d], %s\n",
+                printf("FixSpentCoins found spent coin %s gC %s[%d], %s\n",
                     FormatMoney(pcoin->vout[n].nValue).c_str(), pcoin->GetHash().ToString().c_str(), n, fCheckOnly? "repair not attempted" : "repairing");
                 nMismatchFound++;
                 nBalanceInQuestion += pcoin->vout[n].nValue;


### PR DESCRIPTION
This PR allows the user to disable wallet backups (`-walletbackupinterval=0`) and disables the periodical spent coins fix. Instead it does it once on startup and once on reorg. On second thought, we might not even need to do it on startup.