### PR TITLE
Fix integer overflow with displayed nonce

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -214,7 +214,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
     result.pushKV("mint", mint);
     result.pushKV("MoneySupply", blockindex->nMoneySupply);
     result.pushKV("time", block.GetBlockTime());
-    result.pushKV("nonce", (int)block.nNonce);
+    result.pushKV("nonce", (uint64_t)block.nNonce);
     result.pushKV("bits", strprintf("%08x", block.nBits));
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("blocktrust", leftTrim(blockindex->GetBlockTrust().GetHex(), '0'));


### PR DESCRIPTION
This fixes an integer overflow where many of the early PoW blocks nonces are displayed as negative.

For example, the nonce for testnet block number 2 is currently displayed as -238944000 but with the fix it is displayed as 4056023296.

Note this is only a display issue affecting `getblock` and `getblockbynumber` 