### PR TITLE
Build fixes for ARM and incorrect icon file.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ DIST_DOCS = $(wildcard doc/*.md) $(wildcard doc/release-notes/*.md)
 
 BIN_CHECKS=$(top_srcdir)/contrib/devtools/symbol-check.py
 
-WINDOWS_PACKAGING = $(top_srcdir)/share/pixmaps/bitcoin.ico \
+WINDOWS_PACKAGING = $(top_srcdir)/share/pixmaps/gridcoin.ico \
   $(top_srcdir)/share/pixmaps/nsis-header.bmp \
   $(top_srcdir)/share/pixmaps/nsis-wizard.bmp
 

--- a/depends/packages/bdb53.mk
+++ b/depends/packages/bdb53.mk
@@ -1,0 +1,31 @@
+package=bdb53
+$(package)_version=5.3.28
+$(package)_download_path=http://download.oracle.com/berkeley-db
+$(package)_file_name=db-$($(package)_version).NC.tar.gz
+$(package)_sha256_hash=76a25560d9e52a198d37a31440fd07632b5f1f8f9f2b6d5438f4bc3e7c9013ef
+$(package)_build_subdir=build_unix
+
+define $(package)_set_vars
+$(package)_config_opts=--disable-shared --enable-cxx --disable-replication
+$(package)_config_opts_mingw32=--enable-mingw
+$(package)_config_opts_linux=--with-pic
+$(package)_cxxflags=-std=c++11
+endef
+
+define $(package)_preprocess_cmds
+  sed -i.old 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' src/dbinc/atomic.h && \
+  sed -i.old 's/atomic_init/atomic_init_db/' src/dbinc/atomic.h src/mp/mp_region.c src/mp/mp_mvcc.c src/mp/mp_fget.c src/mutex/mut_method.c src/mutex/mut_tas.c && \
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub dist
+endef
+
+define $(package)_config_cmds
+  ../dist/$($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE) libdb_cxx-5.3.a libdb-5.3.a
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install_lib install_include
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -4,15 +4,11 @@ native_packages := native_ccache
 qt_packages = qrencode
 
 ifeq ($(QT_59),1)
-qt_x86_64_linux_packages:=qt59 expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
-qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
-
+qt_linux_packages:=qt59 expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_darwin_packages=qt59
 qt_mingw32_packages=qt59
 else
-qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
-qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
-
+qt_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_darwin_packages=qt
 qt_mingw32_packages=qt
 endif

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -13,7 +13,11 @@ qt_darwin_packages=qt
 qt_mingw32_packages=qt
 endif
 
+ifeq ($(BDB_53),1)
+wallet_packages=bdb53
+else
 wallet_packages=bdb
+endif
 
 upnp_packages=miniupnpc
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -109,6 +109,7 @@ $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_arm_linux  = -platform linux-g++ -xplatform $(host)
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
+$(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
 $(package)_build_env  = QT_RCC_TEST=1
 endef
 

--- a/depends/packages/qt59.mk
+++ b/depends/packages/qt59.mk
@@ -100,6 +100,7 @@ $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_arm_linux  = -platform linux-g++ -xplatform $(host)
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
+$(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
 $(package)_build_env  = QT_RCC_TEST=1
 endef
 

--- a/depends/packages/qt59.mk
+++ b/depends/packages/qt59.mk
@@ -97,7 +97,7 @@ $(package)_config_opts_linux += -qt-xcb
 $(package)_config_opts_linux += -system-freetype
 $(package)_config_opts_linux += -fontconfig
 $(package)_config_opts_linux += -no-opengl
-$(package)_config_opts_arm_linux  = -platform linux-g++ -xplatform $(host)
+$(package)_config_opts_arm_linux  = -platform linux-g++ -xplatform $(host)-g++
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
@@ -165,7 +165,10 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/0021-Use-.dll.a-as-import-lib-extension.patch &&\
   patch -p1 -i $($(package)_patch_dir)/0030-Prevent-qmake-from-messing-static-lib-dependencies.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_qt_pkgconfig.patch &&\
-  patch -p1 -i $($(package)_patch_dir)/0013-Fix-linking-against-static-pcre.patch
+  patch -p1 -i $($(package)_patch_dir)/0013-Fix-linking-against-static-pcre.patch &&\
+  mv qtbase/mkspecs/linux-arm-gnueabi-g++ qtbase/mkspecs/arm-linux-gnueabi-g++ &&\
+  cp -rf qtbase/mkspecs/arm-linux-gnueabi-g++ qtbase/mkspecs/arm-linux-gnueabihf-g++ &&\
+  sed -i.old "s/arm-linux-gnueabi/arm-linux-gnueabihf/" qtbase/mkspecs/arm-linux-gnueabihf-g++/qmake.conf
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/xextproto.mk
+++ b/depends/packages/xextproto.mk
@@ -4,6 +4,10 @@ $(package)_download_path=http://xorg.freedesktop.org/releases/individual/proto
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=f3f4b23ac8db9c3a9e0d8edb591713f3d70ef9c3b175970dd8823dfc92aa5bb0
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared
 endef


### PR DESCRIPTION
This corrects full Qt depends builds for 32-bit ARM. I have tested this for armeabihf and it works fine. Ravon is working with aarch64.