### PR TITLE
Make display of private key in beaconstatus OPT-IN only

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -149,6 +149,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "walletpassphrase"       , 2 },
 
     // Mining
+    { "beaconstatus"           , 1 },
     { "explainmagnitude"       , 0 },
 
     // Developer


### PR DESCRIPTION
As we all know this has happened numerous times where a user seeking help unknowingly displays their own private keys while displaying `beaconstatus` for help from the community (ex today from yet another user). This private key is not required for a user to receive help from any community member and should be default "eyes-only". I've done an implementation to do as such;

* Allow the cpid string option to be empty or null allowing use of the 2nd paramater argument without user having to enter their cpid

* Add default bool of false for display of private key

* Update the help to reflect that

* removed not needed .c_str()'s for push backs

I used the same method for the bool of int or true/false as @jamescowens had implemented in another PR thou I think we should come up with a static or inline function of some sort that does this determination for us or perhaps modify univalue bool to accept an int as well as text true/false for a bool in future. 