### PR TITLE
Removal of 0123 0124 & implementation of GenerateType/MinedType

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2149,16 +2149,17 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
             int64_t maxStakeReward = std::min(maxStakeReward1, maxStakeReward2);
             if ((nSubsidy+nFees) > maxStakeReward) nSubsidy = maxStakeReward-nFees;
             int64_t nTotalSubsidy = nSubsidy + nFees;
-            if (nBoinc > 1)
+            // This rule does not apply in v11
+            if (nBoinc > 1 && pindexLast->nVersion <= 10)
             {
                 std::string sTotalSubsidy = RoundToString(CoinToDouble(nTotalSubsidy)+.00000123,8);
+
                 if (sTotalSubsidy.length() > 7)
                 {
                     sTotalSubsidy = sTotalSubsidy.substr(0,sTotalSubsidy.length()-4) + "0124";
                     nTotalSubsidy = RoundFromString(sTotalSubsidy,8)*COIN;
                 }
             }
-
             OUT_POR = CoinToDouble(nBoinc);
             OUT_INTEREST = CoinToDouble(nInterest);
             return nTotalSubsidy;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -125,7 +125,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
             default                           :    strHTML += tr("MINED - UNKNOWN");    break;
         }
 
-        strHTML += "<br";
+        strHTML += "<br>";
     }
     // Online transaction
     else if (wtx.mapValue.count("from") && !wtx.mapValue["from"].empty())

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -75,7 +75,7 @@ std::string PubKeyToGRCAddress(const CScript& scriptPubKey)
     return grcaddress;
 }
 
-QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
+QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vout)
 {
     QString strHTML;
 	
@@ -109,8 +109,24 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
         strHTML += "<b>" + tr("Source") + ":</b> " + tr("Generated in CoinBase") + "<br>";
 
     else if (wtx.IsCoinStake())
-        strHTML += "<b>" + tr("Source") + ":</b> " + tr("Generated, PoS") + "<br>";
+    {
+        // Update support for Side Stake and correctly show POS/POR as well
+        strHTML += "<b>" + tr("Source") + ":</b> ";
 
+        MinedType gentype = GenerateType(wtx.GetHash(), vout);
+
+        switch (gentype)
+        {
+            case MinedType::POS               :    strHTML += tr("MINED - POS");        break;
+            case MinedType::POR               :    strHTML += tr("MINED - POR");        break;
+            case MinedType::ORPHANED          :    strHTML += tr("MINED - ORPHANED");   break;
+            case MinedType::POS_SIDE_STAKE    :    strHTML += tr("POS SIDE STAKE");     break;
+            case MinedType::POR_SIDE_STAKE    :    strHTML += tr("POR SIDE STAKE");     break;
+            default                           :    strHTML += tr("MINED - UNKNOWN");    break;
+        }
+
+        strHTML += "<br";
+    }
     // Online transaction
     else if (wtx.mapValue.count("from") && !wtx.mapValue["from"].empty())
         strHTML += "<b>" + tr("From") + ":</b> " + GUIUtil::HtmlEscape(wtx.mapValue["from"]) + "<br>";

--- a/src/qt/transactiondesc.h
+++ b/src/qt/transactiondesc.h
@@ -14,7 +14,7 @@ class TransactionDesc: public QObject
 {
     Q_OBJECT
 public:
-    static QString toHTML(CWallet *wallet, CWalletTx &wtx);
+    static QString toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vout);
 private:
     TransactionDesc() {}
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -100,32 +100,16 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 if (wtx.IsCoinStake())
                 {
                     // Generated (proof-of-stake)
-			        if (hashPrev == hash)
+                    if (hashPrev == hash)
                         continue; // last coinstake output
 
-					if (wtx.vout.size()==2)
-					{
-						//Standard POR CoinStake
-						sub.type = TransactionRecord::Generated;
-						sub.credit = nNet > 0 ? nNet : wtx.GetValueOut() - nDebit;
-						hashPrev = hash;
-					}
-					else
-					{
-						//CryptoLottery - CoinStake - 4-3-2015
-						sub.type = TransactionRecord::Generated;
-						if (nDebit == 0)
-						{
-							sub.credit = GetMyValueOut(wallet,wtx);
-							sub.RemoteFlag = 1;
-						}
-						else
-						{
-							sub.credit = nNet > 0 ? nNet : GetMyValueOut(wallet,wtx) - nDebit;
-						}
-
-						hashPrev = hash;
-					}
+                    if (wtx.vout.size() >= 2)
+                    {
+                        //Standard POR CoinStake
+                        sub.type = TransactionRecord::Generated;
+                        sub.credit = nNet > 0 ? nNet : wtx.GetValueOut() - nDebit;
+                        hashPrev = hash;
+                    }
                 }
 
                 parts.append(sub);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -69,18 +69,19 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
     if (nNet > 0 || wtx.IsCoinBase() || wtx.IsCoinStake())
     {
-        //
-        // Credit - Calculate Net from CryptoLottery Rob Halford - 4-3-2015-1
-        //
-        for (auto const& txout : wtx.vout)
+        // Cannot use range based loop anymore
+        for (unsigned int t = 0; t < wtx.vout.size(); t++)
+        //for (auto const& txout : wtx.vout)
         {
-            if(wallet->IsMine(txout))
+            if(wallet->IsMine(wtx.vout[t]))
             {
                 TransactionRecord sub(hash, nTime);
                 CTxDestination address;
                 sub.idx = parts.size(); // sequence number
-                sub.credit = txout.nValue;
-                if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*wallet, address))
+                sub.credit = wtx.vout[t].nValue;
+                sub.vout = t;
+
+                if (ExtractDestination(wtx.vout[t].scriptPubKey, address) && IsMine(*wallet, address))
                 {
                     // Received by Bitcoin Address
                     sub.type = TransactionRecord::RecvWithAddress;
@@ -105,7 +106,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
                     if (wtx.vout.size() >= 2)
                     {
-                        //Standard POR CoinStake
+                        //Standard POR/POS CoinStake
                         sub.type = TransactionRecord::Generated;
                         sub.credit = nNet > 0 ? nNet : wtx.GetValueOut() - nDebit;
                         hashPrev = hash;
@@ -132,7 +133,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             int64_t nChange = wtx.GetChange();
 
             parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
-                            -(nDebit - nChange), nCredit - nChange));
+                            -(nDebit - nChange), nCredit - nChange, 0));
         }
         else if (fAllFromMe)
         {
@@ -185,7 +186,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             //
             // Mixed debit transaction, can't break down payees
             //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
+            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0, 0));
         }
     }
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -108,7 +108,6 @@ public:
     std::string address;
     qint64 debit;
     qint64 credit;
-    qint64 RemoteFlag;
 
     // Side/Split Stake
     unsigned int vout;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -77,21 +77,21 @@ public:
     static const int RecommendedNumConfirmations = 10;
 
     TransactionRecord():
-            hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0)
+            hash(), time(0), type(Other), address(""), debit(0), credit(0), vout(0), idx(0)
     {
     }
 
     TransactionRecord(uint256 hash, int64_t time):
             hash(hash), time(time), type(Other), address(""), debit(0),
-            credit(0), idx(0)
+            credit(0), vout(0), idx(0)
     {
     }
 
     TransactionRecord(uint256 hash, int64_t time,
                 Type type, const std::string &address,
-                int64_t debit, int64_t credit):
+                int64_t debit, int64_t credit, unsigned int vout):
             hash(hash), time(time), type(type), address(address), debit(debit), credit(credit),
-            idx(0)
+            vout(vout), idx(0)
     {
     }
 
@@ -108,7 +108,10 @@ public:
     std::string address;
     qint64 debit;
     qint64 credit;
-	qint64 RemoteFlag;
+    qint64 RemoteFlag;
+
+    // Side/Split Stake
+    unsigned int vout;
     /**@}*/
 
     /** Subtransaction index, for sort key */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -219,7 +219,7 @@ public:
             std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
             if(mi != wallet->mapWallet.end())
             {
-                return TransactionDesc::toHTML(wallet, mi->second);
+                return TransactionDesc::toHTML(wallet, mi->second, rec->vout);
             }
         }
         return QString("");

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -399,14 +399,24 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
 				return tr("Minted - (Local) DPOR");
 			}
 		}
