### PR TITLE
Remove old research age checks

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -287,14 +287,6 @@ int64_t GetRSAWeightByCPIDWithRA(std::string cpid)
 
 int64_t GetRSAWeightByCPID(std::string cpid)
 {
-
-    if (IsResearchAgeEnabled(pindexBest->nHeight) && AreBinarySuperblocksEnabled(pindexBest->nHeight))
-    {
-            return GetRSAWeightByCPIDWithRA(cpid);
-            //ToDo : During next mandatory, retire this old function.
-    }
-
-
     double weight = 0;
     if (!IsResearcher(cpid)) return 5000;
     if (mvMagnitudes.size() > 0)
@@ -312,7 +304,7 @@ int64_t GetRSAWeightByCPID(std::string cpid)
                         {
                                 weight = (UntrustedHost.owed*14) + UntrustedHost.Magnitude;
                                 if (fTestNet && weight < 0) weight = 0;
-                                if (IsResearchAgeEnabled(pindexBest->nHeight) && weight < 0) weight=0;
+                                if (weight < 0) weight=0;
                         }
 
             }
@@ -379,7 +371,7 @@ int64_t GetRSAWeightByBlock(MiningCPID boincblock)
     }
 
     if (fTestNet && rsa_weight < 0) rsa_weight = 0;
-    if (IsResearchAgeEnabled(pindexBest->nHeight) && rsa_weight < 0) rsa_weight = 0;
+    if (rsa_weight < 0) rsa_weight = 0;
     return rsa_weight;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3256,7 +3256,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // 12-20-2015 : Add support for Binary Superblocks
             std::string superblock = UnpackBinarySuperblock(bb.superblock);
             std::string neural_hash = GetQuorumHash(superblock);
-            std::string legacy_neural_hash = RetrieveMd5(superblock);
             double popularity = 0;
             std::string consensus_hash = GetNeuralNetworkSupermajorityHash(popularity);
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2084,42 +2084,6 @@ int64_t GetProofOfStakeMaxReward(uint64_t nCoinAge, int64_t nFees, int64_t lockt
     return nSubsidy + nFees;
 }
 
-double GetProofOfResearchReward(std::string cpid, bool VerifyingBlock)
-{
-
-        StructCPID mag = GetInitializedStructCPID2(cpid,mvMagnitudes);
-
-        if (!mag.initialized) return 0;
-        double owed = (mag.owed*1.0);
-        if (owed < 0) owed = 0;
-        // Coarse Payment Rule (helps prevent sync problems):
-        if (!VerifyingBlock)
-        {
-            //If owed less than 4% of max subsidy, assess at 0:
-            if (owed < (GetMaximumBoincSubsidy(GetAdjustedTime())/50))
-            {
-                owed = 0;
-            }
-            //Coarse payment rule:
-            if (mag.totalowed > (GetMaximumBoincSubsidy(GetAdjustedTime())*2))
-            {
-                //If owed more than 2* Max Block, pay normal amount
-                owed = (owed*1);
-            }
-            else
-            {
-                owed = owed/2;
-            }
-
-            if (owed > (GetMaximumBoincSubsidy(GetAdjustedTime()))) owed = GetMaximumBoincSubsidy(GetAdjustedTime());
-
-
-        }
-        //End of Coarse Payment Rule
-        return owed * COIN;
-}
-
-
 // miner's coin stake reward based on coin age spent (coin-days)
 int64_t GetConstantBlockReward(const CBlockIndex* index)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2074,16 +2074,6 @@ double GetMagnitudeMultiplier(int64_t nTime)
     return magnitude_multiplier;
 }
 
-
-int64_t GetProofOfStakeMaxReward(uint64_t nCoinAge, int64_t nFees, int64_t locktime)
-{
-    int64_t nInterest = nCoinAge * GetCoinYearReward(locktime) * 33 / (365 * 33 + 8);
-    nInterest += 10*COIN;
-    int64_t nBoinc    = (GetMaximumBoincSubsidy(locktime)+1) * COIN;
-    int64_t nSubsidy  = nInterest + nBoinc;
-    return nSubsidy + nFees;
-}
-
 // miner's coin stake reward based on coin age spent (coin-days)
 int64_t GetConstantBlockReward(const CBlockIndex* index)
 {
@@ -3085,8 +3075,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // ppcoin: coin stake tx earns reward instead of paying fee
         if (!vtx[1].GetCoinAge(txdb, nCoinAge))
             return error("ConnectBlock[] : %s unable to get coin age for coinstake", vtx[1].GetHash().ToString().substr(0,10).c_str());
-
-        double dCalcStakeReward = CoinToDouble(GetProofOfStakeMaxReward(nCoinAge, nFees, nTime));
 
         //9-3-2015
         double dMaxResearchAgeReward = CoinToDouble(GetMaximumBoincSubsidy(nTime) * COIN * 255);

--- a/src/main.h
+++ b/src/main.h
@@ -83,11 +83,6 @@ inline bool IsProtocolV2(int nHeight)
 	return (fTestNet ?  nHeight > 2060 : nHeight > 85400);
 }
 
-inline bool IsResearchAgeEnabled(int nHeight)
-{
-	return (fTestNet ?  nHeight > 0 : nHeight > 364500);
-}
-
 // TODO: Move this and the other height thresholds to their own files.
 // Do not put the code in the headers!
 inline uint32_t IsV8Enabled(int nHeight)


### PR DESCRIPTION
Remove checks which are never triggered due to the grandfather height. The rationale is to get rid of old, unused code to be able to make further improvements.

I have synced from 0 twice using this but I will do another run tonight just to ensure that it works.