### PR TITLE
Introduce update check on startup for UI and NON-UI

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -110,7 +110,7 @@ GRIDCOIN_CORE_H = \
 	version.h \
 	walletdb.h \
 	wallet.h \
-        update.h
+    update.h
 
 GRIDCOIN_CORE_CPP = addrman.cpp \
 	alert.cpp \
@@ -157,7 +157,7 @@ GRIDCOIN_CORE_CPP = addrman.cpp \
 	version.cpp \
 	wallet.cpp \
 	walletdb.cpp \
-        update.cpp
+    update.cpp
 
 
 obj/build.h: FORCE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,7 +109,8 @@ GRIDCOIN_CORE_H = \
 	util.h \
 	version.h \
 	walletdb.h \
-	wallet.h
+	wallet.h \
+        update.h
 
 GRIDCOIN_CORE_CPP = addrman.cpp \
 	alert.cpp \
@@ -155,7 +156,8 @@ GRIDCOIN_CORE_CPP = addrman.cpp \
 	util.cpp \
 	version.cpp \
 	wallet.cpp \
-	walletdb.cpp
+	walletdb.cpp \
+        update.cpp
 
 
 obj/build.h: FORCE

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -24,6 +24,8 @@
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 #include "global_objects_noui.hpp"
 
+void IsUpdateAvailable();
+
 bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 extern boost::thread_group threadGroup;
 
@@ -953,6 +955,9 @@ bool AppInit2(ThreadHandlerPtr threads)
     int nMismatchSpent;
     int64_t nBalanceInQuestion;
     pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
+
+    // Check if a wallet update exists
+    IsUpdateAvailable();
 
     return true;
 }

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -21,9 +21,20 @@ static bool noui_ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCa
     return true;
 }
 
+static int noui_UpdateMessageBox(const std::string& message)
+{
+    std::string caption = _("Gridcoin Update Available");
+
+    LogPrintf("%s:\r\n%s", caption, message);
+    fprintf(stderr, "\r\n%s:\r\n%s\r\n", caption.c_str(), message.c_str());
+
+    return 0;
+}
+
 void noui_connect()
 {
     // Connect bitcoind signal handlers
     uiInterface.ThreadSafeMessageBox.connect(noui_ThreadSafeMessageBox);
     uiInterface.ThreadSafeAskFee.connect(noui_ThreadSafeAskFee);
+    uiInterface.UpdateMessageBox.connect(noui_UpdateMessageBox);
 }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -132,6 +132,24 @@ static void InitMessage(const std::string &message)
     }
 }
 
+static void UpdateMessageBox(const std::string& message)
+{
+    std::string caption = _("Gridcoin Update Available");
+
+    if (guiref)
+    {
+        QMetaObject::invokeMethod(guiref, "update", Qt::QueuedConnection,
+                                   Q_ARG(QString, QString::fromStdString(caption)),
+                                   Q_ARG(QString, QString::fromStdString(message)));
+    }
+
+    else
+    {
+        LogPrintf("\r\n%s:\r\n%s", caption, message);
+        fprintf(stderr, "\r\n%s:\r\n%s\r\n", caption.c_str(), message.c_str());
+    }
+}
+
 static void QueueShutdown()
 {
     QMetaObject::invokeMethod(QCoreApplication::instance(), "quit", Qt::QueuedConnection);
@@ -249,6 +267,8 @@ int main(int argc, char *argv[])
     uiInterface.InitMessage.connect(InitMessage);
     uiInterface.QueueShutdown.connect(QueueShutdown);
     uiInterface.Translate.connect(Translate);
+
+    uiInterface.UpdateMessageBox.connect(UpdateMessageBox);
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -973,6 +973,23 @@ void BitcoinGUI::error(const QString &title, const QString &message, bool modal)
     }
 }
 
