### PR TITLE
Add optional support for Qt5.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -976,6 +976,9 @@ dnl these are only used when qt is enabled
 BUILD_TEST_QT=""
 if test x$bitcoin_enable_qt != xno; then
   CPPFLAGS="$CPPFLAGS -DQT_GUI"
+  if test x$enable_qt59 != xno; then
+    CPPFLAGS="$CPPFLAGS -DQT_CHARTS_LIB"
+  fi
   dnl enable dbus support
   AC_MSG_CHECKING([whether to build GUI with support for D-Bus])
   if test x$bitcoin_enable_qt_dbus != xno; then

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -4,6 +4,7 @@ SOURCES_PATH ?= $(BASEDIR)/sources
 BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
+QT_59 ?= 0
 NO_WALLET ?=
 NO_UPNP ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources

--- a/depends/README.md
+++ b/depends/README.md
@@ -12,6 +12,12 @@ For example:
 
     make HOST=x86_64-w64-mingw32 -j4
 
+You can also pass in an option to build Qt5.9.4 (required for QtCharts and
+charting the vote counts):
+
+   make HOST=host-platform-triple QT_59=1
+
+
 A prefix will be generated that's suitable for plugging into Gridcoin's
 configure. In the above example, a dir named x86_64-w64-mingw32 will be
 created. To use it for Gridcoin:

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -4,12 +4,14 @@ $(package)_download_path=http://www.freedesktop.org/software/fontconfig/release/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
 $(package)_dependencies=freetype expat
+$(package)_patches=0001-Avoid-conflicts-with-integer-width-macros-from-TS-18.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-docs --disable-static
 endef
 
 define $(package)_config_cmds
+  patch -p1 < $($(package)_patch_dir)/0001-Avoid-conflicts-with-integer-width-macros-from-TS-18.patch &&\
   $($(package)_autoconf)
 endef
 

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -3,11 +3,19 @@ native_packages := native_ccache
 
 qt_packages = qrencode zlib
 
+ifeq ($(QT_59),1)
+qt_x86_64_linux_packages:=qt59 expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
+qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
+
+qt_darwin_packages=qt59
+qt_mingw32_packages=qt59
+else
 qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
 
 qt_darwin_packages=qt
 qt_mingw32_packages=qt
+endif
 
 wallet_packages=bdb
 

