### PR TITLE
Log cleanup

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -259,8 +259,6 @@ void CAddrMan::MakeTried(CAddrInfo& info, int nId, int nOrigin)
 
 void CAddrMan::Good_(const CService &addr, int64_t nTime)
 {
-//    LogPrintf("Good: addr=%s\n", addr.ToString().c_str());
-
     int nId;
     CAddrInfo *pinfo = Find(addr, &nId);
 
@@ -302,7 +300,7 @@ void CAddrMan::Good_(const CService &addr, int64_t nTime)
     // TODO: maybe re-add the node, but for now, just bail out
     if (nUBucket == -1) return;
 
-    if (fDebug10) LogPrint("addr", "Moving %s to tried\n", addr.ToString());
+    if (fDebug10) LogPrint("addr", "Moving %s to tried", addr.ToString());
 
     // move nId to the tried tables
     MakeTried(info, nId, nUBucket);
@@ -349,7 +347,6 @@ bool CAddrMan::Add_(const CAddress &addr, const CNetAddr& source, int64_t nTimeP
     } else {
         pinfo = Create(addr, source, &nId);
         pinfo->nTime = max((int64_t)0, (int64_t)pinfo->nTime - nTimePenalty);
-        //        LogPrintf("Added %s [nTime=%fhr]\n", pinfo->ToString().c_str(), (GetAdjustedTime() - pinfo->nTime) / 3600.0);
         nNew++;
         fNew = true;
     }

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -405,7 +405,7 @@ public:
             LOCK(cs);
             int err;
             if ((err=Check_()))
-                LogPrint("addr", "ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);
+                LogPrint("addr", "ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i", err);
         }
 #endif
     }
@@ -421,7 +421,7 @@ public:
             Check();
         }
         if (fRet)
-            LogPrint("addr","Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort(), source.ToString(), nTried, nNew);
+            LogPrint("addr","Added %s from %s: %i tried, %i new", addr.ToStringIPPort(), source.ToString(), nTried, nNew);
         return fRet;
     }
 
@@ -437,7 +437,7 @@ public:
             Check();
         }
         if (nAdd)
-            if (fDebug) LogPrint("addr","Added %i addresses from %s: %i tried, %i new\n", nAdd, source.ToString(), nTried, nNew);
+            if (fDebug) LogPrint("addr","Added %i addresses from %s: %i tried, %i new", nAdd, source.ToString(), nTried, nNew);
         return nAdd > 0;
     }
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -212,13 +212,13 @@ bool CAlert::ProcessAlert(bool fThread)
             const CAlert& alert = (*mi).second;
             if (Cancels(alert))
             {
-                LogPrint("alert", "cancelling alert %d\n", alert.nID);
+                LogPrint("alert", "cancelling alert %d", alert.nID);
                 uiInterface.NotifyAlertChanged((*mi).first, CT_DELETED);
                 mapAlerts.erase(mi++);
             }
             else if (!alert.IsInEffect())
             {
-                LogPrint("alert", "expiring alert %d\n", alert.nID);
+                LogPrint("alert", "expiring alert %d", alert.nID);
                 uiInterface.NotifyAlertChanged((*mi).first, CT_DELETED);
                 mapAlerts.erase(mi++);
             }
@@ -232,7 +232,7 @@ bool CAlert::ProcessAlert(bool fThread)
             const CAlert& alert = item.second;
             if (alert.Cancels(*this))
             {
-                LogPrint("alert", "alert already cancelled by %d\n", alert.nID);
+                LogPrint("alert", "alert already cancelled by %d", alert.nID);
                 return false;
             }
         }
@@ -270,6 +270,6 @@ bool CAlert::ProcessAlert(bool fThread)
         }
     }
 
-    LogPrint("alert", "accepted alert %d, AppliesToMe()=%d\n", nID, AppliesToMe());
+    LogPrint("alert", "accepted alert %d, AppliesToMe()=%d", nID, AppliesToMe());
     return true;
 }

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -53,12 +53,12 @@ bool BackupConfigFile(const std::string& strDest)
         #else
             filesystem::copy_file(ConfigSource, ConfigTarget);
         #endif
-        LogPrintf("BackupConfigFile: Copied gridcoinresearch.conf to %s\n", ConfigTarget.string());
+        LogPrintf("BackupConfigFile: Copied gridcoinresearch.conf to %s", ConfigTarget.string());
         return true;
     }
     catch(const filesystem::filesystem_error &e)
     {
-        LogPrintf("BackupConfigFile: Error copying gridcoinresearch.conf to %s - %s\n", ConfigTarget.string(), e.what());
+        LogPrintf("BackupConfigFile: Error copying gridcoinresearch.conf to %s - %s", ConfigTarget.string(), e.what());
         return false;
     }
     return false;
@@ -92,11 +92,11 @@ bool BackupWallet(const CWallet& wallet, const std::string& strDest)
 #else
             filesystem::copy_file(WalletSource, WalletTarget);
 #endif
-            LogPrintf("BackupWallet: Copied wallet.dat to %s\n", WalletTarget.string());
+            LogPrintf("BackupWallet: Copied wallet.dat to %s", WalletTarget.string());
             return true;
         }
         catch(const filesystem::filesystem_error &e) {
-            LogPrintf("BackupWallet: Error copying wallet.dat to %s - %s\n", WalletTarget.string(), e.what());
+            LogPrintf("BackupWallet: Error copying wallet.dat to %s - %s", WalletTarget.string(), e.what());
             return false;
         }
     }
@@ -126,7 +126,7 @@ bool BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::string&
         }
         myBackup << "Address: " << keyPair.first.ToString() << ", Secret: " << keyPair.second.ToString() << std::endl;
     }
-    LogPrintf("BackupPrivateKeys: Backup made to %s\n", PrivateKeysTarget.string());
+    LogPrintf("BackupPrivateKeys: Backup made to %s", PrivateKeysTarget.string());
     myBackup.close();
     return true;
 }

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -205,7 +205,7 @@ bool VerifyBeaconContractTx(const CTransaction& tx)
         if (tx_out_publickey != chk_out_publickey)
         {
             if (fDebug10)
-                LogPrintf("VBCTX : Beacon tx publickey != publickey in chain. %s != %s", tx_out_publickey.c_str(), chk_out_publickey);
+                LogPrintf("VBCTX : Beacon tx publickey != publickey in chain. %s != %s", tx_out_publickey, chk_out_publickey);
 
             return false;
         }

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -35,13 +35,13 @@ bool GenerateBeaconKeys(const std::string &cpid, std::string &sOutPubKey, std::s
         fResult = SignBlockWithCPID(cpid, hashBlock.GetHex(), sSignature, sError, true);
         if (!fResult)
         {
-            LogPrintf("GenerateNewKeyPair::Failed to sign block with cpid -> %s\n", sError);
+            LogPrintf("GenerateNewKeyPair::Failed to sign block with cpid -> %s", sError);
             return false;
         }
         fResult = VerifyCPIDSignature(cpid, hashBlock.GetHex(), sSignature);
         if (fResult)
         {
-            LogPrintf("\nGenerateNewKeyPair::Current keypair is valid.\n");
+            LogPrintf("GenerateNewKeyPair::Current keypair is valid.");
             return false;
         }
     }
@@ -117,7 +117,7 @@ int64_t BeaconTimeStamp(const std::string& cpid, bool bZeroOutAfterPOR)
     int64_t iLocktime = entry.timestamp;
     int64_t iRSAWeight = GetRSAWeightByCPIDWithRA(cpid);
     if (fDebug10)
-        LogPrintf("\n Beacon %s, Weight %" PRId64 ", Locktime %" PRId64 "\n",sBeacon, iRSAWeight, iLocktime);
+        LogPrintf("Beacon %s, Weight %" PRId64 ", Locktime %" PRId64, sBeacon, iRSAWeight, iLocktime);
     if (bZeroOutAfterPOR && iRSAWeight==0)
         iLocktime = 0;
     return iLocktime;
@@ -172,7 +172,7 @@ bool VerifyBeaconContractTx(const CTransaction& tx)
     if (beaconEntry.value.empty())
     {
         if (fDebug10)
-            LogPrintf("VBCTX : No Previous beacon found for CPID %s\n", chkMessageContractCPID);
+            LogPrintf("VBCTX : No Previous beacon found for CPID %s", chkMessageContractCPID);
 
         return true; // No previous beacon in cache
     }
@@ -187,7 +187,7 @@ bool VerifyBeaconContractTx(const CTransaction& tx)
     if (chkiAge <= chkSecondsBase * 5 && chkiAge >= 1)
     {
         if (fDebug10)
-            LogPrintf("VBCTX : Beacon age violation. Beacon Age %" PRId64 " < Required Age %" PRId64 "\n", chkiAge, (chkSecondsBase * 5));
+            LogPrintf("VBCTX : Beacon age violation. Beacon Age %" PRId64 " < Required Age %" PRId64, chkiAge, (chkSecondsBase * 5));
 
         return false;
     }
@@ -205,7 +205,7 @@ bool VerifyBeaconContractTx(const CTransaction& tx)
         if (tx_out_publickey != chk_out_publickey)
         {
             if (fDebug10)
-                LogPrintf("VBCTX : Beacon tx publickey != publickey in chain. %s != %s\n", tx_out_publickey.c_str(), chk_out_publickey);
+                LogPrintf("VBCTX : Beacon tx publickey != publickey in chain. %s != %s", tx_out_publickey.c_str(), chk_out_publickey);
 
             return false;
         }

--- a/src/boinc.cpp
+++ b/src/boinc.cpp
@@ -39,7 +39,7 @@ std::string GetBoincDataDir(){
             if (boost::filesystem::exists(path)){
                 return path;
             } else {
-                LogPrintf("Cannot find BOINC data dir %s.\n", path);
+                LogPrintf("Cannot find BOINC data dir %s.", path);
             }
         }
         RegCloseKey(hKey);
@@ -68,6 +68,6 @@ std::string GetBoincDataDir(){
     }
     #endif
 
-    LogPrintf("ERROR: Cannot find BOINC data dir\n");
+    LogPrintf("ERROR: Cannot find BOINC data dir");
     return "";
 }

--- a/src/contract/contract.cpp
+++ b/src/contract/contract.cpp
@@ -43,7 +43,7 @@ bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string 
     std::string sConcatMessage = sCPID + sBlockHash;
     bool bValid = CheckMessageSignature("R","cpid", sConcatMessage, sSignature, sBeaconPublicKey);
     if(!bValid)
-        LogPrintf("VerifyCPIDSignature: invalid signature sSignature=%s, cached key=%s\n"
+        LogPrintf("VerifyCPIDSignature: invalid signature sSignature=%s, cached key=%s"
                   ,sSignature, sBeaconPublicKey);
     return bValid;
 }

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -42,7 +42,7 @@ std::pair<std::string, std::string> CreatePollContract(std::string sTitle, int d
 
     if (sTitle.empty() || sQuestion.empty() || sAnswers.empty() || sURL.empty())
     {
-        return std::make_pair("Error", "Must specify a poll title, question, answers, and URL\n");
+        return std::make_pair("Error", "Must specify a poll title, question, answers, and URL");
     }
     else if (days < 7)
         return std::make_pair("Error", "Minimum duration is 7 days; please specify a longer poll duration.");
@@ -69,7 +69,7 @@ std::pair<std::string, std::string> CreatePollContract(std::string sTitle, int d
 std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::string sAnswer)
 {
     if (sTitle.empty() || sAnswer.empty())
-        return std::make_pair("Error", "Must specify a poll title and answers\n");
+        return std::make_pair("Error", "Must specify a poll title and answers");
     if (pwalletMain->IsLocked())
         return std::make_pair("Error", "Please fully unlock the wallet first.");
     else if (fWalletUnlockStakingOnly)
@@ -111,7 +111,7 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
     double stake_age = GetAdjustedTime() - ReadCache("global", "nGRCTime").timestamp;
 
     StructCPID structGRC = GetInitializedStructCPID2(GRCAddress, mvMagnitudes);
-    LogPrintf("CPIDAge %f, StakeAge %f, Poll Duration %f \r\n", cpid_age, stake_age, poll_duration);
+    LogPrintf("CPIDAge %f, StakeAge %f, Poll Duration %f", cpid_age, stake_age, poll_duration);
     double dShareType= RoundFromString(GetPollXMLElementByPollTitle(sTitle, "<SHARETYPE>", "</SHARETYPE>"), 0);
 
     // Share Type 1 == "Magnitude"
@@ -368,7 +368,7 @@ double ReturnVerifiedVotingBalance(std::string sXML, bool bCreatedAfterSecurityU
     double dTotalVotedBalance = RoundFromString(ExtractXML(sPayload,"<TOTALVOTEDBALANCE>","</TOTALVOTEDBALANCE>"),2);
     double dLegacyBalance = RoundFromString(ExtractXML(sXML,"<BALANCE>","</BALANCE>"),0);
 
-    if (fDebug10) LogPrintf(" \n Total Voted Balance %f, Legacy Balance %f \n",(float)dTotalVotedBalance,(float)dLegacyBalance);
+    if (fDebug10) LogPrintf("Total Voted Balance %f, Legacy Balance %f", dTotalVotedBalance, dLegacyBalance);
     if (!bCreatedAfterSecurityUpgrade) return dLegacyBalance;
 
     double dCounted = 0;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -38,7 +38,7 @@ void CDBEnv::EnvShutdown()
     fDbEnvInit = false;
     int ret = dbenv.close(0);
     if (ret != 0)
-        LogPrintf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
+        LogPrintf("EnvShutdown exception: %s (%d)", DbEnv::strerror(ret), ret);
     if (!fMockDb)
         DbEnv((uint32_t)0).remove(strPath.c_str(),0);
 }
@@ -123,7 +123,7 @@ void CDBEnv::MakeMock()
     if (fShutdown)
         throw runtime_error("CDBEnv::MakeMock(): during shutdown");
 
-    LogPrint("db", "CDBEnv::MakeMock()\n");
+    LogPrint("db", "CDBEnv::MakeMock()");
 
     dbenv.set_cachesize(1, 0, 1);
     dbenv.set_lg_bsize(10485760*4);
@@ -182,16 +182,16 @@ bool CDBEnv::Salvage(std::string strFile, bool fAggressive,
     int result = db.verify(strFile.c_str(), NULL, &strDump, flags);
     if (result == DB_VERIFY_BAD)
     {
-        LogPrintf("Error: Salvage found errors, all data may not be recoverable.\n");
+        LogPrintf("Error: Salvage found errors, all data may not be recoverable.");
         if (!fAggressive)
         {
-            LogPrintf("Error: Rerun with aggressive mode to ignore errors and continue.\n");
+            LogPrintf("Error: Rerun with aggressive mode to ignore errors and continue.");
             return false;
         }
     }
     if (result != 0 && result != DB_VERIFY_BAD)
     {
-        LogPrintf("ERROR: db salvage failed: %d\n",result);
+        LogPrintf("ERROR: db salvage failed: %d", result);
         return false;
     }
 
@@ -361,7 +361,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                 bitdb.mapFileUseCount.erase(strFile);
 
                 bool fSuccess = true;
-                LogPrintf("Rewriting %s...\n", strFile);
+                LogPrintf("Rewriting %s...", strFile);
                 string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
                     CDB db(strFile.c_str(), "r");
@@ -375,7 +375,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                                             0);
                     if (ret > 0)
                     {
-                        LogPrintf("Cannot create database file %s\n", strFileRes);
+                        LogPrintf("Cannot create database file %s", strFileRes);
                         fSuccess = false;
                     }
 
@@ -431,7 +431,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                         fSuccess = false;
                 }
                 if (!fSuccess)
-                    LogPrintf("Rewriting of %s FAILED!\n", strFileRes);
+                    LogPrintf("Rewriting of %s FAILED!", strFileRes);
                 return fSuccess;
             }
         }
@@ -446,7 +446,7 @@ void CDBEnv::Flush(bool fShutdown)
     int64_t nStart = GetTimeMillis();
     // Flush log data to the actual data file
     //  on all files that are not in use
-    LogPrint("db", "Flush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
+    LogPrint("db", "Flush(%s)%s", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
     if (!fDbEnvInit)
         return;
     {
@@ -456,23 +456,23 @@ void CDBEnv::Flush(bool fShutdown)
         {
             string strFile = (*mi).first;
             int nRefCount = (*mi).second;
-            LogPrint("db", "%s refcount=%d\n", strFile, nRefCount);
+            LogPrint("db", "%s refcount=%d", strFile, nRefCount);
             if (nRefCount == 0)
             {
                 // Move log data to the dat file
                 CloseDb(strFile);
-                LogPrint("db", "%s checkpoint\n", strFile);
+                LogPrint("db", "%s checkpoint", strFile);
                 dbenv.txn_checkpoint(0, 0, 0);
-                LogPrint("db", "%s detach\n", strFile);
+                LogPrint("db", "%s detach", strFile);
                 if (!fMockDb)
                     dbenv.lsn_reset(strFile.c_str(), 0);
-                LogPrint("db", "%s closed\n", strFile);
+                LogPrint("db", "%s closed", strFile);
                 mapFileUseCount.erase(mi++);
             }
             else
                 mi++;
         }
-        LogPrint("db", "DBFlush(%s)%s ended %15" PRId64 "ms\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started", GetTimeMillis() - nStart);
+        LogPrint("db", "DBFlush(%s)%s ended %15" PRId64 "ms", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started", GetTimeMillis() - nStart);
         if (fShutdown)
         {
             char** listp;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -60,7 +60,7 @@ bool ShutdownRequested()
 void StartShutdown()
 {
 
-    LogPrintf("Calling start shutdown...\n");
+    LogPrintf("Calling start shutdown...");
 
     if(fQtActive)
         // ensure we leave the Qt main loop for a clean GUI exit (Shutdown() is called in bitcoin.cpp afterwards)
@@ -90,7 +90,7 @@ void Shutdown(void* parg)
     static bool fExit;
     if (fFirstThread)
     {
-         LogPrintf("gridcoinresearch exiting...\n");
+         LogPrintf("gridcoinresearch exiting...");
 
         fShutdown = true;
         bitdb.Flush(false);
@@ -105,7 +105,7 @@ void Shutdown(void* parg)
         // lock file.
         //CTxDB().Close();
         MilliSleep(50);
-        LogPrintf("Gridcoin exited\n\n");
+        LogPrintf("Gridcoin exited");
         fExit = true;
     }
     else
@@ -225,7 +225,7 @@ std::string HelpMessage()
         "  -keypool=<n>           " + _("Set key pool size to <n> (default: 100)") + "\n" +
         "  -rescan                " + _("Rescan the block chain for missing wallet transactions") + "\n" +
         "  -salvagewallet         " + _("Attempt to recover private keys from a corrupt wallet.dat") + "\n" +
-        "  -zapwallettxes=<mode>  " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup\n") +
+        "  -zapwallettxes=<mode>  " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") + "\n" +
         "  -checkblocks=<n>       " + _("How many blocks to check at startup (default: 2500, 0 = all)") + "\n" +
         "  -checklevel=<n>        " + _("How thorough the block verification is (0-6, default: 1)") + "\n" +
         "  -loadblock=<file>      " + _("Imports blocks from external blk000?.dat file") + "\n" +
@@ -346,7 +346,7 @@ bool AppInit2(ThreadHandlerPtr threads)
           << BOOST_VERSION % 100                // patch level
           << "\n";
 
-    LogPrintf("\nBoost Version: %s",s.str());
+    LogPrintf("Boost Version: %s", s.str());
 
     //Placeholder: Load Remote CPIDs Here
 
@@ -412,7 +412,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (GetArg("-debug", "false")=="true")
     {
             fDebug = true;
-            LogPrintf("Entering debug mode.\n");
+            LogPrintf("Entering debug mode.");
     }
 
     fDebug2 = false;
@@ -420,7 +420,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (GetArg("-debug2", "false")=="true")
     {
             fDebug2 = true;
-            LogPrintf("Entering GRC debug mode 2.\n");
+            LogPrintf("Entering GRC debug mode 2.");
     }
 
     fDebug3 = false;
@@ -428,13 +428,13 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (GetArg("-debug3", "false")=="true")
     {
             fDebug3 = true;
-            LogPrintf("Entering GRC debug mode 3.\n");
+            LogPrintf("Entering GRC debug mode 3.");
     }
 
     fDebug4 = GetBoolArg("-debug4");
 
     if (fDebug4)
-       LogPrintf("Entering RPC time debug mode\n");
+       LogPrintf("Entering RPC time debug mode");
 
     fDebug10= (GetArg("-debug10","false")=="true");
 
@@ -532,9 +532,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 #endif
 
     ShrinkDebugFile();
-    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-    LogPrintf("***************************************** GRIDCOIN RESEARCH ***************************************************\n");
-
+    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     LogPrintf("Gridcoin version %s (%s)", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s", SSLeay_version(SSLEAY_VERSION));
     if (!fLogTimestamps)
@@ -548,7 +546,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
         fDevbuildCripple = true;
         LogPrintf("WARNING: Running development version outside of testnet!\n"
-               "Staking and sending transactions will be disabled.");
+                  "Staking and sending transactions will be disabled.");
         if( (GetArg("-devbuild", "") == "override") && fDebug )
             fDevbuildCripple = false;
     }
@@ -720,7 +718,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     uiInterface.InitMessage(_("Loading block index..."));
-    LogPrintf("Loading block index...\n");
+    LogPrintf("Loading block index...");
     nStart = GetTimeMillis();
     if (!LoadBlockIndex())
         return InitError(_("Error loading blkindex.dat"));
@@ -730,10 +728,10 @@ bool AppInit2(ThreadHandlerPtr threads)
     // As the program has not fully started yet, Shutdown() is possibly overkill.
     if (fRequestShutdown)
     {
-        LogPrintf("Shutdown requested. Exiting.\n");
+        LogPrintf("Shutdown requested. Exiting.");
         return false;
     }
-    LogPrintf(" block index %15" PRId64 "ms\n", GetTimeMillis() - nStart);
+    LogPrintf(" block index %15" PRId64 "ms", GetTimeMillis() - nStart);
 
     if (GetBoolArg("-printblockindex") || GetBoolArg("-printblocktree"))
     {
@@ -755,19 +753,19 @@ bool AppInit2(ThreadHandlerPtr threads)
                 block.ReadFromDisk(pindex);
                 block.BuildMerkleTree();
                 block.print();
-                LogPrintf("\n");
+                LogPrintf("");
                 nFound++;
             }
         }
         if (nFound == 0)
-            LogPrintf("No blocks matching %s were found\n", strMatch);
+            LogPrintf("No blocks matching %s were found", strMatch);
         return false;
     }
 
     // ********************************************************* Step 8: load wallet
 
     uiInterface.InitMessage(_("Loading wallet..."));
-    LogPrintf("Loading wallet...\n");
+    LogPrintf("Loading wallet...");
     nStart = GetTimeMillis();
     bool fFirstRun = true;
     pwalletMain = new CWallet(strWalletFileName);
@@ -799,12 +797,12 @@ bool AppInit2(ThreadHandlerPtr threads)
         int nMaxVersion = GetArg("-upgradewallet", 0);
         if (nMaxVersion == 0) // the -upgradewallet without argument case
         {
-            LogPrintf("Performing wallet upgrade to %i\n", FEATURE_LATEST);
+            LogPrintf("Performing wallet upgrade to %i", FEATURE_LATEST);
             nMaxVersion = CLIENT_VERSION;
             pwalletMain->SetMinVersion(FEATURE_LATEST); // permanently upgrade the wallet immediately
         }
         else
-            LogPrintf("Allowing wallet upgrade up to %i\n", nMaxVersion);
+            LogPrintf("Allowing wallet upgrade up to %i", nMaxVersion);
         if (nMaxVersion < pwalletMain->GetVersion())
             strErrors << _("Cannot downgrade wallet") << "\n";
         pwalletMain->SetMaxVersion(nMaxVersion);
@@ -824,7 +822,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     LogPrintf("%s", strErrors.str());
-    LogPrintf(" wallet      %15" PRId64 "ms\n", GetTimeMillis() - nStart);
+    LogPrintf(" wallet      %15" PRId64 "ms", GetTimeMillis() - nStart);
 
     RegisterWallet(pwalletMain);
 
@@ -841,10 +839,10 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (pindexBest != pindexRescan && pindexBest && pindexRescan && pindexBest->nHeight > pindexRescan->nHeight)
     {
         uiInterface.InitMessage(_("Rescanning..."));
-        LogPrintf("Rescanning last %i blocks (from block %i)...\n", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);
+        LogPrintf("Rescanning last %i blocks (from block %i)...", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);
         nStart = GetTimeMillis();
         pwalletMain->ScanForWalletTransactions(pindexRescan, true);
-        LogPrintf(" rescan      %15" PRId64 "ms\n", GetTimeMillis() - nStart);
+        LogPrintf(" rescan      %15" PRId64 "ms", GetTimeMillis() - nStart);
     }
 
     // ********************************************************* Step 9: import blocks
@@ -877,13 +875,13 @@ bool AppInit2(ThreadHandlerPtr threads)
     // ********************************************************* Step 10: load peers
 
     uiInterface.InitMessage(_("Loading addresses..."));
-    if (fDebug10) LogPrintf("Loading addresses...\n");
+    if (fDebug10) LogPrintf("Loading addresses...");
     nStart = GetTimeMillis();
 
     {
         CAddrDB adb;
         if (!adb.Read(addrman))
-            LogPrintf("Invalid or missing peers.dat; recreating\n");
+            LogPrintf("Invalid or missing peers.dat; recreating");
     }
 
     LogPrintf("Loaded %i addresses from peers.dat  %" PRId64 "ms",  addrman.size(), GetTimeMillis() - nStart);
@@ -936,7 +934,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     // ********************************************************* Step 12: finished
 
     uiInterface.InitMessage(_("Done loading"));
-    LogPrintf("Done loading\n");
+    LogPrintf("Done loading");
 
     if (!strErrors.str().empty())
         return InitError(strErrors.str());

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -99,7 +99,7 @@ static bool SelectBlockFromCandidates(vector<pair<int64_t, uint256> >& vSortedBy
         }
     }
     if (fDebug && GetBoolArg("-printstakemodifier"))
-        LogPrintf("SelectBlockFromCandidates: selection hash=%s\n", hashBest.ToString());
+        LogPrintf("SelectBlockFromCandidates: selection hash=%s", hashBest.ToString());
     return fSelected;
 }
 
@@ -132,7 +132,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
         return error("ComputeNextStakeModifier: unable to get last modifier");
     if (fDebug10)
     {
-        LogPrintf("ComputeNextStakeModifier: prev modifier=0x%016" PRIx64 " time=%s\n", nStakeModifier, DateTimeStrFormat(nModifierTime));
+        LogPrintf("ComputeNextStakeModifier: prev modifier=0x%016" PRIx64 " time=%s", nStakeModifier, DateTimeStrFormat(nModifierTime));
     }
     if (nModifierTime / nModifierInterval >= pindexPrev->GetBlockTime() / nModifierInterval)
         return true;
@@ -176,7 +176,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
         // add the selected block from candidates to selected list
         mapSelectedBlocks.insert(make_pair(pindex->GetBlockHash(), pindex));
         if (fDebug && GetBoolArg("-printstakemodifier"))
-            LogPrintf("ComputeNextStakeModifier: selected round %d stop=%s height=%d bit=%d\n", nRound, DateTimeStrFormat(nSelectionIntervalStop), pindex->nHeight, pindex->GetStakeEntropyBit());
+            LogPrintf("ComputeNextStakeModifier: selected round %d stop=%s height=%d bit=%d", nRound, DateTimeStrFormat(nSelectionIntervalStop), pindex->nHeight, pindex->GetStakeEntropyBit());
     }
 
     // Print selection map for visualization of the selected blocks
@@ -199,12 +199,12 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
             // 'W' indicates selected proof-of-work blocks
             strSelectionMap.replace(item.second->nHeight - nHeightFirstCandidate, 1, item.second->IsProofOfStake()? "S" : "W");
         }
-        LogPrintf("ComputeNextStakeModifier: selection height [%d, %d] map %s\n", nHeightFirstCandidate,
+        LogPrintf("ComputeNextStakeModifier: selection height [%d, %d] map %s", nHeightFirstCandidate,
             pindexPrev->nHeight, strSelectionMap);
     }
     if (fDebug)
     {
-        LogPrintf("ComputeNextStakeModifier: new modifier=0x%016" PRIx64 " time=%s\n", nStakeModifierNew, DateTimeStrFormat(pindexPrev->GetBlockTime()));
+        LogPrintf("ComputeNextStakeModifier: new modifier=0x%016" PRIx64 " time=%s", nStakeModifierNew, DateTimeStrFormat(pindexPrev->GetBlockTime()));
     }
 
     nStakeModifier = nStakeModifierNew;