+void BitcoinGUI::update(const QString &title, const QString &message)
+{
+    // Create our own message box a dialog can go here in future for qt
+    QMessageBox* updatemsg = new QMessageBox;
+
+    updatemsg->setAttribute(Qt::WA_DeleteOnClose);
+    updatemsg->setWindowTitle(title);
+    updatemsg->setText(message);
+    updatemsg->setIcon(QMessageBox::Information);
+    updatemsg->setStandardButtons(QMessageBox::Ok);
+    updatemsg->setModal(false);
+    // Due to slight delay in gui load this could appear but be behind the gui ui
+    // This only other option available would make the message box stay on top of all applications
+
+    QTimer::singleShot(5000, updatemsg, SLOT(show()));
+}
+
 void BitcoinGUI::changeEvent(QEvent *e)
 {
     QMainWindow::changeEvent(e);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -155,6 +155,9 @@ public slots:
     */
     void setEncryptionStatus(int status);
 
+    /** Notify the user if there is an update available */
+    void update(const QString &title, const QString &message);
+
     /** Notify the user of an error in the network or transaction handling code. */
     void error(const QString &title, const QString &message, bool modal);
     /** Asks the user whether to pay the transaction fee or to cancel the transaction.

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -96,6 +96,9 @@ public:
      * @note called with lock cs_mapAlerts held.
      */
     boost::signals2::signal<void (const uint256 &hash, ChangeType status)> NotifyAlertChanged;
+
+    /** Update notification message box. */
+    boost::signals2::signal<void (const std::string& message)> UpdateMessageBox;
 };
 
 extern CClientUIInterface uiInterface;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1,0 +1,167 @@
+#include "update.h"
+#include "univalue.h"
+#include "version.h"
+#include "ui_interface.h"
+#include "util.h"
+
+#include <string>
+#include <vector>
+
+extern void IsUpdateAvailable();
+
+bool update::VersionCheck()
+{
+    if (fTestNet)
+    {
+        LogPrintf("Update Check: Skipped, client running testnet");
+
+        return true;
+    }
+
+    // Init SSL
+    if (!sslinit())
+    {
+        LogPrintf("Update Check: Failed to initilize SSL");
+
+        return false;
+    }
+
+    // IP look up for api.github.com
+    if (!addresslookup())
+    {
+        LogPrintf("Update Check: Failed to look up host");
+
+        return false;
+    }
+
+    // Init Socket
+    if (!socketinit())
+    {
+        LogPrintf("Update Check: Failed to initilize Socket");
+
+        return false;
+    }
+
+    // Connect Socket
+    if (!socketconnect())
+    {
+        LogPrintf("Update Check: Failed to connect SSL socket (%d)", statuscode);
+
+        return false;
+    }
+
+    // Send Request
+    if (!requestdata())
+    {
+        LogPrintf("Update Check: Failed to request data (%d)", statuscode);
+
+        return false;
+    }
+
+    // Receive Reply
+    if (!recvreply())
+    {
+        LogPrintf("Update Check: Failed to receive reply (%d)", statuscode);
+
+        return false;
+    }
+
+    // Strip reply
+    stripreply();
+
+    clearstatus();
+
+    UniValue json (UniValue::VOBJ);
+
+    // Read into UniValue
+    if (!json.read(strippedreply))
+    {
+        LogPrintf("Update Check: Failed to parse reply into json");
+
+        return false;
+    }
+
+    if (!json.isObject())
+    {
+        LogPrintf("Update Check: It appears the reply is not a json object");
+
+        return false;
+    }
+
+    // We have json and a valid object
+    // tag_name has version
+    // body has change log
+
+    std::string ghversion = find_value(json, "tag_name").get_str();
+    std::string ghbody = find_value(json, "body").get_str();
+
+    std::vector<std::string> githubversion;
+    std::vector<int> localversion;
+
+    ParseString(ghversion, '.', githubversion);
+
+    localversion.push_back(CLIENT_VERSION_MAJOR);
+    localversion.push_back(CLIENT_VERSION_MINOR);
+    localversion.push_back(CLIENT_VERSION_REVISION);
+
+    if (githubversion.size() != 4)
+    {
+        LogPrintf("Update Check: Got malformed version (%s)", ghversion);
+
+        return false;
+    }
+
+    bool newupdate = false;
+
+    try
+    {
+        // Left to right version numbers.
+        // 3 numbers to check for production.
+        for (unsigned int x = 0; x < 3; x++)
+        {
+            if (newupdate)
+                break;
+
+            if (std::stoi(githubversion[x]) > localversion[x])
+                newupdate = true;
+        }
+    }
+
+    catch (std::exception& ex)
+    {
+        LogPrintf("Update Check: Exception occured checking client version against github version (%s)", ToString(ex.what()));
+
+        return false;
+    }
+
+    if (newupdate)
+    {
+        std::string updatemessage = "Local Version: ";
+
+        updatemessage.append(ToString(CLIENT_VERSION_MAJOR));
+        updatemessage.append(".");
+        updatemessage.append(ToString(CLIENT_VERSION_MINOR));
+        updatemessage.append(".");
+        updatemessage.append(ToString(CLIENT_VERSION_REVISION));
+        updatemessage.append(".0\r\n");
+        updatemessage.append("Github Version: ");
+        updatemessage.append(ghversion);
+        updatemessage.append("\r\n\r\n");
+        updatemessage.append(ghbody);
+
+        uiInterface.UpdateMessageBox(updatemessage);
+    }
+
+    else
+        LogPrintf("Update Check: Client Up To Date");
+
+    return true;
+}
+
+void IsUpdateAvailable()
+{
+    update check;
+
+    if (!check.VersionCheck())
+        LogPrintf("Update Check: Failed to check for an update");
+}

