### PR TITLE
Nn test net flag changes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,8 +332,6 @@ bool UpdateNeuralNetworkQuorumData()
     std::string sTimestamp = TimestampToHRDate(superblock_time);
     std::string data = "<QUORUMDATA><AGE>" + sAge + "</AGE><HASH>" + consensus_hash + "</HASH><BLOCKNUMBER>" + sBlock + "</BLOCKNUMBER><TIMESTAMP>"
                        + sTimestamp + "</TIMESTAMP><PRIMARYCPID>" + msPrimaryCPID + "</PRIMARYCPID></QUORUMDATA>";
-    std::string testnet_flag = fTestNet ? "TESTNET" : "MAINNET";
-    NN::SetTestnetFlag(fTestNet);
     NN::ExecuteDotNetStringFunction("SetQuorumData",data);
     return true;
 }
@@ -371,7 +369,6 @@ bool FullSyncWithDPORNodes()
     std::string data = "<WHITELIST>" + sWhitelist + "</WHITELIST><CPIDDATA>"
                        + cpiddata + "</CPIDDATA><QUORUMDATA><AGE>" + sAge + "</AGE><HASH>" + consensus_hash + "</HASH><BLOCKNUMBER>" + sBlock + "</BLOCKNUMBER><TIMESTAMP>"
                        + sTimestamp + "</TIMESTAMP><PRIMARYCPID>" + msPrimaryCPID + "</PRIMARYCPID></QUORUMDATA>";
-    NN::SetTestnetFlag(fTestNet);
     NN::SynchronizeDPOR(data);
     return true;
 }
@@ -7089,7 +7086,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
             if (neural_request=="neural_data")
             {
-                NN::SetTestnetFlag(fTestNet);
                 pfrom->PushMessage("ndata_nresp", NN::GetNeuralContract());
             }
             else if (neural_request=="neural_hash")
@@ -7104,7 +7100,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             else if (neural_request=="quorum")
             {
             // 7-12-2015 Resolve discrepencies in w nodes to speak to each other
-            NN::SetTestnetFlag(fTestNet);
             pfrom->PushMessage("quorum_nresp", NN::GetNeuralContract());
             }
     }
@@ -7215,7 +7210,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             {
                  std::string results = "";
                  //Resolve discrepancies
-                NN::SetTestnetFlag(fTestNet);
                 results = NN::ExecuteDotNetStringFunction("ResolveDiscrepancies",neural_contract);
                  if (fDebug && !results.empty()) LogPrintf("Quorum Resolution: %s \n",results);
             }
@@ -7229,7 +7223,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             {
                  std::string results = "";
                  //Resolve discrepancies
-                NN::SetTestnetFlag(fTestNet);
                     LogPrintf("\n** Sync neural network data from supermajority **\n");
                 results = NN::ExecuteDotNetStringFunction("ResolveCurrentDiscrepancies",neural_contract);
                  if (fDebug && !results.empty()) LogPrintf("Quorum Resolution: %s \n",results);

--- a/src/neuralnet.cpp
+++ b/src/neuralnet.cpp
@@ -49,11 +49,6 @@ namespace NN
         return qtGetNeuralContract("");
     }
 
-    bool SetTestnetFlag(bool onTestnet)
-    {
-        return qtExecuteGenericFunction("SetTestNetFlag", onTestnet ? "TESTNET" : "MAINNET") != 0;
-    }
-
     bool SynchronizeDPOR(const std::string& data)
     {
         qtSyncWithDPORNodes(data);

--- a/src/neuralnet.h
+++ b/src/neuralnet.h
@@ -54,12 +54,6 @@ namespace NN
     std::string GetNeuralContract();
 
     //!
-    //! \brief Enable/disable testnet in neural net.
-    //! \param onTestnet New testnet flag.
-    //!
-    bool SetTestnetFlag(bool onTestnet);
-
-    //!
     //! \brief Synchronize DPOR data.
     //!
     //! Asynchronously asks the neural net to download BOINC statistic files

--- a/src/neuralnet_stub.cpp
+++ b/src/neuralnet_stub.cpp
@@ -23,11 +23,6 @@ namespace NN
         return std::string();
     }
 
-    bool SetTestnetFlag(bool onTestnet)
-    {
-        return false;
-    }
-
     bool SynchronizeDPOR(const std::string& data)
     {
         return false;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1744,10 +1744,8 @@ void ReinstantiateGlobalcom()
 
     bGlobalcomInitialized = true;
     std::string sNetworkFlag = fTestNet ? "TESTNET" : "MAINNET";
-    globalcom->dynamicCall("SetTestNetFlag(QString)", ToQstring(sNetworkFlag)).toInt();
+    globalcom->dynamicCall("SetTestNetFlag(QString)", ToQstring(sNetworkFlag));
 #endif
-
-    return;
 }
 
 void BitcoinGUI::timerfire()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -383,10 +383,8 @@ void qtSyncWithDPORNodes(std::string data)
         int result = 0;
         QString qsData = ToQstring(data);
         if (fDebug3) LogPrintf("FullSyncWDporNodes");
-        std::string testnet_flag = fTestNet ? "TESTNET" : "MAINNET";
-        double function_call = qtExecuteGenericFunction("SetTestNetFlag",testnet_flag);
         result = globalcom->dynamicCall("SyncCPIDsWithDPORNodes(Qstring)",qsData).toInt();
-        LogPrintf("Done syncing. %f %f\n",function_call,(double)result);
+        LogPrintf("Done syncing. %d\n", result);
     #endif
 }
 
@@ -1398,8 +1396,6 @@ void BitcoinGUI::miningClicked()
 
 #ifdef WIN32
     if (!bGlobalcomInitialized) return;
-    std::string testnet_flag = fTestNet ? "TESTNET" : "MAINNET";
-    double function_call = qtExecuteGenericFunction("SetTestNetFlag",testnet_flag);
     globalcom->dynamicCall("ShowMiningConsole()");
 #endif
 }
@@ -1733,19 +1729,25 @@ void ReinstantiateGlobalcom()
     // Note, on Windows, if the performance counters are corrupted, rebuild them
     // by going to an elevated command prompt and issue the command: lodctr /r
     // (to rebuild the performance counters in the registry)
-    LogPrintf("Instantiating globalcom for Windows %f",(double)0);
+    LogPrintf("Instantiating globalcom for Windows.");
     try
     {
         globalcom = new QAxObject("BoincStake.Utilization");
-        LogPrintf("Instantiated globalcom for Windows");
+        LogPrintf("Instantiated globalcom for Windows.");
     }
     catch(...)
     {
         LogPrintf("Failed to instantiate globalcom.");
+
+        return;
     }
 
     bGlobalcomInitialized = true;
+    std::string sNetworkFlag = fTestNet ? "TESTNET" : "MAINNET";
+    globalcom->dynamicCall("SetTestNetFlag(QString)", ToQstring(sNetworkFlag)).toInt();
 #endif
+
+    return;
 }
 
 void BitcoinGUI::timerfire()


### PR DESCRIPTION
Currently we set the testnet flag in various areas of code when we should only set it once. There was an issue i discovered in directly on testnet only that if you pull the hash or contract before a nn call is made with testnet flag set to testnet it actually to pull production data on testnet. this is a one way situation as the default is MAINNET in the nn code. 