### PR TITLE
Update command in beaconstatus help message

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1210,7 +1210,7 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
     if (!sErr.empty())
     {
         res.pushKV("Errors", sErr);
-        res.pushKV("Help", "Note: If your beacon is missing its public key, or is not in the chain, you may try: execute advertisebeacon.");
+        res.pushKV("Help", "Note: If your beacon is missing its public key, or is not in the chain, you may try: advertisebeacon.");
         res.pushKV("Configuration Status","FAIL");
     }
 


### PR DESCRIPTION
Suggest that the user run `advertisebeacon` instead of `execute advertisebeacon` which has been deprecated.