--- a/src/update.h
+++ b/src/update.h
@@ -1,0 +1,192 @@
+#ifndef UPDATE_H
+#define UPDATE_H
+
+
+#pragma once
+#include "netbase.h"
+#include "net.h"
+
+#include <string>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <ostream>
+
+class update
+{
+protected:
+    // HTTPS data
+    std::stringstream reply;
+    std::string strippedreply = "";
+
+private:
+    // SSL
+    int statuscode = 0;
+    int sendlen = 0;
+    int recvlen = 0;
+
+    SSL* ssl = nullptr;
+    const SSL_METHOD* meth = nullptr;
+    SSL_CTX* ctx = nullptr;
+    CService address;
+
+    // Socket
+    int sock = 0;
+    int s = 0;
+    socklen_t socklen;
+    char buffer[16384];
+
+    struct sockaddr_in sa;
+
+    // Private functions
+    bool sslinit()
+    {
+        SSL_library_init();
+        SSLeay_add_ssl_algorithms();
+        SSL_load_error_strings();
+
+        meth = TLS_client_method();
+        ctx = SSL_CTX_new(meth);
+        ssl = SSL_new(ctx);
+
+        if (ssl)
+            return true;
+
+        else
+            return false;
+    }
+
+    bool addresslookup()
+    {
+        const char httpsaddress[] = "api.github.com";
+
+        if(!Lookup(httpsaddress, address, 0, true))
+            return false;
+
+        return true;
+    }
+
+    bool socketinit()
+    {
+        s = socket(AF_INET, SOCK_STREAM, 0);
+
+        if (!s)
+            return false;
+
+        sa.sin_family = AF_INET;
+        sa.sin_port = htons(443);
+        inet_pton(AF_INET, address.ToStringIP().c_str(), &(sa.sin_addr));
+
+        socklen = sizeof(sa);
+
+        return true;
+    }
+
+    bool socketconnect()
+    {
+        if (connect(s, (struct sockaddr*)&sa, socklen) < 0)
+            return false;
+
+        sock = SSL_get_fd(ssl);
+        SSL_set_fd(ssl, s);
+
+        statuscode = SSL_connect(ssl);
+
+        if (statuscode <= 0)
+            return false;
+
+        return true;
+    }
+
+    void clearstatus()
+    {
+        closessl();
+        closeusedsocket();
+        ssl = nullptr;
+        meth = nullptr;
+        ctx = nullptr;
+        sock = 0;
+        s = 0;
+    }
+
+    bool requestdata()
+    {
+        const char webcall[] = "GET /repos/gridcoin-community/Gridcoin-Research/releases/latest HTTP/1.1\r\n"
+                               "Host: api.github.com\r\n"
+                               "User-Agent: Gridcoin\r\n"
+                               "Connection: Close\r\n"
+                               "\r\n";
+
+        sendlen = SSL_write(ssl, webcall, strlen(webcall));
+
+        if (sendlen < 0)
+        {
+            statuscode = SSL_get_error(ssl, sendlen);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    bool recvreply()
+    {
+        while (true)
+        {
+            recvlen = SSL_read(ssl, buffer, 16384);
+
+            if (recvlen < 0)
+            {
+                statuscode = SSL_get_error(ssl, recvlen);
+
+                return false;
+            }
+
+            if (recvlen == 0)
+                break;
+
+            buffer[recvlen] = 0;
+
+            reply << buffer;
+        }
+
+        return true;
+    }
+
+    void closeusedsocket()
+    {
+        close(sock);
+        close(s);
+    }
+
+    void closessl()
+    {
+        SSL_free(ssl);
+        SSL_CTX_free(ctx);
+    }
+
+    void stripreply()
+    {
+        std::string temp;
+
+        bool found = false;
+
+        while (std::getline(reply, temp))
+        {
+            // The body is one line of json
+            if (found)
+            {
+                strippedreply = temp;
+
+                break;
+            }
+
+            // We know there is an empty line with a new line after HTTP header data
+            if (temp[0] == 0x0D)
+                found = true;
+        }
+    }
+public:
+    bool VersionCheck();
+};
+
+#endif // UPDATE_H

--- a/src/update.h
+++ b/src/update.h
@@ -80,7 +80,9 @@ private:
 
         sa.sin_family = AF_INET;
         sa.sin_port = htons(443);
-        inet_pton(AF_INET, address.ToStringIP().c_str(), &(sa.sin_addr));
+
+        if(!address.GetInAddr(&(sa.sin_addr)))
+            return false;
 
         socklen = sizeof(sa);
 
@@ -110,8 +112,6 @@ private:
         ssl = nullptr;
         meth = nullptr;
         ctx = nullptr;
-        sock = 0;
-        s = 0;
     }
 
     bool requestdata()
@@ -160,8 +160,16 @@ private:
 
     void closeusedsocket()
     {
+        // This part needs to be looked at.
+        // we define socketsocket to accept a pointer to myclosesocket which sets to INVALID_SOCKET for win32
+        // So i've set to 0 for closing of the socket
+#ifdef WIN32
+        sock = 0;
+        s = 0;
+#else
         close(sock);
         close(s);
+#endif
     }
 
     void closessl()

--- a/src/update.h
+++ b/src/update.h
@@ -44,7 +44,13 @@ private:
         SSLeay_add_ssl_algorithms();
         SSL_load_error_strings();
 
+        // functions for client method, etc change in 1.1.0 openssl
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
         meth = TLS_client_method();
+#elif (OPENSSL_VERSION_NUMBER < 0x10100000L)
+        meth = TLSv1_2_client_method();
+#endif
+
         ctx = SSL_CTX_new(meth);
         ssl = SSL_new(ctx);
 


### PR DESCRIPTION
This is to staging atm since last i checked the dev branch was not updated yet

* Run a check at end of AppInit2 to check if there is an update available to the client.
* Introduce signals much like threadSafeMessageBox
* Checks for an update for both non-ui and ui.
* Uses UniValue to parse the github API for information
* Most code is in update.cpp/h class.
* Uses socket and openssl to connect to github requiring no libcurl dependency
* For non-ui a stderr is used to show in console and is logged as well. but returns 0 so no signal causes shutdown of wallet
* For ui a message box (non blocking) appears within 5 seconds on top of application mentioning an update is available
* Update information shows local version, github version as well as the change log information provided from the github api.
* Added spacing as to not get bunched up in log
* Added spacing as to not get bunched up and make clearer to read from stderr reply
* Does not check when running as testnet
* Any problems with getting update information is logged in debug.log
* Have \r\n at the moment till i can test how it works in windows
* Update is a self contained class with a single void function for accessing the class and providing results.
* In future a dialog can be made for ui easily and changed away from message box if desired with current setup

TODO:
* Verify SSL certificate of github if need be.

I am sure there is still more to do but thought i'd show the progress made so far

![daemon example](https://user-images.githubusercontent.com/13292864/45600879-fc21e180-b9b8-11e8-879d-cbda8ae05058.png)
![ui example](https://user-images.githubusercontent.com/13292864/45600880-fc21e180-b9b8-11e8-96ec-e04fd808f2a7.png)
