### PR TITLE
CPID rpc issue fixes/changes

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1228,7 +1228,7 @@ UniValue cpids(const UniValue& params, bool fHelp)
                 "\n"
                 "Displays information on your cpids\n");
 
-    UniValue res(UniValue::VOBJ);
+    UniValue res(UniValue::VARR);
 
     //Dump vectors:
 
@@ -1248,16 +1248,19 @@ UniValue cpids(const UniValue& params, bool fHelp)
         {
             if ((GlobalCPUMiningCPID.cpid.length() > 3 &&
                  structcpid.cpid == GlobalCPUMiningCPID.cpid)
-                || !IsResearcher(structcpid.cpid) || !IsResearcher(GlobalCPUMiningCPID.cpid))
+                || IsResearcher(structcpid.cpid) || IsResearcher(GlobalCPUMiningCPID.cpid))
             {
-                res.pushKV("Project",structcpid.projectname);
-                res.pushKV("CPID",structcpid.cpid);
-                res.pushKV("RAC",structcpid.rac);
-                res.pushKV("Team",structcpid.team);
-                res.pushKV("CPID Link",structcpid.link);
-                res.pushKV("Debug Info",structcpid.errors);
-                res.pushKV("Project Settings Valid for Gridcoin",structcpid.Iscpidvalid);
+                UniValue entry(UniValue::VOBJ);
 
+                entry.pushKV("Project",structcpid.projectname);
+                entry.pushKV("CPID",structcpid.cpid);
+                entry.pushKV("RAC",structcpid.rac);
+                entry.pushKV("Team",structcpid.team);
+                entry.pushKV("CPID Link",structcpid.link);
+                entry.pushKV("Debug Info",structcpid.errors);
+                entry.pushKV("Project Settings Valid for Gridcoin",structcpid.Iscpidvalid);
+
+                res.push_back(entry);
             }
         }
     }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1742,7 +1742,7 @@ UniValue validcpids(const UniValue& params, bool fHelp)
         {
             if (structcpid.cpid == GlobalCPUMiningCPID.cpid || !IsResearcher(structcpid.cpid))
             {
-                if (structcpid.verifiedteam == "gridcoin")
+                if (structcpid.team == "gridcoin")
                 {
                     UniValue entry(UniValue::VOBJ);
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1749,7 +1749,6 @@ UniValue validcpids(const UniValue& params, bool fHelp)
                     entry.pushKV("Project", structcpid.projectname);
                     entry.pushKV("CPID", structcpid.cpid);
                     entry.pushKV("CPIDhash", structcpid.cpidhash);
-                    entry.pushKV("Email", structcpid.emailhash);
                     entry.pushKV("UTC", structcpid.utc);
                     entry.pushKV("RAC", structcpid.rac);
                     entry.pushKV("Team", structcpid.team);


### PR DESCRIPTION
* Use VARR to push VOBJ when returning data from rpc `cpids`

* rpc `validcpids` -> Check for `.team` not `.verifiedteam` since we do not verify team nor populate that field under certain circumstances. The Neural network deals with making sure the superblock contains only rewards from team members.
* Remove emailhash field that is no longer populated.

Between both:

Correct the IsResearcher() conditions as in rare cases if an investor ran it they would get blank replies instead of no reply.