### PR TITLE
Replace rpc calls from gui with direct function calls

### DIFF
--- a/src/contract/contract.cpp
+++ b/src/contract/contract.cpp
@@ -6,6 +6,8 @@
 #include "keystore.h"
 #include "beacon.h"
 
+double GetTotalBalance();
+
 std::string GetBurnAddress() { return fTestNet ? "mk1e432zWKH1MW57ragKywuXaWAtHy1AHZ" : "S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB";
                              }
 
@@ -116,3 +118,95 @@ bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, 
     return true;
 }
 
+int64_t AmountFromDouble(double dAmount)
+{
+    if (dAmount <= 0.0 || dAmount > MAX_MONEY)        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    int64_t nAmount = roundint64(dAmount * COIN);
+    if (!MoneyRange(nAmount))         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    return nAmount;
+}
+
+std::string executeRain(std::string sRecipients)
+{
+    CWalletTx wtx;
+    wtx.mapValue["comment"] = "Rain";
+    set<CBitcoinAddress> setAddress;
+    vector<pair<CScript, int64_t> > vecSend;
+    std::string sRainCommand = ExtractXML(sRecipients,"<RAIN>","</RAIN>");
+    std::string sRainMessage = MakeSafeMessage(ExtractXML(sRecipients,"<RAINMESSAGE>","</RAINMESSAGE>"));
+    std::string sRain = "<NARR>Project Rain: " + sRainMessage + "</NARR>";
+
+    if (!sRainCommand.empty())
+        sRecipients = sRainCommand;
+
+    wtx.hashBoinc = sRain;
+    int64_t totalAmount = 0;
+    double dTotalToSend = 0;
+    std::vector<std::string> vRecipients = split(sRecipients.c_str(),"<ROW>");
+    LogPrintf("Creating Rain transaction with %" PRId64 " recipients. ", vRecipients.size());
+
+    for (unsigned int i = 0; i < vRecipients.size(); i++)
+    {
+        std::string sRow = vRecipients[i];
+        std::vector<std::string> vReward = split(sRow.c_str(),"<COL>");
+
+        if (vReward.size() > 1)
+        {
+            std::string sAddress = vReward[0];
+            std::string sAmount = vReward[1];
+
+            if (sAddress.length() > 10 && sAmount.length() > 0)
+            {
+                double dAmount = RoundFromString(sAmount,4);
+                if (dAmount > 0)
+                {
+                    CBitcoinAddress address(sAddress);
+                    if (!address.IsValid())
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Gridcoin address: ")+sAddress);
+
+                    if (setAddress.count(address))
+                        throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+sAddress);
+
+                    setAddress.insert(address);
+                    dTotalToSend += dAmount;
+                    int64_t nAmount = AmountFromDouble(dAmount);
+                    CScript scriptPubKey;
+                    scriptPubKey.SetDestination(address.Get());
+                    totalAmount += nAmount;
+                    vecSend.push_back(make_pair(scriptPubKey, nAmount));
+                }
+            }
+        }
+    }
+
+    EnsureWalletIsUnlocked();
+    // Check funds
+    double dBalance = GetTotalBalance();
+
+    if (dTotalToSend > dBalance)
+        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
+    // Send
+    CReserveKey keyChange(pwalletMain);
+    int64_t nFeeRequired = 0;
+    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired);
+    LogPrintf("Transaction Created.");
+
+    if (!fCreated)
+    {
+        if (totalAmount + nFeeRequired > pwalletMain->GetBalance())
+            throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Transaction creation failed");
+    }
+
+    LogPrintf("Committing.");
+    // Rain the recipients
+    if (!pwalletMain->CommitTransaction(wtx, keyChange))
+    {
+        LogPrintf("Commit failed.");
+
+        throw JSONRPCError(RPC_WALLET_ERROR, "Transaction commit failed");
+    }
+    std::string sNarr = "Rain successful:  Sent " + wtx.GetHash().GetHex() + ".";
+    LogPrintf("Success %s",sNarr.c_str());
+    return sNarr;
+}

--- a/src/contract/contract.h
+++ b/src/contract/contract.h
@@ -8,4 +8,4 @@ std::string SignMessage(std::string sMsg, std::string sPrivateKey);
 bool VerifyCPIDSignature(std::string sCPID, std::string sBlockHash, std::string sSignature);
 bool SignBlockWithCPID(const std::string& sCPID, const std::string& sBlockHash, std::string& sSignature, std::string& sError, bool bAdvertising=false);
 bool CheckMessageSignature(std::string sAction,std::string messagetype, std::string sMsg, std::string sSig, std::string opt_pubkey);
-
+std::string executeRain(std::string sRecipients);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -90,6 +90,7 @@
 #include "rpcclient.h"
 #include "rpcprotocol.h"
 #include "contract/polls.h"
