### PR TITLE
Config to start bv10 block production

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -845,8 +845,11 @@ bool IsMiningAllowed(CWallet *pwallet)
     return status;
 }
 
+volatile int startBV10;
+
 void StakeMiner(CWallet *pwallet)
 {
+    startBV10= GetBoolArg("-startv10", false);
 
     // Make this thread recognisable as the mining thread
     RenameThread("grc-stake-miner");
@@ -873,6 +876,10 @@ void StakeMiner(CWallet *pwallet)
                 StakeBlock.nVersion = 9;
             if(pindexPrev->nVersion == 10)
                 StakeBlock.nVersion = 10;
+            if(startBV10)
+            {
+                StakeBlock.nVersion = 10;
+            }
 
             MinerStatus.Version= StakeBlock.nVersion;
         }


### PR DESCRIPTION
Temporary way to start block version 10.
Enable with cmdline `-startv10=1` or `startv10=1` in config.
Default disabled.