### PR TITLE
Implementation of global flag fQtActive

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -10,6 +10,7 @@ extern int nRegVersion;
 extern bool bNetAveragesLoaded;
 extern bool bForceUpdate;
 extern bool bGlobalcomInitialized;
+extern bool fQtActive;
 extern bool bGridcoinGUILoaded;
 
 struct StructCPID

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -121,6 +121,9 @@ int main(int argc, char* argv[])
 {
     bool fRet = false;
 
+    // Set global boolean to indicate intended absence of GUI to core...
+    fQtActive = false;
+
     // Connect bitcoind signal handlers
     noui_connect();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,6 +228,7 @@ bool bNetAveragesLoaded = false;
 bool bForceUpdate = false;
 bool bGlobalcomInitialized = false;
 bool bStakeMinerOutOfSyncWithNetwork = false;
+bool fQtActive = false;
 bool bGridcoinGUILoaded = false;
 
 extern double LederstrumpfMagnitude2(double Magnitude, int64_t locktime);
@@ -4635,14 +4636,15 @@ void GridcoinServices()
 {
 
     //Dont do this on headless - SeP
-    #if defined(QT_GUI)
+    if(fQtActive)
+    {
        if ((nBestHeight % 125) == 0)
        {
             GetGlobalStatus();
             bForceUpdate=true;
             uiInterface.NotifyBlocksChanged();
        }
-    #endif
+    }
 
     // Services thread activity
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -165,6 +165,9 @@ int main(int argc, char *argv[])
 {
     // Set default value to exit properly. Exit code 42 will trigger restart of the wallet.
     int currentExitCode = 0;
+ 
+    // Set global boolean to indicate intended presence of GUI to core.
+    fQtActive = true;
 
     std::shared_ptr<ThreadHandler> threads = std::make_shared<ThreadHandler>();
 

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -388,7 +388,8 @@ bool CTxDB::LoadBlockIndex()
         // Watch for genesis block
         if (pindexGenesisBlock == NULL && blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))
             pindexGenesisBlock = pindexNew;
-        #ifdef QT_GUI
+        if(fQtActive)
+        {
             if ((pindexNew->nHeight % 10000) == 0)
             {
                 nLoaded +=10000;
@@ -398,7 +399,7 @@ bool CTxDB::LoadBlockIndex()
                 uiInterface.InitMessage(_(sBlocksLoaded.c_str()));
                 fprintf(stdout,"%d ",nLoaded); fflush(stdout);
             }
-        #endif
+        }
 
         // NovaCoin: build setStakeSeen
         if (pindexNew->IsProofOfStake())
@@ -484,7 +485,8 @@ bool CTxDB::LoadBlockIndex()
         // check level 1: verify block validity
         // check level 7: verify block signature too
 
-        #ifdef QT_GUI
+        if(fQtActive)
+        {
             if ((pindex->nHeight % 1000) == 0)
             {
                 nLoaded +=1000;
@@ -493,8 +495,7 @@ bool CTxDB::LoadBlockIndex()
                 std::string sBlocksLoaded = ToString(nLoaded) + "/" + ToString(nHighest) + " Blocks Verified";
                 uiInterface.InitMessage(_(sBlocksLoaded.c_str()));
             }
-        #endif
-
+        }
 
         if (nCheckLevel>0 && !block.CheckBlock("LoadBlockIndex", pindex->nHeight,pindex->nMint, true, true, (nCheckLevel>6), true))
         {
@@ -625,16 +626,17 @@ bool CTxDB::LoadBlockIndex()
             if (pindex == pindexBest) break;
             if (pindex==NULL || !pindex->IsInMainChain()) continue;
 
-#ifdef QT_GUI
-            if ((pindex->nHeight % 10000) == 0)
+            if(fQtActive)
             {
-                nLoaded +=10000;
-                if (nLoaded > nHighest) nHighest=nLoaded;
-                if (nHighest < nGrandfather) nHighest=nGrandfather;
-                std::string sBlocksLoaded = ToString(nLoaded) + "/" + ToString(nHighest) + " POR Blocks Verified";
-                uiInterface.InitMessage(_(sBlocksLoaded.c_str()));
+                if ((pindex->nHeight % 10000) == 0)
+                {
+                    nLoaded +=10000;
+                    if (nLoaded > nHighest) nHighest=nLoaded;
+                    if (nHighest < nGrandfather) nHighest=nGrandfather;
+                    std::string sBlocksLoaded = ToString(nLoaded) + "/" + ToString(nHighest) + " POR Blocks Verified";
+                    uiInterface.InitMessage(_(sBlocksLoaded.c_str()));
+                }
             }
-#endif
 
             if (pindex->nResearchSubsidy > 0 && pindex->IsUserCPID())
             {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -539,25 +539,26 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
         if (fInsertedNew || fUpdated)
             if (!wtx.WriteToDisk())
                 return false;
-#ifndef QT_GUI
-        // If default receiving address gets used, replace it with a new one
-        if (vchDefaultKey.IsValid()) {
-            CScript scriptDefaultKey;
-            scriptDefaultKey.SetDestination(vchDefaultKey.GetID());
-            for (auto const& txout : wtx.vout)
-            {
-                if (txout.scriptPubKey == scriptDefaultKey)
+        if(!fQtActive)
+        {
+            // If default receiving address gets used, replace it with a new one
+            if (vchDefaultKey.IsValid()) {
+                CScript scriptDefaultKey;
+                scriptDefaultKey.SetDestination(vchDefaultKey.GetID());
+                for (auto const& txout : wtx.vout)
                 {
-                    CPubKey newDefaultKey;
-                    if (GetKeyFromPool(newDefaultKey, false))
+                    if (txout.scriptPubKey == scriptDefaultKey)
                     {
-                        SetDefaultKey(newDefaultKey);
-                        SetAddressBookName(vchDefaultKey.GetID(), "");
+                        CPubKey newDefaultKey;
+                        if (GetKeyFromPool(newDefaultKey, false))
+                        {
+                            SetDefaultKey(newDefaultKey);
+                            SetAddressBookName(vchDefaultKey.GetID(), "");
+                        }
                     }
                 }
             }
         }
-#endif
         // since AddToWallet is called directly for self-originating transactions, check for consumption of own coins
         WalletUpdateSpent(wtx, (wtxIn.hashBlock != 0));
 


### PR DESCRIPTION
This small pr implements a global fQtActive boolean that is set
to false in init.cpp, but is set to true if gridcoin is started via
main() in qt/bitcoin.cpp. This flag replaces the QT_GUI macro flag
conditionals in init.cpp to ensure that daemon functionality is correct
when a one-shot build is done of both the daemon and GUI version of
Gridcoin.

Without this change, in a one shot build the daemon will not work properly
unless --without-gui set in configure, which then requires two separate
builds to build both the daemon and gui version.