### PR TITLE
Correct list parsing in sendalert2 command

### DIFF
--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -423,17 +423,17 @@ Value sendalert2(const Array& params, bool fHelp)
     if (fHelp || params.size() != 7)
         throw runtime_error(
             //          0            1    2            3            4        5          6
-            "sendalert <privatekey> <id> <subverlist> <cancellist> <expire> <priority> <message>\n"
+            "sendalert2 <privatekey> <id> <subverlist> <cancellist> <expire> <priority> <message>\n"
             "\n"
-            "<message> ---->is the alert text message\n"
             "<privatekey> -> is hex string of alert master private key\n"
-            "<subverlist> -> comma separated list of versions warning applies to\n"
-            "<priority> ---> integer, >1000->visible\n"
             "<id> ---------> is the unique alert number\n"
+            "<subverlist> -> comma separated list of versions warning applies to\n"
             "<cancellist> -> comma separated ids of alerts to cancel\n"
             "<expire> -----> alert expiration in days\n"
+            "<priority> ---> integer, >1000->visible\n"
+            "<message> ---->is the alert text message\n"
             "\n"
-            "Returns true or false.");
+            "Returns summary of what was done.");
 
     CAlert alert;
     CKey key;

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -446,14 +446,19 @@ Value sendalert2(const Array& params, bool fHelp)
     alert.nVersion = PROTOCOL_VERSION;
     alert.nRelayUntil = alert.nExpiration = GetAdjustedTime() + 24*60*60*params[4].get_int();
 
-    std::vector<std::string> split_subver = split(params[2].get_str(), ",");
-    alert.setSubVer.insert(split_subver.begin(),split_subver.end());
-
-    std::vector<std::string> split_cancel = split(params[3].get_str(), ",");
-    for(std::string &s : split_cancel)
+    if(params[2].get_str().length())
     {
-        int aver = RoundFromString(s, 0);
-        alert.setCancel.insert(aver);
+        std::vector<std::string> split_subver = split(params[2].get_str(), ",");
+        alert.setSubVer.insert(split_subver.begin(),split_subver.end());
+    }
+
+    if(params[3].get_str().length())
+    {
+        for(std::string &s : split(params[3].get_str(), ","))
+        {
+            int aver = RoundFromString(s, 0);
+            alert.setCancel.insert(aver);
+        }
     }
 
     CDataStream sMsg(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -374,4 +374,21 @@ BOOST_AUTO_TEST_CASE(util_VerifySplit)
     BOOST_CHECK_EQUAL("",       res[3]);
 }
 
+BOOST_AUTO_TEST_CASE(util_VerifySplit2)
+{
+    const std::string str(";;");
+    const auto res = split(str, ";;");
+    BOOST_CHECK(res.size() == 2);
+    BOOST_CHECK_EQUAL("",       res[0]);
+    BOOST_CHECK_EQUAL("",       res[1]);
+}
+
+BOOST_AUTO_TEST_CASE(util_VerifySplit3)
+{
+    const std::string str("");
+    const auto res = split(str, ";;");
+    BOOST_CHECK(res.size() == 1);
+    BOOST_CHECK_EQUAL("",       res[0]);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Even though I set it to staging branch, it is not critical for the release. Staging wallets will be able to correctly process alerts even without this patch. Only alert sending, which only admin will do, requires this patch. Only affects alerts with intended empty subver list.