### PR TITLE
Flatten appcache and switch to strong key types

### DIFF
--- a/src/appcache.cpp
+++ b/src/appcache.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 namespace
-{    
+{
     typedef typename std::underlying_type<Section>::type Section_t;    
     std::array<AppCacheSection, static_cast<Section_t>(Section::NUM_CACHES)> caches;
     
@@ -49,7 +49,7 @@ void WriteCache(
 {
     if(key.empty())
         return;
-    
+
     AppCacheSection& cache = GetSection(section);
     cache[key] = AppCacheEntry{ value, locktime };
 }
@@ -71,6 +71,12 @@ AppCacheEntry ReadCache(
 AppCacheSection& ReadCacheSection(Section section)
 {
     return GetSection(section);
+}
+
+SortedAppCacheSection ReadSortedCacheSection(Section section)
+{
+    const auto& cache = ReadCacheSection(section);
+    return SortedAppCacheSection(cache.begin(), cache.end());
 }
 
 void ClearCache(Section section)

--- a/src/appcache.h
+++ b/src/appcache.h
@@ -38,6 +38,16 @@ struct AppCacheEntry
 typedef std::unordered_map<std::string, AppCacheEntry> AppCacheSection;
 
 //!
+//! \brief Application cache section sorted by key.
+//!
+typedef std::map<std::string, AppCacheEntry> SortedAppCacheSection;
+
+//!
+//! \brief Application cache type.
+//!
+typedef std::unordered_map<std::string, AppCacheSection> AppCache;
+
+//!
 //! \brief Write value into application cache.
 //! \param section Cache section to write to.
 //! \param key Entry key to write.
@@ -66,6 +76,19 @@ AppCacheEntry ReadCache(
 //! \returns The data for \p section if available.
 //!
 AppCacheSection& ReadCacheSection(Section section);
+
+//!
+//! \brief Reads a section from cache and sorts it.
+//! \param section Section to read.
+//! \returns The data for \p section if available.
+//! 
+//! Reads a cache section and transfers it to a sorted map. This can be an
+//! expensive operation and should not be used unless there is a need
+//! for sorted traversal.
+//! 
+//! \see ReadCacheSection
+//!
+SortedAppCacheSection ReadSortedCacheSection(Section section);
 
 //!
 //! \brief Clear all values in a cache section.

--- a/src/appcache.h
+++ b/src/appcache.h
@@ -2,6 +2,26 @@
 
 #include <string>
 #include <map>
+#include <unordered_map>
+
+enum class Section
+{
+    BEACON,
+    BEACONALT,
+    SUPERBLOCK,
+    GLOBAL,
+    PROTOCOL,
+    NEURALSECURITY,
+    CURRENTNEURALSECURITY,
+    TRXID,
+    POLL,
+    VOTE,
+    PROJECT,
+    PROJECTMAPPING,
+    
+    // Enum counting entry. Using it will throw.
+    NUM_CACHES
+};
 
 //!
 //! \brief An entry in the application cache.
@@ -15,12 +35,7 @@ struct AppCacheEntry
 //!
 //! \brief Application cache section type.
 //! 
-typedef std::map<std::string, AppCacheEntry> AppCacheSection;
-
-//!
-//! \brief Application cache type.
-//!
-typedef std::map<std::string, AppCacheSection> AppCache;
+typedef std::unordered_map<std::string, AppCacheEntry> AppCacheSection;
 
 //!
 //! \brief Write value into application cache.
@@ -29,7 +44,7 @@ typedef std::map<std::string, AppCacheSection> AppCache;
 //! \param value Entry value to write.
 //!
 void WriteCache(
-        const std::string& section,
+        Section section,
         const std::string& key,
         const std::string& value,
         int64_t locktime);
@@ -42,7 +57,7 @@ void WriteCache(
 //! if either the section or the key don't exist.
 //!
 AppCacheEntry ReadCache(
-        const std::string& section,
+        Section section,
         const std::string& key);
 
 //!
@@ -50,21 +65,21 @@ AppCacheEntry ReadCache(
 //! \param section Section to read.
 //! \returns The data for \p section if available.
 //!
-AppCacheSection ReadCacheSection(const std::string& section);
+AppCacheSection& ReadCacheSection(Section section);
 
 //!
 //! \brief Clear all values in a cache section.
 //! \param section Cache section to clear.
 //! \note This only clears the values. It does not erase them.
 //!
-void ClearCache(const std::string& section);
+void ClearCache(Section section);
 
 //!
 //! \brief Erase key from appcache section.
 //! \param section Cache section to erase from.
 //! \param key Entry key to erase.
 //!
-void DeleteCache(const std::string& section, const std::string& key);
+void DeleteCache(Section section, const std::string& key);
 
 //!
 //! \brief Get a list of section values.
@@ -80,7 +95,7 @@ void DeleteCache(const std::string& section, const std::string& key);
 //! \return Formatted section values string.
 //! \todo Make this return std::vector<std::string> instead.
 //!
-std::string GetListOf(const std::string& section);
+std::string GetListOf(Section section);
 
 //!
 //! \brief Get a list of section values with age restrictions.
@@ -89,7 +104,7 @@ std::string GetListOf(const std::string& section);
 //! \param maxTime Entry max timestamp. Set to 0 to disable limit.
 //!
 std::string GetListOf(
-        const std::string& section,
+        Section section,
         int64_t minTime,
         int64_t maxTime);
 
@@ -102,4 +117,6 @@ std::string GetListOf(
 //! \return Number of values in \p section.
 //! \see GetListOf() for beacon restrictions.
 //!
-size_t GetCountOf(const std::string& section);
+size_t GetCountOf(Section section);
+
+Section StringToSection(const std::string& section);

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -21,12 +21,12 @@ bool GenerateBeaconKeys(const std::string &cpid, CKey &outPrivPubKey)
     const std::string sBeaconPublicKey = GetBeaconPublicKey(cpid,false);
 
     if(!sBeaconPublicKey.empty())
-    {
+{
         CPubKey oldKey(ParseHex(sBeaconPublicKey));
         if(oldKey.IsValid())
-        {
+    {
             if (pwalletMain->GetKey(oldKey.GetID(), outPrivPubKey))
-            {
+        {
                 assert(outPrivPubKey.IsValid());//GetKey gives valid key or false
                 assert(outPrivPubKey.GetPubKey()==oldKey);//GetKey should return the key we ask for
                 LogPrintf("GenerateBeaconKeys: Reusing >5 <6 m old Key");
@@ -50,7 +50,7 @@ bool GenerateBeaconKeys(const std::string &cpid, CKey &outPrivPubKey)
     if (!pwalletMain->GetKey(keyID, outPrivPubKey))
         return error("GenerateBeaconKeys: Failed to get Private Key from Wallet");
 
-    return true;
+        return true;
 }
 
 bool GetStoredBeaconPrivateKey(const std::string& cpid, CKey& outPrivPubKey)
@@ -61,10 +61,10 @@ bool GetStoredBeaconPrivateKey(const std::string& cpid, CKey& outPrivPubKey)
     if(oldKey.IsValid())
     {
         if (pwalletMain->GetKey(oldKey.GetID(), outPrivPubKey))
-        {
+{
             return outPrivPubKey.IsValid();
-        }
-    }
+}
+}
     return false;
 }
 
@@ -97,7 +97,7 @@ std::string GetBeaconPublicKey(const std::string& cpid, bool bAdvertisingBeacon)
 int64_t BeaconTimeStamp(const std::string& cpid, bool bZeroOutAfterPOR)
 {
     AssertLockHeld(cs_main);
-    const AppCacheEntry& entry =  ReadCache("beacon", cpid);
+    const AppCacheEntry& entry =  ReadCache(Section::BEACON, cpid);
     std::string sBeacon = entry.value;
     int64_t iLocktime = entry.timestamp;
     int64_t iRSAWeight = GetRSAWeightByCPIDWithRA(cpid);
@@ -117,7 +117,7 @@ bool HasActiveBeacon(const std::string& cpid)
 std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxSeconds)
 {
     AssertLockHeld(cs_main);
-    const AppCacheEntry& entry = ReadCache("beacon", cpid);
+    const AppCacheEntry& entry = ReadCache(Section::BEACON, cpid);
 
     // Compare the age of the beacon to the age of the current block. If we have
     // no current block we assume that the beacon is valid.
@@ -155,7 +155,7 @@ bool VerifyBeaconContractTx(const CTransaction& tx)
     if (tx_out_cpid.empty() || tx_out_address.empty() || tx_out_publickey.empty() || chkMessageContractCPID.empty())
         return false; // Incomplete contract
 
-    const AppCacheEntry& beaconEntry = ReadCache("beacon", chkMessageContractCPID);
+    const AppCacheEntry& beaconEntry = ReadCache(Section::BEACON, chkMessageContractCPID);
     if (beaconEntry.value.empty())
     {
         if (fDebug10)

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -21,12 +21,12 @@ bool GenerateBeaconKeys(const std::string &cpid, CKey &outPrivPubKey)
     const std::string sBeaconPublicKey = GetBeaconPublicKey(cpid,false);
 
     if(!sBeaconPublicKey.empty())
-{
+    {
         CPubKey oldKey(ParseHex(sBeaconPublicKey));
         if(oldKey.IsValid())
-    {
-            if (pwalletMain->GetKey(oldKey.GetID(), outPrivPubKey))
         {
+            if (pwalletMain->GetKey(oldKey.GetID(), outPrivPubKey))
+            {
                 assert(outPrivPubKey.IsValid());//GetKey gives valid key or false
                 assert(outPrivPubKey.GetPubKey()==oldKey);//GetKey should return the key we ask for
                 LogPrintf("GenerateBeaconKeys: Reusing >5 <6 m old Key");
@@ -50,7 +50,7 @@ bool GenerateBeaconKeys(const std::string &cpid, CKey &outPrivPubKey)
     if (!pwalletMain->GetKey(keyID, outPrivPubKey))
         return error("GenerateBeaconKeys: Failed to get Private Key from Wallet");
 
-        return true;
+    return true;
 }
 
 bool GetStoredBeaconPrivateKey(const std::string& cpid, CKey& outPrivPubKey)
@@ -61,10 +61,10 @@ bool GetStoredBeaconPrivateKey(const std::string& cpid, CKey& outPrivPubKey)
     if(oldKey.IsValid())
     {
         if (pwalletMain->GetKey(oldKey.GetID(), outPrivPubKey))
-{
+        {
             return outPrivPubKey.IsValid();
-}
-}
+        }
+    }
     return false;
 }
 
@@ -122,12 +122,12 @@ std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxS
     // Compare the age of the beacon to the age of the current block. If we have
     // no current block we assume that the beacon is valid.
     int64_t iAge = pindexBest != NULL
-          ? pindexBest->nTime - entry.timestamp
-          : 0;
+                                 ? pindexBest->nTime - entry.timestamp
+                                 : 0;
 
     return (iAge > iMaxSeconds)
-          ? ""
-          : entry.value;
+            ? ""
+            : entry.value;
 }
 
 bool VerifyBeaconContractTx(const CTransaction& tx)
@@ -165,8 +165,8 @@ bool VerifyBeaconContractTx(const CTransaction& tx)
     }
 
     int64_t chkiAge = pindexBest != NULL
-        ? tx.nLockTime - beaconEntry.timestamp
-        : 0;
+                                    ? tx.nLockTime - beaconEntry.timestamp
+                                    : 0;
     int64_t chkSecondsBase = 60 * 24 * 30 * 60;
 
     // Conditions

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -107,8 +107,8 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
     std::string cpid1 = GlobalCPUMiningCPID.cpid;
     std::string GRCAddress1 = DefaultWalletAddress();
     GetEarliestStakeTime(GRCAddress1, cpid1);
-    double cpid_age = GetAdjustedTime() - ReadCache("global", "nCPIDTime").timestamp;
-    double stake_age = GetAdjustedTime() - ReadCache("global", "nGRCTime").timestamp;
+    double cpid_age = GetAdjustedTime() - ReadCache(Section::GLOBAL, "nCPIDTime").timestamp;
+    double stake_age = GetAdjustedTime() - ReadCache(Section::GLOBAL, "nGRCTime").timestamp;
 
     StructCPID structGRC = GetInitializedStructCPID2(GRCAddress, mvMagnitudes);
     LogPrintf("CPIDAge %f, StakeAge %f, Poll Duration %f", cpid_age, stake_age, poll_duration);
@@ -141,9 +141,9 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
     }
 }
 
-std::string GetPollContractByTitle(std::string objecttype, std::string title)
+std::string GetPollContractByTitle(std::string title)
 {
-    for(const auto& item : ReadCacheSection(objecttype))
+    for(const auto& item : ReadCacheSection(Section::POLL))
     {
         const std::string& contract = item.second.value;
         const std::string& PollTitle = ExtractXML(contract,"<TITLE>","</TITLE>");
@@ -155,13 +155,13 @@ std::string GetPollContractByTitle(std::string objecttype, std::string title)
 
 bool PollExists(std::string pollname)
 {
-    std::string contract = GetPollContractByTitle("poll",pollname);
+    std::string contract = GetPollContractByTitle(pollname);
     return contract.length() > 10 ? true : false;
 }
 
 bool PollExpired(std::string pollname)
 {
-    std::string contract = GetPollContractByTitle("poll",pollname);
+    std::string contract = GetPollContractByTitle(pollname);
     double expiration = RoundFromString(ExtractXML(contract,"<EXPIRATION>","</EXPIRATION>"),0);
     return (expiration < (double)GetAdjustedTime()) ? true : false;
 }
@@ -169,14 +169,14 @@ bool PollExpired(std::string pollname)
 bool PollCreatedAfterSecurityUpgrade(std::string pollname)
 {
     // If the expiration is after July 1 2017, use the new security features.
-    std::string contract = GetPollContractByTitle("poll",pollname);
+    std::string contract = GetPollContractByTitle(pollname);
     double expiration = RoundFromString(ExtractXML(contract,"<EXPIRATION>","</EXPIRATION>"),0);
     return (expiration > 1498867200) ? true : false;
 }
 
 double PollDuration(std::string pollname)
 {
-    std::string contract = GetPollContractByTitle("poll",pollname);
+    std::string contract = GetPollContractByTitle(pollname);
     double days = RoundFromString(ExtractXML(contract,"<DAYS>","</DAYS>"),0);
     return days;
 }
@@ -215,7 +215,7 @@ double VotesCount(std::string pollname, std::string answer, double sharetype, do
     double total_shares = 0;
     out_participants = 0;
     double MoneySupplyFactor = GetMoneySupplyFactor();
-    for(const auto& item : ReadCacheSection("vote"))
+    for(const auto& item : ReadCacheSection(Section::VOTE))
     {
         const std::string& contract = item.second.value;
         const std::string& Title = ExtractXML(contract,"<TITLE>","</TITLE>");
@@ -236,14 +236,14 @@ double VotesCount(std::string pollname, std::string answer, double sharetype, do
 
 std::string GetPollXMLElementByPollTitle(std::string pollname, std::string XMLElement1, std::string XMLElement2)
 {
-    std::string contract = GetPollContractByTitle("poll",pollname);
+    std::string contract = GetPollContractByTitle(pollname);
     std::string sElement = ExtractXML(contract,XMLElement1,XMLElement2);
     return sElement;
 }
 
 bool PollAcceptableAnswer(std::string pollname, std::string answer)
 {
-    std::string contract = GetPollContractByTitle("poll",pollname);
+    std::string contract = GetPollContractByTitle(pollname);
     std::string answers = ExtractXML(contract,"<ANSWERS>","</ANSWERS>");
     std::vector<std::string> vAnswers = split(answers.c_str(),";");
     //Allow multiple choice voting:
@@ -269,7 +269,7 @@ bool PollAcceptableAnswer(std::string pollname, std::string answer)
 
 std::string PollAnswers(std::string pollname)
 {
-    std::string contract = GetPollContractByTitle("poll",pollname);
+    std::string contract = GetPollContractByTitle(pollname);
     std::string answers = ExtractXML(contract,"<ANSWERS>","</ANSWERS>");
     return answers;
 
@@ -501,7 +501,7 @@ std::vector<polling::Poll> GetPolls(bool bDetail, bool includeExpired, std::stri
     std::vector<std::string> vAnswers;
     boost::to_lower(byTitle);
 
-    for( const auto& item: ReadCacheSection("poll"))
+    for( const auto& item: ReadCacheSection(Section::POLL))
     {
         polling::Poll poll;
         poll.pollnumber = 0;
@@ -579,7 +579,7 @@ UniValue GetJSONPollsReport(bool bDetail, std::string QueryByTitle, std::string&
     std::string sExportRow;
     out_export.clear();
 
-    for(const auto& item : ReadCacheSection("poll"))
+    for(const auto& item : ReadCacheSection(Section::POLL))
     {
         const std::string& title = boost::to_lower_copy(item.first);
         const std::string& contract = item.second.value;
@@ -682,13 +682,13 @@ UniValue GetJsonVoteDetailsReport(std::string pollname)
     entry.pushKV("GRCAddress,CPID,Question,Answer,ShareType,URL", "Shares");
 
     boost::to_lower(pollname);
-    for(const auto& item : ReadCacheSection("vote"))
+    for(const auto& item : ReadCacheSection(Section::VOTE))
     {
         const std::string& contract = item.second.value;
         const std::string& Title = ExtractXML(contract,"<TITLE>","</TITLE>");
         if(boost::iequals(pollname, Title))
         {
-            const std::string& OriginalContract = GetPollContractByTitle("poll",Title);
+            const std::string& OriginalContract = GetPollContractByTitle(Title);
             const std::string& Question = ExtractXML(OriginalContract,"<QUESTION>","</QUESTION>");
             const std::string& GRCAddress = ExtractXML(contract,"<GRCADDRESS>","</GRCADDRESS>");
             const std::string& CPID = ExtractXML(contract,"<CPID>","</CPID>");

--- a/src/contract/polls.h
+++ b/src/contract/polls.h
@@ -34,7 +34,7 @@ std::pair<std::string, std::string> CreatePollContract(std::string sTitle, int d
 
 std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::string sAnswer);
 
-std::string GetPollContractByTitle(std::string objecttype, std::string title);
+std::string GetPollContractByTitle(std::string title);
 
 bool PollExists(std::string pollname);
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -82,21 +82,15 @@ bool CDBEnv::Open(boost::filesystem::path pathEnv_)
 
     int nDbCache = GetArg("-dbcache", 25);
     dbenv.set_lg_dir(pathLogDir.string().c_str());
-    dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
-    dbenv.set_lg_bsize(1048576);
-    dbenv.set_lg_max(10485760);
-
-    // Bugfix: Bump lk_max_locks default to 537000, to safely handle reorgs with up to 5 blocks reversed
-    // dbenv.set_lk_max_locks(10000);
-    dbenv.set_lk_max_locks(537000);
-
-    dbenv.set_lk_max_objects(10000);
+    dbenv.set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    dbenv.set_lg_bsize(0x10000);
+    dbenv.set_lg_max(1048576);
+    dbenv.set_lk_max_locks(40000);
+    dbenv.set_lk_max_objects(40000);
     dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
     dbenv.set_flags(DB_AUTO_COMMIT, 1);
     dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
-#ifdef DB_LOG_AUTO_REMOVE
     dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-#endif
     int ret = dbenv.open(strPath.c_str(),
                      DB_CREATE     |
                      DB_INIT_LOCK  |

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -82,15 +82,21 @@ bool CDBEnv::Open(boost::filesystem::path pathEnv_)
 
     int nDbCache = GetArg("-dbcache", 25);
     dbenv.set_lg_dir(pathLogDir.string().c_str());
-    dbenv.set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
-    dbenv.set_lg_bsize(0x10000);
-    dbenv.set_lg_max(1048576);
-    dbenv.set_lk_max_locks(40000);
-    dbenv.set_lk_max_objects(40000);
+    dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
+    dbenv.set_lg_bsize(1048576);
+    dbenv.set_lg_max(10485760);
+
+    // Bugfix: Bump lk_max_locks default to 537000, to safely handle reorgs with up to 5 blocks reversed
+    // dbenv.set_lk_max_locks(10000);
+    dbenv.set_lk_max_locks(537000);
+
+    dbenv.set_lk_max_objects(10000);
     dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
     dbenv.set_flags(DB_AUTO_COMMIT, 1);
     dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
+#ifdef DB_LOG_AUTO_REMOVE
     dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
+#endif
     int ret = dbenv.open(strPath.c_str(),
                      DB_CREATE     |
                      DB_INIT_LOCK  |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2138,7 +2138,7 @@ int64_t GetConstantBlockReward(const CBlockIndex* index)
     const int64_t MAX_CBR = DEFAULT_CBR * 2;
 
     int64_t reward = DEFAULT_CBR;
-    AppCacheEntry oCBReward = ReadCache("protocol","blockreward1");
+    AppCacheEntry oCBReward = ReadCache(Section::PROTOCOL, "blockreward1");
 
     //TODO: refactor the expire checking to subroutine
     //Note: time constant is same as GetBeaconPublicKey
@@ -5784,10 +5784,9 @@ bool ComputeNeuralNetworkSupermajorityHashes()
     // switching to v9. We want to clear these to avoid the data stacking up
     // with time. If this causes an issue when syncing then considering making
     // this >=v9 only again.
-        ClearCache(Section::NEURALSECURITY);
-    ClearCache("currentneuralsecurity");
-
+    ClearCache(Section::NEURALSECURITY);
     WriteCache(Section::NEURALSECURITY, "pending","0",GetAdjustedTime());
+
     try
     {
         int nMaxDepth = nBestHeight;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -319,13 +319,13 @@ bool TimerMain(std::string timer_name, int max_ms)
 bool UpdateNeuralNetworkQuorumData()
 {
     if (!bGlobalcomInitialized) return false;
-    int64_t superblock_time = ReadCache("superblock", "magnitudes").timestamp;
+    int64_t superblock_time = ReadCache(Section::SUPERBLOCK, "magnitudes").timestamp;
     int64_t superblock_age = GetAdjustedTime() - superblock_time;
     std::string myNeuralHash = "";
     double popularity = 0;
     std::string consensus_hash = GetNeuralNetworkSupermajorityHash(popularity);
     std::string sAge = ToString(superblock_age);
-    std::string sBlock = ReadCache("superblock", "block_number").value;
+    std::string sBlock = ReadCache(Section::SUPERBLOCK, "block_number").value;
     std::string sTimestamp = TimestampToHRDate(superblock_time);
     std::string data = "<QUORUMDATA><AGE>" + sAge + "</AGE><HASH>" + consensus_hash + "</HASH><BLOCKNUMBER>" + sBlock + "</BLOCKNUMBER><TIMESTAMP>"
                        + sTimestamp + "</TIMESTAMP><PRIMARYCPID>" + msPrimaryCPID + "</PRIMARYCPID></QUORUMDATA>";
@@ -354,14 +354,14 @@ bool FullSyncWithDPORNodes()
     const int64_t iEndTime= (GetAdjustedTime()-CONSENSUS_LOOKBACK) - ( (GetAdjustedTime()-CONSENSUS_LOOKBACK) % BLOCK_GRANULARITY);
     const int64_t nLookback = 30 * 6 * 86400;
     const int64_t iStartTime = (iEndTime - nLookback) - ( (iEndTime - nLookback) % BLOCK_GRANULARITY);
-    std::string cpiddata = GetListOf("beacon", iStartTime, iEndTime);
-    std::string sWhitelist = GetListOf("project");
-    int64_t superblock_time = ReadCache("superblock", "magnitudes").timestamp;
+    std::string cpiddata = GetListOf(Section::BEACON, iStartTime, iEndTime);
+    std::string sWhitelist = GetListOf(Section::PROJECT);
+    int64_t superblock_time = ReadCache(Section::SUPERBLOCK, "magnitudes").timestamp;
     int64_t superblock_age = GetAdjustedTime() - superblock_time;
     double popularity = 0;
     std::string consensus_hash = GetNeuralNetworkSupermajorityHash(popularity);
     std::string sAge = ToString(superblock_age);
-    std::string sBlock = ReadCache("superblock", "block_number").value;
+    std::string sBlock = ReadCache(Section::SUPERBLOCK, "block_number").value;
     std::string sTimestamp = TimestampToHRDate(superblock_time);
     std::string data = "<WHITELIST>" + sWhitelist + "</WHITELIST><CPIDDATA>"
                        + cpiddata + "</CPIDDATA><QUORUMDATA><AGE>" + sAge + "</AGE><HASH>" + consensus_hash + "</HASH><BLOCKNUMBER>" + sBlock + "</BLOCKNUMBER><TIMESTAMP>"
@@ -2200,7 +2200,15 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
 
             /* Constant Block Reward */
             if (pindexLast->nVersion>=10)
-                nInterest = GetConstantBlockReward(pindexLast);
+            {
+                AppCacheEntry oCBReward= ReadCache(Section::PROTOCOL, "blockreward1");
+                //TODO: refactor the expire checking to subroutine
+                //Note: time constant is same as GetBeaconPublicKey
+                if( (pindexLast->nTime - oCBReward.timestamp) <= (60 * 24 * 30 * 6 * 60) )
+                {
+                    nInterest= atoi64(oCBReward.value);
+                }
+            }
             else
                 nInterest = nCoinAge * GetCoinYearReward(nTime) * 33 / (365 * 33 + 8);
 
@@ -2856,14 +2864,14 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
             if(!sMType.empty())
             {
                 std::string sMKey = ExtractXML(vtx[i].hashBoinc, "<MK>", "</MK>");
-                DeleteCache(sMType, sMKey);
+                DeleteCache(StringToSection(sMType), sMKey);
                 if(fDebug)
                     LogPrintf("DisconnectBlock: Delete contract %s %s", sMType, sMKey);
 
                 if("beacon"==sMType)
                 {
                     sMKey=sMKey+"A";
-                    DeleteCache("beaconalt", sMKey+"."+ToString(vtx[i].nTime));
+                    DeleteCache(Section::BEACONALT, sMKey+"."+ToString(vtx[i].nTime));
                 }
             }
         }
@@ -2921,11 +2929,11 @@ std::string PubKeyToAddress(const CScript& scriptPubKey)
 
 bool LoadSuperblock(std::string data, int64_t nTime, int height)
 {
-        WriteCache("superblock","magnitudes",ExtractXML(data,"<MAGNITUDES>","</MAGNITUDES>"),nTime);
-        WriteCache("superblock","averages",ExtractXML(data,"<AVERAGES>","</AVERAGES>"),nTime);
-        WriteCache("superblock","quotes",ExtractXML(data,"<QUOTES>","</QUOTES>"),nTime);
-        WriteCache("superblock","all",data,nTime);
-        WriteCache("superblock","block_number",ToString(height),nTime);
+    WriteCache(Section::SUPERBLOCK, "magnitudes",ExtractXML(data,"<MAGNITUDES>","</MAGNITUDES>"),nTime);
+    WriteCache(Section::SUPERBLOCK, "averages",ExtractXML(data,"<AVERAGES>","</AVERAGES>"),nTime);
+    WriteCache(Section::SUPERBLOCK, "quotes",ExtractXML(data,"<QUOTES>","</QUOTES>"),nTime);
+    WriteCache(Section::SUPERBLOCK, "all",data,nTime);
+    WriteCache(Section::SUPERBLOCK, "block_number",ToString(height),nTime);
         return true;
 }
 
@@ -3165,7 +3173,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                 else if (bIsDPOR && pindex->nHeight > nGrandfather && pindex->nVersion < 10)
                 {
                     // Old rules, does not make sense
-                    // Verify no recipients exist after coinstake (Recipients start at output position 3 (0=Coinstake flag, 1=coinstake amount, 2=splitstake amount)
+                // Verify no recipients exist after coinstake (Recipients start at output position 3 (0=Coinstake flag, 1=coinstake amount, 2=splitstake amount)
                     for (unsigned int i = 3; i < tx.vout.size(); i++)
                     {
                         double      Amount    = CoinToDouble(tx.vout[i].nValue);
@@ -3382,9 +3390,9 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                             else
                                 LogPrintf("WARNING ConnectBlock[ResearchAge] : Researchers Reward Pays too much : bad block ignored: Interest %f and Research %f and StakeReward %f, OUT_POR %f, with Out_Interest %f for CPID %s ",
                                                     bb.InterestSubsidy, bb.ResearchSubsidy, dStakeReward, OUT_POR, OUT_INTEREST,bb.cpid.c_str());
-                                }
                         }
                 }
+        }
         }
 
         //Approve first coinstake in DPOR block
@@ -4554,7 +4562,7 @@ bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent)
 bool NeedASuperblock()
 {
     bool bDireNeedOfSuperblock = false;
-    std::string superblock = ReadCache("superblock","all").value;
+    std::string superblock = ReadCache(Section::SUPERBLOCK, "all").value;
     if (superblock.length() > 20 && !OutOfSyncByAge())
     {
         if (!VerifySuperblock(superblock, pindexBest))
@@ -4567,7 +4575,7 @@ bool NeedASuperblock()
          */
     }
 
-    int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
+    int64_t superblock_age = GetAdjustedTime() - ReadCache(Section::SUPERBLOCK, "magnitudes").timestamp;
     if (superblock_age > GetSuperblockAgeSpacing(nBestHeight))
         bDireNeedOfSuperblock = true;
 
@@ -4612,7 +4620,7 @@ void GridcoinServices()
     }
     else
     {
-        int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
+        int64_t superblock_age = GetAdjustedTime() - ReadCache(Section::SUPERBLOCK, "magnitudes").timestamp;
         bool bNeedSuperblock = (superblock_age > (GetSuperblockAgeSpacing(nBestHeight)));
         if ( nBestHeight % 3 == 0 && NeedASuperblock() ) bNeedSuperblock=true;
 
@@ -4665,12 +4673,6 @@ void GridcoinServices()
             }
         }
     }
-
-    if (TimerMain("clearcache",1000))
-    {
-        ClearCache("neural_data");
-    }
-
 
     //Dont perform the following functions if out of sync
     if (pindexBest->nHeight < nGrandfather || OutOfSyncByAge())
@@ -5308,7 +5310,7 @@ std::set<std::string> GetAlternativeBeaconKeys(const std::string& cpid)
     int64_t iMaxSeconds = 60 * 24 * 30 * 6 * 60;
     std::set<std::string> result;
 
-    for(const auto& item : ReadCacheSection("beaconalt"))
+    for(const auto& item : ReadCacheSection(Section::BEACONALT))
     {
         const std::string& key = item.first;
         const std::string& value = item.second.value;
@@ -5560,13 +5562,13 @@ bool GetEarliestStakeTime(std::string grcaddress, std::string cpid)
     if (nBestHeight < 15)
     {
         // Write entries in the cache to get a timestamp.
-        WriteCache("global", "nGRCTime", "", GetAdjustedTime());
-        WriteCache("global", "nCPIDTime", "", GetAdjustedTime());
+        WriteCache(Section::GLOBAL, "nGRCTime", "", GetAdjustedTime());
+        WriteCache(Section::GLOBAL, "nCPIDTime", "", GetAdjustedTime());
         return true;
     }
 
-    int64_t nGRCTime = ReadCache("global", "nGRCTime").timestamp;
-    int64_t nCPIDTime = ReadCache("global", "nCPIDTime").timestamp;
+    int64_t nGRCTime = ReadCache(Section::GLOBAL, "nGRCTime").timestamp;
+    int64_t nCPIDTime = ReadCache(Section::GLOBAL, "nCPIDTime").timestamp;
     if (IsLockTimeWithinMinutes(nLastGRCtallied, GetAdjustedTime(), 100) &&
         (nGRCTime > 0 || nCPIDTime > 0))
         return true;
@@ -5620,8 +5622,8 @@ bool GetEarliestStakeTime(std::string grcaddress, std::string cpid)
     LogPrintf("CPIDTime %" PRId64 ", GRCTime %" PRId64 ", WalletTime %" PRId64, nCPIDTime, nGRCTime, EarliestStakedWalletTx);
 
     // Update caches with new timestamps.
-    WriteCache("global", "nGRCTime", "", nGRCTime);
-    WriteCache("global", "nCPIDTime", "", nCPIDTime);
+    WriteCache(Section::GLOBAL, "nGRCTime", "", nGRCTime);
+    WriteCache(Section::GLOBAL, "nCPIDTime", "", nCPIDTime);
     return true;
 }
 
@@ -5774,10 +5776,10 @@ bool ComputeNeuralNetworkSupermajorityHashes()
     // switching to v9. We want to clear these to avoid the data stacking up
     // with time. If this causes an issue when syncing then considering making
     // this >=v9 only again.
-        ClearCache("neuralsecurity");
+        ClearCache(Section::NEURALSECURITY);
     ClearCache("currentneuralsecurity");
 
-    WriteCache("neuralsecurity","pending","0",GetAdjustedTime());
+    WriteCache(Section::NEURALSECURITY, "pending","0",GetAdjustedTime());
     try
     {
         int nMaxDepth = nBestHeight;
@@ -5810,7 +5812,7 @@ bool ComputeNeuralNetworkSupermajorityHashes()
                     std::string superblock = UnpackBinarySuperblock(bb.superblock);
                     if (VerifySuperblock(superblock, pblockindex))
                     {
-                        WriteCache("neuralsecurity","pending",ToString(pblockindex->nHeight),GetAdjustedTime());
+                        WriteCache(Section::NEURALSECURITY, "pending",ToString(pblockindex->nHeight),GetAdjustedTime());
                     }
                 }
 
@@ -7554,7 +7556,7 @@ bool ProjectIsValid(std::string sProject)
 
     boost::to_lower(sProject);
 
-    for (const auto& item : ReadCacheSection("project"))
+    for (const auto& item : ReadCacheSection(Section::PROJECT))
     {
         const AppCacheEntry& entry = item.second;
         std::string sProjectName = ToOfficialName(entry.value);
@@ -7590,7 +7592,7 @@ std::string ToOfficialName(std::string proj)
 {
         proj = LowerUnderscore(proj);
         //Convert local XML project name [On the Left] to official [Netsoft] projectname:
-    for(const auto& item : ReadCacheSection("projectmapping"))
+    for(const auto& item : ReadCacheSection(Section::PROJECTMAPPING))
         {
         const std::string& key = item.first;
         const AppCacheEntry& entry = item.second;
@@ -8112,14 +8114,14 @@ void IncrementCurrentNeuralNetworkSupermajority(std::string NeuralHash, std::str
         return;    
 
     // 6-13-2015 ONLY Count Each Neural Hash Once per GRC address / CPID (1 VOTE PER RESEARCHER)
-    const std::string& Security = ReadCache("currentneuralsecurity",GRCAddress).value;
+    const std::string& Security = ReadCache(Section::CURRENTNEURALSECURITY, GRCAddress).value;
     if (Security == NeuralHash)
     {
         //This node has already voted, throw away the vote
         return;
     }
-    
-    WriteCache("currentneuralsecurity",GRCAddress,NeuralHash,GetAdjustedTime());
+
+    WriteCache(Section::CURRENTNEURALSECURITY, GRCAddress,NeuralHash,GetAdjustedTime());
 
     double multiplier = distance < 40 ? 400 : 200;
     double votes = (1/distance)*multiplier;
@@ -8156,14 +8158,14 @@ void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const st
     }
 
     // 6-13-2015 ONLY Count Each Neural Hash Once per GRC address / CPID (1 VOTE PER RESEARCHER)
-    const std::string& Security = ReadCache("neuralsecurity",GRCAddress).value;
+    const std::string& Security = ReadCache(Section::NEURALSECURITY, GRCAddress).value;
     if (Security == NeuralHash)
     {
         //This node has already voted, throw away the vote
         return;
     }
-    
-    WriteCache("neuralsecurity",GRCAddress,NeuralHash,GetAdjustedTime());
+
+    WriteCache(Section::NEURALSECURITY, GRCAddress,NeuralHash,GetAdjustedTime());
 
     double multiplier = distance < 40 ? 400 : 200;
     double votes = (1/distance)*multiplier;
@@ -8301,10 +8303,10 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                                     std::string out_address = "";
                                     std::string out_publickey = "";
                                     GetBeaconElements(sMessageValue, out_cpid, out_address, out_publickey);
-                                    WriteCache("beaconalt",sMessageKey+"."+ToString(nTime),out_publickey,nTime);
+                        WriteCache(Section::BEACONALT, sMessageKey+"."+ToString(nTime),out_publickey,nTime);
                                 }
 
-                                WriteCache(sMessageType,sMessageKey,sMessageValue,nTime);
+                    WriteCache(StringToSection(sMessageType), sMessageKey,sMessageValue,nTime);
                                 if(fDebug10 && sMessageType=="beacon" ){
                                     LogPrintf("BEACON add %s %s %s", sMessageKey, DecodeBase64(sMessageValue), TimestampToHRDate(nTime));
                                 }
@@ -8313,14 +8315,14 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                                 {
                                     msPoll = msg;
                                         }
-                                }
+                                        }
                         else if(sMessageAction=="D")
                         {
                                 if (fDebug10) LogPrintf("Deleting key type %s Key %s Value %s", sMessageType, sMessageKey, sMessageValue);
                                 if(fDebug10 && sMessageType=="beacon" ){
                                     LogPrintf("BEACON DEL %s - %s", sMessageKey, TimestampToHRDate(nTime));
                                 }
-                                DeleteCache(sMessageType,sMessageKey);
+                    DeleteCache(StringToSection(sMessageType), sMessageKey);
                                 fMessageLoaded = true;
                         }
                         // If this is a boinc project, load the projects into the coin:
@@ -8331,7 +8333,7 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                         }
 
                         if(fDebug)
-                            WriteCache("TrxID;"+sMessageType,sMessageKey,tx.GetHash().GetHex(),nTime);
+                    WriteCache(Section::TRXID, sMessageType + ";" + sMessageKey,tx.GetHash().GetHex(),nTime);
                   }
                 }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2864,9 +2864,17 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
             if(!sMType.empty())
             {
                 std::string sMKey = ExtractXML(vtx[i].hashBoinc, "<MK>", "</MK>");
+                
+                try
+                {
                 DeleteCache(StringToSection(sMType), sMKey);
                 if(fDebug)
                     LogPrintf("DisconnectBlock: Delete contract %s %s", sMType, sMKey);
+                }
+                catch(const std::runtime_error& e)
+                {
+                    error("Attempting to delete from unknown cache: %s", sMType);
+                }
 
                 if("beacon"==sMType)
                 {
@@ -8306,10 +8314,17 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                         WriteCache(Section::BEACONALT, sMessageKey+"."+ToString(nTime),out_publickey,nTime);
                                 }
 
+                    try
+                    {
                     WriteCache(StringToSection(sMessageType), sMessageKey,sMessageValue,nTime);
-                                if(fDebug10 && sMessageType=="beacon" ){
+                        if(fDebug10 && sMessageType=="beacon" )
                                     LogPrintf("BEACON add %s %s %s", sMessageKey, DecodeBase64(sMessageValue), TimestampToHRDate(nTime));
                                 }
+                    catch(const std::runtime_error& e)
+                    {
+                        error("Attempting to add to unknown cache: %s", sMessageType);
+                    }
+
                                 fMessageLoaded = true;
                                 if (sMessageType=="poll")
                                 {
@@ -8322,9 +8337,17 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                                 if(fDebug10 && sMessageType=="beacon" ){
                                     LogPrintf("BEACON DEL %s - %s", sMessageKey, TimestampToHRDate(nTime));
                                 }
+                    
+                    try
+                    {                    
                     DeleteCache(StringToSection(sMessageType), sMessageKey);
                                 fMessageLoaded = true;
                         }
+                    catch(const std::runtime_error& e)
+                    {
+                        error("Attempting to add to unknown cache: %s", sMessageType);
+                    }
+                }
                         // If this is a boinc project, load the projects into the coin:
                         if (sMessageType=="project" || sMessageType=="projectmapping")
                         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3398,10 +3398,10 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                             else
                                 LogPrintf("WARNING ConnectBlock[ResearchAge] : Researchers Reward Pays too much : bad block ignored: Interest %f and Research %f and StakeReward %f, OUT_POR %f, with Out_Interest %f for CPID %s ",
                                                     bb.InterestSubsidy, bb.ResearchSubsidy, dStakeReward, OUT_POR, OUT_INTEREST,bb.cpid.c_str());
+                            }
+                        }
                         }
                 }
-        }
-        }
 
         //Approve first coinstake in DPOR block
         if (IsResearcher(bb.cpid) && IsLockTimeWithinMinutes(GetBlockTime(), GetAdjustedTime(), 15) && !IsResearchAgeEnabled(pindex->nHeight))
@@ -7580,13 +7580,13 @@ std::string strReplace(std::string& str, const std::string& oldStr, const std::s
 {
     assert(oldStr.empty() == false && "Cannot replace an empty string");
 
-  size_t pos = 0;
+    size_t pos = 0;
     while((pos = str.find(oldStr, pos)) != std::string::npos)
     {
-     str.replace(pos, oldStr.length(), newStr);
-     pos += newStr.length();
-  }
-  return str;
+        str.replace(pos, oldStr.length(), newStr);
+        pos += newStr.length();
+    }
+    return str;
 }
 
 std::string LowerUnderscore(std::string data)
@@ -7745,7 +7745,7 @@ void HarvestCPIDs(bool cleardata)
                         int64_t elapsed = GetTimeMillis()-nStart;
                         if (fDebug3)
                             LogPrintf("Enumerating boinc local project %s cpid %s valid %s, elapsed %" PRId64, structcpid.projectname, structcpid.cpid, YesNo(structcpid.Iscpidvalid), elapsed);
-
+                        
                         structcpid.rac = RoundFromString(rac,0);
                         structcpid.verifiedrac = RoundFromString(rac,0);
                         std::string sLocalClientEmailHash = RetrieveMd5(email);
@@ -8329,8 +8329,8 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                                 if (sMessageType=="poll")
                                 {
                                     msPoll = msg;
-                                        }
-                                        }
+                                }
+                        }
                         else if(sMessageAction=="D")
                         {
                                 if (fDebug10) LogPrintf("Deleting key type %s Key %s Value %s", sMessageType, sMessageKey, sMessageValue);
@@ -8357,9 +8357,9 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
 
                         if(fDebug)
                     WriteCache(Section::TRXID, sMessageType + ";" + sMessageKey,tx.GetHash().GetHex(),nTime);
+            }
                   }
                 }
-    }
 
    return fMessageLoaded;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1048,7 +1048,7 @@ void AddNeuralContractOrVote(const CBlock &blocknew, MiningCPID &bb)
         return;
     }
 
-    int pending_height = RoundFromString(ReadCache("neuralsecurity","pending").value, 0);
+    int pending_height = RoundFromString(ReadCache(Section::NEURALSECURITY, "pending").value, 0);
 
     if (pending_height>=(pindexBest->nHeight-200))
     {

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -83,7 +83,7 @@ bool DiagnosticsDialog::VerifyIsCPIDValid()
 
 bool DiagnosticsDialog::VerifyCPIDIsInNeuralNetwork()
 {
-    std::string beacons = GetListOf("beacon");
+    std::string beacons = GetListOf(Section::BEACON);
     boost::algorithm::to_lower(beacons);
 
     return IsResearcher(msPrimaryCPID) && beacons.find(msPrimaryCPID) != std::string::npos;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1997,7 +1997,7 @@ UniValue projects(const UniValue& params, bool fHelp)
     if (mvCPIDs.empty())
         HarvestCPIDs(false);
 
-    for (const auto& item : ReadCacheSection(Section::PROJECT))
+    for (const auto& item : ReadSortedCacheSection(Section::PROJECT))
     {
         UniValue entry(UniValue::VOBJ);
 
@@ -2879,7 +2879,7 @@ UniValue GetUpgradedBeaconReport()
     std::string row = "";
     int iBeaconCount = 0;
     int iUpgradedBeaconCount = 0;
-    for(const auto& item : ReadCacheSection(Section::BEACON))
+    for(const auto& item : ReadSortedCacheSection(Section::BEACON))
     {
         const AppCacheEntry& entry = item.second;
         std::string contract = DecodeBase64(entry.value);
@@ -2904,7 +2904,7 @@ UniValue GetJSONBeaconReport()
     UniValue entry(UniValue::VOBJ);
     entry.pushKV("CPID","GRCAddress");
     std::string row;
-    for(const auto& item : ReadCacheSection(Section::BEACON))
+    for(const auto& item : ReadSortedCacheSection(Section::BEACON))
     {
         const std::string& key = item.first;
         const AppCacheEntry& cache = item.second;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -608,7 +608,7 @@ void GetSuperblockProjectCount(std::string data, double& out_project_count, doub
     // This is reserved in case we ever want to resync prematurely when the last superblock contains < .75% of whitelisted projects (remember we allow superblocks with up to .50% of the whitelisted projects, in case some project sites are being ddossed)
     std::string avgs = ExtractXML(data,"<AVERAGES>","</AVERAGES>");
     double avg_of_projects = GetAverageInList(avgs, out_project_count);
-    out_whitelist_count = GetCountOf("project");
+    out_whitelist_count = GetCountOf(Section::PROJECT);
     if (fDebug10) LogPrintf(" GSPC:CountOfProjInBlock %f vs WhitelistedCount %f", out_project_count, out_whitelist_count);
 }
 
@@ -623,8 +623,8 @@ double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out
         if (mags.empty()) return 0;
         double avg_of_magnitudes = GetAverageInList(mags,mag_count);
         double avg_of_projects   = GetAverageInList(avgs,avg_count);
-        if (!bIgnoreBeacons) out_beacon_count = GetCountOf("beacon");
-        double out_project_count = GetCountOf("project");
+        if (!bIgnoreBeacons) out_beacon_count = GetCountOf(Section::BEACON);
+        double out_project_count = GetCountOf(Section::PROJECT);
         out_participant_count = mag_count;
         out_average = avg_of_magnitudes;
         if (avg_of_magnitudes < 000010)  return -1;
@@ -653,7 +653,7 @@ bool TallyMagnitudesInSuperblock()
 {
     try
     {
-        std::string superblock = ReadCache("superblock","magnitudes").value;
+        std::string superblock = ReadCache(Section::SUPERBLOCK, "magnitudes").value;
         if (superblock.empty()) return false;
         std::vector<std::string> vSuperblock = split(superblock.c_str(),";");
         double TotalNetworkMagnitude = 0;
@@ -702,13 +702,13 @@ bool TallyMagnitudesInSuperblock()
         network.NetworkMagnitude = TotalNetworkMagnitude;
         network.NetworkAvgMagnitude = NetworkAvgMagnitude;
         if (fDebug)
-            LogPrintf("TallyMagnitudesInSuperblock: Extracted %.0f magnitude entries from cached superblock %s", TotalNetworkEntries, ReadCache("superblock","block_number").value);
+            LogPrintf("TallyMagnitudesInSuperblock: Extracted %.0f magnitude entries from cached superblock %s", TotalNetworkEntries, ReadCache(Section::SUPERBLOCK, "block_number").value);
 
         double TotalProjects = 0;
         double TotalRAC = 0;
         double AVGRac = 0;
         // Load boinc project averages from neural network
-        std::string projects = ReadCache("superblock","averages").value;
+        std::string projects = ReadCache(Section::SUPERBLOCK, "averages").value;
         if (projects.empty()) return false;
         std::vector<std::string> vProjects = split(projects.c_str(),";");
         if (vProjects.size() > 0)
@@ -909,7 +909,7 @@ UniValue rain(const UniValue& params, bool fHelp)
 }
 
 UniValue rainbymagnitude(const UniValue& params, bool fHelp)
-{
+    {
     if (fHelp || (params.size() < 1 || params.size() > 2))
         throw runtime_error(
                 "rainbymagnitude <amount> [message]\n"
@@ -964,9 +964,9 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
             !structMag.cpid.empty() &&
             structMag.Magnitude > 0
            )
-        {
+    {
             // Find beacon grc address
-            std::string scacheContract = ReadCache("beacon", structMag.cpid).value;
+            std::string scacheContract = ReadCache(Section::BEACON, structMag.cpid).value;
 
             // Should never occur but we know seg faults can occur in some cases
             if (scacheContract.empty())
@@ -1028,7 +1028,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
         LogPrintf("Rain By Magnitude Commit failed.");
 
         throw JSONRPCError(RPC_WALLET_ERROR, "Transaction commit failed");
-    }
+}
     res.pushKV("Rain By Magnitude",  "Sent");
     res.pushKV("TXID", wtx.GetHash().GetHex());
     res.pushKV("Rain Amount Sent", dTotalAmount);
@@ -1444,8 +1444,8 @@ UniValue staketime(const UniValue& params, bool fHelp)
     std::string GRCAddress = DefaultWalletAddress();
     GetEarliestStakeTime(GRCAddress, cpid);
 
-    res.pushKV("GRCTime", ReadCache("global", "nGRCTime").timestamp);
-    res.pushKV("CPIDTime", ReadCache("global", "nCPIDTime").timestamp);
+    res.pushKV("GRCTime", ReadCache(Section::GLOBAL, "nGRCTime").timestamp);
+    res.pushKV("CPIDTime", ReadCache(Section::GLOBAL, "nCPIDTime").timestamp);
 
     return res;
 }
@@ -1460,13 +1460,13 @@ UniValue superblockage(const UniValue& params, bool fHelp)
 
     UniValue res(UniValue::VOBJ);
 
-    int64_t superblock_time = ReadCache("superblock", "magnitudes").timestamp;
+    int64_t superblock_time = ReadCache(Section::SUPERBLOCK,  "magnitudes").timestamp;
     int64_t superblock_age = GetAdjustedTime() - superblock_time;
 
     res.pushKV("Superblock Age", superblock_age);
     res.pushKV("Superblock Timestamp", TimestampToHRDate(superblock_time));
-    res.pushKV("Superblock Block Number", ReadCache("superblock", "block_number").value);
-    res.pushKV("Pending Superblock Height", ReadCache("neuralsecurity", "pending").value);
+    res.pushKV("Superblock Block Number", ReadCache(Section::SUPERBLOCK,  "block_number").value);
+    res.pushKV("Pending Superblock Height", ReadCache(Section::NEURALSECURITY, "pending").value);
 
     return res;
 }
@@ -1509,7 +1509,7 @@ UniValue syncdpor2(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    bool bFull = GetCountOf("beacon") < 50 ? true : false;
+    bool bFull = GetCountOf(Section::BEACON) < 50 ? true : false;
 
     LoadAdminMessages(bFull, sOut);
     FullSyncWithDPORNodes();
@@ -1847,7 +1847,7 @@ UniValue getlistof(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    res.pushKV("Data", GetListOf(sType));
+    res.pushKV("Data", GetListOf(StringToSection(sType)));
 
     return res;
 }
@@ -1889,7 +1889,8 @@ UniValue listdata(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    for(const auto& item : ReadCacheSection(sType))
+    Section section = StringToSection(sType);
+    for(const auto& item : ReadCacheSection(section))
         res.pushKV(item.first, item.second.value);
 
     return res;
@@ -1996,7 +1997,7 @@ UniValue projects(const UniValue& params, bool fHelp)
     if (mvCPIDs.empty())
         HarvestCPIDs(false);
 
-    for (const auto& item : ReadCacheSection("project"))
+    for (const auto& item : ReadCacheSection(Section::PROJECT))
     {
         UniValue entry(UniValue::VOBJ);
 
@@ -2190,12 +2191,12 @@ UniValue superblockaverage(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    std::string superblock = ReadCache("superblock", "all").value;
+    std::string superblock = ReadCache(Section::SUPERBLOCK,  "all").value;
     double out_beacon_count = 0;
     double out_participant_count = 0;
     double out_avg = 0;
     double avg = GetSuperblockAvgMag(superblock, out_beacon_count, out_participant_count, out_avg, false, nBestHeight);
-    int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
+    int64_t superblock_age = GetAdjustedTime() - ReadCache(Section::SUPERBLOCK,  "magnitudes").timestamp;
     bool bDireNeed = NeedASuperblock();
 
     res.pushKV("avg", avg);
@@ -2878,7 +2879,7 @@ UniValue GetUpgradedBeaconReport()
     std::string row = "";
     int iBeaconCount = 0;
     int iUpgradedBeaconCount = 0;
-    for(const auto& item : ReadCacheSection("beacon"))
+    for(const auto& item : ReadCacheSection(Section::BEACON))
     {
         const AppCacheEntry& entry = item.second;
         std::string contract = DecodeBase64(entry.value);
@@ -2903,7 +2904,7 @@ UniValue GetJSONBeaconReport()
     UniValue entry(UniValue::VOBJ);
     entry.pushKV("CPID","GRCAddress");
     std::string row;
-    for(const auto& item : ReadCacheSection("beacon"))
+    for(const auto& item : ReadCacheSection(Section::BEACON))
     {
         const std::string& key = item.first;
         const AppCacheEntry& cache = item.second;
@@ -3005,12 +3006,12 @@ UniValue GetJSONNeuralNetworkReport()
         }
     }
     // If we have a pending superblock, append it to the report:
-    std::string SuperblockHeight = ReadCache("neuralsecurity","pending").value;
+    std::string SuperblockHeight = ReadCache(Section::NEURALSECURITY, "pending").value;
     if (!SuperblockHeight.empty() && SuperblockHeight != "0")
     {
         entry.pushKV("Pending",SuperblockHeight);
     }
-    int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
+    int64_t superblock_age = GetAdjustedTime() - ReadCache(Section::SUPERBLOCK,  "magnitudes").timestamp;
 
     entry.pushKV("Superblock Age",superblock_age);
     if (superblock_age > GetSuperblockAgeSpacing(nBestHeight))
@@ -3066,12 +3067,12 @@ UniValue GetJSONCurrentNeuralNetworkReport()
     }
     
     // If we have a pending superblock, append it to the report:
-    std::string SuperblockHeight = ReadCache("neuralsecurity","pending").value;
+    std::string SuperblockHeight = ReadCache(Section::NEURALSECURITY, "pending").value;
     if (!SuperblockHeight.empty() && SuperblockHeight != "0")
     {
         entry.pushKV("Pending",SuperblockHeight);
     }
-    int64_t superblock_age = GetAdjustedTime() - ReadCache("superblock", "magnitudes").timestamp;
+    int64_t superblock_age = GetAdjustedTime() - ReadCache(Section::SUPERBLOCK,  "magnitudes").timestamp;
 
     entry.pushKV("Superblock Age",superblock_age);
     if (superblock_age > GetSuperblockAgeSpacing(nBestHeight))

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -259,7 +259,7 @@ UniValue rpc_getsupervotes(const UniValue& params, bool fHelp)
     UniValue result1(UniValue::VOBJ);
     if("last"==params[1].get_str())
     {
-        std::string sheight= ReadCache("superblock", "block_number").value;
+        std::string sheight= ReadCache(Section::SUPERBLOCK, "block_number").value;
         long height= RoundFromString(sheight,0);
         if(!height)
         {

--- a/src/test/appcache_tests.cpp
+++ b/src/test/appcache_tests.cpp
@@ -6,48 +6,48 @@ BOOST_AUTO_TEST_SUITE(appcache_tests)
 
 BOOST_AUTO_TEST_CASE(appcache_WrittenCacheShouldBeReadable)
 {
-    ClearCache("section");
-    WriteCache("section", "key", "hello", 123456789);
-    BOOST_CHECK(ReadCache("section", "key").value == "hello");
+    ClearCache(Section::GLOBAL);
+    WriteCache(Section::GLOBAL, "key", "hello", 123456789);
+    BOOST_CHECK(ReadCache(Section::GLOBAL, "key").value == "hello");
 }
 
 BOOST_AUTO_TEST_CASE(appcache_ClearCacheShouldClearEntireSection)
 {
-    ClearCache("section");
-    WriteCache("section", "key1", "hello", 123456789);
-    WriteCache("section", "key2", "hello", 123456789);
-    ClearCache("section");
-    BOOST_CHECK(ReadCache("section", "key1").value.empty() == true);
-    BOOST_CHECK(ReadCache("section", "key2").value.empty() == true);
+    ClearCache(Section::GLOBAL);
+    WriteCache(Section::GLOBAL, "key1", "hello", 123456789);
+    WriteCache(Section::GLOBAL, "key2", "hello", 123456789);
+    ClearCache(Section::GLOBAL);
+    BOOST_CHECK(ReadCache(Section::GLOBAL, "key1").value.empty() == true);
+    BOOST_CHECK(ReadCache(Section::GLOBAL, "key2").value.empty() == true);
 }
 
 BOOST_AUTO_TEST_CASE(appcache_KeyShouldBeEmptyAfterDeleteCache)
 {
-    ClearCache("section");
-    WriteCache("section", "key", "hello", 123456789);
-    DeleteCache("section", "key");
-    BOOST_CHECK(ReadCache("section", "key").value.empty() == true);
-    BOOST_CHECK_EQUAL(GetCountOf("section"),0);
+    ClearCache(Section::GLOBAL);
+    WriteCache(Section::GLOBAL, "key", "hello", 123456789);
+    DeleteCache(Section::GLOBAL, "key");
+    BOOST_CHECK(ReadCache(Section::GLOBAL, "key").value.empty() == true);
+    BOOST_CHECK_EQUAL(GetCountOf(Section::GLOBAL),0);
 }
 
 BOOST_AUTO_TEST_CASE(appcache_GetCountOfShouldCountEntries)
 {
-    ClearCache("section");
-    WriteCache("section", "key1", "hello", 123456789);
-    WriteCache("section", "key2", "hello", 123456789);
-    WriteCache("section", "key3", "hello", 123456789);
-    BOOST_CHECK_EQUAL(GetCountOf("section"), 3);
+    ClearCache(Section::GLOBAL);
+    WriteCache(Section::GLOBAL, "key1", "hello", 123456789);
+    WriteCache(Section::GLOBAL, "key2", "hello", 123456789);
+    WriteCache(Section::GLOBAL, "key3", "hello", 123456789);
+    BOOST_CHECK_EQUAL(GetCountOf(Section::GLOBAL), 3);
 }
 
 BOOST_AUTO_TEST_CASE(appcache_GetListOfBeaconShouldIgnoreInvestors)
 {
-    ClearCache("beacon");
-    WriteCache("beacon", "CPID1", "INVESTOR", 12345);
-    BOOST_CHECK(GetListOf("beacon").empty() == true);
+    ClearCache(Section::BEACON);
+    WriteCache(Section::BEACON, "CPID1", "INVESTOR", 12345);
+    BOOST_CHECK(GetListOf(Section::BEACON).empty() == true);
 
-    WriteCache("beacon", "CPID2", "abc123", 12345);
-    BOOST_CHECK(GetListOf("beacon").empty() == false);
-    BOOST_CHECK(GetListOf("beacon").find("abc123") != std::string::npos);
+    WriteCache(Section::BEACON, "CPID2", "abc123", 12345);
+    BOOST_CHECK(GetListOf(Section::BEACON).empty() == false);
+    BOOST_CHECK(GetListOf(Section::BEACON).find("abc123") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/appcache_tests.cpp
+++ b/src/test/appcache_tests.cpp
@@ -50,4 +50,21 @@ BOOST_AUTO_TEST_CASE(appcache_GetListOfBeaconShouldIgnoreInvestors)
     BOOST_CHECK(GetListOf(Section::BEACON).find("abc123") != std::string::npos);
 }
 
+BOOST_AUTO_TEST_CASE(appcache_SortedSectionsShouldBeSorted)
+{
+    ClearCache(Section::BEACON);
+    WriteCache(Section::BEACON, "b", "321", 0);
+    WriteCache(Section::BEACON, "a", "123", 0);
+    
+    const SortedAppCacheSection& section = ReadSortedCacheSection(Section::BEACON);
+    auto it = section.begin();
+    BOOST_CHECK(it->first == "a");
+    BOOST_CHECK(it->second.value == "123");
+    
+    ++it;
+    BOOST_CHECK(it->first == "b");
+    BOOST_CHECK(it->second.value == "321");
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/beacon_tests.cpp
+++ b/src/test/beacon_tests.cpp
@@ -66,15 +66,15 @@ struct GridcoinBeaconTestsFixture
         // setup function
         /* Add cpid beacon, so it is valid (age 10 minutes)
          * pk: 04a143881f40abb34b928efada2873f6571dbf7583b33359eb128beee309aff25b4e0ca5e9a1d8350791705392cb9445d23cfecce84cbf101344f4f1cd1f877f4b */
-        WriteCache("beacon","b67846ea8547cedd2d61ce492fe14102",
+        WriteCache(Section::BEACON, "b67846ea8547cedd2d61ce492fe14102",
             "YjY3ODQ2ZWE4NTQ3Y2VkZDJkNjFjZTQ5MmZlMTQxMDIzNTM4MzgzZDlhOWEzZWM5OTZjYTk3Mzk0MDM5OTUzNmM3NmM2NjZjMzQ5NDQxYzkzZTlkOTM2OTZkM2M0MjZiNzk2MjZlNmE2ZjZlNzA0MTcwNmU2ZjZhNzU2NjY0NjkyZjZmNjY3NTs3MmQzMDlhMDI5OGJmNjc0NTI2ZmI1NDI3NjMxY2NjZWIyNGQzMDA4NjVlOTM0Mjg1NjJiODIwZGMxNTA2MGQyO21tejQ4UFBBcGhWNk15ZmFxRGlZaTd6OUMzTkVnWGFTajU7MDRhMTQzODgxZjQwYWJiMzRiOTI4ZWZhZGEyODczZjY1NzFkYmY3NTgzYjMzMzU5ZWIxMjhiZWVlMzA5YWZmMjViNGUwY2E1ZTlhMWQ4MzUwNzkxNzA1MzkyY2I5NDQ1ZDIzY2ZlY2NlODRjYmYxMDEzNDRmNGYxY2QxZjg3N2Y0Yg==",
             beacon1_time);
         /* Beacon that is valid, but renewable */
-        WriteCache("beacon","bc0621a4ac4610ffa400a0d298c02e23",
+        WriteCache(Section::BEACON, "bc0621a4ac4610ffa400a0d298c02e23",
             "YmMwNjIxYTRhYzQ2MTBmZmE0MDBhMGQyOThjMDJlMjNjYWMyOWEzZGM1OTc2N2M4OTk5OWM0M2M0MjNjYzM0MzM5NzAzYjk4NjgzMmM4YzgzODk5Njk5Nzk3M2U2NTk4NmI2MjZlNjY3NDcwNzg2NjZmNzQ0MTcwNzE3NTcwNmY2ZDZhNmY2NjJmNmY2Njc1OzBlNWQwODg1ODllYmU3MTBjODBlOWM2YjU1YjgwYWQzOTZkOTk2ZWUxNzBlMGVkNjQyMmVhMWI1ZTk5NDVlYjg7bW42Mm9rNzl2RmFOc3N6ZUVxZGUybldWUXRKVmdaUHo2RjswNGYyMTU1OWViY2Q2NzhmYTg3N2RiZThhYjAwOWE4YjZlNWNkODA3ZWE3Y2FlMzAxNDNiMjU1YTYyNjRmYmMxMjUzMmM2NGZjZGYyMjcxOTk2ODk2ZDQ3NTIzNGYzN2E5YjhjOWE4YTQzMjlhMDQyNGVlMjg2M2NiY2NlMWY1MmRm",
             beacon2_time);
         /* Ensure this cpid is not present */
-        DeleteCache("beacon","363d6c820aef2dbbe082768b40feed0d");
+        DeleteCache(Section::BEACON, "363d6c820aef2dbbe082768b40feed0d");
     }
     ~GridcoinBeaconTestsFixture()
     {     // teardown function
@@ -111,7 +111,7 @@ BOOST_FIXTURE_TEST_CASE(Generate_Retrieve_integration, GridcoinBeaconTestsFixtur
     BOOST_CHECK( GenerateBeaconKeys(TEST_CPID, generatedKey) );
 
     //Simulate that a beacon was accepted
-    WriteCache("beacon",TEST_CPID,
+    WriteCache(Section::BEACON, TEST_CPID,
         EncodeBase64(TEST_CPID+";stuff1;stuff2;"+HexStr(generatedKey.GetPubKey().Raw())),
         pindexBest->nTime - 600);
 
@@ -200,13 +200,13 @@ struct GridcoinBeaconSigningFixture
         CKey generatedKey;
         BOOST_CHECK( GenerateBeaconKeys(TEST_CPID, generatedKey) );
         //Simulate that a beacon was accepted
-        WriteCache("beacon",TEST_CPID,
+        WriteCache(Section::BEACON, TEST_CPID,
             EncodeBase64(TEST_CPID+";stuff1;stuff2;"+HexStr(generatedKey.GetPubKey().Raw())),
             pindexBest->nTime - 600);
     }
     ~GridcoinBeaconSigningFixture()
     {     // teardown function
-        DeleteCache("beacon",TEST_CPID);
+        DeleteCache(Section::BEACON, TEST_CPID);
     }
 };
 

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -178,7 +178,7 @@ struct GridcoinCBRTestConfig
     GridcoinCBRTestConfig()
     {
         // Clear out previous CBR settings.
-        DeleteCache("protocol", "blockreward1");
+        DeleteCache(Section::PROTOCOL, "blockreward1");
     }
 };
 
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldOverrideDefault)
     index.nVersion = 10;
     index.nTime = time;
 
-    WriteCache("protocol", "blockreward1", ToString(cbr), time);
+    WriteCache(Section::PROTOCOL, "blockreward1", ToString(cbr), time);
     BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), cbr);
 }
 
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_NegativeCBRShouldClampTo0)
     CBlockIndex index;
     index.nTime = time;
 
-    WriteCache("protocol", "blockreward1", ToString(-1 * COIN), time);
+    WriteCache(Section::PROTOCOL, "blockreward1", ToString(-1 * COIN), time);
     BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), 0);
 }
 
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldClampTo2xDefault)
     CBlockIndex index;
     index.nTime = time;
 
-    WriteCache("protocol", "blockreward1", ToString(DEFAULT_CBR * 2.1), time);
+    WriteCache(Section::PROTOCOL, "blockreward1", ToString(DEFAULT_CBR * 2.1), time);
     BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), DEFAULT_CBR * 2);
 }
 
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_ObsoleteConfigurableCBRShouldResortToDefault)
 
     // Make the block reward message 1 second older than the max age
     // relative to the block.
-    WriteCache("protocol", "blockreward1", ToString(3 * COIN), index.nTime - max_message_age - 1);
+    WriteCache(Section::PROTOCOL, "blockreward1", ToString(3 * COIN), index.nTime - max_message_age - 1);
 
     BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), DEFAULT_CBR);
 }


### PR DESCRIPTION
This changes the appcache from using a map of maps to using an array of maps. It also changes the section key from a string to an enum. This improves the performance, reduces memory usage by a tiny amount and reduces the risk of using an incorrect string as a section key. It does limit the versatility of admin messages a bit.

This makes #1247 redundant.