### PR TITLE
Catch and display error messages thrown by the vote function.

### DIFF
--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -855,9 +855,8 @@ void VotingVoteDialog::vote(void)
     catch(const UniValue& e)
     {
         voteNote_->setText(
-                    QString("Vote error: %1 (%2)")
-                        .arg(e["message"].get_str().c_str())
-                        .arg(e["code"].get_int()));
+                    QString("Vote error: %1")
+                        .arg(e["message"].get_str().c_str()));
     }
 }
 


### PR DESCRIPTION
Currently errors in the voting process will throw an uncaught exception which causes the wallet to crash. This change catches the error and displays the error message. "-4" in the exception is the error code which we may or may not want to display.

![screenshot_2018-11-29_13-14-26](https://user-images.githubusercontent.com/135439/49221383-3a844580-f3d9-11e8-8f05-aca49d33faca.png)
