### PR TITLE
Log printf modifications

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -434,7 +434,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     fDebug4 = GetBoolArg("-debug4");
 
     if (fDebug4)
-        printf("Entering RPC time debug mode\r\n");
+       LogPrintf("Entering RPC time debug mode\n");
 
     fDebug10= (GetArg("-debug10","false")=="true");
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -665,17 +665,23 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
     return true;
 }
 
-int AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
+void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
 {
     if(OutOfSyncByAge())
-        return LogPrintf("AddNeuralContractOrVote: Out Of Sync\n");
+    {
+        LogPrintf("AddNeuralContractOrVote: Out Of Sync\n");
+        return;
+    }
 
     /* Retrive the neural Contract */
     const std::string& sb_contract = NN::GetNeuralContract();
     const std::string& sb_hash = GetQuorumHash(sb_contract);
 
     if(sb_contract.empty())
-        return LogPrintf("AddNeuralContractOrVote: Local Contract Empty\n");
+    {
+        LogPrintf("AddNeuralContractOrVote: Local Contract Empty\n");
+        return;
+    }
 
     /* To save network bandwidth, start posting the neural hashes in the
        CurrentNeuralHash field, so that out of sync neural network nodes can
@@ -686,7 +692,10 @@ int AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
     bb.CurrentNeuralHash = sb_hash;
 
     if(!IsNeuralNodeParticipant(bb.GRCAddress, blocknew.nTime))
-        return LogPrintf("AddNeuralContractOrVote: Not Participating\n");
+    {
+        LogPrintf("AddNeuralContractOrVote: Not Participating\n");
+        return;
+    }
 
     if(blocknew.nVersion >= 9)
     {
@@ -696,7 +705,10 @@ int AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
     }
 
     if(!NeedASuperblock())
-        return LogPrintf("AddNeuralContractOrVote: not Needed\n");
+    {
+        LogPrintf("AddNeuralContractOrVote: not Needed\n");
+        return;
+    }
 
     int pending_height = RoundFromString(ReadCache("neuralsecurity","pending").value, 0);
 
@@ -705,19 +717,25 @@ int AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
     LogPrintf("AddNeuralContractOrVote: Added our Neural Vote %s\n",sb_hash);
 
     if (pending_height>=(pindexBest->nHeight-200))
-        return LogPrintf("AddNeuralContractOrVote: already Pending\n");
+    {
+        LogPrintf("AddNeuralContractOrVote: already Pending\n");
+        return;
+    }
 
     double popularity = 0;
     std::string consensus_hash = GetNeuralNetworkSupermajorityHash(popularity);
 
     if (consensus_hash!=sb_hash)
-        return LogPrintf("AddNeuralContractOrVote: not in Consensus\n");
+    {
+        LogPrintf("AddNeuralContractOrVote: not in Consensus\n");
+        return;
+    }
 
     /* We have consensus, Add our neural contract */
     bb.superblock = PackBinarySuperblock(sb_contract);
     LogPrintf("AddNeuralContractOrVote: Added our Superblock (size %" PRIszu ")\n",bb.superblock.length());
 
-    return 0;
+    return;
 }
 
 bool CreateGridcoinReward(CBlock &blocknew, MiningCPID& miningcpid, uint64_t &nCoinAge, CBlockIndex* pindexPrev)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -914,7 +914,7 @@ json_spirit::Value CRPCTable::execute(const std::string &strMethod, const json_s
             nRPCtimebegin = GetTimeMillis();
             result = pcmd->actor(params, false);
             nRPCtimetotal = GetTimeMillis() - nRPCtimebegin;
-            printf("RPCTime : Command %s -> Totaltime %" PRId64 "ms\n", strMethod.c_str(), nRPCtimetotal);
+            LogPrintf("RPCTime : Command %s -> Totaltime %" PRId64 "ms\n", strMethod.c_str(), nRPCtimetotal);
         }
         else
             result = pcmd->actor(params, false);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -229,11 +229,10 @@ bool LogAcceptCategory(const char* category)
 
 void LogPrintStr(const std::string &str)
 {
-    int ret = 0;
     if (fPrintToConsole)
     {
         // print to console
-        ret = fwrite(str.data(), 1, str.size(), stdout);
+        fwrite(str.data(), 1, str.size(), stdout);
     }
     //else
     if (!fPrintToDebugger)
@@ -275,7 +274,7 @@ void LogPrintStr(const std::string &str)
             else
                 fStartedNewLine = false;
 
-            ret = fwrite(str.data(), 1, str.size(), fileout);
+            fwrite(str.data(), 1, str.size(), fileout);
             fflush(fileout);
         }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -227,7 +227,7 @@ bool LogAcceptCategory(const char* category)
     return true;
 }
 
