### PR TITLE
Compute research accrual annoyance

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2126,11 +2126,8 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
     else
     {
             // Research Age Subsidy - PROD
-            int64_t nBoinc = 0;
+            int64_t nBoinc = ComputeResearchAccrual(nTime, cpid, operation, pindexLast, VerifyingBlock, VerificationPhase, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
             int64_t nInterest = 0;
-
-            if (IsResearcher(cpid))
-                nBoinc = ComputeResearchAccrual(nTime, cpid, operation, pindexLast, VerifyingBlock, VerificationPhase, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
 
             // TestNet: For any subsidy < 30 day duration, ensure 100% that we have a start magnitude and an end magnitude, otherwise make subsidy 0 : PASS
             // TestNet: For any subsidy > 30 day duration, ensure 100% that we have a midpoint magnitude in Every Period, otherwise, make subsidy 0 : In Test as of 09-06-2015
@@ -8432,6 +8429,10 @@ double GRCMagnitudeUnit(int64_t locktime)
 
 int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string operation, CBlockIndex* pindexLast, bool bVerifyingBlock, int iVerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude)
 {
+    // If not a researcher save cpu cycles and return 0
+    if (!IsResearcher(cpid))
+        return 0;
+
     double dCurrentMagnitude = CalculatedMagnitude2(cpid, nTime, false);
     if(pindexLast->nVersion>=9)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2126,8 +2126,11 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
     else
     {
             // Research Age Subsidy - PROD
-            int64_t nBoinc = ComputeResearchAccrual(nTime, cpid, operation, pindexLast, VerifyingBlock, VerificationPhase, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
+            int64_t nBoinc = 0;
             int64_t nInterest = 0;
+
+            if (IsResearcher(cpid))
+                nBoinc = ComputeResearchAccrual(nTime, cpid, operation, pindexLast, VerifyingBlock, VerificationPhase, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
 
             // TestNet: For any subsidy < 30 day duration, ensure 100% that we have a start magnitude and an end magnitude, otherwise make subsidy 0 : PASS
             // TestNet: For any subsidy > 30 day duration, ensure 100% that we have a midpoint magnitude in Every Period, otherwise, make subsidy 0 : In Test as of 09-06-2015

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -88,8 +88,6 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
 
     if (IsResearcher(msPrimaryCPID))
     {
-        obj.pushKV("RSAWeight",GetRSAWeightByCPID(msPrimaryCPID));
-
         {
             double dMagnitudeUnit = GRCMagnitudeUnit(nTime);
             double dAccrualAge,AvgMagnitude;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -85,14 +85,18 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.pushKV("MyNeuralHash", NN::GetNeuralHash());
 
     obj.pushKV("CPID",msPrimaryCPID);
-    obj.pushKV("RSAWeight",GetRSAWeightByCPID(msPrimaryCPID));
 
+    if (IsResearcher(msPrimaryCPID))
     {
-        double dMagnitudeUnit = GRCMagnitudeUnit(nTime);
-        double dAccrualAge,AvgMagnitude;
-        int64_t nBoinc = ComputeResearchAccrual(nTime, msPrimaryCPID, "getmininginfo", pindexBest, false, 69, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
-        obj.pushKV("Magnitude Unit",dMagnitudeUnit);
-        obj.pushKV("BoincRewardPending",nBoinc/(double)COIN);
+        obj.pushKV("RSAWeight",GetRSAWeightByCPID(msPrimaryCPID));
+
+        {
+            double dMagnitudeUnit = GRCMagnitudeUnit(nTime);
+            double dAccrualAge,AvgMagnitude;
+            int64_t nBoinc = ComputeResearchAccrual(nTime, msPrimaryCPID, "getmininginfo", pindexBest, false, 69, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
+            obj.pushKV("Magnitude Unit",dMagnitudeUnit);
+            obj.pushKV("BoincRewardPending",nBoinc/(double)COIN);
+        }
     }
 
     obj.pushKV("MiningInfo 1", msMiningErrors);


### PR DESCRIPTION
Since `INVESTOR` has no beacon in blockchain some changes should be done.

First currently in `main.cpp` we calculate the `nBoinc = ComputeResearchAccrual();`
We do this for investors too even thou the end result is returned as 0 as they are not a researcher.
This current spams `INVALID BEACON` messages for investors as well in debug.log for each investor block.

Since the result is 0, lets not waste cpu cycles calculating magnitude, searching for a beacon timestamp of INVESTOR, etc.

Here we set `nBoinc = 0`, however if they are a researcher we set `nBoinc` to `ComputerResearchAccrual();` else will continue as to the same affect as if the return of 0 would be from `ComputerResearchAccrual();`

From my time checks the average `ComputeResearchAccrual()` call takes around 65 microseconds on my dev laptop before this change.
With this change for investor blocks it takes 4 microseconds so a savings of around 60 microseconds for said block.

It is a small improvement but adds up in the long run.

Next in `getmininginfo` rpc in `rpcmining.cpp` we check the `ComputeResearchAccrual()` as well for `INVESTORS` and again is a waste of cpu cycles. so I opted for the proposed change in `rpcmining.cpp` imo it makes sense to not display researcher information for investors also a small increase in response time.