### PR TITLE
Import beacon key on unlock instead of on a timer.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -928,6 +928,10 @@ bool AppInit2(ThreadHandlerPtr threads)
     uiInterface.InitMessage(_("Finding first applicable Research Project..."));
     LoadCPIDs();
 
+    if(!pwalletMain->IsLocked() &&
+       ImportBeaconKeysFromConfig(GlobalCPUMiningCPID.cpid, pwalletMain))
+       LogPrintf("Beacon imported");
+
     // Beacon private keys can't be imported here, because the wallet is locked
 
     if (!CheckDiskSpace())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4651,13 +4651,7 @@ void GridcoinServices()
                 LOCK(MinerStatus.lock);
                 msMiningErrors6 = _("Unable To Send Beacon! Unlock Wallet!");
             }
-        } else {
-            /* If public key is set, try to import it's private part from
-             * config. The function fails fast if there are none in config.
-             */
-            ImportBeaconKeysFromConfig(GlobalCPUMiningCPID.cpid, pwalletMain);
         }
-
     }
 
     if (TimerMain("gather_cpids",480))

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -22,6 +22,7 @@
 #include <script.h>
 #include "main.h"
 #include "util.h"
+#include "beacon.h"
 
 using namespace std;
 
@@ -178,7 +179,12 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
             if (!crypter.Decrypt(pMasterKey.second.vchCryptedKey, vMasterKey))
                 return false;
             if (CCryptoKeyStore::Unlock(vMasterKey))
+            {
+                if(ImportBeaconKeysFromConfig(GlobalCPUMiningCPID.cpid, this))
+                   LogPrintf("Beacon imported");
+
                 return true;
+            }
         }
     }
     return false;


### PR DESCRIPTION
Move beacon import from a timer to wallet unlock and on client start. This closes #1353.

*Status*: Needs more testing.

