### PR TITLE
Restore old poll output for getmininginfo RPC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8017,47 +8017,47 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
 {
     const std::string &msg = tx.hashBoinc;
     const int64_t &nTime = tx.nTime;
-          if (msg.empty()) return false;
-          bool fMessageLoaded = false;
+    if (msg.empty()) return false;
+    bool fMessageLoaded = false;
 
-          if (Contains(msg,"<MT>"))
-          {
-              std::string sMessageType      = ExtractXML(msg,"<MT>","</MT>");
-              std::string sMessageKey       = ExtractXML(msg,"<MK>","</MK>");
-              std::string sMessageValue     = ExtractXML(msg,"<MV>","</MV>");
-              std::string sMessageAction    = ExtractXML(msg,"<MA>","</MA>");
-              std::string sSignature        = ExtractXML(msg,"<MS>","</MS>");
-              std::string sMessagePublicKey = ExtractXML(msg,"<MPK>","</MPK>");
-              if (sMessageType=="beacon" && Contains(sMessageValue,"INVESTOR"))
-              {
-                    sMessageValue="";
-              }
+    if (Contains(msg,"<MT>"))
+    {
+        std::string sMessageType      = ExtractXML(msg,"<MT>","</MT>");
+        std::string sMessageKey       = ExtractXML(msg,"<MK>","</MK>");
+        std::string sMessageValue     = ExtractXML(msg,"<MV>","</MV>");
+        std::string sMessageAction    = ExtractXML(msg,"<MA>","</MA>");
+        std::string sSignature        = ExtractXML(msg,"<MS>","</MS>");
+        std::string sMessagePublicKey = ExtractXML(msg,"<MPK>","</MPK>");
+        if (sMessageType=="beacon" && Contains(sMessageValue,"INVESTOR"))
+        {
+              sMessageValue="";
+        }
 
-              if (sMessageType=="superblock")
-              {
-                  // Deny access to superblock processing runtime data
-                  sMessageValue="";
-              }
+        if (sMessageType=="superblock")
+        {
+            // Deny access to superblock processing runtime data
+            sMessageValue="";
+        }
 
-              if (!sMessageType.empty() && !sMessageKey.empty() && !sMessageValue.empty() && !sMessageAction.empty() && !sSignature.empty())
-              {
-                  //Verify sig first
-                  bool Verified = CheckMessageSignature(sMessageAction,sMessageType,sMessageType+sMessageKey+sMessageValue,
-                      sSignature,sMessagePublicKey);
+        if (!sMessageType.empty() && !sMessageKey.empty() && !sMessageValue.empty() && !sMessageAction.empty() && !sSignature.empty())
+        {
+            //Verify sig first
+            bool Verified = CheckMessageSignature(sMessageAction,sMessageType,sMessageType+sMessageKey+sMessageValue,
+                sSignature,sMessagePublicKey);
 
-                  if (Verified)
-                  {
-                        if (sMessageAction=="A")
-                        {
-                                /* With this we allow verifying blocks with stupid beacon */
-                                if("beacon"==sMessageType)
-                                {
-                                    std::string out_cpid = "";
-                                    std::string out_address = "";
-                                    std::string out_publickey = "";
-                                    GetBeaconElements(sMessageValue, out_cpid, out_address, out_publickey);
+            if (Verified)
+            {
+                if (sMessageAction=="A")
+                {
+                    /* With this we allow verifying blocks with stupid beacon */
+                    if("beacon"==sMessageType)
+                    {
+                        std::string out_cpid = "";
+                        std::string out_address = "";
+                        std::string out_publickey = "";
+                        GetBeaconElements(sMessageValue, out_cpid, out_address, out_publickey);
                         WriteCache(Section::BEACONALT, sMessageKey+"."+ToString(nTime),out_publickey,nTime);
-                                }
+                    }
 
                     try
                     {
@@ -8073,18 +8073,18 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                         error("Attempting to add to unknown cache: %s", sMessageType);
                     }
 
-                                fMessageLoaded = true;
-                                if (sMessageType=="poll")
-                                {
+                    fMessageLoaded = true;
+                    if (sMessageType=="poll")
+                    {
                         msPoll = msg;
-                                        }
-                        }
-                        else if(sMessageAction=="D")
-                        {
-                                if (fDebug10) LogPrintf("Deleting key type %s Key %s Value %s", sMessageType, sMessageKey, sMessageValue);
-                                if(fDebug10 && sMessageType=="beacon" ){
-                                    LogPrintf("BEACON DEL %s - %s", sMessageKey, TimestampToHRDate(nTime));
-                                }
+                    }
+                }
+                else if(sMessageAction=="D")
+                {
+                    if (fDebug10) LogPrintf("Deleting key type %s Key %s Value %s", sMessageType, sMessageKey, sMessageValue);
+                    if(fDebug10 && sMessageType=="beacon" ){
+                        LogPrintf("BEACON DEL %s - %s", sMessageKey, TimestampToHRDate(nTime));
+                    }
                     
                     try
                     {
@@ -8098,20 +8098,20 @@ bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipi
                         error("Attempting to add to unknown cache: %s", sMessageType);
                     }
                 }
-                        // If this is a boinc project, load the projects into the coin:
-                        if (sMessageType=="project" || sMessageType=="projectmapping")
-                        {
-                            //Reserved
-                            fMessageLoaded = true;
-                        }
-
-                        if(fDebug)
-                    WriteCache(Section::TRXID, sMessageType + ";" + sMessageKey,tx.GetHash().GetHex(),nTime);
-                  }
+                // If this is a boinc project, load the projects into the coin:
+                if (sMessageType=="project" || sMessageType=="projectmapping")
+                {
+                    //Reserved
+                    fMessageLoaded = true;
                 }
+
+                if(fDebug)
+                    WriteCache(Section::TRXID, sMessageType + ";" + sMessageKey,tx.GetHash().GetHex(),nTime);
+            }
+        }
     }
 
-   return fMessageLoaded;
+    return fMessageLoaded;
 }
 
 double GRCMagnitudeUnit(int64_t locktime)

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -128,7 +128,8 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     }
 
     obj.pushKV("MiningInfo 1", msMiningErrors);
-    obj.pushKV("MiningInfo 2", msPoll);
+    std::string sMessageKey = ExtractXML(msPoll, "<MK>", "</MK>");
+    obj.pushKV("MiningInfo 2", "Poll: " + sMessageKey.substr(0,80));
     obj.pushKV("MiningInfo 5", msMiningErrors5);
     obj.pushKV("MiningInfo 6", msMiningErrors6);
     obj.pushKV("MiningInfo 7", msMiningErrors7);


### PR DESCRIPTION
#1250 changed `msPoll` to contain the whole XML contract, but only adapted the GUI code to this change.
As the XML is rather hard to read for users, this restores the old output for the `getmininginfo` RPC command.

While I was at it, I also fixed the indentation in `MemorizeMessage()` that got messed up somehow.