### PR TITLE
Implement a rain by magnitude rpc command

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1177,7 +1177,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
     res.pushKV("TXID", wtx.GetHash().GetHex());
     res.pushKV("Rain Amount Sent", dTotalAmount);
     res.pushKV("TX Fee", ((double)nFeeRequired) / COIN);
-    res.pushKV("# of Recipients", vecSend.size());
+    res.pushKV("# of Recipients", (uint64_t)vecSend.size());
 
     if (!sMessage.empty())
         res.pushKV("Message", sMessage);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1056,6 +1056,135 @@ UniValue rain(const UniValue& params, bool fHelp)
     return res;
 }
 
+UniValue rainbymagnitude(const UniValue& params, bool fHelp)
+{
+    if (fHelp || (params.size() < 1 || params.size() > 2))
+        throw runtime_error(
+                "rainbymagnitude <amount> [message]\n"
+                "\n"
+                "<amount> --> Required: Specify amount of coints in double to be rained\n"
+                "[message] -> Optional: Provide a message rained to all rainees\n"
+                "\n"
+                "rain coins by magnitude on network");
+
+    UniValue res(UniValue::VOBJ);
+
+    double dAmount = params[0].get_real();
+
+    if (dAmount <= 0)
+        throw runtime_error("Amount must be greater then 0");
+
+    std::string sMessage = "";
+
+    if (params.size() > 1)
+        sMessage = params[1].get_str();
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CWalletTx wtx;
+    wtx.mapValue["comment"] = "Rain By Magnitude";
+    std::set<CBitcoinAddress> setAddress;
+    std::vector<std::pair<CScript, int64_t> > vecSend;
+
+    wtx.hashBoinc = "<NARR>Rain By Magnitude: " + MakeSafeMessage(sMessage) + "</NARR>";
+
+    // Gather Magnitude data
+    std::string sSuperblock = ReadCache("superblock", "magnitudes").value;
+
+    if (sSuperblock.empty())
+        throw runtime_error("Unable to load superblock data");
+
+    std::vector<std::string> vSuperblock = split(sSuperblock, ";");
+
+    double dTotalAmount = 0;
+    int64_t nTotalAmount = 0;
+
+    StructCPID structcpid = mvNetwork["NETWORK"];
+
+    // Use total network magnitude here as using 115000 can results in a lower then intended sent amount due to a missing project
+    double dTotalNetworkMagnitude = structcpid.NetworkMagnitude;
+
+    for (unsigned int i = 0; i < vSuperblock.size(); i++)
+    {
+        if (vSuperblock[i].length() > 1)
+        {
+            // Find GRC address in beacon
+            std::string sCPID = ExtractValue(vSuperblock[i], ",", 0);
+            double dMagnitude = RoundFromString(ExtractValue(vSuperblock[i], ",", 1), 0);
+
+            // No magnitude means no value to be rained on
+            if (dMagnitude == 0)
+                continue;
+
+            std::string scacheContract = ReadCache("beacon", sCPID).value;
+
+            // Should never occur but we know seg faults can occur in some cases
+            if (scacheContract.empty())
+                continue;
+
+            std::string sContract = DecodeBase64(scacheContract);
+            std::string sGRCAddress = ExtractValue(sContract, ";", 2);
+
+            double dPayout = Round(((dMagnitude / dTotalNetworkMagnitude) * dAmount), 4);
+            dTotalAmount += dPayout;
+
+            CBitcoinAddress address(sGRCAddress);
+
+            if (!address.IsValid())
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Gridcoin address: ") + sGRCAddress);
+
+            setAddress.insert(address);
+
+            CScript scriptPubKey;
+            scriptPubKey.SetDestination(address.Get());
+            int64_t nAmount = roundint64(dPayout * COIN);
+            nTotalAmount += nAmount;
+            vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
+        }
+    }
+
+    EnsureWalletIsUnlocked();
+    // Check funds
+    double dBalance = GetTotalBalance();
+
+    if (dTotalAmount > dBalance)
+        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
+    // Send
+    CReserveKey keyChange(pwalletMain);
+
+    int64_t nFeeRequired = 0;
+    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired);
+
+    LogPrintf("Rain By Magnitude Transaction Created.");
+
+    if (!fCreated)
+    {
+        if (nTotalAmount + nFeeRequired > pwalletMain->GetBalance())
+            throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
+
+        throw JSONRPCError(RPC_WALLET_ERROR, "Transaction creation failed");
+    }
+
+    LogPrintf("Committing.");
+    // Rain the recipients
+    if (!pwalletMain->CommitTransaction(wtx, keyChange))
+    {
+        LogPrintf("Rain By Magnitude Commit failed.");
+
+        throw JSONRPCError(RPC_WALLET_ERROR, "Transaction commit failed");
+    }
+    res.pushKV("Rain By Magnitude",  "Sent");
+    res.pushKV("TXID", wtx.GetHash().GetHex());
+    res.pushKV("Rain Amount Sent", dTotalAmount);
+    res.pushKV("TX Fee", ((double)nFeeRequired) / COIN);
+    res.pushKV("# of Recipients", vecSend.size());
+
+    if (!sMessage.empty())
+        res.pushKV("Message", sMessage);
+
+    return res;
+}
+
 UniValue unspentreport(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -135,6 +135,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listunspent"            , 2 },
     { "move"                   , 2 },
     { "move"                   , 3 },
+    { "rainbymagnitude"        , 0 },
     { "reservebalance"         , 0 },
     { "reservebalance"         , 1 },
     { "sendfrom"               , 2 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -314,6 +314,7 @@ static const CRPCCommand vRPCCommands[] =
     { "move",                    &movecmd,                 false,  cat_wallet        },
     { "newburnaddress",          &newburnaddress,          false,  cat_wallet        },
     { "rain",                    &rain,                    false,  cat_wallet        },
+    { "rainbymagnitude",         &rainbymagnitude,         false,  cat_wallet        },
     { "repairwallet",            &repairwallet,            false,  cat_wallet        },
     { "resendtx",                &resendtx,                false,  cat_wallet        },
     { "reservebalance",          &reservebalance,          false,  cat_wallet        },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -141,6 +141,7 @@ extern UniValue makekeypair(const UniValue& params, bool fHelp);
 extern UniValue movecmd(const UniValue& params, bool fHelp);
 extern UniValue newburnaddress(const UniValue& params, bool fHelp);
 extern UniValue rain(const UniValue& params, bool fHelp);
+extern UniValue rainbymagnitude(const UniValue& params, bool fHelp);
 extern UniValue repairwallet(const UniValue& params, bool fHelp);
 extern UniValue resendtx(const UniValue& params, bool fHelp);
 extern UniValue reservebalance(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Addresses #1213 For raining on all magnitudes on the network.

Add optional message as well.

Opted to keep this contained in the RPC function rather then forming for executeRain.

Tested on testnet with success.
Note: Tx Fee is not taken into account with the amount specified as the fee is calculated after the transaction is made. I don't see a need to estimate and calculate that before hand.

rainbymagnitude 100018:14:42
{
"Rain By Magnitude": "Sent",
"TXID": "8e06e0afb13460e972f5f08c5a03eb41ed789783d608a92611ef816523c3fd29",
"Rain Amount Sent": 1000,
"TX Fee": 0.0002,
"# of Recipients": 29
}

18:19:15
rainbymagnitude 3880 "Does this suffice Jim"18:19:16
{
"Rain By Magnitude": "Sent",
"TXID": "c035dec2f6c84a45e5960c7ef28ae95504b56acce791a7254e229955bb55be90",
"Rain Amount Sent": 3879.9998,
"TX Fee": 0.0002,
"# of Recipients": 29,
"Message": "Does this suffice Jim"
}