@@ -502,12 +502,12 @@ static bool CheckStakeKernelHashV1(unsigned int nBits, const CBlock& blockFrom, 
     hashProofOfStake = Hash(ss.begin(), ss.end());
     if (fPrintProofOfStake)
     {
-        LogPrintf("CheckStakeKernelHash() : using modifier 0x%016" PRIx64 " at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
+        LogPrintf("CheckStakeKernelHash() : using modifier 0x%016" PRIx64 " at height=%d timestamp=%s for block from height=%d timestamp=%s",
             nStakeModifier, nStakeModifierHeight,
             DateTimeStrFormat(nStakeModifierTime),
             mapBlockIndex[hashBlockFrom]->nHeight,
             DateTimeStrFormat(blockFrom.GetBlockTime()));
-        LogPrintf("CheckStakeKernelHash() : check modifier=0x%016" PRIx64 " nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
+        LogPrintf("CheckStakeKernelHash() : check modifier=0x%016" PRIx64 " nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s",
             nStakeModifier,
             nTimeBlockFrom, nTxPrevOffset, txPrev.nTime, prevout.n, nTimeTx,
             hashProofOfStake.ToString());
@@ -521,19 +521,19 @@ static bool CheckStakeKernelHashV1(unsigned int nBits, const CBlock& blockFrom, 
             //Use this area to log the submitters cpid and mint amount:
             if (!checking_local || fDebug)
             {
-                if (LessVerbose(75)) LogPrintf("{Vitals}: cpid %s, project %s, RSA_WEIGHT: %f \n",cpid, boincblock.projectname, (double)RSA_WEIGHT);
+                if (LessVerbose(75)) LogPrintf("{Vitals}: cpid %s, project %s, RSA_WEIGHT: %f ",cpid, boincblock.projectname, (double)RSA_WEIGHT);
             }
             return false;
         }
     }
     if (fDebug && !fPrintProofOfStake)
     {
-        LogPrintf("CheckStakeKernelHash() : using modifier 0x%016" PRIx64 " at height=%d timestamp=%s for block from height=%d timestamp=%s\n",
+        LogPrintf("CheckStakeKernelHash() : using modifier 0x%016" PRIx64 " at height=%d timestamp=%s for block from height=%d timestamp=%s",
             nStakeModifier, nStakeModifierHeight,
             DateTimeStrFormat(nStakeModifierTime),
             mapBlockIndex[hashBlockFrom]->nHeight,
             DateTimeStrFormat(blockFrom.GetBlockTime()));
-        LogPrintf("CheckStakeKernelHash() : pass modifier=0x%016" PRIx64 " nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s\n",
+        LogPrintf("CheckStakeKernelHash() : pass modifier=0x%016" PRIx64 " nTimeBlockFrom=%u nTxPrevOffset=%u nTimeTxPrev=%u nPrevout=%u nTimeTx=%u hashProof=%s",
             nStakeModifier,
             nTimeBlockFrom, nTxPrevOffset, txPrev.nTime, prevout.n, nTimeTx,
             hashProofOfStake.ToString());
@@ -646,7 +646,7 @@ static bool CheckStakeKernelHashV3(CBlockIndex* pindexPrev, unsigned int nBits,
     if(fPrintProofOfStake) LogPrintf(
 "CheckStakeKernelHashV3: %sRSA %g, Time1 %.f, Time2 %.f,  Time3 %.f, Por_Nonce %.f Bits %u Weight %.f\n"
 " Stk %72s\n"
-" Trg %72s\n", checking_local?"Local ":"",
+" Trg %72s", checking_local?"Local ":"",
         (double)RSA_WEIGHT,
         (double)blockFrom.nTime, (double)txPrev.nTime, (double)nTimeTx,
         por_nonce,
@@ -890,7 +890,7 @@ bool CheckProofOfStakeV8(
     if(fDebug) LogPrintf(
 "CheckProofOfStakeV8:%s Time1 %.f, Time2 %.f, Time3 %.f, Bits %u, Weight %.f\n"
 " Stk %72s\n"
-" Trg %72s\n", generated_by_me?" Local,":"",
+" Trg %72s", generated_by_me?" Local,":"",
         (double)blockPrev.nTime, (double)txPrev.nTime, (double)tx.nTime,
         Block.nBits, (double)Weight,
         CBigNum(hashProofOfStake).GetHex(), bnTarget.GetHex()

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -521,7 +521,7 @@ static bool CheckStakeKernelHashV1(unsigned int nBits, const CBlock& blockFrom, 
             //Use this area to log the submitters cpid and mint amount:
             if (!checking_local || fDebug)
             {
-                if (LessVerbose(75)) LogPrintf("{Vitals}: cpid %s, project %s, RSA_WEIGHT: %f ",cpid, boincblock.projectname, (double)RSA_WEIGHT);
+                if (LessVerbose(75)) LogPrintf("{Vitals}: cpid %s, project %s, RSA_WEIGHT: %" PRId64, cpid, boincblock.projectname, RSA_WEIGHT);
             }
             return false;
         }
@@ -644,13 +644,13 @@ static bool CheckStakeKernelHashV3(CBlockIndex* pindexPrev, unsigned int nBits,
     targetProofOfStake=bnTarget.getuint256();
 
     if(fPrintProofOfStake) LogPrintf(
-"CheckStakeKernelHashV3: %sRSA %g, Time1 %.f, Time2 %.f,  Time3 %.f, Por_Nonce %.f Bits %u Weight %.f\n"
+"CheckStakeKernelHashV3: %sRSA %" PRId64 ", Time1 %" PRId64 ", Time2 %" PRId64 ", Time3 %d, Por_Nonce %.f Bits %u Weight %" PRId64 "\n"
 " Stk %72s\n"
 " Trg %72s", checking_local?"Local ":"",
-        (double)RSA_WEIGHT,
-        (double)blockFrom.nTime, (double)txPrev.nTime, (double)nTimeTx,
+        RSA_WEIGHT,
+        blockFrom.nTime, txPrev.nTime, nTimeTx,
         por_nonce,
-        nBits, (double)Weight,
+        nBits, Weight,
         CBigNum(hashProofOfStake).GetHex(), bnTarget.GetHex()
     );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -921,13 +921,13 @@ MiningCPID GetNextProject(bool bForce)
 #                                       if 0
                                         if (!bResult)
                                         {
-                                            LogPrintf("GetNextProject: failed to sign block with cpid -> %s", sError.c_str());
+                                            LogPrintf("GetNextProject: failed to sign block with cpid -> %s", sError);
                                             continue;
                                         }
                                         GlobalCPUMiningCPID.BoincSignature = sSignature;
                                         if (!IsCPIDValidv2(GlobalCPUMiningCPID,1))
                                         {
-                                            LogPrintf("CPID INVALID (GetNextProject) %s, %s  ",GlobalCPUMiningCPID.cpid.c_str(),GlobalCPUMiningCPID.cpidv2.c_str());
+                                            LogPrintf("CPID INVALID (GetNextProject) %s, %s  ",GlobalCPUMiningCPID.cpid,GlobalCPUMiningCPID.cpidv2);
                                             continue;
                                         }
 #                                       endif
@@ -2792,7 +2792,7 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
                 std::string sMKey = ExtractXML(vtx[i].hashBoinc, "<MK>", "</MK>");
                 DeleteCache(sMType, sMKey);
                 if(fDebug)
-                    LogPrintf("DisconnectBlock: Delete contract %s %s", sMType.c_str(), sMKey);
+                    LogPrintf("DisconnectBlock: Delete contract %s %s", sMType, sMKey);
 
                 if("beacon"==sMType)
                 {
@@ -4763,7 +4763,7 @@ void GridcoinServices()
             bool fResult = AdvertiseBeacon(sOutPrivKey,sOutPubKey,sError,sMessage);
             if (!fResult)
             {
-                LogPrintf("BEACON ERROR!  Unable to send beacon %s, %s",sError.c_str(), sMessage.c_str());
+                LogPrintf("BEACON ERROR!  Unable to send beacon %s, %s",sError, sMessage);
                 LOCK(MinerStatus.lock);
                 msMiningErrors6 = _("Unable To Send Beacon! Unlock Wallet!");
             }
@@ -6098,7 +6098,7 @@ bool TallyResearchAverages_v9(CBlockIndex* index)
 
         LoadSuperblock(superblock, sbIndex->nTime, sbIndex->nHeight);
         if (fDebug)
-            LogPrintf("TallyResearchAverages_v9: Superblock Loaded {%s %i}", sbIndex->GetBlockHash().GetHex().c_str(), sbIndex->nHeight);
+            LogPrintf("TallyResearchAverages_v9: Superblock Loaded {%s %i}", sbIndex->GetBlockHash().GetHex(), sbIndex->nHeight);
         break;
     }
 
@@ -6429,7 +6429,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     RandAddSeedPerfmon();
     if (fDebug10)
-        LogPrintf("received: %s from %s (%" PRIszu " bytes)", strCommand.c_str(), pfrom->addrName.c_str(), vRecv.size());
+        LogPrintf("received: %s from %s (%" PRIszu " bytes)", strCommand, pfrom->addrName, vRecv.size());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE");
@@ -6485,7 +6485,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion < 180321 && fTestNet)
         {
             // disconnect from peers older than this proto version
-            if (fDebug10) LogPrintf("Testnet partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString().c_str(), pfrom->nVersion);
+            if (fDebug10) LogPrintf("Testnet partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;
         }
@@ -6493,7 +6493,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version
-            if (fDebug10) LogPrintf("partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString().c_str(), pfrom->nVersion);
+            if (fDebug10) LogPrintf("partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;
         }
@@ -6555,7 +6555,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // Disconnect if we connected to ourself
         if (nNonce == nLocalHostNonce && nNonce > 1)
         {
-            if (fDebug3) LogPrintf("connected to self at %s, disconnecting", pfrom->addr.ToString().c_str());
+            if (fDebug3) LogPrintf("connected to self at %s, disconnecting", pfrom->addr.ToString());
             pfrom->fDisconnect = true;
             return true;
         }
@@ -6756,7 +6756,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
             bool fAlreadyHave = AlreadyHave(txdb, inv);
             if (fDebug10)
-                LogPrintf("  got inventory: %s  %s", inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
+                LogPrintf("  got inventory: %s  %s", inv.ToString(), fAlreadyHave ? "have" : "new");
 
             if (!fAlreadyHave)
                 pfrom->AskFor(inv);
@@ -7107,7 +7107,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             uint64_t nonce = 0;
             vRecv >> nonce >> acid;
-            //if (fDebug10) LogPrintf("pong valid %s",YesNo(pong_valid).c_str());
 
             // Echo the message back with the nonce. This allows for two useful features:
             //
@@ -8477,7 +8476,7 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
                     LogPrintf("ComputeResearchAccrual: Newbie special stake too high, reward=500GRC");
                     return (500*COIN);
                 }
-                if (fDebug3) LogPrintf("ComputeResearchAccrual: Newbie Special First Stake for CPID %s, Age %f, Accrual %" PRId64, cpid.c_str(),dNewbieAccrualAge, iAccrual);
+                if (fDebug3) LogPrintf("ComputeResearchAccrual: Newbie Special First Stake for CPID %s, Age %f, Accrual %" PRId64, cpid, dNewbieAccrualAge, iAccrual);
                 if(fDebug && !bVerifyingBlock) LogPrintf("CRE: Newbie Stake, "
                     "dNewbieAccrualAge= %f dCurrentMagnitude= %.1f dMagnitudeUnit= %f Accrual= %f",
                     dNewbieAccrualAge, dCurrentMagnitude, dMagnitudeUnit, iAccrual/(double)COIN);
@@ -8671,7 +8670,6 @@ std::string CPIDHash(double dMagIn, std::string sCPID)
     std::string sMagComponent1 = RoundToString(dMagIn/(dExponent+.01),0);
     std::string sSuffix = RoundToString(dMagLength * dExponent, 0);
     std::string sHash = sCPID + sMagComponent1 + sSuffix;
-    //  LogPrintf("%s, %s, %f, %f, %s",sCPID.c_str(), sMagComponent1.c_str(),dMagLength,dExponent,sSuffix.c_str());
     return sHash;
 }
 
@@ -8774,7 +8772,6 @@ std::string getHardDriveSerial()
         cmd1 = "ls /dev/disk/by-uuid";
     #endif
     std::string result = SystemCommand(cmd1.c_str());
-    //if (fDebug3) LogPrintf("result %s",result.c_str());
     msHDDSerial = result;
     return result;
 }
@@ -8821,8 +8818,6 @@ bool IsNeuralNodeParticipant(const std::string& addr, int64_t locktime)
     }
 
     uint256 uADH = uint256("0x" + address_day_hash);
-    //LogPrintf("%s < %s : %s",uADH.GetHex().c_str() ,uRef.GetHex().c_str(), YesNo(uADH  < uRef).c_str());
-    //LogPrintf("%s < %s : %s",uTest.GetHex().c_str(),uRef.GetHex().c_str(), YesNo(uTest < uRef).c_str());
     return (uADH < uRef);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3046,7 +3046,7 @@ int64_t ReturnCurrentMoneySupply(CBlockIndex* pindexcurrent)
     while (pblockIndex->nHeight > nMinDepth)
     {
             pblockIndex = pblockIndex->pprev;
-            LogPrintf("Money Supply height %f",(double)pblockIndex->nHeight);
+            LogPrintf("Money Supply height %d", pblockIndex->nHeight);
 
             if (pblockIndex == NULL || !pblockIndex->IsInMainChain()) continue;
             if (pblockIndex == pindexGenesisBlock)
@@ -4286,7 +4286,7 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
         {
             if (vtx[i].IsCoinStake())
             {
-                LogPrintf("Found more than one coinstake in coinbase at location %f",(double)i);
+                LogPrintf("Found more than one coinstake in coinbase at location %d", i);
                 return DoS(100, error("CheckBlock[] : more than one coinstake"));
             }
         }
@@ -5959,7 +5959,7 @@ bool TallyResearchAverages_retired(CBlockIndex* index)
         pblockindex = pblockindex->pprev;
     }
 
-    if (fDebug3) LogPrintf("Max block %f, seektime %f",(double)pblockindex->nHeight,(double)GetTimeMillis()-nStart);
+    if (fDebug3) LogPrintf("Max block %d, seektime %" PRId64, pblockindex->nHeight, GetTimeMillis()-nStart);
     nStart=GetTimeMillis();
 
 
@@ -6024,7 +6024,7 @@ bool TallyResearchAverages_retired(CBlockIndex* index)
         bNetAveragesLoaded=true;
     }
 
-    if (fDebug3) LogPrintf("NA loaded in %f",(double)GetTimeMillis()-nStart);
+    if (fDebug3) LogPrintf("NA loaded in %" PRId64, GetTimeMillis() - nStart);
 
     bNetAveragesLoaded=true;
     return false;
@@ -7787,7 +7787,9 @@ void HarvestCPIDs(bool cleardata)
                         structcpid.team = team;
                         InitializeProjectStruct(structcpid);
                         int64_t elapsed = GetTimeMillis()-nStart;
-                        if (fDebug3) LogPrintf("Enumerating boinc local project %s cpid %s valid %s, elapsed %f ", structcpid.projectname, structcpid.cpid, YesNo(structcpid.Iscpidvalid), (double)elapsed);
+                        if (fDebug3)
+                            LogPrintf("Enumerating boinc local project %s cpid %s valid %s, elapsed %" PRId64, structcpid.projectname, structcpid.cpid, YesNo(structcpid.Iscpidvalid), elapsed);
+                        
                         structcpid.rac = RoundFromString(rac,0);
                         structcpid.verifiedrac = RoundFromString(rac,0);
                         std::string sLocalClientEmailHash = RetrieveMd5(email);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -728,7 +728,7 @@ void GetGlobalStatus()
     {
         msMiningErrors = _("Error obtaining status.");
 
-        LogPrintf("Error obtaining status\n");
+        LogPrintf("Error obtaining status");
         return;
     }
 }
@@ -806,10 +806,10 @@ MiningCPID GetNextProject(bool bForce)
     std::string sBoincKey = GetArgument("boinckey","");
     if (!sBoincKey.empty())
     {
-        if (fDebug3 && LessVerbose(50)) LogPrintf("Using cached boinckey for project %s\n",GlobalCPUMiningCPID.projectname);
+        if (fDebug3 && LessVerbose(50)) LogPrintf("Using cached boinckey for project %s",GlobalCPUMiningCPID.projectname);
                     msMiningProject = GlobalCPUMiningCPID.projectname;
                     msMiningCPID = GlobalCPUMiningCPID.cpid;
-                    if (LessVerbose(5)) LogPrintf("BoincKey - Mining project %s     RAC(%f)\n",  GlobalCPUMiningCPID.projectname, GlobalCPUMiningCPID.rac);
+                    if (LessVerbose(5)) LogPrintf("BoincKey - Mining project %s     RAC(%f)",  GlobalCPUMiningCPID.projectname, GlobalCPUMiningCPID.rac);
                     double ProjectRAC = GetNetworkAvgByProject(GlobalCPUMiningCPID.projectname);
                     GlobalCPUMiningCPID.NetworkRAC = ProjectRAC;
                     GlobalCPUMiningCPID.Magnitude = CalculatedMagnitude(GetAdjustedTime(),false);
@@ -896,7 +896,7 @@ MiningCPID GetNextProject(bool bForce)
 
                                         GlobalCPUMiningCPID.email = email;
 
-                                        if (LessVerbose(1) || fDebug || fDebug3) LogPrintf("Ready to CPU Mine project %s with CPID %s, RAC(%f) \n",
+                                        if (LessVerbose(1) || fDebug || fDebug3) LogPrintf("Ready to CPU Mine project %s with CPID %s, RAC(%f) ",
                                             structcpid.projectname.c_str(),structcpid.cpid.c_str(),
                                             structcpid.rac);
                                         //Required for project to be mined in a block:
@@ -908,7 +908,7 @@ MiningCPID GetNextProject(bool bForce)
 
 
                                         GlobalCPUMiningCPID.boincruntimepublickey = structcpid.cpidhash;
-                                        if(fDebug) LogPrintf("\n GNP: Setting bpk to %s\n",structcpid.cpidhash);
+                                        if(fDebug) LogPrintf("GNP: Setting bpk to %s",structcpid.cpidhash);
 
                                         uint256 pbh = 1;
                                         GlobalCPUMiningCPID.cpidv2 = ComputeCPIDv2(GlobalCPUMiningCPID.email,GlobalCPUMiningCPID.boincruntimepublickey, pbh);
@@ -921,7 +921,7 @@ MiningCPID GetNextProject(bool bForce)
 #                                       if 0
                                         if (!bResult)
                                         {
-                                            LogPrintf("GetNextProject: failed to sign block with cpid -> %s\n", sError.c_str());
+                                            LogPrintf("GetNextProject: failed to sign block with cpid -> %s", sError.c_str());
                                             continue;
                                         }
                                         GlobalCPUMiningCPID.BoincSignature = sSignature;
@@ -969,12 +969,12 @@ MiningCPID GetNextProject(bool bForce)
         {
             msMiningErrors = _("Error obtaining next project.  Error 16172014.");
 
-            LogPrintf("Error obtaining next project\n");
+            LogPrintf("Error obtaining next project");
         }
         catch(...)
         {
             msMiningErrors = _("Error obtaining next project.  Error 06172014.");
-            LogPrintf("Error obtaining next project 2.\n");
+            LogPrintf("Error obtaining next project 2.");
         }
         return GlobalCPUMiningCPID;
 
@@ -1102,7 +1102,7 @@ bool AddOrphanTx(const CTransaction& tx)
 
     if (nSize > 5000)
     {
-        LogPrint("mempool", "ignoring large orphan tx (size: %" PRIszu ", hash: %s)\n", nSize, hash.ToString().substr(0,10));
+        LogPrint("mempool", "ignoring large orphan tx (size: %" PRIszu ", hash: %s)", nSize, hash.ToString().substr(0,10));
         return false;
     }
 
@@ -1110,7 +1110,7 @@ bool AddOrphanTx(const CTransaction& tx)
     for (auto const& txin : tx.vin)
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
-    LogPrint("mempool", "stored orphan tx %s (mapsz %" PRIszu ")\n", hash.ToString().substr(0,10), mapOrphanTransactions.size());
+    LogPrint("mempool", "stored orphan tx %s (mapsz %" PRIszu ")", hash.ToString().substr(0,10), mapOrphanTransactions.size());
     return true;
 }
 
@@ -1439,7 +1439,7 @@ int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
     {
         vMerkleBranch.clear();
         nIndex = -1;
-        LogPrintf("ERROR: SetMerkleBranch() : couldn't find tx in block\n");
+        LogPrintf("ERROR: SetMerkleBranch() : couldn't find tx in block");
         return 0;
     }
 
@@ -1657,7 +1657,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
                 if (dFreeCount > GetArg("-limitfreerelay", 15)*10*1000 && !IsFromMe(tx))
                     return error("AcceptToMemoryPool : free transaction rejected by rate limiter");
                 if (fDebug)
-                    LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
+                    LogPrint("mempool", "Rate limit dFreeCount: %g => %g", dFreeCount, dFreeCount+nSize);
                 dFreeCount += nSize;
             }
         }
@@ -1669,7 +1669,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
             // If this happens repeatedly, purge peers
             if (TimerMain("AcceptToMemoryPool", 20))
             {
-                LogPrint("mempool", "\nAcceptToMemoryPool::CleaningInboundConnections\n");
+                LogPrint("mempool", "AcceptToMemoryPool::CleaningInboundConnections");
                 CleanInboundConnections(true);
             }
             if (fDebug || true)
@@ -1688,7 +1688,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         LOCK(pool.cs);
         if (ptxOld)
         {
-            LogPrint("mempool", "AcceptToMemoryPool : replacing tx %s with new version\n", ptxOld->GetHash().ToString());
+            LogPrint("mempool", "AcceptToMemoryPool : replacing tx %s with new version", ptxOld->GetHash().ToString());
             pool.remove(*ptxOld);
         }
         pool.addUnchecked(hash, tx);
@@ -1698,7 +1698,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
     // If updated, erase old tx from wallet
     if (ptxOld)
         EraseFromWallets(ptxOld->GetHash());
-    if (fDebug)     LogPrint("mempool", "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")\n",           hash.ToString(), pool.mapTx.size());
+    if (fDebug)     LogPrint("mempool", "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")",           hash.ToString(), pool.mapTx.size());
     return true;
 }
 
@@ -1964,7 +1964,7 @@ int64_t GetProofOfWorkReward(int64_t nFees, int64_t locktime, int64_t height)
     //NOTE: THIS REWARD IS ONLY USED IN THE POW PHASE (Block < 8000):
     int64_t nSubsidy = CalculatedMagnitude(locktime,true) * COIN;
     if (fDebug && GetBoolArg("-printcreation"))
-        LogPrintf("GetProofOfWorkReward() : create=%s nSubsidy=%" PRId64 "\n", FormatMoney(nSubsidy), nSubsidy);
+        LogPrintf("GetProofOfWorkReward() : create=%s nSubsidy=%" PRId64 "", FormatMoney(nSubsidy), nSubsidy);
     if (nSubsidy < (30*COIN)) nSubsidy=30*COIN;
     //Gridcoin Foundation Block:
     if (height==10)
@@ -2102,7 +2102,7 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
             int64_t nSubsidy  = nInterest + nBoinc;
             if (fDebug10 || GetBoolArg("-printcreation"))
             {
-                LogPrintf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRIu64 " nBoinc=%" PRId64 "   \n",
+                LogPrintf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRIu64 " nBoinc=%" PRId64 "   ",
                 FormatMoney(nSubsidy), nCoinAge, nBoinc);
             }
             int64_t maxStakeReward1 = GetProofOfStakeMaxReward(nCoinAge, nFees, nTime);
@@ -2148,7 +2148,7 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
 
             if (fDebug10 || GetBoolArg("-printcreation"))
             {
-                LogPrintf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRIu64 " nBoinc=%" PRId64 "   \n",
+                LogPrintf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRIu64 " nBoinc=%" PRId64 "   ",
                 FormatMoney(nSubsidy), nCoinAge, nBoinc);
             }
 
@@ -2375,7 +2375,7 @@ bool CheckProofOfResearch(
         if (bb.ResearchSubsidy > ((OUT_POR*1.25)+1))
         {
             if (fDebug) LogPrintf("CheckProofOfResearch: Researchers Reward Pays too much : Retallying : "
-                                "claimedand %f vs calculated StakeReward %f for CPID %s\n",
+                                "claimedand %f vs calculated StakeReward %f for CPID %s",
                                 bb.ResearchSubsidy, OUT_POR, bb.cpid);
 
             TallyResearchAverages(pindexBest);
@@ -2431,11 +2431,11 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
     uint256 nBestInvalidBlockTrust = pindexNew->nChainTrust - pindexNew->pprev->nChainTrust;
     uint256 nBestBlockTrust = pindexBest->nHeight != 0 ? (pindexBest->nChainTrust - pindexBest->pprev->nChainTrust) : pindexBest->nChainTrust;
 
-    LogPrintf("InvalidChainFound: invalid block=%s  height=%d  trust=%s  blocktrust=%" PRId64 "  date=%s\n",
+    LogPrintf("InvalidChainFound: invalid block=%s  height=%d  trust=%s  blocktrust=%" PRId64 "  date=%s",
       pindexNew->GetBlockHash().ToString().substr(0,20), pindexNew->nHeight,
       CBigNum(pindexNew->nChainTrust).ToString(), nBestInvalidBlockTrust.Get64(),
       DateTimeStrFormat("%x %H:%M:%S", pindexNew->GetBlockTime()));
-    LogPrintf("InvalidChainFound:  current best=%s  height=%d  trust=%s  blocktrust=%" PRId64 "  date=%s\n",
+    LogPrintf("InvalidChainFound:  current best=%s  height=%d  trust=%s  blocktrust=%" PRId64 "  date=%s",
       hashBestChain.ToString().substr(0,20), nBestHeight,
       CBigNum(pindexBest->nChainTrust).ToString(),
       nBestBlockTrust.Get64(),
@@ -2749,7 +2749,7 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs, map<uint256, CTx
         {
             if (nValueIn < GetValueOut())
             {
-                LogPrintf("ConnectInputs(): VALUE IN < VALUEOUT \n");
+                LogPrintf("ConnectInputs(): VALUE IN < VALUEOUT ");
                 return DoS(100, error("ConnectInputs() : %s value in < value out", GetHash().ToString().substr(0,10).c_str()));
             }
 
@@ -2792,7 +2792,7 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
                 std::string sMKey = ExtractXML(vtx[i].hashBoinc, "<MK>", "</MK>");
                 DeleteCache(sMType, sMKey);
                 if(fDebug)
-                    LogPrintf("DisconnectBlock: Delete contract %s %s\n", sMType.c_str(), sMKey);
+                    LogPrintf("DisconnectBlock: Delete contract %s %s", sMType.c_str(), sMKey);
 
                 if("beacon"==sMType)
                 {
@@ -2961,7 +2961,6 @@ std::string UnpackBinarySuperblock(std::string sBlock)
             double dMagnitude = ConvertHexToDouble("0x" + sHexMagnitude);
             std::string sRow = sCPID + "," + RoundToString(dMagnitude,0) + ";";
             sReconstructedMagnitudes += sRow;
-            // if (fDebug3) LogPrintf("\n HEX CPID %s, HEX MAG %s, dMag %f, Row %s   ",sCPID.c_str(),sHexMagnitude.c_str(),dMagnitude,sRow.c_str());
         }
     }
     // Append zero magnitude researchers so the beacon count matches
@@ -2999,7 +2998,6 @@ std::string PackBinarySuperblock(std::string sBlock)
                 std::string sHexMagnitude = DoubleToHexStr(magnitude,4);
                 std::string sBinaryMagnitude = ConvertHexToBin(sHexMagnitude);
                 std::string sBinaryEntry  = sBinaryCPID+sBinaryMagnitude;
-                // if (fDebug3) LogPrintf("\n PackBinarySuperblock: DecMag %f HEX MAG %s bin_cpid_len %f bm_len %f be_len %f,",  magnitude,sHexMagnitude.c_str(),(double)sBinaryCPID.length(),(double)sBinaryMagnitude.length(),(double)sBinaryEntry.length());
                 if (sCPID=="00000000000000000000000000000000")
                 {
                     dZeroMagCPIDCount += 1;
@@ -3073,7 +3071,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
     // Check it again in case a previous version let a bad block in, but skip BlockSig checking
     if (!CheckBlock("ConnectBlock",pindex->pprev->nHeight, 395*COIN, !fJustCheck, !fJustCheck, false,false))
     {
-        LogPrintf("ConnectBlock::Failed - \n");
+        LogPrintf("ConnectBlock::Failed - ");
         return false;
     }
     //// issue here: it doesn't know the version
@@ -3169,8 +3167,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                     {
                         nTotalCoinstake += tx.vout[i].nValue;
                     }
-                    if (fDebug10)   LogPrintf(" nHeight %f; nTCS %f; nTxValueOut %f     ",
-                        (double)pindex->nHeight,CoinToDouble(nTotalCoinstake),CoinToDouble(nTxValueOut));
+                    if (fDebug10)   LogPrintf(" nHeight %d; nTCS %f; nTxValueOut %f",
+                        pindex->nHeight,CoinToDouble(nTotalCoinstake),CoinToDouble(nTxValueOut));
                 }
 
                 // Verify no recipients exist after coinstake (Recipients start at output position 3 (0=Coinstake flag, 1=coinstake amount, 2=splitstake amount)
@@ -3180,12 +3178,12 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                     {
                         std::string Recipient = PubKeyToAddress(tx.vout[i].scriptPubKey);
                         double      Amount    = CoinToDouble(tx.vout[i].nValue);
-                        if (fDebug10) LogPrintf("Iterating Recipient #%f  %s with Amount %f \n,",(double)i,Recipient, Amount);
+                        if (fDebug10) LogPrintf("Iterating Recipient #%d  %s with Amount %f", i, Recipient, Amount);
                         if (Amount > 0)
                         {
-                            if (fDebug3) LogPrintf("Iterating Recipient #%f  %s with Amount %f \n,",(double)i,Recipient, Amount);
-                            LogPrintf("POR Payment results in an overpayment; Recipient %s, Amount %f \n",Recipient, Amount);
-                            return DoS(50,error("POR Payment results in an overpayment; Recipient %s, Amount %f \n",
+                            if (fDebug3) LogPrintf("Iterating Recipient #%d  %s with Amount %f", i, Recipient, Amount);
+                            LogPrintf("POR Payment results in an overpayment; Recipient %s, Amount %f ",Recipient, Amount);
+                            return DoS(50,error("POR Payment results in an overpayment; Recipient %s, Amount %f ",
                                                 Recipient.c_str(), Amount));
                         }
                     }
@@ -3327,7 +3325,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                 if (bb.lastblockhash != pindex->pprev->GetBlockHash().GetHex())
                 {
                             std::string sNarr = "ConnectBlock[ResearchAge] : Historical DPOR Replay attack : lastblockhash != actual last block hash.";
-                            LogPrintf("\n ******  %s ***** \n",sNarr);
+                            LogPrintf("******  %s ***** ",sNarr);
                 }
 
                 if (IsResearchAgeEnabled(pindex->nHeight)
@@ -3367,7 +3365,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                                     "ConnectBlock[ResearchAge]: Bad CPID or Block Signature : CPID %s, cpidv2 %s, LBH %s, Bad Hashboinc [%s]",
                                      bb.cpid.c_str(), bb.cpidv2.c_str(),
                                      bb.lastblockhash.c_str(), vtx[0].hashBoinc.c_str()));
-                            else LogPrintf("WARNING: ignoring invalid hashBoinc signature on block %s\n", pindex->GetBlockHash().ToString());
+                            else LogPrintf("WARNING: ignoring invalid hashBoinc signature on block %s", pindex->GetBlockHash().ToString());
                         }
 
                         // Mitigate DPOR Relay attack
@@ -3375,7 +3373,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                         if (bb.lastblockhash != pindex->pprev->GetBlockHash().GetHex())
                         {
                             std::string sNarr = "ConnectBlock[ResearchAge] : DPOR Replay attack : lastblockhash != actual last block hash.";
-                            LogPrintf("\n ******  %s ***** \n", sNarr);
+                            LogPrintf("******  %s ***** ", sNarr);
                             if (fTestNet || (pindex->nHeight > 975000)) return DoS(20, error(" %s ",sNarr.c_str()));
                         }
 
@@ -3435,7 +3433,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
         if(nVersion >= 9)
         {
             // break away from block timing
-            if (fDebug) LogPrintf("ConnectBlock: Updating Neural Supermajority (v9 CB) height %d\n",pindex->nHeight);
+            if (fDebug) LogPrintf("ConnectBlock: Updating Neural Supermajority (v9 CB) height %d",pindex->nHeight);
             ComputeNeuralNetworkSupermajorityHashes();
             // Prevent duplicate superblocks
             if(nVersion >= 9 && !NeedASuperblock())
@@ -3513,13 +3511,13 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                     {
                         LoadSuperblock(superblock,pindex->nTime,pindex->nHeight);
                         if (fDebug)
-                            LogPrintf("ConnectBlock(): Superblock Loaded %d\n", pindex->nHeight);
+                            LogPrintf("ConnectBlock(): Superblock Loaded %d", pindex->nHeight);
 
                         TallyResearchAverages(pindexBest);
                     }
                     else
                     {
-                        if (fDebug3) LogPrintf("ConnectBlock(): Superblock Not Loaded %d\n", pindex->nHeight);
+                        if (fDebug3) LogPrintf("ConnectBlock(): Superblock Not Loaded %d", pindex->nHeight);
                     }
                 }
             }
@@ -3619,14 +3617,14 @@ bool ForceReorganizeToHash(uint256 NewHash)
 
     CBlockIndex* pindexCur = pindexBest;
     CBlockIndex* pindexNew = mapItem->second;
-    LogPrintf("\n** Force Reorganize **\n");
-    LogPrintf(" Current best height %i hash %s\n", pindexCur->nHeight,pindexCur->GetBlockHash().GetHex());
-    LogPrintf(" Target height %i hash %s\n", pindexNew->nHeight,pindexNew->GetBlockHash().GetHex());
+    LogPrintf("** Force Reorganize **");
+    LogPrintf(" Current best height %i hash %s", pindexCur->nHeight,pindexCur->GetBlockHash().GetHex());
+    LogPrintf(" Target height %i hash %s", pindexNew->nHeight,pindexNew->GetBlockHash().GetHex());
 
     CBlock blockNew;
     if (!blockNew.ReadFromDisk(pindexNew))
     {
-        LogPrintf("ForceReorganizeToHash: Fatal Error while reading new best block.\n");
+        LogPrintf("ForceReorganizeToHash: Fatal Error while reading new best block.");
         return false;
     }
 
@@ -3637,15 +3635,15 @@ bool ForceReorganizeToHash(uint256 NewHash)
     success = ReorganizeChain(txdb, cnt_dis, cnt_con, blockNew, pindexNew);
 
     if(pindexBest->nChainTrust < pindexCur->nChainTrust)
-        LogPrintf("WARNING ForceReorganizeToHash: Chain trust is now less then before!\n");
+        LogPrintf("WARNING ForceReorganizeToHash: Chain trust is now less then before!");
 
     if (!success)
     {
-        return error("ForceReorganizeToHash: Fatal Error while setting best chain.\n");
+        return error("ForceReorganizeToHash: Fatal Error while setting best chain.");
     }
 
     AskForOutstandingBlocks(uint256(0));
-    LogPrintf("ForceReorganizeToHash: success! height %f hash %s\n\n",(double)pindexBest->nHeight,pindexBest->GetBlockHash().GetHex());
+    LogPrintf("ForceReorganizeToHash: success! height %d hash %s", pindexBest->nHeight,pindexBest->GetBlockHash().GetHex());
     return true;
 }
 
@@ -3657,7 +3655,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
         if(!pindexBest->pprev)
             return error("DisconnectBlocksBatch: attempt to reorganize beyond genesis"); /*fatal*/
 
-        if (fDebug) LogPrintf("DisconnectBlocksBatch: %s\n",pindexBest->GetBlockHash().GetHex());
+        if (fDebug) LogPrintf("DisconnectBlocksBatch: %s",pindexBest->GetBlockHash().GetHex());
 
         CBlock block;
         if (!block.ReadFromDisk(pindexBest))
@@ -3719,7 +3717,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
             return error("DisconnectBlocksBatch: TxnCommit failed"); /*fatal*/
 
         // Need to reload all contracts
-        if (fDebug10) LogPrintf("DisconnectBlocksBatch: LoadAdminMessages\n");
+        if (fDebug10) LogPrintf("DisconnectBlocksBatch: LoadAdminMessages");
         std::string admin_messages;
         LoadAdminMessages(true, admin_messages);
 
@@ -3727,7 +3725,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
         if(IsV9Enabled_Tally(nBestHeight))
         {
             assert(IsTallyTrigger(pindexBest));
-            if (fDebug) LogPrintf("DisconnectBlocksBatch: TallyResearchAverages (v9P %%%d) height %d\n", TALLY_GRANULARITY, nBestHeight);
+            if (fDebug) LogPrintf("DisconnectBlocksBatch: TallyResearchAverages (v9P %%%d) height %d", TALLY_GRANULARITY, nBestHeight);
             TallyResearchAverages(pindexBest);
         }
         else
@@ -3736,7 +3734,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
         }
 
         // Re-read researchers history after all blocks disconnected
-        if (fDebug10) LogPrintf("DisconnectBlocksBatch: GetLifetimeCPID\n");
+        if (fDebug10) LogPrintf("DisconnectBlocksBatch: GetLifetimeCPID");
         for( const string& sRereadCPID : vRereadCPIDs )
             GetLifetimeCPID(sRereadCPID,"DisconnectBlocksBatch");
 
@@ -3782,10 +3780,10 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
 
         if (pcommon!=pindexBest || pindexNew->pprev!=pcommon)
         {
-            LogPrintf("\nReorganizeChain: from {%s %d}\n"
+            LogPrintf("ReorganizeChain: from {%s %d}\n"
                      "ReorganizeChain: comm {%s %d}\n"
                      "ReorganizeChain: to   {%s %d}\n"
-                     "REORGANIZE: disconnect %d, connect %d blocks\n"
+                     "REORGANIZE: disconnect %d, connect %d blocks"
                 ,pindexBest->GetBlockHash().GetHex().c_str(), pindexBest->nHeight
                 ,pcommon->GetBlockHash().GetHex().c_str(), pcommon->nHeight
                 ,pindexNew->GetBlockHash().GetHex().c_str(), pindexNew->nHeight
@@ -3803,7 +3801,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
         {
             error("ReorganizeChain: DisconnectBlocksBatch() failed");
             LogPrintf("This is fatal error. Chain index may be corrupt. Aborting.\n"
-                "Please Reindex the chain and Restart.\n");
+                      "Please Reindex the chain and Restart.");
             exit(1); //todo
         }
 
@@ -3812,7 +3810,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
         pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
     }
 
-    if (fDebug && cnt_dis>0) LogPrintf("ReorganizeChain: disconnected %d blocks\n",cnt_dis);
+    if (fDebug && cnt_dis>0) LogPrintf("ReorganizeChain: disconnected %d blocks",cnt_dis);
 
     for(CBlockIndex *p = pindexNew; p != pcommon; p=p->pprev)
         vConnect.push_front(p);
@@ -3839,7 +3837,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
         uint256 hash = block.GetHash();
         uint256 nBestBlockTrust;
 
-        if (fDebug) LogPrintf("ReorganizeChain: connect %s\n",hash.ToString());
+        if (fDebug) LogPrintf("ReorganizeChain: connect %s",hash.ToString());
 
         if (!txdb.TxnBegin())
             return error("ReorganizeChain: TxnBegin failed");
@@ -3861,7 +3859,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
             {
                 txdb.TxnAbort();
                 error("ReorganizeChain: ConnectBlock %s failed", hash.ToString().c_str());
-                LogPrintf("Previous block %s\n",pindex->pprev->GetBlockHash().ToString());
+                LogPrintf("Previous block %s",pindex->pprev->GetBlockHash().ToString());
                 InvalidChainFound(pindex);
                 return false;
             }
@@ -3913,7 +3911,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
             // Tally research averages.
             if(IsTallyTrigger(pindexBest))
             {
-                if (fDebug) LogPrintf("ReorganizeChain: TallyNetworkAverages (v9N %%%d) height %d\n",TALLY_GRANULARITY,nBestHeight);
+                if (fDebug) LogPrintf("ReorganizeChain: TallyNetworkAverages (v9N %%%d) height %d",TALLY_GRANULARITY,nBestHeight);
                 TallyResearchAverages(pindexBest);
             }
         }
@@ -3927,7 +3925,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
     }
 
     if (fDebug && (cnt_dis>0 || cnt_con>1))
-        LogPrintf("ReorganizeChain: Disconnected %d and Connected %d blocks.\n",cnt_dis,cnt_con);
+        LogPrintf("ReorganizeChain: Disconnected %d and Connected %d blocks.",cnt_dis,cnt_con);
 
     return true;
 }
@@ -3943,7 +3941,7 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew)
 
     if(origBestIndex && origBestIndex->nChainTrust > nBestChainTrust)
     {
-        LogPrintf("SetBestChain: Reorganize caused lower chain trust than before. Reorganizing back.\n");
+        LogPrintf("SetBestChain: Reorganize caused lower chain trust than before. Reorganizing back.");
         CBlock origBlock;
         if (!origBlock.ReadFromDisk(origBestIndex))
             return error("SetBestChain: Fatal Error while reading original best block");
@@ -3972,13 +3970,13 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew)
         // Update quorum data.
         if ((nBestHeight % 3) == 0)
         {
-            if (fDebug) LogPrintf("SetBestChain: Updating Neural Supermajority (v9 %%3) height %d\n",nBestHeight);
+            if (fDebug) LogPrintf("SetBestChain: Updating Neural Supermajority (v9 %%3) height %d",nBestHeight);
             ComputeNeuralNetworkSupermajorityHashes();
         }
         // Update quorum data.
         if ((nBestHeight % 10) == 0 && !OutOfSyncByAge() && NeedASuperblock())
         {
-            if (fDebug) LogPrintf("SetBestChain: Updating Neural Quorum (v9 M) height %d\n",nBestHeight);
+            if (fDebug) LogPrintf("SetBestChain: Updating Neural Quorum (v9 M) height %d",nBestHeight);
             UpdateNeuralNetworkQuorumData();
         }
     }
@@ -3988,7 +3986,7 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew)
 
     if (fDebug)
     {
-        LogPrintf("{SBC} {%s %d}  trust=%s  date=%s\n",
+        LogPrintf("{SBC} {%s %d}  trust=%s  date=%s",
                hashBestChain.ToString(), nBestHeight,
                CBigNum(nBestChainTrust).ToString(),
                DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()));
@@ -4048,12 +4046,12 @@ bool CTransaction::GetCoinAge(CTxDB& txdb, uint64_t& nCoinAge) const
         bnCentSecond += CBigNum(nValueIn) * (nTime-txPrev.nTime) / CENT;
 
         if (fDebug && GetBoolArg("-printcoinage"))
-            LogPrintf("coin age nValueIn=%" PRId64 " nTimeDiff=%d bnCentSecond=%s\n", nValueIn, nTime - txPrev.nTime, bnCentSecond.ToString());
+            LogPrintf("coin age nValueIn=%" PRId64 " nTimeDiff=%d bnCentSecond=%s", nValueIn, nTime - txPrev.nTime, bnCentSecond.ToString());
     }
 
     CBigNum bnCoinDay = bnCentSecond * CENT / COIN / (24 * 60 * 60);
     if (fDebug && GetBoolArg("-printcoinage"))
-        LogPrintf("coin age bnCoinDay=%s\n", bnCoinDay.ToString());
+        LogPrintf("coin age bnCoinDay=%s", bnCoinDay.ToString());
     nCoinAge = bnCoinDay.getuint64();
     return true;
 }
