### PR TITLE
Show hand cursor when hovering ClickLabel

### DIFF
--- a/src/qt/clicklabel.cpp
+++ b/src/qt/clicklabel.cpp
@@ -3,7 +3,8 @@
 
 ClickLabel::ClickLabel(QWidget *parent, Qt::WindowFlags f)
 : QLabel(parent){
-
+        this->setMouseTracking(true);
+        this->setCursor(Qt::PointingHandCursor);
 }
 
 ClickLabel::~ClickLabel() {}


### PR DESCRIPTION
Closes #1329

Tested using development branch on macOS, Qt 5.11.2.

![screen capture](https://user-images.githubusercontent.com/7941193/47271262-c2ef0b00-d53c-11e8-83eb-63520af3db8b.gif)
