### PR TITLE
Fix magnitude call issue and remove unusable limit

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1592,32 +1592,21 @@ UniValue magnitude(const UniValue& params, bool fHelp)
         throw runtime_error(
                 "magnitude <cpid>\n"
                 "\n"
-                "<cpid> -> Required to be used on mainnet\n"
+                "<cpid> -> cpid to look up\n"
                 "\n"
                 "Displays information for the magnitude of all cpids or specified in the network\n");
 
     UniValue results(UniValue::VARR);
 
-    std::string cpid = "";
+    std::string cpid;
 
-    if (params.size() > 1)
+    if (params.size() > 0)
         cpid = params[0].get_str();
 
     {
         LOCK(cs_main);
 
-        results = MagnitudeReport(cpid);
-    }
-
-    if (results.size() > 1000)
-    {
-        results.clear();
-
-        UniValue entry(UniValue::VOBJ);
-
-        entry.pushKV("Error","Magnitude report too large; try specifying the cpid : magnitude <cpid>.");
-
-        results.push_back(entry);
+        results.push_back(MagnitudeReport(cpid));
     }
 
     return results;


### PR DESCRIPTION
Fix RPC call for magnitude

* Removed limit on size of > 1000 as the magnitude report is an array and all data within that area equals to the size of 1 when returned
* Push back the Magnitude Report into results as `=` breaks this
* Fixed the params size check to >0 so that a cpid can be passed through. (this one likely my fault)

If chosen a size limit can be added in the `UniValue MagnitudeReport`section itself but Univalue seems to handle the entire list without any issues and relatively fast as well. (took 1 second exactly for full report)

TESTED ACK