### PR TITLE
Treat help rpc call like a string

### DIFF
--- a/src/contract/rpccontract.cpp
+++ b/src/contract/rpccontract.cpp
@@ -158,7 +158,7 @@ Value votedetails(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw std::runtime_error(
-                "votedetails <pollname>]n"
+                "votedetails <pollname>\n"
                 "\n"
                 "<pollname> Specified poll name\n"
                 "\n"

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -201,7 +201,7 @@ string CRPCTable::help(string strCommand, rpccategory category) const
 Value help(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() == 0 || params.size() > 1)
-        throw runtime_error(
+        return
             "help [command/category]\n"
             "Returns help on a specific command or category you request\n"
             "\n"
@@ -211,7 +211,7 @@ Value help(const Array& params, bool fHelp)
             "wallet --------> Returns help for blockchain related commands\n"
             "mining --------> Returns help for neural network/cpid/beacon related commands\n"
             "developer -----> Returns help for developer commands\n"
-            "network -------> Returns help for network related commands\n");
+            "network -------> Returns help for network related commands\n";
     
     // Allow to process through if params size is > 0
     string strCommand;


### PR DESCRIPTION
We always throw a runtime error for help however from there its returned as a string and processed for response. With the help part of code where we throw a runtime_error it is put out as a runtime_error and not into a string before showing response so the '\n' are displayed as is and not new lines. I changed this since help everywhere else does not show error codes to display the same by simply returning the string of help. much like when that section receives the runtimes from the tableRPC and then is returned as string. This solves the daemon rpc call for help and does not affect any other outputs. 

Tested and works correctly.