### PR TITLE
Remove 0123 0124 detection to determine POS/POR

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -399,14 +399,24 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
 				return tr("Minted - (Local) DPOR");
 			}
 		}
-		else if (((IsPoR(CoinToDouble(wtx->credit + wtx->debit)))))
-		{
-				return tr("Mined - PoR");
-		}
-		else
-		{
-				return tr("Mined - Interest");
-		}
+
+        else
+        {
+            MinedType gentype = GenerateType(wtx->hash);
+
+            if (gentype == MinedType::POS)
+                return tr("Mined - POS");
+
+            else if (gentype == MinedType::POR)
+                return tr("Mined - POR");
+
+            else if (gentype == MinedType::ORPHANED)
+                return tr("Mined - ORPHANED");
+
+            else
+                return tr("Mined - UNKNOWN");
+        }
+
     default:
         return QString();
     }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -425,21 +425,19 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
 
 QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx) const
 {
-	double reward = CoinToDouble(wtx->credit + wtx->debit);
-	double max = GetMaximumBoincSubsidy(GetAdjustedTime());
-	bool is_por = IsPoR(reward);
-	switch(wtx->type)
+    switch(wtx->type)
     {
     case TransactionRecord::Generated:
-        if (is_por)
-        {
-            return QIcon(":/icons/tx_cpumined");
-        }
-        else
-        {
-            return QIcon(":/icons/tx_mined");
-        }
+    {
+        MinedType gentype = GenerateType(wtx->hash);
 
+        if (gentype == MinedType::POR)
+            return QIcon(":/icons/tx_cpumined");
+
+        // TODO lets make a ORPHANED ICON/UNKNOWN ICON
+        else
+            return QIcon(":/icons/tx_mined");
+    }
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:
         return QIcon(":/icons/tx_input");

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -21,9 +21,6 @@
 
 int64_t GetMaximumBoincSubsidy(int64_t nTime);
 double CoinToDouble(double surrogate);
-extern bool IsPoR(double amt);
-
-
 
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
@@ -352,23 +349,6 @@ QString TransactionTableModel::lookupAddress(const std::string &address, bool to
     }
 
     return description;
-}
-
-
-
-
-bool IsPoR(double amt)
-{
-	std::string sAmt = RoundToString(amt,8);
-	if (sAmt.length() > 8)
-	{
-		std::string suffix = sAmt.substr(sAmt.length()-4,4);
-		if (suffix =="0124" || suffix=="0123")
-		{
-			return true;
-		}
-	}
-	return false;
 }
 
 QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -388,7 +388,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
                 case MinedType::POS        :    return tr("MINED - POS");
                 case MinedType::POR        :    return tr("MINED - POR");
                 case MinedType::ORPHANED   :    return tr("MINED - ORPHANED");
-                case MinedType::UNKNOWN    :    return tr("MINED - UNKNOWN");
                 default                    :    return tr("MINED - UNKNOWN");
             }
         }
