### PR TITLE
Optimize ExtractXML() calls by avoiding unnecessary string copies

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -12,7 +12,7 @@
 std::string RetrieveBeaconValueWithMaxAge(const std::string& cpid, int64_t iMaxSeconds);
 int64_t GetRSAWeightByCPIDWithRA(std::string cpid);
 
-std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
+std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 bool GenerateBeaconKeys(const std::string &cpid, CKey &outPrivPubKey)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5028,21 +5028,21 @@ bool LoadBlockIndex(bool fAllowNew)
     return true;
 }
 
-std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end)
+std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end)
 {
+    string::size_type loc = XMLdata.find(key, 0);
 
-    std::string extraction = "";
-    string::size_type loc = XMLdata.find( key, 0 );
-    if( loc != string::npos )
-    {
-        string::size_type loc_end = XMLdata.find( key_end, loc+3);
-        if (loc_end != string::npos )
-        {
-            extraction = XMLdata.substr(loc+(key.length()),loc_end-loc-(key.length()));
-
-        }
+    if (loc == string::npos) {
+        return "";
     }
-    return extraction;
+
+    string::size_type loc_end = XMLdata.find(key_end, loc + 3);
+
+    if (loc_end == string::npos) {
+        return "";
+    }
+
+    return XMLdata.substr(loc + (key.length()), loc_end - loc - (key.length()));
 }
 
 std::string RetrieveMd5(std::string s1)

--- a/src/main.h
+++ b/src/main.h
@@ -256,7 +256,7 @@ bool ProcessMessages(CNode* pfrom);
 bool SendMessages(CNode* pto, bool fSendTrickle);
 bool LoadExternalBlockFile(FILE* fileIn);
 double GetBlockDifficulty(unsigned int nBits);
-std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
+std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 std::string GetCurrentOverviewTabPoll();
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -41,7 +41,7 @@ extern std::string GetCommandNonce(std::string command);
 
 bool IsCPIDValidv3(std::string cpidv2, bool allow_investor);
 extern int nMaxConnections;
-std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
+std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 int MAX_OUTBOUND_CONNECTIONS = 8;
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -95,7 +95,6 @@ extern std::string getMacAddress();
 extern std::string FromQString(QString qs);
 extern std::string qtExecuteDotNetStringFunction(std::string function, std::string data);
 
-std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
 std::string getfilecontents(std::string filename);
 
 void GetGlobalStatus();

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -33,8 +33,6 @@
 #include "util.h"
 #include "rpcprotocol.h"
 
-extern std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
-
 static std::string GetFoundationGuid(const std::string &sTitle)
 {
     const std::string foundation("[foundation ");

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -52,7 +52,7 @@ double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t lockt
 bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 int64_t GetMaximumBoincSubsidy(int64_t nTime);
 double GRCMagnitudeUnit(int64_t locktime);
-std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
+std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 std::string NeuralRequest(std::string MyNeuralRequest);
 extern bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -24,7 +24,7 @@ static CCriticalSection cs_nWalletUnlockTime;
 extern void ThreadTopUpKeyPool(void* parg);
 
 double CoinToDouble(double surrogate);
-std::string ExtractXML(std::string XMLdata, std::string key, std::string key_end);
+std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 extern void ThreadCleanWalletPassphrase(void* parg);
 

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -69,7 +69,7 @@ mTeamIDs TeamIDMap;
 
 std::string urlsanity(const std::string& s, const std::string& type);
 std::string lowercase(std::string s);
-std::string ExtractXML(const std::string XMLdata, const std::string key, const std::string key_end);
+std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 ScraperFileManifest StructScraperFileManifest = {};
 
 // Global cache for converged scraper stats. Access must be through a lock.


### PR DESCRIPTION
Low-hanging fruit: calls to `ExtractXML()` passed input by value, which results in a at least one extra copy operation per invocation. The application uses this function everywhere, so we can reduce a little bit of overhead by passing references. 

Also, this removes the forward declaration from files that don't use it.