### PR TITLE
Remove help button from debug window

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -206,7 +206,7 @@ void RPCExecutor::request(const QString &command)
     }
 }
 
-RPCConsole::RPCConsole(QWidget *parent) :
+RPCConsole::RPCConsole(QWidget *parent, Qt::WindowFlags f) :
     QDialog(parent),
     ui(new Ui::RPCConsole),
     historyPtr(0)

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -14,7 +14,7 @@ class RPCConsole: public QDialog
     Q_OBJECT
 
 public:
-    explicit RPCConsole(QWidget *parent = 0);
+    explicit RPCConsole(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags() & ~Qt::WindowContextHelpButtonHint);
     ~RPCConsole();
 
     void setClientModel(ClientModel *model);


### PR DESCRIPTION
Closes #547

Adapted from [this SO answer](https://stackoverflow.com/a/30934930/4896937), but I don't know if this is the right way to do so.

I have **not** tested this commit since I do not have Windows build environment set up. Can anyone volunteer to test it?

**Edit:** @barton2526 has offered to test this