### PR TITLE
Side staking (extends stake splitting PR #1244)

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -626,113 +626,193 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
 
 
 
-void SplitCoinStakeOutput(CBlock &blocknew)
+void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStakeSplit, bool &fEnableSideStaking, SideStakeAlloc &vSideStakeAlloc, int64_t &nMinStakeSplitValue, double &dEfficiency)
 {
     // When this function is called, CreateCoinStake and CreateGridcoinReward have already been called
     // and there will be a single coinstake output (besides the empty one) that has the combined stake + research
-    // reward. This function will determine whether more than one UTXO is justified/desired to optimize
-    // staking, and if so, it will pop off the single output and replace it with the output split among the
-    // calculated number of outputs to meet efficiency requirements.
-    
-    int64_t nTotalStakeOutputValue = 0;
-    CScript scriptPubKey;
-    unsigned int nUTXOCount = 1;
-    int64_t nActualStakeOutputValue = 0;
+    // reward. This function does the following...
+    // 1. Perform reward payment to specified addresses ("sidestaking") in the following manner...
+    //      a. Check if both flags false and if so return with no action.
+    //      b. Limit number of outputs based on bv. 3 for <=9 and 8 for >= 10.
+    //      c. Pull the nValue from the original output and store locally. (nReward was passed in.)
+    //      d. Pop the existing outputs.
+    //      e. Validate each address provided for redirection in turn. If valid, create an output of the
+    //         reward * the specified percentage at the validated address. Keep a running total of the reward
+    //         redirected. If the percentages add up to less than 100%, then the running total will be less
+    //         than the original specified reward after pushing up to two reward outputs. Check before each allocation
+    //         that 100% will not be exceeded. If there is a residual reward left, then add (nReward - running total)
+    //         back to the base coinstake. This also works beautifully if the redirection is disabled, because then
+    //         no reward outputs will be created, the accumulated total of redirected rewards will be zero,
+    //         and therefore the subtraction will put the entire rewards back on the base coinstake.
+    // 2. Perform stake output splitting of remaining value.
+    //      a. With the remainder value left which is now the original coinstake minus (rewards outputs pushed
+    //         - up to two), call GGetNumberOfStakeOutputs(int64_t nValue, unsigned int nOutputsAlreadyPushed)
+    //         to determine how many pieces to split into, limiting to 8 - OutputsAlreadyPushed.
+    //      b. SplitCoinStakeOutput will then push the remaining value into the determined number of outputs
+    //         of equal size using the original coinstake input address.
+    //      c. The outputs will be in the wrong order, so add the empty vout to the end and then reverse
+    //         vout.begin() to vout.end() to make sure the empty vout is in [0] position and a coinstake
+    //         vout is in the [1] position. This is required by block validation.
 
-    // Pull out total value of output for stake, which also includes (interest or CBR) and research rewards at this point.
-    nTotalStakeOutputValue = blocknew.vtx[1].vout[1].nValue;
+    // If somehow we got here and both flags are false, return immediately. This should not happen if called
+    // from StakeMiner, because one or both of the flags must be set to trigger the call, but check anyway.
+    if (!fEnableStakeSplit && !fEnableSideStaking)
+        return;
 
-    // vtx[1].vout size should be 2 at this point. If not something is really wrong so assert.
+    // vtx[1].vout size should be 2 at this point. If not something is really wrong so assert immediately.
     assert(blocknew.vtx[1].vout.size() == 2);
     
-    // Compute number of stake outputs needed.
-    nUTXOCount = GetNumberOfStakeOutputs(nTotalStakeOutputValue);
+    // Record the script public key for the base coinstake so we can reuse.
+    CScript CoinStakeScriptPubKey = blocknew.vtx[1].vout[1].scriptPubKey;
     
-    // Only go to the effort to split if nUTXOCount > 1, otherwise leave undisturbed.
-    if (nUTXOCount > 1)
-    {
-        scriptPubKey = blocknew.vtx[1].vout[1].scriptPubKey;
-        
-        // Remove the existing single stake output.
-        blocknew.vtx[1].vout.pop_back();
+    // The maximum number of outputs allowed on the coinstake txn is 3 for block version 9 and below and
+    // 8 for 10 and above. The first one must be empty, so that gives 2 and 7 usable ones, respectively.
+    unsigned int nMaxOutputs = (blocknew.nVersion >= 10) ? 8 : 3;
+    // Set the maximum number of sidestake ouputs to two less than the maximum allowable coinstake outputs
+    // to ensure outputs are reserved for the coinstake output itself and the empty one. Any sidestake
+    // addresses and percentages in excess of this number will be ignored.
+    unsigned int nMaxSideStakeOutputs = nMaxOutputs - 2;
+    // Initialize nOutputUsed at 1, because one is already used for the empty coinstake flag output.
+    unsigned int nOutputsUsed = 1;
     
-        nActualStakeOutputValue = nTotalStakeOutputValue / nUTXOCount;
+    // Initialize remaining stake output value to the total value of output for stake, which also includes
+    // (interest or CBR) and research rewards.
+    int64_t nRemainingStakeOutputValue = blocknew.vtx[1].vout[1].nValue;
 
-        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nUTXOCount = %f", nUTXOCount);
-        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nActualStakeOutputValue = %f", CoinToDouble(nActualStakeOutputValue));
-        
-        int64_t nSumStakeUTXOValue = 0;
-        for (unsigned int i = 1; i < nUTXOCount; i++)
+    // Remove the existing single stake output and the empty coinstake to prepare for splitting. (The empty one
+    // needs to be removed too, because we need to reverse the order of the outputs at the end. See the bottom of
+    // this function.
+    blocknew.vtx[1].vout.pop_back();
+    blocknew.vtx[1].vout.pop_back();
+    
+    CScript SideStakeScriptPubKey;
+    double dSumAllocation = 0.0;
+    
+    if (fEnableSideStaking)
+    {
+        // Iterate through passed in SideStake vector until either all elements processed, the maximum number of
+        // sidestake outputs is reached, or accumulated allocation will exceed 100%.
+        for(auto iterSideStake = vSideStakeAlloc.begin(); (iterSideStake != vSideStakeAlloc.end()) && (nOutputsUsed <= nMaxSideStakeOutputs); ++iterSideStake)
         {
-            blocknew.vtx[1].vout.push_back(CTxOut(nActualStakeOutputValue, scriptPubKey));
-            LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", i, CoinToDouble(nActualStakeOutputValue));
-            nSumStakeUTXOValue += nActualStakeOutputValue;
+            CBitcoinAddress address(iterSideStake->first);
+            if (!address.IsValid())
+            {
+                LogPrintf("WARN: SplitCoinStakeOutput: ignoring sidestake invalid address %s.", iterSideStake->first.c_str());
+                continue;
+            }
+
+            // Do not process a distribution that would result in an output less than 1 CENT. This will flow back into the coinstake below.
+            // Prevents dust build-up.
+            if (nReward * iterSideStake->second < CENT)
+            {
+                LogPrintf("WARN: SplitCoinStakeOutput: distribution %f too small to address %s.", CoinToDouble(nReward * iterSideStake->second), iterSideStake->first.c_str());
+                continue;
+            }
+            
+            if (dSumAllocation + iterSideStake->second > 1.0)
+            {
+                LogPrintf("WARN: SplitCoinStakeOutput: allocation percentage over 100\%, ending sidestake allocations.");
+                break;
+            }
+
+            // Push to an output the (reward times the allocation) to the address, increment the accumulator for allocation,
+            // decrement the remaining stake output value, and increment outputs used.
+            SideStakeScriptPubKey.SetDestination(address.Get());
+            blocknew.vtx[1].vout.push_back(CTxOut(nReward * iterSideStake->second, SideStakeScriptPubKey));
+            LogPrintf("SplitCoinStakeOutput: create sidestake UTXO %i value %f to address %s", nOutputsUsed, CoinToDouble(nReward * iterSideStake->second), iterSideStake->first.c_str());
+            dSumAllocation += iterSideStake->second;
+            nRemainingStakeOutputValue -= nReward * iterSideStake->second;
+            nOutputsUsed++;
         }
-        // For the last UTXO, subtract the running sum from the desired total, which does not include the last UTXO so far,
-        // to recover anything lost from rounding. This will be a very small difference from the others.
+        // If we get here and dSumAllocation is zero then the enablesidestaking flag was set, but no VALID distribution
+        // was in the vSideStakeAlloc vector. (Note that this is also in the parsing routine in StakeMiner, so it will show
+        // up when the wallet is first started, but also needs to be here, to remind the user periodically that something
+        // is amiss.
+        if (dSumAllocation == 0.0)
+            LogPrintf("WARN: SplitCoinStakeOutput: enablesidestaking was set in config but nothing has been allocated for distribution!");
+    }
+    
+    // By this point, if SideStaking was used and 100% was allocated nRemainingStakeOutputValue will be
+    // the original base coinstake. The other extreme is no sidestaking, in which case nRemainingStakeOutputValue is the
+    // base coinstake + all of the reward. In any case, we will now compute the number of split stake outputs needed,
+    // limiting actual number of split stake outputs to remaining available (nMaxOutputs - nOutputsUsed). There will be
+    // at least one available, because if sidestaking is activated, it is limited to nMaxOutputs - 2.
+    // Don't do any work here except pushing a single output if flag is false.
+    if (fEnableStakeSplit)
+    {
+        unsigned int nSplitStakeOutputs = min((nMaxOutputs - nOutputsUsed), GetNumberOfStakeOutputs(nRemainingStakeOutputValue, nMinStakeSplitValue, dEfficiency));
+        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nStakeOutputs = %u", nSplitStakeOutputs);
+
+        // Set Actual Stake output value for split stakes to remaining output value divided by the number of split
+        // stake outputs.
+        int64_t nActualStakeOutputValue = nRemainingStakeOutputValue / nSplitStakeOutputs;
+
+        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nSplitStakeOutputs = %f", nSplitStakeOutputs);
+        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nActualStakeOutputValue = %f", CoinToDouble(nActualStakeOutputValue));
+
+        int64_t nSumStakeOutputValue = 0;
+        for (unsigned int i = 1; i < nSplitStakeOutputs; i++)
+        {
+            blocknew.vtx[1].vout.push_back(CTxOut(nActualStakeOutputValue, CoinStakeScriptPubKey));
+            LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nOutputsUsed, CoinToDouble(nActualStakeOutputValue));
+            nOutputsUsed++;
+            nSumStakeOutputValue += nActualStakeOutputValue;
+        }
+        // For the last UTXO, subtract the running sum from the desired total, which does not include the last UTXO
+        // so far, to recover anything lost from rounding. This will be a very small difference from the others.
         // The reason we go through this trouble is that integer division rounds down, and we don't even want
         // to have the wallet lose 1 Halford.
-        blocknew.vtx[1].vout.push_back(CTxOut((nTotalStakeOutputValue - nSumStakeUTXOValue), scriptPubKey));
-        LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nUTXOCount, CoinToDouble(nTotalStakeOutputValue - nSumStakeUTXOValue));
+        blocknew.vtx[1].vout.push_back(CTxOut((nRemainingStakeOutputValue - nSumStakeOutputValue), CoinStakeScriptPubKey));
+        LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nOutputsUsed, CoinToDouble(nRemainingStakeOutputValue - nSumStakeOutputValue));
     }