@@ -412,7 +411,8 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
         {
             case MinedType::POS        :    return QIcon(":/icons/tx_mined");
             case MinedType::POR        :    return QIcon(":/icons/tx_cpumined");
-            default                    :    return QIcon(":/icons/tx_mined");
+            case MinedType::ORPHANED   :    return QIcon(":/icons/transaction_conflicted");
+            default                    :    return QIcon(":/icons/transaction_0");
         }
     }
     case TransactionRecord::RecvWithAddress:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -365,21 +365,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::SendToSelf:
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
-        if (wtx->RemoteFlag==1 && false)
-        {
-            double reward = CoinToDouble(wtx->credit + wtx->debit);
-            double max = GetMaximumBoincSubsidy(GetAdjustedTime());
-            if (reward==max)
-            {
-                return tr("Mined - DPOR");
-            }
-            else
-            {
-                return tr("Minted - (Local) DPOR");
-            }
-        }
-
-        else
         {
             MinedType gentype = GenerateType(wtx->hash);
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -365,20 +365,19 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::SendToSelf:
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
-	    if (wtx->RemoteFlag==1 && false)
-		{
-
-			double reward = CoinToDouble(wtx->credit + wtx->debit);
-			double max = GetMaximumBoincSubsidy(GetAdjustedTime());
-			if (reward==max)
-			{
-				return tr("Mined - DPOR");
-			}
-			else
-			{
-				return tr("Minted - (Local) DPOR");
-			}
-		}
+        if (wtx->RemoteFlag==1 && false)
+        {
+            double reward = CoinToDouble(wtx->credit + wtx->debit);
+            double max = GetMaximumBoincSubsidy(GetAdjustedTime());
+            if (reward==max)
+            {
+                return tr("Mined - DPOR");
+            }
+            else
+            {
+                return tr("Minted - (Local) DPOR");
+            }
+        }
 
         else
         {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -383,17 +383,14 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         {
             MinedType gentype = GenerateType(wtx->hash);
 
-            if (gentype == MinedType::POS)
-                return tr("Mined - POS");
-
-            else if (gentype == MinedType::POR)
-                return tr("Mined - POR");
-
-            else if (gentype == MinedType::ORPHANED)
-                return tr("Mined - ORPHANED");
-
-            else
-                return tr("Mined - UNKNOWN");
+            switch (gentype)
+            {
+                case MinedType::POS        :    return tr("MINED - POS");
+                case MinedType::POR        :    return tr("MINED - POR");
+                case MinedType::ORPHANED   :    return tr("MINED - ORPHANED");
+                case MinedType::UNKNOWN    :    return tr("MINED - UNKNOWN");
+                default                    :    return tr("MINED - UNKNOWN");
+            }
         }
 
     default:
@@ -408,14 +405,15 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     {
     case TransactionRecord::Generated:
     {
+        // TODO consider an icon for least unknown thou unlikely we would have that and orphan only seen when showorphans option set to true
         MinedType gentype = GenerateType(wtx->hash);
 
-        if (gentype == MinedType::POR)
-            return QIcon(":/icons/tx_cpumined");
-
-        // TODO lets make a ORPHANED ICON/UNKNOWN ICON
-        else
-            return QIcon(":/icons/tx_mined");
+        switch (gentype)
+        {
+            case MinedType::POS        :    return QIcon(":/icons/tx_mined");
+            case MinedType::POR        :    return QIcon(":/icons/tx_cpumined");
+            default                    :    return QIcon(":/icons/tx_mined");
+        }
     }
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1430,9 +1430,14 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                         entry.pushKV("category", "generate");
 
                     }
-                    std::string type = IsPoR2(-nFee) ? "POR" : "Interest";
+                    MinedType gentype = GenerateType(wtx.GetHash());
+
+                    switch (gentype)
                     {
-                        entry.pushKV("Type", type);
+                        case MinedType::POR         :   entry.pushKV("Type", "POR");        break;
+                        case MinedType::POS         :   entry.pushKV("Type", "POS");        break;
+                        case MinedType::ORPHANED    :   entry.pushKV("Type", "ORPHANED");   break;
+                        default                     :   entry.pushKV("Type", "UNKNOWN");    break;
                     }
                 }
                 else

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1359,11 +1359,15 @@ static void MaybePushAddress(UniValue& entry, const CTxDestination& dest)
                     else
                         entry.pushKV("category", "generate");
 
-                    std::string type = IsPoR2(CoinToDouble(r.amount)) ? "POR" : "Interest";
-                    {
-                        entry.pushKV("Type", type);
-                    }
+                    MinedType gentype = GenerateType(wtx.GetHash());
 
+                    switch (gentype)
+                    {
+                        case MinedType::POR         :   entry.pushKV("Type", "POR");  break;
+                        case MinedType::POS         :   entry.pushKV("Type", "POS");  break;
+                        case MinedType::ORPHANED    :   entry.pushKV("Type", "ORPHANED"); break;
+                        default                     :   entry.pushKV("Type", "UNKNOWN"); break;
+                    }
                 }
                 else
                 {

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -58,20 +58,6 @@ void EnsureWalletIsUnlocked()
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Wallet is unlocked for staking only.");
 }
 
