### PR TITLE
Poll Refactor 

### DIFF
--- a/src/contract/polls.h
+++ b/src/contract/polls.h
@@ -56,8 +56,6 @@ std::string PollAnswers(std::string pollname);
 
 std::string GetProvableVotingWeightXML();
 
-std::string GetShareType(double dShareType);
-
 double ReturnVerifiedVotingBalance(std::string sXML, bool bCreatedAfterSecurityUpgrade);
 
 double ReturnVerifiedVotingMagnitude(std::string sXML, bool bCreatedAfterSecurityUpgrade);

--- a/src/contract/polls.h
+++ b/src/contract/polls.h
@@ -5,6 +5,31 @@
 #include <string>
 #include <utility> //std::pair
 
+namespace polling {
+
+struct Vote {
+    std::string answer;
+    double shares;
+    double participants;
+};
+
+struct Poll {
+    std::string title;
+    std::string question;
+    std::string url;
+    std::string expiration;
+    std::string sharetype;
+    std::string type;
+    std::vector<Vote> answers;
+    std::string sAnswers;
+    double highest_share;
+    double total_shares;
+    double total_participants;
+    std::string best_answer;
+    int pollnumber;
+};
+};
+
 std::pair<std::string, std::string> CreatePollContract(std::string sTitle, int days, std::string sQuestion, std::string sAnswers, int sSharetype, std::string sURL);
 
 std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::string sAnswer);
@@ -38,6 +63,10 @@ double ReturnVerifiedVotingBalance(std::string sXML, bool bCreatedAfterSecurityU
 double ReturnVerifiedVotingMagnitude(std::string sXML, bool bCreatedAfterSecurityUpgrade);
 
 double GetMoneySupplyFactor();
+
+UniValue getjsonpoll(bool bDetail, bool includeExpired, std::string byTitle);
+
+std::vector<polling::Poll> GetPolls(bool bDetail, bool includeExpired, std::string byTitle);
 
 UniValue GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string& out_export, bool IncludeExpired);
 

--- a/src/contract/rpccontract.cpp
+++ b/src/contract/rpccontract.cpp
@@ -49,7 +49,7 @@ UniValue listallpolls(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
     std::string out1;
-    UniValue res = GetJSONPollsReport(false, "", out1, true);
+    UniValue res = getjsonpoll(false, true, "");
     return res;
 }
 
@@ -63,7 +63,7 @@ UniValue listallpolldetails(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
     std::string out1;
-    UniValue res = GetJSONPollsReport(true, "", out1, true);
+    UniValue res = getjsonpoll(true, true, "");
     return res;
 }
 
@@ -77,7 +77,7 @@ UniValue listpolldetails(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
     std::string out1;
-    UniValue res = GetJSONPollsReport(true, "", out1, false);
+    UniValue res = getjsonpoll(true, false, "");
     return res;
 }
 
@@ -112,7 +112,7 @@ UniValue listpollresults(const UniValue& params, bool fHelp)
     {
         std::string Title = params[0].get_str();
         std::string out1 = "";
-        UniValue myPolls = GetJSONPollsReport(true, Title, out1, bIncExpired);
+        UniValue myPolls = getjsonpoll(true, bIncExpired, Title);
         res.push_back(myPolls);
     }
     return res;
@@ -128,7 +128,7 @@ UniValue listpolls(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
     std::string out1;
-    UniValue res = GetJSONPollsReport(false, "", out1, false);
+    UniValue res = getjsonpoll(false, false, "");
     return res;
 }
 

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -31,7 +31,6 @@
 
 #include "votingdialog.h"
 #include "util.h"
-#include "contract/polls.h"
 
 extern std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 
@@ -252,41 +251,46 @@ void VotingTableModel::resetData(bool history)
     // retrieve data
     std::vector<VotingItem *> items;
     std::string sVotingPayload;
-    GetJSONPollsReport(true, "", sVotingPayload, history);
+    //GetJSONPollsReport(true, "", sVotingPayload, history);
+    Polls = GetPolls(true, history, "");
 
     //time_t now = time(NULL); // needed if history should be limited
 
