### PR TITLE
Cleanup of extra newline from AcceptBlock debug log entry and enable refhash rpc command for all platforms

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -383,9 +383,7 @@ static const CRPCCommand vRPCCommands[] =
     { "projects",                &projects,                false,  cat_developer     },
     { "readconfig",              &readconfig,              false,  cat_developer     },
     { "readdata",                &readdata,                false,  cat_developer     },
-#ifdef WIN32
     { "refhash",                 &refhash,                 false,  cat_developer     },
-#endif
     { "reorganize",              &rpc_reorganize,          false,  cat_developer     },
     { "seefile",                 &seefile,                 false,  cat_developer     },
     { "sendalert",               &sendalert,               false,  cat_developer     },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -269,9 +269,7 @@ extern json_spirit::Value neuralrequest(const json_spirit::Array& params, bool f
 extern json_spirit::Value projects(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value readconfig(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value readdata(const json_spirit::Array& params, bool fHelp);
-#ifdef WIN32
 extern json_spirit::Value refhash(const json_spirit::Array& params, bool fHelp);
-#endif
 extern json_spirit::Value rpc_reorganize(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value seefile(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendalert(const json_spirit::Array& params, bool fHelp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4421,7 +4421,7 @@ bool CBlock::AcceptBlock(bool generated_by_me)
         //must be proof of stake
         //no grandfather exceptions
         //if (IsProofOfStake())
-        LogPrintf("AcceptBlock: Proof Of Stake V8 %d\n",nVersion);
+        LogPrintf("AcceptBlock: Proof Of Stake V8 %d",nVersion);
         if(!CheckProofOfStakeV8(pindexPrev, *this, generated_by_me, hashProof))
         {
             error("WARNING: AcceptBlock(): check proof-of-stake failed for block %s, nonce %f    \n", hash.ToString().c_str(),(double)nNonce);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4421,7 +4421,6 @@ bool CBlock::AcceptBlock(bool generated_by_me)
         //must be proof of stake
         //no grandfather exceptions
         //if (IsProofOfStake())
-        LogPrintf("AcceptBlock: Proof Of Stake V8 %d",nVersion);
         if(!CheckProofOfStakeV8(pindexPrev, *this, generated_by_me, hashProof))
         {
             error("WARNING: AcceptBlock(): check proof-of-stake failed for block %s, nonce %f    \n", hash.ToString().c_str(),(double)nNonce);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2520,7 +2520,6 @@ Value seefile(const Array& params, bool fHelp)
     return res;
 }
 
-#ifdef WIN32
 Value refhash(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
@@ -2543,7 +2542,6 @@ Value refhash(const Array& params, bool fHelp)
 
     return res;
 }
-#endif
 
 Value sendblock(const Array& params, bool fHelp)
 {


### PR DESCRIPTION
Two small commits here to polish for release...

1. Removes an unneeded newline from the LogPrintf for AcceptBlock which was injecting unsightly extra blank lines in the debug log.

2. Removes the WIN32 define around the refhash rpc command because we need it enabled on all platforms now.