+    else
+    {
+        // Stake splitting flag is false, so just push back a single output with the remaining output value.
+        blocknew.vtx[1].vout.push_back(CTxOut(nRemainingStakeOutputValue, CoinStakeScriptPubKey));
+    }
+
+    // Now, the outputs are in the wrong order. We had to do the rewards distribution first
+    // because it can be of variable number of elements, and if someone puts an address on the list,
+    // there is a reasonable expectation it should succeed, while the stake splitting is a luxury.
+    // One of the coinstake outputs MUST be at vout[1] to pass block validation, so we will
+    // add the empty one at the end. And then use std::reverse to reverse vout.begin() to vout.end().
+    // This will put the correct vout[0] and vout[1] in the right place.
+    blocknew.vtx[1].vout.push_back(CTxOut(0, CScript()));
+    reverse(blocknew.vtx[1].vout.begin(), blocknew.vtx[1].vout.end());
 }
 
 
 
-unsigned int GetNumberOfStakeOutputs(int64_t nValue)
+unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency)
 {
-    int64_t nMinUTXOPostSplitValue = 0;
-    double dEfficiency = 0.0;
-    int64_t nDesiredStakeUTXOValue = 0;
-    unsigned int nUTXOCount = 1;
+    int64_t nDesiredStakeOutputValue = 0;
+    unsigned int nStakeOutputs = 1;
 
     // For the definition of the constant G, please see
     // https://docs.google.com/document/d/1OyuTwdJx1Ax2YZ42WYkGn_UieN0uY13BTlA5G5IAN00/edit?usp=sharing
     // Refer to page 5 for G. This link is a draft of an upcoming bluepaper section.
     const double G = 9942.2056;
 
-    // Pull Minimum Post Stake UTXO Split Value from config or command line parameter.
-    // Default to 800 and do not allow it to be specified below 800 GRC.
-    nMinUTXOPostSplitValue = max(GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC), MIN_STAKE_SPLIT_VALUE_GRC) * COIN;
-
-    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nMinUTXOPostSplitValue = %f", CoinToDouble(nMinUTXOPostSplitValue));
-
-    // If the stake output provided to GetNumberofStakeOutputs is less than or equal to nMinUTXOPostSplitValue then there will
+    // If the stake output provided to GetNumberofStakeOutputs is less than or equal to nMinStakeSplitValue then there will
     // be only one output, so return(1) immediately.