-    std::vector<std::string> vPolls = split(sVotingPayload, "<POLL>");
-    for(size_t y=0; y < vPolls.size(); y++) {
-        // replace underscores with spaces
-        for(size_t nPos=0; (nPos=vPolls[y].find('_', nPos)) != std::string::npos; )
-            vPolls[y][nPos] = ' ';
+    //std::vector<std::string> vPolls = split(sVotingPayload, "<POLL>");
+    for(const auto& iterPoll: Polls)
+    {
 
-        std::string sTitle = ExtractXML(vPolls[y], "<TITLE>", "</TITLE>");
+    //for(size_t y=0; y < vPolls.size(); y++) {
+        // replace underscores with spaces
+        //for(size_t nPos=0; (nPos=vPolls[y].find('_', nPos)) != std::string::npos; )
+          //  vPolls[y][nPos] = ' ';
+
+        std::string sTitle = iterPoll.title;
         std::string sId = GetFoundationGuid(sTitle);
-        if (sTitle.size() && (sId.empty())) {
-            QString sExpiration = QString::fromStdString(ExtractXML(vPolls[y], "<EXPIRATION>", "</EXPIRATION>"));
-            std::string sShareType = ExtractXML(vPolls[y], "<SHARETYPE>", "</SHARETYPE>");
-            std::string sQuestion = ExtractXML(vPolls[y], "<QUESTION>", "</QUESTION>");
-            std::string sAnswers = ExtractXML(vPolls[y], "<ANSWERS>", "</ANSWERS>");
-            std::string sArrayOfAnswers = ExtractXML(vPolls[y], "<ARRAYANSWERS>", "</ARRAYANSWERS>");
-            std::string sTotalParticipants = ExtractXML(vPolls[y], "<TOTALPARTICIPANTS>", "</TOTALPARTICIPANTS>");
-            std::string sTotalShares = ExtractXML(vPolls[y], "<TOTALSHARES>", "</TOTALSHARES>");
-            std::string sUrl = ExtractXML(vPolls[y], "<URL>", "</URL>");
-            std::string sBestAnswer = ExtractXML(vPolls[y], "<BESTANSWER>", "</BESTANSWER>");
+        if (sTitle.size() && (sId.empty()))
+        {
+            QString sExpiration = QString::fromStdString(iterPoll.expiration);
+            //std::string sShareType = ExtractXML(vPolls[y], "<SHARETYPE>", "</SHARETYPE>");
+            //std::string sQuestion = ExtractXML(vPolls[y], "<QUESTION>", "</QUESTION>");
+            //std::string sAnswers = ExtractXML(vPolls[y], "<ANSWERS>", "</ANSWERS>");
+            //std::string sArrayOfAnswers = ExtractXML(vPolls[y], "<ARRAYANSWERS>", "</ARRAYANSWERS>");
+            //std::string sTotalParticipants = ExtractXML(vPolls[y], "<TOTALPARTICIPANTS>", "</TOTALPARTICIPANTS>");
+            //std::string sTotalShares = ExtractXML(vPolls[y], "<TOTALSHARES>", "</TOTALSHARES>");
+            //std::string sUrl = ExtractXML(vPolls[y], "<URL>", "</URL>");
+            //std::string sBestAnswer = ExtractXML(vPolls[y], "<BESTANSWER>", "</BESTANSWER>");
 
             VotingItem *item = new VotingItem;
             item->rowNumber_ = items.size() + 1;
-            item->title_ = QString::fromStdString(sTitle);
-            item->expiration_ = QDateTime::fromString(sExpiration, "M-d-yyyy HH:mm:ss");
-            item->shareType_ = QString::fromStdString(sShareType);
-            item->question_ = QString::fromStdString(sQuestion);
-            item->answers_ = QString::fromStdString(sAnswers);
-            item->arrayOfAnswers_ = QString::fromStdString(sArrayOfAnswers);
-            item->totalParticipants_ = std::stoul(sTotalParticipants);
-            item->totalShares_ = std::stoul(sTotalShares);
-            item->url_ = QString::fromStdString(sUrl);
-            item->bestAnswer_ = QString::fromStdString(sBestAnswer);
+            item->title_ = QString::fromStdString(iterPoll.title);
+            item->expiration_ = QDateTime::fromString(QString::fromStdString(iterPoll.expiration), "M-d-yyyy HH:mm:ss");
+            item->shareType_ = QString::fromStdString(iterPoll.sharetype);
+            item->question_ = QString::fromStdString(iterPoll.question);
+            item->answers_ = QString::fromStdString(iterPoll.sAnswers);
+            item->vectorOfAnswers_ = iterPoll.answers;
+            item->totalParticipants_ = iterPoll.total_participants;
+            item->totalShares_ = iterPoll.total_shares;
+            item->url_ = QString::fromStdString(iterPoll.url);
+            item->bestAnswer_ = QString::fromStdString(iterPoll.best_answer);
             items.push_back(item);
         }
     }
@@ -709,19 +713,20 @@ void VotingChartDialog::resetData(const VotingItem *item)
     url_->setText("<a href=\""+item->url_+"\">"+item->url_+"</a>");
     answer_->setText(item->bestAnswer_);
 
-    std::string arrayOfAnswers = item->arrayOfAnswers_.toUtf8().constData();
-    std::vector<std::string> vAnswers = split(arrayOfAnswers, "<RESERVED>"); // the first entry is empty
-    answerTable_->setRowCount(vAnswers.size()-1);
+    std::vector<polling::Vote> vectorOfAnswers = item->vectorOfAnswers_;
+    answerTable_->setRowCount(vectorOfAnswers.size()-1);
     std::vector<int> iShares;
     std::vector<QString> sAnswerNames;
     int sharesSum = 0;
-    for(size_t y=1; y < vAnswers.size(); y++) {
-        sAnswerNames.push_back(QString::fromStdString(ExtractXML(vAnswers[y], "<ANSWERNAME>", "</ANSWERNAME>")));
-        int iShare = atoi(ExtractXML(vAnswers[y], "<SHARES>", "</SHARES>").c_str());
-        iShares.push_back(iShare);
-        sharesSum += iShare;
+    //for(size_t y=1; y < vAnswers.size(); y++)
+    for(polling::Vote iterAnswer: vectorOfAnswers)
+    {
+        sAnswerNames.push_back(QString::fromStdString(iterAnswer.answer));
+        iShares.push_back(iterAnswer.shares);
+        sharesSum += iterAnswer.shares;
     }
-    for(size_t y=0; y < sAnswerNames.size(); y++) {
+    for(size_t y=0; y < sAnswerNames.size(); y++)
+    {
         answerTable_->setItem(y, 0, new QTableWidgetItem(sAnswerNames[y]));
         QTableWidgetItem *iSharesItem = new QTableWidgetItem();
         iSharesItem->setData(Qt::DisplayRole,iShares[y]);

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -251,34 +251,17 @@ void VotingTableModel::resetData(bool history)
     // retrieve data
     std::vector<VotingItem *> items;
     std::string sVotingPayload;
-    //GetJSONPollsReport(true, "", sVotingPayload, history);
     Polls = GetPolls(true, history, "");
 
     //time_t now = time(NULL); // needed if history should be limited
 
-    //std::vector<std::string> vPolls = split(sVotingPayload, "<POLL>");
     for(const auto& iterPoll: Polls)
     {
-
-    //for(size_t y=0; y < vPolls.size(); y++) {
-        // replace underscores with spaces
-        //for(size_t nPos=0; (nPos=vPolls[y].find('_', nPos)) != std::string::npos; )
-          //  vPolls[y][nPos] = ' ';
-
         std::string sTitle = iterPoll.title;
         std::string sId = GetFoundationGuid(sTitle);
         if (sTitle.size() && (sId.empty()))
         {
             QString sExpiration = QString::fromStdString(iterPoll.expiration);
-            //std::string sShareType = ExtractXML(vPolls[y], "<SHARETYPE>", "</SHARETYPE>");
-            //std::string sQuestion = ExtractXML(vPolls[y], "<QUESTION>", "</QUESTION>");
-            //std::string sAnswers = ExtractXML(vPolls[y], "<ANSWERS>", "</ANSWERS>");
-            //std::string sArrayOfAnswers = ExtractXML(vPolls[y], "<ARRAYANSWERS>", "</ARRAYANSWERS>");
-            //std::string sTotalParticipants = ExtractXML(vPolls[y], "<TOTALPARTICIPANTS>", "</TOTALPARTICIPANTS>");
-            //std::string sTotalShares = ExtractXML(vPolls[y], "<TOTALSHARES>", "</TOTALSHARES>");
-            //std::string sUrl = ExtractXML(vPolls[y], "<URL>", "</URL>");
-            //std::string sBestAnswer = ExtractXML(vPolls[y], "<BESTANSWER>", "</BESTANSWER>");
-
             VotingItem *item = new VotingItem;
             item->rowNumber_ = items.size() + 1;
             item->title_ = QString::fromStdString(iterPoll.title);
@@ -714,7 +697,7 @@ void VotingChartDialog::resetData(const VotingItem *item)
     answer_->setText(item->bestAnswer_);
 
     std::vector<polling::Vote> vectorOfAnswers = item->vectorOfAnswers_;
-    answerTable_->setRowCount(vectorOfAnswers.size()-1);
+    answerTable_->setRowCount(vectorOfAnswers.size());
     std::vector<int> iShares;
     std::vector<QString> sAnswerNames;
     int sharesSum = 0;

--- a/src/qt/votingdialog.h
+++ b/src/qt/votingdialog.h
@@ -1,6 +1,8 @@
 #ifndef VOTINGDIALOG_H
 #define VOTINGDIALOG_H
 
+#include "contract/polls.h"
+
 #include <time.h>
 #include <QAbstractTableModel>
 #include <QDialog>
@@ -50,7 +52,7 @@ public:
     QString shareType_;
     QString question_;
     QString answers_;
-    QString arrayOfAnswers_;
+    std::vector<polling::Vote> vectorOfAnswers_;
     unsigned int totalParticipants_;
     unsigned int totalShares_;
     QString url_;
@@ -100,6 +102,7 @@ public:
     void resetData(bool history);
 
 private:
+    std::vector<polling::Poll> Polls;
     QStringList columns_;
     QList<VotingItem *> data_;
 };


### PR DESCRIPTION
The mechanism to lookup the voting magnitude weight was changed. The BLOCKHASH field is dropped and everything is done with the HEIGHT field. This saves space in the blockchain and is faster to verify.

A data structure was created to hold the poll data. Rpc calls and voting consume this data separately without needing to know their respective formatting. 

This closes #996 