### PR TITLE
Remove bitcoin.moc in Makefile.qt.include

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -130,8 +130,7 @@ GRIDCOIN_MM = \
 
 QT_MOC = \
   qt/overviewpage.moc \
-  qt/rpcconsole.moc \
-  qt/bitcoin.moc
+  qt/rpcconsole.moc
 
 QT_QRC_CPP = qt/qrc_bitcoin.cpp
 QT_QRC = qt/bitcoin.qrc


### PR DESCRIPTION
See issue #1326. This file doesn't show up anywhere in our codebase. Was able to build without issue with Makefile.qt.include not including birtcoin.moc.