### PR TITLE
Fix off-by-one error during init RA.

### DIFF
--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -619,12 +619,10 @@ bool CTxDB::LoadBlockIndex()
     if (pindex && pindexBest && pindexBest->nHeight > 10 && pindex->pnext)
     {
         LogPrintf(" RA Starting %i %i %i ", pindex->nHeight, pindex->pnext->nHeight, pindexBest->nHeight);
-        while (pindex->nHeight < pindexBest->nHeight)
+        for(; pindex != NULL; pindex = pindex->pnext)
         {
-            if (!pindex || !pindex->pnext) break;
-            pindex = pindex->pnext;
-            if (pindex == pindexBest) break;
-            if (pindex==NULL || !pindex->IsInMainChain()) continue;
+            if (!pindex->IsInMainChain())
+                continue;
 
             if(fQtActive)
             {


### PR DESCRIPTION
The tip of the chain was never included in the RA collecting process. This would manifest as an inability to stake for the researcher who staked the chain head and then restarted. The system would calculate the
rewards based on the researcher's _previously_ staked block. The network, which sees the researcher's _current_ block would reject the stake.