### PR TITLE
Addition of stress test script to contrib

### DIFF
--- a/contrib/rpcstresstest/README.md
+++ b/contrib/rpcstresstest/README.md
@@ -1,0 +1,66 @@
+rpc_stress_test.sh
+
+Original Author: James C. Owens
+Current Version: 4.0
+
+rpc_stress_test.sh is a bash script that runs rpc commands against the Gridcoin client at a controllable rate to provide for stress testing. The script is multithreaded (using subshells with the & ending). It will only run under Linux. It may run under WSL or cygwin but has not been tested in that environment. The script has no error checking, and so must be used only by people able to properly diagnose possible error conditions encountered during testing. Additions to improve the script are always welcome.
+
+The usage is rpc_stress_test.sh <gridcoindaemon> <command_file> <rpc_test_output_log> <debug_log> <iterations> <sleep_time> <maximum_parallelism> <random>
+
+<gridcoindaemon> : The name of the gridcoin daemon executable. This will typically be gridcoindaemon.
+<command_file> : The name of the file that contains the commands that will be executed as part of the test. You may use # in front of a command to "comment it out" which allows you to conveniently turn off a command. Note that the script uses eval to execute the command, so some script variables can be used in the commands.
+<rpc_test_output_log> : The name of the file that will contain the command outputs.
+<debug.log> : The name of the gridcoin debug log (usually debug.log), to integrate the rpc timings into the main log to provide an integrated picture.
+<iterations> : The number of commands desired to be run during the test.
+<sleep_time> : The amount of seconds (in decimal form) to wait from one command invocation to the next.
+<maximum_parallelism> : The maximum number of commands that will be allowed to be in flight at any one time. This is to prevent a runaway situation with a pileup of many commands in case some of them become unresponsive, which could happen in a stress testing scenario.
+<random> : 0 will cause the script to execute the commands sequentially in the order listed in the command file. 1 will cause the script to pick commands at random from the command file.
+
+The script should usually be run while in the .GridcoinResearch directory (for mainnet) or .GridcoinResearch/testnet directory (if testnet). It is STRONGLY ADVISED that any stress testing be done against wallets in testnet and not mainnet.
+
+Stress testing involving commands that generate transactions on the network is not allowed at any time on mainnet, and will only be allowed on testnet by permission of the testnet coordinator, under carefully reviewed and controlled conditions.
+
+A typical commandline for testnet (from the testnet subdirectory) would be
+
+./rpc_stress_test.sh ../gridcoinresearchd command_file.dat rpc_test_output.log debug.log 1000 0.5 100 1 | tee rpc_test.log
+
+This would be a test of 1000 command invocations at random from the command file, with a 0.5 second spacing between command invocations.
+
+The purpose of the pipe and tee at the end is to provide the output of the script to both the console and a log at the same time.
+
+The script console output looks like the following (this is an example run with the provided example command file:
+
+05/23/2018 01:53:37.715987571,1,1,begin,../gridcoinresearchd-staging.sh -testnet getblockchaininfo
+05/23/2018 01:53:37.823599886,2,2,begin,../gridcoinresearchd-staging.sh -testnet dumpprivkey $($gridcoindaemon getnewaddress; sleep 0.25)
+05/23/2018 01:53:37.826900191,1,1,end,../gridcoinresearchd-staging.sh -testnet getblockchaininfo
+05/23/2018 01:53:37.915069162,3,2,begin,../gridcoinresearchd-staging.sh -testnet dumpprivkey $($gridcoindaemon getnewaddress; sleep 0.25)
+05/23/2018 01:53:38.021945936,4,3,begin,../gridcoinresearchd-staging.sh -testnet getnetworkinfo
+05/23/2018 01:53:38.139469907,5,4,begin,../gridcoinresearchd-staging.sh -testnet getnetworkinfo
+05/23/2018 01:53:38.266971443,6,5,begin,../gridcoinresearchd-staging.sh -testnet getblockchaininfo
+05/23/2018 01:53:38.361519191,7,6,begin,../gridcoinresearchd-staging.sh -testnet listtransactions
+05/23/2018 01:53:38.487301179,8,7,begin,../gridcoinresearchd-staging.sh -testnet listtransactions
+05/23/2018 01:53:38.608563671,9,8,begin,../gridcoinresearchd-staging.sh -testnet getwalletinfo
+05/23/2018 01:53:38.687542740,4,6,end,../gridcoinresearchd-staging.sh -testnet getnetworkinfo
+05/23/2018 01:53:38.683003108,5,7,end,../gridcoinresearchd-staging.sh -testnet getnetworkinfo
+05/23/2018 01:53:38.725206893,10,7,begin,../gridcoinresearchd-staging.sh -testnet getwalletinfo
+05/23/2018 01:53:38.733894002,7,6,end,../gridcoinresearchd-staging.sh -testnet listtransactions
+05/23/2018 01:53:38.795346312,2,5,end,../gridcoinresearchd-staging.sh -testnet dumpprivkey $($gridcoindaemon getnewaddress; sleep 0.25)
+05/23/2018 01:53:38.839347841,6,4,end,../gridcoinresearchd-staging.sh -testnet getblockchaininfo
+05/23/2018 01:53:38.885275421,8,3,end,../gridcoinresearchd-staging.sh -testnet listtransactions
+05/23/2018 01:53:38.895480791,11,4,begin,../gridcoinresearchd-staging.sh -testnet listunspent
+05/23/2018 01:53:38.963203747,12,5,begin,../gridcoinresearchd-staging.sh -testnet getwalletinfo
+05/23/2018 01:53:38.997576132,9,4,end,../gridcoinresearchd-staging.sh -testnet getwalletinfo
+05/23/2018 01:53:39.015189015,10,3,end,../gridcoinresearchd-staging.sh -testnet getwalletinfo
+05/23/2018 01:53:39.031542876,3,2,end,../gridcoinresearchd-staging.sh -testnet dumpprivkey $($gridcoindaemon getnewaddress; sleep 0.25)
+05/23/2018 01:53:39.035421544,12,1,end,../gridcoinresearchd-staging.sh -testnet getwalletinfo
+05/23/2018 01:53:39.055025731,11,0,end,../gridcoinresearchd-staging.sh -testnet listunspent
+
+This is in CSV format to be easily processed by an analysis script or spreadsheet.
+
+The columns are as follows:
+Date/time, Invocation Sequence Number, Parallelism Number, command begin or end, command.
+
+For the parallelism number, if it is the command begin, it represents the number of tasks in flight including the one that was just started. If it is the command end, it represents the number of commands in flight still after the command has ended (i.e. not including the just finished command).
+
+
+

--- a/contrib/rpcstresstest/command_file.dat
+++ b/contrib/rpcstresstest/command_file.dat
@@ -1,0 +1,7 @@
+#getinfo
+getblockchaininfo
+getnetworkinfo
+getwalletinfo
+listtransactions
+dumpprivkey $($gridcoindaemon getnewaddress; sleep 0.25)
+listunspent

--- a/contrib/rpcstresstest/rpc_stress_test.sh
+++ b/contrib/rpcstresstest/rpc_stress_test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Author James C. Owens
+# Version 2.5 - includes datetime stamps in UTC and also puts in output log and debug.log
+# Version 3.0 - includes option for random or sequential execution of command file
+# Version 3.5 - includes parallelism counter (j) and parallelism limiter
+# Version 4.0 - Parameterize rpc_test_output.log and debug.log locations
+
+timestamp() {
+  date --utc +"%m/%d/%Y %H:%M:%S.%N"
+}
+
+lock="./$BASHPID.lock"
+exec 8>$lock;
+
+j_atom() {
+(
+flock -w 60.0 -x 8
+echo $(<$lock)
+) 8<$lock
+}
+
+j++() {
+(
+flock -w 60.0 -x 8
+j=$(<$lock)
+echo $((j + 1)) | tee $lock
+) 8<$lock
+}
+
+j--() {
+(
+flock -w 60.0 -x 8
+j=$(<$lock)
+echo $((j - 1)) | tee $lock
+)
+} 8<$lock
+
+
+gridcoindaemon=$1
+command_file=$2
+rpc_test_output_log=$3
+debug_log=$4
+iterations=$5
+sleep_time=$6
+maximum_parallelism=$7
+random=$8
+
+readarray -t command < <(cat $command_file | sed -e "s|\r||" | grep -v "^#")
+array_size=${#command[@]}
+
+# For troubleshooting, uncomment the below
+#echo "lockfile" $lock
+#echo "command_file" $command_file
+#echo "rpc test output log" $rpc_test_output_log
+#echo "debug log" $debug_log
+#echo "iterations" $iterations
+#echo "array size" $array_size
+#echo "sleep time" $sleep_time
+#echo "maximum parallelism" $maximum_parallelism
+#echo "random" $random
+
+$gridcoindaemon debug4 true 1> /dev/null 2> /dev/null
+
+# shells in progress (parallelism) count initialization
+echo "0" > $lock
+
+for ((i=1;i<=iterations;i++)); do
+
+	if ((random==1)); then
+	  index=$(shuf -i 1-$array_size -n 1)
+	else
+	  index=$((i%array_size)) 
+	fi
+
+	#echo "index" $index
+
+	cmd=${command[$((index-1))]}
+
+	#echo i=$i
+	#echo j=$(j_atom)
+
+	if (($(j_atom)<maximum_parallelism)); then
+
+		# The below is executed in a subshell with an ampersand to achieve parallelism.
+		(
+			j_begin=$(j++)
+			datetime_begin=$(timestamp)
+			echo "$datetime_begin,$i,$j_begin,begin,$gridcoindaemon" $cmd | tee -a $rpc_test_output_log $debug_log
+
+			eval $gridcoindaemon $cmd >> $rpc_test_output_log;
+			
+			j_end=$(j--)
+			datetime_end=$(timestamp)
+			echo "$datetime_end,$i,$j_end,end,$gridcoindaemon" $cmd | tee -a $rpc_test_output_log $debug_log
+			
+		) &
+
+	else ((i--))
+	fi
+
+	sleep $sleep_time
+
+done
+
+wait
+
+rm $lock


### PR DESCRIPTION
This is the initial posting of a bash script that can be used to stress test rpc commands to the gridcoin daemon. Please refer to the README.txt file for usage.

I have used this script extensively in the stress tests for 3.7.11.0 and the pending 3.7.12.0.