### PR TITLE
Use default colors for pie chart

### DIFF
--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -720,11 +720,6 @@ void VotingChartDialog::resetData(const VotingItem *item)
 
 #ifdef QT_CHARTS_LIB
         QtCharts::QPieSlice *slice = new QtCharts::QPieSlice(sAnswerNames[y], iShares[y]);
-        unsigned int num = rand();
-        int r = (num >>  0) % 0xFF;
-        int g = (num >>  8) % 0xFF;
-        int b = (num >> 16) % 0xFF;
-        slice->setColor(QColor(r, g, b));
         series->append(slice);
         chart_->addSeries(series);
 #endif


### PR DESCRIPTION
…instead of using random colors

Closes #1323

Tested on development branch using macOS, Qt 5.11.2

@EnzoCaricoTri Please see screenshot below; would you consider this an an acceptable solution? This is Qt's default color scheme, and since it is monochrome it should be colorblind-friendly.

![screen shot 2018-10-21 at 3 38 26 am](https://user-images.githubusercontent.com/7941193/47264825-67dcfa00-d4e3-11e8-9004-7df1f13e261d.png)