-    if (nValue <= nMinUTXOPostSplitValue)
+    if (nValue <= nMinStakeSplitValue)
         return(1);
 
-    // Pull efficiency for UTXO staking from config, but constrain to the interval [0.75, 0.98]. Use default of 0.90.
-    dEfficiency = (double)GetArg("-stakingefficiency", 90) / 100;
-    if (dEfficiency > 0.98)
-        dEfficiency = 0.98;
-    else if (dEfficiency < 0.75)
-        dEfficiency = 0.75;
+    // Set Desired UTXO size post stake based on passed in efficiency and difficulty, but do not allow to go below
+    // passed in MinStakeSplitValue. Note that we use GetAverageDifficulty over a 4 hour (160 block period) rather than
+    // StakeKernelDiff, because the block to block difficulty has too much scatter. Please refer to the above link,
+    // equation (27) on page 10 as a reference for the below formula.
+    nDesiredStakeOutputValue = G * GetAverageDifficulty(160) * (3.0 / 2.0) * (1 / dEfficiency  - 1) * COIN;
+    nDesiredStakeOutputValue = max(nMinStakeSplitValue, nDesiredStakeOutputValue);
 
-    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: dEfficiency = %f", dEfficiency);
-
-    // Set Desired UTXO size post stake based on efficiency and difficulty, but do not allow to go below MinUTXOPostSplitValue.
-    // Note that we use GetAverageDifficulty over a 4 hour (160 block period) rather than StakeKernelDiff, because the block
-    // to block difficulty has too much scatter. Please refer to the above link, equation (27) on page 10 as a reference for
-    // the below formula.
-    nDesiredStakeUTXOValue = G * GetAverageDifficulty(160) * (3.0 / 2.0) * (1 / dEfficiency  - 1) * COIN;
-    nDesiredStakeUTXOValue = max(nMinUTXOPostSplitValue, nDesiredStakeUTXOValue);
-
-    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nDesiredStakeUTXOValue = %f", CoinToDouble(nDesiredStakeUTXOValue));
+    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nDesiredStakeOutputValue = %f", CoinToDouble(nDesiredStakeOutputValue));
 
     // Divide nValue by nDesiredStakeUTXOValue. We purposely want this to be integer division to round down.
