### PR TITLE
Issue 294

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -360,4 +360,40 @@ BOOST_AUTO_TEST_CASE(util_VerifySplit3)
     BOOST_CHECK_EQUAL("",       res[0]);
 }
 
+BOOST_AUTO_TEST_CASE(util_mapArgsComparator)
+{
+    mapArgs.clear();
+
+    mapArgs["-UPPERCASE"] = "uppertest";
+    mapArgs["-MuLtIcAsE"] = "multitest";
+    mapArgs["-lowercase"] = "lowertest";
+
+    BOOST_CHECK_EQUAL(mapArgs["-UpPeRcAsE"], mapArgs["-uppercase"]);
+    BOOST_CHECK_EQUAL(mapArgs["-uppercase"], mapArgs["-UPPERCASE"]);
+    BOOST_CHECK_EQUAL(mapArgs["-multicase"], mapArgs["-multicase"]);
+    BOOST_CHECK_EQUAL(mapArgs["-MULTICASE"], mapArgs["-MuLtIcAsE"]);
+    BOOST_CHECK_EQUAL(mapArgs["-LOWERCASE"], mapArgs["-LoWeRcAsE"]);
+    BOOST_CHECK_EQUAL(mapArgs["-LoWeRcAsE"], mapArgs["-lowercase"]);
+
+    mapArgs["-modify"] = "testa";
+
+    BOOST_CHECK_EQUAL(mapArgs["-modify"], "testa");
+
+    mapArgs["-MoDiFy"] = "testb";
+
+    BOOST_CHECK_EQUAL(mapArgs["-modify"], "testb");
+    BOOST_CHECK_NE(mapArgs["-modify"], "testa");
+
+    mapArgs["-MODIFY"] = "testc";
+
+    BOOST_CHECK_EQUAL(mapArgs["-modify"], "testc");
+    BOOST_CHECK_NE(mapArgs["-modify"], "testb");
+
+    BOOST_CHECK_EQUAL(mapArgs.count("-modify"), 1);
+    BOOST_CHECK_EQUAL(mapArgs.count("-MODIFY"), 1);
+    BOOST_CHECK_EQUAL(mapArgs.count("-MoDiFy"), 1);
+
+    BOOST_CHECK_EQUAL(mapArgs.size(), 4);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,8 +63,8 @@ namespace boost {
 
 using namespace std;
 
-map<string, string> mapArgs;
-map<string, vector<string> > mapMultiArgs;
+map<string, string, mapArgscomp> mapArgs;
+map<string, vector<string>, mapArgscomp> mapMultiArgs;
 bool fDebug = false;
 bool fDebugNet = false;
 bool fDebug2 = false;
@@ -467,7 +467,7 @@ vector<unsigned char> ParseHex(const string& str)
     return ParseHex(str.c_str());
 }
 
-static void InterpretNegativeSetting(string name, map<string, string>& mapSettingsRet)
+static void InterpretNegativeSetting(string name, map<string, string, mapArgscomp>& mapSettingsRet)
 {
     // interpret -nofoo as -foo=0 (and -nofoo=0 as -foo=1) as long as -foo not set
     if (name.find("-no") == 0)
@@ -1166,8 +1166,8 @@ bool IsConfigFileEmpty()
 
 
 
-void ReadConfigFile(map<string, string>& mapSettingsRet,
-                    map<string, vector<string> >& mapMultiSettingsRet)
+void ReadConfigFile(map<string, string, mapArgscomp>& mapSettingsRet,
+                    map<string, vector<string>, mapArgscomp>& mapMultiSettingsRet)
 {
     boost::filesystem::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,8 +63,8 @@ namespace boost {
 
 using namespace std;
 
-tArgs mapArgs;
-tMultiArgs mapMultiArgs;
+ArgsMap mapArgs;
+ArgsMultiMap mapMultiArgs;
 
 bool fDebug = false;
 bool fDebugNet = false;
@@ -468,7 +468,7 @@ vector<unsigned char> ParseHex(const string& str)
     return ParseHex(str.c_str());
 }
 
-static void InterpretNegativeSetting(string name, tArgs& mapSettingsRet)
+static void InterpretNegativeSetting(string name, ArgsMap& mapSettingsRet)
 {
     // interpret -nofoo as -foo=0 (and -nofoo=0 as -foo=1) as long as -foo not set
     if (name.find("-no") == 0)
@@ -1167,8 +1167,8 @@ bool IsConfigFileEmpty()
 
 
 
-void ReadConfigFile(tArgs& mapSettingsRet,
-                    tMultiArgs& mapMultiSettingsRet)
+void ReadConfigFile(ArgsMap& mapSettingsRet,
+                    ArgsMultiMap& mapMultiSettingsRet)
 {
     boost::filesystem::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,8 +63,9 @@ namespace boost {
 
 using namespace std;
 
-map<string, string, mapArgscomp> mapArgs;
-map<string, vector<string>, mapArgscomp> mapMultiArgs;
+tArgs mapArgs;
+tMultiArgs mapMultiArgs;
+
 bool fDebug = false;
 bool fDebugNet = false;
 bool fDebug2 = false;
@@ -467,7 +468,7 @@ vector<unsigned char> ParseHex(const string& str)
     return ParseHex(str.c_str());
 }
 
-static void InterpretNegativeSetting(string name, map<string, string, mapArgscomp>& mapSettingsRet)
+static void InterpretNegativeSetting(string name, tArgs& mapSettingsRet)
 {
     // interpret -nofoo as -foo=0 (and -nofoo=0 as -foo=1) as long as -foo not set
     if (name.find("-no") == 0)
@@ -1166,8 +1167,8 @@ bool IsConfigFileEmpty()
 
 
 
-void ReadConfigFile(map<string, string, mapArgscomp>& mapSettingsRet,
-                    map<string, vector<string>, mapArgscomp>& mapMultiSettingsRet)
+void ReadConfigFile(tArgs& mapSettingsRet,
+                    tMultiArgs& mapMultiSettingsRet)
 {
     boost::filesystem::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())

--- a/src/util.h
+++ b/src/util.h
@@ -94,11 +94,11 @@ struct mapArgscomp
    }
 };
 
-typedef std::map<std::string, std::string, mapArgscomp> tArgs;
-typedef std::map<std::string, std::vector<std::string>, mapArgscomp> tMultiArgs;
+typedef std::map<std::string, std::string, mapArgscomp> ArgsMap;
+typedef std::map<std::string, std::vector<std::string>, mapArgscomp> ArgsMultiMap;
 
-extern tArgs mapArgs;
-extern tMultiArgs mapMultiArgs;
+extern ArgsMap mapArgs;
+extern ArgsMultiMap mapMultiArgs;
 
 extern bool fDebug;
 extern bool fDebugNet;
@@ -206,7 +206,7 @@ boost::filesystem::path GetPidFile();
 #ifndef WIN32
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 #endif
-void ReadConfigFile(tArgs& mapSettingsRet, tMultiArgs& mapMultiSettingsRet);
+void ReadConfigFile(ArgsMap& mapSettingsRet, ArgsMultiMap& mapMultiSettingsRet);
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -82,7 +82,6 @@ void MilliSleep(int64_t n);
 
 extern int GetDayOfYear(int64_t timestamp);
 
-
 /**
  * Allows search of mapArgs and mapMultiArgs in a case insensitive way
  */

--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <ostream>
 #include <locale>
+#include <strings.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
@@ -80,8 +81,22 @@ static const int64_t CENT = 1000000;
 void MilliSleep(int64_t n);
 
 extern int GetDayOfYear(int64_t timestamp);
-extern std::map<std::string, std::string> mapArgs;
-extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
+
+
+/**
+ * Allows search of mapArgs and mapMultiArgs in a case insensitive way
+ */
+
+struct mapArgscomp
+{
+   bool operator() (const std::string& lhs, const std::string& rhs) const
+   {
+       return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
+   }
+};
+
+extern std::map<std::string, std::string, mapArgscomp> mapArgs;
+extern std::map<std::string, std::vector<std::string>, mapArgscomp> mapMultiArgs;
 extern bool fDebug;
 extern bool fDebugNet;
 extern bool fDebug2;
@@ -188,7 +203,7 @@ boost::filesystem::path GetPidFile();
 #ifndef WIN32
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 #endif
-void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
+void ReadConfigFile(std::map<std::string, std::string, mapArgscomp>& mapSettingsRet, std::map<std::string, std::vector<std::string>, mapArgscomp>& mapMultiSettingsRet);
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
@@ -376,7 +391,6 @@ inline bool IsSwitchChar(char c)
     return c == '-';
 #endif
 }
-
 /**
  * Return string argument or default value
  *

--- a/src/util.h
+++ b/src/util.h
@@ -94,8 +94,12 @@ struct mapArgscomp
    }
 };
 
-extern std::map<std::string, std::string, mapArgscomp> mapArgs;
-extern std::map<std::string, std::vector<std::string>, mapArgscomp> mapMultiArgs;
+typedef std::map<std::string, std::string, mapArgscomp> tArgs;
+typedef std::map<std::string, std::vector<std::string>, mapArgscomp> tMultiArgs;
+
+extern tArgs mapArgs;
+extern tMultiArgs mapMultiArgs;
+
 extern bool fDebug;
 extern bool fDebugNet;
 extern bool fDebug2;
@@ -202,7 +206,7 @@ boost::filesystem::path GetPidFile();
 #ifndef WIN32
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 #endif
-void ReadConfigFile(std::map<std::string, std::string, mapArgscomp>& mapSettingsRet, std::map<std::string, std::vector<std::string>, mapArgscomp>& mapMultiSettingsRet);
+void ReadConfigFile(tArgs& mapSettingsRet, tMultiArgs& mapMultiSettingsRet);
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif


### PR DESCRIPTION
Issue #294 

After some investigating I found the least intrusive way to was to add a struct comparator for the std::map. This also works with the command line arguments as well.

I've done testing with complete success and even thrown in an overkill test case for this. (since we should be providing more test cases etc)

Examples:
1) so if you sent a -DeBuG2=true in command line it would still be picked up as debug2=true when checking the mapArgs, etc.
2) PRIMARYCPID=cpidhere is still the same as looking up PrimaryCPID=cpidhere, etc.

Allows:
Setting a key in the map in any case
Find a key in the map in any case
Count a key in the map in any case

test case passes and usage in the wallet passes.