-		else if (((IsPoR(CoinToDouble(wtx->credit + wtx->debit)))))
-		{
-				return tr("Mined - PoR");
-		}
-		else
-		{
-				return tr("Mined - Interest");
-		}
+
+        else
+        {
+            MinedType gentype = GenerateType(wtx->hash);
+
+            if (gentype == MinedType::POS)
+                return tr("Mined - POS");
+
+            else if (gentype == MinedType::POR)
+                return tr("Mined - POR");
+
+            else if (gentype == MinedType::ORPHANED)
+                return tr("Mined - ORPHANED");
+
+            else
+                return tr("Mined - UNKNOWN");
+        }
+
     default:
         return QString();
     }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -425,21 +425,19 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
 
 QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx) const
 {
-	double reward = CoinToDouble(wtx->credit + wtx->debit);
-	double max = GetMaximumBoincSubsidy(GetAdjustedTime());
-	bool is_por = IsPoR(reward);
-	switch(wtx->type)
+    switch(wtx->type)
     {
     case TransactionRecord::Generated:
-        if (is_por)
-        {
-            return QIcon(":/icons/tx_cpumined");
-        }
-        else
-        {
-            return QIcon(":/icons/tx_mined");
-        }
+    {
+        MinedType gentype = GenerateType(wtx->hash);
 
+        if (gentype == MinedType::POR)
+            return QIcon(":/icons/tx_cpumined");
+
+        // TODO lets make a ORPHANED ICON/UNKNOWN ICON
+        else
+            return QIcon(":/icons/tx_mined");
+    }
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:
         return QIcon(":/icons/tx_input");

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -21,9 +21,6 @@
 
 int64_t GetMaximumBoincSubsidy(int64_t nTime);
 double CoinToDouble(double surrogate);
-extern bool IsPoR(double amt);
-
-
 
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
@@ -352,23 +349,6 @@ QString TransactionTableModel::lookupAddress(const std::string &address, bool to
     }
 
     return description;
-}
-
-
-
-
-bool IsPoR(double amt)
-{
-	std::string sAmt = RoundToString(amt,8);
-	if (sAmt.length() > 8)
-	{
-		std::string suffix = sAmt.substr(sAmt.length()-4,4);
-		if (suffix =="0124" || suffix=="0123")
-		{
-			return true;
-		}
-	}
-	return false;
 }
 
 QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -388,7 +388,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
                 case MinedType::POS        :    return tr("MINED - POS");
                 case MinedType::POR        :    return tr("MINED - POR");
                 case MinedType::ORPHANED   :    return tr("MINED - ORPHANED");
-                case MinedType::UNKNOWN    :    return tr("MINED - UNKNOWN");
                 default                    :    return tr("MINED - UNKNOWN");
             }
         }