-int LogPrintStr(const std::string &str)
+void LogPrintStr(const std::string &str)
 {
     int ret = 0;
     if (fPrintToConsole)
@@ -305,7 +305,7 @@ int LogPrintStr(const std::string &str)
         }
     }
 #endif */
-    return ret;
+    return;
 }
 
 int GetDayOfYear(int64_t timestamp)

--- a/src/util.h
+++ b/src/util.h
@@ -123,10 +123,11 @@ int LogPrintStr(const std::string &str);
 #define MAKE_ERROR_AND_LOG_FUNC(n)                                        \
     /*   Print to debug.log if -debug=category switch is given OR category is NULL. */ \
     template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int LogPrint(const char* category, const char* format, TINYFORMAT_VARARGS(n))  \
+    static inline void LogPrint(const char* category, const char* format, TINYFORMAT_VARARGS(n))  \
     {                                                                         \
         if(!LogAcceptCategory(category)) return 0;                            \
-        return LogPrintStr(tfm::format(format, TINYFORMAT_PASSARGS(n)) + "\n"); \
+        LogPrintStr(tfm::format(format, TINYFORMAT_PASSARGS(n)) + "\n");      \
+        return;                                                               \
     }                                                                         \
     /*   Log error and return false */                                        \
     template<TINYFORMAT_ARGTYPES(n)>                                          \
@@ -141,10 +142,11 @@ TINYFORMAT_FOREACH_ARGNUM(MAKE_ERROR_AND_LOG_FUNC)
 /* Zero-arg versions of logging and error, these are not covered by
  * TINYFORMAT_FOREACH_ARGNUM
 */
-static inline int LogPrint(const char* category, const char* format)
+static inline void LogPrint(const char* category, const char* format)
 {
     if(!LogAcceptCategory(category)) return 0;
-    return LogPrintStr(format);
+    LogPrintStr(format);
+    return;
 }
 static inline bool error(const char* format)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -112,7 +112,7 @@ void RandAddSeedPerfmon();
 /* Return true if log accepts specified category */
 bool LogAcceptCategory(const char* category);
 /* Send a string to the log output */
-int LogPrintStr(const std::string &str);
+void LogPrintStr(const std::string &str);
 
 #define strprintf tfm::format
 #define LogPrintf(...) LogPrint(NULL, __VA_ARGS__)

--- a/src/util.h
+++ b/src/util.h
@@ -125,7 +125,7 @@ void LogPrintStr(const std::string &str);
     template<TINYFORMAT_ARGTYPES(n)>                                          \
     static inline void LogPrint(const char* category, const char* format, TINYFORMAT_VARARGS(n))  \
     {                                                                         \
-        if(!LogAcceptCategory(category)) return 0;                            \
+        if(!LogAcceptCategory(category)) return;                            \
         LogPrintStr(tfm::format(format, TINYFORMAT_PASSARGS(n)) + "\n");      \
         return;                                                               \
     }                                                                         \
@@ -144,7 +144,7 @@ TINYFORMAT_FOREACH_ARGNUM(MAKE_ERROR_AND_LOG_FUNC)
 */
 static inline void LogPrint(const char* category, const char* format)
 {
-    if(!LogAcceptCategory(category)) return 0;
+    if(!LogAcceptCategory(category)) return;
     LogPrintStr(format);
     return;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -115,7 +115,7 @@ bool LogAcceptCategory(const char* category);
 void LogPrintStr(const std::string &str);
 
 #define strprintf tfm::format
-#define LogPrintf(...) LogPrint(NULL, __VA_ARGS__)
+#define LogPrintf(...) do { LogPrint(NULL, __VA_ARGS__); } while (0)
 
 /* When we switch to C++11, this can be switched to variadic templates instead
  * of this macro-based construction (see tinyformat.h).

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1163,7 +1163,7 @@ void CWallet::ResendWalletTransactions(bool fForce)
     }
 
     // Rebroadcast any of our txes that aren't in a block yet
-    //if (fDebug10) printf("ResendWalletTransactions()\n");
+    //if (fDebug10) LogPrintf("ResendWalletTransactions()\n");
     CTxDB txdb("r");
     {
         LOCK(cs_wallet);


### PR DESCRIPTION
* Change LogPrint to void since we don't use the return on ret (count of characters written)
* Change LogPrintStr to void as well
* Remove ints from LogPrintStr
* Modify miner logs to support the LogPrintf changes
* changed last of printf to LogPrintf
* Redefine LogPrintf to support the void

Pulled from a bitcoin PR that was merged.
@tomasbrod : Left the rest of that function alone thou it could be converted to void as well for adding neural contract since you don't use the int return either. (your call)