### PR TITLE
quick fix: minor change for Neural Network tab

### DIFF
--- a/contrib/Installer/boinc/boinc/frmMining.vb
+++ b/contrib/Installer/boinc/boinc/frmMining.vb
@@ -234,7 +234,7 @@ Public Class frmMining
         Try
 
             Call OneMinuteUpdate()
-            Me.TabControl1.SelectedIndex = 2
+            Me.TabControl1.SelectedIndex = 1
             If mbTestNet Then lblTestnet.Text = "TESTNET"
             PopulateNeuralData()
 


### PR DESCRIPTION
Make Neural network tab the default displayed tab on startup;

This was behavior before till the unused tab was removed; This returns this back to original default state.