### PR TITLE
getblockstats rpc call bug

### DIFF
--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -200,9 +200,8 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
         result.pushKV("blocksizek", size_sum_blk/(double)blockcount/(double)1024);
         result.pushKV("posdiff", diff_sum/(double)poscount);
         if (super_count > 0)
-            result.pushKV("super_spacing_hrs", (((double)l_last_time-(double)l_first_time)/(double)super_count)/3600.0);
-        else
-            result.pushKV("super_spacing_hrs", "N/A");
+            result.pushKV("super_spacing_hrs", ((l_last_time-l_first_time)/(double)super_count)/3600.0);
+
         result1.pushKV("averages", result);
     }
     {

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -199,7 +199,10 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
         result.pushKV("transaction", transactioncount/(double)(blockcount-emptyblockscount));
         result.pushKV("blocksizek", size_sum_blk/(double)blockcount/(double)1024);
         result.pushKV("posdiff", diff_sum/(double)poscount);
-        result.pushKV("super_spacing_hrs", (((double)l_last_time-(double)l_first_time)/(double)super_count)/3600.0);
+        if (super_count > 0)
+            result.pushKV("super_spacing_hrs", (((double)l_last_time-(double)l_first_time)/(double)super_count)/3600.0);
+        else
+            result.pushKV("super_spacing_hrs", "N/A");
         result1.pushKV("averages", result);
     }
     {


### PR DESCRIPTION
Fix for the rpc call of getblockstats.

essentially what was happening was the univalue handles differently between ui and command line call/http call

The problem was the division by 0 when the super_count was 0 resulting in a result leaving an empty result in json reply. essentially when univalue tried to process the read on it the json was invalid.

```
{
    "result": {
        "general": {
            "blocks": 300,
            "first_height": 662970,
            "last_height": 663269,
            "first_time": "09-08-2018 13:34:08",
            "last_time": "09-08-2018 21:42:56",
            "time_span_hour": 8.146666666666667,
            "min_blocksizek": 0.66796875,
            "max_blocksizek": 2.3623046875,
            "min_posdiff": 0.1908121344114042,
            "max_posdiff": 1.079405079553315
        },
        "counts": {
            "block": 300,
            "empty_block": 294,
            "transaction": 16,
            "proof_of_stake": 300,
            "boincreward": 57,
            "super": 0
        },
        "totals": {
            "block": 300,
            "research": 5959.07,
            "interest": 3000,
            "mint": 8959.02707068,
            "blocksizek": 277.5283203125,
            "posdiff": 132.7511044050859
        },
        "averages": {
            "research": 104.5450877192982,
            "interest": 10,
            "mint": 29.86342356893334,
            "spacing_sec": 97.76000000000001,
            "block_per_day": 883.7970540098199,
            "transaction": 2.666666666666667,
            "blocksizek": 0.9250944010416666,
            "posdiff": 0.4425036813502863,
            "super_spacing_hrs": 
        },
        "versions": {
            "v3.7.16.1-gf5ba8a39d": 0.6899999999999999,
            "v3.7.16.1-unk": 0.18,
            "v3.7.16.1-gb8a05cc63": 0.06,
            "v3.7.16.1-g79490a2c9": 0.03666666666666667,
            "v3.7.16.1-g44df901f0-dirty": 0.03,
            "v3.7.16.1-g44df901f0": 0.003333333333333334
        },
        "cpids": {
            "1963a6f109ea770c195a0e1afacd2eba": 0.4533333333333333,
            "INVESTOR": 0.34,
            "8f2a530cf6f73647af4c680c3471ea65": 0.08666666666666667,
            "363d6c820aef2dbbe082768b40feed0d": 0.02,
            "ae09ae64245d408ee781bcca0841e218": 0.01666666666666667,
            "bc0621a4ac4610ffa400a0d298c02e23": 0.01666666666666667,
            "d0cea85e7a4a3e30af709e672dace08b": 0.01666666666666667,
            "163f049997e8a2dee054d69a7720bf05": 0.01333333333333333,
            "d40e500cd13f2eaa895d374a3e7f3d86": 0.01333333333333333,
            "a914eba952be5dfcf73d926b508fd5fa": 0.01,
            "7d0d73fe026d66fd4ab8d5d8da32a611": 0.006666666666666667,
            "17029c4576fc8e66b21dfec118099199": 0.003333333333333334,
            "71e89425d98117eba0b2e86a5e517803": 0.003333333333333334
        },
        "orgs": {
            "bgb-desktop": 0.4533333333333333,
            "caraka": 0.1,
            "langfod-f1": 0.09,
            "barton26-pi": 0.08666666666666667,
            "TomasBrod.Sa.E": 0.06,
            "dc7d": 0.05,
            "noah-blaker": 0.02,
            "shmoogleosukami-win10-NN": 0.01666666666666667,
            "jamescowens-windows": 0.01666666666666667,
            "Nethhlek": 0.01666666666666667,
            "bgb-test-pool-stake-3": 0.01333333333333333,
            "ToggletonLinuxGit": 0.01333333333333333,
            "bgb-test-pool-stake-2": 0.01,
            "G_UK-Pi64-Buster": 0.006666666666666667,
            "bgb-test-pool-stake-1": 0.006666666666666667,
            "G_UK-x64-DebianStretch": 0.006666666666666667,
            "G_UK-Pi64-Stretch": 0.006666666666666667,
            "delta": 0.003333333333333334,
            "jamescowens-Odroid-XU4": 0.003333333333333334,
            "jamescowens-linux-compiled_from_git": 0.003333333333333334,
            "KarVi71": 0.003333333333333334,
            "koolobus-0-Win": 0.003333333333333334,
            "langfod": 0.003333333333333334,
            "langfod-nn1": 0.003333333333333334,
            "G_UK-PiZeroW-Raspbian": 0.003333333333333334
        }
    },
    "error": null,
    "id": 1
}
```

as you can see `super_spacing_hrs`