@@ -412,7 +411,8 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
         {
             case MinedType::POS        :    return QIcon(":/icons/tx_mined");
             case MinedType::POR        :    return QIcon(":/icons/tx_cpumined");
-            default                    :    return QIcon(":/icons/tx_mined");
+            case MinedType::ORPHANED   :    return QIcon(":/icons/transaction_conflicted");
+            default                    :    return QIcon(":/icons/transaction_0");
         }
     }
     case TransactionRecord::RecvWithAddress:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -365,21 +365,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::SendToSelf:
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
-        if (wtx->RemoteFlag==1 && false)
-        {
-            double reward = CoinToDouble(wtx->credit + wtx->debit);
-            double max = GetMaximumBoincSubsidy(GetAdjustedTime());
-            if (reward==max)
-            {
-                return tr("Mined - DPOR");
-            }
-            else
-            {
-                return tr("Minted - (Local) DPOR");
-            }
-        }
-
-        else
         {
             MinedType gentype = GenerateType(wtx->hash);
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -452,9 +452,6 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
 
 QString TransactionTableModel::formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed) const
 {
-
-	//4-3-2015 R Halford; Display the correct Tx Amount; Ensure credits sourced from CryptoLottery display the correct amount (not Block Stake minus Credit):
-
     QString str = BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), wtx->credit + wtx->debit);
     if(showUnconfirmed)
     {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -365,20 +365,19 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::SendToSelf:
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
-	    if (wtx->RemoteFlag==1 && false)
-		{
-
-			double reward = CoinToDouble(wtx->credit + wtx->debit);
-			double max = GetMaximumBoincSubsidy(GetAdjustedTime());
-			if (reward==max)
-			{
-				return tr("Mined - DPOR");
-			}
-			else
-			{
-				return tr("Minted - (Local) DPOR");
-			}
-		}
+        if (wtx->RemoteFlag==1 && false)
+        {
+            double reward = CoinToDouble(wtx->credit + wtx->debit);
+            double max = GetMaximumBoincSubsidy(GetAdjustedTime());
+            if (reward==max)
+            {
+                return tr("Mined - DPOR");
+            }
+            else
+            {
+                return tr("Minted - (Local) DPOR");
+            }
+        }
 
         else
         {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -366,14 +366,16 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         {
-            MinedType gentype = GenerateType(wtx->hash);
+            MinedType gentype = GenerateType(wtx->hash, wtx->vout);
 
             switch (gentype)
             {
-                case MinedType::POS        :    return tr("MINED - POS");
-                case MinedType::POR        :    return tr("MINED - POR");
-                case MinedType::ORPHANED   :    return tr("MINED - ORPHANED");
-                default                    :    return tr("MINED - UNKNOWN");
+                case MinedType::POS             :    return tr("MINED - POS");
+                case MinedType::POR             :    return tr("MINED - POR");
+                case MinedType::ORPHANED        :    return tr("MINED - ORPHANED");
+                case MinedType::POS_SIDE_STAKE  :    return tr("MINED - POS SIDE STAKE");
+                case MinedType::POR_SIDE_STAKE  :    return tr("MINED - POR SIDE STAKE");
+                default                         :    return tr("MINED - UNKNOWN");
             }
         }
 
@@ -390,7 +392,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     case TransactionRecord::Generated:
     {
         // TODO consider an icon for least unknown thou unlikely we would have that and orphan only seen when showorphans option set to true
-        MinedType gentype = GenerateType(wtx->hash);
+        MinedType gentype = GenerateType(wtx->hash, wtx->vout);
 
         switch (gentype)
         {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -391,15 +391,17 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     {
     case TransactionRecord::Generated:
     {
-        // TODO consider an icon for least unknown thou unlikely we would have that and orphan only seen when showorphans option set to true
+        // TODO Make an icon for POS/POR SIDE STAKE
         MinedType gentype = GenerateType(wtx->hash, wtx->vout);
 
         switch (gentype)
         {
-            case MinedType::POS        :    return QIcon(":/icons/tx_mined");
-            case MinedType::POR        :    return QIcon(":/icons/tx_cpumined");
-            case MinedType::ORPHANED   :    return QIcon(":/icons/transaction_conflicted");
-            default                    :    return QIcon(":/icons/transaction_0");
+            case MinedType::POS               :    return QIcon(":/icons/tx_mined");
+            case MinedType::POR               :    return QIcon(":/icons/tx_cpumined");
+            case MinedType::ORPHANED          :    return QIcon(":/icons/transaction_conflicted");
+            case MinedType::POS_SIDE_STAKE    :    return QIcon(":/icons/transaction_0");
+            case MinedType::POR_SIDE_STAKE    :    return QIcon(":/icons/transaction_0");
+            default                           :    return QIcon(":/icons/transaction_0");
         }
     }
     case TransactionRecord::RecvWithAddress:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -370,12 +370,12 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
 
             switch (gentype)
             {
-                case MinedType::POS             :    return tr("MINED - POS");
-                case MinedType::POR             :    return tr("MINED - POR");
-                case MinedType::ORPHANED        :    return tr("MINED - ORPHANED");
-                case MinedType::POS_SIDE_STAKE  :    return tr("MINED - POS SIDE STAKE");
-                case MinedType::POR_SIDE_STAKE  :    return tr("MINED - POR SIDE STAKE");
-                default                         :    return tr("MINED - UNKNOWN");
+                case MinedType::POS               :    return tr("MINED - POS");
+                case MinedType::POR               :    return tr("MINED - POR");
+                case MinedType::ORPHANED          :    return tr("MINED - ORPHANED");
+                case MinedType::POS_SIDE_STAKE    :    return tr("POS SIDE STAKE");
+                case MinedType::POR_SIDE_STAKE    :    return tr("POR SIDE STAKE");
+                default                           :    return tr("MINED - UNKNOWN");
             }
         }
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -383,17 +383,14 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         {
             MinedType gentype = GenerateType(wtx->hash);
 
-            if (gentype == MinedType::POS)
-                return tr("Mined - POS");
-
-            else if (gentype == MinedType::POR)
-                return tr("Mined - POR");
-
-            else if (gentype == MinedType::ORPHANED)
-                return tr("Mined - ORPHANED");
-
-            else
-                return tr("Mined - UNKNOWN");
+            switch (gentype)
+            {
+                case MinedType::POS        :    return tr("MINED - POS");
+                case MinedType::POR        :    return tr("MINED - POR");
+                case MinedType::ORPHANED   :    return tr("MINED - ORPHANED");
+                case MinedType::UNKNOWN    :    return tr("MINED - UNKNOWN");
+                default                    :    return tr("MINED - UNKNOWN");
+            }
         }
 
     default:
@@ -408,14 +405,15 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     {
     case TransactionRecord::Generated:
     {
+        // TODO consider an icon for least unknown thou unlikely we would have that and orphan only seen when showorphans option set to true
         MinedType gentype = GenerateType(wtx->hash);
 
-        if (gentype == MinedType::POR)
-            return QIcon(":/icons/tx_cpumined");
-
-        // TODO lets make a ORPHANED ICON/UNKNOWN ICON
-        else
-            return QIcon(":/icons/tx_mined");
+        switch (gentype)
+        {
+            case MinedType::POS        :    return QIcon(":/icons/tx_mined");
+            case MinedType::POR        :    return QIcon(":/icons/tx_cpumined");
+            default                    :    return QIcon(":/icons/tx_mined");
+        }
     }
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1430,9 +1430,14 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                         entry.pushKV("category", "generate");
 
                     }
-                    std::string type = IsPoR2(-nFee) ? "POR" : "Interest";
+                    MinedType gentype = GenerateType(wtx.GetHash());
+
+                    switch (gentype)
                     {
-                        entry.pushKV("Type", type);
+                        case MinedType::POR         :   entry.pushKV("Type", "POR");        break;
+                        case MinedType::POS         :   entry.pushKV("Type", "POS");        break;
+                        case MinedType::ORPHANED    :   entry.pushKV("Type", "ORPHANED");   break;
+                        default                     :   entry.pushKV("Type", "UNKNOWN");    break;
                     }
                 }
                 else

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1359,11 +1359,15 @@ static void MaybePushAddress(UniValue& entry, const CTxDestination& dest)
                     else
                         entry.pushKV("category", "generate");
 
-                    std::string type = IsPoR2(CoinToDouble(r.amount)) ? "POR" : "Interest";
-                    {
-                        entry.pushKV("Type", type);
-                    }
+                    MinedType gentype = GenerateType(wtx.GetHash());
 
+                    switch (gentype)
+                    {
+                        case MinedType::POR         :   entry.pushKV("Type", "POR");  break;
+                        case MinedType::POS         :   entry.pushKV("Type", "POS");  break;
+                        case MinedType::ORPHANED    :   entry.pushKV("Type", "ORPHANED"); break;
+                        default                     :   entry.pushKV("Type", "UNKNOWN"); break;
+                    }
                 }
                 else
                 {

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1430,7 +1430,6 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                     else
                     {
                         entry.pushKV("category", "generate");
-
                     }
                 }
                 else

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1345,14 +1345,16 @@ static void MaybePushAddress(UniValue& entry, const CTxDestination& dest)
                     else
                         entry.pushKV("category", "generate");
 
-                    MinedType gentype = GenerateType(wtx.GetHash());
+                    MinedType gentype = GenerateType(wtx.GetHash(), r.vout);
 
                     switch (gentype)
                     {
-                        case MinedType::POR         :   entry.pushKV("Type", "POR");  break;
-                        case MinedType::POS         :   entry.pushKV("Type", "POS");  break;
-                        case MinedType::ORPHANED    :   entry.pushKV("Type", "ORPHANED"); break;
-                        default                     :   entry.pushKV("Type", "UNKNOWN"); break;
+                        case MinedType::POR             :   entry.pushKV("Type", "POR");                break;
+                        case MinedType::POS             :   entry.pushKV("Type", "POS");                break;
+                        case MinedType::ORPHANED        :   entry.pushKV("Type", "ORPHANED");           break;
+                        case MinedType::POS_SIDE_STAKE  :   entry.pushKV("Type", "POS SIDE STAKE");     break;
+                        case MinedType::POR_SIDE_STAKE  :   entry.pushKV("Type", "POR SIDE STAKE");     break;
+                        default                         :   entry.pushKV("Type", "UNKNOWN");            break;
                     }
                 }
                 else
@@ -1429,15 +1431,6 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                     {
                         entry.pushKV("category", "generate");
 
-                    }
-                    MinedType gentype = GenerateType(wtx.GetHash());
-
-                    switch (gentype)
-                    {
-                        case MinedType::POR         :   entry.pushKV("Type", "POR");        break;
-                        case MinedType::POS         :   entry.pushKV("Type", "POS");        break;
-                        case MinedType::ORPHANED    :   entry.pushKV("Type", "ORPHANED");   break;
-                        default                     :   entry.pushKV("Type", "UNKNOWN");    break;
                     }
                 }
                 else

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1349,12 +1349,12 @@ static void MaybePushAddress(UniValue& entry, const CTxDestination& dest)
 
                     switch (gentype)
                     {
-                        case MinedType::POR             :   entry.pushKV("Type", "POR");                break;
-                        case MinedType::POS             :   entry.pushKV("Type", "POS");                break;
-                        case MinedType::ORPHANED        :   entry.pushKV("Type", "ORPHANED");           break;
-                        case MinedType::POS_SIDE_STAKE  :   entry.pushKV("Type", "POS SIDE STAKE");     break;
-                        case MinedType::POR_SIDE_STAKE  :   entry.pushKV("Type", "POR SIDE STAKE");     break;
-                        default                         :   entry.pushKV("Type", "UNKNOWN");            break;
+                        case MinedType::POR               :    entry.pushKV("Type", "POR");               break;
+                        case MinedType::POS               :    entry.pushKV("Type", "POS");               break;
+                        case MinedType::ORPHANED          :    entry.pushKV("Type", "ORPHANED");          break;
+                        case MinedType::POS_SIDE_STAKE    :    entry.pushKV("Type", "POS SIDE STAKE");    break;
+                        case MinedType::POR_SIDE_STAKE    :    entry.pushKV("Type", "POR SIDE STAKE");    break;
+                        default                           :    entry.pushKV("Type", "UNKNOWN");           break;
                     }
                 }
                 else

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -58,20 +58,6 @@ void EnsureWalletIsUnlocked()
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Wallet is unlocked for staking only.");
 }
 
