### PR TITLE
Added alternative boinc data dir for Linux.

### DIFF
--- a/src/boinc.cpp
+++ b/src/boinc.cpp
@@ -57,6 +57,9 @@ std::string GetBoincDataDir(){
     if (boost::filesystem::exists("/var/lib/boinc-client/")){
         return "/var/lib/boinc-client/";
     }
+    else if (boost::filesystem::exists("/var/lib/boinc/")){
+        return "/var/lib/boinc/";
+    }
     #endif
 
     #ifdef __APPLE__


### PR DESCRIPTION
Added check for /var/lib/boinc/ directory on Linux, which may exist on some setups, e.g. on [Fedora](https://boinc.berkeley.edu/wiki/Installing_BOINC_on_Fedora) and when compiled from source.