--- a/depends/packages/qt59.mk
+++ b/depends/packages/qt59.mk
@@ -1,0 +1,210 @@
+PACKAGE=qt59
+$(package)_version=5.9.4
+$(package)_download_path=http://download.qt.io/official_releases/qt/5.9/$($(package)_version)/submodules
+$(package)_suffix=opensource-src-$($(package)_version).tar.xz
+$(package)_file_name=qtbase-$($(package)_suffix)
+$(package)_sha256_hash=69e6bde3ab00673a77e1506173551fec7d0cd899fcbf9b1260517db1b61004cf
+$(package)_dependencies=openssl zlib
+$(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
+$(package)_build_subdir=qtbase
+$(package)_qt_libs=corelib network widgets gui plugins testlib concurrent xml
+$(package)_patches=0001-Fix-linguist-macro.patch mac-qmake.conf 0005-Make-sure-.pc-files-are-installed-correctly.patch 0008-Fix-linking-against-shared-static-libpng.patch 0011-Fix-linking-against-static-freetype2.patch 0012-Fix-linking-against-static-harfbuzz.patch 0001-Add-profile-for-cross-compilation-with-mingw-w64.patch 0030-Prevent-qmake-from-messing-static-lib-dependencies.patch 0021-Use-.dll.a-as-import-lib-extension.patch fix_qt_pkgconfig.patch 0013-Fix-linking-against-static-pcre.patch
+
+$(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
+$(package)_qttranslations_sha256_hash=e5cf81f88cc6811166ea631e6b7faa869a578a910dce61e951f98ff83f27bad6
+
+$(package)_qttools_file_name=qttools-$($(package)_suffix)
+$(package)_qttools_sha256_hash=95aa5782d5a79be22fba36cea4dc2319cf2a2060a3cc1e24e6585b8d98996e87
+
+$(package)_qtcharts_file_name=qtcharts-$($(package)_suffix)
+$(package)_qtcharts_sha256_hash=75f72983fde6720a093d5f065d33f47e77a4bd2188ae9d41ebb9a4fcc459d3e7
+
+$(package)_qtactiveqt_file_name=qtactiveqt-$($(package)_suffix)
+$(package)_qtactiveqt_sha256_hash=5664c60bb4f68531070770dc3df6279fc736337660bdf0f9da3fb7be145ac5aa
+$(package)_qtactiveqt_libs=axcontainer
+
+$(package)_qtsvg_file_name=qtsvg-$($(package)_suffix)
+$(package)_qtsvg_sha256_hash=a2f22732bfd4f0f0204443daaa59448298ab5018750dce4600d01d969355037a
+
+$(package)_extra_sources  = $($(package)_qttranslations_file_name)
+$(package)_extra_sources += $($(package)_qttools_file_name)
+$(package)_extra_sources += $($(package)_qtcharts_file_name)
+$(package)_extra_sources += $($(package)_qtactiveqt_file_name)
+$(package)_extra_source += $($(package)_qtsvg)
+
+define $(package)_set_vars
+$(package)_config_opts_release = -release
+$(package)_config_opts_debug = -debug
+$(package)_config_opts += -bindir $(build_prefix)/bin
+$(package)_config_opts += -c++std c++11
+$(package)_config_opts += -confirm-license
+$(package)_config_opts += -dbus-runtime
+$(package)_config_opts += -hostprefix $(build_prefix)
+$(package)_config_opts += -no-cups
+$(package)_config_opts += -no-egl
+$(package)_config_opts += -no-eglfs
+$(package)_config_opts += -no-freetype
+$(package)_config_opts += -no-gif
+$(package)_config_opts += -no-glib
+$(package)_config_opts += -no-icu
+$(package)_config_opts += -no-iconv
+$(package)_config_opts += -no-kms
+$(package)_config_opts += -no-linuxfb
+$(package)_config_opts += -no-libudev
+$(package)_config_opts += -no-mtdev
+$(package)_config_opts += -no-openvg
+$(package)_config_opts += -no-reduce-relocations
+$(package)_config_opts += -no-qml-debug
+$(package)_config_opts += -no-sql-db2
+$(package)_config_opts += -no-sql-ibase
+$(package)_config_opts += -no-sql-oci
+$(package)_config_opts += -no-sql-tds
+$(package)_config_opts += -no-sql-mysql
+$(package)_config_opts += -no-sql-odbc
+$(package)_config_opts += -no-sql-psql
+$(package)_config_opts += -no-sql-sqlite
+$(package)_config_opts += -no-sql-sqlite2
+$(package)_config_opts += -no-use-gold-linker
+$(package)_config_opts += -nomake examples
+$(package)_config_opts += -nomake tests
+$(package)_config_opts += -opensource
+$(package)_config_opts += -openssl-linked
+$(package)_config_opts += -optimized-qmake
+$(package)_config_opts += -pch
+$(package)_config_opts += -pkg-config
+$(package)_config_opts += -prefix $(host_prefix)
+$(package)_config_opts += -qt-libpng
+$(package)_config_opts += -qt-libjpeg
+$(package)_config_opts += -qt-pcre
+$(package)_config_opts += -system-zlib
+#$(package)_config_opts += -reduce-exports
+$(package)_config_opts += -static
+$(package)_config_opts += -silent
+$(package)_config_opts += -v
+
+ifneq ($(build_os),darwin)
+$(package)_config_opts_darwin = -xplatform macx-clang-linux
+$(package)_config_opts_darwin += -device-option MAC_SDK_PATH=$(OSX_SDK)
+$(package)_config_opts_darwin += -device-option MAC_SDK_VERSION=$(OSX_SDK_VERSION)
+$(package)_config_opts_darwin += -device-option CROSS_COMPILE="$(host)-"
+$(package)_config_opts_darwin += -device-option MAC_MIN_VERSION=$(OSX_MIN_VERSION)
+$(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
+$(package)_config_opts_darwin += -device-option MAC_LD64_VERSION=$(LD64_VERSION)
+endif
+
+$(package)_config_opts_linux  = -qt-xkbcommon
+$(package)_config_opts_linux += -qt-xcb
+$(package)_config_opts_linux += -system-freetype
+$(package)_config_opts_linux += -fontconfig
+$(package)_config_opts_linux += -no-opengl
+$(package)_config_opts_arm_linux  = -platform linux-g++ -xplatform $(host)
+$(package)_config_opts_i686_linux  = -xplatform linux-g++-32
+$(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
+$(package)_build_env  = QT_RCC_TEST=1
+endef
+
+define $(package)_fetch_cmds
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttranslations_file_name),$($(package)_qttranslations_file_name),$($(package)_qttranslations_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttools_file_name),$($(package)_qttools_file_name),$($(package)_qttools_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtcharts_file_name),$($(package)_qtcharts_file_name),$($(package)_qtcharts_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtactiveqt_file_name),$($(package)_qtactiveqt_file_name),$($(package)_qtactiveqt_sha256_hash)) &&\
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtsvg_file_name),$($(package)_qtsvg_file_name),$($(package)_qtsvg_sha256_hash))
+endef
+
+define $(package)_extract_cmds
+  mkdir -p $($(package)_extract_dir) && \
+  echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qttranslations_sha256_hash)  $($(package)_source_dir)/$($(package)_qttranslations_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qttools_sha256_hash)  $($(package)_source_dir)/$($(package)_qttools_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtcharts_sha256_hash)  $($(package)_source_dir)/$($(package)_qtcharts_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtactiveqt_sha256_hash)  $($(package)_source_dir)/$($(package)_qtactiveqt_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtsvg_sha256_hash)  $($(package)_source_dir)/$($(package)_qtsvg_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  mkdir qtbase && \
+  tar --strip-components=1 -xf $($(package)_source) -C qtbase && \
+  mkdir qttranslations && \
+  tar --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttranslations_file_name) -C qttranslations && \
+  mkdir qttools && \
+  tar --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttools_file_name) -C qttools &&\
+  mkdir qtcharts && \
+  tar --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtcharts_file_name) -C qtcharts &&\
+  mkdir qtactiveqt && \
+  tar --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtactiveqt_file_name) -C qtactiveqt &&\
+  mkdir qtsvg && \
+  tar --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtsvg_file_name) -C qtsvg
+endef
+
+define $(package)_preprocess_cmds
+  sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
+  sed -i.old "/updateqm.depends =/d" qttranslations/translations/translations.pro && \
+  sed -i.old "s/src_plugins.depends = src_sql src_xml src_network/src_plugins.depends = src_xml src_network/" qtbase/src/src.pro && \
+  sed -i.old "s|X11/extensions/XIproto.h|X11/X.h|" qtbase/src/plugins/platforms/xcb/qxcbxsettings.cpp && \
+  sed -i.old 's/if \[ "$$$$XPLATFORM_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/if \[ "$$$$BUILD_ON_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/' qtbase/configure && \
+  sed -i.old 's/CGEventCreateMouseEvent(0, kCGEventMouseMoved, pos, 0)/CGEventCreateMouseEvent(0, kCGEventMouseMoved, pos, kCGMouseButtonLeft)/' qtbase/src/plugins/platforms/cocoa/qcocoacursor.mm && \
+  mkdir -p qtbase/mkspecs/macx-clang-linux &&\
+  cp -f qtbase/mkspecs/macx-clang/Info.plist.lib qtbase/mkspecs/macx-clang-linux/ &&\
+  cp -f qtbase/mkspecs/macx-clang/Info.plist.app qtbase/mkspecs/macx-clang-linux/ &&\
+  cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
+  cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \
+  echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
+  echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
+  echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
+  echo "QMAKE_LINK_OBJECT_MAX = 10" >> qtbase/mkspecs/win32-g++/qmake.conf &&\
+  echo "QMAKE_LINK_OBJECT_SCRIPT = object_script" >> qtbase/mkspecs/win32-g++/qmake.conf &&\
+  sed -i.old "s|QMAKE_CFLAGS            = |!host_build: QMAKE_CFLAGS            = $($(package)_cflags) $($(package)_cppflags) |" qtbase/mkspecs/win32-g++/qmake.conf && \
+  sed -i.old "s|QMAKE_LFLAGS            = |!host_build: QMAKE_LFLAGS            = $($(package)_ldflags) |" qtbase/mkspecs/win32-g++/qmake.conf && \
+  sed -i.old "s|QMAKE_CXXFLAGS          = |!host_build: QMAKE_CXXFLAGS            = $($(package)_cxxflags) $($(package)_cppflags) |" qtbase/mkspecs/win32-g++/qmake.conf &&\
+  patch -p1 -i $($(package)_patch_dir)/0001-Fix-linguist-macro.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0005-Make-sure-.pc-files-are-installed-correctly.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0008-Fix-linking-against-shared-static-libpng.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0011-Fix-linking-against-static-freetype2.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0012-Fix-linking-against-static-harfbuzz.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0001-Add-profile-for-cross-compilation-with-mingw-w64.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0021-Use-.dll.a-as-import-lib-extension.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0030-Prevent-qmake-from-messing-static-lib-dependencies.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/fix_qt_pkgconfig.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/0013-Fix-linking-against-static-pcre.patch
+endef
+
+define $(package)_config_cmds
+  export PKG_CONFIG_SYSROOT_DIR=/ && \
+  export PKG_CONFIG_LIBDIR=$(host_prefix)/lib/pkgconfig && \
+  export PKG_CONFIG_PATH=$(host_prefix)/share/pkgconfig  && \
+  ./configure $($(package)_config_opts) && \
+  echo "host_build: QT_CONFIG ~= s/system-zlib/zlib" >> mkspecs/qconfig.pri && \
+  echo "CONFIG += force_bootstrap" >> mkspecs/qconfig.pri && \
+  $(MAKE) sub-src-clean && \
+  cd ../qttranslations && ../qtbase/bin/qmake qttranslations.pro -o Makefile && \
+  cd translations && ../../qtbase/bin/qmake translations.pro -o Makefile && cd ../.. && \
+  cd qttools/src/linguist/lrelease/ && ../../../../qtbase/bin/qmake lrelease.pro -o Makefile && cd ../../../.. && \
+  cd qtcharts/src/charts/ && ../../../qtbase/bin/qmake charts.pro -o Makefile && cd ../../.. && \
+  cd qtactiveqt/src/activeqt && ../../../qtbase/bin/qmake activeqt.pro -o Makefile && cd ../../.. &&\
+  cd qtsvg/src && ../../qtbase/bin/qmake -o Makefile && cd ../..
+endef
+
+define $(package)_build_cmds
+  $(MAKE) -C src $(addprefix sub-,$($(package)_qt_libs)) && \
+  $(MAKE) -C ../qttools/src/linguist/lrelease && \
+  $(MAKE) -C ../qtactiveqt/src/activeqt && \
+  $(MAKE) -C ../qtcharts/src/charts && \
+  $(MAKE) -C ../qtsvg/src &&\
+  $(MAKE) -C ../qttranslations
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) -C src INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_qt_libs))) && cd .. && \
+  $(MAKE) -C qttools/src/linguist/lrelease INSTALL_ROOT=$($(package)_staging_dir) install_target && \
+  $(MAKE) -C qtactiveqt/src/activeqt INSTALL_ROOT=$($(package)_staging_dir) install &&\
+  $(MAKE) -C qtcharts/src/charts INSTALL_ROOT=$($(package)_staging_dir) install &&\
+  $(MAKE) -C qtsvg/src INSTALL_ROOT=$($(package)_staging_dir) install &&\
+  $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
+  if `test -f qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a`; then \
+    cp qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a $($(package)_staging_prefix_dir)/lib; \
+  fi
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf native/mkspecs/ native/lib/ lib/cmake/ && \
+  rm -f lib/lib*.la lib/*.prl plugins/*/*.prl
+endef

