### PR TITLE
Fix LoadAdminMessages range

### DIFF
--- a/src/beacon.h
+++ b/src/beacon.h
@@ -35,6 +35,18 @@ bool GenerateBeaconKeys(const std::string &cpid, CKey &outPrivPubKey);
 //!
 bool GetStoredBeaconPrivateKey(const std::string& cpid, CKey& outPrivPubKey);
 
+//!
+//! \brief Get maximum beacon age.
+//! \return Maximum beacon age in seconds.
+//!
+int64_t MaxBeaconAge();
+
+//!
+//! \brief Get beacon age advertise threshold.
+//! \return The point at which a beacon should be re-advertised.
+//!
+int64_t BeaconAgeAdvertiseThreshold();
+
 // Lets move more of the beacon functions out of rpcblockchain.cpp and main.cpp
 // Lets also use header space where applicable - iFoggz
 

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -37,12 +37,17 @@ CBlockIndex* BlockFinder::FindByHeight(int height)
 
 CBlockIndex* BlockFinder::FindByMinTime(int64_t time)
 {
+    // Select starting point depending on time proximity. While this is not as
+    // accurate as in the FindByHeight case it will still give us a reasonable
+    // estimate.
     CBlockIndex *index = abs(time - pindexBest->nTime) < abs(time - pindexGenesisBlock->nTime)
             ? pindexBest
             : pindexGenesisBlock;
 
     if(index != nullptr)
     {
+        // If we have a cache that's closer to target than our current index,
+        // use it.
         if(cache && abs(time - index->nTime) > abs(time - int64_t(cache->nTime)))
             index = cache;
 

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -14,18 +14,18 @@ CBlockIndex* BlockFinder::FindByHeight(int height)
     CBlockIndex *index = height < nBestHeight / 2
             ? pindexGenesisBlock
             : pindexBest;
-    
+
     if(index != nullptr)
     {
         // Use the cache if it's closer to the target than the current
         // start block.
         if (cache && abs(height - index->nHeight) > std::abs(height - cache->nHeight))
             index = cache;
-        
+
         // Traverse towards the tail.
         while (index && index->pprev && index->nHeight > height)
             index = index->pprev;
-        
+
         // Traverse towards the head.
         while (index && index->pnext && index->nHeight < height)
             index = index->pnext;
@@ -33,6 +33,30 @@ CBlockIndex* BlockFinder::FindByHeight(int height)
    
     cache = index;
     return index;  
+}
+
+CBlockIndex* BlockFinder::FindByTime(int64_t time)
+{
+    CBlockIndex *index = abs(time - pindexBest->nTime) < abs(time - pindexGenesisBlock->nTime)
+            ? pindexBest
+            : pindexGenesisBlock;
+
+    if(index != nullptr)
+    {
+        if(cache && abs(time - index->nTime) > abs(time - int64_t(cache->nTime)))
+            index = cache;
+
+        // Move back until the previous block is no longer younger than "time".
+        while(index && index->pprev && index->pprev->nTime > time)
+            index = index->pprev;
+
+        // Move forward until the current block is younger than "time".
+        while(index && index->pnext && index->nTime < time)
+            index = index->pnext;
+    }
+
+    cache = index;
+    return index;
 }
 
 void BlockFinder::Reset()

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -35,7 +35,7 @@ CBlockIndex* BlockFinder::FindByHeight(int height)
     return index;  
 }
 
-CBlockIndex* BlockFinder::FindByTime(int64_t time)
+CBlockIndex* BlockFinder::FindByMinTime(int64_t time)
 {
     CBlockIndex *index = abs(time - pindexBest->nTime) < abs(time - pindexGenesisBlock->nTime)
             ? pindexBest

--- a/src/block.h
+++ b/src/block.h
@@ -36,7 +36,7 @@ public:
     //! \return The youngest block which is not older than \p time, or the
     //! head of the chain if it is older than \p time.
     //!
-    CBlockIndex* FindByTime(int64_t time);
+    CBlockIndex* FindByMinTime(int64_t time);
     
     //!
     //! \brief Reset finder cache.

--- a/src/block.h
+++ b/src/block.h
@@ -24,6 +24,19 @@ public:
     //! \a nullptr is returned.
     //!
     CBlockIndex* FindByHeight(int height);
+
+    //!
+    //! \brief Find block by time.
+    //! 
+    //! Traverses the chain in the same way as FindByHeight() and stops at the
+    //! block which is not older than \p time, or the youngest block if it is
+    //! older than \p time.
+    //! 
+    //! \param time Block time to search for.
+    //! \return The youngest block which is not older than \p time, or the
+    //! head of the chain if it is older than \p time.
+    //!
+    CBlockIndex* FindByTime(int64_t time);
     
     //!
     //! \brief Reset finder cache.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8356,7 +8356,8 @@ bool LoadAdminMessages(bool bFullTableScan, std::string& out_errors)
     if(pindex->nHeight < (fTestNet ? 1 : 164618))
        return true;
 
-    // These are memorized consecutively in order from oldest to newest
+    // These are memorized consecutively in order from oldest to newest.
+    // Chain head intentionally left out for backward compatibility.
     for(; pindex && pindex->pnext; pindex = pindex->pnext)
     {
         if (!pindex->IsInMainChain())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8350,7 +8350,7 @@ bool LoadAdminMessages(bool bFullTableScan, std::string& out_errors)
     // Find starting block. On full table scan we want to scan 6 months back.
     // On a shallow scan we can limit to 6 blocks back.
     CBlockIndex* pindex = bFullTableScan
-            ? blockFinder.FindByTime(pindexBest->nTime - MaxBeaconAge())
+            ? blockFinder.FindByMinTime(pindexBest->nTime - MaxBeaconAge())
             : blockFinder.FindByHeight(pindexBest->nHeight - 6);
 
     if(pindex->nHeight < (fTestNet ? 1 : 164618))

--- a/src/test/block_tests.cpp
+++ b/src/test/block_tests.cpp
@@ -71,16 +71,16 @@ BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnNextYoungestBlock)
     
     // Finding the block older than time 10 should return block #2
     // which has time 20.
-    BOOST_CHECK_EQUAL(&chain.blocks[2], finder.FindByTime(11));
-    BOOST_CHECK_EQUAL(&chain.blocks[2], finder.FindByTime(10));
-    BOOST_CHECK_EQUAL(&chain.blocks[1], finder.FindByTime(9));
+    BOOST_CHECK_EQUAL(&chain.blocks[2], finder.FindByMinTime(11));
+    BOOST_CHECK_EQUAL(&chain.blocks[2], finder.FindByMinTime(10));
+    BOOST_CHECK_EQUAL(&chain.blocks[1], finder.FindByMinTime(9));
 }
 
 BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnLastBlockIfOlderThanTime)
 {
     BlockChain<10> chain;
     BlockFinder finder;
-    BOOST_CHECK_EQUAL(&chain.blocks.back(), finder.FindByTime(999999));    
+    BOOST_CHECK_EQUAL(&chain.blocks.back(), finder.FindByMinTime(999999));    
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/block_tests.cpp
+++ b/src/test/block_tests.cpp
@@ -72,6 +72,8 @@ BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnNextYoungestBlock)
     // Finding the block older than time 10 should return block #2
     // which has time 20.
     BOOST_CHECK_EQUAL(&chain.blocks[2], finder.FindByTime(11));
