### PR TITLE
Fix rpc client

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -259,13 +259,13 @@ int CommandLineRPC(int argc, char *argv[])
         UniValue params = RPCConvertValues(strMethod, strParams);
 
         // Execute
-        UniValue reply = CallRPC(strMethod, params);
+        const UniValue reply = CallRPC(strMethod, params);
 
         // Parse reply
         const UniValue& result = find_value(reply, "result");
         const UniValue& error  = find_value(reply, "error");
 
-        if (error.isNull())
+        if (!error.isNull())
         {
             // Error
             strPrint = "error: " + error.write();

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -197,7 +197,7 @@ string JSONRPCRequest(const string& strMethod, const UniValue& params, const Uni
     request.push_back(Pair("method", strMethod));
     request.push_back(Pair("params", params));
     request.push_back(Pair("id", id));
-    return request.write(), false + "\n";
+    return request.write() + "\n";
 }
 
 UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const UniValue& id)


### PR DESCRIPTION
Rpc client was not tested during the univalue conversion after multiple
rebases. This fixes a typo and inverted boolean.