-    nUTXOCount = nValue / nDesiredStakeUTXOValue;
+    nStakeOutputs = nValue / nDesiredStakeOutputValue;
 
-    // Currently limited to 2 UTXO's for coinstakes, so limit to 2 for right now. This can be removed when the limit in the coinstake txnew
-    // is expanded.
-    if (nUTXOCount < 1)
-        nUTXOCount = 1;
-    else if (nUTXOCount > 2)
-        nUTXOCount = 2;
+    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nStakeOutputs = %u", nStakeOutputs);
 
-    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nUTXOCount = %u", nUTXOCount);
-
-    return(nUTXOCount);
+    return(nStakeOutputs);
 }
 
 
@@ -1020,7 +1100,7 @@ void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
     return;
 }
 
-bool CreateGridcoinReward(CBlock &blocknew, MiningCPID& miningcpid, uint64_t &nCoinAge, CBlockIndex* pindexPrev)
+bool CreateGridcoinReward(CBlock &blocknew, MiningCPID& miningcpid, uint64_t &nCoinAge, CBlockIndex* pindexPrev, int64_t &nReward)
 {
     //remove fees from coinbase
     int64_t nFees = blocknew.vtx[0].vout[0].nValue;
@@ -1037,7 +1117,7 @@ bool CreateGridcoinReward(CBlock &blocknew, MiningCPID& miningcpid, uint64_t &nC
     // Note: Since research Age must be exact, we need to transmit the Block nTime here so it matches AcceptBlock
 
 
-    int64_t nReward = GetProofOfStakeReward(
+        nReward = GetProofOfStakeReward(
         nCoinAge, nFees, GlobalCPUMiningCPID.cpid, false, 0,
         pindexPrev->nTime, pindexPrev,"createcoinstake",
         OUT_POR,out_interest,dAccrualAge,dAccrualMagnitudeUnit,dAccrualMagnitude);
@@ -1140,6 +1220,98 @@ void StakeMiner(CWallet *pwallet)
     RenameThread("grc-stake-miner");
 
     MinerAutoUnlockFeature(pwallet);
+    
+    // Parse StakeSplit and SideStaking flags.
+    bool fEnableStakeSplit = GetBoolArg("-enablestakesplit");
+    LogPrintf("StakeMiner: fEnableStakeSplit = %u", fEnableStakeSplit);
+
+    bool fEnableSideStaking = GetBoolArg("-enablesidestaking");
+    LogPrintf("StakeMiner: fEnableSideStaking = %u", fEnableSideStaking);
+
+    vector<string> vSubParam;
+    SideStakeAlloc vSideStakeAlloc;
+    std::string sAddress;
+    int64_t nMinStakeSplitValue;
+    double dEfficiency;
+    double dAllocation = 0.0;
+    double dSumAllocation = 0.0;
+    
+    // If side staking is enabled, parse destinations and allocations. We don't need to worry about any that are rejected
+    // other than a warning message, because any unallocated rewards will go back into the coinstake output(s).
+    if (fEnableSideStaking)
+    {
+        if (mapArgs.count("-sidestake") && mapMultiArgs["-sidestake"].size() > 0)
+        {
+            for (auto const& sSubParam : mapMultiArgs["-sidestake"])
+            {
+                ParseString(sSubParam, ',', vSubParam);
+                sAddress = vSubParam[0];
+
+                CBitcoinAddress address(sAddress);
+                if (!address.IsValid())
+                {
+                    LogPrintf("WARN: StakeMiner: ignoring sidestake invalid address %s.", sAddress.c_str());
+                    continue;
+                }
+
+                try
+                {
+                    dAllocation = atof(vSubParam[1].c_str()) / 100.0;
+                }
+                catch(...)
+                {
+                    LogPrintf("WARN: StakeMiner: Invalid allocation provided. Skipping allocation.");
+                    continue;
+                }
+                
+                if (dAllocation <= 0)
+                {
+                    LogPrintf("WARN: StakeMiner: Negative or zero allocation provided. Skipping allocation.");
+                    continue;
+                }
+
+                // The below will stop allocations if someone has made a mistake and the total adds up to more than 100%.
+                // Note this same check is also done in SplitCoinStakeOutput, but it needs to be done here for two reasons:
+                // 1. Early alertment in the debug log, rather than when the first kernel is found, and 2. When the UI is
+                // hooked up, the SideStakeAlloc vector will be filled in by other than reading the config file and will
+                // skip the above code.
+                dSumAllocation += dAllocation;
+                if (dSumAllocation > 1.0)
+                {
+                    LogPrintf("WARN: StakeMiner: allocation percentage over 100\%, ending sidestake allocations.");
+                    break;
+                }
+                
+                vSideStakeAlloc.push_back(std::pair<std::string, double>(sAddress, dAllocation));
+                LogPrintf("StakeMiner: SideStakeAlloc Address %s, Allocation %f", sAddress.c_str(), dAllocation);
+
+                vSubParam.clear();   
+            }
+        }
+        // If we get here and dSumAllocation is zero then the enablesidestaking flag was set, but no VALID distribution
+        // was provided in the config file, so warn in the debug log.
+        if (!dSumAllocation)
+            LogPrintf("WARN: StakeMiner: enablesidestaking was set in config but nothing has been allocated for distribution!");
+    }
+
+    // If stake output splitting is enabled, determine efficiency and minimum stake split value.
+    if (fEnableStakeSplit)
+    {
+        // Pull efficiency for UTXO staking from config, but constrain to the interval [0.75, 0.98]. Use default of 0.90.
+        dEfficiency = (double)GetArg("-stakingefficiency", 90) / 100;
+        if (dEfficiency > 0.98)
+            dEfficiency = 0.98;
+        else if (dEfficiency < 0.75)
+            dEfficiency = 0.75;
+
+        LogPrintf("StakeMiner: dEfficiency = %f", dEfficiency);
+
+        // Pull Minimum Post Stake UTXO Split Value from config or command line parameter.
+        // Default to 800 and do not allow it to be specified below 800 GRC.
+        nMinStakeSplitValue = max(GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC), MIN_STAKE_SPLIT_VALUE_GRC) * COIN;
+
+        LogPrintf("StakeMiner: nMinStakeSplitValue = %f", CoinToDouble(nMinStakeSplitValue));
+    }
 
     supercfwd::fEnable= GetBoolArg("-supercfwd",true);
     if(fDebug) LogPrintf("supercfwd::fEnable= %d",supercfwd::fEnable);
@@ -1199,19 +1371,21 @@ void StakeMiner(CWallet *pwallet)
             continue;
         StakeBlock.nTime= StakeTX.nTime;
 
-        // * create rest of the block
+        // * create rest of the block. This needs to be moved to after CreateGridcoinReward,
+        // because stake output splitting needs to be done beforehand for size considerations.
         if( !CreateRestOfTheBlock(StakeBlock,pindexPrev) )
             continue;
         LogPrintf("StakeMiner: created rest of the block");
 
-        // * add gridcoin reward to coinstake
-        if( !CreateGridcoinReward(StakeBlock,BoincData,StakeCoinAge,pindexPrev) )
+        // * add gridcoin reward to coinstake, fill-in nReward
+        int64_t nReward;
+        if( !CreateGridcoinReward(StakeBlock, BoincData, StakeCoinAge, pindexPrev, nReward) )
             continue;
         LogPrintf("StakeMiner: added gridcoin reward to coinstake");
         
-        // * If argument is supplied desiring stake output splitting, then split stake outputs if needed.
-        if (GetBoolArg("-enablestakesplit"))
-            SplitCoinStakeOutput(StakeBlock);
+        // * If argument is supplied desiring stake output splitting or side staking, then call SplitCoinStakeOutput.
+        if (fEnableStakeSplit || fEnableSideStaking)
+            SplitCoinStakeOutput(StakeBlock, nReward, fEnableStakeSplit, fEnableSideStaking, vSideStakeAlloc, nMinStakeSplitValue, dEfficiency);
 
         AddNeuralContractOrVote(StakeBlock, BoincData);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -15,6 +15,7 @@
 #include "util.h"
 
 #include <memory>
+#include <algorithm>
 
 using namespace std;
 
@@ -600,7 +601,6 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
 
             txnew.vout.push_back(CTxOut(0, CScript())); // First Must be empty
             txnew.vout.push_back(CTxOut(nCredit, scriptPubKeyOut));
-            //txnew.vout.push_back(CTxOut(0, scriptPubKeyOut));
 
             LogPrintf("CreateCoinStake: added kernel type=%d credit=%f", whichType,CoinToDouble(nCredit));
 
@@ -623,6 +623,119 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
     MinerStatus.nLastCoinStakeSearchInterval= txnew.nTime;
     return false;
 }
+
+
+
+void SplitCoinStakeOutput(CBlock &blocknew)
+{
+    // When this function is called, CreateCoinStake and CreateGridcoinReward have already been called
+    // and there will be a single coinstake output (besides the empty one) that has the combined stake + research
+    // reward. This function will determine whether more than one UTXO is justified/desired to optimize
+    // staking, and if so, it will pop off the single output and replace it with the output split among the
+    // calculated number of outputs to meet efficiency requirements.
+    
+    int64_t nTotalStakeOutputValue = 0;
+    CScript scriptPubKey;
+    unsigned int nUTXOCount = 1;
+    int64_t nActualStakeOutputValue = 0;
+
+    // Pull out total value of output for stake, which also includes (interest or CBR) and research rewards at this point.
+    nTotalStakeOutputValue = blocknew.vtx[1].vout[1].nValue;
+
+    // vtx[1].vout size should be 2 at this point. If not something is really wrong so assert.
+    assert(blocknew.vtx[1].vout.size() == 2);
+    
+    // Compute number of stake outputs needed.
+    nUTXOCount = GetNumberOfStakeOutputs(nTotalStakeOutputValue);
+    
+    // Only go to the effort to split if nUTXOCount > 1, otherwise leave undisturbed.
+    if (nUTXOCount > 1)
+    {
+        scriptPubKey = blocknew.vtx[1].vout[1].scriptPubKey;
+        
+        // Remove the existing single stake output.
+        blocknew.vtx[1].vout.pop_back();
+    
+        nActualStakeOutputValue = nTotalStakeOutputValue / nUTXOCount;
+
+        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nUTXOCount = %f", nUTXOCount);
+        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nActualStakeOutputValue = %f", CoinToDouble(nActualStakeOutputValue));
+        
+        int64_t nSumStakeUTXOValue = 0;
+        for (unsigned int i = 1; i < nUTXOCount; i++)
+        {
+            blocknew.vtx[1].vout.push_back(CTxOut(nActualStakeOutputValue, scriptPubKey));
+            LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", i, CoinToDouble(nActualStakeOutputValue));
+            nSumStakeUTXOValue += nActualStakeOutputValue;
+        }
+        // For the last UTXO, subtract the running sum from the desired total, which does not include the last UTXO so far,
+        // to recover anything lost from rounding. This will be a very small difference from the others.
+        // The reason we go through this trouble is that integer division rounds down, and we don't even want
+        // to have the wallet lose 1 Halford.
+        blocknew.vtx[1].vout.push_back(CTxOut((nTotalStakeOutputValue - nSumStakeUTXOValue), scriptPubKey));
+        LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nUTXOCount, CoinToDouble(nTotalStakeOutputValue - nSumStakeUTXOValue));
+    }
+}
+
+
+
+unsigned int GetNumberOfStakeOutputs(int64_t nValue)
+{
+    int64_t nMinUTXOPostSplitValue = 0;
+    double dEfficiency = 0.0;
+    int64_t nDesiredStakeUTXOValue = 0;
+    unsigned int nUTXOCount = 1;
+
+    // For the definition of the constant G, please see
+    // https://docs.google.com/document/d/1OyuTwdJx1Ax2YZ42WYkGn_UieN0uY13BTlA5G5IAN00/edit?usp=sharing
+    // Refer to page 5 for G. This link is a draft of an upcoming bluepaper section.
+    const double G = 9942.2056;
+
+    // Pull Minimum Post Stake UTXO Split Value from config or command line parameter.
+    // Default to 800 and do not allow it to be specified below 800 GRC.
+    nMinUTXOPostSplitValue = max(GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC), MIN_STAKE_SPLIT_VALUE_GRC) * COIN;
+
+    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nMinUTXOPostSplitValue = %f", CoinToDouble(nMinUTXOPostSplitValue));
+
+    // If the stake output provided to GetNumberofStakeOutputs is less than or equal to nMinUTXOPostSplitValue then there will
+    // be only one output, so return(1) immediately.
+    if (nValue <= nMinUTXOPostSplitValue)
+        return(1);
+
+    // Pull efficiency for UTXO staking from config, but constrain to the interval [0.75, 0.98]. Use default of 0.90.
+    dEfficiency = (double)GetArg("-stakingefficiency", 90) / 100;
+    if (dEfficiency > 0.98)
+        dEfficiency = 0.98;
+    else if (dEfficiency < 0.75)
+        dEfficiency = 0.75;
+
+    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: dEfficiency = %f", dEfficiency);
+
+    // Set Desired UTXO size post stake based on efficiency and difficulty, but do not allow to go below MinUTXOPostSplitValue.
+    // Note that we use GetAverageDifficulty over a 4 hour (160 block period) rather than StakeKernelDiff, because the block
+    // to block difficulty has too much scatter. Please refer to the above link, equation (27) on page 10 as a reference for
+    // the below formula.
+    nDesiredStakeUTXOValue = G * GetAverageDifficulty(160) * (3.0 / 2.0) * (1 / dEfficiency  - 1) * COIN;
+    nDesiredStakeUTXOValue = max(nMinUTXOPostSplitValue, nDesiredStakeUTXOValue);
+
+    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nDesiredStakeUTXOValue = %f", CoinToDouble(nDesiredStakeUTXOValue));
+
+    // Divide nValue by nDesiredStakeUTXOValue. We purposely want this to be integer division to round down.
+    nUTXOCount = nValue / nDesiredStakeUTXOValue;
+
+    // Currently limited to 2 UTXO's for coinstakes, so limit to 2 for right now. This can be removed when the limit in the coinstake txnew
+    // is expanded.
+    if (nUTXOCount < 1)
+        nUTXOCount = 1;
+    else if (nUTXOCount > 2)
+        nUTXOCount = 2;
+
+    if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nUTXOCount = %u", nUTXOCount);
+
+    return(nUTXOCount);
+}
+
+
 
 bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInputs, CWallet *pwallet, MiningCPID& BoincData)
 {
@@ -1095,6 +1208,10 @@ void StakeMiner(CWallet *pwallet)
         if( !CreateGridcoinReward(StakeBlock,BoincData,StakeCoinAge,pindexPrev) )
             continue;
         LogPrintf("StakeMiner: added gridcoin reward to coinstake");
+        
+        // * If argument is supplied desiring stake output splitting, then split stake outputs if needed.
+        if (GetBoolArg("-enablestakesplit"))
+            SplitCoinStakeOutput(StakeBlock);
 
         AddNeuralContractOrVote(StakeBlock, BoincData);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -718,6 +718,13 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
             // Push to an output the (reward times the allocation) to the address, increment the accumulator for allocation,
             // decrement the remaining stake output value, and increment outputs used.
             SideStakeScriptPubKey.SetDestination(address.Get());
+            
+            // It is entirely possible that the coinstake could be from an address that is specified in one of the sidestake entries
+            // if the sidestake address(es) are local to the staking wallet. There is no reason to sidestake in that case. The
+            // coins should flow down to the coinstake outputs and be returned there. This will also simplify the display logic in
+            // the UI, because it makes the sidestake and coinstake outputs disjoint from an address point of view.
+            if (SideStakeScriptPubKey == CoinStakeScriptPubKey)
+                continue;
             blocknew.vtx[1].vout.push_back(CTxOut(nReward * iterSideStake->second, SideStakeScriptPubKey));
             LogPrintf("SplitCoinStakeOutput: create sidestake UTXO %i value %f to address %s", nOutputsUsed, CoinToDouble(nReward * iterSideStake->second), iterSideStake->first.c_str());
             dSumAllocation += iterSideStake->second;

--- a/src/miner.h
+++ b/src/miner.h
@@ -39,4 +39,12 @@ namespace supercfwd
     void SendResponse(CNode* fromNode, const std::string& req_hash);
 }
 