@@ -4076,7 +4074,7 @@ bool CBlock::GetCoinAge(uint64_t& nCoinAge) const
     if (nCoinAge == 0) // block coin age minimum 1 coin-day
         nCoinAge = 1;
     if (fDebug && GetBoolArg("-printcoinage"))
-        LogPrintf("block coin age total nCoinDays=%" PRIu64 "\n", nCoinAge);
+        LogPrintf("block coin age total nCoinDays=%" PRIu64 "", nCoinAge);
     return true;
 }
 
@@ -4171,7 +4169,7 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
     double blockdiff = GetBlockDifficulty(nBits);
     if (height1 > nGrandfather && blockdiff > 10000000000000000)
     {
-       return DoS(1, error("CheckBlock[] : Block Bits larger than 10000000000000000.\n"));
+       return DoS(1, error("CheckBlock[] : Block Bits larger than 10000000000000000."));
     }
 
     // First transaction must be coinbase, the rest must not be
@@ -4192,7 +4190,7 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
             if (fDebug10) LogPrintf("BV %f, CV %f   ",blockVersion,cvn);
             // Enforce Beacon Age
             if (blockVersion < 3588 && height1 > 860500 && !fTestNet)
-                return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade \n");
+                return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade ");
         }
 
         //Orphan Flood Attack
@@ -4203,7 +4201,7 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
             if (fDebug10) LogPrintf("BV %f, CV %f   ",bv,cvn);
             // Enforce Beacon Age
             if (bv < 3588 && height1 > 860500 && !fTestNet)
-                return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade \n");
+                return error("CheckBlock[]:  Old client spamming new blocks after mandatory upgrade ");
         }
     }
 
@@ -4257,12 +4255,12 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
         double mint1 = CoinToDouble(Mint);
         double total_subsidy = bb.ResearchSubsidy + bb.InterestSubsidy;
         double limiter = MintLimiter(PORDiff,bb.RSAWeight,bb.cpid,GetBlockTime());
