### PR TITLE
Disable Qt for windows Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
 # 32-bit + dash
     - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib" DEP_OPTS="NO_QT=1" RUN_TESTS=false GOAL="install" GRIDCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
 # Win64
-    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 xvfb" RUN_TESTS=false GOAL="" GRIDCOIN_CONFIG="--enable-reduce-exports" NEED_XVFB=1
+    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 xvfb" DEP_OPTS="NO_QT=1" RUN_TESTS=false GOAL="" GRIDCOIN_CONFIG="--enable-reduce-exports" NEED_XVFB=1
 # Cross-Mac - disabled for now, since we cannot compile QtSVG with the SDK
     #- HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" GRIDCOIN_CONFIG="--enable-gui --enable-reduce-exports" OSX_SDK=10.11 RUN_TESTS=false GOAL="deploy"
 


### PR DESCRIPTION
Compiling them from scratch takes too long and makes the Travis Jobs timeout. Not sure, why this suddenly occured. Probably Travis decreased the maximum build time for a single test.