### PR TITLE
Fix macdeploy

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -426,7 +426,7 @@ def deployPlugins(appBundleInfo, deploymentInfo, strip, verbose):
             elif pluginPath == "imageformats/libqsvg.dylib" or pluginPath == "iconengines/libqsvgicon.dylib":
                 # Deploy the svg plugins only if QtSvg is in use
                 if not deploymentInfo.usesFramework("QtSvg"):
-                    continue
+                    print("Ignore non existing framework for svg, just get the plugin")
             elif pluginPath == "accessible/libqtaccessiblecompatwidgets.dylib":
                 # Deploy accessibility for Qt3Support only if the Qt3Support is in use
                 if not deploymentInfo.usesFramework("Qt3Support"):


### PR DESCRIPTION
Instead of going the hard way and finding out why the SVG framework is
not correctly found, macdeployqtplus always links in the svg plugin now.