--- a/depends/patches/fontconfig/0001-Avoid-conflicts-with-integer-width-macros-from-TS-18.patch
+++ b/depends/patches/fontconfig/0001-Avoid-conflicts-with-integer-width-macros-from-TS-18.patch
@@ -1,0 +1,73 @@
+From 20cddc824c6501c2082cac41b162c34cd5fcc530 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 11 Dec 2016 14:32:00 -0800
+Subject: [PATCH] Avoid conflicts with integer width macros from TS
+ 18661-1:2014
+
+glibc 2.25+ has now defined these macros in <limits.h>
+https://sourceware.org/git/?p=glibc.git;a=commit;h=5b17fd0da62bf923cb61d1bb7b08cf2e1f1f9c1a
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Submitted
+
+ fontconfig/fontconfig.h | 2 +-
+ src/fcobjs.h            | 2 +-
+ src/fcobjshash.gperf    | 2 +-
+ src/fcobjshash.h        | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+Index: fontconfig-2.12.1/fontconfig/fontconfig.h
+===================================================================
+--- fontconfig-2.12.1.orig/fontconfig/fontconfig.h
++++ fontconfig-2.12.1/fontconfig/fontconfig.h
+@@ -128,7 +128,8 @@ typedef int		FcBool;
+ #define FC_USER_CACHE_FILE	    ".fonts.cache-" FC_CACHE_VERSION
+ 
+ /* Adjust outline rasterizer */
+-#define FC_CHAR_WIDTH	    "charwidth"	/* Int */
++#define FC_CHARWIDTH	    "charwidth"	/* Int */
++#define FC_CHAR_WIDTH	    FC_CHARWIDTH
+ #define FC_CHAR_HEIGHT	    "charheight"/* Int */
+ #define FC_MATRIX	    "matrix"    /* FcMatrix */
+ 
+Index: fontconfig-2.12.1/src/fcobjs.h
+===================================================================
+--- fontconfig-2.12.1.orig/src/fcobjs.h
++++ fontconfig-2.12.1/src/fcobjs.h
+@@ -51,7 +51,7 @@ FC_OBJECT (DPI,			FcTypeDouble,	NULL)
+ FC_OBJECT (RGBA,		FcTypeInteger,	NULL)
+ FC_OBJECT (SCALE,		FcTypeDouble,	NULL)
+ FC_OBJECT (MINSPACE,		FcTypeBool,	NULL)
+-FC_OBJECT (CHAR_WIDTH,		FcTypeInteger,	NULL)
++FC_OBJECT (CHARWIDTH,		FcTypeInteger,	NULL)
+ FC_OBJECT (CHAR_HEIGHT,		FcTypeInteger,	NULL)
+ FC_OBJECT (MATRIX,		FcTypeMatrix,	NULL)
+ FC_OBJECT (CHARSET,		FcTypeCharSet,	FcCompareCharSet)
+Index: fontconfig-2.12.1/src/fcobjshash.gperf
+===================================================================
+--- fontconfig-2.12.1.orig/src/fcobjshash.gperf
++++ fontconfig-2.12.1/src/fcobjshash.gperf
+@@ -44,7 +44,7 @@ int id;
+ "rgba",FC_RGBA_OBJECT
+ "scale",FC_SCALE_OBJECT
+ "minspace",FC_MINSPACE_OBJECT
+-"charwidth",FC_CHAR_WIDTH_OBJECT
++"charwidth",FC_CHARWIDTH_OBJECT
+ "charheight",FC_CHAR_HEIGHT_OBJECT
+ "matrix",FC_MATRIX_OBJECT
+ "charset",FC_CHARSET_OBJECT
+Index: fontconfig-2.12.1/src/fcobjshash.h
+===================================================================
+--- fontconfig-2.12.1.orig/src/fcobjshash.h
++++ fontconfig-2.12.1/src/fcobjshash.h
+@@ -284,7 +284,7 @@ FcObjectTypeLookup (register const char
+       {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str43,FC_CHARSET_OBJECT},
+       {-1},
+ #line 47 "fcobjshash.gperf"
+-      {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str45,FC_CHAR_WIDTH_OBJECT},
++      {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str45,FC_CHARWIDTH_OBJECT},
+ #line 48 "fcobjshash.gperf"
+       {(int)(long)&((struct FcObjectTypeNamePool_t *)0)->FcObjectTypeNamePool_str46,FC_CHAR_HEIGHT_OBJECT},
+ #line 55 "fcobjshash.gperf"
+

--- a/depends/patches/qt59/0001-Add-profile-for-cross-compilation-with-mingw-w64.patch
+++ b/depends/patches/qt59/0001-Add-profile-for-cross-compilation-with-mingw-w64.patch
@@ -1,0 +1,308 @@
+From 519d5f635192522a5dd273a19446071fd4c6970a Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Fri, 3 Feb 2017 18:30:51 +0100
+Subject: [PATCH 01/31] Add profile for cross compilation with mingw-w64
+
+---
+ mkspecs/mingw-w64-g++/qmake.conf      | 126 +++++++++++++++++++++++++++
+ mkspecs/mingw-w64-g++/qplatformdefs.h | 155 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 281 insertions(+)
+ create mode 100644 mkspecs/mingw-w64-g++/qmake.conf
+ create mode 100644 mkspecs/mingw-w64-g++/qplatformdefs.h
+
+diff --git a/qtbase/mkspecs/mingw-w64-g++/qmake.conf b/qtbase/mkspecs/mingw-w64-g++/qmake.conf
+new file mode 100644
+index 0000000000..c929483fcd
+--- /dev/null
++++ b/qtbase/mkspecs/mingw-w64-g++/qmake.conf
+@@ -0,0 +1,126 @@
++#
++# qmake configuration for i686-w64-mingw32-g++ and x86_64-w64-mingw32-g++
++#
++# Written for cross compilation with mingw-w64 under GNU/Linux
++#
++# Cross compile example for i686-w64-mingw32-g++:
++#   configure -xplatform mingw-w64-g++ -device-option CROSS_COMPILE=i686-w64-mingw32-
++#
++
++load(device_config)
++include(../common/angle.conf)
++
++MAKEFILE_GENERATOR          = MINGW
++QMAKE_PLATFORM              = win32 win32-g++ mingw
++CONFIG                     += debug_and_release debug_and_release_target precompile_header $${CROSS_COMPILE_CUSTOM_CONFIG}
++DEFINES                    += UNICODE
++QMAKE_COMPILER_DEFINES     += __GNUC__ WIN32
++
++QMAKE_EXT_OBJ               = .o
++QMAKE_EXT_RES               = _res.o
++
++QMAKE_COMPILER              = gcc
++
++QMAKE_CC                    = $${CROSS_COMPILE}gcc
++QMAKE_LEX                   = flex
++QMAKE_LEXFLAGS              =
++QMAKE_YACC                  = bison -y
++QMAKE_YACCFLAGS             = -d
++QMAKE_CFLAGS                = -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 -fno-keep-inline-dllexport $${CROSS_COMPILE_CFLAGS}
++QMAKE_CFLAGS_DEPS           = -M
++QMAKE_CFLAGS_WARN_ON        = -Wall -Wextra
++QMAKE_CFLAGS_WARN_OFF       = -w
++QMAKE_CFLAGS_RELEASE        = -O2
++QMAKE_CFLAGS_RELEASE_WITH_DEBUGINFO = -O2 -g
++QMAKE_CFLAGS_DEBUG          = -g
++QMAKE_CFLAGS_YACC           = -Wno-unused -Wno-parentheses
++QMAKE_CFLAGS_SPLIT_SECTIONS = -ffunction-sections
++QMAKE_CFLAGS_SSE2           = -msse2 -mstackrealign
++QMAKE_CFLAGS_SSE3           = -msse3
++QMAKE_CFLAGS_SSSE3          = -mssse3
++QMAKE_CFLAGS_SSE4_1         = -msse4.1
++QMAKE_CFLAGS_SSE4_2         = -msse4.2
++QMAKE_CFLAGS_AVX            = -mavx
++QMAKE_CFLAGS_AVX2           = -mavx2
++QMAKE_CFLAGS_NEON           = -mfpu=neon
++
++QMAKE_CXX                   = $${CROSS_COMPILE}g++
++QMAKE_CXXFLAGS              = $$QMAKE_CFLAGS
++QMAKE_CXXFLAGS_DEPS         = $$QMAKE_CFLAGS_DEPS
++QMAKE_CXXFLAGS_WARN_ON      = $$QMAKE_CFLAGS_WARN_ON
++QMAKE_CXXFLAGS_WARN_OFF     = $$QMAKE_CFLAGS_WARN_OFF
++QMAKE_CXXFLAGS_RELEASE      = $$QMAKE_CFLAGS_RELEASE
++QMAKE_CXXFLAGS_RELEASE_WITH_DEBUGINFO = $$QMAKE_CFLAGS_RELEASE_WITH_DEBUGINFO
++QMAKE_CXXFLAGS_DEBUG        = $$QMAKE_CFLAGS_DEBUG
++QMAKE_CXXFLAGS_YACC         = $$QMAKE_CFLAGS_YACC
++QMAKE_CXXFLAGS_THREAD       = $$QMAKE_CFLAGS_THREAD
++QMAKE_CXXFLAGS_RTTI_ON      = -frtti
++QMAKE_CXXFLAGS_RTTI_OFF     = -fno-rtti
++QMAKE_CXXFLAGS_EXCEPTIONS_ON = -fexceptions -mthreads
++QMAKE_CXXFLAGS_EXCEPTIONS_OFF = -fno-exceptions
++QMAKE_CXXFLAGS_CXX11        = -std=c++11
++QMAKE_CXXFLAGS_CXX14        = -std=c++1y
++QMAKE_CXXFLAGS_CXX1Z        = -std=c++1z
++QMAKE_CXXFLAGS_GNUCXX11     = -std=gnu++11
++QMAKE_CXXFLAGS_GNUCXX14     = -std=gnu++1y
++QMAKE_CXXFLAGS_GNUCXX1Z     = -std=gnu++1z
++QMAKE_CXXFLAGS_SPLIT_SECTIONS = $$QMAKE_CFLAGS_SPLIT_SECTIONS
++
++QMAKE_INCDIR                =
++
++QMAKE_RUN_CC                = $(CC) -c $(CFLAGS) $(INCPATH) -o $obj $src
++QMAKE_RUN_CC_IMP            = $(CC) -c $(CFLAGS) $(INCPATH) -o $@ $<
++QMAKE_RUN_CXX               = $(CXX) -c $(CXXFLAGS) $(INCPATH) -o $obj $src
++QMAKE_RUN_CXX_IMP           = $(CXX) -c $(CXXFLAGS) $(INCPATH) -o $@ $<
++
++QMAKE_LINK                  = $${CROSS_COMPILE}g++
++QMAKE_LINK_C                = $${CROSS_COMPILE}gcc
++QMAKE_LFLAGS                = -g
++QMAKE_LFLAGS_EXCEPTIONS_ON  = -mthreads
++QMAKE_LFLAGS_EXCEPTIONS_OFF =
++QMAKE_LFLAGS_RELEASE        =
++QMAKE_LFLAGS_DEBUG          =
++QMAKE_LFLAGS_CONSOLE        = -Wl,-subsystem,console
++QMAKE_LFLAGS_WINDOWS        = -Wl,-subsystem,windows
++QMAKE_LFLAGS_DLL            = -shared
++QMAKE_LFLAGS_CXX11          =
++QMAKE_LFLAGS_CXX14          =
++QMAKE_LFLAGS_CXX1Z          =
++QMAKE_LFLAGS_GCSECTIONS     = -Wl,--gc-sections
++QMAKE_LINK_OBJECT_MAX       = 10
++QMAKE_LINK_OBJECT_SCRIPT    = object_script
++QMAKE_PREFIX_SHLIB          =
++QMAKE_EXTENSION_SHLIB       = dll
++QMAKE_PREFIX_STATICLIB      = lib
++QMAKE_EXTENSION_STATICLIB   = a
++QMAKE_EXTENSION_IMPORTLIB   = dll.a
++
++QMAKE_IDL                   = $${CROSS_COMPILE}widl
++QMAKE_LIB                   = $${CROSS_COMPILE}ar -rc
++QMAKE_RC                    = $${CROSS_COMPILE}windres
++QMAKE_DLLTOOL               = $${CROSS_COMPILE}dlltool
++QMAKE_LRELEASE              = $${CROSS_COMPILE}lrelease-qt5
++
++QMAKE_STRIP                 = $${CROSS_COMPILE}strip
++QMAKE_STRIPFLAGS_LIB       += --strip-unneeded
++QMAKE_OBJCOPY               = $${CROSS_COMPILE}objcopy
++QMAKE_NM                    = $${CROSS_COMPILE}nm -P
++
++PKG_CONFIG                  = $${CROSS_COMPILE}pkg-config
++QMAKE_PKG_CONFIG            = $${CROSS_COMPILE}pkg-config
++
++QMAKE_LIBS                  =
++QMAKE_LIBS_CORE             = -lz -lpcre2-16 -lversion -lole32 -luuid -lwinmm -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32
++QMAKE_LIBS_GUI              = -lgdi32 -lcomdlg32 -loleaut32 -limm32 -lwinmm -lws2_32 -lole32 -luuid -luser32 -ladvapi32 -ljpeg -lpng \
++                              $$system($${QMAKE_PKG_CONFIG} --static --libs harfbuzz) \
++                              $$system($${QMAKE_PKG_CONFIG} --static --libs freetype2)
++QMAKE_LIBS_NETWORK          = -lws2_32 -lcrypt32 -ldnsapi
++QMAKE_LIBS_NETWORK_STATIC   = $${CROSS_COMPILE_PREFIX}/lib/qtbase/openssl-1.0/libssl.a $${CROSS_COMPILE_PREFIX}/lib/openssl-1.0/libcrypto.a -lgdi32
++QMAKE_LIBS_DBUS             = $$system($${QMAKE_PKG_CONFIG} --static --libs dbus-1)
++QMAKE_LIBS_OPENGL           = -lglu32 -lopengl32 -lgdi32 -luser32
++QMAKE_LIBS_OPENGL_ES2       = -l$${LIBEGL_NAME} -l$${LIBGLESV2_NAME} -ld3d9 -ldxguid -lgdi32 -luser32
++QMAKE_LIBS_OPENGL_ES2_DEBUG = -l$${LIBEGL_NAME} -l$${LIBGLESV2_NAME} -ld3d9 -ldxguid -lgdi32 -luser32
++QMAKE_LIBS_COMPAT           = -ladvapi32 -lshell32 -lcomdlg32 -luser32 -lgdi32 -lws2_32
++QMAKE_LIBS_QT_ENTRY         = -lmingw32 -lqt5main
++
++load(qt_config)
+diff --git a/qtbase/mkspecs/mingw-w64-g++/qplatformdefs.h b/qtbase/mkspecs/mingw-w64-g++/qplatformdefs.h
+new file mode 100644
+index 0000000000..c5a70b1445
+--- /dev/null
++++ b/qtbase/mkspecs/mingw-w64-g++/qplatformdefs.h
+@@ -0,0 +1,155 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the qmake spec of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QPLATFORMDEFS_H
++#define QPLATFORMDEFS_H
++
++#ifdef UNICODE
++#ifndef _UNICODE
++#define _UNICODE
++#endif
++#endif
++
++// Get Qt defines/settings
++
++#include "qglobal.h"
++
++#include <tchar.h>
++#include <io.h>
++#include <direct.h>
++#include <stdio.h>
++#include <fcntl.h>
++#include <errno.h>
++#include <sys/stat.h>
++#include <stdlib.h>
++#include <limits.h>
++
++#if !defined(_WIN32_WINNT) || (_WIN32_WINNT-0 < 0x0500)
++typedef enum {
++    NameUnknown           = 0,
++    NameFullyQualifiedDN  = 1,
++    NameSamCompatible     = 2,
++    NameDisplay           = 3,
++    NameUniqueId          = 6,
++    NameCanonical         = 7,
++    NameUserPrincipal     = 8,
++    NameCanonicalEx       = 9,
++    NameServicePrincipal  = 10,
++    NameDnsDomain         = 12
++} EXTENDED_NAME_FORMAT, *PEXTENDED_NAME_FORMAT;
++#endif
++
++#ifdef QT_LARGEFILE_SUPPORT
++#define QT_STATBUF              struct _stati64         // non-ANSI defs
++#define QT_STATBUF4TSTAT        struct _stati64         // non-ANSI defs
++#define QT_STAT                 ::_stati64
++#define QT_FSTAT                ::_fstati64
++#else
++#define QT_STATBUF              struct _stat            // non-ANSI defs
++#define QT_STATBUF4TSTAT        struct _stat            // non-ANSI defs
++#define QT_STAT                 ::_stat
++#define QT_FSTAT                ::_fstat
++#endif
++#define QT_STAT_REG             _S_IFREG
++#define QT_STAT_DIR             _S_IFDIR
++#define QT_STAT_MASK            _S_IFMT
++#if defined(_S_IFLNK)
++#  define QT_STAT_LNK           _S_IFLNK
++#endif
++#define QT_FILENO               _fileno
++#define QT_OPEN                 ::_open
++#define QT_CLOSE                ::_close
++#ifdef QT_LARGEFILE_SUPPORT
++#define QT_LSEEK                ::_lseeki64
++#ifndef UNICODE
++#define QT_TSTAT                ::_stati64
++#else
++#define QT_TSTAT                ::_wstati64
++#endif
++#else
++#define QT_LSEEK                ::_lseek
++#ifndef UNICODE
++#define QT_TSTAT                ::_stat
++#else
++#define QT_TSTAT                ::_wstat
++#endif
++#endif
++#define QT_READ                 ::_read
++#define QT_WRITE                ::_write
++#define QT_ACCESS               ::_access
++#define QT_GETCWD               ::_getcwd
++#define QT_CHDIR                ::_chdir
++#define QT_MKDIR                ::_mkdir
++#define QT_RMDIR                ::_rmdir
++#define QT_OPEN_LARGEFILE       0
++#define QT_OPEN_RDONLY          _O_RDONLY
++#define QT_OPEN_WRONLY          _O_WRONLY
++#define QT_OPEN_RDWR            _O_RDWR
++#define QT_OPEN_CREAT           _O_CREAT
++#define QT_OPEN_TRUNC           _O_TRUNC
++#define QT_OPEN_APPEND          _O_APPEND
++#if defined(O_TEXT)
++# define QT_OPEN_TEXT           _O_TEXT
++# define QT_OPEN_BINARY         _O_BINARY
++#endif
++
++#include "../common/c89/qplatformdefs.h"
++
++#ifdef QT_LARGEFILE_SUPPORT
++#undef QT_FSEEK
++#undef QT_FTELL
++#undef QT_OFF_T
++
++#define QT_FSEEK                ::fseeko64
++#define QT_FTELL                ::ftello64
++#define QT_OFF_T                off64_t
++#endif
++
++#define QT_SIGNAL_ARGS          int
++
++#define QT_VSNPRINTF            ::_vsnprintf
++#define QT_SNPRINTF             ::_snprintf
++
++# define F_OK   0
++# define X_OK   1
++# define W_OK   2
++# define R_OK   4
++
++
++#endif // QPLATFORMDEFS_H
+-- 
+2.13.2
+

--- a/depends/patches/qt59/0001-Fix-linguist-macro.patch
+++ b/depends/patches/qt59/0001-Fix-linguist-macro.patch
@@ -1,0 +1,42 @@
+From 74188cdf0f85a90bf86f251480d6a41b7ea61be2 Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Sun, 25 Sep 2016 21:44:42 +0200
+Subject: [PATCH] Fix linguist macro
+
+- Prevent CMake appending extra 'Qt5::lupdate'/'Qt5::lrelease' to
+  command line when invoking lupdate/lrelease
+- Achieved by resolveing the IMPORTED_LOCATION manually
+---
+ src/linguist/Qt5LinguistToolsMacros.cmake | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/linguist/Qt5LinguistToolsMacros.cmake b/qttools/src/linguist/Qt5LinguistToolsMacros.cmake
+index 6013cc6e..2e797326 100644
+--- a/qttools/src/linguist/Qt5LinguistToolsMacros.cmake
++++ b/qttools/src/linguist/Qt5LinguistToolsMacros.cmake
+@@ -71,8 +71,10 @@ function(QT5_CREATE_TRANSLATION _qm_files)
+ 
+           file(WRITE ${_ts_lst_file} "${_lst_file_srcs}")
+         endif()
++
++        get_target_property(LUPDATE_LOC ${Qt5_LUPDATE_EXECUTABLE} IMPORTED_LOCATION)
+         add_custom_command(OUTPUT ${_ts_file}
+-            COMMAND ${Qt5_LUPDATE_EXECUTABLE}
++            COMMAND ${LUPDATE_LOC}
+             ARGS ${_lupdate_options} "@${_ts_lst_file}" -ts ${_ts_file}
+             DEPENDS ${_my_sources} ${_ts_lst_file} VERBATIM)
+     endforeach()
+@@ -93,8 +95,9 @@ function(QT5_ADD_TRANSLATION _qm_files)
+             set(qm "${CMAKE_CURRENT_BINARY_DIR}/${qm}.qm")
+         endif()
+ 
++        get_target_property(LRELEASE_LOC ${Qt5_LRELEASE_EXECUTABLE} IMPORTED_LOCATION)
+         add_custom_command(OUTPUT ${qm}
+-            COMMAND ${Qt5_LRELEASE_EXECUTABLE}
++            COMMAND ${LRELEASE_LOC}
+             ARGS ${_abs_FILE} -qm ${qm}
+             DEPENDS ${_abs_FILE} VERBATIM
+         )
+-- 
+2.13.2
+

--- a/depends/patches/qt59/0005-Make-sure-.pc-files-are-installed-correctly.patch
+++ b/depends/patches/qt59/0005-Make-sure-.pc-files-are-installed-correctly.patch
@@ -1,0 +1,66 @@
+From 6c77b092c06551fbbed5df56e674f7ce0370a02a Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Sun, 18 Sep 2016 13:54:12 +0200
+Subject: [PATCH 05/31] Make sure *.pc files are installed correctly
+
+---
+ qmake/generators/makefile.cpp          | 8 ++++++--
+ qmake/generators/makefile.h            | 2 +-
+ qmake/generators/win32/winmakefile.cpp | 2 +-
+ 3 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/qtbase/qmake/generators/makefile.cpp b/qtbase/qmake/generators/makefile.cpp
+index a1f3352aa3..0be4b1ef01 100644
+--- a/qtbase/qmake/generators/makefile.cpp
++++ b/qtbase/qmake/generators/makefile.cpp
+@@ -3146,7 +3146,7 @@ MakefileGenerator::openOutput(QFile &file, const QString &build) const
+ }
+ 
+ QString
+-MakefileGenerator::pkgConfigFileName(bool fixify)
++MakefileGenerator::pkgConfigFileName(bool fixify, bool onlyPrependDestdir)
+ {
+     QString ret = project->first("QMAKE_PKGCONFIG_FILE").toQString();
+     if (ret.isEmpty()) {
+@@ -3171,7 +3171,11 @@ MakefileGenerator::pkgConfigFileName(bool fixify)
+     if(fixify) {
+         if(QDir::isRelativePath(ret) && !project->isEmpty("DESTDIR"))
+             ret.prepend(project->first("DESTDIR").toQString());
+-        ret = fileFixify(ret, FileFixifyBackwards);
++        if (onlyPrependDestdir) {
++            ret = Option::fixPathToLocalOS(ret);
++        } else {
++            ret = fileFixify(ret, FileFixifyBackwards);
++        }
+     }
+     return ret;
+ }
+diff --git a/qtbase/qmake/generators/makefile.h b/qtbase/qmake/generators/makefile.h
+index 4ced3bd121..f7cc3b9e9b 100644
+--- a/qtbase/qmake/generators/makefile.h
++++ b/qtbase/qmake/generators/makefile.h
+@@ -89,7 +89,7 @@ protected:
+     virtual void writeDefaultVariables(QTextStream &t);
+ 
+     QString pkgConfigPrefix() const;
+-    QString pkgConfigFileName(bool fixify=true);
++    QString pkgConfigFileName(bool fixify=true, bool onlyPrependDestdir = false);
+     QString pkgConfigFixPath(QString) const;
+     void writePkgConfigFile();   // for pkg-config
+ 
+diff --git a/qtbase/qmake/generators/win32/winmakefile.cpp b/qtbase/qmake/generators/win32/winmakefile.cpp
+index 75bb5d236d..737f3abc3a 100644
+--- a/qtbase/qmake/generators/win32/winmakefile.cpp
++++ b/qtbase/qmake/generators/win32/winmakefile.cpp
+@@ -726,7 +726,7 @@ QString Win32MakefileGenerator::defaultInstall(const QString &t)
+                 }
+                 if(!ret.isEmpty())
+                     ret += "\n\t";
+-                ret += installMetaFile(ProKey("QMAKE_PKGCONFIG_INSTALL_REPLACE"), pkgConfigFileName(true), dst_pc);
++                ret += installMetaFile(ProKey("QMAKE_PKGCONFIG_INSTALL_REPLACE"), pkgConfigFileName(true, true), dst_pc);
+                 if(!uninst.isEmpty())
+                     uninst.append("\n\t");
+                 uninst.append("-$(DEL_FILE) " + escapeFilePath(dst_pc));
+-- 
+2.13.2
+

