### PR TITLE
Automatic stake UTXO splitting to optimize staking efficiency

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -31,4 +31,12 @@ struct CMinerStatus
 extern CMinerStatus MinerStatus;
 extern unsigned int nMinerSleep;
 
+// Note the below constant controls the minimum value allowed for post
+// split UTXO size. It is int64_t but in GRC so that it matches the entry in the config file.
+// It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
+static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
+
+void SplitCoinStakeOutput(CBlock &blocknew);
+unsigned int GetNumberOfStakeOutputs(int64_t nValue);
+
 #endif // NOVACOIN_MINER_H


### PR DESCRIPTION
This PR implements three conf file parameters:

minstakesplitvalue
enablestakesplit
stakingefficiency

enablestakesplit=1 will enable the automatic splitting of UTXO's in the coinstake transaction (stake outputs). Zero is the default (disabled).

stakingefficiency=xx is an integer that specifies the desired staking efficiency. This is constrained by the code to be between 75% and 98%, in case someone puts some nonsense value in there.

minstakesplitvalue=xxx is an integer that specifies the minimum UTXO size desired post split to provide a secondary control on UTXO size. If difficulty drops and a high efficiency is specified, the efficiency alone may split UTXO's into amounts smaller than the user desires. This will prevent that from occurring. If a user specifies less than 800 GRC, then the code uses 800 GRC. Note that the stake splitter uses a 160 block averaging interval for calculating the difficulty to smooth out the difficulty swings.

The code is implemented as a modification to the UTXO push at the end of the CreateCoinStake, and the addition of the Gridcoin reward to the UTXO(s) at the end of CreateGridcoinReward. Note that the code can handle an n-way UTXO split in the case of giant UTXO's that need to be split more than 2-way, but there is a current limit placed of 2-way because of the limitation of the number of Coinstake outputs in AcceptBlock. This may be changed in the future.

This addresses issue #1240.

This PR is already staking successfully on testnet with my testnet Windows node.