-        if (fDebug10) LogPrintf("CheckBlock[]: TotalSubsidy %f, Height %i, %s, %f, Res %f, Interest %f, hb: %s \n",
+        if (fDebug10) LogPrintf("CheckBlock[]: TotalSubsidy %f, Height %i, %s, %f, Res %f, Interest %f, hb: %s ",
                              total_subsidy, height1, bb.cpid,
                              mint1,bb.ResearchSubsidy,bb.InterestSubsidy,vtx[0].hashBoinc);
         if (total_subsidy < limiter)
         {
-            if (fDebug3) LogPrintf("****CheckBlock[]: Total Mint too Small %s, mint %f, Res %f, Interest %f, hash %s \n",bb.cpid,
+            if (fDebug3) LogPrintf("****CheckBlock[]: Total Mint too Small %s, mint %f, Res %f, Interest %f, hash %s ",bb.cpid,
                                 mint1,bb.ResearchSubsidy,bb.InterestSubsidy,vtx[0].hashBoinc);
             //1-21-2015 - Prevent Hackers from spamming the network with small blocks
             return error("****CheckBlock[]: Total Mint too Small %f < %f Research %f Interest %f BOINC %s",
@@ -4288,7 +4286,7 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
         {
             if (vtx[i].IsCoinStake())
             {
-                LogPrintf("Found more than one coinstake in coinbase at location %f\n",(double)i);
+                LogPrintf("Found more than one coinstake in coinbase at location %f",(double)i);
                 return DoS(100, error("CheckBlock[] : more than one coinstake"));
             }
         }
@@ -4407,7 +4405,7 @@ bool CBlock::AcceptBlock(bool generated_by_me)
                     uint256 targetProofOfStake;
                     if (!CheckProofOfStake(pindexPrev, vtx[1], nBits, hashProof, targetProofOfStake, vtx[0].hashBoinc, generated_by_me, nNonce) && (IsLockTimeWithinMinutes(GetBlockTime(), GetAdjustedTime(), 600) || nHeight >= 999000))
                     {
-                        return error("WARNING: AcceptBlock(): check proof-of-stake failed for block %s, nonce %f    \n", hash.ToString().c_str(),(double)nNonce);
+                        return error("WARNING: AcceptBlock(): check proof-of-stake failed for block %s, nonce %f    ", hash.ToString().c_str(),(double)nNonce);
                     }
 
                 }
@@ -4419,8 +4417,8 @@ bool CBlock::AcceptBlock(bool generated_by_me)
         //if (IsProofOfStake())
         if(!CheckProofOfStakeV8(pindexPrev, *this, generated_by_me, hashProof))
         {
-            error("WARNING: AcceptBlock(): check proof-of-stake failed for block %s, nonce %f    \n", hash.ToString().c_str(),(double)nNonce);
-            LogPrintf(" prev %s\n",pindexPrev->GetBlockHash().ToString());
+            error("WARNING: AcceptBlock(): check proof-of-stake failed for block %s, nonce %f    ", hash.ToString().c_str(),(double)nNonce);
+            LogPrintf(" prev %s",pindexPrev->GetBlockHash().ToString());
             return false;
         }
     }
@@ -4430,7 +4428,7 @@ bool CBlock::AcceptBlock(bool generated_by_me)
         // Verify proof of research.
         if(!CheckProofOfResearch(pindexPrev, *this))
         {
-            return error("WARNING: AcceptBlock(): check proof-of-research failed for block %s, nonce %i\n", hash.ToString().c_str(), nNonce);
+            return error("WARNING: AcceptBlock(): check proof-of-research failed for block %s, nonce %i", hash.ToString().c_str(), nNonce);
         }
     }
     /*else Do not check v9 rewards here as context here is insufficient and it is
@@ -4560,7 +4558,6 @@ bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent)
     if (!bPassed)
     {
         if (fDebug) LogPrintf(" Verification of Superblock Failed ");
-        //if (fDebug3) LogPrintf("\n Verification of Superblock Failed outavg: %f, avg_mag %f, Height %f, Out_Beacon_count %f, Out_participant_count %f, block %s", (double)out_avg,(double)avg_mag,(double)nHeight,(double)out_beacon_count,(double)out_participant_count,superblock.c_str());
     }
 
     return bPassed;
@@ -4631,18 +4628,18 @@ void GridcoinServices()
         bool bNeedSuperblock = (superblock_age > (GetSuperblockAgeSpacing(nBestHeight)));
         if ( nBestHeight % 3 == 0 && NeedASuperblock() ) bNeedSuperblock=true;
 
-        if (fDebug10) LogPrintf(" MRSA %" PRId64 ", BH %d\n", superblock_age, nBestHeight);
+        if (fDebug10) LogPrintf(" MRSA %" PRId64 ", BH %d", superblock_age, nBestHeight);
 
         if (bNeedSuperblock)
         {
             if ((nBestHeight % 3) == 0)
             {
-                if (fDebug) LogPrintf("SVC: Updating Neural Supermajority (v3 A) height %d\n",nBestHeight);
+                if (fDebug) LogPrintf("SVC: Updating Neural Supermajority (v3 A) height %d",nBestHeight);
                 ComputeNeuralNetworkSupermajorityHashes();
             }
             if ((nBestHeight % 3) == 0 && !OutOfSyncByAge())
             {
-                if (fDebug) LogPrintf("SVC: Updating Neural Quorum (v3 A) height %d\n",nBestHeight);
+                if (fDebug) LogPrintf("SVC: Updating Neural Quorum (v3 A) height %d",nBestHeight);
                 if (fDebug10) LogPrintf("#CNNSH# ");
                 UpdateNeuralNetworkQuorumData();
             }
@@ -4651,7 +4648,7 @@ void GridcoinServices()
             // V9 tally switch (1144120) or else blocks will be rejected in between.
             if (IsV9Enabled(nBestHeight) && (nBestHeight % 20) == 0)
             {
-                if (fDebug) LogPrintf("SVC: set off Tally (v3 B) height %d\n",nBestHeight);
+                if (fDebug) LogPrintf("SVC: set off Tally (v3 B) height %d",nBestHeight);
                 if (fDebug10) LogPrintf("#TIB# ");
                 TallyResearchAverages(pindexBest);
             }
@@ -4662,19 +4659,19 @@ void GridcoinServices()
             int nTallyGranularity = fTestNet ? 60 : 20;
             if (IsV9Enabled(nBestHeight) && (nBestHeight % nTallyGranularity) == 0)
             {
-                if (fDebug) LogPrintf("SVC: set off Tally (v3 C) height %d\n",nBestHeight);
+                if (fDebug) LogPrintf("SVC: set off Tally (v3 C) height %d",nBestHeight);
                 if (fDebug3) LogPrintf("TIB1 ");
                 TallyResearchAverages(pindexBest);
             }
 
             if ((nBestHeight % 5)==0)
             {
-                if (fDebug) LogPrintf("SVC: Updating Neural Supermajority (v3 D) height %d\n",nBestHeight);
+                if (fDebug) LogPrintf("SVC: Updating Neural Supermajority (v3 D) height %d",nBestHeight);
                 ComputeNeuralNetworkSupermajorityHashes();
             }
             if ((nBestHeight % 5)==0 && !OutOfSyncByAge())
             {
-                if (fDebug) LogPrintf("SVC: Updating Neural Quorum (v3 E) height %d\n",nBestHeight);
+                if (fDebug) LogPrintf("SVC: Updating Neural Quorum (v3 E) height %d",nBestHeight);
                 if (fDebug3) LogPrintf("CNNSH2 ");
                 UpdateNeuralNetworkQuorumData();
             }
@@ -4699,7 +4696,7 @@ void GridcoinServices()
     {
         bool bWalletBackupResults = BackupWallet(*pwalletMain, GetBackupFilename("wallet.dat"));
         bool bConfigBackupResults = BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"));
-        LogPrintf("Daily backup results: Wallet -> %s Config -> %s\n", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
+        LogPrintf("Daily backup results: Wallet -> %s Config -> %s", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
     }
 
     if (TimerMain("MyNeuralMagnitudeReport",30))
@@ -4711,7 +4708,7 @@ void GridcoinServices()
                 AsyncNeuralRequest("explainmag",msPrimaryCPID,5);
                 if (fDebug3) LogPrintf("Async explainmag sent for %s.",msPrimaryCPID);
             }
-            if (fDebug3) LogPrintf("\n MR Complete \n");
+            if (fDebug3) LogPrintf("MR Complete");
         }
         catch (std::exception &e)
         {
@@ -4766,7 +4763,7 @@ void GridcoinServices()
             bool fResult = AdvertiseBeacon(sOutPrivKey,sOutPubKey,sError,sMessage);
             if (!fResult)
             {
-                LogPrintf("BEACON ERROR!  Unable to send beacon %s, %s\n",sError.c_str(), sMessage.c_str());
+                LogPrintf("BEACON ERROR!  Unable to send beacon %s, %s",sError.c_str(), sMessage.c_str());
                 LOCK(MinerStatus.lock);
                 msMiningErrors6 = _("Unable To Send Beacon! Unlock Wallet!");
             }
@@ -4862,7 +4859,7 @@ void CleanInboundConnections(bool bClearAll)
                         pNode->fDisconnect=true;
                 }
         }
-        LogPrintf("\n Cleaning inbound connections \n");
+        LogPrintf("Cleaning inbound connections");
 }
 
 bool WalletOutOfSync()
@@ -4932,7 +4929,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
                     setStakeSeenOrphan.clear();
                 }
 
-                LogPrintf("\nClearing mapAlreadyAskedFor.\n");
+                LogPrintf("Clearing mapAlreadyAskedFor.");
                 mapAlreadyAskedFor.clear();
                 AskForOutstandingBlocks(uint256(0));
             }
@@ -4943,7 +4940,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
             ResetTimerMain("CheckForFutileSync");
         }
 
-        LogPrintf("ProcessBlock: ORPHAN BLOCK, prev=%s\n", pblock->hashPrevBlock.ToString());
+        LogPrintf("ProcessBlock: ORPHAN BLOCK, prev=%s", pblock->hashPrevBlock.ToString());
         // ppcoin: check proof-of-stake
         if (pblock->IsProofOfStake())
         {
@@ -5002,7 +4999,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
 
     }
 
-    LogPrintf("{PB}: ACC; \n");
+    LogPrintf("{PB}: ACC; ");
 
     // Compatiblity while V8 is in use. Can be removed after the V9 switch.
     if(IsV9Enabled(pindexBest->nHeight) == false)
@@ -5049,7 +5046,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes)
         fShutdown = true;
         string strMessage = _("Warning: Disk space is low!");
         strMiscWarning = strMessage;
-        LogPrintf("*** %s\n", strMessage);
+        LogPrintf("*** %s", strMessage);
         uiInterface.ThreadSafeMessageBox(strMessage, "Gridcoin", CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION | CClientUIInterface::MODAL);
         StartShutdown();
         return false;
@@ -5188,7 +5185,7 @@ bool LoadBlockIndex(bool fAllowNew)
         // If genesis block hash does not match, then generate new genesis hash.
         if (block.GetHash() != (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))
         {
-            LogPrintf("Searching for genesis block...\n");
+            LogPrintf("Searching for genesis block...");
             // This will figure out a valid hash and Nonce if you're
             // creating a different genesis block: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000xFFF
             uint256 hashTarget = CBigNum().SetCompact(block.nBits).getuint256();
@@ -5200,18 +5197,18 @@ bool LoadBlockIndex(bool fAllowNew)
                     break;
                 if ((block.nNonce & 0xFFF) == 0)
                 {
-                    LogPrintf("nonce %08X: hash = %s (target = %s)\n", block.nNonce, thash.ToString(), hashTarget.ToString());
+                    LogPrintf("nonce %08X: hash = %s (target = %s)", block.nNonce, thash.ToString(), hashTarget.ToString());
                 }
                 ++block.nNonce;
                 if (block.nNonce == 0)
                 {
-                    LogPrintf("NONCE WRAPPED, incrementing time\n");
+                    LogPrintf("NONCE WRAPPED, incrementing time");
                     ++block.nTime;
                 }
             }
-            LogPrintf("block.nTime = %u \n", block.nTime);
-            LogPrintf("block.nNonce = %u \n", block.nNonce);
-            LogPrintf("block.GetHash = %s\n", block.GetHash().ToString());
+            LogPrintf("block.nTime = %u ", block.nTime);
+            LogPrintf("block.nNonce = %u ", block.nNonce);
+            LogPrintf("block.GetHash = %s", block.GetHash().ToString());
         }
 
 
@@ -5314,7 +5311,7 @@ bool WriteKey(std::string sKey, std::string sValue)
                 }
             }
             sLine = strReplace(sLine,"\r","");
-            sLine = strReplace(sLine,"\n","");
+            sLine = strReplace(sLine,"","");
             sLine += "\n";
             sConfig += sLine;
        }
@@ -5441,14 +5438,14 @@ bool IsCPIDValidv2(MiningCPID& mc, int height)
                 kmval = key_alt == mc.BoincPublicKey;
                 if(scval_alt)
                 {
-                    LogPrintf("WARNING: IsCPIDValidv2: good signature with alternative key\n");
+                    LogPrintf("WARNING: IsCPIDValidv2: good signature with alternative key");
                     result= true;
                 }
             }
         }
 
         if( !kmval )
-            LogPrintf("WARNING: IsCPIDValidv2: block key mismatch\n");
+            LogPrintf("WARNING: IsCPIDValidv2: block key mismatch");
 
     }
 
@@ -5485,18 +5482,18 @@ bool IsCPIDValid_Retired(std::string cpid, std::string ENCboincpubkey)
             std::string bpk = AdvancedDecrypt(ENCboincpubkey);
             std::string bpmd5 = RetrieveMd5(bpk);
             if (bpmd5==cpid) return true;
-            if (fDebug10) LogPrintf("Md5<>cpid, md5 %s cpid %s  root bpk %s \n     ",bpmd5, cpid, bpk);
+            if (fDebug10) LogPrintf("Md5<>cpid, md5 %s cpid %s  root bpk %s",bpmd5, cpid, bpk);
 
             return false;
     }
     catch (std::exception &e)
     {
-                LogPrintf("Error while resolving CPID\n");
+                LogPrintf("Error while resolving CPID");
                 return false;
     }
     catch(...)
     {
-                LogPrintf("Error while Resolving CPID[2].\n");
+                LogPrintf("Error while Resolving CPID[2].");
                 return false;
     }
     return false;
@@ -5631,7 +5628,7 @@ void AddResearchMagnitude(CBlockIndex* pIndex)
     }
     catch (const std::bad_alloc& ba)
     {
-        LogPrintf("\nBad Allocation in AddResearchMagnitude() \n");
+        LogPrintf("Bad Allocation in AddResearchMagnitude()");
     }
 }
 
@@ -5741,7 +5738,7 @@ StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sCalledFr
     for (HashSet::iterator it = hashes.begin(); it != hashes.end(); ++it)
     {
         const uint256& uHash = *it;
-        if (fDebug10) LogPrintf("GetLifetimeCPID: trying %s\n",uHash.GetHex());
+        if (fDebug10) LogPrintf("GetLifetimeCPID: trying %s",uHash.GetHex());
 
         // Ensure that we have this block.
         auto mapItem = mapBlockIndex.find(uHash);
@@ -5757,11 +5754,11 @@ StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sCalledFr
 
         // Block located and verified.
         if (fDebug10)
-            LogPrintf("GetLifetimeCPID: verified %s height= %d LastBlock= %d nResearchSubsidy= %.3f\n",
+            LogPrintf("GetLifetimeCPID: verified %s height= %d LastBlock= %d nResearchSubsidy= %.3f",
             uHash.GetHex().c_str(),pblockindex->nHeight,(int)stCPID.LastBlock,pblockindex->nResearchSubsidy);
         if(!pblockindex->pnext && pblockindex!=pindexBest)
             LogPrintf("WARNING GetLifetimeCPID: index {%s %d} for cpid %s, "
-                "is not in the main chain\n",pblockindex->GetBlockHash().GetHex(),
+                "is not in the main chain",pblockindex->GetBlockHash().GetHex(),
                 pblockindex->nHeight,cpid);
 
         if(pblockindex->nResearchSubsidy> 0)
@@ -5787,7 +5784,7 @@ StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sCalledFr
     }
 
     // Save updated CPID data holder.
-    if (fDebug10) LogPrintf("GetLifetimeCPID.END: %s set {%s %d}\n",cpid, stCPID.BlockHash, (int)stCPID.LastBlock);
+    if (fDebug10) LogPrintf("GetLifetimeCPID.END: %s set {%s %d}",cpid, stCPID.BlockHash, (int)stCPID.LastBlock);
     mvResearchAge[cpid] = stCPID;
     return stCPID;
 }
@@ -5897,11 +5894,11 @@ bool ComputeNeuralNetworkSupermajorityHashes()
     }
     catch (std::exception &e)
     {
-            LogPrintf("Neural Error while memorizing hashes.\n");
+            LogPrintf("Neural Error while memorizing hashes.");
     }
     catch(...)
     {
-        LogPrintf("Neural error While Memorizing Hashes! [1]\n");
+        LogPrintf("Neural error While Memorizing Hashes! [1]");
     }
     return true;
 
@@ -5919,7 +5916,7 @@ bool TallyResearchAverages(CBlockIndex* index)
 
 bool TallyResearchAverages_retired(CBlockIndex* index)
 {
-    LogPrintf("Tally (retired)\n");
+    LogPrintf("Tally (retired)");
 
     if (!index)
     {
@@ -5928,7 +5925,7 @@ bool TallyResearchAverages_retired(CBlockIndex* index)
     }
 
     if(IsV9Enabled_Tally(index->nHeight))
-        return error("TallyResearchAverages_retired: called while V9 tally enabled\n");
+        return error("TallyResearchAverages_retired: called while V9 tally enabled");
 
     //Iterate throught last 14 days, tally network averages
     if (index->nHeight < 15)
@@ -5951,7 +5948,7 @@ bool TallyResearchAverages_retired(CBlockIndex* index)
     int nMinDepth = (nMaxDepth - nLookback) - ( (nMaxDepth-nLookback) % TALLY_GRANULARITY);
     if (fDebug3) LogPrintf("START BLOCK %d, END BLOCK %d", nMaxDepth, nMinDepth);
     if (nMinDepth < 2)              nMinDepth = 2;
-    if(fDebug) LogPrintf("TallyResearchAverages_retired: beginning start %d end %d\n",nMaxDepth,nMinDepth);
+    if(fDebug) LogPrintf("TallyResearchAverages_retired: beginning start %d end %d",nMaxDepth,nMinDepth);
     mvMagnitudesCopy.clear();
     int iRow = 0;
 
@@ -5991,7 +5988,7 @@ bool TallyResearchAverages_retired(CBlockIndex* index)
                         LoadSuperblock(superblock,pblockindex->nTime,pblockindex->nHeight);
                         superblockloaded=true;
                         if (fDebug)
-                            LogPrintf("TallyResearchAverages_retired: Superblock Loaded {%s %i}\n", pblockindex->GetBlockHash().GetHex(), pblockindex->nHeight);
+                            LogPrintf("TallyResearchAverages_retired: Superblock Loaded {%s %i}", pblockindex->GetBlockHash().GetHex(), pblockindex->nHeight);
                     }
                 }
             }
@@ -6023,7 +6020,7 @@ bool TallyResearchAverages_retired(CBlockIndex* index)
     }
     catch (bad_alloc ba)
     {
-        LogPrintf("Bad Alloc while tallying network averages. [1]\n");
+        LogPrintf("Bad Alloc while tallying network averages. [1]");
         bNetAveragesLoaded=true;
     }
 
@@ -6038,7 +6035,7 @@ bool TallyResearchAverages_v9(CBlockIndex* index)
     if(!IsV9Enabled_Tally(index->nHeight))
         return error("TallyResearchAverages_v9: called while V9 tally disabled");
 
-    LogPrintf("Tally (v9)\n");
+    LogPrintf("Tally (v9)");
 
     //Iterate throught last 14 days, tally network averages
     if (index->nHeight < 15)
@@ -6142,7 +6139,7 @@ bool TallyResearchAverages_v9(CBlockIndex* index)
     }
     catch (const std::bad_alloc& ba)
     {
-        LogPrintf("Bad Alloc while tallying network averages. [1]\n");
+        LogPrintf("Bad Alloc while tallying network averages. [1]");
         bNetAveragesLoaded=true;
     }
 
@@ -6178,13 +6175,13 @@ void PrintBlockTree()
         {
             for (int i = 0; i < nCol-1; i++)
                 LogPrintf("| ");
-            LogPrintf("|\\\n");
+            LogPrintf("|\\");
         }
         else if (nCol < nPrevCol)
         {
             for (int i = 0; i < nCol; i++)
                 LogPrintf("| ");
-            LogPrintf("|\n");
+            LogPrintf("|");
        }
         nPrevCol = nCol;
 
@@ -6276,11 +6273,11 @@ bool LoadExternalBlockFile(FILE* fileIn)
             }
         }
         catch (std::exception &e) {
-            LogPrintf("%s() : Deserialize or I/O error caught during load\n",
+            LogPrintf("%s() : Deserialize or I/O error caught during load",
                    __PRETTY_FUNCTION__);
         }
     }
-    LogPrintf("Loaded %i blocks from external file in %" PRId64 "ms\n", nLoaded, GetTimeMillis() - nStart);
+    LogPrintf("Loaded %i blocks from external file in %" PRId64 "ms", nLoaded, GetTimeMillis() - nStart);
     return nLoaded > 0;
 }
 
@@ -6432,10 +6429,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 {
     RandAddSeedPerfmon();
     if (fDebug10)
-        LogPrintf("received: %s from %s (%" PRIszu " bytes)\n", strCommand.c_str(), pfrom->addrName.c_str(), vRecv.size());
+        LogPrintf("received: %s from %s (%" PRIszu " bytes)", strCommand.c_str(), pfrom->addrName.c_str(), vRecv.size());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
-        LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");
+        LogPrintf("dropmessagestest DROPPING RECV MESSAGE");
         return true;
     }
 
@@ -6444,7 +6441,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     {
         if ((!IsLockTimeWithinMinutes(nLastAskedForBlocks, GetAdjustedTime(), 5) && WalletOutOfSync()) || (WalletOutOfSync() && fTestNet))
         {
-            if(fDebug) LogPrintf("\nBootup\n");
+            if(fDebug) LogPrintf("Bootup");
             AskForOutstandingBlocks(uint256(0));
         }
     }
@@ -6469,15 +6466,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vRecv >> pfrom->nVersion >> pfrom->boinchashnonce >> pfrom->boinchashpw >> pfrom->cpid >> pfrom->enccpid >> acid >> pfrom->nServices >> nTime >> addrMe;
 
         if (fDebug10)
-            LogPrintf("received aries version %i boinchashnonce %s boinchashpw %s cpid %s enccpid %s acid %s ...\n"
-            ,pfrom->nVersion, pfrom->boinchashnonce.c_str(), pfrom->boinchashpw.c_str()
-            ,pfrom->cpid.c_str(), pfrom->enccpid.c_str(), acid.c_str());
+            LogPrintf("received aries version %i boinchashnonce %s boinchashpw %s cpid %s enccpid %s acid %s ..."
+                      ,pfrom->nVersion, pfrom->boinchashnonce, pfrom->boinchashpw
+                      ,pfrom->cpid.c_str(), pfrom->enccpid, acid);
 
-        double timedrift = std::abs(GetAdjustedTime() - nTime);
+        int64_t timedrift = std::abs(GetAdjustedTime() - nTime);
 
             if (timedrift > (8*60))
             {
-            if (fDebug10) LogPrintf("Disconnecting unauthorized peer with Network Time so far off by %f seconds!\n",(double)timedrift);
+            if (fDebug10) LogPrintf("Disconnecting unauthorized peer with Network Time so far off by %" PRId64 " seconds!", timedrift);
             pfrom->Misbehaving(100);
             pfrom->fDisconnect = true;
             return false;
@@ -6488,7 +6485,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion < 180321 && fTestNet)
         {
             // disconnect from peers older than this proto version
-            if (fDebug10) LogPrintf("Testnet partner %s using obsolete version %i; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->nVersion);
+            if (fDebug10) LogPrintf("Testnet partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString().c_str(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;
         }
@@ -6496,7 +6493,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version
-            if (fDebug10) LogPrintf("partner %s using obsolete version %i; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->nVersion);
+            if (fDebug10) LogPrintf("partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString().c_str(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;
         }
@@ -6504,7 +6501,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion < 180323 && !fTestNet && pindexBest->nHeight > 860500)
         {
             // disconnect from peers older than this proto version - Enforce Beacon Age - 3-26-2017
-            if (fDebug10) LogPrintf("partner %s using obsolete version %i (before enforcing beacon age); disconnecting\n", pfrom->addr.ToString(), pfrom->nVersion);
+            if (fDebug10) LogPrintf("partner %s using obsolete version %i (before enforcing beacon age); disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;
         }
@@ -6512,7 +6509,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (!fTestNet && pfrom->nVersion < 180314 && IsResearchAgeEnabled(pindexBest->nHeight))
         {
             // disconnect from peers older than this proto version
-            if (fDebug10) LogPrintf("ResearchAge: partner %s using obsolete version %i; disconnecting\n", pfrom->addr.ToString(), pfrom->nVersion);
+            if (fDebug10) LogPrintf("ResearchAge: partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;
        }
@@ -6541,7 +6538,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 if (pfrom->nStartingHeight < 1 && pfrom->nServices == 0 )
                 {
                     pfrom->Misbehaving(100);
-                    if (fDebug3) LogPrintf("Disconnecting possible hacker node with no services.  Banned for 24 hours.\n");
+                    if (fDebug3) LogPrintf("Disconnecting possible hacker node with no services.  Banned for 24 hours.");
                     pfrom->fDisconnect=true;
                     return false;
                 }
@@ -6558,7 +6555,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // Disconnect if we connected to ourself
         if (nNonce == nLocalHostNonce && nNonce > 1)
         {
-            if (fDebug3) LogPrintf("connected to self at %s, disconnecting\n", pfrom->addr.ToString().c_str());
+            if (fDebug3) LogPrintf("connected to self at %s, disconnecting", pfrom->addr.ToString().c_str());
             pfrom->fDisconnect = true;
             return true;
         }
@@ -6625,7 +6622,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             nAskedForBlocks++;
             pfrom->PushGetBlocks(pindexBest, uint256(0), true);
-            if (fDebug3) LogPrintf("\nAsked For blocks.\n");
+            if (fDebug3) LogPrintf("Asked For blocks.");
         }
 
         // Relay alerts
@@ -6637,15 +6634,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         pfrom->fSuccessfullyConnected = true;
 
-        if (fDebug10) LogPrintf("receive version message: version %d, blocks=%d, us=%s, them=%s, peer=%s\n", pfrom->nVersion,
-            pfrom->nStartingHeight, addrMe.ToString().c_str(), addrFrom.ToString().c_str(), pfrom->addr.ToString().c_str());
+        if (fDebug10) LogPrintf("receive version message: version %d, blocks=%d, us=%s, them=%s, peer=%s", pfrom->nVersion,
+            pfrom->nStartingHeight, addrMe.ToString(), addrFrom.ToString(), pfrom->addr.ToString());
 
         cPeerBlockCounts.input(pfrom->nStartingHeight);
     }
     else if (pfrom->nVersion == 0)
     {
         // Must have a version message before anything else 1-10-2015 Halford
-        LogPrintf("Hack attempt from %s - %s (banned) \n",pfrom->addrName, NodeAddress(pfrom));
+        LogPrintf("Hack attempt from %s - %s (banned) ",pfrom->addrName, NodeAddress(pfrom));
         pfrom->Misbehaving(100);
         pfrom->fDisconnect=true;
         return false;
@@ -6759,7 +6756,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
             bool fAlreadyHave = AlreadyHave(txdb, inv);
             if (fDebug10)
-                LogPrintf("  got inventory: %s  %s\n", inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
+                LogPrintf("  got inventory: %s  %s", inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
 
             if (!fAlreadyHave)
                 pfrom->AskFor(inv);
@@ -6771,7 +6768,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 // this situation and push another getblocks to continue.
                 pfrom->PushGetBlocks(mapBlockIndex[inv.hash], uint256(0), true);
                 if (fDebug10)
-                    LogPrintf("force getblock request: %s\n", inv.ToString());
+                    LogPrintf("force getblock request: %s", inv.ToString());
             }
 
             // Track requests for our stuff
@@ -6792,7 +6789,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         if (fDebugNet || (vInv.size() != 1))
         {
-            if (fDebug10)  LogPrintf("received getdata (%" PRIszu " invsz)\n", vInv.size());
+            if (fDebug10)  LogPrintf("received getdata (%" PRIszu " invsz)", vInv.size());
         }
 
         LOCK(cs_main);
@@ -6802,7 +6799,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 return true;
             if (fDebugNet || (vInv.size() == 1))
             {
-              if (fDebug10)   LogPrintf("received getdata for: %s\n", inv.ToString());
+              if (fDebug10)   LogPrintf("received getdata for: %s", inv.ToString());
             }
 
             if (inv.type == MSG_BLOCK)
@@ -6874,12 +6871,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pindex = pindex->pnext;
         int nLimit = 500;
 
-        if (fDebug3) LogPrintf("getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20), nLimit);
+        if (fDebug3) LogPrintf("getblocks %d to %s limit %d", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20), nLimit);
         for (; pindex; pindex = pindex->pnext)
         {
             if (pindex->GetBlockHash() == hashStop)
             {
-                if (fDebug3) LogPrintf("getblocks stopping at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20));
+                if (fDebug3) LogPrintf("getblocks stopping at %d %s", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20));
                 // ppcoin: tell downloading node about the latest block if it's
                 // without risk being rejected due to stake connection check
                 if (hashStop != hashBestChain && pindex->GetBlockTime() + nStakeMinAge > pindexBest->GetBlockTime())
@@ -6891,7 +6888,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             {
                 // When this block is requested, we'll send an inv that'll make them
                 // getblocks the next batch of inventory.
-                if (fDebug3) LogPrintf("getblocks stopping at limit %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20));
+                if (fDebug3) LogPrintf("getblocks stopping at limit %d %s", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20));
                 pfrom->hashContinue = pindex->GetBlockHash();
                 break;
             }
@@ -6924,7 +6921,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         vector<CBlock> vHeaders;
         int nLimit = 1000;
-        LogPrintf("\ngetheaders %d to %s\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20));
+        LogPrintf("getheaders %d to %s", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20));
         for (; pindex; pindex = pindex->pnext)
         {
             vHeaders.push_back(pindex->GetBlockHeader());
@@ -6967,7 +6964,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
                     if (AcceptToMemoryPool(mempool, orphanTx, &fMissingInputs2))
                     {
-                        LogPrintf("   accepted orphan tx %s\n", orphanTxHash.ToString().substr(0,10));
+                        LogPrintf("   accepted orphan tx %s", orphanTxHash.ToString().substr(0,10));
                         RelayTransaction(orphanTx, orphanTxHash);
                         mapAlreadyAskedFor.erase(CInv(MSG_TX, orphanTxHash));
                         vWorkQueue.push_back(orphanTxHash);
@@ -6978,7 +6975,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     {
                         // invalid orphan
                         vEraseQueue.push_back(orphanTxHash);
-                        LogPrintf("   removed invalid orphan tx %s\n", orphanTxHash.ToString().substr(0,10));
+                        LogPrintf("   removed invalid orphan tx %s", orphanTxHash.ToString().substr(0,10));
                     }
                 }
             }
@@ -6993,7 +6990,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             // DoS prevention: do not allow mapOrphanTransactions to grow unbounded
             unsigned int nEvicted = LimitOrphanTxSize(MAX_ORPHAN_TRANSACTIONS);
             if (nEvicted > 0)
-                LogPrintf("mapOrphan overflow, removed %u tx\n", nEvicted);
+                LogPrintf("mapOrphan overflow, removed %u tx", nEvicted);
         }
         if (tx.nDoS) pfrom->Misbehaving(tx.nDoS);
     }
@@ -7171,10 +7168,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         if (!(sProblem.empty())) {
-            LogPrintf("pong %s %s: %s, %" PRIx64 " expected, %" PRIx64 " received, %f bytes\n"
+            LogPrintf("pong %s %s: %s, %" PRIx64 " expected, %" PRIx64 " received, %" PRIu64 " bytes"
                 , pfrom->addr.ToString()
                 , pfrom->strSubVer
-                , sProblem, pfrom->nPingNonceSent, nonce, (double)nAvail);
+                , sProblem, pfrom->nPingNonceSent, nonce, nAvail);
         }
         if (bPingFinished) {
             pfrom->nPingNonceSent = 0;
@@ -7187,7 +7184,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             // if (pfrom->nNeuralRequestSent != 0)
             // nNeuralNonce must match request ID
             pfrom->NeuralHash = neural_response;
-            if (fDebug10) LogPrintf("hash_Neural Response %s \n",neural_response);
+            if (fDebug10) LogPrintf("hash_Neural Response %s ",neural_response);
     }
     else if (strCommand == "expmag_nresp")
     {
@@ -7199,7 +7196,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 //If invalid, try again 10-20-2015
                 VerifyExplainMagnitudeResponse();
             }
-            if (fDebug10) LogPrintf("expmag_Neural Response %s \n",neural_response);
+            if (fDebug10) LogPrintf("expmag_Neural Response %s ",neural_response);
     }
     else if (strCommand == "quorum_nresp")
     {
@@ -7211,7 +7208,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                  std::string results = "";
                  //Resolve discrepancies
                 results = NN::ExecuteDotNetStringFunction("ResolveDiscrepancies",neural_contract);
-                 if (fDebug && !results.empty()) LogPrintf("Quorum Resolution: %s \n",results);
+                 if (fDebug && !results.empty()) LogPrintf("Quorum Resolution: %s ",results);
             }
     }
     else if (strCommand == "ndata_nresp")
@@ -7223,9 +7220,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             {
                  std::string results = "";
                  //Resolve discrepancies
-                    LogPrintf("\n** Sync neural network data from supermajority **\n");
+                LogPrintf("Sync neural network data from supermajority");
                 results = NN::ExecuteDotNetStringFunction("ResolveCurrentDiscrepancies",neural_contract);
-                 if (fDebug && !results.empty()) LogPrintf("Quorum Resolution: %s \n",results);
+                if (fDebug && !results.empty()) LogPrintf("Quorum Resolution: %s ",results);
                  // Resume the full DPOR sync at this point now that we have the supermajority data
                  if (results=="SUCCESS")  FullSyncWithDPORNodes();
             }
@@ -7306,7 +7303,7 @@ bool ProcessMessages(CNode* pfrom)
         CNetMessage& msg = *it;
 
         //if (fDebug10)
-        //    LogPrintf("ProcessMessages(message %u msgsz, %zu bytes, complete:%s)\n",
+        //    LogPrintf("ProcessMessages(message %u msgsz, %zu bytes, complete:%s)",
         //            msg.hdr.nMessageSize, msg.vRecv.size(),
         //            msg.complete() ? "Y" : "N");
 
@@ -7319,7 +7316,7 @@ bool ProcessMessages(CNode* pfrom)
 
         // Scan for message start
         if (memcmp(msg.hdr.pchMessageStart, pchMessageStart, sizeof(pchMessageStart)) != 0) {
-            if (fDebug10) LogPrintf("\n\nPROCESSMESSAGE: INVALID MESSAGESTART\n\n");
+            if (fDebug10) LogPrintf("PROCESSMESSAGE: INVALID MESSAGESTART");
             fOk = false;
             break;
         }
@@ -7328,7 +7325,7 @@ bool ProcessMessages(CNode* pfrom)
         CMessageHeader& hdr = msg.hdr;
         if (!hdr.IsValid())
         {
-            LogPrintf("\n\nPROCESSMESSAGE: ERRORS IN HEADER %s\n\n\n", hdr.GetCommand().c_str());
+            LogPrintf("PROCESSMESSAGE: ERRORS IN HEADER %s", hdr.GetCommand());
             continue;
         }
         string strCommand = hdr.GetCommand();
@@ -7344,7 +7341,7 @@ bool ProcessMessages(CNode* pfrom)
         memcpy(&nChecksum, &hash, sizeof(nChecksum));
         if (nChecksum != hdr.nChecksum)
         {
-            LogPrintf("ProcessMessages(%s, %u bytes) : CHECKSUM ERROR nChecksum=%08x hdr.nChecksum=%08x\n",
+            LogPrintf("ProcessMessages(%s, %u bytes) : CHECKSUM ERROR nChecksum=%08x hdr.nChecksum=%08x",
                strCommand, nMessageSize, nChecksum, hdr.nChecksum);
             continue;
         }
@@ -7362,12 +7359,12 @@ bool ProcessMessages(CNode* pfrom)
             if (strstr(e.what(), "end of data"))
             {
                 // Allow exceptions from under-length message on vRecv
-                LogPrintf("ProcessMessages(%s, %u bytes) : Exception '%s' caught, normally caused by a message being shorter than its stated length\n", strCommand, nMessageSize, e.what());
+                LogPrintf("ProcessMessages(%s, %u bytes) : Exception '%s' caught, normally caused by a message being shorter than its stated length", strCommand, nMessageSize, e.what());
             }
             else if (strstr(e.what(), "size too large"))
             {
                 // Allow exceptions from over-long size
-                LogPrintf("ProcessMessages(%s, %u bytes) : Exception '%s' caught\n", strCommand, nMessageSize, e.what());
+                LogPrintf("ProcessMessages(%s, %u bytes) : Exception '%s' caught", strCommand, nMessageSize, e.what());
             }
             else
             {
@@ -7382,7 +7379,7 @@ bool ProcessMessages(CNode* pfrom)
 
         if (!fRet)
         {
-           if (fDebug10) LogPrintf("ProcessMessage(%s, %u bytes) FAILED\n", strCommand, nMessageSize);
+           if (fDebug10) LogPrintf("ProcessMessage(%s, %u bytes) FAILED", strCommand, nMessageSize);
         }
     }
 
@@ -7581,7 +7578,7 @@ MiningCPID DeserializeBoincBlock(std::string block, int BlockVersion)
     }
     catch (...)
     {
-            LogPrintf("Deserialize ended with an error (06182014) \n");
+            LogPrintf("Deserialize ended with an error (06182014) ");
     }
     return surrogate;
 }
@@ -7666,7 +7663,7 @@ std::string ToOfficialName(std::string proj)
 void HarvestCPIDs(bool cleardata)
 {
 
-    if (fDebug10) LogPrintf("loading BOINC cpids ...\n");
+    if (fDebug10) LogPrintf("loading BOINC cpids ...");
 
     //Remote Boinc Feature - R Halford
     std::string sBoincKey = GetArgument("boinckey","");
@@ -7674,12 +7671,12 @@ void HarvestCPIDs(bool cleardata)
     if (!sBoincKey.empty())
     {
         //Deserialize key into Global CPU Mining CPID 2-6-2015
-        LogPrintf("Using key %s \n",sBoincKey);
+        LogPrintf("Using key %s ",sBoincKey);
 
         std::string sDec=DecodeBase64(sBoincKey);
-        LogPrintf("Using key %s \n",sDec);
+        LogPrintf("Using key %s ",sDec);
 
-        if (sDec.empty()) LogPrintf("Error while deserializing boinc key!  Please use execute genboinckey to generate a boinc key from the host with boinc installed.\n");
+        if (sDec.empty()) LogPrintf("Error while deserializing boinc key!  Please use execute genboinckey to generate a boinc key from the host with boinc installed.");
         //Version not needed for keys for now
         GlobalCPUMiningCPID = DeserializeBoincBlock(sDec,7);
 
@@ -7687,17 +7684,17 @@ void HarvestCPIDs(bool cleardata)
 
         if (GlobalCPUMiningCPID.cpid.empty())
         {
-                 LogPrintf("Error while deserializing boinc key!  Please use execute genboinckey to generate a boinc key from the host with boinc installed.\n");
+                 LogPrintf("Error while deserializing boinc key!  Please use execute genboinckey to generate a boinc key from the host with boinc installed.");
         }
         else
         {
-            LogPrintf("CPUMiningCPID Initialized.\n");
+            LogPrintf("CPUMiningCPID Initialized.");
         }
 
             GlobalCPUMiningCPID.email = GlobalCPUMiningCPID.aesskein;
-            LogPrintf("Using Serialized Boinc CPID %s with orig email of %s and bpk of %s with cpidhash of %s \n",GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.email, GlobalCPUMiningCPID.boincruntimepublickey, GlobalCPUMiningCPID.cpidhash);
+            LogPrintf("Using Serialized Boinc CPID %s with orig email of %s and bpk of %s with cpidhash of %s ",GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.email, GlobalCPUMiningCPID.boincruntimepublickey, GlobalCPUMiningCPID.cpidhash);
             GlobalCPUMiningCPID.cpidhash = GlobalCPUMiningCPID.boincruntimepublickey;
-            LogPrintf("Using Serialized Boinc CPID %s with orig email of %s and bpk of %s with cpidhash of %s \n",GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.email, GlobalCPUMiningCPID.boincruntimepublickey, GlobalCPUMiningCPID.cpidhash);
+            LogPrintf("Using Serialized Boinc CPID %s with orig email of %s and bpk of %s with cpidhash of %s ",GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.email, GlobalCPUMiningCPID.boincruntimepublickey, GlobalCPUMiningCPID.cpidhash);
             StructCPID structcpid = GetStructCPID();
             structcpid.initialized = true;
             structcpid.cpidhash = GlobalCPUMiningCPID.cpidhash;
@@ -7711,7 +7708,7 @@ void HarvestCPIDs(bool cleardata)
             structcpid.NetworkRAC = GlobalCPUMiningCPID.NetworkRAC;
             structcpid.email = GlobalCPUMiningCPID.email;
             // 2-6-2015 R Halford - Ensure CPIDv2 Is populated After deserializing GenBoincKey
-            LogPrintf("GenBoincKey using email %s and cpidhash %s key %s \n", structcpid.email, structcpid.cpidhash, sDec);
+            LogPrintf("GenBoincKey using email %s and cpidhash %s key %s ", structcpid.email, structcpid.cpidhash, sDec);
             structcpid.cpidv2 = ComputeCPIDv2(structcpid.email, structcpid.cpidhash, 0);
             // Old link: structcpid.link = "http://boinc.netsoft-online.com/get_user.php?cpid=" + structcpid.cpid;
             structcpid.link = "http://boinc.netsoft-online.com/e107_plugins/boinc/get_user.php?cpid=" + structcpid.cpid;
@@ -7720,7 +7717,7 @@ void HarvestCPIDs(bool cleardata)
             // CreditCheck(structcpid.cpid,false);
             GetNextProject(false);
             if (fDebug10) LogPrintf("GCMCPI %s",GlobalCPUMiningCPID.cpid);
-            if (fDebug10)           LogPrintf("Finished getting first remote boinc project\n");
+            if (fDebug10)           LogPrintf("Finished getting first remote boinc project");
         return;
   }
 
@@ -7731,14 +7728,14 @@ void HarvestCPIDs(bool cleardata)
     sout = getfilecontents(sourcefile);
     if (sout == "-1")
     {
-        LogPrintf("Unable to obtain Boinc CPIDs \n");
+        LogPrintf("Unable to obtain Boinc CPIDs ");
 
         if (mapArgs.count("-boincdatadir") && mapArgs["-boincdatadir"].length() > 0)
         {
-            LogPrintf("Boinc data directory set in gridcoinresearch.conf has been incorrectly specified \n");
+            LogPrintf("Boinc data directory set in gridcoinresearch.conf has been incorrectly specified ");
         }
 
-        else LogPrintf("Boinc data directory is not in the operating system's default location \nPlease move it there or specify its current location in gridcoinresearch.conf \n");
+        else LogPrintf("Boinc data directory is not in the operating system's default location \nPlease move it there or specify its current location in gridcoinresearch.conf");
 
         return;
     }
@@ -7830,7 +7827,7 @@ void HarvestCPIDs(bool cleardata)
 
                         if (!externalcpid.empty())
                         {
-                            LogPrintf("\n** External CPID not empty %s **\n",externalcpid);
+                            LogPrintf("External CPID not empty %s", externalcpid);
 
                             bTestExternal = CPIDAcidTest2(cpidhash,externalcpid);
                             bTestInternal = CPIDAcidTest2(cpidhash,structcpid.cpid);
@@ -7849,7 +7846,7 @@ void HarvestCPIDs(bool cleardata)
                             {
                                 structcpid.Iscpidvalid = false;
                                 structcpid.errors = "CPID corrupted Internal: %s, External: %s" + structcpid.cpid + "," + externalcpid.c_str();
-                                LogPrintf("CPID corrupted Internal: %s, External: %s \n", structcpid.cpid, externalcpid);
+                                LogPrintf("CPID corrupted Internal: %s, External: %s", structcpid.cpid, externalcpid);
                             }
                             mvCPIDs[proj] = structcpid;
                         }
@@ -7862,7 +7859,7 @@ void HarvestCPIDs(bool cleardata)
                                     GlobalCPUMiningCPID.cpidhash = cpidhash;
                                     GlobalCPUMiningCPID.email = email;
                                     GlobalCPUMiningCPID.boincruntimepublickey = cpidhash;
-                                    LogPrintf("\nSetting bpk to %s\n", cpidhash);
+                                    LogPrintf("Setting bpk to %s", cpidhash);
 
                                     if (structcpid.team=="gridcoin")
                                     {
@@ -7877,7 +7874,7 @@ void HarvestCPIDs(bool cleardata)
                         }
 
                         mvCPIDs[proj] = structcpid;
-                        if (fDebug10) LogPrintf("Adding Local Project %s \n", structcpid.cpid);
+                        if (fDebug10) LogPrintf("Adding Local Project %s ", structcpid.cpid);
 
                     }
 
@@ -7891,11 +7888,11 @@ void HarvestCPIDs(bool cleardata)
     }
     catch (std::exception &e)
     {
-             LogPrintf("Error while harvesting CPIDs.\n");
+             LogPrintf("Error while harvesting CPIDs.");
     }
     catch(...)
     {
-             LogPrintf("Error while harvesting CPIDs 2.\n");
+             LogPrintf("Error while harvesting CPIDs 2.");
     }
 }
 
@@ -7905,7 +7902,7 @@ void LoadCPIDs()
     HarvestCPIDs(true);
     LogPrintf(" Getting first project;");
     GetNextProject(false);
-    LogPrintf(" Finished getting first project\n");
+    LogPrintf(" Finished getting first project");
 }
 
 StructCPID GetStructCPID()
@@ -8144,7 +8141,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         const CInv& inv = (*pto->mapAskFor.begin()).second;
         if (!AlreadyHave(txdb, inv))
         {
-            if (fDebugNet)        LogPrintf("sending getdata: %s\n", inv.ToString());
+            if (fDebugNet)        LogPrintf("sending getdata: %s", inv.ToString());
             vGetData.push_back(inv);
             if (vGetData.size() >= 1000)
             {
@@ -8201,18 +8198,18 @@ void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const st
             bool validaddresstovote = address.IsValid();
             if (!validaddresstovote)
             {
-                LogPrintf("INNS : Vote found in block with invalid GRC address. HASH: %s GRC: %s\n", NeuralHash, GRCAddress);
+                LogPrintf("INNS : Vote found in block with invalid GRC address. HASH: %s GRC: %s", NeuralHash, GRCAddress);
                 return;
             }
             if (!IsNeuralNodeParticipant(GRCAddress, pblockindex->nTime))
             {
-                LogPrintf("INNS : Vote found in block from ineligible neural node participant. HASH: %s GRC: %s\n", NeuralHash, GRCAddress);
+                LogPrintf("INNS : Vote found in block from ineligible neural node participant. HASH: %s GRC: %s", NeuralHash, GRCAddress);
                 return;
             }
         }
         catch (const bignum_error& innse)
         {
-            LogPrintf("INNS : Exception: %s\n", innse.what());
+            LogPrintf("INNS : Exception: %s", innse.what());
             return;
         }
     }
@@ -8372,7 +8369,7 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
 
                                 WriteCache(sMessageType,sMessageKey,sMessageValue,nTime);
                                 if(fDebug10 && sMessageType=="beacon" ){
-                                    LogPrintf("BEACON add %s %s %s\n", sMessageKey, DecodeBase64(sMessageValue), TimestampToHRDate(nTime));
+                                    LogPrintf("BEACON add %s %s %s", sMessageKey, DecodeBase64(sMessageValue), TimestampToHRDate(nTime));
                                 }
                                 fMessageLoaded = true;
                                 if (sMessageType=="poll")
@@ -8389,9 +8386,9 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                         }
                         else if(sMessageAction=="D")
                         {
-                                if (fDebug10) LogPrintf("Deleting key type %s Key %s Value %s\n", sMessageType, sMessageKey, sMessageValue);
+                                if (fDebug10) LogPrintf("Deleting key type %s Key %s Value %s", sMessageType, sMessageKey, sMessageValue);
                                 if(fDebug10 && sMessageType=="beacon" ){
-                                    LogPrintf("BEACON DEL %s - %s\n", sMessageKey, TimestampToHRDate(nTime));
+                                    LogPrintf("BEACON DEL %s - %s", sMessageKey, TimestampToHRDate(nTime));
                                 }
                                 DeleteCache(sMessageType,sMessageKey);
                                 fMessageLoaded = true;
@@ -8439,15 +8436,15 @@ double GRCMagnitudeUnit(int64_t locktime)
 int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string operation, CBlockIndex* pindexLast, bool bVerifyingBlock, int iVerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude)
 {
     double dCurrentMagnitude = CalculatedMagnitude2(cpid, nTime, false);
-    if(fDebug && !bVerifyingBlock) LogPrintf("ComputeResearchAccrual.CRE.Begin: cpid=%s {%s %d} (best %d)\n", cpid, pindexLast->GetBlockHash().GetHex(), pindexLast->nHeight, pindexBest->nHeight);
+    if(fDebug && !bVerifyingBlock) LogPrintf("ComputeResearchAccrual.CRE.Begin: cpid=%s {%s %d} (best %d)", cpid, pindexLast->GetBlockHash().GetHex(), pindexLast->nHeight, pindexBest->nHeight);
     if(pindexLast->nVersion>=9)
     {
         // Bugfix for newbie rewards always being around 1 GRC
         dMagnitudeUnit = GRCMagnitudeUnit(nTime);
     }
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: dCurrentMagnitude= %.1f in.dMagnitudeUnit= %f\n", dCurrentMagnitude,dMagnitudeUnit);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: dCurrentMagnitude= %.1f in.dMagnitudeUnit= %f", dCurrentMagnitude,dMagnitudeUnit);
     CBlockIndex* pHistorical = GetHistoricalMagnitude(cpid);
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: pHistorical {%s %d} hasNext= %d nMagnitude= %.1f\n", pHistorical->GetBlockHash().GetHex(), pHistorical->nHeight, !!pHistorical->pnext, pHistorical->nMagnitude);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: pHistorical {%s %d} hasNext= %d nMagnitude= %.1f", pHistorical->GetBlockHash().GetHex(), pHistorical->nHeight, !!pHistorical->pnext, pHistorical->nMagnitude);
     bool bIsNewbie = (pHistorical->nHeight <= nNewIndex || pHistorical->nTime==0);
     if(pindexLast->nVersion<9)
     {
@@ -8457,11 +8454,11 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
     if (bIsNewbie)
     {
         //No prior block exists... Newbies get .01 age to bootstrap the CPID (otherwise they will not have any prior block to refer to, thus cannot get started):
-        if(fDebug && !bVerifyingBlock) LogPrintf("CRE: No prior block exists...\n");
+        if(fDebug && !bVerifyingBlock) LogPrintf("CRE: No prior block exists...");
         if (!AreBinarySuperblocksEnabled(pindexLast->nHeight))
         {
                 if(fDebug && !bVerifyingBlock) LogPrintf("CRE: Newbie Stake, Binary SB not enabled, "
-                                                  "dCurrentMagnitude= %.1f\n", dCurrentMagnitude);
+                                                  "dCurrentMagnitude= %.1f", dCurrentMagnitude);
             return dCurrentMagnitude > 0 ? ((dCurrentMagnitude/100)*COIN) : 0;
         }
         else
@@ -8478,15 +8475,15 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
                     LogPrintf("ComputeResearchAccrual: Newbie special stake too high, reward=500GRC");
                     return (500*COIN);
                 }
-                if (fDebug3) LogPrintf("\n ComputeResearchAccrual: Newbie Special First Stake for CPID %s, Age %f, Accrual %f \n",cpid.c_str(),dNewbieAccrualAge,(double)iAccrual);
+                if (fDebug3) LogPrintf("ComputeResearchAccrual: Newbie Special First Stake for CPID %s, Age %f, Accrual %" PRId64, cpid.c_str(),dNewbieAccrualAge, iAccrual);
                 if(fDebug && !bVerifyingBlock) LogPrintf("CRE: Newbie Stake, "
-                    "dNewbieAccrualAge= %f dCurrentMagnitude= %.1f dMagnitudeUnit= %f Accrual= %f\n",
+                    "dNewbieAccrualAge= %f dCurrentMagnitude= %.1f dMagnitudeUnit= %f Accrual= %f",
                     dNewbieAccrualAge, dCurrentMagnitude, dMagnitudeUnit, iAccrual/(double)COIN);
                 return iAccrual;
             }
             else
             {
-                if(fDebug && !bVerifyingBlock) LogPrintf("CRE: Invalid Beacon, Using 0.01 age bootstrap\n");
+                if(fDebug && !bVerifyingBlock) LogPrintf("CRE: Invalid Beacon, Using 0.01 age bootstrap");
                 return dCurrentMagnitude > 0 ? (((dCurrentMagnitude/100)*COIN) + (1*COIN)): 0;
             }
         }
@@ -8495,7 +8492,7 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
     int iRABlockSpan = pindexLast->nHeight - pHistorical->nHeight;
     StructCPID stCPID = GetInitializedStructCPID2(cpid,mvResearchAge);
     double dAvgMag = stCPID.ResearchAverageMagnitude;
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: iRABlockSpan= %d  ResearchAverageMagnitude= %.1f\n", iRABlockSpan, dAvgMag);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: iRABlockSpan= %d  ResearchAverageMagnitude= %.1f", iRABlockSpan, dAvgMag);
     // ResearchAge: If the accrual age is > 20 days, add in the midpoint lifetime average magnitude to ensure the overall avg magnitude accurate:
     if (iRABlockSpan > (int)(BLOCKS_PER_DAY*20))
     {
@@ -8506,22 +8503,22 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
             AvgMagnitude = (pHistorical->nMagnitude + dCurrentMagnitude) / 2;
     }
     if (AvgMagnitude > 20000) AvgMagnitude = 20000;
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: AvgMagnitude= %.3f\n", AvgMagnitude);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: AvgMagnitude= %.3f", AvgMagnitude);
 
     dAccrualAge = ((double)nTime - (double)pHistorical->nTime) / 86400;
     if (dAccrualAge < 0) dAccrualAge=0;
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: dAccrualAge= %.8f\n", dAccrualAge);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: dAccrualAge= %.8f", dAccrualAge);
     dMagnitudeUnit = GRCMagnitudeUnit(nTime);
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: new.dMagnitudeUnit= %f\n", dMagnitudeUnit);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: new.dMagnitudeUnit= %f", dMagnitudeUnit);
 
     int64_t Accrual = (int64_t)(dAccrualAge*AvgMagnitude*dMagnitudeUnit*COIN);
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: Accrual= %f\n", Accrual/(double)COIN);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE: Accrual= %f", Accrual/(double)COIN);
     // Double check researcher lifetime paid
     double days = (nTime - stCPID.LowLockTime) / 86400.0;
     double PPD = stCPID.ResearchSubsidy/(days+.01);
     double ReferencePPD = dMagnitudeUnit*dAvgMag;
     if(fDebug && !bVerifyingBlock) LogPrintf("CRE: RSA$ "
-        "LowLockTime= %u days= %f stCPID.ResearchSubsidy= %f PPD= %f ReferencePPD= %f\n",
+        "LowLockTime= %u days= %f stCPID.ResearchSubsidy= %f PPD= %f ReferencePPD= %f",
         stCPID.LowLockTime,days,   stCPID.ResearchSubsidy,    PPD,    ReferencePPD );
     if ((PPD > ReferencePPD*5))
     {
@@ -8533,10 +8530,10 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string oper
     if (iRABlockSpan < 10 && iVerificationPhase != 2) Accrual = 0;
 
     double verbosity = (operation == "createnewblock" || operation == "createcoinstake") ? 10 : 1000;
-    if ((fDebug && LessVerbose(verbosity)) || (fDebug3 && iVerificationPhase==2)) LogPrintf(" Operation %s, ComputedAccrual %f, StakeHeight %f, RABlockSpan %f, HistoryHeight%f, AccrualAge %f, AvgMag %f, MagUnit %f, PPD %f, Reference PPD %f  \n",
+    if ((fDebug && LessVerbose(verbosity)) || (fDebug3 && iVerificationPhase==2)) LogPrintf(" Operation %s, ComputedAccrual %f, StakeHeight %f, RABlockSpan %f, HistoryHeight%f, AccrualAge %f, AvgMag %f, MagUnit %f, PPD %f, Reference PPD %f  ",
         operation.c_str(),CoinToDouble(Accrual),(double)pindexLast->nHeight,(double)iRABlockSpan,
         (double)pHistorical->nHeight,   dAccrualAge,AvgMagnitude,dMagnitudeUnit, PPD, ReferencePPD);
-    if(fDebug && !bVerifyingBlock) LogPrintf("CRE.End: Accrual= %f\n",Accrual/(double)COIN);
+    if(fDebug && !bVerifyingBlock) LogPrintf("CRE.End: Accrual= %f",Accrual/(double)COIN);
     return Accrual;
 }
 
@@ -8563,12 +8560,12 @@ CBlockIndex* GetHistoricalMagnitude(std::string cpid)
         CBlockIndex* pblockindex = mapItem->second;
         if(!pblockindex->pnext && pblockindex!=pindexBest)
             LogPrintf("WARNING GetHistoricalMagnitude: index {%s %d} for cpid %s, "
-            "is not in the main chain\n",pblockindex->GetBlockHash().GetHex().c_str(),
+            "is not in the main chain",pblockindex->GetBlockHash().GetHex().c_str(),
             pblockindex->nHeight,cpid.c_str());
         if (pblockindex->nHeight < nMinIndex)
         {
             // In this case, the last staked block was Found, but it is over 6 months old....
-            LogPrintf("GetHistoricalMagnitude: Last staked block found at height %d, but cannot verify magnitude older than 6 months (min %d)!\n",pblockindex->nHeight,nMinIndex);
+            LogPrintf("GetHistoricalMagnitude: Last staked block found at height %d, but cannot verify magnitude older than 6 months (min %d)!",pblockindex->nHeight,nMinIndex);
             return pindexGenesisBlock;
         }
 
@@ -8672,7 +8669,7 @@ std::string CPIDHash(double dMagIn, std::string sCPID)
     std::string sMagComponent1 = RoundToString(dMagIn/(dExponent+.01),0);
     std::string sSuffix = RoundToString(dMagLength * dExponent, 0);
     std::string sHash = sCPID + sMagComponent1 + sSuffix;
-    //  LogPrintf("%s, %s, %f, %f, %s\n",sCPID.c_str(), sMagComponent1.c_str(),dMagLength,dExponent,sSuffix.c_str());
+    //  LogPrintf("%s, %s, %f, %f, %s",sCPID.c_str(), sMagComponent1.c_str(),dMagLength,dExponent,sSuffix.c_str());
     return sHash;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -421,7 +421,7 @@ public:
 
     void print() const
     {
-        LogPrintf("%s\n", ToString());
+        LogPrintf("%s", ToString());
     }
 };
 
@@ -504,7 +504,7 @@ public:
 
     void print() const
     {
-        LogPrintf("%s\n", ToString());
+        LogPrintf("%s", ToString());
     }
 };
 
@@ -588,7 +588,7 @@ public:
 
     void print() const
     {
-        LogPrintf("%s\n", ToString());
+        LogPrintf("%s", ToString());
     }
 };
 
@@ -1123,7 +1123,7 @@ public:
         // Take last bit of block hash as entropy bit
         unsigned int nEntropyBit = ((GetHash().Get64()) & 1llu);
         if (fDebug && GetBoolArg("-printstakemodifier"))
-            LogPrintf("GetStakeEntropyBit: hashBlock=%s nEntropyBit=%u\n", GetHash().ToString(), nEntropyBit);
+            LogPrintf("GetStakeEntropyBit: hashBlock=%s nEntropyBit=%u", GetHash().ToString(), nEntropyBit);
         return nEntropyBit;
     }
 
@@ -1259,7 +1259,7 @@ public:
 
     void print() const
     {
-        LogPrintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%" PRIszu ", vchBlockSig=%s)\n",
+        LogPrintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%" PRIszu ", vchBlockSig=%s)",
             GetHash().ToString(),
             nVersion,
             hashPrevBlock.ToString(),
@@ -1274,8 +1274,7 @@ public:
         }
         LogPrintf("  vMerkleTree: ");
         for (unsigned int i = 0; i < vMerkleTree.size(); i++)
-            LogPrintf("%s ", vMerkleTree[i].ToString().substr(0,10));
-        LogPrintf("\n");
+            LogPrintf("%s", vMerkleTree[i].ToString().substr(0,10));
     }
 
 
@@ -1562,7 +1561,7 @@ public:
 
     void print() const
     {
-        LogPrintf("%s\n", ToString());
+        LogPrintf("%s", ToString());
     }
 };
 
@@ -1683,7 +1682,7 @@ public:
 
     void print() const
     {
-        LogPrintf("%s\n", ToString());
+        LogPrintf("%s", ToString());
     }
 };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -54,10 +54,10 @@ public:
 
     void print() const
     {
-        LogPrintf("COrphan(hash=%s, dPriority=%.1f, dFeePerKb=%.1f)\n",
+        LogPrintf("COrphan(hash=%s, dPriority=%.1f, dFeePerKb=%.1f)",
                ptx->GetHash().ToString().substr(0,10), dPriority, dFeePerKb);
         for (auto const& hash : setDependsOn)
-            LogPrintf("   setDependsOn %s\n", hash.ToString().substr(0,10));
+            LogPrintf("   setDependsOn %s", hash.ToString().substr(0,10));
     }
 };
 
@@ -224,7 +224,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
                     // or other transactions in the memory pool.
                     if (!mempool.mapTx.count(txin.prevout.hash))
                     {
-                        LogPrintf("ERROR: mempool transaction missing input\n");
+                        LogPrintf("ERROR: mempool transaction missing input");
                         if (fDebug) assert("mempool transaction missing input" == 0);
                         fMissingInputs = true;
                         if (porphan)
@@ -393,7 +393,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
 
             if (fDebug10 || GetBoolArg("-printpriority"))
             {
-                LogPrintf("priority %.1f feeperkb %.1f txid %s\n",
+                LogPrintf("priority %.1f feeperkb %.1f txid %s",
                        dPriority, dFeePerKb, tx.GetHash().ToString());
             }
 
@@ -417,7 +417,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
         }
 
         if (fDebug10 || GetBoolArg("-printpriority"))
-            LogPrintf("CreateNewBlock(): total size %" PRIu64 "\n", nBlockSize);
+            LogPrintf("CreateNewBlock(): total size %" PRIu64 "", nBlockSize);
     }
 
     //Add fees to coinbase
@@ -469,7 +469,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
     }
     BalanceToStake -= nReserveBalance;
 
-    if(fDebug2) LogPrintf("\nCreateCoinStake: Staking nTime/16= %d Bits= %u",
+    if(fDebug2) LogPrintf("CreateCoinStake: Staking nTime/16= %d Bits= %u",
     txnew.nTime/16,blocknew.nBits);
 
     for(const auto& pcoin : CoinsToStake)
@@ -541,7 +541,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
 " RSA_WEIGHT %.f\n"
 " Stk %72s\n"
 " Trg %72s\n"
-" Diff %0.7f of %0.7f\n",
+" Diff %0.7f of %0.7f",
             blocknew.nVersion,
             (double)txnew.nTime, mdPORNonce,
             (intmax_t)blocknew.nBits,(intmax_t)CoinWeight,
@@ -554,7 +554,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
         if( StakeKernelHash <= StakeTarget )
         {
             // Found a kernel
-            LogPrintf("\nCreateCoinStake: Found Kernel;\n");
+            LogPrintf("CreateCoinStake: Found Kernel;");
             blocknew.nNonce= mdPORNonce;
             vector<valtype> vSolutions;
             txnouttype whichType;
@@ -563,7 +563,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             scriptPubKeyKernel = CoinTx.vout[CoinTxN].scriptPubKey;
             if (!Solver(scriptPubKeyKernel, whichType, vSolutions))
             {
-                LogPrintf("CreateCoinStake: failed to parse kernel\n");
+                LogPrintf("CreateCoinStake: failed to parse kernel");
                 break;
             }
             if (whichType == TX_PUBKEYHASH) // pay to address type
@@ -571,7 +571,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
                 // convert to pay to public key type
                 if (!wallet.GetKey(uint160(vSolutions[0]), key))
                 {
-                    LogPrintf("CreateCoinStake: failed to get key for kernel type=%d\n", whichType);
+                    LogPrintf("CreateCoinStake: failed to get key for kernel type=%d", whichType);
                     break;  // unable to find corresponding public key
                 }
                 scriptPubKeyOut << key.GetPubKey() << OP_CHECKSIG;
@@ -582,7 +582,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
                 if (!wallet.GetKey(Hash160(vchPubKey), key)
                     || key.GetPubKey() != vchPubKey)
                 {
-                    LogPrintf("CreateCoinStake: failed to get key for kernel type=%d\n", whichType);
+                    LogPrintf("CreateCoinStake: failed to get key for kernel type=%d", whichType);
                     break;  // unable to find corresponding public key
                 }
 
@@ -590,7 +590,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             }
             else
             {
-                LogPrintf("CreateCoinStake: no support for kernel type=%d\n", whichType);
+                LogPrintf("CreateCoinStake: no support for kernel type=%d", whichType);
                 break;  // only support pay to public key and pay to address
             }
 
@@ -604,7 +604,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             txnew.vout.push_back(CTxOut(nCredit, scriptPubKeyOut));
             //txnew.vout.push_back(CTxOut(0, scriptPubKeyOut));
 
-            LogPrintf("CreateCoinStake: added kernel type=%d credit=%f\n", whichType,CoinToDouble(nCredit));
+            LogPrintf("CreateCoinStake: added kernel type=%d credit=%f", whichType,CoinToDouble(nCredit));
 
             LOCK(MinerStatus.lock);
             MinerStatus.KernelsFound++;
@@ -637,13 +637,13 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
         bool bResult = SignBlockWithCPID(GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash, sBoincSignature, sError);
         if (!bResult)
         {
-            return error("SignStakeBlock: Failed to sign boinchash -> %s\n", sError);
+            return error("SignStakeBlock: Failed to sign boinchash -> %s", sError);
         }
         BoincData.BoincSignature = sBoincSignature;
-        if(fDebug2) LogPrintf("Signing BoincBlock for cpid %s and blockhash %s with sig %s\n", GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash, BoincData.BoincSignature);
+        if(fDebug2) LogPrintf("Signing BoincBlock for cpid %s and blockhash %s with sig %s", GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash, BoincData.BoincSignature);
     }
     block.vtx[0].hashBoinc = SerializeBoincBlock(BoincData,block.nVersion);
-    //if (fDebug2)  LogPrintf("SignStakeBlock: %s\n",SerializedBoincData.c_str());
+    //if (fDebug2)  LogPrintf("SignStakeBlock: %s",SerializedBoincData.c_str());
 
     //Sign the coinstake transaction
     unsigned nIn = 0;
@@ -669,7 +669,7 @@ void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
 {
     if(OutOfSyncByAge())
     {
-        LogPrintf("AddNeuralContractOrVote: Out Of Sync\n");
+        LogPrintf("AddNeuralContractOrVote: Out Of Sync");
         return;
     }
 
@@ -679,7 +679,7 @@ void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
 
     if(sb_contract.empty())
     {
-        LogPrintf("AddNeuralContractOrVote: Local Contract Empty\n");
+        LogPrintf("AddNeuralContractOrVote: Local Contract Empty");
         return;
     }
 
@@ -693,20 +693,20 @@ void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
 
     if(!IsNeuralNodeParticipant(bb.GRCAddress, blocknew.nTime))
     {
-        LogPrintf("AddNeuralContractOrVote: Not Participating\n");
+        LogPrintf("AddNeuralContractOrVote: Not Participating");
         return;
     }
 
     if(blocknew.nVersion >= 9)
     {
         // break away from block timing
-        if (fDebug) LogPrintf("AddNeuralContractOrVote: Updating Neural Supermajority (v9 M) height %d\n",nBestHeight);
+        if (fDebug) LogPrintf("AddNeuralContractOrVote: Updating Neural Supermajority (v9 M) height %d",nBestHeight);
         ComputeNeuralNetworkSupermajorityHashes();
     }
 
     if(!NeedASuperblock())
     {
-        LogPrintf("AddNeuralContractOrVote: not Needed\n");
+        LogPrintf("AddNeuralContractOrVote: not Needed");
         return;
     }
 
@@ -714,11 +714,11 @@ void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
 
     /* Add our Neural Vote */
     bb.NeuralHash = sb_hash;
-    LogPrintf("AddNeuralContractOrVote: Added our Neural Vote %s\n",sb_hash);
+    LogPrintf("AddNeuralContractOrVote: Added our Neural Vote %s",sb_hash);
 
     if (pending_height>=(pindexBest->nHeight-200))
     {
-        LogPrintf("AddNeuralContractOrVote: already Pending\n");
+        LogPrintf("AddNeuralContractOrVote: already Pending");
         return;
     }
 
@@ -727,13 +727,13 @@ void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
 
     if (consensus_hash!=sb_hash)
     {
-        LogPrintf("AddNeuralContractOrVote: not in Consensus\n");
+        LogPrintf("AddNeuralContractOrVote: not in Consensus");
         return;
     }
 
     /* We have consensus, Add our neural contract */
     bb.superblock = PackBinarySuperblock(sb_contract);
-    LogPrintf("AddNeuralContractOrVote: Added our Superblock (size %" PRIszu ")\n",bb.superblock.length());
+    LogPrintf("AddNeuralContractOrVote: Added our Superblock (size %" PRIszu ")",bb.superblock.length());
 
     return;
 }
