### PR TITLE
Remove obsolete rpc call data return fields.

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -70,7 +70,6 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.pushKV("errors",        GetWarnings("statusbar"));
     obj.pushKV("pooledtx",      (uint64_t)mempool.size());
     //double nCutoff =  GetAdjustedTime() - (60*60*24*14);
-    obj.pushKV("stakeinterest", GetCoinYearReward( GetAdjustedTime())/(double)COIN);
     obj.pushKV("testnet",       fTestNet);
     double neural_popularity = 0;
     std::string neural_hash = GetNeuralNetworkSupermajorityHash(neural_popularity);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -62,11 +62,6 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         obj.pushKV("mining-created", MinerStatus.CreatedCnt);
         obj.pushKV("mining-accepted", MinerStatus.AcceptedCnt);
         obj.pushKV("mining-kernels-found", MinerStatus.KernelsFound);
-        // Avoid calculating coinage of all coins just to get interest,
-        // reuse value found by miner which has to load blocks anyway
-        double dInterest = MinerStatus.CoinAgeSum * GetCoinYearReward(nTime) * 33 / (365 * 33 + 8);
-        obj.pushKV("InterestPending",dInterest/(double)COIN);
-
         obj.pushKV("kernel-diff-best",MinerStatus.KernelDiffMax);
         obj.pushKV("kernel-diff-sum",MinerStatus.KernelDiffSum);
     }

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -130,7 +130,6 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.pushKV("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string()));
     obj.pushKV("ip",            addrSeenByPeer.ToStringIP());
 
-    diff.pushKV("proof-of-work",  GetDifficulty());
     diff.pushKV("proof-of-stake", GetDifficulty(GetLastBlockIndex(pindexBest, true)));
     obj.pushKV("difficulty",    diff);
 


### PR DESCRIPTION
This removes the proof-of-work difficulty and InterestPending fields,
which are now obsolete.