### PR TITLE
add constant block reward

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1909,6 +1909,11 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
             // TestNet: Ensure no magnitudes are out of bounds to ensure we do not generate an insane payment : PASS (Lifetime PPD takes care of this)
             // TestNet: Any subsidy with a duration wider than 6 months should not be paid : PASS
 
+            AppCacheEntry oCBReward= ReadCache("constblkreward","constblkreward");
+            int64_t nCBReward = RoundFromString(oCBReward.value,12);
+            if(nCBReward)
+                nInterest= nCBReward;
+
             int64_t maxStakeReward = GetMaximumBoincSubsidy(nTime) * COIN * 255;
 
             if (nBoinc > maxStakeReward) nBoinc = maxStakeReward;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -605,6 +605,7 @@ bool CheckMessageSignature(std::string sAction,std::string messagetype, std::str
      if (sAction=="D" && messagetype=="beacon") strMasterPubKey = msMasterProjectPublicKey;
 	 if (sAction=="D" && messagetype=="poll")   strMasterPubKey = msMasterProjectPublicKey;
 	 if (sAction=="D" && messagetype=="vote")   strMasterPubKey = msMasterProjectPublicKey;
+     if (messagetype=="constblkreward")         strMasterPubKey = msMasterProjectPublicKey;
 
      std::string db64 = DecodeBase64(sSig);
      CKey key;


### PR DESCRIPTION
CBR value set by message (`constblkreward` for both type and key).
Does not bump version, but block version should be bumped preferably.