@@ -795,7 +795,7 @@ bool CreateGridcoinReward(CBlock &blocknew, MiningCPID& miningcpid, uint64_t &nC
     double PORDiff = GetBlockDifficulty(blocknew.nBits);
     double mintlimit = MintLimiter(PORDiff,RSA_WEIGHT,miningcpid.cpid,blocknew.nTime);
 
-    LogPrintf("CreateGridcoinReward: for %s mint %f {RSAWeight %f} Research %f, Interest %f \n",
+    LogPrintf("CreateGridcoinReward: for %s mint %f {RSAWeight %f} Research %f, Interest %f ",
         miningcpid.cpid.c_str(), mint, (double)RSA_WEIGHT,miningcpid.ResearchSubsidy,miningcpid.InterestSubsidy);
 
     //INVESTORS
@@ -909,19 +909,19 @@ void StakeMiner(CWallet *pwallet)
         // * create rest of the block
         if( !CreateRestOfTheBlock(StakeBlock,pindexPrev) )
             continue;
-        LogPrintf("StakeMiner: created rest of the block\n");
+        LogPrintf("StakeMiner: created rest of the block");
 
         // * add gridcoin reward to coinstake
         if( !CreateGridcoinReward(StakeBlock,BoincData,StakeCoinAge,pindexPrev) )
             continue;
-        LogPrintf("StakeMiner: added gridcoin reward to coinstake\n");
+        LogPrintf("StakeMiner: added gridcoin reward to coinstake");
 
         AddNeuralContractOrVote(StakeBlock, BoincData);
 
         // * sign boinchash, coinstake, wholeblock
         if( !SignStakeBlock(StakeBlock,BlockKey,StakeInputs,pwallet,BoincData) )
             continue;
-        LogPrintf("StakeMiner: signed boinchash, coinstake, wholeblock\n");
+        LogPrintf("StakeMiner: signed boinchash, coinstake, wholeblock");
 
         { LOCK(MinerStatus.lock);
             MinerStatus.CreatedCnt++;
@@ -934,7 +934,7 @@ void StakeMiner(CWallet *pwallet)
             continue;
         }
 
-        LogPrintf("StakeMiner: block processed\n");
+        LogPrintf("StakeMiner: block processed");
         { LOCK(MinerStatus.lock);
             MinerStatus.AcceptedCnt++;
             nLastBlockSolved = GetAdjustedTime();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -294,11 +294,10 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
 
             // Size limits
             unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
-            if (fDebug10) LogPrintf("Tx Size for %s  %f",tx.GetHash().GetHex(), (double)nTxSize);
 
             if (nBlockSize + nTxSize >= nBlockMaxSize)
             {
-                if (fDebug10) LogPrintf("Tx size too large for tx %s  blksize %f , tx siz %f",tx.GetHash().GetHex().c_str(),(double)nBlockSize,(double)nTxSize);
+                LogPrintf("Tx size too large for tx %s blksize %" PRIu64 ", tx size %" PRId64, tx.GetHash().GetHex(), nBlockSize, nTxSize);
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":SizeTooLarge("
                     + ToString(nBlockSize) + "," + ToString(nTxSize) + ")("
                     + ToString(nBlockSize) + ");";
@@ -356,7 +355,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             int64_t nTxFees = tx.GetValueIn(mapInputs)-tx.GetValueOut();
             if (nTxFees < nMinFee)
             {
-                if (fDebug10) LogPrintf("Not including tx %s  due to TxFees of %f ; bare min fee is %f", tx.GetHash().GetHex(), (double)nTxFees, (double)nMinFee);
+                if (fDebug10) LogPrintf("Not including tx %s  due to TxFees of %" PRId64 ", bare min fee is %" PRId64, tx.GetHash().GetHex(), nTxFees, nMinFee);
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":FeeTooSmall("
                     + RoundToString(CoinToDouble(nFees),8) + "," +RoundToString(CoinToDouble(nMinFee),8) + ");";
                 continue;
@@ -365,8 +364,8 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             nTxSigOps += tx.GetP2SHSigOpCount(mapInputs);
             if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
             {
-                if (fDebug10) LogPrintf("Not including tx %s  due to exceeding max sigops of %f ; sigops is %f",
-                    tx.GetHash().GetHex(), (double)(nBlockSigOps+nTxSigOps), (double)MAX_BLOCK_SIGOPS);
+                if (fDebug10) LogPrintf("Not including tx %s due to exceeding max sigops of %d, sigops is %d",
+                    tx.GetHash().GetHex(), (nBlockSigOps+nTxSigOps), MAX_BLOCK_SIGOPS);
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":ExceededSigOps("
                     + ToString(nBlockSigOps) + "," + ToString(nTxSigOps) + ")("
                     + ToString(MAX_BLOCK_SIGOPS) + ");";

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -642,7 +642,6 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
         if(fDebug2) LogPrintf("Signing BoincBlock for cpid %s and blockhash %s with sig %s", GlobalCPUMiningCPID.cpid, GlobalCPUMiningCPID.lastblockhash, BoincData.BoincSignature);
     }
     block.vtx[0].hashBoinc = SerializeBoincBlock(BoincData,block.nVersion);
-    //if (fDebug2)  LogPrintf("SignStakeBlock: %s",SerializedBoincData.c_str());
 
     //Sign the coinstake transaction
     unsigned nIn = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -227,7 +227,7 @@ bool RecvLine2(SOCKET hSocket, string& strLine)
             {
                 // socket error
                 int nErr = WSAGetLastError();
-                if (fDebug3) LogPrintf("recv socket err: %d\n", nErr);
+                if (fDebug3) LogPrintf("recv socket err: %d", nErr);
                 return false;
             }
         }
@@ -284,14 +284,14 @@ bool RecvLine(SOCKET hSocket, string& strLine)
             if (nBytes == 0)
             {
                 // socket closed
-                if (fDebug10) LogPrintf("socket closed\n");
+                if (fDebug10) LogPrintf("socket closed");
                 return false;
             }
             else
             {
                 // socket error
                 int nErr = WSAGetLastError();
-                if (fDebug10) LogPrintf("recv err: %d\n", nErr);
+                if (fDebug10) LogPrintf("recv err: %d", nErr);
                 return false;
             }
         }
@@ -339,7 +339,7 @@ bool AddLocal(const CService& addr, int nScore)
 
     try
     {
-    if (fDebug10) LogPrintf("AddLocal(%s,%i)\n", addr.ToString(), nScore);
+    if (fDebug10) LogPrintf("AddLocal(%s,%i)", addr.ToString(), nScore);
 
     {
         LOCK(cs_mapLocalHost);
@@ -455,7 +455,7 @@ bool GetMyExternalIP2(const CService& addrConnect, const char* pszGet, const cha
             while (strLine.size() > 0 && isspace(strLine[strLine.size()-1]))
                 strLine.resize(strLine.size()-1);
             CService addr(strLine,0,true);
-            if (fDebug10) LogPrintf("GetMyExternalIP() received [%s] %s\n", strLine, addr.ToString());
+            if (fDebug10) LogPrintf("GetMyExternalIP() received [%s] %s", strLine, addr.ToString());
             if (!addr.IsValid() || !addr.IsRoutable())
                 return false;
             ipRet.SetIP(addr);
@@ -534,7 +534,7 @@ void ThreadGetMyExternalIP(void* parg)
         CNetAddr addrLocalHost;
         if (GetMyExternalIP(addrLocalHost))
         {
-            LogPrintf("GetMyExternalIP() returned %s\n", addrLocalHost.ToStringIP());
+            LogPrintf("GetMyExternalIP() returned %s", addrLocalHost.ToStringIP());
             AddLocal(addrLocalHost, LOCAL_HTTP);
         }
     }
@@ -618,15 +618,15 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
     {
         addrman.Attempt(addrConnect);
         /// debug print
-        if (fDebug10) LogPrintf("connected %s\n", pszDest ? pszDest : addrConnect.ToString());
+        if (fDebug10) LogPrintf("connected %s", pszDest ? pszDest : addrConnect.ToString());
         // Set to non-blocking
 #ifdef WIN32
         u_long nOne = 1;
         if (ioctlsocket(hSocket, FIONBIO, &nOne) == SOCKET_ERROR)
-            LogPrintf("ConnectSocket() : ioctlsocket non-blocking setting error %d\n", WSAGetLastError());
+            LogPrintf("ConnectSocket() : ioctlsocket non-blocking setting error %d", WSAGetLastError());
 #else
         if (fcntl(hSocket, F_SETFL, O_NONBLOCK) == SOCKET_ERROR)
-            LogPrintf("ConnectSocket() : fcntl non-blocking setting error %d\n", errno);
+            LogPrintf("ConnectSocket() : fcntl non-blocking setting error %d", errno);
 #endif
 
         // Add node
@@ -652,7 +652,7 @@ void CNode::CloseSocketDisconnect()
     fDisconnect = true;
     if (hSocket != INVALID_SOCKET)
     {
-        if (fDebug10) LogPrintf("disconnecting node %s\n", addrName);
+        if (fDebug10) LogPrintf("disconnecting node %s", addrName);
         closesocket(hSocket);
         hSocket = INVALID_SOCKET;
 
@@ -670,7 +670,7 @@ void CNode::PushVersion()
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0",0)));
     CAddress addrMe = GetLocalAddress(&addr);
     RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
-    if (fDebug10) LogPrintf("send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s\n",
+    if (fDebug10) LogPrintf("send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s",
         PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), addr.ToString());
 
     std::string sboinchashargs;
@@ -715,7 +715,7 @@ bool CNode::Misbehaving(int howmuch)
 {
     if (addr.IsLocal())
     {
-        LogPrintf("Warning: Local node %s misbehaving (delta: %d)!\n", addrName, howmuch);
+        LogPrintf("Warning: Local node %s misbehaving (delta: %d)!", addrName, howmuch);
         return false;
     }
 
@@ -723,7 +723,7 @@ bool CNode::Misbehaving(int howmuch)
     if (nMisbehavior >= GetArg("-banscore", 100))
     {
         int64_t banTime = GetAdjustedTime()+GetArg("-bantime", 60*60*24);  // Default 24-hour ban
-        if (fDebug10) LogPrintf("Misbehaving: %s (%d -> %d) DISCONNECTING\n", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
+        if (fDebug10) LogPrintf("Misbehaving: %s (%d -> %d) DISCONNECTING", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
         {
             LOCK(cs_setBanned);
             if (setBanned[addr] < banTime)
@@ -732,7 +732,7 @@ bool CNode::Misbehaving(int howmuch)
         CloseSocketDisconnect();
         return true;
     } else
-        if (fDebug10) LogPrintf("Misbehaving: %s (%d -> %d)\n", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
+        if (fDebug10) LogPrintf("Misbehaving: %s (%d -> %d)", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
     return false;
 }
 
@@ -885,7 +885,7 @@ void SocketSendData(CNode *pnode)
                 int nErr = WSAGetLastError();
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
-                    if (fDebug10) LogPrintf("socket send error %d\n", nErr);
+                    if (fDebug10) LogPrintf("socket send error %d", nErr);
                     pnode->CloseSocketDisconnect();
                 }
             }
@@ -916,19 +916,19 @@ void ThreadSocketHandler(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        LogPrintf("ThreadSocketHandler exited (interrupt)\n");
+        LogPrintf("ThreadSocketHandler exited (interrupt)");
         return;
     }
     catch (...)
     {
         throw; // support pthread_cancel()
     }
-    LogPrintf("ThreadSocketHandler exited\n");
+    LogPrintf("ThreadSocketHandler exited");
 }
 
 void ThreadSocketHandler2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadSocketHandler started\n");
+    if (fDebug10) LogPrintf("ThreadSocketHandler started");
     list<CNode*> vNodesDisconnected;
     unsigned int nPrevNodeCount = 0;
 
@@ -1061,7 +1061,7 @@ void ThreadSocketHandler2(void* parg)
             if (have_fds)
             {
                 int nErr = WSAGetLastError();
-                if (fDebug10) LogPrintf("socket select error %d\n", nErr);
+                if (fDebug10) LogPrintf("socket select error %d", nErr);
                 for (unsigned int i = 0; i <= hSocketMax; i++)
                     FD_SET(i, &fdsetRecv);
             }
@@ -1085,7 +1085,7 @@ void ThreadSocketHandler2(void* parg)
 
             if (hSocket != INVALID_SOCKET)
                 if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))
-                    LogPrintf("Warning: Unknown socket family\n");
+                    LogPrintf("Warning: Unknown socket family");
 
             {
                 LOCK(cs_vNodes);
@@ -1098,22 +1098,22 @@ void ThreadSocketHandler2(void* parg)
             {
                 int nErr = WSAGetLastError();
                 if (nErr != WSAEWOULDBLOCK)
-                    LogPrintf("socket error accept INVALID_SOCKET: %d\n", nErr);
+                    LogPrintf("socket error accept INVALID_SOCKET: %d", nErr);
             }
             else if (nInbound >= GetArg("-maxconnections", 250) - MAX_OUTBOUND_CONNECTIONS)
             {
                 if (fDebug10)
-                    LogPrintf("\n Surpassed max inbound connections maxconnections:%" PRId64 " minus max_outbound:%i", GetArg("-maxconnections",250), MAX_OUTBOUND_CONNECTIONS);
+                    LogPrintf("Surpassed max inbound connections maxconnections:%" PRId64 " minus max_outbound:%i", GetArg("-maxconnections",250), MAX_OUTBOUND_CONNECTIONS);
                 closesocket(hSocket);
             }
             else if (CNode::IsBanned(addr))
             {
-                if (fDebug10) LogPrintf("connection from %s dropped (banned)\n", addr.ToString());
+                if (fDebug10) LogPrintf("connection from %s dropped (banned)", addr.ToString());
                 closesocket(hSocket);
             }
             else
             {
-                if (fDebug10) LogPrintf("accepted connection %s\n", addr.ToString());
+                if (fDebug10) LogPrintf("accepted connection %s", addr.ToString());
                 CNode* pnode = new CNode(hSocket, addr, "", true);
                 pnode->AddRef();
                 {
@@ -1151,7 +1151,7 @@ void ThreadSocketHandler2(void* parg)
                 {
                     if (pnode->GetTotalRecvSize() > ReceiveFloodSize()) {
                         if (!pnode->fDisconnect)
-                            LogPrintf("socket recv flood control disconnect (%u bytes)\n", pnode->GetTotalRecvSize());
+                            LogPrintf("socket recv flood control disconnect (%u bytes)", pnode->GetTotalRecvSize());
                         pnode->CloseSocketDisconnect();
                     }
                     else {
@@ -1170,7 +1170,7 @@ void ThreadSocketHandler2(void* parg)
                             // socket closed gracefully
                             if (!pnode->fDisconnect)
                             {
-                              if (fDebug10)   LogPrintf("socket closed\n");
+                              if (fDebug10)   LogPrintf("socket closed");
                             }
                             pnode->CloseSocketDisconnect();
                         }
@@ -1182,7 +1182,7 @@ void ThreadSocketHandler2(void* parg)
                             {
                                 if (!pnode->fDisconnect)
                                 {
-                                   if (fDebug10)  LogPrintf("socket recv error %d\n", nErr);
+                                   if (fDebug10)  LogPrintf("socket recv error %d", nErr);
                                 }
                                 pnode->CloseSocketDisconnect();
                             }
@@ -1212,7 +1212,7 @@ void ThreadSocketHandler2(void* parg)
             {
                 if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
                 {
-                    if (fDebug10) LogPrintf("Socket no message in first 24 seconds, IP %s, %d %d\n", NodeAddress(pnode), pnode->nLastRecv != 0, pnode->nLastSend != 0);
+                    if (fDebug10) LogPrintf("Socket no message in first 24 seconds, IP %s, %d %d", NodeAddress(pnode), pnode->nLastRecv != 0, pnode->nLastSend != 0);
                     pnode->Misbehaving(1);
                     pnode->fDisconnect = true;
                 }
@@ -1221,7 +1221,7 @@ void ThreadSocketHandler2(void* parg)
             if ((GetAdjustedTime() - pnode->nTimeConnected) > (60*60*2) && (vNodes.size() > (MAX_OUTBOUND_CONNECTIONS*.75)))
             {
                     if (fDebug10)
-                        LogPrintf("Node %s connected longer than 2 hours with connection count of %zd, disconnecting. \n", NodeAddress(pnode), vNodes.size());
+                        LogPrintf("Node %s connected longer than 2 hours with connection count of %zd, disconnecting. ", NodeAddress(pnode), vNodes.size());
                     pnode->fDisconnect = true;
             }
 
@@ -1229,22 +1229,22 @@ void ThreadSocketHandler2(void* parg)
             {
                 if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
                 {
-                    if (fDebug10) LogPrintf("socket no message in first 24 seconds, %d %d\n", pnode->nLastRecv != 0, pnode->nLastSend != 0);
+                    if (fDebug10) LogPrintf("socket no message in first 24 seconds, %d %d", pnode->nLastRecv != 0, pnode->nLastSend != 0);
                     pnode->fDisconnect = true;
                 }
                 else if (nTime - pnode->nLastSend > TIMEOUT_INTERVAL)
                 {
-                    LogPrintf("socket sending timeout: %" PRId64 "s\n", nTime - pnode->nLastSend);
+                    LogPrintf("socket sending timeout: %" PRId64 "s", nTime - pnode->nLastSend);
                     pnode->fDisconnect = true;
                 }
                 else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
                 {
-                    LogPrintf("socket receive timeout: %" PRId64 "s\n", nTime - pnode->nLastRecv);
+                    LogPrintf("socket receive timeout: %" PRId64 "s", nTime - pnode->nLastRecv);
                     pnode->fDisconnect = true;
                 }
                 else if (pnode->nPingNonceSent && pnode->nPingUsecStart + TIMEOUT_INTERVAL * 1000000 < GetTimeMicros())
                 {
-                    LogPrintf("ping timeout: %fs\n", 0.000001 * (GetTimeMicros() - pnode->nPingUsecStart));
+                    LogPrintf("ping timeout: %fs", 0.000001 * (GetTimeMicros() - pnode->nPingUsecStart));
                     pnode->fDisconnect = true;
                 }
             }
@@ -1274,19 +1274,19 @@ void ThreadMapPort(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        LogPrintf("ThreadMapPort exited (interrupt)\n");
+        LogPrintf("ThreadMapPort exited (interrupt)");
         return;
     }
     catch (...)
     {
         PrintException(NULL, "ThreadMapPort()");
     }
-    LogPrintf("ThreadMapPort exited\n");
+    LogPrintf("ThreadMapPort exited");
 }
 
 void ThreadMapPort2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadMapPort started\n");
+    if (fDebug10) LogPrintf("ThreadMapPort started");
 
     std::string port = strprintf("%u", GetListenPort());
     const char * multicastif = 0;
@@ -1318,16 +1318,16 @@ void ThreadMapPort2(void* parg)
             char externalIPAddress[40];
             r = UPNP_GetExternalIPAddress(urls.controlURL, data.first.servicetype, externalIPAddress);
             if(r != UPNPCOMMAND_SUCCESS)
-                LogPrintf("UPnP: GetExternalIPAddress() returned %d\n", r);
+                LogPrintf("UPnP: GetExternalIPAddress() returned %d", r);
             else
             {
                 if(externalIPAddress[0])
                 {
-                    LogPrintf("UPnP: ExternalIPAddress = %s\n", externalIPAddress);
+                    LogPrintf("UPnP: ExternalIPAddress = %s", externalIPAddress);
                     AddLocal(CNetAddr(externalIPAddress), LOCAL_UPNP);
                 }
                 else
-                    LogPrintf("UPnP: GetExternalIPAddress not successful.\n");
+                    LogPrintf("UPnP: GetExternalIPAddress not successful.");
             }
         }
 
@@ -1343,17 +1343,17 @@ void ThreadMapPort2(void* parg)
 #endif
 
         if(r!=UPNPCOMMAND_SUCCESS)
-            LogPrintf("AddPortMapping(%s, %s, %s) unsuccessful with code %d (%s)\n",
+            LogPrintf("AddPortMapping(%s, %s, %s) unsuccessful with code %d (%s)",
                 port, port, lanaddr, r, strupnperror(r));
         else
-            LogPrintf("UPnP Port Mapping successful.\n");
+            LogPrintf("UPnP Port Mapping successful.");
         int i = 1;
         while (true)
         {
             if (fShutdown || !fUseUPnP)
             {
                 r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype, port.c_str(), "TCP", 0);
-                LogPrintf("UPNP_DeletePortMapping() returned : %d\n", r);
+                LogPrintf("UPNP_DeletePortMapping() returned : %d", r);
                 freeUPNPDevlist(devlist); devlist = 0;
                 FreeUPNPUrls(&urls);
                 return;
@@ -1371,16 +1371,16 @@ void ThreadMapPort2(void* parg)
 #endif
 
                 if(r!=UPNPCOMMAND_SUCCESS)
-                    LogPrintf("AddPortMapping(%s, %s, %s) was not successful - code %d (%s)\n",
+                    LogPrintf("AddPortMapping(%s, %s, %s) was not successful - code %d (%s)",
                         port, port, lanaddr, r, strupnperror(r));
                 else
-                    LogPrintf("UPnP Port Mapping successful.\n");;
+                    LogPrintf("UPnP Port Mapping successful.");;
             }
             MilliSleep(2000);
             i++;
         }
     } else {
-        if (fDebug10) LogPrintf("No valid UPnP IGDs found\n");
+        if (fDebug10) LogPrintf("No valid UPnP IGDs found");
         freeUPNPDevlist(devlist); devlist = 0;
         if (r != 0)
             FreeUPNPUrls(&urls);
@@ -1398,7 +1398,7 @@ void MapPort()
     if (fUseUPnP && !netThreads->threadExists("ThreadMapPort"))
     {
         if (!netThreads->createThread(ThreadMapPort,NULL,"ThreadMapPort"))
-            LogPrintf("Error: createThread(ThreadMapPort) failed\n");
+            LogPrintf("Error: createThread(ThreadMapPort) failed");
     }
 }
 #else
@@ -1437,24 +1437,24 @@ void ThreadDNSAddressSeed(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        if (fDebug10) LogPrintf("ThreadDNSAddressSeed exited (interrupt)\n");
+        if (fDebug10) LogPrintf("ThreadDNSAddressSeed exited (interrupt)");
         return;
     }
     catch (...)
     {
         throw; // support pthread_cancel()
     }
-    if (fDebug10) LogPrintf("ThreadDNSAddressSeed exited\n");
+    if (fDebug10) LogPrintf("ThreadDNSAddressSeed exited");
 }
 
 void ThreadDNSAddressSeed2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadDNSAddressSeed started\n");
+    if (fDebug10) LogPrintf("ThreadDNSAddressSeed started");
     int found = 0;
 
     if (!fTestNet)
     {
-        if (fDebug10) LogPrintf("Loading addresses from DNS seeds (could take a while)\n");
+        if (fDebug10) LogPrintf("Loading addresses from DNS seeds (could take a while)");
 
         for (unsigned int seed_idx = 0; seed_idx < ARRAYLEN(strDNSSeed); seed_idx++) {
             if (HaveNameProxy()) {
@@ -1478,7 +1478,7 @@ void ThreadDNSAddressSeed2(void* parg)
         }
     }
 
-    if (fDebug10) LogPrintf("%d addresses found from DNS seeds\n", found);
+    if (fDebug10) LogPrintf("%d addresses found from DNS seeds", found);
 }
 
 
@@ -1506,7 +1506,7 @@ void DumpAddresses()
     CAddrDB adb;
     adb.Write(addrman);
 
-    if (fDebug10) LogPrintf("Flushed %d addresses to peers.dat  %" PRId64 "ms\n",           addrman.size(), GetTimeMillis() - nStart);
+    if (fDebug10) LogPrintf("Flushed %d addresses to peers.dat  %" PRId64 "ms",           addrman.size(), GetTimeMillis() - nStart);
 
 }
 
@@ -1534,14 +1534,14 @@ void ThreadDumpAddress(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        LogPrintf("ThreadDumpAddress exited (interrupt)\n");
+        LogPrintf("ThreadDumpAddress exited (interrupt)");
         return;
     }
     catch (...)
     {
         PrintException(NULL, "ThreadDumpAddress");
     }
-    LogPrintf("ThreadDumpAddress exited\n");
+    LogPrintf("ThreadDumpAddress exited");
 }
 
 void ThreadOpenConnections(void* parg)
@@ -1559,14 +1559,14 @@ void ThreadOpenConnections(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        LogPrintf("ThreadOpenConnections exited (interrupt)\n");
+        LogPrintf("ThreadOpenConnections exited (interrupt)");
         return;
     }
     catch (...)
     {
         PrintException(NULL, "ThreadOpenConnections()");
     }
-    LogPrintf("ThreadOpenConnections exited\n");
+    LogPrintf("ThreadOpenConnections exited");
 }
 
 void static ProcessOneShot()
@@ -1590,7 +1590,7 @@ void static ProcessOneShot()
 void static ThreadStakeMiner(void* parg)
 {
 
-    if (fDebug10) LogPrintf("ThreadStakeMiner started\n");
+    if (fDebug10) LogPrintf("ThreadStakeMiner started");
     CWallet* pwallet = (CWallet*)parg;
     try
     {
@@ -1602,14 +1602,14 @@ void static ThreadStakeMiner(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        LogPrintf("ThreadStakeMiner exited (interrupt)\n");
+        LogPrintf("ThreadStakeMiner exited (interrupt)");
         return;
     }
     catch (...)
     {
         PrintException(NULL, "ThreadStakeMiner()");
     }
-    LogPrintf("ThreadStakeMiner exited\n");
+    LogPrintf("ThreadStakeMiner exited");
 }
 
 
@@ -1636,7 +1636,7 @@ uint64_t CNode::GetTotalBytesSent()
 
 void ThreadOpenConnections2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadOpenConnections started\n");
+    if (fDebug10) LogPrintf("ThreadOpenConnections started");
 
     // Connect to specific addresses
     if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0)
@@ -1766,19 +1766,19 @@ void ThreadOpenAddedConnections(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        LogPrintf("ThreadOpenAddedConnections exited (interrupt)\n");
+        LogPrintf("ThreadOpenAddedConnections exited (interrupt)");
         return;
     }
     catch (...)
     {
         PrintException(NULL, "ThreadOpenAddedConnections()");
     }
-    LogPrintf("ThreadOpenAddedConnections exited\n");
+    LogPrintf("ThreadOpenAddedConnections exited");
 }
 
 void ThreadOpenAddedConnections2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadOpenAddedConnections started\n");
+    if (fDebug10) LogPrintf("ThreadOpenAddedConnections started");
 
     if (mapArgs.count("-addnode") == 0)
         return;
@@ -1888,19 +1888,19 @@ void ThreadMessageHandler(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        LogPrintf("ThreadMessageHandler exited (interrupt)\n");
+        LogPrintf("ThreadMessageHandler exited (interrupt)");
         return;
     }
     catch (...)
     {
         PrintException(NULL, "ThreadMessageHandler()");
     }
-    LogPrintf("ThreadMessageHandler exited\n");
+    LogPrintf("ThreadMessageHandler exited");
 }
 
 void ThreadMessageHandler2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadMessageHandler started\n");
+    if (fDebug10) LogPrintf("ThreadMessageHandler started");
     while (!fShutdown)
     {
         vector<CNode*> vNodesCopy;
@@ -1974,7 +1974,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
     if (ret != NO_ERROR)
     {
         strError = strprintf("Error: TCP/IP socket library refused to start (WSAStartup returned error %d)", ret);
-        LogPrintf("%s\n", strError);
+        LogPrintf("%s", strError);
         return false;
     }
 #endif
@@ -1985,7 +1985,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
     if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
     {
         strError = strprintf("Error: bind address family for %s not supported", addrBind.ToString());
-        LogPrintf("%s\n", strError);
+        LogPrintf("%s", strError);
         return false;
     }
 
@@ -1993,7 +1993,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
     if (hListenSocket == INVALID_SOCKET)
     {
         strError = strprintf("Error: Couldn't open socket for incoming connections (socket returned error %d)", WSAGetLastError());
-        LogPrintf("%s\n", strError);
+        LogPrintf("%s", strError);
         return false;
     }
 
@@ -2024,7 +2024,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
 #endif
     {
         strError = strprintf("Error: Couldn't set properties on socket for incoming connections (error %d)", WSAGetLastError());
-        LogPrintf("%s\n", strError);
+        LogPrintf("%s", strError);
         return false;
     }
 
@@ -2053,16 +2053,16 @@ bool BindListenPort(const CService &addrBind, string& strError)
             strError = strprintf(_("Unable to bind to %s on this computer. Gridcoin is probably already running."), addrBind.ToString());
         else
             strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %d, %s)"), addrBind.ToString(), nErr, strerror(nErr));
-        LogPrintf("%s\n", strError);
+        LogPrintf("%s", strError);
         return false;
     }
-    if (fDebug10) LogPrintf("Bound to %s\n", addrBind.ToString().c_str());
+    if (fDebug10) LogPrintf("Bound to %s", addrBind.ToString().c_str());
 
     // Listen for incoming connections
     if (listen(hListenSocket, SOMAXCONN) == SOCKET_ERROR)
     {
         strError = strprintf("Error: Listening for incoming connections died with %d", WSAGetLastError());
-        LogPrintf("%s\n", strError);
+        LogPrintf("%s", strError);
         return false;
     }
 
@@ -2109,14 +2109,14 @@ void static Discover()
                 struct sockaddr_in* s4 = (struct sockaddr_in*)(ifa->ifa_addr);
                 CNetAddr addr(s4->sin_addr);
                 if (AddLocal(addr, LOCAL_IF))
-                    LogPrintf("IPv4 %s: %s\n", ifa->ifa_name, addr.ToString().c_str());
+                    LogPrintf("IPv4 %s: %s", ifa->ifa_name, addr.ToString().c_str());
             }
             else if (ifa->ifa_addr->sa_family == AF_INET6)
             {
                 struct sockaddr_in6* s6 = (struct sockaddr_in6*)(ifa->ifa_addr);
                 CNetAddr addr(s6->sin6_addr);
                 if (AddLocal(addr, LOCAL_IF))
-                    LogPrintf("IPv6 %s: %s\n", ifa->ifa_name, addr.ToString().c_str());
+                    LogPrintf("IPv6 %s: %s", ifa->ifa_name, addr.ToString().c_str());
             }
         }
         freeifaddrs(myaddrs);
@@ -2141,7 +2141,7 @@ void StartNode(void* parg)
         semOutbound = new CSemaphore(nMaxOutbound);
     }
 
