### PR TITLE
Arm/Arm64 cross compile

### DIFF
--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -4,15 +4,11 @@ native_packages := native_ccache
 qt_packages = qrencode
 
 ifeq ($(QT_59),1)
-qt_x86_64_linux_packages:=qt59 expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
-qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
-
+qt_linux_packages:=qt59 expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_darwin_packages=qt59
 qt_mingw32_packages=qt59
 else
-qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
-qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
-
+qt_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_darwin_packages=qt
 qt_mingw32_packages=qt
 endif

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -109,6 +109,7 @@ $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_arm_linux  = -platform linux-g++ -xplatform $(host)
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
+$(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
 $(package)_build_env  = QT_RCC_TEST=1
 endef
 

--- a/depends/packages/qt59.mk
+++ b/depends/packages/qt59.mk
@@ -100,6 +100,7 @@ $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_arm_linux  = -platform linux-g++ -xplatform $(host)
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
+$(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
 $(package)_build_env  = QT_RCC_TEST=1
 endef
 

--- a/depends/packages/xextproto.mk
+++ b/depends/packages/xextproto.mk
@@ -4,6 +4,10 @@ $(package)_download_path=http://xorg.freedesktop.org/releases/individual/proto
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=f3f4b23ac8db9c3a9e0d8edb591713f3d70ef9c3b175970dd8823dfc92aa5bb0
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared
 endef


### PR DESCRIPTION
This includes Bitcoin patches from @TheCharlatan to allow for ARM cross compile using Depends. I have successfully built for aarch64-linux-gnu but I have not tested it yet. @G_UK reported on Slack that he ran into issues when trying to launch the UI wallet:

> After some tweaking I got it to build however I could not get it to run without throwing the following error "Failed to load platform plugin "xcb". Available platforms are:"

@TheCharlatan Do you think we need any patches other than this?