### PR TITLE
Remove expired polls from overview page

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -690,7 +690,22 @@ void GetGlobalStatus()
         GlobalStatusStruct.ERRperday = RoundToString(boincmagnitude * GRCMagnitudeUnit(GetAdjustedTime()),2);
         GlobalStatusStruct.project = msMiningProject;
         GlobalStatusStruct.cpid = GlobalCPUMiningCPID.cpid;
-        GlobalStatusStruct.poll = msPoll;
+
+        std::string sMessageKey = ExtractXML(msPoll, "<MK>", "</MK>");
+        std::string sPollExpiration = ExtractXML(msPoll, "<EXPIRATION>", "</EXPIRATION>");
+        // Alerts are displayed as polls but do not have an expiration
+        if(sPollExpiration.empty())
+        {
+            sPollExpiration = std::to_string(pindexBest->nTime);
+        }
+        if (stoll(sPollExpiration) >= pindexBest->nTime)
+        {
+            GlobalStatusStruct.poll = sMessageKey.substr(0,80);
+        }
+        else
+        {
+            GlobalStatusStruct.poll = "No current polls";
+        }
 
         GlobalStatusStruct.status.clear();
 
@@ -8370,14 +8385,7 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                                 fMessageLoaded = true;
                                 if (sMessageType=="poll")
                                 {
-                                        if (Contains(sMessageKey,"[Foundation"))
-                                        {
-                                                msPoll = "Foundation Poll: " + sMessageKey.substr(0,80);
-                                        }
-                                        else
-                                        {
-                                                msPoll = "Poll: " + sMessageKey.substr(0,80);
-                                        }
+                                    msPoll = msg;
                                 }
                         }
                         else if(sMessageAction=="D")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -696,8 +696,8 @@ void GetGlobalStatus()
         }
         catch (std::exception &e)
         {
-            GlobalStatusStruct.poll = "Error obtaining last poll";
-            LogPrintf("Error obtaining last poll");
+            GlobalStatusStruct.poll = _("No current polls");
+            LogPrintf("Error obtaining last poll: %s", e.what());
         }
 
         GlobalStatusStruct.status.clear();
@@ -768,7 +768,7 @@ std::string GetCurrentOverviewTabPoll()
     }
     else
     {
-        poll = "No current polls";
+        poll = _("No current polls");
     }
     return poll;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -690,7 +690,16 @@ void GetGlobalStatus()
         GlobalStatusStruct.ERRperday = RoundToString(boincmagnitude * GRCMagnitudeUnit(GetAdjustedTime()),2);
         GlobalStatusStruct.project = msMiningProject;
         GlobalStatusStruct.cpid = GlobalCPUMiningCPID.cpid;
-        GlobalStatusStruct.poll = GetPoll();
+        try
+        {
+            GlobalStatusStruct.poll = GetCurrentOverviewTabPoll();
+        }
+        catch (std::exception &e)
+        {
+            GlobalStatusStruct.poll = "Error obtaining last poll";
+            LogPrintf("Error obtaining last poll");
+        }
+
         GlobalStatusStruct.status.clear();
 
         if(MinerStatus.WeightSum)
@@ -730,7 +739,7 @@ void GetGlobalStatus()
     }
 }
 
-std::string GetPoll()
+std::string GetCurrentOverviewTabPoll()
 {
     std::string poll = "";
     std::string sMessageKey = ExtractXML(msPoll, "<MK>", "</MK>");

--- a/src/main.h
+++ b/src/main.h
@@ -260,7 +260,7 @@ bool WriteKey(std::string sKey, std::string sValue);
 double GetBlockDifficulty(unsigned int nBits);
 std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 
-std::string GetPoll();
+std::string GetCurrentOverviewTabPoll();
 
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
 // Validate researcher rewards.

--- a/src/main.h
+++ b/src/main.h
@@ -260,6 +260,8 @@ bool WriteKey(std::string sKey, std::string sValue);
 double GetBlockDifficulty(unsigned int nBits);
 std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 
+std::string GetPoll();
+
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
 // Validate researcher rewards.
 bool CheckProofOfResearch(


### PR DESCRIPTION
This is my first contribution to an open source project so please tell me if I'm doing anything wrong.
This is a fix for #1168. I moved the logic into `GetGlobalStatus` because `MemorizeMessage` is only run when a message is received, meaning users would have to restart their client for an expired poll to disappear. As a result `msPoll` now contains the entire message XML so it can be processed in `GetGlobalStatus`.
The "Poll: " and "Foundation Poll: " concats were removed because it looked silly to me.