-    LogPrintf("\nUsing %i OutboundConnections with a MaxConnections of %" PRId64 "\n", MAX_OUTBOUND_CONNECTIONS, GetArg("-maxconnections", 125));
+    LogPrintf("Using %i OutboundConnections with a MaxConnections of %" PRId64 "", MAX_OUTBOUND_CONNECTIONS, GetArg("-maxconnections", 125));
 
     if (pnodeLocalHost == NULL)
         pnodeLocalHost = new CNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices));
@@ -2153,10 +2153,10 @@ void StartNode(void* parg)
     //
 
     if (!GetBoolArg("-dnsseed", true))
-        LogPrintf("DNS seeding disabled\n");
+        LogPrintf("DNS seeding disabled");
     else
         if (!netThreads->createThread(ThreadDNSAddressSeed,NULL,"ThreadDNSAddressSeed"))
-            LogPrintf("Error: createThread(ThreadDNSAddressSeed) failed\n");
+            LogPrintf("Error: createThread(ThreadDNSAddressSeed) failed");
 
     // Map ports with UPnP
     if (fUseUPnP)
@@ -2164,35 +2164,35 @@ void StartNode(void* parg)
 
     // Send and receive from sockets, accept connections
     if (!netThreads->createThread(ThreadSocketHandler,NULL,"ThreadSocketHandler"))
-        LogPrintf("Error: createThread(ThreadSocketHandler) failed\n");
+        LogPrintf("Error: createThread(ThreadSocketHandler) failed");
 
     // Initiate outbound connections from -addnode
     if (!netThreads->createThread(ThreadOpenAddedConnections,NULL,"ThreadOpenAddedConnections"))
-        LogPrintf("Error: createThread(ThreadOpenAddedConnections) failed\n");
+        LogPrintf("Error: createThread(ThreadOpenAddedConnections) failed");
 
     // Initiate outbound connections
     if (!netThreads->createThread(ThreadOpenConnections,NULL,"ThreadOpenConnections"))
-        LogPrintf("Error: createThread(ThreadOpenConnections) failed\n");
+        LogPrintf("Error: createThread(ThreadOpenConnections) failed");
 
     // Process messages
     if (!netThreads->createThread(ThreadMessageHandler,NULL,"ThreadMessageHandler"))
-        LogPrintf("Error: createThread(ThreadMessageHandler) failed\n");
+        LogPrintf("Error: createThread(ThreadMessageHandler) failed");
 
     // Dump network addresses
     if (!netThreads->createThread(ThreadDumpAddress,NULL,"ThreadDumpAddress"))
-        LogPrintf("Error: createThread(ThreadDumpAddress) failed\n");
+        LogPrintf("Error: createThread(ThreadDumpAddress) failed");
 
     // Mine proof-of-stake blocks in the background
     if (!GetBoolArg("-staking", true))
-        LogPrintf("Staking disabled\n");
+        LogPrintf("Staking disabled");
     else
         if (!netThreads->createThread(ThreadStakeMiner,pwalletMain,"ThreadStakeMiner"))
-            LogPrintf("Error: createThread(ThreadStakeMiner) failed\n");
+            LogPrintf("Error: createThread(ThreadStakeMiner) failed");
 }
 
 bool StopNode()
 {
-    LogPrintf("StopNode()\n");
+    LogPrintf("StopNode()");
     fShutdown = true;
     if (semOutbound)
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
@@ -2220,7 +2220,7 @@ public:
         for (auto &hListenSocket : vhListenSocket)
             if (hListenSocket != INVALID_SOCKET)
                 if (closesocket(hListenSocket) == SOCKET_ERROR)
-                    LogPrintf("closesocket(hListenSocket) died with error %d\n", WSAGetLastError());
+                    LogPrintf("closesocket(hListenSocket) died with error %d", WSAGetLastError());
 
 #ifdef WIN32
         // Shutdown Windows Sockets

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2056,7 +2056,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
         LogPrintf("%s", strError);
         return false;
     }
-    if (fDebug10) LogPrintf("Bound to %s", addrBind.ToString().c_str());
+    if (fDebug10) LogPrintf("Bound to %s", addrBind.ToString());
 
     // Listen for incoming connections
     if (listen(hListenSocket, SOMAXCONN) == SOCKET_ERROR)
@@ -2109,14 +2109,14 @@ void static Discover()
                 struct sockaddr_in* s4 = (struct sockaddr_in*)(ifa->ifa_addr);
                 CNetAddr addr(s4->sin_addr);
                 if (AddLocal(addr, LOCAL_IF))
-                    LogPrintf("IPv4 %s: %s", ifa->ifa_name, addr.ToString().c_str());
+                    LogPrintf("IPv4 %s: %s", ifa->ifa_name, addr.ToString());
             }
             else if (ifa->ifa_addr->sa_family == AF_INET6)
             {
                 struct sockaddr_in6* s6 = (struct sockaddr_in6*)(ifa->ifa_addr);
                 CNetAddr addr(s6->sin6_addr);
                 if (AddLocal(addr, LOCAL_IF))
-                    LogPrintf("IPv6 %s: %s", ifa->ifa_name, addr.ToString().c_str());
+                    LogPrintf("IPv6 %s: %s", ifa->ifa_name, addr.ToString());
             }
         }
         freeifaddrs(myaddrs);

--- a/src/net.h
+++ b/src/net.h
@@ -424,7 +424,7 @@ public:
         // the key is the earliest time the request can be sent
         int64_t& nRequestTime = mapAlreadyAskedFor[inv];
         if (fDebugNet)
-            LogPrintf("askfor %s   %" PRId64 " (%s)\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
+            LogPrintf("askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
 
         // Make sure not to reuse time indexes to keep things in the same order
         int64_t nNow = (GetAdjustedTime() - 1) * 1000000;
@@ -452,14 +452,14 @@ public:
         LEAVE_CRITICAL_SECTION(cs_vSend);
 
         if (fDebug10)
-            LogPrintf("(aborted)\n");
+            LogPrintf("(aborted)");
     }
 
     void EndMessage()
     {
         if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
         {
-            LogPrintf("dropmessages DROPPING SEND MESSAGE\n");
+            LogPrintf("dropmessages DROPPING SEND MESSAGE");
             AbortMessage();
             return;
         }
@@ -480,7 +480,7 @@ public:
 
         if (fDebug10)
 		{
-            LogPrintf("(%d bytes)\n", nSize);
+            LogPrintf("(%d bytes)", nSize);
         }
 
         std::deque<CSerializeData>::iterator it = vSendMsg.insert(vSendMsg.end(), CSerializeData());

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -161,7 +161,7 @@ bool LookupNumeric(const char *pszName, CService& addr, int portDefault)
 
 bool static Socks4(const CService &addrDest, SOCKET& hSocket)
 {
-    LogPrintf("SOCKS4 connecting %s\n", addrDest.ToString());
+    LogPrintf("SOCKS4 connecting %s", addrDest.ToString());
     if (!addrDest.IsIPv4())
     {
         closesocket(hSocket);
@@ -196,16 +196,16 @@ bool static Socks4(const CService &addrDest, SOCKET& hSocket)
     {
         closesocket(hSocket);
         if (pchRet[1] != 0x5b)
-            LogPrintf("ERROR: Proxy returned error %d\n", pchRet[1]);
+            LogPrintf("ERROR: Proxy returned error %d", pchRet[1]);
         return false;
     }
-    LogPrintf("SOCKS4 connected %s\n", addrDest.ToString());
+    LogPrintf("SOCKS4 connected %s", addrDest.ToString());
     return true;
 }
 
 bool static Socks5(string strDest, int port, SOCKET& hSocket)
 {
-    LogPrintf("SOCKS5 connecting %s\n", strDest);
+    LogPrintf("SOCKS5 connecting %s", strDest);
     if (strDest.size() > 255)
     {
         closesocket(hSocket);
@@ -304,7 +304,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         closesocket(hSocket);
         return error("Error reading from proxy");
     }
-    LogPrintf("SOCKS5 connected %s\n", strDest);
+    LogPrintf("SOCKS5 connected %s", strDest);
     return true;
 }
 
@@ -315,7 +315,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
     if (!addrConnect.GetSockAddr((struct sockaddr*)&sockaddr, &len)) {
-        LogPrintf("Cannot connect to %s: unsupported network\n", addrConnect.ToString());
+        LogPrintf("Cannot connect to %s: unsupported network", addrConnect.ToString());
         return false;
     }
 
@@ -355,13 +355,12 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             int nRet = select(hSocket + 1, NULL, &fdset, NULL, &timeout);
             if (nRet == 0)
             {
-                //LogPrintf("connection timeout\n");
                 closesocket(hSocket);
                 return false;
             }
             if (nRet == SOCKET_ERROR)
             {
-                LogPrintf("select() for connection failed: %i\n",WSAGetLastError());
+                LogPrintf("select() for connection failed: %i",WSAGetLastError());
                 closesocket(hSocket);
                 return false;
             }
@@ -372,13 +371,13 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             if (getsockopt(hSocket, SOL_SOCKET, SO_ERROR, &nRet, &nRetSize) == SOCKET_ERROR)
 #endif
             {
-                LogPrintf("getsockopt() for connection failed: %i\n",WSAGetLastError());
+                LogPrintf("getsockopt() for connection failed: %i",WSAGetLastError());
                 closesocket(hSocket);
                 return false;
             }
             if (nRet != 0)
             {
-                if (fDebug10) LogPrintf("socket connect() failed after select(): %s, Destination Addr %s \n",strerror(nRet),addrConnect.ToString());
+                if (fDebug10) LogPrintf("socket connect() failed after select(): %s, Destination Addr %s ",strerror(nRet),addrConnect.ToString());
                 closesocket(hSocket);
                 return false;
             }
@@ -389,7 +388,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
         else
 #endif
         {
-            LogPrintf("connect() failed: %i\n",WSAGetLastError());
+            LogPrintf("connect() failed: %i",WSAGetLastError());
             closesocket(hSocket);
             return false;
         }
@@ -906,7 +905,7 @@ uint64_t CNetAddr::GetHash() const
 
 void CNetAddr::print() const
 {
-    LogPrintf("CNetAddr(%s)\n", ToString());
+    LogPrintf("CNetAddr(%s)", ToString());
 }
 
 // private extensions to enum Network, only returned by GetExtNetwork,
@@ -1145,7 +1144,7 @@ std::string CService::ToString() const
 
 void CService::print() const
 {
-    LogPrintf("CService(%s)\n", ToString());
+    LogPrintf("CService(%s)", ToString());
 }
 
 void CService::SetPort(unsigned short portIn)

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -11,7 +11,7 @@
 
 static int noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style)
 {
-    LogPrintf("%s: %s\n", caption, message);
+    LogPrintf("%s: %s", caption, message);
     fprintf(stderr, "%s: %s\n", caption.c_str(), message.c_str());
     return 4;
 }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -69,7 +69,7 @@ bool CMessageHeader::IsValid() const
     // Message size
     if (nMessageSize > MAX_SIZE)
     {
-        LogPrintf("CMessageHeader::IsValid() : (%s, %u bytes) nMessageSize > MAX_SIZE\n", GetCommand(), nMessageSize);
+        LogPrintf("CMessageHeader::IsValid() : (%s, %u bytes) nMessageSize > MAX_SIZE", GetCommand(), nMessageSize);
         return false;
     }
 
@@ -148,6 +148,6 @@ std::string CInv::ToString() const
 
 void CInv::print() const
 {
-    LogPrintf("CInv(%s)\n", ToString());
+    LogPrintf("CInv(%s)", ToString());
 }
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -91,7 +91,7 @@ public:
         case CT_NEW:
             if(inModel)
             {
-                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_NEW, but entry is already in model\n");
+                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_NEW, but entry is already in model");
                 break;
             }
             parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex);
@@ -101,7 +101,7 @@ public:
         case CT_UPDATED:
             if(!inModel)
             {
-                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_UPDATED, but entry is not in model\n");
+                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_UPDATED, but entry is not in model");
                 break;
             }
             lower->type = newEntryType;
@@ -111,7 +111,7 @@ public:
         case CT_DELETED:
             if(!inModel)
             {
-                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_DELETED, but entry is not in model\n");
+                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_DELETED, but entry is not in model");
                 break;
             }
             parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex-1);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -77,7 +77,7 @@ static void ThreadSafeMessageBox(const std::string& message, const std::string& 
     }
     else
     {
-        LogPrintf("%s: %s\n", caption, message);
+        LogPrintf("%s: %s", caption, message);
         fprintf(stderr, "%s: %s\n", caption.c_str(), message.c_str());
     }
 }
