### PR TITLE
Remove bOPReturnEnabled and correct handling of OP_RETURN

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,7 +172,6 @@ CBigNum bnProofOfWorkLimitTestNet(~uint256(0) >> 16);
 unsigned int nStakeMinAge = 16 * 60 * 60; // 16 hours
 unsigned int nStakeMaxAge = -1; // unlimited
 unsigned int nModifierInterval = 10 * 60; // time to elapse before new modifier is computed
-bool bOPReturnEnabled = true;
 
 // Gridcoin:
 int nCoinbaseMaturity = 100;
@@ -5115,7 +5114,6 @@ bool LoadBlockIndex(bool fAllowNew)
         nGrandfather = 196550;
         nNewIndex = 10;
         nNewIndex2 = 36500;
-        bOPReturnEnabled = false;
         //1-24-2016
         MAX_OUTBOUND_CONNECTIONS = (int)GetArg("-maxoutboundconnections", 8);
     }

--- a/src/main.h
+++ b/src/main.h
@@ -170,8 +170,6 @@ extern std::set<CWallet*> setpwalletRegistered;
 extern unsigned char pchMessageStart[4];
 extern std::map<uint256, CBlock*> mapOrphanBlocks;
 
-extern bool bOPReturnEnabled;
-
 // Settings
 extern int64_t nTransactionFee;
 extern int64_t nReserveBalance;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -26,6 +26,17 @@ bool TransactionRecord::showTransaction(const CWalletTx &wtx)
             return false;
         }
     }
+
+    // Suppress OP_RETURN transactions if they did not originate from you.
+    // This is not "very" taxing but necessary since the transaction is in the wallet already.
+    if (!wtx.IsFromMe())
+    {
+        for (auto const& txout : wtx.vout)
+        {
+            if (txout.scriptPubKey == (CScript() << OP_RETURN))
+                return false;
+        }
+    }
     return true;
 }
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1506,7 +1506,7 @@ int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned c
     case TX_NONSTANDARD:
         return -1; // Note, this was empty (thats -1);
     case TX_NULL_DATA:
-        return (bOPReturnEnabled) ? -1 : -1;
+        return -1;
         // Script Sig Args Expected:  Bitcoin=-1, PPCoin=1
     case TX_PUBKEY:
         return 1;
@@ -1584,8 +1584,7 @@ bool IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
     {
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
-        // Note this was always false, til 3-13-2016.
-        return (bOPReturnEnabled) ? true : false;
+        return false;
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
         return keystore.HaveKey(keyID);
@@ -1620,8 +1619,8 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
     if (!Solver(scriptPubKey, whichType, vSolutions))
         return false;
 
-    if (bOPReturnEnabled && whichType == TX_NULL_DATA)
-        return true;
+    if (whichType == TX_NULL_DATA)
+        return false;
 
     if (whichType == TX_PUBKEY)
     {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -818,8 +818,8 @@ void CWalletTx::GetAmounts2(list<COutputEntry>& listReceived,
         }
         else
         {
-            if (   (  !bOPReturnEnabled && !ExtractDestination(txout.scriptPubKey, address) )
-                || (   bOPReturnEnabled && !ExtractDestination(txout.scriptPubKey, address) && txout.scriptPubKey[0] != OP_RETURN) )
+            if (   ( !ExtractDestination(txout.scriptPubKey, address) )
+                || ( !ExtractDestination(txout.scriptPubKey, address) && txout.scriptPubKey[0] != OP_RETURN) )
             {
                 LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                      this->GetHash().ToString().c_str());


### PR DESCRIPTION
This removes the bOPReturnEnabled flag and corrects
the handling of OP_RETURN outputs.

Note TX_NULL_DATA behavior is corrected.

Unfortunately a vout loop is required in TransactionRecord::showTransaction(const CWalletTx &wtx) to suppress the transactions that are not IsFromMe() and have a vout that is OP_RETURN. Inelegant, but effective.