### PR TITLE
Windows shutdown handling improvement

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -178,7 +178,8 @@ GRIDCOINRESEARCH_QT_H = \
   qt/transactiontablemodel.h \
   qt/transactionview.h \
   qt/votingdialog.h \
-  qt/walletmodel.h
+  qt/walletmodel.h \
+  qt/winshutdownmonitor.h
 
 GRIDCOINRESEARCH_QT_CPP = \
   qt/aboutdialog.cpp \
@@ -217,7 +218,8 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/transactiontablemodel.cpp \
   qt/transactionview.cpp \
   qt/votingdialog.cpp \
-  qt/walletmodel.cpp
+  qt/walletmodel.cpp \
+  qt/winshutdownmonitor.cpp
 
 RES_ICONS = \
   qt/res/icons/add.png \

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2014-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/winshutdownmonitor.h>
+
+#if defined(WIN32) && QT_VERSION >= 0x050000
+#include <init.h>
+#include <util.h>
+
+#include <windows.h>
+
+#include <QDebug>
+
+#include <openssl/rand.h>
+
+// If we don't want a message to be processed by Qt, return true and set result to
+// the value that the window procedure should return. Otherwise return false.
+bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult)
+{
+       Q_UNUSED(eventType);
+
+       MSG *pMsg = static_cast<MSG *>(pMessage);
+
+       // Seed OpenSSL PRNG with Windows event data (e.g.  mouse movements and other user interactions)
+       if (RAND_event(pMsg->message, pMsg->wParam, pMsg->lParam) == 0) {
+            // Warn only once as this is performance-critical
+            static bool warned = false;
+            if (!warned) {
+                LogPrintf("%s: OpenSSL RAND_event() failed to seed OpenSSL PRNG with enough data.\n", __func__);
+                warned = true;
+            }
+       }
+
+       switch(pMsg->message)
+       {
+           case WM_QUERYENDSESSION:
+           {
+               // Initiate a client shutdown after receiving a WM_QUERYENDSESSION and block
+               // Windows session end until we have finished client shutdown.
+               StartShutdown();
+               *pnResult = FALSE;
+               return true;
+           }
+
+           case WM_ENDSESSION:
+           {
+               *pnResult = FALSE;
+               return true;
+           }
+       }
+
+       return false;
+}
+
+void WinShutdownMonitor::registerShutdownBlockReason(const QString& strReason, const HWND& mainWinId)
+{
+    typedef BOOL (WINAPI *PSHUTDOWNBRCREATE)(HWND, LPCWSTR);
+    PSHUTDOWNBRCREATE shutdownBRCreate = (PSHUTDOWNBRCREATE)GetProcAddress(GetModuleHandleA("User32.dll"), "ShutdownBlockReasonCreate");
+    if (shutdownBRCreate == nullptr) {
+        qWarning() << "registerShutdownBlockReason: GetProcAddress for ShutdownBlockReasonCreate failed";
+        return;
+    }
+
+    if (shutdownBRCreate(mainWinId, strReason.toStdWString().c_str()))
+        qWarning() << "registerShutdownBlockReason: Successfully registered: " + strReason;
+    else
+        qWarning() << "registerShutdownBlockReason: Failed to register: " + strReason;
+}
+#endif

--- a/src/qt/winshutdownmonitor.h
+++ b/src/qt/winshutdownmonitor.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_WINSHUTDOWNMONITOR_H
+#define BITCOIN_QT_WINSHUTDOWNMONITOR_H
+
+#ifdef WIN32
+#include <QByteArray>
+#include <QString>
+
+#if QT_VERSION >= 0x050000
+#include <windef.h> // for HWND
+
+#include <QAbstractNativeEventFilter>
+
+class WinShutdownMonitor : public QAbstractNativeEventFilter
+{
+public:
+    /** Implements QAbstractNativeEventFilter interface for processing Windows messages */
+    bool nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult);
+
+    /** Register the reason for blocking shutdown on Windows to allow clean client exit */
+    static void registerShutdownBlockReason(const QString& strReason, const HWND& mainWinId);
+};
+#endif
+#endif
+
+#endif // BITCOIN_QT_WINSHUTDOWNMONITOR_H


### PR DESCRIPTION
This PR is to improve wallet shutdown behavior on Windows

This is a port of Bitcoin https://github.com/bitcoin/bitcoin/pull/4043/ and https://github.com/bitcoin/bitcoin/pull/13131/ to block Windows shutdown until the wallet is successfully shutdown, and also address proper shutdown of the gridcoinresearchd.exe (the console version) if run in a command window and the "X" (close) button is pushed on the window. This should address the issues with the wallet getting corrupted due to logoffs, shutdowns, and automatic installation of updates without shutting down Gridcoin first.

Addresses #1234, #1293, #1302.