+#include "contract/contract.h"
 
 #include <iostream>
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
@@ -106,9 +107,6 @@ extern double qtPushGridcoinDiagnosticData(std::string data);
 
 extern std::string FromQString(QString qs);
 extern std::string qtExecuteDotNetStringFunction(std::string function, std::string data);
-
-std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2);
-std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2, std::string arg3, std::string arg4, std::string arg5, std::string arg6);
 
 std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 
@@ -1783,35 +1781,11 @@ void BitcoinGUI::timerfire()
                         std::string Argument1 = ExtractXML(sData,"<ARG1>","</ARG1>");
                         std::string Argument2 = ExtractXML(sData,"<ARG2>","</ARG2>");
 
-                        if (RPCCommand=="vote")
+                        if (RPCCommand=="rain")
                         {
-                            std::string testnet_flag = fTestNet ? "TESTNET" : "MAINNET";
-                            double function_call = qtExecuteGenericFunction("SetTestNetFlag",testnet_flag);
-                            std::string response = ExecuteRPCCommand("vote",Argument1,Argument2);
+                            std::string response = executeRain(Argument1+Argument2);
                             double resultcode = qtExecuteGenericFunction("SetRPCResponse"," "+response);
                         }
-                        else if (RPCCommand=="rain")
-                        {
-                            std::string response = ExecuteRPCCommand("rain",Argument1,Argument2);
-                            double resultcode = qtExecuteGenericFunction("SetRPCResponse"," "+response);
-                        }
-                        else if (RPCCommand=="addpoll")
-                        {
-                            std::string testnet_flag = fTestNet ? "TESTNET" : "MAINNET";
-                            double function_call = qtExecuteGenericFunction("SetTestNetFlag",testnet_flag);
-                            std::string Argument3 = ExtractXML(sData,"<ARG3>","</ARG3>");
-                            std::string Argument4 = ExtractXML(sData,"<ARG4>","</ARG4>");
-                            std::string Argument5 = ExtractXML(sData,"<ARG5>","</ARG5>");
-                            std::string Argument6 = ExtractXML(sData,"<ARG6>","</ARG6>");
-                            std::string response = ExecuteRPCCommand("addpoll",Argument1,Argument2,Argument3,Argument4,Argument5,Argument6);
-                            double resultcode = qtExecuteGenericFunction("SetRPCResponse"," "+response);
-                        }
-                        else if (RPCCommand == "addattachment")
-                        {
-                            msAttachmentGuid = Argument1;
-                            LogPrintf("\n attachment added %s \n",msAttachmentGuid);
-                        }
-
                     }
                 #endif
         }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -90,7 +90,6 @@ extern bool PollExpired(std::string pollname);
 extern bool PollAcceptableAnswer(std::string pollname, std::string answer);
 extern std::string PollAnswers(std::string pollname);
 
-extern std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2);
 bool GetEarliestStakeTime(std::string grcaddress, std::string cpid);
 
 StructCPID GetLifetimeCPID(const std::string& cpid, const std::string& sFrom);
@@ -910,87 +909,6 @@ bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::str
     }
 }
 
-std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2, std::string arg3, std::string arg4, std::string arg5, std::string arg6)
-{
-    UniValue params(UniValue::VARR);
-    params.push_back(method);
-    params.push_back(arg1);
-    params.push_back(RoundFromString(arg2, 0));
-    params.push_back(arg3);
-    params.push_back(arg4);
-    params.push_back(RoundFromString(arg5, 0));
-    params.push_back(arg6);
-
-    LogPrintf("Executing method %s\n",method);
-    UniValue vResult(UniValue::VSTR);
-    try
-    {
-        if (method == "addpoll")
-            vResult = addpoll(params, false);
-    }
-    catch (std::exception& e)
-    {
-        LogPrintf("Std exception %s \n",method);
-
-        std::string caught = e.what();
-        return "Exception " + caught;
-    }
-    catch (...)
-    {
-        LogPrintf("Generic exception (Please try unlocking the wallet) %s \n",method);
-        return "Generic Exception (Please try unlocking the wallet).";
-    }
-    std::string sResult = "";
-     sResult = vResult.write() + "\n";
-    LogPrintf("Response %s",sResult);
-    return sResult;
-}
-
-std::string ExecuteRPCCommand(std::string method, std::string arg1, std::string arg2)
-{
-    UniValue params(UniValue::VARR);
-    params.push_back(method);
-    params.push_back(arg1);
-
-    if (method == "vote")
-    params.push_back(arg2);
-    LogPrintf("Executing method %s\n",method);
-    UniValue vResult(UniValue::VSTR);
-    try
-    {
-        if (method == "vote")
-            vResult = vote(params,false);
-
-        if (method == "rain")
-            vResult = rain(params,false);
-    }
-    catch (std::exception& e)
-    {
-        LogPrintf("Std exception %s \n",method);
-
-        std::string caught = e.what();
-        return "Exception " + caught;
-
-    }
-    catch (...)
-    {
-        LogPrintf("Generic exception (Please try unlocking the wallet). %s \n",method);
-        return "Generic Exception (Please try unlocking the wallet).";
-    }
-    std::string sResult = "";
-     sResult = vResult.write() + "\n";
-    LogPrintf("Response %s",sResult);
-    return sResult;
-}
-
-int64_t AmountFromDouble(double dAmount)
-{
-    if (dAmount <= 0.0 || dAmount > MAX_MONEY)        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    int64_t nAmount = roundint64(dAmount * COIN);
-    if (!MoneyRange(nAmount))         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    return nAmount;
-}
-
 // Rpc
 
 UniValue backupprivatekeys(const UniValue& params, bool fHelp)
