### PR TITLE
Add stake splitting and side staking info to getmininginfo

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -48,5 +48,7 @@ static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
 
 void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStakeSplit, bool &fEnableSideStaking, SideStakeAlloc &vSideStakeAlloc, double &dEfficiency);
 unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency);
+bool GetSideStakingStatusAndAlloc(SideStakeAlloc& vSideStakeAlloc);
+bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue);
 
 #endif // NOVACOIN_MINER_H


### PR DESCRIPTION
I refactored the parameter parsing in miner.cpp into separate
callable functions that can be used safely from both the miner and
rpc calls.

getmininginfo has been changed to include information on the status
and parameters of stake splitting and side staking.