### PR TITLE
add bool conversion for listtransactions

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1199,6 +1199,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "sendfrom"               && n > 3) ConvertTo<int64_t>(params[3]);
     if (strMethod == "listtransactions"       && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "listtransactions"       && n > 2) ConvertTo<int64_t>(params[2]);
+    if (strMethod == "listtransactions"       && n > 3) ConvertTo<bool>(params[3]);
     if (strMethod == "listaccounts"           && n > 0) ConvertTo<int64_t>(params[0]);
     if (strMethod == "walletpassphrase"       && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "walletpassphrase"       && n > 2) ConvertTo<bool>(params[2]);


### PR DESCRIPTION
#1055 

Add bool conversion. default this is false however since the beginning of time we have not been able to set this bool due to a string to bool conversion problem (which i fixed in rpc overhaul).

I do not know if this will address the flype.me issue but when you set the bool to true via argument send transactions show in the list. The code is pretty much identical to bitcoins thou bitcoin has the conversion fix in.

This may be why flype.me had issue as they could never specify the bool. I'm not aware of how to request the same data from bitcoin or any other wallet without that information I cannot dip much further.

i'm open to ideas but it would be better if flype.me would provide similar requests they do to bitcoin so i can verify its not different as i'm sure (with limited information) that they are using all arguments with other wallets but unable to do so with gridcoin rpc.