### PR TITLE
Remove neuralhash from the getpeerinfo and node stats

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -750,7 +750,6 @@ void CNode::copyStats(CNodeStats &stats)
     X(fInbound);
     X(nStartingHeight);
     X(nMisbehavior);
-    X(NeuralHash);
     X(sGRCAddress);
     X(nTrust);
 

--- a/src/net.h
+++ b/src/net.h
@@ -138,7 +138,6 @@ public:
     double dPingTime;
     double dPingWait;
 	std::string addrLocal;
-	std::string NeuralHash;
 	int nTrust;
 	std::string sGRCAddress;
 	//std::string securityversion;

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -332,7 +332,6 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
         obj.pushKV("Neural Network", bNeural);
         if (bNeural)
         {
-            obj.pushKV("Neural Hash", stats.NeuralHash);
             obj.pushKV("Neural Participant", IsNeuralNodeParticipant(stats.sGRCAddress, GetAdjustedTime()));
 
         }


### PR DESCRIPTION
remove neural hash field from getpeerinfo and nodestats. this was always static to the start of client. never updates so shows invalid data after a sync