### PR TITLE
Remove unnecessary cs_main lock on beacon import.

### DIFF
--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -233,7 +233,7 @@ bool ImportBeaconKeysFromConfig(const std::string& cpid, CWallet* wallet)
         return error("ImportBeaconKeysFromConfig: Invalid private key");
     CKeyID vchAddress = key.GetPubKey().GetID();
 
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK(wallet->cs_wallet);
 
     // Don't throw error in case a key is already there
     if (!wallet->HaveKey(vchAddress))


### PR DESCRIPTION
Some users have reported freezes when unlocking the wallet. It triggers a beacon import which locks both cs_main and cs_wallet and this triggered a deadlock when I tested it. It doesn't seem like the cs_main lock is needed.