--- a/depends/patches/qt59/0008-Fix-linking-against-shared-static-libpng.patch
+++ b/depends/patches/qt59/0008-Fix-linking-against-shared-static-libpng.patch
@@ -1,0 +1,27 @@
+From dcc3c951ab71f84f0cc32ffd75ac375b56de1e1a Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Thu, 26 Jan 2017 17:51:31 +0100
+Subject: [PATCH 08/31] Fix linking against shared/static libpng
+
+Change-Id: Ic7a0ec9544059b8e647a5d0186f1b88c00911dcf
+---
+ src/gui/configure.json | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/qtbase/src/gui/configure.json b/qtbase/src/gui/configure.json
+index 2fb03a452a..3f07fba4d5 100644
+--- a/qtbase/src/gui/configure.json
++++ b/qtbase/src/gui/configure.json
+@@ -176,7 +176,8 @@
+             "sources": [
+                 { "type": "pkgConfig", "args": "libpng" },
+                 { "libs": "-llibpng", "condition": "config.msvc" },
+-                { "libs": "-lpng", "condition": "!config.msvc" }
++                { "libs": "-lpng -lz", "condition": "!config.msvc && !features.shared" },
++                { "libs": "-lpng", "condition": "!config.msvc && features.shared" }
+             ],
+             "use": [
+                 { "lib": "zlib", "condition": "features.system-zlib" }
+-- 
+2.13.2
+

--- a/depends/patches/qt59/0011-Fix-linking-against-static-freetype2.patch
+++ b/depends/patches/qt59/0011-Fix-linking-against-static-freetype2.patch
@@ -1,0 +1,30 @@
+From 531643d6b3f73cd23ccd6e8d1229874c306d3057 Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Fri, 3 Feb 2017 20:51:19 +0100
+Subject: [PATCH 11/31] Fix linking against static freetype2
+
+---
+ src/gui/configure.json | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/qtbase/src/gui/configure.json b/qtbase/src/gui/configure.json
+index 3f07fba4d5..b000d00801 100644
+--- a/qtbase/src/gui/configure.json
++++ b/qtbase/src/gui/configure.json
+@@ -107,8 +107,11 @@
+             "label": "FreeType",
+             "test": "unix/freetype",
+             "sources": [
+-                { "type": "pkgConfig", "args": "freetype2" },
+-                { "type": "freetype", "libs": "-lfreetype" }
++                { "type": "pkgConfig", "args": "--static --libs freetype2", "condition": "!features.shared" },
++                { "type": "pkgConfig", "args": "--libs freetype2", "condition": "features.shared" },
++                { "libs": "-lfreetype -lharfbuzz -lfreetype -lglib-2.0 -lintl -lws2_32 -lole32 -lwinmm -lshlwapi -lpcre -lintl -lpcre -lintl -liconv -lgraphite2 -lbz2", "condition": "!features.shared" },
++                { "libs": "-Wl,-Bdynamic -lfreetype -Wl,-Bstatic", "condition": "!features.shared" },
++                { "libs": "-lfreetype", "condition": "features.shared" }
+             ]
+         },
+         "fontconfig": {
+-- 
+2.13.2
+

--- a/depends/patches/qt59/0012-Fix-linking-against-static-harfbuzz.patch
+++ b/depends/patches/qt59/0012-Fix-linking-against-static-harfbuzz.patch
@@ -1,0 +1,29 @@
+From 3b6fa1aeceb994d9d845f6de533c6c1517e56ab8 Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Sun, 18 Sep 2016 14:22:56 +0200
+Subject: [PATCH 12/31] Fix linking against static harfbuzz
+
+---
+ src/gui/configure.json | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/qtbase/src/gui/configure.json b/qtbase/src/gui/configure.json
+index b000d00801..5ba7fa26ae 100644
+--- a/qtbase/src/gui/configure.json
++++ b/qtbase/src/gui/configure.json
+@@ -133,7 +133,11 @@
+             "label": "HarfBuzz",
+             "test": "unix/harfbuzz",
+             "sources": [
+-                "-lharfbuzz"
++                { "type": "pkgConfig", "args": "--static --libs harfbuzz", "condition": "!features.shared" },
++                { "type": "pkgConfig", "args": "--libs harfbuzz", "condition": "features.shared" },
++                { "libs": "-lharfbuzz  -lfreetype -lharfbuzz -lglib-2.0 -lintl -lws2_32 -lole32 -lwinmm -lshlwapi -lpcre -lintl -lpcre -lintl -liconv -lgraphite2 -lbz2", "condition": "!features.shared" },
++                { "libs": "-Wl,-Bdynamic -lharfbuzz -Wl,-Bstatic", "condition": "!features.shared" },
++                { "libs": "-lharfbuzz", "condition": "features.shared" }
+             ]
+         },
+         "imf": {
+-- 
+2.13.2
+

--- a/depends/patches/qt59/0013-Fix-linking-against-static-pcre.patch
+++ b/depends/patches/qt59/0013-Fix-linking-against-static-pcre.patch
@@ -1,0 +1,28 @@
+From f5a1650b08d90f854b1b8eb12c0e6b9a5c3f5cc4 Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Sun, 18 Sep 2016 14:24:01 +0200
+Subject: [PATCH 13/33] Fix linking against static pcre
+
+Change-Id: I3225c6e82dc4d17aef37d4289c16eb7a5ea3c5a1
+---
+ src/corelib/tools/qregularexpression.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/qtbase/src/corelib/tools/qregularexpression.cpp b/qtbase/src/corelib/tools/qregularexpression.cpp
+index 88b696f53a..afe444027e 100644
+--- a/qtbase/src/corelib/tools/qregularexpression.cpp
++++ b/qtbase/src/corelib/tools/qregularexpression.cpp
+@@ -55,6 +55,10 @@
+ #include <QtCore/qdatastream.h>
+ 
+ #define PCRE2_CODE_UNIT_WIDTH 16
++#ifdef QT_STATIC
++#define PCRE_STATIC
++#define PCRE2_STATIC
++#endif
+ 
+ #include <pcre2.h>
+ 
+-- 
+2.14.2
+

--- a/depends/patches/qt59/0021-Use-.dll.a-as-import-lib-extension.patch
+++ b/depends/patches/qt59/0021-Use-.dll.a-as-import-lib-extension.patch
@@ -1,0 +1,68 @@
+From 049d164d606149cb8b7052dfa8fd67c55e135fa8 Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Sun, 18 Sep 2016 18:26:18 +0200
+Subject: [PATCH 21/31] Use *.dll.a as import lib extension
+
+The variables used here are provided by
+mingw-w64 specific mkspec
+---
+ mkspecs/features/create_cmake.prf      |  5 +++--
+ qmake/generators/win32/winmakefile.cpp | 17 ++++++++++++-----
+ 2 files changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/qtbase/mkspecs/features/create_cmake.prf b/qtbase/mkspecs/features/create_cmake.prf
+index 146e83ae67..15fc070008 100644
+--- a/qtbase/mkspecs/features/create_cmake.prf
++++ b/qtbase/mkspecs/features/create_cmake.prf
+@@ -236,8 +236,9 @@ mac {
+             CMAKE_PRL_FILE_LOCATION_DEBUG = lib$${CMAKE_QT_STEM}d.prl
+             CMAKE_PRL_FILE_LOCATION_RELEASE = lib$${CMAKE_QT_STEM}.prl
+         } else {
+-            CMAKE_IMPLIB_FILE_LOCATION_DEBUG = lib$${CMAKE_QT_STEM}d.a
+-            CMAKE_IMPLIB_FILE_LOCATION_RELEASE = lib$${CMAKE_QT_STEM}.a
++            isEmpty(QMAKE_EXTENSION_IMPORTLIB): QMAKE_EXTENSION_IMPORTLIB = a
++            CMAKE_IMPLIB_FILE_LOCATION_DEBUG = lib$${CMAKE_QT_STEM}d.$${QMAKE_EXTENSION_IMPORTLIB}
++            CMAKE_IMPLIB_FILE_LOCATION_RELEASE = lib$${CMAKE_QT_STEM}.$${QMAKE_EXTENSION_IMPORTLIB}
+         }
+     } else {
+         CMAKE_WINMAIN_FILE_LOCATION_DEBUG = qtmain$${QT_LIBINFIX}d.lib
+diff --git a/qtbase/qmake/generators/win32/winmakefile.cpp b/qtbase/qmake/generators/win32/winmakefile.cpp
+index 737f3abc3a..2e6d5d94a9 100644
+--- a/qtbase/qmake/generators/win32/winmakefile.cpp
++++ b/qtbase/qmake/generators/win32/winmakefile.cpp
+@@ -80,10 +80,14 @@ Win32MakefileGenerator::parseLibFlag(const ProString &flag, ProString *arg)
+ bool
+ Win32MakefileGenerator::findLibraries(bool linkPrl, bool mergeLflags)
+ {
+-    ProStringList impexts = project->values("QMAKE_LIB_EXTENSIONS");
+-    if (impexts.isEmpty())
+-        impexts = project->values("QMAKE_EXTENSION_STATICLIB");
+-    QList<QMakeLocalFileName> dirs;
++  ProStringList impexts;
++  if (project->isActiveConfig("staticlib")) {
++    impexts.append(project->values("QMAKE_EXTENSION_STATICLIB"));
++  } else {
++    impexts.append(project->values("QMAKE_EXTENSION_IMPORTLIB"));
++    impexts.append(project->values("QMAKE_EXTENSION_STATICLIB"));
++  }
++  QList<QMakeLocalFileName> dirs;
+   static const char * const lflags[] = { "QMAKE_LIBS", "QMAKE_LIBS_PRIVATE", 0 };
+   for (int i = 0; lflags[i]; i++) {
+     ProStringList &l = project->values(lflags[i]);
+@@ -234,9 +238,12 @@ void Win32MakefileGenerator::fixTargetExt()
+     if (!project->values("QMAKE_APP_FLAG").isEmpty()) {
+         project->values("TARGET_EXT").append(".exe");
+     } else if (project->isActiveConfig("shared")) {
++        ProString impext = project->first("QMAKE_EXTENSION_IMPORTLIB");
++        if (impext.isEmpty())
++          impext = project->first("QMAKE_PREFIX_STATICLIB");
+         project->values("LIB_TARGET").prepend(project->first("QMAKE_PREFIX_STATICLIB")
+                                               + project->first("TARGET") + project->first("TARGET_VERSION_EXT")
+-                                              + '.' + project->first("QMAKE_EXTENSION_STATICLIB"));
++                                              + '.' + impext);
+         project->values("TARGET_EXT").append(project->first("TARGET_VERSION_EXT") + "."
+                 + project->first("QMAKE_EXTENSION_SHLIB"));
+         project->values("TARGET").first() = project->first("QMAKE_PREFIX_SHLIB") + project->first("TARGET");
+-- 
+2.13.2
+

--- a/depends/patches/qt59/0030-Prevent-qmake-from-messing-static-lib-dependencies.patch
+++ b/depends/patches/qt59/0030-Prevent-qmake-from-messing-static-lib-dependencies.patch
@@ -1,0 +1,43 @@
+From a24b99d6679a8ca39fdaa90e35a4fd4c4e3d60c8 Mon Sep 17 00:00:00 2001
+From: Martchus <martchus@gmx.net>
+Date: Tue, 7 Feb 2017 18:25:28 +0100
+Subject: [PATCH 30/31] Prevent qmake from messing static lib dependencies
+
+In particular, it messes resolving cyclic dependency between
+static freetype2 and harfbuzz
+---
+ qmake/generators/unix/unixmake.cpp     | 3 +++
+ qmake/generators/win32/winmakefile.cpp | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/qtbase/qmake/generators/unix/unixmake.cpp b/qtbase/qmake/generators/unix/unixmake.cpp
+index 30f99174f8..154edd67d4 100644
+--- a/qtbase/qmake/generators/unix/unixmake.cpp
++++ b/qtbase/qmake/generators/unix/unixmake.cpp
+@@ -414,6 +414,9 @@ UnixMakefileGenerator::fixLibFlag(const ProString &lib)
+ bool
+ UnixMakefileGenerator::findLibraries(bool linkPrl, bool mergeLflags)
+ {
++    if(project->isActiveConfig("staticlib")) {
++        return false; // prevent qmake from messing static lib dependencies
++    }
+     QList<QMakeLocalFileName> libdirs, frameworkdirs;
+     int libidx = 0, fwidx = 0;
+     for (const ProString &dlib : project->values("QMAKE_DEFAULT_LIBDIRS"))
+diff --git a/qtbase/qmake/generators/win32/winmakefile.cpp b/qtbase/qmake/generators/win32/winmakefile.cpp
+index 2e6d5d94a9..a8320bae09 100644
+--- a/qtbase/qmake/generators/win32/winmakefile.cpp
++++ b/qtbase/qmake/generators/win32/winmakefile.cpp
+@@ -87,6 +87,9 @@ Win32MakefileGenerator::findLibraries(bool linkPrl, bool mergeLflags)
+     impexts.append(project->values("QMAKE_EXTENSION_IMPORTLIB"));
+     impexts.append(project->values("QMAKE_EXTENSION_STATICLIB"));
+   }
++  if(project->isActiveConfig("staticlib")) {
++    return false; // prevent qmake from messing static lib dependencies
++  }
+   QList<QMakeLocalFileName> dirs;
+   static const char * const lflags[] = { "QMAKE_LIBS", "QMAKE_LIBS_PRIVATE", 0 };
+   for (int i = 0; lflags[i]; i++) {
+-- 
+2.13.2
+

--- a/depends/patches/qt59/fix_qt_pkgconfig.patch
+++ b/depends/patches/qt59/fix_qt_pkgconfig.patch
@@ -1,0 +1,11 @@
+--- old/qtbase/mkspecs/features/qt_module.prf
++++ new/qtbase/mkspecs/features/qt_module.prf
+@@ -245,7 +245,7 @@
+ load(qt_targets)
+ 
+ # this builds on top of qt_common
+-!internal_module:!lib_bundle:if(unix|mingw) {
++unix|mingw {
+     CONFIG += create_pc
+     QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+     host_build: \

--- a/depends/patches/qt59/mac-qmake.conf
+++ b/depends/patches/qt59/mac-qmake.conf
@@ -1,0 +1,25 @@
+MAKEFILE_GENERATOR = UNIX
+CONFIG += app_bundle incremental global_init_link_order lib_version_first plugin_no_soname absolute_library_soname
+QMAKE_INCREMENTAL_STYLE = sublib
+include(../common/macx.conf)
+include(../common/gcc-base-mac.conf)
+include(../common/clang.conf)
+include(../common/clang-mac.conf)
+QMAKE_MAC_SDK_PATH=$${MAC_SDK_PATH}
+QMAKE_XCODE_VERSION=4.3
+QMAKE_XCODE_DEVELOPER_PATH=/Developer
+QMAKE_MACOSX_DEPLOYMENT_TARGET = $${MAC_MIN_VERSION}
+QMAKE_MAC_SDK=macosx
+QMAKE_MAC_SDK.macosx.Path = $${MAC_SDK_PATH}
+QMAKE_MAC_SDK.macosx.platform_name = macosx
+QMAKE_MAC_SDK.macosx.SDKVersion = $${MAC_SDK_VERSION}
+QMAKE_MAC_SDK.macosx.PlatformPath = /phony
+!host_build: QMAKE_CFLAGS += -target $${MAC_TARGET}
+!host_build: QMAKE_OBJECTIVE_CFLAGS += $$QMAKE_CFLAGS
+!host_build: QMAKE_CXXFLAGS += $$QMAKE_CFLAGS
+!host_build: QMAKE_LFLAGS += -target $${MAC_TARGET} -mlinker-version=$${MAC_LD64_VERSION}
+QMAKE_AR = $${CROSS_COMPILE}ar cq
+QMAKE_RANLIB=$${CROSS_COMPILE}ranlib
+QMAKE_LIBTOOL=$${CROSS_COMPILE}libtool
+QMAKE_INSTALL_NAME_TOOL=$${CROSS_COMPILE}install_name_tool
+load(qt_config)

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -104,6 +104,21 @@ Then build using:
     CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
     make
 
+Ubuntu Bionic Beaver 18.04:
+
+    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+
+Bionic Beaver has a modern mingw version. You can therefore use it to build the
+Gridcoin Wallet with Qt5.9.4 and subsequently enable charting of vote results
+in the wallet. Follow these steps:
+
+    cd depends
+    make HOST=x86_64-w64-mingw32 QT_59=1
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/ --enable-qt59
+    make
+
 ## Building for 32-bit Windows
 
 To build executables for Windows 32-bit, install the following dependencies:

--- a/src/qt/votingdialog.h
+++ b/src/qt/votingdialog.h
@@ -22,6 +22,7 @@
 
 #ifdef QT_CHARTS_LIB
 #include <QtCharts/QChartGlobal>
+#include <QtCharts>
 QT_CHARTS_BEGIN_NAMESPACE
 class QChart;
 QT_CHARTS_END_NAMESPACE
@@ -213,7 +214,7 @@ private:
     QPushButton *voteButton;
     QString GetVoteValue(void);
     QString sVoteTitle;
-    
+
 private slots:
     void vote(void);
 };


### PR DESCRIPTION
To build Qt5.9 in depends build with: `make HOST=$triple QT_59=1`.
Then configure with: CONFIG_SITE=`pwd`/depends/$triple/share/config.site ./configure --prefix=/ --enable-qt59