### PR TITLE
GetBalance fix

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1202,7 +1202,7 @@ int64_t CWallet::GetBalance() const
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
-            if (pcoin->IsTrusted() && pcoin->IsConfirmed())
+            if (pcoin->IsTrusted() && (pcoin->IsConfirmed() || pcoin->fFromMe))
                 nTotal += pcoin->GetAvailableCredit();
         }
     }


### PR DESCRIPTION
Here is a simple fix to issue #1175 

What happened in GUI is we check if `IsTrusted()` which in the case where if the input `fFromMe` its automatically trusted as it in a in wallet transaction only allowing u to use those inputs without the minimum required confirmations.

With `sendtoaddress` it pulls data from `GetBalance()`

In `GetBalance()` it does use `IsTrusted()` but also checks is `IsConfirmed()` (requires 10 confirmations to be true) this breaks the rule allowance from `IsTrusted()` resulting in the issue quez had in #1175 . The fix is to use `(pcoin->IsConfirmed() || pcoin->fFromMe)` which respects the 10 confirmation required from received transactions from outside the wallet while respecting the in wallet -> in wallet transactions.

This could also explain the occasional erroneous balance numbers when the case of available balance + unconfirmed balance != Total Balance. As unconfirmed does not include fFromMe as the rule considers it trusted as it is in-wallet->in-wallet transaction. and Available Balance did not show the right value as it did not include the in-wallet->in-wallet transaction.

Ive tested both scenarios with complete success.

1) sent a tx to my test wallet and tried to `sendtoaddress` with that being less then 10 confirmations and resulted in a fail.
2) sent a tx in-wallet -> in-wallet with less the 3 confirmations and worked correctly as it should
3) `getbalance` rpc now shows the available balance in wallet properly to include if it is a in-wallet->in-wallet transaction while respecting incoming transactions from foreign addresses as unconfirmed. and gui balance shows correctly as well now.