### PR TITLE
Catch exception for JSON to prevent runaway exception when NN calling executeRain function

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -50,6 +50,7 @@
 #include "main.h"
 #include "backup.h"
 #include "clicklabel.h"
+#include "univalue.h"
 
 #ifdef Q_OS_MAC
 #include "macdockiconhandler.h"
@@ -1569,24 +1570,30 @@ void BitcoinGUI::timerfire()
 
         if (bGlobalcomInitialized)
         {
-                //R Halford - Allow .NET to talk to Core: 6-21-2015
-                #ifdef WIN32
-                    std::string sData = qtExecuteDotNetStringFunction("GetDotNetMessages","");
-                    if (!sData.empty())
-                    {
-                        std::string RPCCommand = ExtractXML(sData,"<COMMAND>","</COMMAND>");
-                        std::string Argument1 = ExtractXML(sData,"<ARG1>","</ARG1>");
-                        std::string Argument2 = ExtractXML(sData,"<ARG2>","</ARG2>");
+            //R Halford - Allow .NET to talk to Core: 6-21-2015
+            #ifdef WIN32
+                std::string sData = qtExecuteDotNetStringFunction("GetDotNetMessages","");
+                if (!sData.empty())
+                {
+                    std::string RPCCommand = ExtractXML(sData,"<COMMAND>","</COMMAND>");
+                    std::string Argument1 = ExtractXML(sData,"<ARG1>","</ARG1>");
+                    std::string Argument2 = ExtractXML(sData,"<ARG2>","</ARG2>");
 
-                        if (RPCCommand=="rain")
+                    if (RPCCommand=="rain")
+                    {
+                        try
                         {
                             std::string response = executeRain(Argument1+Argument2);
-                            double resultcode = qtExecuteGenericFunction("SetRPCResponse"," "+response);
+                            qtExecuteGenericFunction("SetRPCResponse"," "+response);
+                        }
+                        catch (const UniValue& objError)
+                        {
+                            qtExecuteGenericFunction("SetRPCResponse", find_value(objError, "message").get_str());
                         }
                     }
-                #endif
+                }
+            #endif
         }
-
 
         if (Timer("status_update",5))
         {


### PR DESCRIPTION
@barton2526 discovered a runaway exception (which turned out to be many possible runaway exceptions) when the neural network RPC calls to do a rain on a project. The function `executeRain` throws JSON Error which is handled by univalue/json. This results in a `UniValue objError` for reply and display of information in RPC however when neural network which is not calling from the JSON RPC ends up resulting in a run away exception that causes the client to shutdown. This catch will process the same exception as the JSON RPC does and display the error in result to the Neural network client.

Possible runaways that could occur before this implementation fix:
* Insufficient balance
* Invalid gridcoin address
* Failing to create transaction
* Wallet locked
* Wallet unlocked for staking only
* Invalid parameter/duplicated address
* Transaction commit failed

This catch now handles these event successfully while providing the rpc reply to neural network with the error message.