@@ -1161,91 +1079,8 @@ UniValue rain(const UniValue& params, bool fHelp)
                 "rains coins on the network\n");
 
     UniValue res(UniValue::VOBJ);
-
-    CWalletTx wtx;
-    wtx.mapValue["comment"] = "Rain";
-    set<CBitcoinAddress> setAddress;
-    vector<pair<CScript, int64_t> > vecSend;
-    std::string sRecipients = params[0].get_str();
-    std::string sRainCommand = ExtractXML(sRecipients,"<RAIN>","</RAIN>");
-    std::string sRainMessage = MakeSafeMessage(ExtractXML(sRecipients,"<RAINMESSAGE>","</RAINMESSAGE>"));
-    std::string sRain = "<NARR>Project Rain: " + sRainMessage + "</NARR>";
-
-    if (!sRainCommand.empty())
-        sRecipients = sRainCommand;
-
-    wtx.hashBoinc = sRain;
-    int64_t totalAmount = 0;
-    double dTotalToSend = 0;
-    std::vector<std::string> vRecipients = split(sRecipients.c_str(),"<ROW>");
-    LogPrintf("Creating Rain transaction with %" PRId64 " recipients. ", vRecipients.size());
-
-    for (unsigned int i = 0; i < vRecipients.size(); i++)
-    {
-        std::string sRow = vRecipients[i];
-        std::vector<std::string> vReward = split(sRow.c_str(),"<COL>");
-
-        if (vReward.size() > 1)
-        {
-            std::string sAddress = vReward[0];
-            std::string sAmount = vReward[1];
-
-            if (sAddress.length() > 10 && sAmount.length() > 0)
-            {
-                double dAmount = RoundFromString(sAmount,4);
-                if (dAmount > 0)
-                {
-                    CBitcoinAddress address(sAddress);
-                    if (!address.IsValid())
-                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Gridcoin address: ")+sAddress);
-
-                    if (setAddress.count(address))
-                        throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+sAddress);
-
-                    setAddress.insert(address);
-                    dTotalToSend += dAmount;
-                    int64_t nAmount = AmountFromDouble(dAmount);
-                    CScript scriptPubKey;
-                    scriptPubKey.SetDestination(address.Get());
-                    totalAmount += nAmount;
-                    vecSend.push_back(make_pair(scriptPubKey, nAmount));
-                }
-            }
-        }
-    }
-
-    EnsureWalletIsUnlocked();
-    // Check funds
-    double dBalance = GetTotalBalance();
-
-    if (dTotalToSend > dBalance)
-        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
-    // Send
-    CReserveKey keyChange(pwalletMain);
-    int64_t nFeeRequired = 0;
-    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired);
-    LogPrintf("Transaction Created.");
-
-    if (!fCreated)
-    {
-        if (totalAmount + nFeeRequired > pwalletMain->GetBalance())
-            throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
-        throw JSONRPCError(RPC_WALLET_ERROR, "Transaction creation failed");
-    }
-
-    LogPrintf("Committing.");
-    // Rain the recipients
-    if (!pwalletMain->CommitTransaction(wtx, keyChange))
-    {
-        LogPrintf("Commit failed.");
-
-        throw JSONRPCError(RPC_WALLET_ERROR, "Transaction commit failed");
-    }
-    std::string sNarr = "Rain successful:  Sent " + wtx.GetHash().GetHex() + ".";
-    LogPrintf("Success %s",sNarr.c_str());
-
+    std::string sNarr = executeRain(params[0].get_str());
     res.pushKV("Response", sNarr);
-
     return res;
 }
 


### PR DESCRIPTION
    Remove the unused calls to vote, addpoll and addattachment.
    Replace the rpc call to rain with a direct function call.
    Split the rain rpc function into a rpc call `rain` and a function `executeRain`.