-bool IsPoR2(double amt)
-{
-    std::string sAmt = RoundToString(amt,8);
-    if (sAmt.length() > 8)
-    {
-        std::string suffix = sAmt.substr(sAmt.length()-4,4);
-        if (suffix == "0124" || suffix=="0123")
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
 {
     int confirms = wtx.GetDepthInMainChain();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2611,3 +2611,27 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const {
         mapKeyBirth[it->first] = it->second->nTime - 7200; // block times can be 2h off
 }
 
+MinedType GenerateType(const uint256& tx)
+{
+    CWalletTx wallettx;
+    uint256 hashblock;
+
+    if (!GetTransaction(tx, wallettx, hashblock))
+        return MinedType::ORPHANED;
+
+    BlockMap::iterator mi = mapBlockIndex.find(hashblock);
+
+    if (mi == mapBlockIndex.end())
+        return MinedType::UNKNOWN;
+
+    CBlockIndex* blkindex = (*mi).second;
+
+    if (blkindex->nResearchSubsidy == 0)
+        return MinedType::POS;
+
+    else if (blkindex->nResearchSubsidy > 0)
+        return MinedType::POR;
+
+    else
+        return MinedType::UNKNOWN;
+}

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -33,7 +33,7 @@ enum WalletFeature
     FEATURE_LATEST = 60000
 };
 
-/** (POS/POR) enums for CoinStake Transactions*/
+/** (POS/POR) enums for CoinStake Transactions -- We should never get unknown but just incase!*/
 enum MinedType
 {
     UNKNOWN = 0,

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -33,6 +33,15 @@ enum WalletFeature
     FEATURE_LATEST = 60000
 };
 
+/** (POS/POR) enums for CoinStake Transactions*/
+enum MinedType
+{
+    UNKNOWN = 0,
+    POS = 1,
+    POR = 2,
+    ORPHANED = 3
+};
+
 /** A key pool entry */
 class CKeyPool
 {
@@ -936,5 +945,7 @@ private:
 };
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
+
+MinedType GenerateType(const uint256& tx);
 
 #endif


### PR DESCRIPTION
This POR removes the ability to have to use 0123 0124 in stake amount.

Feel Free To NIT and PICK to make this better then its current state.

Made an `enum MinedType` in wallet.h:
* POR
* POS
* ORPHANED
* UNKNOWN
Reasoning to go beyond POS/POR:
In cases where a block is orphaned the block does not exist anymore so you can't pull the transaction and blockhash it is apart of. we should consider an icon as for now i'm using the ! icon
I've also added UNKNOWN thou I do not think we should run into a case of such, plz comment on that

`GenerateType` function added:
Looks for the blockhash and if it cannot find it returns `MinedType::ORPHANED`
If block is found for the transaction of the coinstake then It will check the Research Subsidy field (which seems like the best bet for this kind of implementation:
If finds 0 subsidy it returns `MinedType::POS`
if finds > 0 subsidy it returns `MinedType::POR`
Should not find anything less the 0 if so `MinedType::UNKNOWN` this could be in case a bug ever came through that resulted in a negative `ResearchReward`. (open to removal)

transactiontablemode.cpp:

Changed the detection for the icons based on new implementation
Changes the text shown for the type of mined block based on new implementation

rpcwallet.cpp:

Changes listtransactions to use new implementations

removed:
IsPoR and IsPoR2 functions


Only last part to remove would be the lines from main.cpp:
`
            if (nBoinc > 1)
            {
                std::string sTotalSubsidy = RoundToString(CoinToDouble(nTotalSubsidy)+.00000123,8);
                if (sTotalSubsidy.length() > 7)
                {
                    sTotalSubsidy = sTotalSubsidy.substr(0,sTotalSubsidy.length()-4) + "0124";
                    nTotalSubsidy = RoundFromString(sTotalSubsidy,8)*COIN;
                }
            }
`
My changes are not mandatory and backward compatible. the above lines for the final change would likely be mandatory since it is in `GetProofOfStakeReward` so this change is safe to merge till a mandatory that we modify GetProofOfStakeReward with say a block 10 or 11 change for that. this will now not change the last 4 digits of reward once removed as well.

I did think about putting this somewhere in wallet however with rebase coming over the next while this would complicate things more i'm sure so it is separated.

This should have a more positive impact on issue #1269 on a cosmetic at this time and we should consider the above code change with the release of cbr and @jamescowens split stake. bonus is we can also now even at ease add even an icon so another wallet receiving a split could show up that icon based on the vouts meaning separate icon for stake split 