### PR TITLE
Allow to Disable staking in Config.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -804,6 +804,13 @@ bool IsMiningAllowed(CWallet *pwallet)
         status=false;
     }
 
+    if(false==GetBoolArg("-staking",true))
+    {
+        LOCK(MinerStatus.lock);
+        MinerStatus.ReasonNotStaking+=_("Disabled in Config; ");
+        status=false;
+    }
+
     if(fDevbuildCripple)
     {
         LOCK(MinerStatus.lock);


### PR DESCRIPTION
shmoogleosukami 8:48
Staking=0 in config should work right. Thats what exchanges do i think.
gridcoin2moon 10:25
what is the reason that exchanges don't want their wallet to stake? @shmoogleosukami
sounds like free money for them...
shmoogleosukami 10:28
I donno. It complicates accounting i guess. Ethics perhaps them making money off of other peoples coins
gridcoin2moon 11:16
okay ty 🙂
timo425 12:44
Perhaps if they staked they would be forced by law to give the profits to clients or something and they are an exchange not a bank.. Just guessing wildly here
brod 12:55
Staking=0 does nothing. todo 