### PR TITLE
Fix Winsock Warnings

### DIFF
--- a/src/appcache.cpp
+++ b/src/appcache.cpp
@@ -1,6 +1,6 @@
 #include "appcache.h"
-#include "util.h"
 #include "main.h"
+#include "util.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -54,7 +54,7 @@ void DeleteCache(const std::string& section, const std::string& key)
     if(cache == mvApplicationCache.end())
        return;
 
-    cache->second.erase(key); 
+    cache->second.erase(key);
 }
 
 std::string GetListOf(const std::string& section)

--- a/src/boinc.cpp
+++ b/src/boinc.cpp
@@ -2,11 +2,6 @@
 #include "util.h"
 
 #include <boost/filesystem.hpp>
-#ifdef WIN32
-#include <windows.h>
-#define KEY_WOW64_64KEY 0x0100
-#endif
-
 
 std::string GetBoincDataDir(){
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -25,6 +25,7 @@
 
 #include <winsock2.h>
 #include <mswsock.h>
+#include <windows.h>
 #include <ws2tcpip.h>
 #else
 #include <sys/types.h>
@@ -35,10 +36,9 @@
 #include <net/if.h>
 #include <netinet/in.h>
 #include <ifaddrs.h>
-
+#include <unistd.h>
 typedef u_int SOCKET;
 #endif
-
 
 #ifdef WIN32
 #define MSG_NOSIGNAL        0

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -6,14 +6,14 @@
 #include <openssl/evp.h>
 #include <vector>
 #include <string>
+
+#include "util.h"
+#include "crypter.h"
+#include "scrypt.h"
+
 #ifdef WIN32
 #include <windows.h>
 #endif
-
-#include "crypter.h"
-#include "scrypt.h"
-#include "util.h"
-
 
 unsigned char chKeyGridcoin[256];
 unsigned char chIVGridcoin[256];

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,9 +5,10 @@
 
 #include "db.h"
 #include "net.h"
-#include "util.h"
 #include "main.h"
 #include "ui_interface.h"
+#include "util.h"
+
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <stdint.h>

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -7,13 +7,13 @@
 #include "config/gridcoin-config.h"
 #endif
 
-#include "rpcserver.h"
-#include "rpcclient.h"
+#include "util.h"
+#include "net.h"
 #include "txdb.h"
 #include "walletdb.h"
-#include "net.h"
 #include "init.h"
-#include "util.h"
+#include "rpcserver.h"
+#include "rpcclient.h"
 #include "ui_interface.h"
 
 #include <boost/thread.hpp>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2,12 +2,14 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+#include "util.h"
+#include "net.h"
 #include "txdb.h"
 #include "walletdb.h"
 #include "rpcserver.h"
-#include "net.h"
 #include "init.h"
-#include "util.h"
 #include "ui_interface.h"
 #include "tally.h"
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -5,8 +5,8 @@
 
 #include "kernel.h"
 #include "txdb.h"
-#include "util.h"
 #include "main.h"
+#include "util.h"
 
 bool IsCPIDValidv2(MiningCPID& mc,int height);
 using namespace std;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,18 +3,18 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "util.h"
+#include "net.h"
 #include "alert.h"
 #include "checkpoints.h"
 #include "db.h"
 #include "txdb.h"
-#include "net.h"
 #include "init.h"
 #include "ui_interface.h"
 #include "kernel.h"
 #include "block.h"
 #include "scrypt.h"
 #include "global_objects_noui.hpp"
-#include "util.h"
 #include "cpid.h"
 #include "rpcserver.h"
 #include "rpcclient.h"

--- a/src/main.h
+++ b/src/main.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_MAIN_H
 #define BITCOIN_MAIN_H
 
-#include "sync.h"
+#include "util.h"
 #include "net.h"
+#include "sync.h"
 #include "script.h"
 #include "scrypt.h"
-#include "util.h"
 
 #include "global_objects_noui.hpp"
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -8,11 +8,11 @@
 #include "miner.h"
 #include "kernel.h"
 #include "cpid.h"
-#include "util.h"
 #include "main.h"
 #include "appcache.h"
 #include "neuralnet.h"
 #include "contract/contract.h"
+#include "util.h"
 
 #include <memory>
 

--- a/src/net.h
+++ b/src/net.h
@@ -11,15 +11,14 @@
 #include <atomic>
 #include <openssl/rand.h>
 
+#include "netbase.h"
+#include "mruset.h"
+#include "protocol.h"
+#include "addrman.h"
 
 #ifndef WIN32
 #include <arpa/inet.h>
 #endif
-
-#include "mruset.h"
-#include "netbase.h"
-#include "protocol.h"
-#include "addrman.h"
 
 #include "gridcoin.h"
 class CRequestTracker;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 
-#include "serialize.h"
 #include "compat.h"
+#include "serialize.h"
 
 extern int nConnectTimeout;
 extern bool fNameLookup;

--- a/src/neuralnet.cpp
+++ b/src/neuralnet.cpp
@@ -1,7 +1,7 @@
 #include "neuralnet.h"
-#include "util.h"
 #include "version.h"
 #include "sync.h"
+#include "util.h"
 
 #include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -3,9 +3,9 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "netbase.h"
 #include "protocol.h"
 #include "util.h"
-#include "netbase.h"
 
 #ifndef WIN32
 # include <arpa/inet.h>

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -10,8 +10,8 @@
 #ifndef __INCLUDED_PROTOCOL_H__
 #define __INCLUDED_PROTOCOL_H__
 
-#include "serialize.h"
 #include "netbase.h"
+#include "serialize.h"
 #include <string>
 #include "uint256.h"
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -11,11 +11,12 @@
 #include "walletmodel.h"
 #include "optionsmodel.h"
 #include "guiutil.h"
-#include "util.h"
 #include "guiconstants.h"
 #include "init.h"
 #include "ui_interface.h"
 #include "qtipcserver.h"
+#include "util.h"
+
 #include <QMessageBox>
 #include <QTextCodec>
 #include <QLocale>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -18,7 +18,6 @@
 // include <QtSql> // Future Use
 
 #include <fstream>
-#include "util.h"
 
 #include "bitcoingui.h"
 #include "transactiontablemodel.h"
@@ -95,6 +94,8 @@
 #include <iostream>
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include "boinc.h"
+#include "util.h"
+
 
 extern CWallet* pwalletMain;
 int ReindexWallet();

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -1,7 +1,7 @@
 #include "main.h"
-#include "util.h"
 #include "boinc.h"
 #include "appcache.h"
+#include "util.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -1,9 +1,9 @@
 #include "optionsdialog.h"
 #include "ui_optionsdialog.h"
 
+#include "netbase.h"
 #include "bitcoinunits.h"
 #include "monitoreddatamapper.h"
-#include "netbase.h"
 #include "optionsmodel.h"
 
 #include <QDir>

--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -1,8 +1,8 @@
 #include "transactiondescdialog.h"
+#include "transactiontablemodel.h"
 #include "ui_transactiondescdialog.h"
 #include "main.h"
 #include "util.h"
-#include "transactiontablemodel.h"
 #include <QMessageBox>
 #include <QModelIndex>
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -12,7 +12,6 @@
 #include "block.h"
 #include "txdb.h"
 #include "beacon.h"
-#include "util.h"
 #include "neuralnet.h"
 #include "grcrestarter.h"
 #include "backup.h"
@@ -20,6 +19,7 @@
 #include "tally.h"
 #include "contract/polls.h"
 #include "contract/contract.h"
+#include "util.h"
 
 #include <boost/filesystem.hpp>
 #include <iostream>

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -4,7 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "init.h"
-#include "util.h"
 #include "sync.h"
 #include "ui_interface.h"
 #include "base58.h"
@@ -12,6 +11,7 @@
 #include "rpcclient.h"
 #include "rpcserver.h"
 #include "db.h"
+#include "util.h"
 
 // #undef printf
 #include <set>

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -11,8 +11,8 @@
 #include "block.h"
 #include "txdb.h"
 #include "beacon.h"
-#include "util.h"
 #include "appcache.h"
+#include "util.h"
 
 #include <boost/filesystem.hpp>
 #include <iostream>

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "net.h"
 #include "rpcserver.h"
 #include "rpcprotocol.h"
 #include "alert.h"
 #include "wallet.h"
 #include "db.h"
 #include "walletdb.h"
+#include "net.h"
 
 using namespace std;
 extern std::string NeuralRequest(std::string MyNeuralRequest);

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -4,12 +4,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "init.h"
-#include "util.h"
 #include "sync.h"
 #include "ui_interface.h"
 #include "rpcprotocol.h"
 #include "base58.h"
 #include "db.h"
+#include "util.h"
 
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -4,7 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "init.h"
-#include "util.h"
 #include "sync.h"
 #include "ui_interface.h"
 #include "base58.h"
@@ -12,6 +11,7 @@
 #include "rpcclient.h"
 #include "rpcprotocol.h"
 #include "db.h"
+#include "util.h"
 
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -14,8 +14,8 @@ class CBlockIndex;
 #include <univalue.h>
 
 #include "global_objects_noui.hpp"
-#include "util.h"
 #include "checkpoints.h"
+#include "util.h"
 
 void StartRPCThreads();
 void StopRPCThreads();

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -11,8 +11,8 @@
 #include "rpcprotocol.h"
 #include "init.h"
 #include "base58.h"
-#include "util.h"
 #include "backup.h"
+#include "util.h"
 
 #include <univalue.h>
 

--- a/src/scrypt.cpp
+++ b/src/scrypt.cpp
@@ -30,10 +30,10 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "util.h"
 #include "scrypt.h"
 #include "pbkdf2.h"
 
-#include "util.h"
 #include "net.h"
 #include "uint256.h"
 

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -15,10 +15,10 @@
 
 #include "kernel.h"
 #include "txdb.h"
-#include "util.h"
 #include "main.h"
 #include "block.h"
 #include "ui_interface.h"
+#include "util.h"
 
 using namespace std;
 using namespace boost;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,12 +3,12 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
+#include "netbase.h" // for AddTimeData
 #include "sync.h"
 #include "strlcpy.h"
 #include "version.h"
-#include "netbase.h" // for AddTimeData
 #include "ui_interface.h"
+#include "util.h"
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>  //For day of year

--- a/src/util.h
+++ b/src/util.h
@@ -9,14 +9,6 @@
 #include "uint256.h"
 #include "fwd.h"
 
-#ifndef WIN32
-#include <sys/types.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#else
-#include <windows.h> // For LARGE_INTEGER
-#endif
-
 #include <map>
 #include <vector>
 #include <string>
@@ -33,9 +25,16 @@
 #include <openssl/sha.h>
 #include <openssl/ripemd.h>
 
+#include <compat.h>
 #include "fwd.h"
 #include "serialize.h"
 #include "tinyformat.h"
+
+#ifndef WIN32
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#endif
 
 // to obtain PRId64 on some old systems
 #define __STDC_FORMAT_MACROS 1

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -18,11 +18,11 @@
 #include "rpcserver.h"
 #include "rpcclient.h"
 #include "rpcprotocol.h"
-#include "util.h"
 #include "grcrestarter.h"
 #include <boost/variant/apply_visitor.hpp>
 #include <script.h>
 #include "main.h"
+#include "util.h"
 
 using namespace std;
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -12,8 +12,8 @@
 #include "keystore.h"
 #include "script.h"
 #include "ui_interface.h"
-#include "util.h"
 #include "walletdb.h"
+#include "util.h"
 
 extern bool fWalletUnlockStakingOnly;
 extern bool fConfChange;


### PR DESCRIPTION
Reorder header includes to ensure that winsock2.h is always included
before windows.h . Also gets rid of redundant includes in crypter.cpp,
boinc.cpp and util.h .