@@ -156,7 +156,7 @@ void timerfire()
 static void handleRunawayException(std::exception *e)
 {
     PrintExceptionContinue(e, "Runaway exception");
-    QMessageBox::critical(0, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. Gridcoin can no longer continue safely and will quit.") + QString("\n\n") + QString::fromStdString(strMiscWarning));
+    QMessageBox::critical(0, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. Gridcoin can no longer continue safely and will quit.") + QString("\n") + QString::fromStdString(strMiscWarning));
     exit(1);
 }
 
@@ -280,14 +280,14 @@ int main(int argc, char *argv[])
         guiref = &window;
 
 		QTimer *timer = new QTimer(guiref);
-		LogPrintf("\nStarting Gridcoin\n");
+		LogPrintf("Starting Gridcoin");
 
 		QObject::connect(timer, SIGNAL(timeout()), guiref, SLOT(timerfire()));
 
 	    //Start globalcom
         if (!threads->createThread(ThreadAppInit2,threads,"AppInit2 Thread"))
 		{
-				LogPrintf("Error; NewThread(ThreadAppInit2) failed\n");
+				LogPrintf("Error; NewThread(ThreadAppInit2) failed");
 		        return 1;
 		}
 		else
@@ -334,7 +334,7 @@ int main(int argc, char *argv[])
                 guiref = 0;
             }
             // Shutdown the core and its threads, but don't exit Bitcoin-Qt here
-			LogPrintf("\nbitcoin.cpp:main calling Shutdown...\n");
+			LogPrintf("Main calling Shutdown...");
             Shutdown(NULL);
         }
 
@@ -356,7 +356,7 @@ int main(int argc, char *argv[])
     // use exit codes to trigger restart of the wallet
     if(currentExitCode == EXIT_CODE_REBOOT)
     {
-        LogPrintf("Restarting wallet...\n");
+        LogPrintf("Restarting wallet...");
         QStringList args = QApplication::arguments();
         args.removeFirst();
         QProcess::startDetached(QApplication::applicationFilePath(), args);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -382,7 +382,7 @@ void qtSyncWithDPORNodes(std::string data)
         QString qsData = ToQstring(data);
         if (fDebug3) LogPrintf("FullSyncWDporNodes");
         result = globalcom->dynamicCall("SyncCPIDsWithDPORNodes(Qstring)",qsData).toInt();
-        LogPrintf("Done syncing. %d\n", result);
+        LogPrintf("Done syncing. %d", result);
     #endif
 }
 
@@ -486,7 +486,7 @@ int64_t IsNeural()
     }
     catch(...)
     {
-        LogPrintf("Exception\n");
+        LogPrintf("Exception");
         return 0;
     }
 }
@@ -1242,7 +1242,7 @@ void BitcoinGUI::NewUserWizard()
         std::string sBoincNarr = "";
         if (sout == "-1")
         {
-            LogPrintf("Boinc not installed in default location! \n");
+            LogPrintf("Boinc not installed in default location! ");
             //BoincInstalled=false;
             std::string nicePath = GetBoincDataDir();
             sBoincNarr = "Boinc is not installed in default location " + nicePath + "!  Please set boincdatadir=c:\\programdata\\boinc\\    to the correct path where Boincs programdata directory resides.";
@@ -1257,7 +1257,7 @@ void BitcoinGUI::NewUserWizard()
         {
             std::string new_email = tostdstring(boincemail);
             boost::to_lower(new_email);
-            LogPrintf("User entered %s \n",new_email);
+            LogPrintf("User entered %s ",new_email);
             //Create Config File
             CreateNewConfigFile(new_email);
             QString strMessage = tr("Created new Configuration File Successfully. ");
@@ -1320,7 +1320,7 @@ void BitcoinGUI::incomingTransaction(const QModelIndex & parent, int start, int 
                               tr("Date: %1\n"
                                  "Amount: %2\n"
                                  "Type: %3\n"
-                                 "Address: %4\n")
+                                 "Address: %4")
                               .arg(date)
                               .arg(BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), amount, true))
                               .arg(type)
@@ -1866,7 +1866,7 @@ void BitcoinGUI::updateStakingIcon()
 
     if (staking)
     {
-        if (fDebug10) LogPrintf("StakeIcon Vitals BH %f, NetWeight %f, Weight %f \n", (double)GetTargetSpacing(nBestHeight),(double)nNetworkWeight,(double)nWeight);
+        if (fDebug10) LogPrintf("StakeIcon Vitals BH %f, NetWeight %f, Weight %f ", (double)GetTargetSpacing(nBestHeight),(double)nNetworkWeight,(double)nWeight);
         QString text = GetEstimatedTime(nEstimateTime);
         labelStakingIcon->setPixmap(QIcon(":/icons/staking_on").pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
         labelStakingIcon->setToolTip(tr("Staking.<br>Your weight is %1<br>Network weight is %2<br><b>Estimated</b> time to earn reward is %3.")

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -378,10 +378,9 @@ void qtSyncWithDPORNodes(std::string data)
 
     #if defined(WIN32) && defined(QT_GUI)
         if (!bGlobalcomInitialized) return;
-        int result = 0;
         QString qsData = ToQstring(data);
         if (fDebug3) LogPrintf("FullSyncWDporNodes");
-        result = globalcom->dynamicCall("SyncCPIDsWithDPORNodes(Qstring)",qsData).toInt();
+        int result = globalcom->dynamicCall("SyncCPIDsWithDPORNodes(Qstring)",qsData).toInt();
         LogPrintf("Done syncing. %d", result);
     #endif
 }
@@ -447,11 +446,10 @@ void qtSetSessionInfo(std::string defaultgrcaddress, std::string cpid, double ma
     if (!bGlobalcomInitialized) return;
 
     #if defined(WIN32) && defined(QT_GUI)
-        int result = 0;
         std::string session = defaultgrcaddress + "<COL>" + cpid + "<COL>" + RoundToString(magnitude,1);
         QString qsSession = ToQstring(session);
-        result = globalcom->dynamicCall("SetSessionInfo(Qstring)",qsSession).toInt();
-        LogPrintf("rs%f",(double)result);
+        int result = globalcom->dynamicCall("SetSessionInfo(Qstring)",qsSession).toInt();
+        LogPrintf("Set session info result %d", result);
     #endif
 }
 
@@ -1866,12 +1864,10 @@ void BitcoinGUI::updateStakingIcon()
 
     if (staking)
     {
-        if (fDebug10) LogPrintf("StakeIcon Vitals BH %f, NetWeight %f, Weight %f ", (double)GetTargetSpacing(nBestHeight),(double)nNetworkWeight,(double)nWeight);
         QString text = GetEstimatedTime(nEstimateTime);
         labelStakingIcon->setPixmap(QIcon(":/icons/staking_on").pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
         labelStakingIcon->setToolTip(tr("Staking.<br>Your weight is %1<br>Network weight is %2<br><b>Estimated</b> time to earn reward is %3.")
                                      .arg(nWeight).arg(nNetworkWeight).arg(text));
-
     }
     else
     {

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -201,14 +201,14 @@ static void NotifyBlocksChanged(ClientModel *clientmodel)
 
 static void NotifyNumConnectionsChanged(ClientModel *clientmodel, int newNumConnections)
 {
-    // Too noisy: LogPrintf("NotifyNumConnectionsChanged %i\n", newNumConnections);
+    // Too noisy: LogPrintf("NotifyNumConnectionsChanged %i", newNumConnections);
     QMetaObject::invokeMethod(clientmodel, "updateNumConnections", Qt::QueuedConnection,
                               Q_ARG(int, newNumConnections));
 }
 
 static void NotifyAlertChanged(ClientModel *clientmodel, const uint256 &hash, ChangeType status)
 {
-    LogPrintf("NotifyAlertChanged %s status=%i\n", hash.GetHex(), status);
+    LogPrintf("NotifyAlertChanged %s status=%i", hash.GetHex(), status);
     QMetaObject::invokeMethod(clientmodel, "updateAlert", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(hash.GetHex())),
                               Q_ARG(int, status));

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -57,7 +57,7 @@ static bool ipcScanCmd(int argc, char *argv[], bool fRelay)
                 // the first start of the first instance
                 if (ex.get_error_code() != boost::interprocess::not_found_error || !fRelay)
                 {
-                    LogPrintf("main() - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+                    LogPrintf("main() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
                     break;
                 }
             }
@@ -86,12 +86,12 @@ static void ipcThread(void* pArg)
     } catch (...) {
         PrintExceptionContinue(NULL, "ipcThread()");
     }
-    LogPrintf("ipcThread exited\n");
+    LogPrintf("ipcThread exited");
 }
 
 static void ipcThread2(void* pArg)
 {
-    if (fDebug) LogPrintf("ipcThread started\n");
+    if (fDebug) LogPrintf("ipcThread started");
 
     message_queue* mq = (message_queue*)pArg;
     char buffer[MAX_URI_LENGTH + 1] = "";
@@ -146,7 +146,7 @@ void ipcInit(int argc, char *argv[])
         mq = new message_queue(open_or_create, BITCOINURI_QUEUE_NAME, 2, MAX_URI_LENGTH);
     }
     catch (interprocess_exception &ex) {
-        LogPrintf("ipcInit() - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+        LogPrintf("ipcInit() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
         return;
     }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -185,7 +185,7 @@ void RPCExecutor::request(const QString &command)
     }
     catch (UniValue& objError)
     {
-		LogPrintf("gridcoinresearch:  Handling Error [Request %s]...\n",command.toStdString());
+		LogPrintf("gridcoinresearch:  Handling Error [Request %s]...",command.toStdString());
 
         try // Nice formatting for standard-format error
         {
@@ -200,7 +200,7 @@ void RPCExecutor::request(const QString &command)
     }
     catch (std::exception& e)
     {
-		LogPrintf("gridcoinresearch:  Handling Error[2]...\n");
+		LogPrintf("gridcoinresearch:  Handling Error[2]...");
 
         emit reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
     }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -73,7 +73,7 @@ public:
      */
     void refreshWallet()
     {
-        if (fDebug) LogPrintf("refreshWallet\n");
+        if (fDebug) LogPrintf("refreshWallet");
         cachedWallet.clear();
         {
             LOCK2(cs_main, wallet->cs_wallet);
@@ -92,7 +92,7 @@ public:
      */
     void updateWallet(const uint256 &hash, int status)
     {
-        if (fDebug) LogPrintf("updateWallet %s %i\n", hash.ToString(), status);
+        if (fDebug) LogPrintf("updateWallet %s %i", hash.ToString(), status);
         {
             LOCK2(cs_main, wallet->cs_wallet);
 
@@ -122,7 +122,7 @@ public:
                     status = CT_DELETED; /* In model, but want to hide, treat as deleted */
             }
 
-            if (fDebug) LogPrintf("   inWallet=%i inModel=%i Index=%i-%i showTransaction=%i derivedStatus=%i\n",                     inWallet, inModel, lowerIndex, upperIndex, showTransaction, status);
+            if (fDebug) LogPrintf("   inWallet=%i inModel=%i Index=%i-%i showTransaction=%i derivedStatus=%i",                     inWallet, inModel, lowerIndex, upperIndex, showTransaction, status);
 
 
             switch(status)
@@ -130,12 +130,12 @@ public:
             case CT_NEW:
                 if(inModel)
                 {
-                    if (fDebug) LogPrintf("Warning: updateWallet: Got CT_NEW, but transaction is already in model\n");
+                    if (fDebug) LogPrintf("Warning: updateWallet: Got CT_NEW, but transaction is already in model");
                     break;
                 }
                 if(!inWallet)
                 {
-                    if (fDebug) LogPrintf("Warning: updateWallet: Got CT_NEW, but transaction is not in wallet\n");
+                    if (fDebug) LogPrintf("Warning: updateWallet: Got CT_NEW, but transaction is not in wallet");
                     break;
                 }
                 if(showTransaction)
@@ -159,7 +159,7 @@ public:
             case CT_DELETED:
                 if(!inModel)
                 {
-                    LogPrintf("Warning: updateWallet: Got CT_DELETED, but transaction is not in model\n");
+                    LogPrintf("Warning: updateWallet: Got CT_DELETED, but transaction is not in model");
                     break;
                 }
                 // Removed -- remove entire transaction from table
@@ -534,7 +534,7 @@ QVariant TransactionTableModel::txStatusDecoration(const TransactionRecord *wtx)
 
 QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
 {
-    QString tooltip = formatTxStatus(rec) + QString("\n") + formatTxType(rec);
+    QString tooltip = formatTxStatus(rec) + QString("") + formatTxType(rec);
     if(rec->type==TransactionRecord::RecvFromOther || rec->type==TransactionRecord::SendToOther ||
        rec->type==TransactionRecord::SendToAddress || rec->type==TransactionRecord::RecvWithAddress)
     {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -354,13 +354,13 @@ bool WalletModel::changePassphrase(const SecureString &oldPass, const SecureStri
 // Handlers for core signals
 static void NotifyKeyStoreStatusChanged(WalletModel *walletmodel, CCryptoKeyStore *wallet)
 {
-    LogPrintf("NotifyKeyStoreStatusChanged\n");
+    LogPrintf("NotifyKeyStoreStatusChanged");
     QMetaObject::invokeMethod(walletmodel, "updateStatus", Qt::QueuedConnection);
 }
 
 static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet, const CTxDestination &address, const std::string &label, bool isMine, ChangeType status)
 {
-    LogPrintf("NotifyAddressBookChanged %s %s isMine=%i status=%i\n", CBitcoinAddress(address).ToString(), label, isMine, status);
+    LogPrintf("NotifyAddressBookChanged %s %s isMine=%i status=%i", CBitcoinAddress(address).ToString(), label, isMine, status);
     QMetaObject::invokeMethod(walletmodel, "updateAddressBook", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(CBitcoinAddress(address).ToString())),
                               Q_ARG(QString, QString::fromStdString(label)),
@@ -370,7 +370,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet, 
 
 static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)
 {
-    if (fDebug) LogPrintf("NotifyTransactionChanged %s status=%i\n", hash.GetHex(), status);
+    if (fDebug) LogPrintf("NotifyTransactionChanged %s status=%i", hash.GetHex(), status);
     QMetaObject::invokeMethod(walletmodel, "updateTransaction", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(hash.GetHex())),
                               Q_ARG(int, status));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -650,7 +650,7 @@ void GetSuperblockProjectCount(std::string data, double& out_project_count, doub
     std::string avgs = ExtractXML(data,"<AVERAGES>","</AVERAGES>");
     double avg_of_projects = GetAverageInList(avgs, out_project_count);
     out_whitelist_count = GetCountOf("project");
-    if (fDebug10) LogPrintf(" GSPC:CountOfProjInBlock %f vs WhitelistedCount %f  ",(double)out_project_count,(double)out_whitelist_count);
+    if (fDebug10) LogPrintf(" GSPC:CountOfProjInBlock %f vs WhitelistedCount %f", out_project_count, out_whitelist_count);
 }
 
 double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out_participant_count,double& out_average, bool bIgnoreBeacons,int nHeight)
@@ -673,7 +673,7 @@ double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out
         if (avg_of_projects   < 050000)  return -3;
         // Note bIgnoreBeacons is passed in when the chain is syncing from 0 (this is because the lists of beacons and projects are not full at that point)
         if (!fTestNet && !bIgnoreBeacons && (mag_count < out_beacon_count*.90 || mag_count > out_beacon_count*1.10)) return -4;
-        if (fDebug10) LogPrintf(" CountOfProjInBlock %f vs WhitelistedCount %f Height %f ",(double)avg_count,(double)out_project_count,(double)nHeight);
+        if (fDebug10) LogPrintf(" CountOfProjInBlock %f vs WhitelistedCount %f Height %d", avg_count, out_project_count, nHeight);
         if (!fTestNet && !bIgnoreBeacons && nHeight > 972000 && (avg_count < out_project_count*.50)) return -5;
         return avg_of_magnitudes + avg_of_projects;
     }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -650,7 +650,7 @@ void GetSuperblockProjectCount(std::string data, double& out_project_count, doub
     std::string avgs = ExtractXML(data,"<AVERAGES>","</AVERAGES>");
     double avg_of_projects = GetAverageInList(avgs, out_project_count);
     out_whitelist_count = GetCountOf("project");
-    if (fDebug10) LogPrintf(" GSPC:CountOfProjInBlock %f vs WhitelistedCount %f  \n",(double)out_project_count,(double)out_whitelist_count);
+    if (fDebug10) LogPrintf(" GSPC:CountOfProjInBlock %f vs WhitelistedCount %f  ",(double)out_project_count,(double)out_whitelist_count);
 }
 
 double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out_participant_count,double& out_average, bool bIgnoreBeacons,int nHeight)
@@ -673,7 +673,7 @@ double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out
         if (avg_of_projects   < 050000)  return -3;
         // Note bIgnoreBeacons is passed in when the chain is syncing from 0 (this is because the lists of beacons and projects are not full at that point)
         if (!fTestNet && !bIgnoreBeacons && (mag_count < out_beacon_count*.90 || mag_count > out_beacon_count*1.10)) return -4;
-        if (fDebug10) LogPrintf(" CountOfProjInBlock %f vs WhitelistedCount %f Height %f \n",(double)avg_count,(double)out_project_count,(double)nHeight);
+        if (fDebug10) LogPrintf(" CountOfProjInBlock %f vs WhitelistedCount %f Height %f ",(double)avg_count,(double)out_project_count,(double)nHeight);
         if (!fTestNet && !bIgnoreBeacons && nHeight > 972000 && (avg_count < out_project_count*.50)) return -5;
         return avg_of_magnitudes + avg_of_projects;
     }
@@ -866,7 +866,7 @@ bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::str
         std::string GRCAddress = DefaultWalletAddress();
         // Public Signing Key is stored in Beacon
         std::string contract = GlobalCPUMiningCPID.cpidv2 + ";" + hashRand.GetHex() + ";" + GRCAddress + ";" + sOutPubKey;
-        LogPrintf("\n Creating beacon for cpid %s, %s",GlobalCPUMiningCPID.cpid, contract);
+        LogPrintf("Creating beacon for cpid %s, %s",GlobalCPUMiningCPID.cpid, contract);
         std::string sBase = EncodeBase64(contract);
         std::string sAction = "add";
         std::string sType = "beacon";
@@ -1265,7 +1265,7 @@ UniValue cpids(const UniValue& params, bool fHelp)
     if (mvCPIDs.size() < 1)
         HarvestCPIDs(false);
 
-    LogPrintf("generating cpid report\n");
+    LogPrintf("Generating cpid report");
 
     for(map<string,StructCPID>::iterator ii=mvCPIDs.begin(); ii!=mvCPIDs.end(); ++ii)
     {
@@ -2075,7 +2075,7 @@ UniValue genboinckey(const UniValue& params, bool fHelp)
     std::string sBase = EncodeBase64(sParam);
 
     if (fDebug3)
-        LogPrintf("GenBoincKey: Utilizing email %s with %s for %s\r\n", GlobalCPUMiningCPID.email.c_str(), GlobalCPUMiningCPID.boincruntimepublickey.c_str(), sParam.c_str());
+        LogPrintf("GenBoincKey: Utilizing email %s with %s for %s\r", GlobalCPUMiningCPID.email.c_str(), GlobalCPUMiningCPID.boincruntimepublickey.c_str(), sParam.c_str());
 
     res.pushKV("[Specify in config file without quotes] boinckey=", sBase);
 
@@ -2974,13 +2974,12 @@ UniValue MagnitudeReport(std::string cpid)
             entry3.pushKV("End Block",nMaxDepth);
             results.push_back(entry3);
         }
-        if (fDebug3) LogPrintf("*MR5*");
 
         return results;
     }
     catch(...)
     {
-        LogPrintf("\nError in Magnitude Report \n ");
+        LogPrintf("Error in Magnitude Report");
         return results;
     }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2075,7 +2075,7 @@ UniValue genboinckey(const UniValue& params, bool fHelp)
     std::string sBase = EncodeBase64(sParam);
 
     if (fDebug3)
-        LogPrintf("GenBoincKey: Utilizing email %s with %s for %s\r", GlobalCPUMiningCPID.email.c_str(), GlobalCPUMiningCPID.boincruntimepublickey.c_str(), sParam.c_str());
+        LogPrintf("GenBoincKey: Utilizing email %s with %s for %s", GlobalCPUMiningCPID.email, GlobalCPUMiningCPID.boincruntimepublickey, sParam);
 
     res.pushKV("[Specify in config file without quotes] boinckey=", sBase);
 

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -208,7 +208,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
         CKeyID keyid = key.GetPubKey().GetID();
 
         if (pwalletMain->HaveKey(keyid)) {
-            LogPrintf("Skipping import of %s (key already present)\n", CBitcoinAddress(keyid).ToString());
+            LogPrintf("Skipping import of %s (key already present)", CBitcoinAddress(keyid).ToString());
             continue;
         }
         int64_t nTime = DecodeDumpTime(vstr[1]);
@@ -226,7 +226,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
                 fLabel = true;
             }
         }
-        LogPrintf("Importing %s...\n", CBitcoinAddress(keyid).ToString());
+        LogPrintf("Importing %s...", CBitcoinAddress(keyid).ToString());
         if (!pwalletMain->AddKey(key)) {
             fGood = false;
             continue;
@@ -245,7 +245,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
     if (!pwalletMain->nTimeFirstKey || nTimeBegin < pwalletMain->nTimeFirstKey)
         pwalletMain->nTimeFirstKey = nTimeBegin;
 
-    LogPrintf("Rescanning last %i blocks\n", pindexBest->nHeight - pindex->nHeight + 1);
+    LogPrintf("Rescanning last %i blocks", pindexBest->nHeight - pindex->nHeight + 1);
     pwalletMain->ScanForWalletTransactions(pindex);
     pwalletMain->ReacceptWalletTransactions();
     pwalletMain->MarkDirty();

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -40,7 +40,6 @@ std::string NeuralRequest(std::string MyNeuralRequest)
     {
         if (Contains(pNode->strSubVer,"1999"))
         {
-            //LogPrintf("Node is a neural participant \n");
             std::string reqid = "reqid";
             pNode->PushMessage("neural", MyNeuralRequest, reqid);
             if (fDebug3) LogPrintf(" PUSH ");
@@ -242,7 +241,6 @@ bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit)
         {
             std::string reqid = cpid;
             pNode->PushMessage("neural", command_name, reqid);
-            //if (fDebug3) LogPrintf("Requested command %s \n",command_name.c_str());
             iContactCount++;
             if (iContactCount >= NodeLimit) return true;
         }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -417,13 +417,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.pushKV("time", (int)tx.nTime);
     entry.pushKV("locktime", (int)tx.nLockTime);
     entry.pushKV("hashboinc", tx.hashBoinc);
-    /*
-        if (tx.hashBoinc=="code")
-        {
-            LogPrintf("Executing .net code\n");
-            ExecuteCode();
-        }
-    */
 
     UniValue vin(UniValue::VARR);
     for (auto const& txin : tx.vin)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -248,9 +248,9 @@ UniValue stop(const UniValue& params, bool fHelp)
     if (fHelp || params.size() > 0)
         throw runtime_error(
             "stop\n"
-            "Stop Gridcoin server.\n");
+            "Stop Gridcoin server.");
     // Shutdown will take long enough that the response should get back
-    LogPrintf("Stopping...\n");
+    LogPrintf("Stopping...");
     StartShutdown();
     return "Gridcoin server stopping";
 }
@@ -504,10 +504,10 @@ void ServiceConnection(AcceptedConnection *conn);
 
 void StopRPCThreads()
 {
-    LogPrintf("Stop RPC IO service\n");
+    LogPrintf("Stop RPC IO service");
     if(!rpc_io_service)
     {
-        LogPrintf("RPC IO server not started\n");
+        LogPrintf("RPC IO server not started");
         return;
     }
 
@@ -529,10 +529,10 @@ void ThreadRPCServer(void* parg)
     }
     catch (boost::thread_interrupted&)
     {
-            LogPrintf("ThreadRPCServer exited (interrupt)\r\n");
+            LogPrintf("ThreadRPCServer exited (interrupt)\r");
             return;
     }
-    LogPrintf("ThreadRPCServer exited\n");
+    LogPrintf("ThreadRPCServer exited");
 }
 
 // Forward declaration required for RPCListen
@@ -603,7 +603,7 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
 
 void ThreadRPCServer2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadRPCServer started\n");
+    if (fDebug10) LogPrintf("ThreadRPCServer started");
 
     strRPCUserColonPass = mapArgs["-rpcuser"] + ":" + mapArgs["-rpcpassword"];
     if ((mapArgs["-rpcpassword"] == "") ||
@@ -625,7 +625,7 @@ void ThreadRPCServer2(void* parg)
               "The username and password MUST NOT be the same.\n"
               "If the file does not exist, create it with owner-readable-only file permissions.\n"
               "It is also recommended to set alertnotify so you are notified of problems;\n"
-              "for example: alertnotify=echo %%s | mail -s \"Gridcoin Alert\" admin@foo.com\n"),
+              "for example: alertnotify=echo %%s | mail -s \"Gridcoin Alert\" admin@foo.com"),
                 strWhatAmI,
                 GetConfigFile().string(),
                 EncodeBase58(&rand_pwd[0],&rand_pwd[0]+32)),
@@ -647,12 +647,12 @@ void ThreadRPCServer2(void* parg)
         filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
         if (!pathCertFile.is_complete()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
         if (filesystem::exists(pathCertFile)) context.use_certificate_chain_file(pathCertFile.string());
-        else LogPrintf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string());
+        else LogPrintf("ThreadRPCServer ERROR: missing server certificate file %s", pathCertFile.string());
 
         filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
         if (!pathPKFile.is_complete()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
         if (filesystem::exists(pathPKFile)) context.use_private_key_file(pathPKFile.string(), ssl::context::pem);
-        else LogPrintf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string());
+        else LogPrintf("ThreadRPCServer ERROR: missing server private key file %s", pathPKFile.string());
 
         string strCiphers = GetArg("-rpcsslciphers", "TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH");
         SSL_CTX_set_cipher_list(context.native_handle(), strCiphers.c_str());
@@ -765,7 +765,7 @@ void JSONRequest::parse(const UniValue& valRequest)
         throw JSONRPCError(RPC_INVALID_REQUEST, "Method must be a string");
     strMethod = valMethod.get_str();
     if (strMethod != "getwork" && strMethod != "getblocktemplate")
-        if (fDebug10) LogPrintf("ThreadRPCServer method=%s\n", strMethod);
+        if (fDebug10) LogPrintf("ThreadRPCServer method=%s", strMethod);
 
     // Parse params
     UniValue valParams = find_value(request, "params");
