### PR TITLE
Update the data acquisition RPCs.

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -369,7 +369,7 @@ static const CRPCCommand vRPCCommands[] =
     { "debug4",                  &debug4,                  true,   cat_developer     },
     { "debugnet",                &debugnet,                true,   cat_developer     },
     { "dportally",               &dportally,               false,  cat_developer     },
-    { "exportstats1",            &rpc_exportstats,         false,  cat_developer     },
+    { "exportstats2",            &rpc_exportstats,         false,  cat_developer     },
     { "forcequorum",             &forcequorum,             false,  cat_developer     },
     { "gatherneuralhashes",      &gatherneuralhashes,      false,  cat_developer     },
     { "genboinckey",             &genboinckey,             false,  cat_developer     },


### PR DESCRIPTION
* add stake output display in getblockstats
* add harmonic average of difficulty to getblockstats, exportstats2
* add lowest and highest sections to getblockstats
* change error message to exception (unknown block)
* change exportstats point to include requested number of seconds
  Instead of including X blocks into one point, it now outputs
  one point per time interval.
* align exportstats points to middle of requested interval
* change filename for export: export_topheight_maxblocks_smoothing
* change what fields are in exports, remove redundant
* add option to specify starting point of getrecentblocks