### PR TITLE
Fix RA on testnet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3293,7 +3293,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
     pindex->nMoneySupply = ReturnCurrentMoneySupply(pindex) + nValueOut - nValueIn;
 
     // Gridcoin: Store verified magnitude and CPID in block index (7-11-2015)
-    if (pindex->nHeight > nNewIndex2)
+    if(IsResearchAgeEnabled(pindex->nHeight))
     {
         pindex->SetCPID(bb.cpid);
         pindex->nMagnitude = bb.Magnitude;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5983,7 +5983,7 @@ bool TallyResearchAverages_retired(CBlockIndex* index)
         bNetAveragesLoaded = true;
         return true;
     }
-    catch (bad_alloc ba)
+    catch (const std::bad_alloc& ba)
     {
         LogPrintf("Bad Alloc while tallying network averages. [1]");
         bNetAveragesLoaded=true;

--- a/src/main.h
+++ b/src/main.h
@@ -85,7 +85,7 @@ inline bool IsProtocolV2(int nHeight)
 
 inline bool IsResearchAgeEnabled(int nHeight)
 {
-	return (fTestNet ?  nHeight > 0 : nHeight > 364500);
+    return (fTestNet ?  nHeight > 36500 : nHeight > 364500);
 }
 
 // TODO: Move this and the other height thresholds to their own files.

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -374,15 +374,12 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nNonce         = diskindex.nNonce;
 
         //9-26-2016 - Gridcoin - New Accrual Fields
-        if (diskindex.nHeight > nNewIndex)
-        {
-            pindexNew->cpid              = diskindex.cpid;
-            pindexNew->nResearchSubsidy  = diskindex.nResearchSubsidy;
-            pindexNew->nInterestSubsidy  = diskindex.nInterestSubsidy;
-            pindexNew->nMagnitude        = diskindex.nMagnitude;
-            pindexNew->nIsContract       = diskindex.nIsContract;
-            pindexNew->nIsSuperBlock     = diskindex.nIsSuperBlock;
-        }
+        pindexNew->cpid              = diskindex.cpid;
+        pindexNew->nResearchSubsidy  = diskindex.nResearchSubsidy;
+        pindexNew->nInterestSubsidy  = diskindex.nInterestSubsidy;
+        pindexNew->nMagnitude        = diskindex.nMagnitude;
+        pindexNew->nIsContract       = diskindex.nIsContract;
+        pindexNew->nIsSuperBlock     = diskindex.nIsSuperBlock;
 
         nBlockCount++;
         // Watch for genesis block
@@ -619,32 +616,31 @@ bool CTxDB::LoadBlockIndex()
     nLoaded=pindex->nHeight;
     for ( ; pindex ; pindex= pindex->pnext )
     {
-
-        if( pindex->IsUserCPID() && pindex->cpid == uint128() )
+        if(IsResearchAgeEnabled(pindex->nHeight))
         {
-            /* There were reports of 0000 cpid in index where INVESTOR should have been. Check */
-            auto bb = GetBoincBlockByIndex(pindex);
-            if( bb.cpid != pindex->GetCPID() )
+            if( pindex->IsUserCPID() && pindex->cpid == uint128() )
             {
-                if(fDebug)
-                    LogPrintf("WARNING: BlockIndex CPID %s did not match %s in block {%s %d}",
-                        pindex->GetCPID(), bb.cpid,
-                        pindex->GetBlockHash().GetHex(), pindex->nHeight );
+                /* There were reports of 0000 cpid in index where INVESTOR should have been. Check */
+                auto bb = GetBoincBlockByIndex(pindex);
+                if( bb.cpid != pindex->GetCPID() )
+                {
+                    if(fDebug)
+                        LogPrintf("WARNING: BlockIndex CPID %s did not match %s in block {%s %d}",
+                            pindex->GetCPID(), bb.cpid,
+                            pindex->GetBlockHash().GetHex(), pindex->nHeight );
 
-                /* Repair the cpid field */
-                pindex->SetCPID(bb.cpid);
+                    /* Repair the cpid field */
+                    pindex->SetCPID(bb.cpid);
 
-                #if 0
-                if(!WriteBlockIndex(CDiskBlockIndex(pindex)))
-                    error("LoadBlockIndex: writing CDiskBlockIndex failed");
-                #endif
+                    #if 0
+                    if(!WriteBlockIndex(CDiskBlockIndex(pindex)))
+                        error("LoadBlockIndex: writing CDiskBlockIndex failed");
+                    #endif
+                }
             }
-        }
 
-        /* Note: AddRARewardBlock is called here even for non-RA blocks. Non-RA
-         * blocks are ignored in AddRARewardBlock so this is not a problem.
-         * The range of this loop should be adjusted to save some time. */
-        AddRARewardBlock(pindex);
+            AddRARewardBlock(pindex);
+        }
 
         if(fQtActive)
         {
@@ -657,7 +653,6 @@ bool CTxDB::LoadBlockIndex()
                 uiInterface.InitMessage(_(sBlocksLoaded.c_str()));
             }
         }
-
     }
 
     LogPrintf("RA Complete - RA Time %15" PRId64 "ms\n", GetTimeMillis() - nStart);


### PR DESCRIPTION
IsResearchAgeEnabled claimed that >0 for testnet was valid which was not the case. Research Age blocks started at 36500 so by including blocks below it we would, if we used an old snapshot, include blocks which had unitialized variables and the calculations were way off.