+    BOOST_CHECK_EQUAL(&chain.blocks[2], finder.FindByTime(10));
+    BOOST_CHECK_EQUAL(&chain.blocks[1], finder.FindByTime(9));
 }
 
 BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnLastBlockIfOlderThanTime)

--- a/src/test/block_tests.cpp
+++ b/src/test/block_tests.cpp
@@ -22,6 +22,7 @@ namespace
             {
                block->pprev = &prev;
                block->nHeight = prev.nHeight + 1;
+               block->nTime = prev.nTime + 10;
             }
             if(block != &blocks.back())
                block->pnext = &next;
@@ -60,6 +61,24 @@ BOOST_AUTO_TEST_CASE(FindBlockByHeightShouldWorkOnChainsWithJustOneBlock)
    BOOST_CHECK_EQUAL(&chain.blocks.front(), finder.FindByHeight(0));
    BOOST_CHECK_EQUAL(&chain.blocks.front(), finder.FindByHeight(1));
    BOOST_CHECK_EQUAL(&chain.blocks.front(), finder.FindByHeight(-1));
+}
+
+BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnNextYoungestBlock)
+{
+    // Chain with block times 0, 10, 20, 30, 40 etc.
+    BlockChain<10> chain;
+    BlockFinder finder;
+    
+    // Finding the block older than time 10 should return block #2
+    // which has time 20.
+    BOOST_CHECK_EQUAL(&chain.blocks[2], finder.FindByTime(11));
+}
+
+BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnLastBlockIfOlderThanTime)
+{
+    BlockChain<10> chain;
+    BlockFinder finder;
+    BOOST_CHECK_EQUAL(&chain.blocks.back(), finder.FindByTime(999999));    
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
LoadAdminMessages previously scanned 6 months back (in depth). This caused some discrepancies in beacon acceptance since the max beacon age is 6 months in time, not height. LoadAdminMessages was changed to scan 12 months which circumvented the issue but also made the scan a lot slower than it needs to be.
    
This changes the behaviour to actually scan 6 months (in time) back on full table scans while retaining the 6 block scan on small table scans. This greatly improves the speed of a reorganize.
