### PR TITLE
Voting dialog call fixes

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -981,19 +981,19 @@ bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::str
 std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2, std::string arg3, std::string arg4, std::string arg5, std::string arg6)
 {
     Array params;
-    params.push_back(method);
     params.push_back(arg1);
-    params.push_back(arg2);
+    params.push_back(RoundFromString(arg2, 0));
     params.push_back(arg3);
     params.push_back(arg4);
-    params.push_back(arg5);
+    params.push_back(RoundFromString(arg5, 0));
     params.push_back(arg6);
 
     LogPrintf("Executing method %s\n",method);
     Value vResult;
     try
     {
-        vResult = execute(params,false);
+        if (method == "addpoll")
+            vResult = addpoll(params, false);
     }
     catch (std::exception& e)
     {
@@ -1053,14 +1053,14 @@ std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string 
 std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2)
 {
     Array params;
-    params.push_back(method);
     params.push_back(arg1);
     params.push_back(arg2);
     LogPrintf("Executing method %s\n",method);
     Value vResult;
     try
     {
-        vResult = execute(params,false);
+        if (method == "vote")
+            vResult = vote(params,false);
     }
     catch (std::exception& e)
     {

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1054,13 +1054,18 @@ std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string 
 {
     Array params;
     params.push_back(arg1);
-    params.push_back(arg2);
+
+    if (method == "vote")
+        params.push_back(arg2);
     LogPrintf("Executing method %s\n",method);
     Value vResult;
     try
     {
         if (method == "vote")
             vResult = vote(params,false);
+
+        if (method == "rain")
+            vResult = rain(params,false);
     }
     catch (std::exception& e)
     {


### PR DESCRIPTION
Fix voting dialog issue affect windows clients only on master branch.

* Find method and send to proper value call for both 2 and 6 argument `ExecuteRPCCommand`
* Don't include the method as argument since method is an rpc call now and not one inside deprecated `execute`
* convert the arg2 and arg5 to double from string before passing to `addpoll` since it bypasses the `ConvertTo` function in rpc.
* add ifs on the method just to make sure it does not get used incorrectly by something unrelated. (not needed but why not)

voting will be restored via dialog with this