### PR TITLE
Fix RPC after high priority alert

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6030,8 +6030,6 @@ string GetWarnings(string strFor)
             {
                 nPriority = alert.nPriority;
                 strStatusBar = alert.strStatusBar;
-                if (nPriority > 1000)
-                    strRPC = strStatusBar;
             }
         }
     }


### PR DESCRIPTION
This was an addition made to Gridcoin and it breaks RPC commands when a high priority alert is broadcast. This closes #1095.

Needs to be addressed during Denise testing.