### PR TITLE
Change from AddContract/AddMessage to SendContract/SendMessage

### DIFF
--- a/src/contract/contract.cpp
+++ b/src/contract/contract.cpp
@@ -64,7 +64,7 @@ std::string SignMessage(std::string sMsg, std::string sPrivateKey)
     return SignedMessage;
 }
 
-std::string AddMessage(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue,
+std::string SendMessage(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue,
                        std::string sMasterKey, int64_t MinimumBalance, double dFees, std::string strPublicKey)
 {
     std::string sAddress = GetBurnAddress();
@@ -88,10 +88,10 @@ std::string AddMessage(bool bAdd, std::string sType, std::string sPrimaryKey, st
     return wtx.GetHash().GetHex().c_str();
 }
 
-std::string AddContract(std::string sType, std::string sName, std::string sContract)
+std::string SendContract(std::string sType, std::string sName, std::string sContract)
 {
     std::string sPass = (sType=="project" || sType=="projectmapping" || sType=="smart_contract") ? GetArgument("masterprojectkey", msMasterMessagePrivateKey) : msMasterMessagePrivateKey;
-    std::string result = AddMessage(true,sType,sName,sContract,sPass,AmountFromValue(1),.00001,"");
+    std::string result = SendMessage(true,sType,sName,sContract,sPass,AmountFromValue(1),.00001,"");
     return result;
 }
 

--- a/src/contract/contract.h
+++ b/src/contract/contract.h
@@ -1,7 +1,7 @@
 #pragma once
 
-std::string AddContract(std::string sType, std::string sName, std::string sContract);
-std::string AddMessage(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue,
+std::string SendContract(std::string sType, std::string sName, std::string sContract);
+std::string SendMessage(bool bAdd, std::string sType, std::string sPrimaryKey, std::string sValue,
                     std::string sMasterKey, int64_t MinimumBalance, double dFees, std::string strPublicKey);
 std::string GetBurnAddress();
 std::string SignMessage(std::string sMsg, std::string sPrivateKey);

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -59,7 +59,7 @@ std::pair<std::string, std::string> CreatePollContract(std::string sTitle, int d
             {
                 std::string expiration = RoundToString(GetAdjustedTime() + (days*86400), 0);
                 std::string contract = "<TITLE>" + sTitle + "</TITLE><DAYS>" + std::to_string(days) + "</DAYS><QUESTION>" + sQuestion + "</QUESTION><ANSWERS>" + sAnswers + "</ANSWERS><SHARETYPE>" + std::to_string(iSharetype) + "</SHARETYPE><URL>" + sURL + "</URL><EXPIRATION>" + expiration + "</EXPIRATION>";
-                std::string result = AddContract("poll", sTitle, contract);
+                std::string result = SendContract("poll", sTitle, contract);
                 return std::make_pair("Success",result);
             }
         }
@@ -135,7 +135,7 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
         voter += GetProvableVotingWeightXML();
         std::string pk = sTitle + ";" + GRCAddress + ";" + GlobalCPUMiningCPID.cpid;
         std::string contract = "<TITLE>" + sTitle + "</TITLE><ANSWER>" + sAnswer + "</ANSWER>" + voter;
-        std::string result = AddContract("vote",pk,contract);
+        std::string result = SendContract("vote",pk,contract);
         std::string narr = "Your CPID weight is " + RoundToString(dmag,0) + " and your Balance weight is " + RoundToString(nBalance,0) + ".";
         return std::make_pair("Success", narr + " " + "Your vote has been cast for topic " + sTitle + ": With an Answer of " + sAnswer + ": " + result.c_str());
     }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -888,7 +888,7 @@ bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::str
             }
 
             // Send the beacon transaction
-            sMessage = AddContract(sType,sName,sBase);
+            sMessage = SendContract(sType,sName,sBase);
             // This prevents repeated beacons
             nLastBeaconAdvertised = nBestHeight;
             // Activate Beacon Keys in memory. This process is not automatic and has caused users who have a new keys while old ones exist in memory to perform a restart of wallet.
@@ -1841,7 +1841,7 @@ UniValue addkey(const UniValue& params, bool fHelp)
     res.pushKV("Name", sName);
     res.pushKV("Value", sValue);
 
-    std::string result = AddMessage(bAdd, sType, sName, sValue, sPass, AmountFromValue(5), .1, "");
+    std::string result = SendMessage(bAdd, sType, sName, sValue, sPass, AmountFromValue(5), .1, "");
 
     res.pushKV("Results", result);
 


### PR DESCRIPTION
Addresses ISSUE #1180 

After this is merged I plan to clean up the contract/poll files a bit as we copy a lot in function calls when we should `const std::string&`