### PR TITLE
bitcoins 20% speed up on listunspent

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -559,11 +559,7 @@ Value listunspent(const Array& params, bool fHelp)
 
     vector<COutput> vecOutputs;
 
-    {
-        LOCK2(cs_main, pwalletMain->cs_wallet);
-
-        pwalletMain->AvailableCoins(vecOutputs, false, NULL, false);
-    }
+    pwalletMain->AvailableCoins(vecOutputs, false, NULL, false);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -600,7 +596,7 @@ Value listunspent(const Array& params, bool fHelp)
 
                 if (GetBoolArg("-enableaccounts", false))
                     entry.push_back(Pair("account", item->second));
-                }
+            }
         }
         entry.push_back(Pair("scriptPubKey", HexStr(pk.begin(), pk.end())));
         entry.push_back(Pair("amount", ValueFromAmount(nValue)));

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -559,9 +559,14 @@ Value listunspent(const Array& params, bool fHelp)
 
     vector<COutput> vecOutputs;
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    pwalletMain->AvailableCoins(vecOutputs, false,NULL,false);
+        pwalletMain->AvailableCoins(vecOutputs, false, NULL, false);
+    }
+
+    LOCK(pwalletMain->cs_wallet);
+
     for (auto const& out : vecOutputs)
     {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)
@@ -586,12 +591,21 @@ Value listunspent(const Array& params, bool fHelp)
         if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address))
         {
             entry.push_back(Pair("address", CBitcoinAddress(address).ToString()));
-            if (pwalletMain->mapAddressBook.count(address))
-                entry.push_back(Pair("account", pwalletMain->mapAddressBook[address]));
+
+            auto item = pwalletMain->mapAddressBook.find(address);
+
+            if (item != pwalletMain->mapAddressBook.end())
+            {
+                if (!GetBoolArg("-enableaccounts", false))
+                    entry.push_back(Pair("label", item->second));
+
+                else
+                    entry.push_back(Pair("account", item->second));
+            }
         }
         entry.push_back(Pair("scriptPubKey", HexStr(pk.begin(), pk.end())));
-        entry.push_back(Pair("amount",ValueFromAmount(nValue)));
-        entry.push_back(Pair("confirmations",out.nDepth));
+        entry.push_back(Pair("amount", ValueFromAmount(nValue)));
+        entry.push_back(Pair("confirmations", out.nDepth));
         results.push_back(entry);
     }
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -596,12 +596,11 @@ Value listunspent(const Array& params, bool fHelp)
 
             if (item != pwalletMain->mapAddressBook.end())
             {
-                if (!GetBoolArg("-enableaccounts", false))
-                    entry.push_back(Pair("label", item->second));
+                entry.push_back(Pair("label", item->second));
 
-                else
+                if (GetBoolArg("-enableaccounts", false))
                     entry.push_back(Pair("account", item->second));
-            }
+                }
         }
         entry.push_back(Pair("scriptPubKey", HexStr(pk.begin(), pk.end())));
         entry.push_back(Pair("amount", ValueFromAmount(nValue)));


### PR DESCRIPTION
thought about copying the address book during the first locks instead of having a wallet only lock for that part but bitcoin seems against it simply because the address book can be quite large. so I left it as the speed up with a minor few changes.

anyway reports of 20% speed up on 10000 unspents.