+// Note the below constant controls the minimum value allowed for post
+// split UTXO size. It is int64_t but in GRC so that it matches the entry in the config file.
+// It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
+static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
+
+void SplitCoinStakeOutput(CBlock &blocknew);
+unsigned int GetNumberOfStakeOutputs(int64_t nValue);
+
 #endif // NOVACOIN_MINER_H

--- a/src/miner.h
+++ b/src/miner.h
@@ -28,6 +28,8 @@ struct CMinerStatus
     CMinerStatus();
 };
 
+typedef std::vector< std::pair<std::string, double> > SideStakeAlloc;
+
 extern CMinerStatus MinerStatus;
 extern unsigned int nMinerSleep;
 
@@ -44,7 +46,7 @@ namespace supercfwd
 // It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
 static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
 
-void SplitCoinStakeOutput(CBlock &blocknew);
-unsigned int GetNumberOfStakeOutputs(int64_t nValue);
+void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStakeSplit, bool &fEnableSideStaking, SideStakeAlloc &vSideStakeAlloc, double &dEfficiency);
+unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency);
 
 #endif // NOVACOIN_MINER_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -59,7 +59,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     if (nNet > 0 || wtx.IsCoinBase() || wtx.IsCoinStake())
     {
         //
-        // Credit - Calculate Net from CryptoLottery Rob Halford - 4-3-2015-1
+        // Credit - Calculate Net from CryptoLottery Rob Halford - 4-3-2015-1 - deprecated. See below.
         //
         for (auto const& txout : wtx.vout)
         {
@@ -101,7 +101,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 					}
 					else
 					{
-						//CryptoLottery - CoinStake - 4-3-2015
+                        // This part used to be used for a deprecated "crypto lottery". It is now
+                        // necessary for the implementation of side staking in PR 1265.
 						sub.type = TransactionRecord::Generated;
 						if (nDebit == 0)
 						{


### PR DESCRIPTION
This PR extends the work I have done in PR #1244 and implements the ability to "side stake" or distribute the CBR and research rewards to valid addresses. These addresses may be in the same wallet or any other valid Gridcoin address. The potential uses for sidestaking range from a person insuring that all reward go into the same address (and key) for easier backup and recovery to someone donating CBR and rewards to a charity, or sending it to their grandma! :). This functionality is very similar to Pinkcoin.

This addresses #1240, and along with #1260, addresses #1173.

The PR adds the following additional conf file parameters on top of 1244...

enablesidestaking=0|1
sidestake=address,allocation_percentage

You can specify multiple sidetake entries, just like addnode or connect. Note that the total number of ouputs for the coinstake will be limited to 8 in V10, and vout[0] must be empty, so that gives 7 usable outputs. One must always be reserved for the actual coinstake output (return), so that leaves up to 6 usuable outputs for rewards distribution.

Note that the total of all of the percentages can add up to less than 100%, in which cases the leftover reward will be returned back on the coinstake(s).

The SplitCoinStakeOutput function in miner.cpp has good comments on how it all actually works, but I am including here for easy reference...

When this function is called, CreateCoinStake and CreateGridcoinReward have already been called and there will be a single coinstake output (besides the empty one) that has the combined stake + research reward. This function does the following...
1. Perform reward payment to specified addresses ("sidestaking") in the following manner...
      a. Check if both flags false and if so return with no action.
      b. Limit number of outputs based on bv. 3 for <=9 and 8 for >= 10.
      c. Pull the nValue from the original output and store locally. (nReward was passed in.)
      d. Pop the existing outputs.
      e. Validate each address provided for redirection in turn. If valid, create an output of the reward * the specified percentage at the validated address. Keep a running total of the reward redirected. If the percentages add up to less than 100%, then the running total will be less than the original specified reward after pushing up to two reward outputs. Check before each allocation that 100% will not be exceeded. Also check if the distribution is less than 1 CENT, and if so skip it. (This will cause the small distribution to flow to the coinstake instead.) If there is a residual reward left, then add (nReward - running total) back to the base coinstake. This also works beautifully if the redirection is disabled, because then no reward outputs will be created, the accumulated total of redirected rewards will be zero, and therefore the subtraction will put the entire rewards back on the base coinstake.
2. Perform stake output splitting of remaining value.
      a. With the remainder value left which is now the original coinstake minus (rewards outputs pushed - up to two), call GGetNumberOfStakeOutputs(int64_t nValue, unsigned int nOutputsAlreadyPushed) to determine how many pieces to split into, limiting to 8 - OutputsAlreadyPushed.
      b. SplitCoinStakeOutput will then push the remaining value into the determined number of outputs of equal size using the original coinstake input address.
      c. The outputs will be in the wrong order, so add the empty vout to the end and then reverse vout.begin() to vout.end() to make sure the empty vout is in [0] position and a coinstake vout is in the [1] position. This is required by block validation.

Note that @tomasbrod has suggested that I might split SplitCoinStakeOutput into two functions, one to perform the reward sidestaking, and the other to do the coinstake output splitting (UTXO optimization), but as long as we have an overall limit over both of them in terms of the overall number of outputs, it couples the two together. Further, vout[0] has to be blank, and the reward distribution has to be done before the splitting, because the reward distribution outputs are determinate, but the stake splitting is highly variable... so splitting the function into two requires some real gymnastics with the vector element order.

I have moved the conf parameter parsing all into the top part of StakeMiner, so that it executes only once when the miner thread is created, and not every time the miner loop is executed. The functions are now fully parameterized. Further changes to the parsing location and scope of the flags may be required to hook in the UI part. I would love commentary on that.

One last thing. This can be used on testnet, but you have to be careful because if you enable both enablestakesplit and enablesidestaking and more than three outputs are formed, the staked block will be rejected. This is because testnet is on V10, but does not currently have the expansion of the coinstake outputs to 8, so the test I have at miner.cpp:670 doesn't work properly.

So if you try this out in testnet, do not include more than one address, percent entry, and do not simultaneously enable both enablestakesplit and enablesidestaking.

One other thing. I have not moved CreateRestOfTheBlock(StakeBlock,pindexPrev) to later after the SplitCoinStakeOutput. I tried it, but was having trouble with it, so moved it back.