### PR TITLE
Use smallest utxos first for messate types beacon vote, project, poll and beacon

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1675,17 +1675,8 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
                 set<pair<const CWalletTx*,unsigned int> > setCoins;
                 int64_t nValueIn = 0;
 
-                if (!contract)
-                {
-                    if (!SelectCoins(nTotalValue, wtxNew.nTime, setCoins, nValueIn, coinControl))
-                        return false;
-                }
-
-                else
-                {
-                    if (!SelectCoins(nTotalValue, wtxNew.nTime, setCoins, nValueIn, coinControl, true))
-                        return false;
-                }
+                if (!SelectCoins(nTotalValue, wtxNew.nTime, setCoins, nValueIn, coinControl, contract))
+                    return false;
 
                 for (auto const& pcoin : setCoins)
                 {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1663,7 +1663,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
                 // Determine if this beacon or vote tx
                 bool contract = false;
 
-                if (!wtxNew.hashBoinc.empty())
+                if (!wtxNew.hashBoinc.empty() && !coinControl)
                 {
                     std::string contracttype = ExtractXML(wtxNew.hashBoinc, "<MT>", "</MT>");
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1410,8 +1410,6 @@ bool CWallet::SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, 
         // We will follow normal rules as well
         sort(vCoins.begin(), vCoins.end(), smallestcoinscomp());
 
-        int64_t collectedcoins = 0;
-
         for (auto c : vCoins)
         {
             const CWalletTx *pcoin = c.tx;
@@ -1426,24 +1424,21 @@ bool CWallet::SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, 
                 continue;
 
             int64_t n = pcoin->vout[i].nValue;
-            collectedcoins += n;
 
             pair<int64_t,pair<const CWalletTx*,unsigned int>> coin = make_pair(n,make_pair(pcoin, i));
 
-            if (collectedcoins >= nTargetValue)
-            {
-                setCoinsRet.insert(coin.second);
-                nValueRet += coin.first;
+            setCoinsRet.insert(coin.second);
+            nValueRet += coin.first;
 
+            if (nValueRet >= nTargetValue)
                 return true;
-            }
 
             else
                 continue;
         }
 
         // Not enough coins
-        if (collectedcoins < nTargetValue)
+        if (nValueRet < nTargetValue)
             return false;
     }
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -66,7 +66,7 @@ public:
 class CWallet : public CCryptoKeyStore
 {
 private:
-    bool SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, const CCoinControl *coinControl=NULL) const;
+    bool SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, const CCoinControl *coinControl=NULL, bool smallest = false) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -132,7 +132,7 @@ public:
 	void AvailableCoinsForStaking(std::vector<COutput>& vCoins, unsigned int nSpendTime) const;
     bool SelectCoinsForStaking(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, bool fIncludeStakingCoins=false) const;
-    bool SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
+    bool SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, bool smallest = false) const;
 
     // keystore implementation
     // Generate a new key


### PR DESCRIPTION
* Made a comparator to help aid in the sorting.
* Uses smallest to largest txs till it reaches equal to or greater of the targets amount needed.
* Once it does it returns true with the setCoinsRet containing the inputs for it.

Tested and works.

non contract will still use the old method. and coincontrol methods will not take part in this case.