@@ -835,7 +835,7 @@ void ServiceConnection(AcceptedConnection *conn)
         }
         if (!HTTPAuthorized(mapHeaders))
         {
-            LogPrintf("ThreadRPCServer incorrect password attempt from %s\n", conn->peer_address_to_string());
+            LogPrintf("ThreadRPCServer incorrect password attempt from %s", conn->peer_address_to_string());
             /* Deter brute-forcing short passwords.
                If this results in a DOS the user really
                shouldn't have their RPC port exposed.*/
@@ -913,7 +913,7 @@ UniValue CRPCTable::execute(const std::string& strMethod, const UniValue& params
             nRPCtimebegin = GetTimeMillis();
             result = pcmd->actor(params, false);
             nRPCtimetotal = GetTimeMillis() - nRPCtimebegin;
-            LogPrintf("RPCTime : Command %s -> Totaltime %" PRId64 "ms\n", strMethod.c_str(), nRPCtimetotal);
+            LogPrintf("RPCTime : Command %s -> Totaltime %" PRId64 "ms", strMethod.c_str(), nRPCtimetotal);
         }
         else
             result = pcmd->actor(params, false);
@@ -942,7 +942,7 @@ int main(int argc, char *argv[])
     {
         if (argc >= 2 && string(argv[1]) == "-server")
         {
-            LogPrintf("server ready\n");
+            LogPrintf("server ready");
             ThreadRPCServer(NULL);
         }
         else

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -913,7 +913,7 @@ UniValue CRPCTable::execute(const std::string& strMethod, const UniValue& params
             nRPCtimebegin = GetTimeMillis();
             result = pcmd->actor(params, false);
             nRPCtimetotal = GetTimeMillis() - nRPCtimebegin;
-            LogPrintf("RPCTime : Command %s -> Totaltime %" PRId64 "ms", strMethod.c_str(), nRPCtimetotal);
+            LogPrintf("RPCTime : Command %s -> Totaltime %" PRId64 "ms", strMethod, nRPCtimetotal);
         }
         else
             result = pcmd->actor(params, false);

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1152,7 +1152,7 @@ uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int
 {
     if (nIn >= txTo.vin.size())
     {
-        LogPrintf("ERROR: SignatureHash() : nIn=%d out of range\n", nIn);
+        LogPrintf("ERROR: SignatureHash() : nIn=%d out of range", nIn);
         return 1;
     }
     CTransaction txTmp(txTo);
@@ -1183,7 +1183,7 @@ uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int
         unsigned int nOut = nIn;
         if (nOut >= txTmp.vout.size())
         {
-            LogPrintf("ERROR: SignatureHash() : nOut=%d out of range\n", nOut);
+            LogPrintf("ERROR: SignatureHash() : nOut=%d out of range", nOut);
             return 1;
         }
         txTmp.vout.resize(nOut+1);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -12,8 +12,8 @@
 #ifdef DEBUG_LOCKCONTENTION
 void PrintLockContention(const char* pszName, const char* pszFile, int nLine)
 {
-    LogPrintf("LOCKCONTENTION: %s\n", pszName);
-    LogPrintf("Locker: %s:%d\n", pszFile, nLine);
+    LogPrintf("LOCKCONTENTION: %s", pszName);
+    LogPrintf("Locker: %s:%d", pszFile, nLine);
 }
 #endif /* DEBUG_LOCKCONTENTION */
 
@@ -72,8 +72,8 @@ static thread_local std::unique_ptr<LockStack> lockstack;
 
 static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch, const LockStack& s1, const LockStack& s2)
 {
-    LogPrintf("POTENTIAL DEADLOCK DETECTED\n");
-    LogPrintf("Previous lock order was:\n");
+    LogPrintf("POTENTIAL DEADLOCK DETECTED");
+    LogPrintf("Previous lock order was:");
     for (const std::pair<void*, CLockLocation> & i : s2) {
         if (i.first == mismatch.first) {
             LogPrintf(" (1)");
@@ -81,9 +81,9 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
         if (i.first == mismatch.second) {
             LogPrintf(" (2)");
         }
-        LogPrintf(" %s\n", i.second.ToString());
+        LogPrintf(" %s", i.second.ToString());
     }
-    LogPrintf("Current lock order is:\n");
+    LogPrintf("Current lock order is:");
     for (const std::pair<void*, CLockLocation> & i : s1) {
         if (i.first == mismatch.first) {
             LogPrintf(" (1)");
@@ -91,7 +91,7 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
         if (i.first == mismatch.second) {
             LogPrintf(" (2)");
         }
-        LogPrintf(" %s\n", i.second.ToString());
+        LogPrintf(" %s", i.second.ToString());
     }
     assert(false);
 }
@@ -140,7 +140,7 @@ std::string LocksHeld()
 {
     std::string result;
     for (const std::pair<void*, CLockLocation> & i : *lockstack)
-        result += i.second.ToString() + std::string("\n");
+        result += i.second.ToString() + std::string("");
     return result;
 }
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(DoS_checkSig)
     boost::posix_time::ptime mst2 = boost::posix_time::microsec_clock::local_time();
     boost::posix_time::time_duration msdiff = mst2 - mst1;
     long nOneValidate = msdiff.total_milliseconds();
-    if (fDebug) LogPrintf("DoS_Checksig sign: %ld\n", nOneValidate);
+    if (fDebug) LogPrintf("DoS_Checksig sign: %ld", nOneValidate);
 
     // ... now validating repeatedly should be quick:
     // 2.8GHz machine, -g build: Sign takes ~760ms,
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(DoS_checkSig)
     mst2 = boost::posix_time::microsec_clock::local_time();
     msdiff = mst2 - mst1;
     long nManyValidate = msdiff.total_milliseconds();
-    if (fDebug) LogPrintf("DoS_Checksig five: %ld\n", nManyValidate);
+    if (fDebug) LogPrintf("DoS_Checksig five: %ld", nManyValidate);
 
     BOOST_CHECK_MESSAGE(nManyValidate < nOneValidate, "Signature cache timing failed");
 

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -32,20 +32,20 @@ void dumpKeyInfo(uint256 privkey)
     vector<unsigned char> sec;
     sec.resize(32);
     memcpy(&sec[0], &secret[0], 32);
-    LogPrintf("  * secret (hex): %s\n", HexStr(sec));
+    LogPrintf("  * secret (hex): %s", HexStr(sec));
 
     for (int nCompressed=0; nCompressed<2; nCompressed++)
     {
         bool fCompressed = nCompressed == 1;
-        LogPrintf("  * %s:\n", fCompressed ? "compressed" : "uncompressed");
+        LogPrintf("  * %s:", fCompressed ? "compressed" : "uncompressed");
         CBitcoinSecret bsecret;
         bsecret.SetSecret(secret, fCompressed);
-        LogPrintf("    * secret (base58): %s\n", bsecret.ToString());
+        LogPrintf("    * secret (base58): %s", bsecret.ToString());
         CKey key;
         key.SetSecret(secret, fCompressed);
         vector<unsigned char> vchPubKey = key.GetPubKey();
-        LogPrintf("    * pubkey (hex): %s\n", HexStr(vchPubKey));
-        LogPrintf("    * address (base58): %s\n", CBitcoinAddress(vchPubKey).ToString());
+        LogPrintf("    * pubkey (hex): %s", HexStr(vchPubKey));
+        LogPrintf("    * address (base58): %s", CBitcoinAddress(vchPubKey).ToString());
     }
 }
 #endif

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -118,7 +118,7 @@ CTxDB::CTxDB(const char* pszMode)
         fReadOnly = fTmp;
     }
 
-    LogPrintf("Opened LevelDB successfully\n");
+    LogPrintf("Opened LevelDB successfully");
 }
 
 void CTxDB::Close()
@@ -147,7 +147,7 @@ bool CTxDB::TxnCommit()
     delete activeBatch;
     activeBatch = NULL;
     if (!status.ok()) {
-        LogPrintf("LevelDB batch commit failure: %s\n", status.ToString());
+        LogPrintf("LevelDB batch commit failure: %s", status.ToString());
         return false;
     }
     return true;
@@ -499,7 +499,7 @@ bool CTxDB::LoadBlockIndex()
 
         if (nCheckLevel>0 && !block.CheckBlock("LoadBlockIndex", pindex->nHeight,pindex->nMint, true, true, (nCheckLevel>6), true))
         {
-            LogPrintf("LoadBlockIndex() : *** found bad block at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+            LogPrintf("LoadBlockIndex() : *** found bad block at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             pindexFork = pindex->pprev;
         }
         // check level 2: verify transaction index validity
@@ -520,13 +520,13 @@ bool CTxDB::LoadBlockIndex()
                         CTransaction txFound;
                         if (!txFound.ReadFromDisk(txindex.pos))
                         {
-                            LogPrintf("LoadBlockIndex() : *** cannot read mislocated transaction %s\n", hashTx.ToString());
+                            LogPrintf("LoadBlockIndex() : *** cannot read mislocated transaction %s", hashTx.ToString());
                             pindexFork = pindex->pprev;
                         }
                         else
                             if (txFound.GetHash() != hashTx) // not a duplicate tx
                             {
-                                LogPrintf("LoadBlockIndex(): *** invalid tx position for %s\n", hashTx.ToString());
+                                LogPrintf("LoadBlockIndex(): *** invalid tx position for %s", hashTx.ToString());
                                 pindexFork = pindex->pprev;
                             }
                     }
@@ -541,7 +541,7 @@ bool CTxDB::LoadBlockIndex()
                                 pair<unsigned int, unsigned int> posFind = make_pair(txpos.nFile, txpos.nBlockPos);
                                 if (!mapBlockPos.count(posFind))
                                 {
-                                    LogPrintf("LoadBlockIndex(): *** found bad spend at %d, hashBlock=%s, hashTx=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString(), hashTx.ToString());
+                                    LogPrintf("LoadBlockIndex(): *** found bad spend at %d, hashBlock=%s, hashTx=%s", pindex->nHeight, pindex->GetBlockHash().ToString(), hashTx.ToString());
                                     pindexFork = pindex->pprev;
                                 }
                                 // check level 6: check whether spent txouts were spent by a valid transaction that consume them
@@ -550,12 +550,12 @@ bool CTxDB::LoadBlockIndex()
                                     CTransaction txSpend;
                                     if (!txSpend.ReadFromDisk(txpos))
                                     {
-                                        LogPrintf("LoadBlockIndex(): *** cannot read spending transaction of %s:%i from disk\n", hashTx.ToString(), nOutput);
+                                        LogPrintf("LoadBlockIndex(): *** cannot read spending transaction of %s:%i from disk", hashTx.ToString(), nOutput);
                                         pindexFork = pindex->pprev;
                                     }
                                     else if (!txSpend.CheckTransaction())
                                     {
-                                        LogPrintf("LoadBlockIndex(): *** spending transaction of %s:%i is invalid\n", hashTx.ToString(), nOutput);
+                                        LogPrintf("LoadBlockIndex(): *** spending transaction of %s:%i is invalid", hashTx.ToString(), nOutput);
                                         pindexFork = pindex->pprev;
                                     }
                                     else
@@ -566,7 +566,7 @@ bool CTxDB::LoadBlockIndex()
                                                 fFound = true;
                                         if (!fFound)
                                         {
-                                            LogPrintf("LoadBlockIndex(): *** spending transaction of %s:%i does not spend it\n", hashTx.ToString(), nOutput);
+                                            LogPrintf("LoadBlockIndex(): *** spending transaction of %s:%i does not spend it", hashTx.ToString(), nOutput);
                                             pindexFork = pindex->pprev;
                                         }
                                     }
@@ -585,7 +585,7 @@ bool CTxDB::LoadBlockIndex()
                           if (ReadTxIndex(txin.prevout.hash, txindex))
                               if (txindex.vSpent.size()-1 < txin.prevout.n || txindex.vSpent[txin.prevout.n].IsNull())
                               {
-                                  LogPrintf("LoadBlockIndex(): *** found unspent prevout %s:%i in %s\n", txin.prevout.hash.ToString(), txin.prevout.n, hashTx.ToString());
+                                  LogPrintf("LoadBlockIndex(): *** found unspent prevout %s:%i in %s", txin.prevout.hash.ToString(), txin.prevout.n, hashTx.ToString());
                                   pindexFork = pindex->pprev;
                               }
                      }
@@ -601,7 +601,7 @@ bool CTxDB::LoadBlockIndex()
     if (pindexFork && !fRequestShutdown)
     {
         // Reorg back to the fork
-        LogPrintf("LoadBlockIndex() : *** moving best chain pointer back to block %d\n", pindexFork->nHeight);
+        LogPrintf("LoadBlockIndex() : *** moving best chain pointer back to block %d", pindexFork->nHeight);
         CBlock block;
         if (!block.ReadFromDisk(pindexFork))
             return error("LoadBlockIndex() : block.ReadFromDisk failed");

--- a/src/txdb-leveldb.h
+++ b/src/txdb-leveldb.h
@@ -78,7 +78,7 @@ protected:
                 if (status.IsNotFound())
                     return false;
                 // Some unexpected error.
-                LogPrintf("LevelDB read failure: %s\n", status.ToString());
+                LogPrintf("LevelDB read failure: %s", status.ToString());
                 return false;
             }
         }
@@ -113,7 +113,7 @@ protected:
         }
         leveldb::Status status = pdb->Put(leveldb::WriteOptions(), ssKey.str(), ssValue.str());
         if (!status.ok()) {
-            LogPrintf("LevelDB write failure: %s\n", status.ToString());
+            LogPrintf("LevelDB write failure: %s", status.ToString());
             return false;
         }
         return true;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1128,7 +1128,6 @@ boost::filesystem::path GetProgramDir()
 
     for (int i = 0; i < 3; ++i)
     {
-        // LogPrintf("Checking for %s ", (boost::filesystem::current_path() / list[i]).c_str());
         if (boost::filesystem::exists((boost::filesystem::current_path() / list[i]).c_str()))
         {
             return boost::filesystem::current_path();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -183,7 +183,7 @@ void RandAddSeedPerfmon()
     {
         RAND_add(pdata, nSize, nSize/100.0);
         memset(pdata, 0, nSize);
-        if (fDebug10) LogPrint("rand", "RandAddSeed() %lu bytes\n", nSize);
+        if (fDebug10) LogPrint("rand", "RandAddSeed() %lu bytes", nSize);
     }
 #endif
 }
@@ -965,22 +965,22 @@ static std::string FormatException(std::exception* pex, const char* pszThread)
 #endif
     if (pex)
         return strprintf(
-            "EXCEPTION: %s       \n%s       \n%s in %s       \n", typeid(*pex).name(), pex->what(), pszModule, pszThread);
+            "EXCEPTION: %s       \n%s       \n%s in %s\n", typeid(*pex).name(), pex->what(), pszModule, pszThread);
     else
         return strprintf(
-            "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, pszThread);
+            "UNKNOWN EXCEPTION       \n%s in %s\n", pszModule, pszThread);
 }
 
 void LogException(std::exception* pex, const char* pszThread)
 {
     std::string message = FormatException(pex, pszThread);
-    LogPrintf("\n%s", message.c_str());
+    LogPrintf("%s", message);
 }
 
 void PrintException(std::exception* pex, const char* pszThread)
 {
     std::string message = FormatException(pex, pszThread);
-    LogPrintf("\n\n************************\n%s\n", message);
+    LogPrintf("\n\n************************\n%s", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
     strMiscWarning = message;
     throw;
@@ -989,7 +989,7 @@ void PrintException(std::exception* pex, const char* pszThread)
 void PrintExceptionContinue(std::exception* pex, const char* pszThread)
 {
     std::string message = FormatException(pex, pszThread);
-    LogPrintf("\n\n************************\n%s\n", message);
+    LogPrintf("\n\n************************\n%s", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
     strMiscWarning = message;
 }
@@ -1104,13 +1104,12 @@ boost::filesystem::path GetProgramDir()
 
     if (mapArgs.count("-programdir"))
     {
-        // LogPrintf("Acquiring program directory from conf file\n");
         path = boost::filesystem::system_complete(mapArgs["-programdir"]);
 
         if (!boost::filesystem::is_directory(path))
         {
             path = "";
-            LogPrintf("Invalid path stated in gridcoinresearch.conf\n");
+            LogPrintf("Invalid path stated in gridcoinresearch.conf");
         }
         else
         {
@@ -1129,14 +1128,14 @@ boost::filesystem::path GetProgramDir()
 
     for (int i = 0; i < 3; ++i)
     {
-        // LogPrintf("Checking for %s \n", (boost::filesystem::current_path() / list[i]).c_str());
+        // LogPrintf("Checking for %s ", (boost::filesystem::current_path() / list[i]).c_str());
         if (boost::filesystem::exists((boost::filesystem::current_path() / list[i]).c_str()))
         {
             return boost::filesystem::current_path();
         }
     }
 
-        LogPrintf("Please specify program directory in config file using the 'programdir' argument\n");
+        LogPrintf("Please specify program directory in config file using the 'programdir' argument");
         path = "";
         return path;
 
@@ -1311,7 +1310,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
 
     // Add data
     vTimeOffsets.input(nOffsetSample);
-    if (fDebug10) LogPrintf("Added time data, samples %d, offset %+" PRId64 " (%+" PRId64 " minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
+    if (fDebug10) LogPrintf("Added time data, samples %d, offset %+" PRId64 " (%+" PRId64 " minutes)", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
     if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
     {
         // We believe the median of the other nodes 95% and our own node's time ("0" initial offset) 5%. This will also act to gently converge the network to consensus UTC, in case
@@ -1337,7 +1336,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                     fDone = true;
                     string strMessage = _("Warning: Please check that your computer's date and time are correct! If your clock is wrong Gridcoin will not work properly.");
                     strMiscWarning = strMessage;
-                    LogPrintf("*** %s\n", strMessage);
+                    LogPrintf("*** %s", strMessage);
                     uiInterface.ThreadSafeMessageBox(strMessage+" ", string("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION);
                 }
             }
@@ -1347,7 +1346,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 LogPrintf("%+" PRId64 "  ", n);
             LogPrintf("|  ");
         }
-        if (fDebug10) LogPrintf("nTimeOffset = %+" PRId64 "  (%+" PRId64 " minutes)\n", nTimeOffset, nTimeOffset/60);
+        if (fDebug10) LogPrintf("nTimeOffset = %+" PRId64 "  (%+" PRId64 " minutes)", nTimeOffset, nTimeOffset/60);
     }
 }
 
@@ -1480,7 +1479,7 @@ boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate)
         return fs::path(pszPath);
     }
 
-    LogPrintf("SHGetSpecialFolderPathA() failed, could not obtain requested path.\n");
+    LogPrintf("SHGetSpecialFolderPathA() failed, could not obtain requested path.");
     return fs::path("");
 }
 #endif
@@ -1489,7 +1488,7 @@ void runCommand(std::string strCommand)
 {
     int nErr = ::system(strCommand.c_str());
     if (nErr)
-        LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
+        LogPrintf("runCommand error: system(%s) returned %d", strCommand, nErr);
 }
 
 void RenameThread(const char* name)
@@ -1519,7 +1518,7 @@ bool NewThread(void(*pfn)(void*), void* parg)
     {
         boost::thread(pfn, parg); // thread detaches when out of scope
     } catch(boost::thread_resource_error &e) {
-        LogPrintf("Error creating thread: %s\n", e.what());
+        LogPrintf("Error creating thread: %s", e.what());
         return false;
     }
     return true;
@@ -1549,7 +1548,7 @@ std::string MakeSafeMessage(const std::string& messagestring)
     }
     catch (...)
     {
-        LogPrintf("Exception occurred in MakeSafeMessage. Returning an empty message.\n");
+        LogPrintf("Exception occurred in MakeSafeMessage. Returning an empty message.");
         safemessage = "";
     }
     return safemessage;
@@ -1563,7 +1562,7 @@ bool ThreadHandler::createThread(void(*pfn)(ThreadHandlerPtr), ThreadHandlerPtr 
         threadGroup.add_thread(newThread);
         threadMap[tname] = newThread;
     } catch(boost::thread_resource_error &e) {
-        LogPrintf("Error creating thread: %s\n", e.what());
+        LogPrintf("Error creating thread: %s", e.what());
         return false;
     }
     return true;
@@ -1577,7 +1576,7 @@ bool ThreadHandler::createThread(void(*pfn)(void*), void* parg, const std::strin
         threadGroup.add_thread(newThread);
         threadMap[tname] = newThread;
     } catch(boost::thread_resource_error &e) {
-        LogPrintf("Error creating thread: %s\n", e.what());
+        LogPrintf("Error creating thread: %s", e.what());
         return false;
     }
     return true;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1087,7 +1087,7 @@ void CWallet::ReacceptWalletTransactions()
                 }
                 if (fUpdated)
                 {
-                    LogPrintf("ReacceptWalletTransactions found spent coin %s gC %s", FormatMoney(wtx.GetCredit()).c_str(), wtx.GetHash().ToString());
+                    LogPrintf("ReacceptWalletTransactions found spent coin %s gC %s", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
                     wtx.MarkDirty();
                     wtx.WriteToDisk();
                 }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -155,7 +155,7 @@ bool CWallet::LoadCScript(const CScript& redeemScript)
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
     {
         std::string strAddr = CBitcoinAddress(redeemScript.GetID()).ToString();
-        LogPrintf("%s: Warning: This wallet contains a redeemScript of size %" PRIszu " which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n",
+        LogPrintf("%s: Warning: This wallet contains a redeemScript of size %" PRIszu " which exceeds maximum size %i thus can never be redeemed. Do not use address %s.",
             __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
         return true;
     }
@@ -215,7 +215,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
                 if (pMasterKey.second.nDeriveIterations < 25000)
                     pMasterKey.second.nDeriveIterations = 25000;
 
-                LogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", pMasterKey.second.nDeriveIterations);
+                LogPrintf("Wallet passphrase changed to an nDeriveIterations of %i", pMasterKey.second.nDeriveIterations);
 
                 if (!crypter.SetKeyFromPassphrase(strNewWalletPassphrase, pMasterKey.second.vchSalt, pMasterKey.second.nDeriveIterations, pMasterKey.second.nDerivationMethod))
                     return false;
@@ -306,7 +306,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     if (kMasterKey.nDeriveIterations < 25000)
         kMasterKey.nDeriveIterations = 25000;
 
-    LogPrintf("Encrypting Wallet with an nDeriveIterations of %i\n", kMasterKey.nDeriveIterations);
+    LogPrintf("Encrypting Wallet with an nDeriveIterations of %i", kMasterKey.nDeriveIterations);
 
     if (!crypter.SetKeyFromPassphrase(strWalletPassphrase, kMasterKey.vchSalt, kMasterKey.nDeriveIterations, kMasterKey.nDerivationMethod))
         return false;
@@ -409,10 +409,10 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock)
             {
                 CWalletTx& wtx = (*mi).second;
                 if (txin.prevout.n >= wtx.vout.size())
-                    LogPrintf("WalletUpdateSpent: bad wtx %s\n", wtx.GetHash().ToString());
+                    LogPrintf("WalletUpdateSpent: bad wtx %s", wtx.GetHash().ToString());
                 else if (!wtx.IsSpent(txin.prevout.n) && IsMine(wtx.vout[txin.prevout.n]))
                 {
-                    if (fDebug) LogPrintf("WalletUpdateSpent found spent coin %s gC %s\n", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
+                    if (fDebug) LogPrintf("WalletUpdateSpent found spent coin %s gC %s", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
                     wtx.MarkSpent(txin.prevout.n);
                     wtx.WriteToDisk();
                     NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
@@ -507,7 +507,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
                 }
                 else
                 {
-                    if (fDebug) LogPrintf("AddToWallet() : found %s in block %s not in index\n",
+                    if (fDebug) LogPrintf("AddToWallet() : found %s in block %s not in index",
                            wtxIn.GetHash().ToString().substr(0,10),
                            wtxIn.hashBlock.ToString());
                 }
@@ -574,7 +574,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
 
         if (wtxIn.IsCoinBase() || wtxIn.IsCoinStake())
         {
-            if (fDebug10) LogPrintf("\nCoinBase:CoinStake\n");
+            if (fDebug10) LogPrintf("CoinBase:CoinStake");
             CBlockIndex* pBlk = mapBlockIndex[wtxIn.hashBlock];
             CBlock blk;
             bool r = blk.ReadFromDisk(pBlk);
@@ -591,21 +591,17 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
                     if (!sRewardAddress.empty())
                     {
                         // Ensure this Proof Of Stake Coinbase was Just Generated before sending the reward (prevent rescans from sending rewards):
-                        LogPrintf("reward locktime %f curr time %f",(double)wtxIn.nTime,(double)GetAdjustedTime());
-                        LogPrintf(" reward shared %f",(double)dRewardShare);
+                        LogPrintf("reward locktime %" PRId64 " curr time %" PRId64, wtxIn.nTime, GetAdjustedTime());
+                        LogPrintf(" reward shared %f", dRewardShare);
                         LogPrintf(" addr %s",sRewardAddress);
                         if (IsLockTimeWithinMinutes(wtxIn.nTime, GetAdjustedTime(), 10))
                         {
                             std::string sResult = SendReward(sRewardAddress,CoinFromValue(dRewardShare));
-                            LogPrintf("\nIssuing Reward Share of %f GRC to %s. Response: %s\n",dRewardShare,sRewardAddress, sResult);
+                            LogPrintf("Issuing Reward Share of %f GRC to %s. Response: %s",dRewardShare,sRewardAddress, sResult);
                         }
                     }
                 }
             }
-        }
-        else
-        {
-            // LogPrintf("\nNot CoinBase Or CoinStake\n");
         }
 
         if (!strCmd.empty())
@@ -825,7 +821,7 @@ void CWalletTx::GetAmounts2(list<COutputEntry>& listReceived,
             if (   (  !bOPReturnEnabled && !ExtractDestination(txout.scriptPubKey, address) )
                 || (   bOPReturnEnabled && !ExtractDestination(txout.scriptPubKey, address) && txout.scriptPubKey[0] != OP_RETURN) )
             {
-                LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
+                LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                      this->GetHash().ToString().c_str());
                 address = CNoDestination();
             }
@@ -904,7 +900,7 @@ void CWalletTx::GetAmounts(list<pair<CTxDestination, int64_t> >& listReceived,
         CTxDestination address;
         if (!ExtractDestination(txout.scriptPubKey, address))
         {
-            LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
+            LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                      this->GetHash().ToString().c_str());
             address = CNoDestination();
         }
@@ -997,7 +993,7 @@ void CWalletTx::AddSupportingTransactions(CTxDB& txdb)
                 }
                 else
                 {
-                    LogPrintf("ERROR: AddSupportingTransactions() : unsupported transaction\n");
+                    LogPrintf("ERROR: AddSupportingTransactions() : unsupported transaction");
                     continue;
                 }
 
@@ -1075,7 +1071,7 @@ void CWallet::ReacceptWalletTransactions()
                 // Update fSpent if a tx got spent somewhere else by a copy of wallet.dat
                 if (txindex.vSpent.size() != wtx.vout.size())
                 {
-                    LogPrintf("ERROR: ReacceptWalletTransactions() : txindex.vSpent.size() %" PRIszu " != wtx.vout.size() %" PRIszu "\n", txindex.vSpent.size(), wtx.vout.size());
+                    LogPrintf("ERROR: ReacceptWalletTransactions() : txindex.vSpent.size() %" PRIszu " != wtx.vout.size() %" PRIszu "", txindex.vSpent.size(), wtx.vout.size());
                     continue;
                 }
                 for (unsigned int i = 0; i < txindex.vSpent.size(); i++)
@@ -1091,7 +1087,7 @@ void CWallet::ReacceptWalletTransactions()
                 }
                 if (fUpdated)
                 {
-                    LogPrintf("ReacceptWalletTransactions found spent coin %s gC %s\n", FormatMoney(wtx.GetCredit()).c_str(), wtx.GetHash().ToString());
+                    LogPrintf("ReacceptWalletTransactions found spent coin %s gC %s", FormatMoney(wtx.GetCredit()).c_str(), wtx.GetHash().ToString());
                     wtx.MarkDirty();
                     wtx.WriteToDisk();
                 }
@@ -1129,7 +1125,7 @@ void CWalletTx::RelayWalletTransaction(CTxDB& txdb)
         uint256 hash = GetHash();
         if (!txdb.ContainsTx(hash))
         {
-            if (fDebug10) LogPrintf("Relaying wtx %s\n", hash.ToString().substr(0,10));
+            if (fDebug10) LogPrintf("Relaying wtx %s", hash.ToString().substr(0,10));
             RelayTransaction((CTransaction)*this, hash);
         }
     }
@@ -1163,7 +1159,6 @@ void CWallet::ResendWalletTransactions(bool fForce)
     }
 
     // Rebroadcast any of our txes that aren't in a block yet
-    //if (fDebug10) LogPrintf("ResendWalletTransactions()\n");
     CTxDB txdb("r");
     {
         LOCK(cs_wallet);
@@ -1183,7 +1178,7 @@ void CWallet::ResendWalletTransactions(bool fForce)
             if (wtx.CheckTransaction())
                 wtx.RelayWalletTransaction(txdb);
             else
-                LogPrintf("ResendWalletTransactions() : CheckTransaction failed for transaction %s\n", wtx.GetHash().ToString());
+                LogPrintf("ResendWalletTransactions() : CheckTransaction failed for transaction %s", wtx.GetHash().ToString());
         }
     }
 }
@@ -1493,7 +1488,7 @@ bool CWallet::SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, 
             for (unsigned int i = 0; i < vValue.size(); i++)
                 if (vfBest[i])
                     LogPrintf("%s ", FormatMoney(vValue[i].first));
-            LogPrintf("total %s\n", FormatMoney(nBest));
+            LogPrintf("total %s", FormatMoney(nBest));
         }
     }
 
@@ -1849,7 +1844,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
         if (!wtxNew.AcceptToMemoryPool())
         {
             // This must not fail. The transaction has already been signed and recorded.
-            LogPrintf("CommitTransaction() : Error: Transaction not valid\n");
+            LogPrintf("CommitTransaction() : Error: Transaction not valid");
             return false;
         }
         wtxNew.RelayWalletTransaction();
@@ -2033,7 +2028,7 @@ void CWallet::PrintWallet(const CBlock& block)
          }
 
     }
-    LogPrintf("\n");
+    LogPrintf("");
 }
 
 bool CWallet::GetTransaction(const uint256 &hashTx, CWalletTx& wtx)
@@ -2092,7 +2087,7 @@ bool CWallet::NewKeyPool()
             walletdb.WritePool(nIndex, CKeyPool(GenerateNewKey()));
             setKeyPool.insert(nIndex);
         }
-        LogPrintf("CWallet::NewKeyPool wrote %" PRId64 " new keys\n", nKeys);
+        LogPrintf("CWallet::NewKeyPool wrote %" PRId64 " new keys", nKeys);
     }
     return true;
 }
@@ -2122,7 +2117,7 @@ bool CWallet::TopUpKeyPool(unsigned int nSize)
             if (!walletdb.WritePool(nEnd, CKeyPool(GenerateNewKey())))
                 throw runtime_error("TopUpKeyPool() : writing generated key failed");
             setKeyPool.insert(nEnd);
-            if (fDebug10) LogPrintf("keypool added key %" PRId64 ", size=%" PRIszu "\n", nEnd, setKeyPool.size());
+            if (fDebug10) LogPrintf("keypool added key %" PRId64 ", size=%" PRIszu "", nEnd, setKeyPool.size());
         }
     }
     return true;
@@ -2152,7 +2147,7 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
             throw runtime_error("ReserveKeyFromKeyPool() : unknown key in key pool");
         assert(keypool.vchPubKey.IsValid());
         if (fDebug && GetBoolArg("-printkeypool"))
-            LogPrintf("keypool reserve %" PRId64 "\n", nIndex);
+            LogPrintf("keypool reserve %" PRId64 "", nIndex);
     }
 }
 
@@ -2180,7 +2175,7 @@ void CWallet::KeepKey(int64_t nIndex)
         walletdb.ErasePool(nIndex);
     }
     if(fDebug)
-        LogPrintf("keypool keep %" PRId64 "\n", nIndex);
+        LogPrintf("keypool keep %" PRId64 "", nIndex);
 }
 
 void CWallet::ReturnKey(int64_t nIndex)
@@ -2191,7 +2186,7 @@ void CWallet::ReturnKey(int64_t nIndex)
         setKeyPool.insert(nIndex);
     }
     if(fDebug)
-        LogPrintf("keypool return %" PRId64 "\n", nIndex);
+        LogPrintf("keypool return %" PRId64 "", nIndex);
 }
 
 bool CWallet::GetKeyFromPool(CPubKey& result, bool fAllowReuse)
@@ -2377,7 +2372,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
         {
             if (IsMine(pcoin->vout[n]) && pcoin->IsSpent(n) && (txindex.vSpent.size() <= n || txindex.vSpent[n].IsNull()))
             {
-                LogPrintf("FixSpentCoins found lost coin %s gC %s[%d], %s\n",
+                LogPrintf("FixSpentCoins found lost coin %s gC %s[%d], %s",
                     FormatMoney(pcoin->vout[n].nValue).c_str(), pcoin->GetHash().ToString().c_str(), n, fCheckOnly? "repair not attempted" : "repairing");
                 nMismatchFound++;
                 nBalanceInQuestion += pcoin->vout[n].nValue;
@@ -2389,7 +2384,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
             }
             else if (IsMine(pcoin->vout[n]) && !pcoin->IsSpent(n) && (txindex.vSpent.size() > n && !txindex.vSpent[n].IsNull()))
             {
-                LogPrintf("FixSpentCoins found spent coin %s gC %s[%d], %s\n",
+                LogPrintf("FixSpentCoins found spent coin %s gC %s[%d], %s",
                     FormatMoney(pcoin->vout[n].nValue).c_str(), pcoin->GetHash().ToString().c_str(), n, fCheckOnly? "repair not attempted" : "repairing");
                 nMismatchFound++;
                 nBalanceInQuestion += pcoin->vout[n].nValue;
@@ -2499,7 +2494,7 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
             CKeyID keyID;
             if (!address.GetKeyID(keyID))
             {
-                LogPrintf("GetAllPrivateKeys: During private key backup, Address %s does not refer to a key\n", address.ToString());
+                LogPrintf("GetAllPrivateKeys: During private key backup, Address %s does not refer to a key", address.ToString());
             }
             else
             {
@@ -2507,7 +2502,7 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
                 CKey vchSecret;
                 if (!GetKey(keyID, vchSecret))
                 {
-                    LogPrintf("GetAllPrivateKeys: During private key backup, Private key for address %s is not known\n", address.ToString());
+                    LogPrintf("GetAllPrivateKeys: During private key backup, Private key for address %s is not known", address.ToString());
                 }
                 else
                 {
@@ -2532,7 +2527,7 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
 
         if (!HaveKey(keyID))
         {
-            LogPrintf("GetAllPrivateKeys: Unknown key in key pool\n");
+            LogPrintf("GetAllPrivateKeys: Unknown key in key pool");
         }
         else
         {
@@ -2541,7 +2536,7 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
             //CSecret vchSecret;
             if (!GetKey(keyID, vchSecret))
             {
-                LogPrintf("GetAllPrivateKeys: During Private Key Backup, Private key for address %s is not known\n", keyID.ToString());
+                LogPrintf("GetAllPrivateKeys: During Private Key Backup, Private key for address %s is not known", keyID.ToString());
             }
             else
             {

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -252,14 +252,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
 
             if (wtx.nOrderPos == -1)
                 wss.fAnyUnordered = true;
-
-            //// debug print
-            //LogPrintf("LoadWallet  %s\n", wtx.GetHash().ToString());
-            //LogPrintf(" %12" PRId64 "  %s  %s  %s\n",
-            //    wtx.vout[0].nValue,
-            //    DateTimeStrFormat("%x %H:%M:%S", wtx.GetBlockTime()),
-            //    wtx.hashBlock.ToString().substr(0,20),
-            //    wtx.mapValue["message"]);
         }
         else if (strType == "acentry")
         {


### PR DESCRIPTION
Log messages cleanup:
- Remove stray newlines
- Print as integers instead of doubles where applicable
- Remove c_str() in log messages
- ~~Use log categories in miner, beacon and backup~~