-bool IsPoR2(double amt)
-{
-    std::string sAmt = RoundToString(amt,8);
-    if (sAmt.length() > 8)
-    {
-        std::string suffix = sAmt.substr(sAmt.length()-4,4);
-        if (suffix == "0124" || suffix=="0123")
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
 {
     int confirms = wtx.GetDepthInMainChain();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2611,3 +2611,27 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const {
         mapKeyBirth[it->first] = it->second->nTime - 7200; // block times can be 2h off
 }
 
+MinedType GenerateType(const uint256& tx)
+{
+    CWalletTx wallettx;
+    uint256 hashblock;
+
+    if (!GetTransaction(tx, wallettx, hashblock))
+        return MinedType::ORPHANED;
+
+    BlockMap::iterator mi = mapBlockIndex.find(hashblock);
+
+    if (mi == mapBlockIndex.end())
+        return MinedType::UNKNOWN;
+
+    CBlockIndex* blkindex = (*mi).second;
+
+    if (blkindex->nResearchSubsidy == 0)
+        return MinedType::POS;
+
+    else if (blkindex->nResearchSubsidy > 0)
+        return MinedType::POR;
+
+    else
+        return MinedType::UNKNOWN;
+}

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -39,7 +39,9 @@ enum MinedType
     UNKNOWN = 0,
     POS = 1,
     POR = 2,
-    ORPHANED = 3
+    ORPHANED = 3,
+    POS_SIDE_STAKE = 4,
+    POR_SIDE_STAKE = 5
 };
 
 /** A key pool entry */
@@ -946,6 +948,5 @@ private:
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
 
-MinedType GenerateType(const uint256& tx);
-
+MinedType GenerateType(const uint256& tx, unsigned int vout);
 #endif

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -33,7 +33,7 @@ enum WalletFeature
     FEATURE_LATEST = 60000
 };
 
-/** (POS/POR) enums for CoinStake Transactions*/
+/** (POS/POR) enums for CoinStake Transactions -- We should never get unknown but just incase!*/
 enum MinedType
 {
     UNKNOWN = 0,

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -33,6 +33,15 @@ enum WalletFeature
     FEATURE_LATEST = 60000
 };
 
+/** (POS/POR) enums for CoinStake Transactions*/
+enum MinedType
+{
+    UNKNOWN = 0,
+    POS = 1,
+    POR = 2,
+    ORPHANED = 3
+};
+
 /** A key pool entry */
 class CKeyPool
 {
@@ -936,5 +945,7 @@ private:
 };
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
+
+MinedType GenerateType(const uint256& tx);
 
 #endif


### PR DESCRIPTION
## Conform main.cpp

* Add condition to use the old 0123 0124 for block version <= 10 since this will be in bv11
* If block version is not <= 10 then it will not modify the last 4 halfords of the generated block
* TODO implement a IsV11Enabled??

## Conform transactiondesc.cpp/h

toHTML:
* Add vout addition to accruately describe what the transaction is
* Removed Generated PoS porition as it said this for both POR/POS so lets just identify the coinstake transaction to what it is; yes a POS but they should know its a POR or not
* Implement GenerateType/MinedType
* Use the vout it receives to determine what it is (Even if multiple vouts the toHTML only sends 1 for the description
* Now shows if it is a POR, POS, POR SIDE STAKE, POS SIDE STAKE, or ORPHAN

## Conform transactionrecord.cpp/h

* Use a for loop instead of range based loop to get the vout in question
* Add a vout field to the TransactionRecord class
* Modify other calls to the class in order to work with new constructor
* vout does not cause any issues with functions that do not use the vout
* Remove cryptolottery section
* Tabs to spaces
* If vout size is >= 2 then set as generated
* Remove RemoteFlag usage

## Conform transactiontablemodel.cpp

* Remove IsPoR

formattxtype:
* Remove RemoteFlag
* Implement GenerateType/MinedType
* Return the MinedType

txaddressdecoration:
* Return icon based on what it is
* Side stake is as ? icon until the two icons can be made
* Tabs to spaces

## Conform rpcwallet.cpp

* Removed IsPoR2

wallettxtojson:
* remove IsPoR2
* Implement GenerateType/MinedType

## Conform wallet.cpp/h

* Implement GenerateType enum function which returns an enum of MinedType
* Implement enum MinedType which returns POR, POS, UNKNOWN (incase), POR side stake, POS side stake and orphan
* If its simply a split stake then return what it is either POR/POS


All changes are not mandatory except the handling of 0123/0124 may be considered mandatory thou I highly doubt the 0.00000001 to 0.00009999 would ever breach the 25% tolereance 25% of 1GRC is 0.25

Feel free to review and ask questions. I chose to keep everything working through the new enum for easier future changes