### PR TITLE
update version check api URL to new repo so version check passes

### DIFF
--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -304,7 +304,7 @@ void DiagnosticsDialog::on_testBtn_clicked()
 
     //client version
     ui->checkClientVersionResultLbl->setText("Testing...");
-    networkManager->get(QNetworkRequest(QUrl("https://api.github.com/repos/gridcoin/Gridcoin-Research/releases/latest")));
+    networkManager->get(QNetworkRequest(QUrl("https://api.github.com/repos/gridcoin-community/Gridcoin-Research/releases/latest")));
 
     return;
 }


### PR DESCRIPTION
update URL used for api check on version. the network manager does not follow a forwarding so makes more sense to just update the location for version as it is a permanent move. this will prevent a std::stoi error displaying in version label.