### PR TITLE
Change dumpwallet to use appropriate data directory

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -14,6 +14,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 
@@ -305,12 +306,20 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
             "\n"
             "<filename> -> filename to dump wallet to\n"
             "\n"
-            "Dumps all wallet keys in a human-readable format\n");
+            "Dumps all wallet keys in a human-readable format into the specified file.\n"
+            "If a path is not specified in the filename, the data directory is used.");
 
     EnsureWalletIsUnlocked();
 
+    boost::filesystem::path PathForDump = boost::filesystem::path(params[0].get_str());
+    boost::filesystem::path DefaultPathDataDir = GetDataDir();
+
+    // If provided filename does not have a path, then append parent path, otherwise leave alone.
+    if (PathForDump.parent_path().empty())
+        PathForDump = DefaultPathDataDir / PathForDump;
+
     ofstream file;
-    file.open(params[0].get_str().c_str());
+    file.open(PathForDump.string().c_str());
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
 


### PR DESCRIPTION
by default, with the ability to provide an override to
that in the filespec.

This should also fix the functionality in the debug console.

I have tested in the debug console of both Linux and Windows with just

dumpwallet filename and it works - it appropriately put it in the testnet subdirectory under the data directory.

I tested Linux with dumpwallet /home/jco/walletkeys.dat on testnet and it put it in the specified pathspec.

I tested Windows with dumpwallet "C:\users\JCO\Documents\walletkeys.dat" and it put it in the correct directory. You need to use the quotes. Before the functionality was totally broken in the UI debug console on Windows. 