### PR TITLE
Re-enable scrypt optimizations.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,7 @@ else
   CXXFLAGS_overridden=no
 fi
 AC_PROG_CXX
+AM_PROG_AS
 
 dnl By default, libtool for mingw refuses to link static libs into a dll for
 dnl fear of mixing pic/non-pic objects, and import/export complications. Since
@@ -179,6 +180,41 @@ if test "x$use_asm" = xyes; then
   AC_DEFINE(USE_ASM, 1, [Define this symbol to build in assembly routines])
 fi
 
+BUILD_TARGET=`$CC -dumpmachine 2>&1`
+case $BUILD_TARGET in
+  x86_64-*-*|amd64-*-*)
+    have_x86_64=true
+    ;;
+esac
+
+if test x$enable_assembly != xno -a x$have_x86_64 = xtrue
+then
+  AC_MSG_CHECKING(whether we can compile AVX code)
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[asm ("vmovdqa %ymm0, %ymm1");])],
+    AC_DEFINE(ENABLE_AVX, 1, [Define to 1 if AVX assembly is available.])
+    AC_MSG_RESULT(yes)
+    AC_MSG_CHECKING(whether we can compile XOP code)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[asm ("vprotd \$7, %xmm0, %xmm1");])],
+      AC_DEFINE(ENABLE_XOP, 1, [Define to 1 if XOP assembly is available.])
+      AC_MSG_RESULT(yes)
+    ,
+      AC_MSG_RESULT(no)
+      AC_MSG_WARN([The assembler does not support the XOP instruction set.])
+    )
+    AC_MSG_CHECKING(whether we can compile AVX2 code)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[asm ("vpaddd %ymm0, %ymm1, %ymm2");])],
+      AC_DEFINE(enable_avx2=yes; ENABLE_AVX2, 1, [Define to 1 if AVX2 assembly is available.])
+      AC_MSG_RESULT(yes)
+    ,
+      AC_MSG_RESULT(no)
+      AC_MSG_WARN([The assembler does not support the AVX2 instruction set.])
+    )
+  ,
+    AC_MSG_RESULT(no)
+    AC_MSG_WARN([The assembler does not support the AVX instruction set.])
+  )
+fi
+
 # Enable debug
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug],
@@ -286,25 +322,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     return _mm_extract_epi32(l, 3);
   ]])],
  [ AC_MSG_RESULT(yes); enable_sse41=yes; AC_DEFINE(ENABLE_SSE41, 1, [Define this symbol to build code that uses SSE4.1 intrinsics]) ],
- [ AC_MSG_RESULT(no)]
-)
-CXXFLAGS="$TEMP_CXXFLAGS"
-
-TEMP_CXXFLAGS="$CXXFLAGS"
-CXXFLAGS="$CXXFLAGS $AVX2_CXXFLAGS"
-AC_MSG_CHECKING(for AVX2 intrinsics)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    #include <stdint.h>
-    #if defined(_MSC_VER)
-    #include <immintrin.h>
-    #elif defined(__GNUC__) && defined(__AVX2__)
-    #include <x86intrin.h>
-    #endif
-  ]],[[
-    __m256i l = _mm256_set1_epi32(0);
-    return _mm256_extract_epi32(l, 7);
-  ]])],
- [ AC_MSG_RESULT(yes); enable_avx2=yes; AC_DEFINE(ENABLE_AVX2, 1, [Define this symbol to build code that uses AVX2 intrinsics]) ],
  [ AC_MSG_RESULT(no)]
 )
 CXXFLAGS="$TEMP_CXXFLAGS"
@@ -1141,7 +1158,6 @@ if test x$build_bitcoin_utils$build_bitcoin_libs$build_gridcoinresearchd$bitcoin
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
 
-
 AM_CONDITIONAL([TARGET_DARWIN], [test x$TARGET_OS = xdarwin])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
@@ -1159,6 +1175,9 @@ AM_CONDITIONAL([ENABLE_SSE41],[test x$enable_sse41 = xyes])
 AM_CONDITIONAL([ENABLE_AVX2],[test x$enable_avx2 = xyes])
 AM_CONDITIONAL([ENABLE_SHANI],[test x$enable_shani = xyes])
 AM_CONDITIONAL([USE_ASM],[test x$use_asm = xyes])
+AM_CONDITIONAL([ARCH_x86], [test x$have_x86 = xtrue])
+AM_CONDITIONAL([ARCH_x86_64], [test x$have_x86_64 = xtrue])
+AM_CONDITIONAL([ARCH_ARM], [test x$have_arm = xtrue])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])
@@ -1285,4 +1304,6 @@ echo "  CPPFLAGS      = $CPPFLAGS"
 echo "  CXX           = $CXX"
 echo "  CXXFLAGS      = $CXXFLAGS"
 echo "  LDFLAGS       = $LDFLAGS"
+echo "  AS            = $CCAS"
+echo "  ASFLAGS       = $CCASFLAGS"
 echo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -186,6 +186,9 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
 	scraper/scraper.cpp \
 	script.cpp \
 	scrypt.cpp \
+	scrypt-arm.S \
+	scrypt-x86_64.S \
+	scrypt-x86.S \
     scheduler.cpp \
 	support/cleanse.cpp \
 	support/lockedpool.cpp \

--- a/src/scrypt-arm.S
+++ b/src/scrypt-arm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 pooler@litecoinpool.org
+ * Copyright 2012, 2014 pooler@litecoinpool.org
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -7,12 +7,9 @@
  * any later version.  See COPYING for more details.
  */
 
+#include <config/gridcoin-config.h>
 
-#if defined(OPTIMIZED_SALSA) &&  defined(__arm__) && defined(__APCS_32__)
-
-#if defined(__linux__) && defined(__ELF__)
-.section .note.GNU-stack,"",%progbits
-#endif
+#if defined(USE_ASM) && defined(__arm__) && defined(__APCS_32__)
 
 #if defined(__ARM_ARCH_5E__) || defined(__ARM_ARCH_5TE__) || \
 	defined(__ARM_ARCH_5TEJ__) || defined(__ARM_ARCH_6__) || \
@@ -30,406 +27,437 @@
 
 #ifdef __ARM_ARCH_5E_OR_6__
 
-#define scrypt_shuffle() \
-	add	lr, r0, #9*4; \
-	ldmia	r0, {r2-r7}; \
-	ldmia	lr, {r2, r8-r12, lr}; \
-	str	r3, [r0, #5*4]; \
-	str	r5, [r0, #15*4]; \
-	str	r6, [r0, #12*4]; \
-	str	r7, [r0, #1*4]; \
-	ldr r5, [r0, #7*4]; \
-	str	r2, [r0, #13*4]; \
-	str	r8, [r0, #2*4]; \
-	strd	r4, [r0, #10*4]; \
-	str	r9, [r0, #7*4]; \
-	str	r10, [r0, #4*4]; \
-	str	r11, [r0, #9*4]; \
-	str	lr, [r0, #3*4]; \
-	add	r2, r0, #64+0*4; \
-	add	lr, r0, #64+9*4; \
-	ldmia	r2, {r2-r7}; \
-	ldmia	lr, {r2, r8-r12, lr}; \
-	str	r3, [r0, #64+5*4]; \
-	str	r5, [r0, #64+15*4]; \
-	str	r6, [r0, #64+12*4]; \
-	str	r7, [r0, #64+1*4]; \
-	ldr r5, [r0, #64+7*4]; \
-	str	r2, [r0, #64+13*4]; \
-	str	r8, [r0, #64+2*4]; \
-	strd	r4, [r0, #64+10*4]; \
-	str	r9, [r0, #64+7*4]; \
-	str	r10, [r0, #64+4*4]; \
-	str	r11, [r0, #64+9*4]; \
-	str	lr, [r0, #64+3*4]; \
+.macro scrypt_shuffle
+	add	lr, r0, #9*4
+	ldmia	r0, {r2-r7}
+	ldmia	lr, {r2, r8-r12, lr}
+	str	r3, [r0, #5*4]
+	str	r5, [r0, #15*4]
+	str	r6, [r0, #12*4]
+	str	r7, [r0, #1*4]
+	ldr r5, [r0, #7*4]
+	str	r2, [r0, #13*4]
+	str	r8, [r0, #2*4]
+	strd	r4, [r0, #10*4]
+	str	r9, [r0, #7*4]
+	str	r10, [r0, #4*4]
+	str	r11, [r0, #9*4]
+	str	lr, [r0, #3*4]
+	
+	add	r2, r0, #64+0*4
+	add	lr, r0, #64+9*4
+	ldmia	r2, {r2-r7}
+	ldmia	lr, {r2, r8-r12, lr}
+	str	r3, [r0, #64+5*4]
+	str	r5, [r0, #64+15*4]
+	str	r6, [r0, #64+12*4]
+	str	r7, [r0, #64+1*4]
+	ldr r5, [r0, #64+7*4]
+	str	r2, [r0, #64+13*4]
+	str	r8, [r0, #64+2*4]
+	strd	r4, [r0, #64+10*4]
+	str	r9, [r0, #64+7*4]
+	str	r10, [r0, #64+4*4]
+	str	r11, [r0, #64+9*4]
+	str	lr, [r0, #64+3*4]
+.endm
 
+.macro salsa8_core_doubleround_body
+	add	r6, r2, r6
+	add	r7, r3, r7
+	eor	r10, r10, r6, ror #25
+	add	r6, r0, r4
+	eor	r11, r11, r7, ror #25
+	add	r7, r1, r5
+	strd	r10, [sp, #14*4]
+	eor	r12, r12, r6, ror #25
+	eor	lr, lr, r7, ror #25
+	
+	ldrd	r6, [sp, #10*4]
+	add	r2, r10, r2
+	add	r3, r11, r3
+	eor	r6, r6, r2, ror #23
+	add	r2, r12, r0
+	eor	r7, r7, r3, ror #23
+	add	r3, lr, r1
+	strd	r6, [sp, #10*4]
+	eor	r8, r8, r2, ror #23
+	eor	r9, r9, r3, ror #23
+	
+	ldrd	r2, [sp, #6*4]
+	add	r10, r6, r10
+	add	r11, r7, r11
+	eor	r2, r2, r10, ror #19
+	add	r10, r8, r12
+	eor	r3, r3, r11, ror #19
+	add	r11, r9, lr
+	eor	r4, r4, r10, ror #19
+	eor	r5, r5, r11, ror #19
+	
+	ldrd	r10, [sp, #2*4]
+	add	r6, r2, r6
+	add	r7, r3, r7
+	eor	r10, r10, r6, ror #14
+	add	r6, r4, r8
+	eor	r11, r11, r7, ror #14
+	add	r7, r5, r9
+	eor	r0, r0, r6, ror #14
+	eor	r1, r1, r7, ror #14
+	
+	
+	ldrd	r6, [sp, #14*4]
+	strd	r2, [sp, #6*4]
+	strd	r10, [sp, #2*4]
+	add	r6, r11, r6
+	add	r7, r0, r7
+	eor	r4, r4, r6, ror #25
+	add	r6, r1, r12
+	eor	r5, r5, r7, ror #25
+	add	r7, r10, lr
+	eor	r2, r2, r6, ror #25
+	eor	r3, r3, r7, ror #25
+	strd	r2, [sp, #6*4]
+	
+	add	r10, r3, r10
+	ldrd	r6, [sp, #10*4]
+	add	r11, r4, r11
+	eor	r8, r8, r10, ror #23
+	add	r10, r5, r0
+	eor	r9, r9, r11, ror #23
+	add	r11, r2, r1
+	eor	r6, r6, r10, ror #23
+	eor	r7, r7, r11, ror #23
+	strd	r6, [sp, #10*4]
+	
+	add	r2, r7, r2
+	ldrd	r10, [sp, #14*4]
+	add	r3, r8, r3
+	eor	r12, r12, r2, ror #19
+	add	r2, r9, r4
+	eor	lr, lr, r3, ror #19
+	add	r3, r6, r5
+	eor	r10, r10, r2, ror #19
+	eor	r11, r11, r3, ror #19
+	
+	ldrd	r2, [sp, #2*4]
+	add	r6, r11, r6
+	add	r7, r12, r7
+	eor	r0, r0, r6, ror #14
+	add	r6, lr, r8
+	eor	r1, r1, r7, ror #14
+	add	r7, r10, r9
+	eor	r2, r2, r6, ror #14
+	eor	r3, r3, r7, ror #14
+.endm
 
-#define salsa8_core_doubleround_body() \
-	add	r6, r2, r6; \
-	add	r7, r3, r7; \
-	eor	r10, r10, r6, ror #25; \
-	add	r6, r0, r4; \
-	eor	r11, r11, r7, ror #25; \
-	add	r7, r1, r5; \
-	strd	r10, [sp, #14*4]; \
-	eor	r12, r12, r6, ror #25; \
-	eor	lr, lr, r7, ror #25; \
-	ldrd	r6, [sp, #10*4]; \
-	add	r2, r10, r2; \
-	add	r3, r11, r3; \
-	eor	r6, r6, r2, ror #23; \
-	add	r2, r12, r0; \
-	eor	r7, r7, r3, ror #23; \
-	add	r3, lr, r1; \
-	strd	r6, [sp, #10*4]; \
-	eor	r8, r8, r2, ror #23; \
-	eor	r9, r9, r3, ror #23; \
-	ldrd	r2, [sp, #6*4]; \
-	add	r10, r6, r10; \
-	add	r11, r7, r11; \
-	eor	r2, r2, r10, ror #19; \
-	add	r10, r8, r12; \
-	eor	r3, r3, r11, ror #19; \
-	add	r11, r9, lr; \
-	eor	r4, r4, r10, ror #19; \
-	eor	r5, r5, r11, ror #19; \
-	ldrd	r10, [sp, #2*4]; \
-	add	r6, r2, r6; \
-	add	r7, r3, r7; \
-	eor	r10, r10, r6, ror #14; \
-	add	r6, r4, r8; \
-	eor	r11, r11, r7, ror #14; \
-	add	r7, r5, r9; \
-	eor	r0, r0, r6, ror #14; \
-	eor	r1, r1, r7, ror #14; \
-	ldrd	r6, [sp, #14*4]; \
-	strd	r2, [sp, #6*4]; \
-	strd	r10, [sp, #2*4]; \
-	add	r6, r11, r6; \
-	add	r7, r0, r7; \
-	eor	r4, r4, r6, ror #25; \
-	add	r6, r1, r12; \
-	eor	r5, r5, r7, ror #25; \
-	add	r7, r10, lr; \
-	eor	r2, r2, r6, ror #25; \
-	eor	r3, r3, r7, ror #25; \
-	strd	r2, [sp, #6*4]; \
-	add	r10, r3, r10; \
-	ldrd	r6, [sp, #10*4]; \
-	add	r11, r4, r11; \
-	eor	r8, r8, r10, ror #23; \
-	add	r10, r5, r0; \
-	eor	r9, r9, r11, ror #23; \
-	add	r11, r2, r1; \
-	eor	r6, r6, r10, ror #23; \
-	eor	r7, r7, r11, ror #23; \
-	strd	r6, [sp, #10*4]; \
-	add	r2, r7, r2; \
-	ldrd	r10, [sp, #14*4]; \
-	add	r3, r8, r3; \
-	eor	r12, r12, r2, ror #19; \
-	add	r2, r9, r4; \
-	eor	lr, lr, r3, ror #19; \
-	add	r3, r6, r5; \
-	eor	r10, r10, r2, ror #19; \
-	eor	r11, r11, r3, ror #19; \
-	ldrd	r2, [sp, #2*4]; \
-	add	r6, r11, r6; \
-	add	r7, r12, r7; \
-	eor	r0, r0, r6, ror #14; \
-	add	r6, lr, r8; \
-	eor	r1, r1, r7, ror #14; \
-	add	r7, r10, r9; \
-	eor	r2, r2, r6, ror #14; \
-	eor	r3, r3, r7, ror #14; \
-
-
-#define salsa8_core() \
-	ldmia	sp, {r0-r12, lr}; \
-	ldrd	r10, [sp, #14*4]; \
-	salsa8_core_doubleround_body(); \
-	ldrd	r6, [sp, #6*4]; \
-	strd	r2, [sp, #2*4]; \
-	strd	r10, [sp, #14*4]; \
-	salsa8_core_doubleround_body(); \
-	ldrd	r6, [sp, #6*4]; \
-	strd	r2, [sp, #2*4]; \
-	strd	r10, [sp, #14*4]; \
-	salsa8_core_doubleround_body(); \
-	ldrd	r6, [sp, #6*4]; \
-	strd	r2, [sp, #2*4]; \
-	strd	r10, [sp, #14*4]; \
-	salsa8_core_doubleround_body(); \
-	stmia	sp, {r0-r5}; \
-	strd	r8, [sp, #8*4]; \
-	str	r12, [sp, #12*4]; \
-	str	lr, [sp, #13*4]; \
-	strd	r10, [sp, #14*4]; \
-
+.macro salsa8_core
+	ldmia	sp, {r0-r12, lr}
+	
+	ldrd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	ldrd	r6, [sp, #6*4]
+	strd	r2, [sp, #2*4]
+	strd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	ldrd	r6, [sp, #6*4]
+	strd	r2, [sp, #2*4]
+	strd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	ldrd	r6, [sp, #6*4]
+	strd	r2, [sp, #2*4]
+	strd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	
+	stmia	sp, {r0-r5}
+	strd	r8, [sp, #8*4]
+	str	r12, [sp, #12*4]
+	str	lr, [sp, #13*4]
+	strd	r10, [sp, #14*4]
+.endm
 
 #else
 
-#define scrypt_shuffle() \
+.macro scrypt_shuffle
+.endm
 
+.macro salsa8_core_doubleround_body
+	ldr	r8, [sp, #8*4]
+	add	r11, r11, r10
+	ldr	lr, [sp, #13*4]
+	add	r12, r12, r3
+	eor	r2, r2, r11, ror #23
+	add	r11, r4, r0
+	eor	r7, r7, r12, ror #23
+	add	r12, r9, r5
+	str	r9, [sp, #9*4]
+	eor	r8, r8, r11, ror #23
+	str	r10, [sp, #14*4]
+	eor	lr, lr, r12, ror #23
+	
+	ldr	r11, [sp, #11*4]
+	add	r9, lr, r9
+	ldr	r12, [sp, #12*4]
+	add	r10, r2, r10
+	eor	r1, r1, r9, ror #19
+	add	r9, r7, r3
+	eor	r6, r6, r10, ror #19
+	add	r10, r8, r4
+	str	r8, [sp, #8*4]
+	eor	r11, r11, r9, ror #19
+	str	lr, [sp, #13*4]
+	eor	r12, r12, r10, ror #19
+	
+	ldr	r9, [sp, #10*4]
+	add	r8, r12, r8
+	ldr	r10, [sp, #15*4]
+	add	lr, r1, lr
+	eor	r0, r0, r8, ror #14
+	add	r8, r6, r2
+	eor	r5, r5, lr, ror #14
+	add	lr, r11, r7
+	eor	r9, r9, r8, ror #14
+	ldr	r8, [sp, #9*4]
+	eor	r10, r10, lr, ror #14
+	ldr	lr, [sp, #14*4]
+	
+	
+	add	r8, r9, r8
+	str	r9, [sp, #10*4]
+	add	lr, r10, lr
+	str	r10, [sp, #15*4]
+	eor	r11, r11, r8, ror #25
+	add	r8, r0, r3
+	eor	r12, r12, lr, ror #25
+	add	lr, r5, r4
+	eor	r1, r1, r8, ror #25
+	ldr	r8, [sp, #8*4]
+	eor	r6, r6, lr, ror #25
+	
+	add	r9, r11, r9
+	ldr	lr, [sp, #13*4]
+	add	r10, r12, r10
+	eor	r8, r8, r9, ror #23
+	add	r9, r1, r0
+	eor	lr, lr, r10, ror #23
+	add	r10, r6, r5
+	str	r11, [sp, #11*4]
+	eor	r2, r2, r9, ror #23
+	str	r12, [sp, #12*4]
+	eor	r7, r7, r10, ror #23
+	
+	ldr	r9, [sp, #9*4]
+	add	r11, r8, r11
+	ldr	r10, [sp, #14*4]
+	add	r12, lr, r12
+	eor	r9, r9, r11, ror #19
+	add	r11, r2, r1
+	eor	r10, r10, r12, ror #19
+	add	r12, r7, r6
+	str	r8, [sp, #8*4]
+	eor	r3, r3, r11, ror #19
+	str	lr, [sp, #13*4]
+	eor	r4, r4, r12, ror #19
+.endm
 
-#define salsa8_core_doubleround_body() \
-	ldr	r8, [sp, #8*4]; \
-	add	r11, r11, r10; \
-	ldr	lr, [sp, #13*4]; \
-	add	r12, r12, r3; \
-	eor	r2, r2, r11, ror #23; \
-	add	r11, r4, r0; \
-	eor	r7, r7, r12, ror #23; \
-	add	r12, r9, r5; \
-	str	r9, [sp, #9*4]; \
-	eor	r8, r8, r11, ror #23; \
-	str	r10, [sp, #14*4]; \
-	eor	lr, lr, r12, ror #23; \
-	ldr	r11, [sp, #11*4]; \
-	add	r9, lr, r9; \
-	ldr	r12, [sp, #12*4]; \
-	add	r10, r2, r10; \
-	eor	r1, r1, r9, ror #19; \
-	add	r9, r7, r3; \
-	eor	r6, r6, r10, ror #19; \
-	add	r10, r8, r4; \
-	str	r8, [sp, #8*4]; \
-	eor	r11, r11, r9, ror #19; \
-	str	lr, [sp, #13*4]; \
-	eor	r12, r12, r10, ror #19; \
-	ldr	r9, [sp, #10*4]; \
-	add	r8, r12, r8; \
-	ldr	r10, [sp, #15*4]; \
-	add	lr, r1, lr; \
-	eor	r0, r0, r8, ror #14; \
-	add	r8, r6, r2; \
-	eor	r5, r5, lr, ror #14; \
-	add	lr, r11, r7; \
-	eor	r9, r9, r8, ror #14; \
-	ldr	r8, [sp, #9*4]; \
-	eor	r10, r10, lr, ror #14; \
-	ldr	lr, [sp, #14*4]; \
-	add	r8, r9, r8; \
-	str	r9, [sp, #10*4]; \
-	add	lr, r10, lr; \
-	str	r10, [sp, #15*4]; \
-	eor	r11, r11, r8, ror #25; \
-	add	r8, r0, r3; \
-	eor	r12, r12, lr, ror #25; \
-	add	lr, r5, r4; \
-	eor	r1, r1, r8, ror #25; \
-	ldr	r8, [sp, #8*4]; \
-	eor	r6, r6, lr, ror #25; \
-	add	r9, r11, r9; \
-	ldr	lr, [sp, #13*4]; \
-	add	r10, r12, r10; \
-	eor	r8, r8, r9, ror #23; \
-	add	r9, r1, r0; \
-	eor	lr, lr, r10, ror #23; \
-	add	r10, r6, r5; \
-	str	r11, [sp, #11*4]; \
-	eor	r2, r2, r9, ror #23; \
-	str	r12, [sp, #12*4]; \
-	eor	r7, r7, r10, ror #23; \
-	ldr	r9, [sp, #9*4]; \
-	add	r11, r8, r11; \
-	ldr	r10, [sp, #14*4]; \
-	add	r12, lr, r12; \
-	eor	r9, r9, r11, ror #19; \
-	add	r11, r2, r1; \
-	eor	r10, r10, r12, ror #19; \
-	add	r12, r7, r6; \
-	str	r8, [sp, #8*4]; \
-	eor	r3, r3, r11, ror #19; \
-	str	lr, [sp, #13*4]; \
-	eor	r4, r4, r12, ror #19; \
-
-
-#define salsa8_core() \
-	ldmia	sp, {r0-r7}; \
-	ldr	r12, [sp, #15*4]; \
-	ldr	r8, [sp, #11*4]; \
-	ldr	lr, [sp, #12*4]; \
-	ldr	r9, [sp, #9*4]; \
-	add	r8, r8, r12; \
-	ldr	r11, [sp, #10*4]; \
-	add	lr, lr, r0; \
-	eor	r3, r3, r8, ror #25; \
-	add	r8, r5, r1; \
-	ldr	r10, [sp, #14*4]; \
-	eor	r4, r4, lr, ror #25; \
-	add	lr, r11, r6; \
-	eor	r9, r9, r8, ror #25; \
-	eor	r10, r10, lr, ror #25; \
-	salsa8_core_doubleround_body(); \
-	ldr	r11, [sp, #10*4]; \
-	add	r8, r9, r8; \
-	ldr	r12, [sp, #15*4]; \
-	add	lr, r10, lr; \
-	eor	r11, r11, r8, ror #14; \
-	add	r8, r3, r2; \
-	eor	r12, r12, lr, ror #14; \
-	add	lr, r4, r7; \
-	eor	r0, r0, r8, ror #14; \
-	ldr	r8, [sp, #11*4]; \
-	eor	r5, r5, lr, ror #14; \
-	ldr	lr, [sp, #12*4]; \
-	add	r8, r8, r12; \
-	str	r11, [sp, #10*4]; \
-	add	lr, lr, r0; \
-	str	r12, [sp, #15*4]; \
-	eor	r3, r3, r8, ror #25; \
-	add	r8, r5, r1; \
-	eor	r4, r4, lr, ror #25; \
-	add	lr, r11, r6; \
-	str	r9, [sp, #9*4]; \
-	eor	r9, r9, r8, ror #25; \
-	str	r10, [sp, #14*4]; \
-	eor	r10, r10, lr, ror #25; \
-	salsa8_core_doubleround_body(); \
-	ldr	r11, [sp, #10*4]; \
-	add	r8, r9, r8; \
-	ldr	r12, [sp, #15*4]; \
-	add	lr, r10, lr; \
-	eor	r11, r11, r8, ror #14; \
-	add	r8, r3, r2; \
-	eor	r12, r12, lr, ror #14; \
-	add	lr, r4, r7; \
-	eor	r0, r0, r8, ror #14; \
-	ldr	r8, [sp, #11*4]; \
-	eor	r5, r5, lr, ror #14; \
-	ldr	lr, [sp, #12*4]; \
-	add	r8, r8, r12; \
-	str	r11, [sp, #10*4]; \
-	add	lr, lr, r0; \
-	str	r12, [sp, #15*4]; \
-	eor	r3, r3, r8, ror #25; \
-	add	r8, r5, r1; \
-	eor	r4, r4, lr, ror #25; \
-	add	lr, r11, r6; \
-	str	r9, [sp, #9*4]; \
-	eor	r9, r9, r8, ror #25; \
-	str	r10, [sp, #14*4]; \
-	eor	r10, r10, lr, ror #25; \
-	salsa8_core_doubleround_body(); \
-	ldr	r11, [sp, #10*4]; \
-	add	r8, r9, r8; \
-	ldr	r12, [sp, #15*4]; \
-	add	lr, r10, lr; \
-	eor	r11, r11, r8, ror #14; \
-	add	r8, r3, r2; \
-	eor	r12, r12, lr, ror #14; \
-	add	lr, r4, r7; \
-	eor	r0, r0, r8, ror #14; \
-	ldr	r8, [sp, #11*4]; \
-	eor	r5, r5, lr, ror #14; \
-	ldr	lr, [sp, #12*4]; \
-	add	r8, r8, r12; \
-	str	r11, [sp, #10*4]; \
-	add	lr, lr, r0; \
-	str	r12, [sp, #15*4]; \
-	eor	r3, r3, r8, ror #25; \
-	add	r8, r5, r1; \
-	eor	r4, r4, lr, ror #25; \
-	add	lr, r11, r6; \
-	str	r9, [sp, #9*4]; \
-	eor	r9, r9, r8, ror #25; \
-	str	r10, [sp, #14*4]; \
-	eor	r10, r10, lr, ror #25; \
-	salsa8_core_doubleround_body(); \
-	ldr	r11, [sp, #10*4]; \
-	add	r8, r9, r8; \
-	ldr	r12, [sp, #15*4]; \
-	add	lr, r10, lr; \
-	str	r9, [sp, #9*4]; \
-	eor	r11, r11, r8, ror #14; \
-	eor	r12, r12, lr, ror #14; \
-	add	r8, r3, r2; \
-	str	r10, [sp, #14*4]; \
-	add	lr, r4, r7; \
-	str	r11, [sp, #10*4]; \
-	eor	r0, r0, r8, ror #14; \
-	str	r12, [sp, #15*4]; \
-	eor	r5, r5, lr, ror #14; \
-	stmia	sp, {r0-r7}; \
-
+.macro salsa8_core
+	ldmia	sp, {r0-r7}
+	
+	ldr	r12, [sp, #15*4]
+	ldr	r8, [sp, #11*4]
+	ldr	lr, [sp, #12*4]
+	
+	ldr	r9, [sp, #9*4]
+	add	r8, r8, r12
+	ldr	r11, [sp, #10*4]
+	add	lr, lr, r0
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	ldr	r10, [sp, #14*4]
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	eor	r9, r9, r8, ror #25
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	eor	r11, r11, r8, ror #14
+	add	r8, r3, r2
+	eor	r12, r12, lr, ror #14
+	add	lr, r4, r7
+	eor	r0, r0, r8, ror #14
+	ldr	r8, [sp, #11*4]
+	eor	r5, r5, lr, ror #14
+	ldr	lr, [sp, #12*4]
+	
+	add	r8, r8, r12
+	str	r11, [sp, #10*4]
+	add	lr, lr, r0
+	str	r12, [sp, #15*4]
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	str	r9, [sp, #9*4]
+	eor	r9, r9, r8, ror #25
+	str	r10, [sp, #14*4]
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	eor	r11, r11, r8, ror #14
+	add	r8, r3, r2
+	eor	r12, r12, lr, ror #14
+	add	lr, r4, r7
+	eor	r0, r0, r8, ror #14
+	ldr	r8, [sp, #11*4]
+	eor	r5, r5, lr, ror #14
+	ldr	lr, [sp, #12*4]
+	
+	add	r8, r8, r12
+	str	r11, [sp, #10*4]
+	add	lr, lr, r0
+	str	r12, [sp, #15*4]
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	str	r9, [sp, #9*4]
+	eor	r9, r9, r8, ror #25
+	str	r10, [sp, #14*4]
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	eor	r11, r11, r8, ror #14
+	add	r8, r3, r2
+	eor	r12, r12, lr, ror #14
+	add	lr, r4, r7
+	eor	r0, r0, r8, ror #14
+	ldr	r8, [sp, #11*4]
+	eor	r5, r5, lr, ror #14
+	ldr	lr, [sp, #12*4]
+	
+	add	r8, r8, r12
+	str	r11, [sp, #10*4]
+	add	lr, lr, r0
+	str	r12, [sp, #15*4]
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	str	r9, [sp, #9*4]
+	eor	r9, r9, r8, ror #25
+	str	r10, [sp, #14*4]
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	str	r9, [sp, #9*4]
+	eor	r11, r11, r8, ror #14
+	eor	r12, r12, lr, ror #14
+	add	r8, r3, r2
+	str	r10, [sp, #14*4]
+	add	lr, r4, r7
+	str	r11, [sp, #10*4]
+	eor	r0, r0, r8, ror #14
+	str	r12, [sp, #15*4]
+	eor	r5, r5, lr, ror #14
+	
+	stmia	sp, {r0-r7}
+.endm
 
 #endif
 
 
-#define scrypt_core_macro1a_x4() \
-	ldmia	r0, {r4-r7}; \
-	ldmia	lr!, {r8-r11}; \
-	stmia	r1!, {r4-r7}; \
-	stmia	r3!, {r8-r11}; \
-	eor	r4, r4, r8; \
-	eor	r5, r5, r9; \
-	eor	r6, r6, r10; \
-	eor	r7, r7, r11; \
-	stmia	r0!, {r4-r7}; \
-	stmia	r12!, {r4-r7}; \
+.macro scrypt_core_macro1a_x4
+	ldmia	r0, {r4-r7}
+	ldmia	lr!, {r8-r11}
+	stmia	r1!, {r4-r7}
+	stmia	r3!, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	stmia	r0!, {r4-r7}
+	stmia	r12!, {r4-r7}
+.endm
 
+.macro scrypt_core_macro1b_x4
+	ldmia	r3!, {r8-r11}
+	ldmia	r2, {r4-r7}
+	eor	r8, r8, r4
+	eor	r9, r9, r5
+	eor	r10, r10, r6
+	eor	r11, r11, r7
+	ldmia	r0, {r4-r7}
+	stmia	r2!, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	ldmia	r1!, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	stmia	r0!, {r4-r7}
+	stmia	r12!, {r4-r7}
+.endm
 
-#define scrypt_core_macro1b_x4() \
-	ldmia	r3!, {r8-r11}; \
-	ldmia	r2, {r4-r7}; \
-	eor	r8, r8, r4; \
-	eor	r9, r9, r5; \
-	eor	r10, r10, r6; \
-	eor	r11, r11, r7; \
-	ldmia	r0, {r4-r7}; \
-	stmia	r2!, {r8-r11}; \
-	eor	r4, r4, r8; \
-	eor	r5, r5, r9; \
-	eor	r6, r6, r10; \
-	eor	r7, r7, r11; \
-	ldmia	r1!, {r8-r11}; \
-	eor	r4, r4, r8; \
-	eor	r5, r5, r9; \
-	eor	r6, r6, r10; \
-	eor	r7, r7, r11; \
-	stmia	r0!, {r4-r7}; \
-	stmia	r12!, {r4-r7}; \
+.macro scrypt_core_macro2_x4
+	ldmia	r12, {r4-r7}
+	ldmia	r0, {r8-r11}
+	add	r4, r4, r8
+	add	r5, r5, r9
+	add	r6, r6, r10
+	add	r7, r7, r11
+	stmia	r0!, {r4-r7}
+	ldmia	r2, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	stmia	r2!, {r4-r7}
+	stmia	r12!, {r4-r7}
+.endm
 
+.macro scrypt_core_macro3_x4
+	ldmia	r1!, {r4-r7}
+	ldmia	r0, {r8-r11}
+	add	r4, r4, r8
+	add	r5, r5, r9
+	add	r6, r6, r10
+	add	r7, r7, r11
+	stmia	r0!, {r4-r7}
+.endm
 
-#define scrypt_core_macro2_x4() \
-	ldmia	r12, {r4-r7}; \
-	ldmia	r0, {r8-r11}; \
-	add	r4, r4, r8; \
-	add	r5, r5, r9; \
-	add	r6, r6, r10; \
-	add	r7, r7, r11; \
-	stmia	r0!, {r4-r7}; \
-	ldmia	r2, {r8-r11}; \
-	eor	r4, r4, r8; \
-	eor	r5, r5, r9; \
-	eor	r6, r6, r10; \
-	eor	r7, r7, r11; \
-	stmia	r2!, {r4-r7}; \
-	stmia	r12!, {r4-r7}; \
-
-
-#define scrypt_core_macro3_x4() \
-	ldmia	r1!, {r4-r7}; \
-	ldmia	r0, {r8-r11}; \
-	add	r4, r4, r8; \
-	add	r5, r5, r9; \
-	add	r6, r6, r10; \
-	add	r7, r7, r11; \
-	stmia	r0!, {r4-r7}; \
-
-
-#define scrypt_core_macro3_x6() \
-	ldmia	r1!, {r2-r7}; \
-	ldmia	r0, {r8-r12, lr}; \
-	add	r2, r2, r8; \
-	add	r3, r3, r9; \
-	add	r4, r4, r10; \
-	add	r5, r5, r11; \
-	add	r6, r6, r12; \
-	add	r7, r7, lr; \
-	stmia	r0!, {r2-r7}; \
-
+.macro scrypt_core_macro3_x6
+	ldmia	r1!, {r2-r7}
+	ldmia	r0, {r8-r12, lr}
+	add	r2, r2, r8
+	add	r3, r3, r9
+	add	r4, r4, r10
+	add	r5, r5, r11
+	add	r6, r6, r12
+	add	r7, r7, lr
+	stmia	r0!, {r2-r7}
+.endm
 
 
 	.text
@@ -444,57 +472,61 @@ scrypt_core:
 _scrypt_core:
 	stmfd	sp!, {r4-r11, lr}
 	mov	r12, sp
-	sub	sp, sp, #21*4
+	sub	sp, sp, #22*4
 	bic	sp, sp, #63
 	str	r12, [sp, #20*4]
+	str	r2, [sp, #21*4]
 	
-	scrypt_shuffle()
+	scrypt_shuffle
 	
+	ldr	r2, [sp, #21*4]
 	str	r0, [sp, #16*4]
-	add	r12, r1, #1024*32*4
+	add	r12, r1, r2, lsl #7
 	str	r12, [sp, #18*4]
 scrypt_core_loop1:
 	add	lr, r0, #16*4
 	add	r3, r1, #16*4
 	mov	r12, sp
-	scrypt_core_macro1a_x4()
-	scrypt_core_macro1a_x4()
-	scrypt_core_macro1a_x4()
-	scrypt_core_macro1a_x4()
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
 	str	r1, [sp, #17*4]
 	
-	salsa8_core()
+	salsa8_core
 	
 	ldr	r0, [sp, #16*4]
 	mov	r12, sp
 	add	r2, r0, #16*4
-	scrypt_core_macro2_x4()
-	scrypt_core_macro2_x4()
-	scrypt_core_macro2_x4()
-	scrypt_core_macro2_x4()
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
 	
-	salsa8_core()
+	salsa8_core
 	
 	ldr	r0, [sp, #16*4]
 	mov	r1, sp
 	add	r0, r0, #16*4
-	scrypt_core_macro3_x6()
-	scrypt_core_macro3_x6()
+	scrypt_core_macro3_x6
+	scrypt_core_macro3_x6
 	ldr	r3, [sp, #17*4]
 	ldr	r12, [sp, #18*4]
-	scrypt_core_macro3_x4()
+	scrypt_core_macro3_x4
 	
 	add	r1, r3, #16*4
 	sub	r0, r0, #32*4
 	cmp	r1, r12
 	bne	scrypt_core_loop1
 	
+	ldr	r12, [sp, #21*4]
 	ldr	r4, [r0, #16*4]
-	sub	r1, r1, #1024*32*4
+	sub	r2, r12, #1
+	str	r2, [sp, #21*4]
+	sub	r1, r1, r12, lsl #7
 	str	r1, [sp, #17*4]
-	mov	r4, r4, lsl #32-10
-	mov	r12, #1024
-	add	r1, r1, r4, lsr #32-10-7
+	and	r4, r4, r2
+	add	r1, r1, r4, lsl #7
 scrypt_core_loop2:
 	add	r2, r0, #16*4
 	add	r3, r1, #16*4
@@ -504,37 +536,38 @@ scrypt_core_loop2:
 	pld [r1, #24*4]
 	pld [r1, #8*4]
 #endif
-	scrypt_core_macro1b_x4()
-	scrypt_core_macro1b_x4()
-	scrypt_core_macro1b_x4()
-	scrypt_core_macro1b_x4()
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
 	
-	salsa8_core()
+	salsa8_core
 	
 	ldr	r0, [sp, #16*4]
 	mov	r12, sp
 	add	r2, r0, #16*4
-	scrypt_core_macro2_x4()
-	scrypt_core_macro2_x4()
-	scrypt_core_macro2_x4()
-	scrypt_core_macro2_x4()
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
 	
-	salsa8_core()
+	salsa8_core
 	
 	ldr	r0, [sp, #16*4]
 	mov	r1, sp
 	ldr	r3, [sp, #17*4]
 	add	r0, r0, #16*4
-	scrypt_core_macro3_x4()
-	mov	r4, r4, lsl #32-10
-	add	r3, r3, r4, lsr #32-10-7
+	ldr	r2, [sp, #21*4]
+	scrypt_core_macro3_x4
+	and	r4, r4, r2
+	add	r3, r3, r4, lsl #7
 	str	r3, [sp, #19*4]
 #ifdef __ARM_ARCH_5E_OR_6_OR_7__
 	pld	[r3, #16*4]
 	pld	[r3]
 #endif
-	scrypt_core_macro3_x6()
-	scrypt_core_macro3_x6()
+	scrypt_core_macro3_x6
+	scrypt_core_macro3_x6
 	
 	ldr	r12, [sp, #18*4]
 	sub	r0, r0, #32*4
@@ -542,7 +575,7 @@ scrypt_core_loop2:
 	subs	r12, r12, #1
 	bne	scrypt_core_loop2
 	
-	scrypt_shuffle()
+	scrypt_shuffle
 	
 	ldr	sp, [sp, #20*4]
 #ifdef __thumb__
@@ -551,5 +584,603 @@ scrypt_core_loop2:
 #else
 	ldmfd	sp!, {r4-r11, pc}
 #endif
+
+
+#ifdef __ARM_NEON__
+
+.macro salsa8_core_3way_doubleround
+	ldrd	r6, [sp, #6*4]
+	vadd.u32	q4, q0, q1
+	add	r6, r2, r6
+	vadd.u32	q6, q8, q9
+	add	r7, r3, r7
+	vshl.u32	q5, q4, #7
+	eor	r10, r10, r6, ror #25
+	vshl.u32	q7, q6, #7
+	add	r6, r0, r4
+	vshr.u32	q4, q4, #32-7
+	eor	r11, r11, r7, ror #25
+	vshr.u32	q6, q6, #32-7
+	add	r7, r1, r5
+	veor.u32	q3, q3, q5
+	strd	r10, [sp, #14*4]
+	veor.u32	q11, q11, q7
+	eor	r12, r12, r6, ror #25
+	veor.u32	q3, q3, q4
+	eor	lr, lr, r7, ror #25
+	veor.u32	q11, q11, q6
+	
+	ldrd	r6, [sp, #10*4]
+	vadd.u32	q4, q3, q0
+	add	r2, r10, r2
+	vadd.u32	q6, q11, q8
+	add	r3, r11, r3
+	vshl.u32	q5, q4, #9
+	eor	r6, r6, r2, ror #23
+	vshl.u32	q7, q6, #9
+	add	r2, r12, r0
+	vshr.u32	q4, q4, #32-9
+	eor	r7, r7, r3, ror #23
+	vshr.u32	q6, q6, #32-9
+	add	r3, lr, r1
+	veor.u32	q2, q2, q5
+	strd	r6, [sp, #10*4]
+	veor.u32	q10, q10, q7
+	eor	r8, r8, r2, ror #23
+	veor.u32	q2, q2, q4
+	eor	r9, r9, r3, ror #23
+	veor.u32	q10, q10, q6
+	
+	ldrd	r2, [sp, #6*4]
+	vadd.u32	q4, q2, q3
+	add	r10, r6, r10
+	vadd.u32	q6, q10, q11
+	add	r11, r7, r11
+	vext.u32	q3, q3, q3, #3
+	eor	r2, r2, r10, ror #19
+	vshl.u32	q5, q4, #13
+	add	r10, r8, r12
+	vext.u32	q11, q11, q11, #3
+	eor	r3, r3, r11, ror #19
+	vshl.u32	q7, q6, #13
+	add	r11, r9, lr
+	vshr.u32	q4, q4, #32-13
+	eor	r4, r4, r10, ror #19
+	vshr.u32	q6, q6, #32-13
+	eor	r5, r5, r11, ror #19
+	veor.u32	q1, q1, q5
+	veor.u32	q9, q9, q7
+	veor.u32	q1, q1, q4
+	veor.u32	q9, q9, q6
+	
+	ldrd	r10, [sp, #2*4]
+	vadd.u32	q4, q1, q2
+	add	r6, r2, r6
+	vadd.u32	q6, q9, q10
+	add	r7, r3, r7
+	vswp.u32	d4, d5
+	eor	r10, r10, r6, ror #14
+	vshl.u32	q5, q4, #18
+	add	r6, r4, r8
+	vswp.u32	d20, d21
+	eor	r11, r11, r7, ror #14
+	vshl.u32	q7, q6, #18
+	add	r7, r5, r9
+	vshr.u32	q4, q4, #32-18
+	eor	r0, r0, r6, ror #14
+	vshr.u32	q6, q6, #32-18
+	eor	r1, r1, r7, ror #14
+	veor.u32	q0, q0, q5
+	ldrd	r6, [sp, #14*4]
+	veor.u32	q8, q8, q7
+	veor.u32	q0, q0, q4
+	veor.u32	q8, q8, q6
+	
+	
+	strd	r2, [sp, #6*4]
+	vadd.u32	q4, q0, q3
+	strd	r10, [sp, #2*4]
+	vadd.u32	q6, q8, q11
+	add	r6, r11, r6
+	vext.u32	q1, q1, q1, #1
+	add	r7, r0, r7
+	vshl.u32	q5, q4, #7
+	eor	r4, r4, r6, ror #25
+	vext.u32	q9, q9, q9, #1
+	add	r6, r1, r12
+	vshl.u32	q7, q6, #7
+	eor	r5, r5, r7, ror #25
+	vshr.u32	q4, q4, #32-7
+	add	r7, r10, lr
+	vshr.u32	q6, q6, #32-7
+	eor	r2, r2, r6, ror #25
+	veor.u32	q1, q1, q5
+	eor	r3, r3, r7, ror #25
+	veor.u32	q9, q9, q7
+	strd	r2, [sp, #6*4]
+	veor.u32	q1, q1, q4
+	veor.u32	q9, q9, q6
+	
+	add	r10, r3, r10
+	vadd.u32	q4, q1, q0
+	ldrd	r6, [sp, #10*4]
+	vadd.u32	q6, q9, q8
+	add	r11, r4, r11
+	vshl.u32	q5, q4, #9
+	eor	r8, r8, r10, ror #23
+	vshl.u32	q7, q6, #9
+	add	r10, r5, r0
+	vshr.u32	q4, q4, #32-9
+	eor	r9, r9, r11, ror #23
+	vshr.u32	q6, q6, #32-9
+	add	r11, r2, r1
+	veor.u32	q2, q2, q5
+	eor	r6, r6, r10, ror #23
+	veor.u32	q10, q10, q7
+	eor	r7, r7, r11, ror #23
+	veor.u32	q2, q2, q4
+	strd	r6, [sp, #10*4]
+	veor.u32	q10, q10, q6
+	
+	add	r2, r7, r2
+	vadd.u32	q4, q2, q1
+	ldrd	r10, [sp, #14*4]
+	vadd.u32	q6, q10, q9
+	add	r3, r8, r3
+	vext.u32	q1, q1, q1, #3
+	eor	r12, r12, r2, ror #19
+	vshl.u32	q5, q4, #13
+	add	r2, r9, r4
+	vext.u32	q9, q9, q9, #3
+	eor	lr, lr, r3, ror #19
+	vshl.u32	q7, q6, #13
+	add	r3, r6, r5
+	vshr.u32	q4, q4, #32-13
+	eor	r10, r10, r2, ror #19
+	vshr.u32	q6, q6, #32-13
+	eor	r11, r11, r3, ror #19
+	veor.u32	q3, q3, q5
+	veor.u32	q11, q11, q7
+	veor.u32	q3, q3, q4
+	veor.u32	q11, q11, q6
+	
+	ldrd	r2, [sp, #2*4]
+	vadd.u32	q4, q3, q2
+	add	r6, r11, r6
+	vadd.u32	q6, q11, q10
+	add	r7, r12, r7
+	vswp.u32	d4, d5
+	eor	r0, r0, r6, ror #14
+	vshl.u32	q5, q4, #18
+	add	r6, lr, r8
+	vswp.u32	d20, d21
+	eor	r1, r1, r7, ror #14
+	vshl.u32	q7, q6, #18
+	add	r7, r10, r9
+	vext.u32	q3, q3, q3, #1
+	eor	r2, r2, r6, ror #14
+	vshr.u32	q4, q4, #32-18
+	eor	r3, r3, r7, ror #14
+	vshr.u32	q6, q6, #32-18
+	strd	r2, [sp, #2*4]
+	vext.u32	q11, q11, q11, #1
+	strd	r10, [sp, #14*4]
+	veor.u32	q0, q0, q5
+	veor.u32	q8, q8, q7
+	veor.u32	q0, q0, q4
+	veor.u32	q8, q8, q6
+.endm
+
+.macro salsa8_core_3way
+	ldmia	sp, {r0-r12, lr}
+	ldrd	r10, [sp, #14*4]
+	salsa8_core_3way_doubleround
+	salsa8_core_3way_doubleround
+	salsa8_core_3way_doubleround
+	salsa8_core_3way_doubleround
+	stmia	sp, {r0-r5}
+	strd	r8, [sp, #8*4]
+	str	r12, [sp, #12*4]
+	str	lr, [sp, #13*4]
+.endm
+
+	.text
+	.code 32
+	.align 2
+	.globl scrypt_core_3way
+	.globl _scrypt_core_3way
+#ifdef __ELF__
+	.type scrypt_core_3way, %function
+#endif
+scrypt_core_3way:
+_scrypt_core_3way:
+	stmfd	sp!, {r4-r11, lr}
+	vpush	{q4-q7}
+	mov	r12, sp
+	sub	sp, sp, #24*16
+	bic	sp, sp, #63
+	str	r2, [sp, #4*16+3*4]
+	str	r12, [sp, #4*16+4*4]
+	
+	mov	r3, r0
+	vldmia	r3!, {q8-q15}
+	vmov.u64	q0, #0xffffffff
+	vmov.u32	q1, q8
+	vmov.u32	q2, q12
+	vbif.u32	q8, q9, q0
+	vbif.u32	q12, q13, q0
+	vbif.u32	q9, q10, q0
+	vbif.u32	q13, q14, q0
+	vbif.u32	q10, q11, q0
+	vbif.u32	q14, q15, q0
+	vbif.u32	q11, q1, q0
+	vbif.u32	q15, q2, q0
+	vldmia	r3!, {q0-q7}
+	vswp.u32	d17, d21
+	vswp.u32	d25, d29
+	vswp.u32	d18, d22
+	vswp.u32	d26, d30
+	vstmia	r0, {q8-q15}
+	vmov.u64	q8, #0xffffffff
+	vmov.u32	q9, q0
+	vmov.u32	q10, q4
+	vbif.u32	q0, q1, q8
+	vbif.u32	q4, q5, q8
+	vbif.u32	q1, q2, q8
+	vbif.u32	q5, q6, q8
+	vbif.u32	q2, q3, q8
+	vbif.u32	q6, q7, q8
+	vbif.u32	q3, q9, q8
+	vbif.u32	q7, q10, q8
+	vldmia	r3, {q8-q15}
+	vswp.u32	d1, d5
+	vswp.u32	d9, d13
+	vswp.u32	d2, d6
+	vswp.u32	d10, d14
+	add	r12, sp, #8*16
+	vstmia	r12!, {q0-q7}
+	vmov.u64	q0, #0xffffffff
+	vmov.u32	q1, q8
+	vmov.u32	q2, q12
+	vbif.u32	q8, q9, q0
+	vbif.u32	q12, q13, q0
+	vbif.u32	q9, q10, q0
+	vbif.u32	q13, q14, q0
+	vbif.u32	q10, q11, q0
+	vbif.u32	q14, q15, q0
+	vbif.u32	q11, q1, q0
+	vbif.u32	q15, q2, q0
+	vswp.u32	d17, d21
+	vswp.u32	d25, d29
+	vswp.u32	d18, d22
+	vswp.u32	d26, d30
+	vstmia	r12, {q8-q15}
+	
+	add	lr, sp, #128
+	vldmia	lr, {q0-q7}
+	add	r2, r1, r2, lsl #7
+	str	r0, [sp, #4*16+0*4]
+	str	r2, [sp, #4*16+2*4]
+scrypt_core_3way_loop1:
+	add	lr, r0, #16*4
+	add	r3, r1, #16*4
+	str	r1, [sp, #4*16+1*4]
+	mov	r12, sp
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
+	ldr	r2, [sp, #4*16+3*4]
+	scrypt_core_macro1a_x4
+	sub	r1, r1, #4*16
+	
+	add	r1, r1, r2, lsl #7
+	vstmia	r1, {q0-q7}
+	add	r3, r1, r2, lsl #7
+	vstmia	r3, {q8-q15}
+	
+	add	lr, sp, #128
+	veor.u32	q0, q0, q4
+	veor.u32	q1, q1, q5
+	veor.u32	q2, q2, q6
+	veor.u32	q3, q3, q7
+	vstmia	lr, {q0-q3}
+	veor.u32	q8, q8, q12
+	veor.u32	q9, q9, q13
+	veor.u32	q10, q10, q14
+	veor.u32	q11, q11, q15
+	add	r12, sp, #256
+	vstmia	r12, {q8-q11}
+	
+	salsa8_core_3way
+	
+	ldr	r0, [sp, #4*16+0*4]
+	mov	r12, sp
+	add	r2, r0, #16*4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	
+	add	lr, sp, #128
+	vldmia	lr, {q4-q7}
+	vadd.u32	q4, q4, q0
+	vadd.u32	q5, q5, q1
+	vadd.u32	q6, q6, q2
+	vadd.u32	q7, q7, q3
+	add	r12, sp, #256
+	vldmia	r12, {q0-q3}
+	vstmia	lr, {q4-q7}
+	vadd.u32	q8, q8, q0
+	vadd.u32	q9, q9, q1
+	vadd.u32	q10, q10, q2
+	vadd.u32	q11, q11, q3
+	
+	add	r4, sp, #128+4*16
+	vldmia	r4, {q0-q3}
+	vstmia	r12, {q8-q11}
+	veor.u32	q0, q0, q4
+	veor.u32	q1, q1, q5
+	veor.u32	q2, q2, q6
+	veor.u32	q3, q3, q7
+	vstmia	r4, {q0-q3}
+	veor.u32	q8, q8, q12
+	veor.u32	q9, q9, q13
+	veor.u32	q10, q10, q14
+	veor.u32	q11, q11, q15
+	vmov	q12, q8
+	vmov	q13, q9
+	vmov	q14, q10
+	vmov	q15, q11
+	
+	salsa8_core_3way
+	
+	ldr	r0, [sp, #4*16+0*4]
+	mov	r1, sp
+	add	r0, r0, #16*4
+	scrypt_core_macro3_x6
+	scrypt_core_macro3_x6
+	scrypt_core_macro3_x4
+	sub	r0, r0, #8*16
+	
+	ldr	r1, [sp, #4*16+1*4]
+	ldr	r2, [sp, #4*16+2*4]
+	add	lr, sp, #128
+	add	r4, sp, #128+4*16
+	vldmia	r4, {q4-q7}
+	vadd.u32	q4, q4, q0
+	vadd.u32	q5, q5, q1
+	vadd.u32	q6, q6, q2
+	vadd.u32	q7, q7, q3
+	vstmia	r4, {q4-q7}
+	vldmia	lr, {q0-q3}
+	vadd.u32	q12, q12, q8
+	vadd.u32	q13, q13, q9
+	vadd.u32	q14, q14, q10
+	vadd.u32	q15, q15, q11
+	add	r12, sp, #256
+	vldmia	r12, {q8-q11}
+	
+	add	r1, r1, #8*16
+	cmp	r1, r2
+	bne	scrypt_core_3way_loop1
+	
+	ldr	r2, [sp, #4*16+3*4]
+	add	r5, sp, #256+4*16
+	vstmia	r5, {q12-q15}
+	
+	sub	r1, r1, r2, lsl #7
+	str	r1, [sp, #4*16+1*4]
+scrypt_core_3way_loop2:
+	str	r2, [sp, #4*16+2*4]
+	
+	ldr	r0, [sp, #4*16+0*4]
+	ldr	r1, [sp, #4*16+1*4]
+	ldr	r2, [sp, #4*16+3*4]
+	ldr	r4, [r0, #16*4]
+	sub	r2, r2, #1
+	and	r4, r4, r2
+	add	r1, r1, r4, lsl #7
+	add	r2, r0, #16*4
+	add	r3, r1, #16*4
+	mov	r12, sp
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	
+	ldr	r1, [sp, #4*16+1*4]
+	ldr	r2, [sp, #4*16+3*4]
+	add	r1, r1, r2, lsl #7
+	add	r3, r1, r2, lsl #7
+	sub	r2, r2, #1
+	vmov	r6, r7, d8
+	and	r6, r6, r2
+	add	r6, r1, r6, lsl #7
+	vmov	r7, r8, d24
+	add	lr, sp, #128
+	vldmia	lr, {q0-q3}
+	pld	[r6]
+	pld	[r6, #8*4]
+	pld	[r6, #16*4]
+	pld	[r6, #24*4]
+	vldmia	r6, {q8-q15}
+	and	r7, r7, r2
+	add	r7, r3, r7, lsl #7
+	veor.u32	q8, q8, q0
+	veor.u32	q9, q9, q1
+	veor.u32	q10, q10, q2
+	veor.u32	q11, q11, q3
+	pld	[r7]
+	pld	[r7, #8*4]
+	pld	[r7, #16*4]
+	pld	[r7, #24*4]
+	veor.u32	q12, q12, q4
+	veor.u32	q13, q13, q5
+	veor.u32	q14, q14, q6
+	veor.u32	q15, q15, q7
+	vldmia	r7, {q0-q7}
+	vstmia	lr, {q8-q15}
+	add	r12, sp, #256
+	vldmia	r12, {q8-q15}
+	veor.u32	q8, q8, q0
+	veor.u32	q9, q9, q1
+	veor.u32	q10, q10, q2
+	veor.u32	q11, q11, q3
+	veor.u32	q12, q12, q4
+	veor.u32	q13, q13, q5
+	veor.u32	q14, q14, q6
+	veor.u32	q15, q15, q7
+	
+	vldmia	lr, {q0-q7}
+	veor.u32	q0, q0, q4
+	veor.u32	q1, q1, q5
+	veor.u32	q2, q2, q6
+	veor.u32	q3, q3, q7
+	vstmia	lr, {q0-q3}
+	veor.u32	q8, q8, q12
+	veor.u32	q9, q9, q13
+	veor.u32	q10, q10, q14
+	veor.u32	q11, q11, q15
+	vstmia	r12, {q8-q15}
+	
+	salsa8_core_3way
+	
+	ldr	r0, [sp, #4*16+0*4]
+	mov	r12, sp
+	add	r2, r0, #16*4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	
+	add	lr, sp, #128
+	vldmia	lr, {q4-q7}
+	vadd.u32	q4, q4, q0
+	vadd.u32	q5, q5, q1
+	vadd.u32	q6, q6, q2
+	vadd.u32	q7, q7, q3
+	add	r12, sp, #256
+	vldmia	r12, {q12-q15}
+	vstmia	lr, {q4-q7}
+	vadd.u32	q12, q12, q8
+	vadd.u32	q13, q13, q9
+	vadd.u32	q14, q14, q10
+	vadd.u32	q15, q15, q11
+	
+	add	r4, sp, #128+4*16
+	vldmia	r4, {q0-q3}
+	vstmia	r12, {q12-q15}
+	veor.u32	q0, q0, q4
+	veor.u32	q1, q1, q5
+	veor.u32	q2, q2, q6
+	veor.u32	q3, q3, q7
+	add	r5, sp, #256+4*16
+	vldmia	r5, {q8-q11}
+	vstmia	r4, {q0-q3}
+	veor.u32	q8, q8, q12
+	veor.u32	q9, q9, q13
+	veor.u32	q10, q10, q14
+	veor.u32	q11, q11, q15
+	vmov	q12, q8
+	vmov	q13, q9
+	vmov	q14, q10
+	vmov	q15, q11
+	
+	salsa8_core_3way
+	
+	ldr	r0, [sp, #4*16+0*4]
+	ldr	r3, [sp, #4*16+1*4]
+	ldr	r2, [sp, #4*16+3*4]
+	mov	r1, sp
+	add	r0, r0, #16*4
+	sub	r2, r2, #1
+	scrypt_core_macro3_x4
+	and	r4, r4, r2
+	add	r3, r3, r4, lsl #7
+	pld	[r3, #16*4]
+	pld	[r3]
+	pld	[r3, #24*4]
+	pld	[r3, #8*4]
+	scrypt_core_macro3_x6
+	scrypt_core_macro3_x6
+	
+	add	lr, sp, #128
+	add	r4, sp, #128+4*16
+	vldmia	r4, {q4-q7}
+	vadd.u32	q4, q4, q0
+	vadd.u32	q5, q5, q1
+	vadd.u32	q6, q6, q2
+	vadd.u32	q7, q7, q3
+	vstmia	r4, {q4-q7}
+	vadd.u32	q12, q12, q8
+	vadd.u32	q13, q13, q9
+	vadd.u32	q14, q14, q10
+	vadd.u32	q15, q15, q11
+	add	r5, sp, #256+4*16
+	vstmia	r5, {q12-q15}
+	
+	ldr	r2, [sp, #4*16+2*4]
+	subs	r2, r2, #1
+	bne	scrypt_core_3way_loop2
+	
+	ldr	r0, [sp, #4*16+0*4]
+	vldmia	r0, {q8-q15}
+	vmov.u64	q0, #0xffffffff
+	vmov.u32	q1, q8
+	vmov.u32	q2, q12
+	vbif.u32	q8, q9, q0
+	vbif.u32	q12, q13, q0
+	vbif.u32	q9, q10, q0
+	vbif.u32	q13, q14, q0
+	vbif.u32	q10, q11, q0
+	vbif.u32	q14, q15, q0
+	vbif.u32	q11, q1, q0
+	vbif.u32	q15, q2, q0
+	add	r12, sp, #8*16
+	vldmia	r12!, {q0-q7}
+	vswp.u32	d17, d21
+	vswp.u32	d25, d29
+	vswp.u32	d18, d22
+	vswp.u32	d26, d30
+	vstmia	r0!, {q8-q15}
+	vmov.u64	q8, #0xffffffff
+	vmov.u32	q9, q0
+	vmov.u32	q10, q4
+	vbif.u32	q0, q1, q8
+	vbif.u32	q4, q5, q8
+	vbif.u32	q1, q2, q8
+	vbif.u32	q5, q6, q8
+	vbif.u32	q2, q3, q8
+	vbif.u32	q6, q7, q8
+	vbif.u32	q3, q9, q8
+	vbif.u32	q7, q10, q8
+	vldmia	r12, {q8-q15}
+	vswp.u32	d1, d5
+	vswp.u32	d9, d13
+	vswp.u32	d2, d6
+	vswp.u32	d10, d14
+	vstmia	r0!, {q0-q7}
+	vmov.u64	q0, #0xffffffff
+	vmov.u32	q1, q8
+	vmov.u32	q2, q12
+	vbif.u32	q8, q9, q0
+	vbif.u32	q12, q13, q0
+	vbif.u32	q9, q10, q0
+	vbif.u32	q13, q14, q0
+	vbif.u32	q10, q11, q0
+	vbif.u32	q14, q15, q0
+	vbif.u32	q11, q1, q0
+	vbif.u32	q15, q2, q0
+	vswp.u32	d17, d21
+	vswp.u32	d25, d29
+	vswp.u32	d18, d22
+	vswp.u32	d26, d30
+	vstmia	r0, {q8-q15}
+	
+	ldr	sp, [sp, #4*16+4*4]
+	vpop	{q4-q7}
+	ldmfd	sp!, {r4-r11, pc}
+
+#endif /* __ARM_NEON__ */
 
 #endif

--- a/src/scrypt-x86.S
+++ b/src/scrypt-x86.S
@@ -1,363 +1,402 @@
-# Copyright 2011 pooler@litecoinpool.org
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-# SUCH DAMAGE.
+/*
+ * Copyright 2011-2012, 2014 pooler@litecoinpool.org
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 
-#if defined(OPTIMIZED_SALSA) &&  defined(__i386__)
+#include <config/gridcoin-config.h>
 
 #if defined(__linux__) && defined(__ELF__)
-.section .note.GNU-stack,"",%progbits
+	.section .note.GNU-stack,"",%progbits
 #endif
 
-#define gen_salsa8_core_quadround() \
-	movl	52(%esp), %ecx; \
-	movl	4(%esp), %edx; \
-	movl	20(%esp), %ebx; \
-	movl	8(%esp), %esi; \
-	leal	(%ecx, %edx), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	%ebx, 4(%esp); \
-	movl	36(%esp), %edi; \
-	leal	(%edx, %ebx), %ebp; \
-	roll	$9, %ebp; \
-	xorl	%ebp, %edi; \
-	movl	24(%esp), %ebp; \
-	movl	%edi, 8(%esp); \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	40(%esp), %ebx; \
-	movl	%ecx, 20(%esp); \
-	addl	%edi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%esi, %ebp), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	%ebx, 24(%esp); \
-	movl	56(%esp), %edi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %edi; \
-	movl	%edi, 36(%esp); \
-	movl	28(%esp), %ecx; \
-	movl	%edx, 28(%esp); \
-	movl	44(%esp), %edx; \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %esi; \
-	movl	60(%esp), %ebx; \
-	movl	%esi, 40(%esp); \
-	addl	%edi, %esi; \
-	roll	$18, %esi; \
-	leal	(%ecx, %edx), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	%ebx, 44(%esp); \
-	movl	12(%esp), %edi; \
-	xorl	%esi, %ebp; \
-	leal	(%edx, %ebx), %esi; \
-	roll	$9, %esi; \
-	xorl	%esi, %edi; \
-	movl	%edi, 12(%esp); \
-	movl	48(%esp), %esi; \
-	movl	%ebp, 48(%esp); \
-	movl	64(%esp), %ebp; \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	16(%esp), %ebx; \
-	movl	%ecx, 16(%esp); \
-	addl	%edi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%esi, %ebp), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	32(%esp), %edi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %edi; \
-	movl	%edi, 32(%esp); \
-	movl	%ebx, %ecx; \
-	movl	%edx, 52(%esp); \
-	movl	28(%esp), %edx; \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %esi; \
-	movl	40(%esp), %ebx; \
-	movl	%esi, 28(%esp); \
-	addl	%edi, %esi; \
-	roll	$18, %esi; \
-	leal	(%ecx, %edx), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	%ebx, 40(%esp); \
-	movl	12(%esp), %edi; \
-	xorl	%esi, %ebp; \
-	leal	(%edx, %ebx), %esi; \
-	roll	$9, %esi; \
-	xorl	%esi, %edi; \
-	movl	%edi, 12(%esp); \
-	movl	4(%esp), %esi; \
-	movl	%ebp, 4(%esp); \
-	movl	48(%esp), %ebp; \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	16(%esp), %ebx; \
-	movl	%ecx, 16(%esp); \
-	addl	%edi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%esi, %ebp), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	%ebx, 48(%esp); \
-	movl	32(%esp), %edi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %edi; \
-	movl	%edi, 32(%esp); \
-	movl	24(%esp), %ecx; \
-	movl	%edx, 24(%esp); \
-	movl	52(%esp), %edx; \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %esi; \
-	movl	28(%esp), %ebx; \
-	movl	%esi, 28(%esp); \
-	addl	%edi, %esi; \
-	roll	$18, %esi; \
-	leal	(%ecx, %edx), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	%ebx, 52(%esp); \
-	movl	8(%esp), %edi; \
-	xorl	%esi, %ebp; \
-	leal	(%edx, %ebx), %esi; \
-	roll	$9, %esi; \
-	xorl	%esi, %edi; \
-	movl	%edi, 8(%esp); \
-	movl	44(%esp), %esi; \
-	movl	%ebp, 44(%esp); \
-	movl	4(%esp), %ebp; \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	20(%esp), %ebx; \
-	movl	%ecx, 4(%esp); \
-	addl	%edi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%esi, %ebp), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	36(%esp), %edi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %edi; \
-	movl	%edi, 20(%esp); \
-	movl	%ebx, %ecx; \
-	movl	%edx, 36(%esp); \
-	movl	24(%esp), %edx; \
-	addl	%edi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %esi; \
-	movl	28(%esp), %ebx; \
-	movl	%esi, 24(%esp); \
-	addl	%edi, %esi; \
-	roll	$18, %esi; \
-	leal	(%ecx, %edx), %edi; \
-	roll	$7, %edi; \
-	xorl	%edi, %ebx; \
-	movl	%ebx, 28(%esp); \
-	xorl	%esi, %ebp; \
-	movl	8(%esp), %esi; \
-	leal	(%edx, %ebx), %edi; \
-	roll	$9, %edi; \
-	xorl	%edi, %esi; \
-	movl	40(%esp), %edi; \
-	movl	%ebp, 8(%esp); \
-	movl	44(%esp), %ebp; \
-	movl	%esi, 40(%esp); \
-	addl	%esi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	4(%esp), %ebx; \
-	movl	%ecx, 44(%esp); \
-	addl	%esi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%edi, %ebp), %esi; \
-	roll	$7, %esi; \
-	xorl	%esi, %ebx; \
-	movl	%ebx, 4(%esp); \
-	movl	20(%esp), %esi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %esi; \
-	movl	%esi, 56(%esp); \
-	movl	48(%esp), %ecx; \
-	movl	%edx, 20(%esp); \
-	movl	36(%esp), %edx; \
-	addl	%esi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %edi; \
-	movl	24(%esp), %ebx; \
-	movl	%edi, 24(%esp); \
-	addl	%esi, %edi; \
-	roll	$18, %edi; \
-	leal	(%ecx, %edx), %esi; \
-	roll	$7, %esi; \
-	xorl	%esi, %ebx; \
-	movl	%ebx, 60(%esp); \
-	movl	12(%esp), %esi; \
-	xorl	%edi, %ebp; \
-	leal	(%edx, %ebx), %edi; \
-	roll	$9, %edi; \
-	xorl	%edi, %esi; \
-	movl	%esi, 12(%esp); \
-	movl	52(%esp), %edi; \
-	movl	%ebp, 36(%esp); \
-	movl	8(%esp), %ebp; \
-	addl	%esi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	16(%esp), %ebx; \
-	movl	%ecx, 16(%esp); \
-	addl	%esi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%edi, %ebp), %esi; \
-	roll	$7, %esi; \
-	xorl	%esi, %ebx; \
-	movl	32(%esp), %esi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %esi; \
-	movl	%esi, 32(%esp); \
-	movl	%ebx, %ecx; \
-	movl	%edx, 48(%esp); \
-	movl	20(%esp), %edx; \
-	addl	%esi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %edi; \
-	movl	24(%esp), %ebx; \
-	movl	%edi, 20(%esp); \
-	addl	%esi, %edi; \
-	roll	$18, %edi; \
-	leal	(%ecx, %edx), %esi; \
-	roll	$7, %esi; \
-	xorl	%esi, %ebx; \
-	movl	%ebx, 8(%esp); \
-	movl	12(%esp), %esi; \
-	xorl	%edi, %ebp; \
-	leal	(%edx, %ebx), %edi; \
-	roll	$9, %edi; \
-	xorl	%edi, %esi; \
-	movl	%esi, 12(%esp); \
-	movl	28(%esp), %edi; \
-	movl	%ebp, 52(%esp); \
-	movl	36(%esp), %ebp; \
-	addl	%esi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	16(%esp), %ebx; \
-	movl	%ecx, 16(%esp); \
-	addl	%esi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%edi, %ebp), %esi; \
-	roll	$7, %esi; \
-	xorl	%esi, %ebx; \
-	movl	%ebx, 28(%esp); \
-	movl	32(%esp), %esi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %esi; \
-	movl	%esi, 32(%esp); \
-	movl	4(%esp), %ecx; \
-	movl	%edx, 4(%esp); \
-	movl	48(%esp), %edx; \
-	addl	%esi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %edi; \
-	movl	20(%esp), %ebx; \
-	movl	%edi, 20(%esp); \
-	addl	%esi, %edi; \
-	roll	$18, %edi; \
-	leal	(%ecx, %edx), %esi; \
-	roll	$7, %esi; \
-	xorl	%esi, %ebx; \
-	movl	%ebx, 48(%esp); \
-	movl	40(%esp), %esi; \
-	xorl	%edi, %ebp; \
-	leal	(%edx, %ebx), %edi; \
-	roll	$9, %edi; \
-	xorl	%edi, %esi; \
-	movl	%esi, 36(%esp); \
-	movl	60(%esp), %edi; \
-	movl	%ebp, 24(%esp); \
-	movl	52(%esp), %ebp; \
-	addl	%esi, %ebx; \
-	roll	$13, %ebx; \
-	xorl	%ebx, %ecx; \
-	movl	44(%esp), %ebx; \
-	movl	%ecx, 40(%esp); \
-	addl	%esi, %ecx; \
-	roll	$18, %ecx; \
-	leal	(%edi, %ebp), %esi; \
-	roll	$7, %esi; \
-	xorl	%esi, %ebx; \
-	movl	%ebx, 52(%esp); \
-	movl	56(%esp), %esi; \
-	xorl	%ecx, %edx; \
-	leal	(%ebp, %ebx), %ecx; \
-	roll	$9, %ecx; \
-	xorl	%ecx, %esi; \
-	movl	%esi, 56(%esp); \
-	addl	%esi, %ebx; \
-	movl	%edx, 44(%esp); \
-	roll	$13, %ebx; \
-	xorl	%ebx, %edi; \
-	movl	%edi, 60(%esp); \
-	addl	%esi, %edi; \
-	roll	$18, %edi; \
-	xorl	%edi, %ebp; \
-	movl	%ebp, 64(%esp); \
+#if defined(USE_ASM) && defined(__i386__)
+	
+.macro scrypt_shuffle src, so, dest, do
+	movl	\so+60(\src), %eax
+	movl	\so+44(\src), %ebx
+	movl	\so+28(\src), %ecx
+	movl	\so+12(\src), %edx
+	movl	%eax, \do+12(\dest)
+	movl	%ebx, \do+28(\dest)
+	movl	%ecx, \do+44(\dest)
+	movl	%edx, \do+60(\dest)
+	movl	\so+40(\src), %eax
+	movl	\so+8(\src), %ebx
+	movl	\so+48(\src), %ecx
+	movl	\so+16(\src), %edx
+	movl	%eax, \do+8(\dest)
+	movl	%ebx, \do+40(\dest)
+	movl	%ecx, \do+16(\dest)
+	movl	%edx, \do+48(\dest)
+	movl	\so+20(\src), %eax
+	movl	\so+4(\src), %ebx
+	movl	\so+52(\src), %ecx
+	movl	\so+36(\src), %edx
+	movl	%eax, \do+4(\dest)
+	movl	%ebx, \do+20(\dest)
+	movl	%ecx, \do+36(\dest)
+	movl	%edx, \do+52(\dest)
+	movl	\so+0(\src), %eax
+	movl	\so+24(\src), %ebx
+	movl	\so+32(\src), %ecx
+	movl	\so+56(\src), %edx
+	movl	%eax, \do+0(\dest)
+	movl	%ebx, \do+24(\dest)
+	movl	%ecx, \do+32(\dest)
+	movl	%edx, \do+56(\dest)
+.endm
 
+.macro salsa8_core_gen_quadround
+	movl	52(%esp), %ecx
+	movl	4(%esp), %edx
+	movl	20(%esp), %ebx
+	movl	8(%esp), %esi
+	leal	(%ecx, %edx), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	%ebx, 4(%esp)
+	movl	36(%esp), %edi
+	leal	(%edx, %ebx), %ebp
+	roll	$9, %ebp
+	xorl	%ebp, %edi
+	movl	24(%esp), %ebp
+	movl	%edi, 8(%esp)
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	40(%esp), %ebx
+	movl	%ecx, 20(%esp)
+	addl	%edi, %ecx
+	roll	$18, %ecx
+	leal	(%esi, %ebp), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	%ebx, 24(%esp)
+	movl	56(%esp), %edi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %edi
+	movl	%edi, 36(%esp)
+	movl	28(%esp), %ecx
+	movl	%edx, 28(%esp)
+	movl	44(%esp), %edx
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %esi
+	movl	60(%esp), %ebx
+	movl	%esi, 40(%esp)
+	addl	%edi, %esi
+	roll	$18, %esi
+	leal	(%ecx, %edx), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	%ebx, 44(%esp)
+	movl	12(%esp), %edi
+	xorl	%esi, %ebp
+	leal	(%edx, %ebx), %esi
+	roll	$9, %esi
+	xorl	%esi, %edi
+	movl	%edi, 12(%esp)
+	movl	48(%esp), %esi
+	movl	%ebp, 48(%esp)
+	movl	64(%esp), %ebp
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	16(%esp), %ebx
+	movl	%ecx, 16(%esp)
+	addl	%edi, %ecx
+	roll	$18, %ecx
+	leal	(%esi, %ebp), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	32(%esp), %edi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %edi
+	movl	%edi, 32(%esp)
+	movl	%ebx, %ecx
+	movl	%edx, 52(%esp)
+	movl	28(%esp), %edx
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %esi
+	movl	40(%esp), %ebx
+	movl	%esi, 28(%esp)
+	addl	%edi, %esi
+	roll	$18, %esi
+	leal	(%ecx, %edx), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	%ebx, 40(%esp)
+	movl	12(%esp), %edi
+	xorl	%esi, %ebp
+	leal	(%edx, %ebx), %esi
+	roll	$9, %esi
+	xorl	%esi, %edi
+	movl	%edi, 12(%esp)
+	movl	4(%esp), %esi
+	movl	%ebp, 4(%esp)
+	movl	48(%esp), %ebp
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	16(%esp), %ebx
+	movl	%ecx, 16(%esp)
+	addl	%edi, %ecx
+	roll	$18, %ecx
+	leal	(%esi, %ebp), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	%ebx, 48(%esp)
+	movl	32(%esp), %edi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %edi
+	movl	%edi, 32(%esp)
+	movl	24(%esp), %ecx
+	movl	%edx, 24(%esp)
+	movl	52(%esp), %edx
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %esi
+	movl	28(%esp), %ebx
+	movl	%esi, 28(%esp)
+	addl	%edi, %esi
+	roll	$18, %esi
+	leal	(%ecx, %edx), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	%ebx, 52(%esp)
+	movl	8(%esp), %edi
+	xorl	%esi, %ebp
+	leal	(%edx, %ebx), %esi
+	roll	$9, %esi
+	xorl	%esi, %edi
+	movl	%edi, 8(%esp)
+	movl	44(%esp), %esi
+	movl	%ebp, 44(%esp)
+	movl	4(%esp), %ebp
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	20(%esp), %ebx
+	movl	%ecx, 4(%esp)
+	addl	%edi, %ecx
+	roll	$18, %ecx
+	leal	(%esi, %ebp), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	36(%esp), %edi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %edi
+	movl	%edi, 20(%esp)
+	movl	%ebx, %ecx
+	movl	%edx, 36(%esp)
+	movl	24(%esp), %edx
+	addl	%edi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %esi
+	movl	28(%esp), %ebx
+	movl	%esi, 24(%esp)
+	addl	%edi, %esi
+	roll	$18, %esi
+	leal	(%ecx, %edx), %edi
+	roll	$7, %edi
+	xorl	%edi, %ebx
+	movl	%ebx, 28(%esp)
+	xorl	%esi, %ebp
+	movl	8(%esp), %esi
+	leal	(%edx, %ebx), %edi
+	roll	$9, %edi
+	xorl	%edi, %esi
+	movl	40(%esp), %edi
+	movl	%ebp, 8(%esp)
+	movl	44(%esp), %ebp
+	movl	%esi, 40(%esp)
+	addl	%esi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	4(%esp), %ebx
+	movl	%ecx, 44(%esp)
+	addl	%esi, %ecx
+	roll	$18, %ecx
+	leal	(%edi, %ebp), %esi
+	roll	$7, %esi
+	xorl	%esi, %ebx
+	movl	%ebx, 4(%esp)
+	movl	20(%esp), %esi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %esi
+	movl	%esi, 56(%esp)
+	movl	48(%esp), %ecx
+	movl	%edx, 20(%esp)
+	movl	36(%esp), %edx
+	addl	%esi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %edi
+	movl	24(%esp), %ebx
+	movl	%edi, 24(%esp)
+	addl	%esi, %edi
+	roll	$18, %edi
+	leal	(%ecx, %edx), %esi
+	roll	$7, %esi
+	xorl	%esi, %ebx
+	movl	%ebx, 60(%esp)
+	movl	12(%esp), %esi
+	xorl	%edi, %ebp
+	leal	(%edx, %ebx), %edi
+	roll	$9, %edi
+	xorl	%edi, %esi
+	movl	%esi, 12(%esp)
+	movl	52(%esp), %edi
+	movl	%ebp, 36(%esp)
+	movl	8(%esp), %ebp
+	addl	%esi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	16(%esp), %ebx
+	movl	%ecx, 16(%esp)
+	addl	%esi, %ecx
+	roll	$18, %ecx
+	leal	(%edi, %ebp), %esi
+	roll	$7, %esi
+	xorl	%esi, %ebx
+	movl	32(%esp), %esi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %esi
+	movl	%esi, 32(%esp)
+	movl	%ebx, %ecx
+	movl	%edx, 48(%esp)
+	movl	20(%esp), %edx
+	addl	%esi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %edi
+	movl	24(%esp), %ebx
+	movl	%edi, 20(%esp)
+	addl	%esi, %edi
+	roll	$18, %edi
+	leal	(%ecx, %edx), %esi
+	roll	$7, %esi
+	xorl	%esi, %ebx
+	movl	%ebx, 8(%esp)
+	movl	12(%esp), %esi
+	xorl	%edi, %ebp
+	leal	(%edx, %ebx), %edi
+	roll	$9, %edi
+	xorl	%edi, %esi
+	movl	%esi, 12(%esp)
+	movl	28(%esp), %edi
+	movl	%ebp, 52(%esp)
+	movl	36(%esp), %ebp
+	addl	%esi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	16(%esp), %ebx
+	movl	%ecx, 16(%esp)
+	addl	%esi, %ecx
+	roll	$18, %ecx
+	leal	(%edi, %ebp), %esi
+	roll	$7, %esi
+	xorl	%esi, %ebx
+	movl	%ebx, 28(%esp)
+	movl	32(%esp), %esi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %esi
+	movl	%esi, 32(%esp)
+	movl	4(%esp), %ecx
+	movl	%edx, 4(%esp)
+	movl	48(%esp), %edx
+	addl	%esi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %edi
+	movl	20(%esp), %ebx
+	movl	%edi, 20(%esp)
+	addl	%esi, %edi
+	roll	$18, %edi
+	leal	(%ecx, %edx), %esi
+	roll	$7, %esi
+	xorl	%esi, %ebx
+	movl	%ebx, 48(%esp)
+	movl	40(%esp), %esi
+	xorl	%edi, %ebp
+	leal	(%edx, %ebx), %edi
+	roll	$9, %edi
+	xorl	%edi, %esi
+	movl	%esi, 36(%esp)
+	movl	60(%esp), %edi
+	movl	%ebp, 24(%esp)
+	movl	52(%esp), %ebp
+	addl	%esi, %ebx
+	roll	$13, %ebx
+	xorl	%ebx, %ecx
+	movl	44(%esp), %ebx
+	movl	%ecx, 40(%esp)
+	addl	%esi, %ecx
+	roll	$18, %ecx
+	leal	(%edi, %ebp), %esi
+	roll	$7, %esi
+	xorl	%esi, %ebx
+	movl	%ebx, 52(%esp)
+	movl	56(%esp), %esi
+	xorl	%ecx, %edx
+	leal	(%ebp, %ebx), %ecx
+	roll	$9, %ecx
+	xorl	%ecx, %esi
+	movl	%esi, 56(%esp)
+	addl	%esi, %ebx
+	movl	%edx, 44(%esp)
+	roll	$13, %ebx
+	xorl	%ebx, %edi
+	movl	%edi, 60(%esp)
+	addl	%esi, %edi
+	roll	$18, %edi
+	xorl	%edi, %ebp
+	movl	%ebp, 64(%esp)
+.endm
 
 	.text
-	.align 32
-gen_salsa8_core:
-	gen_salsa8_core_quadround()
-	gen_salsa8_core_quadround()
+	.p2align 5
+salsa8_core_gen:
+	salsa8_core_gen_quadround
+	salsa8_core_gen_quadround
 	ret
 	
 	
 	.text
-	.align 32
+	.p2align 5
 	.globl scrypt_core
 	.globl _scrypt_core
 scrypt_core:
@@ -367,191 +406,196 @@ _scrypt_core:
 	pushl	%edi
 	pushl	%esi
 	
-	# Check for SSE2 availability
+	/* Check for SSE2 availability */
 	movl	$1, %eax
 	cpuid
 	andl	$0x04000000, %edx
-	jnz xmm_scrypt_core
+	jnz scrypt_core_sse2
 	
-gen_scrypt_core:
+scrypt_core_gen:
 	movl	20(%esp), %edi
 	movl	24(%esp), %esi
+	movl	28(%esp), %ecx
 	subl	$72, %esp
 	
-#define scrypt_core_macro1a(p, q) \
-	movl	p(%edi), %eax; \
-	movl	q(%edi), %edx; \
-	movl	%eax, p(%esi); \
-	movl	%edx, q(%esi); \
-	xorl	%edx, %eax; \
-	movl	%eax, p(%edi); \
-	movl	%eax, p(%esp); \
-
+.macro scrypt_core_macro1a p, q
+	movl	\p(%edi), %eax
+	movl	\q(%edi), %edx
+	movl	%eax, \p(%esi)
+	movl	%edx, \q(%esi)
+	xorl	%edx, %eax
+	movl	%eax, \p(%edi)
+	movl	%eax, \p(%esp)
+.endm
 	
-#define scrypt_core_macro1b(p, q) \
-	movl	p(%edi), %eax; \
-	xorl	p(%esi, %edx), %eax; \
-	movl	q(%edi), %ebx; \
-	xorl	q(%esi, %edx), %ebx; \
-	movl	%ebx, q(%edi); \
-	xorl	%ebx, %eax; \
-	movl	%eax, p(%edi); \
-	movl	%eax, p(%esp); \
-
+.macro scrypt_core_macro1b p, q
+	movl	\p(%edi), %eax
+	xorl	\p(%esi, %edx), %eax
+	movl	\q(%edi), %ebx
+	xorl	\q(%esi, %edx), %ebx
+	movl	%ebx, \q(%edi)
+	xorl	%ebx, %eax
+	movl	%eax, \p(%edi)
+	movl	%eax, \p(%esp)
+.endm
 	
-#define scrypt_core_macro2(p, q) \
-	movl	p(%esp), %eax; \
-	addl	p(%edi), %eax; \
-	movl	%eax, p(%edi); \
-	xorl	q(%edi), %eax; \
-	movl	%eax, q(%edi); \
-	movl	%eax, p(%esp); \
-
+.macro scrypt_core_macro2 p, q
+	movl	\p(%esp), %eax
+	addl	\p(%edi), %eax
+	movl	%eax, \p(%edi)
+	xorl	\q(%edi), %eax
+	movl	%eax, \q(%edi)
+	movl	%eax, \p(%esp)
+.endm
 	
-#define scrypt_core_macro3(p, q) \
-	movl	p(%esp), %eax; \
-	addl	q(%edi), %eax; \
-	movl	%eax, q(%edi); \
-
+.macro scrypt_core_macro3 p, q
+	movl	\p(%esp), %eax
+	addl	\q(%edi), %eax
+	movl	%eax, \q(%edi)
+.endm
 	
-	leal	131072(%esi), %ecx
-gen_scrypt_core_loop1:
+	shll	$7, %ecx
+	addl	%esi, %ecx
+scrypt_core_gen_loop1:
 	movl	%esi, 64(%esp)
 	movl	%ecx, 68(%esp)
 	
-	scrypt_core_macro1a(0, 64)
-	scrypt_core_macro1a(4, 68)
-	scrypt_core_macro1a(8, 72)
-	scrypt_core_macro1a(12, 76)
-	scrypt_core_macro1a(16, 80)
-	scrypt_core_macro1a(20, 84)
-	scrypt_core_macro1a(24, 88)
-	scrypt_core_macro1a(28, 92)
-	scrypt_core_macro1a(32, 96)
-	scrypt_core_macro1a(36, 100)
-	scrypt_core_macro1a(40, 104)
-	scrypt_core_macro1a(44, 108)
-	scrypt_core_macro1a(48, 112)
-	scrypt_core_macro1a(52, 116)
-	scrypt_core_macro1a(56, 120)
-	scrypt_core_macro1a(60, 124)
+	scrypt_core_macro1a	0, 64
+	scrypt_core_macro1a	4, 68
+	scrypt_core_macro1a	8, 72
+	scrypt_core_macro1a	12, 76
+	scrypt_core_macro1a	16, 80
+	scrypt_core_macro1a	20, 84
+	scrypt_core_macro1a	24, 88
+	scrypt_core_macro1a	28, 92
+	scrypt_core_macro1a	32, 96
+	scrypt_core_macro1a	36, 100
+	scrypt_core_macro1a	40, 104
+	scrypt_core_macro1a	44, 108
+	scrypt_core_macro1a	48, 112
+	scrypt_core_macro1a	52, 116
+	scrypt_core_macro1a	56, 120
+	scrypt_core_macro1a	60, 124
 	
-	call gen_salsa8_core
-	
-	movl	92(%esp), %edi
-	scrypt_core_macro2(0, 64)
-	scrypt_core_macro2(4, 68)
-	scrypt_core_macro2(8, 72)
-	scrypt_core_macro2(12, 76)
-	scrypt_core_macro2(16, 80)
-	scrypt_core_macro2(20, 84)
-	scrypt_core_macro2(24, 88)
-	scrypt_core_macro2(28, 92)
-	scrypt_core_macro2(32, 96)
-	scrypt_core_macro2(36, 100)
-	scrypt_core_macro2(40, 104)
-	scrypt_core_macro2(44, 108)
-	scrypt_core_macro2(48, 112)
-	scrypt_core_macro2(52, 116)
-	scrypt_core_macro2(56, 120)
-	scrypt_core_macro2(60, 124)
-	
-	call gen_salsa8_core
+	call salsa8_core_gen
 	
 	movl	92(%esp), %edi
-	scrypt_core_macro3(0, 64)
-	scrypt_core_macro3(4, 68)
-	scrypt_core_macro3(8, 72)
-	scrypt_core_macro3(12, 76)
-	scrypt_core_macro3(16, 80)
-	scrypt_core_macro3(20, 84)
-	scrypt_core_macro3(24, 88)
-	scrypt_core_macro3(28, 92)
-	scrypt_core_macro3(32, 96)
-	scrypt_core_macro3(36, 100)
-	scrypt_core_macro3(40, 104)
-	scrypt_core_macro3(44, 108)
-	scrypt_core_macro3(48, 112)
-	scrypt_core_macro3(52, 116)
-	scrypt_core_macro3(56, 120)
-	scrypt_core_macro3(60, 124)
+	scrypt_core_macro2	0, 64
+	scrypt_core_macro2	4, 68
+	scrypt_core_macro2	8, 72
+	scrypt_core_macro2	12, 76
+	scrypt_core_macro2	16, 80
+	scrypt_core_macro2	20, 84
+	scrypt_core_macro2	24, 88
+	scrypt_core_macro2	28, 92
+	scrypt_core_macro2	32, 96
+	scrypt_core_macro2	36, 100
+	scrypt_core_macro2	40, 104
+	scrypt_core_macro2	44, 108
+	scrypt_core_macro2	48, 112
+	scrypt_core_macro2	52, 116
+	scrypt_core_macro2	56, 120
+	scrypt_core_macro2	60, 124
+	
+	call salsa8_core_gen
+	
+	movl	92(%esp), %edi
+	scrypt_core_macro3	0, 64
+	scrypt_core_macro3	4, 68
+	scrypt_core_macro3	8, 72
+	scrypt_core_macro3	12, 76
+	scrypt_core_macro3	16, 80
+	scrypt_core_macro3	20, 84
+	scrypt_core_macro3	24, 88
+	scrypt_core_macro3	28, 92
+	scrypt_core_macro3	32, 96
+	scrypt_core_macro3	36, 100
+	scrypt_core_macro3	40, 104
+	scrypt_core_macro3	44, 108
+	scrypt_core_macro3	48, 112
+	scrypt_core_macro3	52, 116
+	scrypt_core_macro3	56, 120
+	scrypt_core_macro3	60, 124
 	
 	movl	64(%esp), %esi
 	movl	68(%esp), %ecx
 	addl	$128, %esi
 	cmpl	%ecx, %esi
-	jne gen_scrypt_core_loop1
+	jne scrypt_core_gen_loop1
 
 	movl	96(%esp), %esi
-	movl	$1024, %ecx
-gen_scrypt_core_loop2:
+	movl	100(%esp), %ecx
+	movl	%ecx, %eax
+	subl	$1, %eax
+	movl	%eax, 100(%esp)
+scrypt_core_gen_loop2:
 	movl	%ecx, 68(%esp)
 	
 	movl	64(%edi), %edx
-	andl	$1023, %edx
+	andl	100(%esp), %edx
 	shll	$7, %edx
 	
-	scrypt_core_macro1b(0, 64)
-	scrypt_core_macro1b(4, 68)
-	scrypt_core_macro1b(8, 72)
-	scrypt_core_macro1b(12, 76)
-	scrypt_core_macro1b(16, 80)
-	scrypt_core_macro1b(20, 84)
-	scrypt_core_macro1b(24, 88)
-	scrypt_core_macro1b(28, 92)
-	scrypt_core_macro1b(32, 96)
-	scrypt_core_macro1b(36, 100)
-	scrypt_core_macro1b(40, 104)
-	scrypt_core_macro1b(44, 108)
-	scrypt_core_macro1b(48, 112)
-	scrypt_core_macro1b(52, 116)
-	scrypt_core_macro1b(56, 120)
-	scrypt_core_macro1b(60, 124)
+	scrypt_core_macro1b	0, 64
+	scrypt_core_macro1b	4, 68
+	scrypt_core_macro1b	8, 72
+	scrypt_core_macro1b	12, 76
+	scrypt_core_macro1b	16, 80
+	scrypt_core_macro1b	20, 84
+	scrypt_core_macro1b	24, 88
+	scrypt_core_macro1b	28, 92
+	scrypt_core_macro1b	32, 96
+	scrypt_core_macro1b	36, 100
+	scrypt_core_macro1b	40, 104
+	scrypt_core_macro1b	44, 108
+	scrypt_core_macro1b	48, 112
+	scrypt_core_macro1b	52, 116
+	scrypt_core_macro1b	56, 120
+	scrypt_core_macro1b	60, 124
 	
-	call gen_salsa8_core
+	call salsa8_core_gen
 	
 	movl	92(%esp), %edi
-	scrypt_core_macro2(0, 64)
-	scrypt_core_macro2(4, 68)
-	scrypt_core_macro2(8, 72)
-	scrypt_core_macro2(12, 76)
-	scrypt_core_macro2(16, 80)
-	scrypt_core_macro2(20, 84)
-	scrypt_core_macro2(24, 88)
-	scrypt_core_macro2(28, 92)
-	scrypt_core_macro2(32, 96)
-	scrypt_core_macro2(36, 100)
-	scrypt_core_macro2(40, 104)
-	scrypt_core_macro2(44, 108)
-	scrypt_core_macro2(48, 112)
-	scrypt_core_macro2(52, 116)
-	scrypt_core_macro2(56, 120)
-	scrypt_core_macro2(60, 124)
+	scrypt_core_macro2	0, 64
+	scrypt_core_macro2	4, 68
+	scrypt_core_macro2	8, 72
+	scrypt_core_macro2	12, 76
+	scrypt_core_macro2	16, 80
+	scrypt_core_macro2	20, 84
+	scrypt_core_macro2	24, 88
+	scrypt_core_macro2	28, 92
+	scrypt_core_macro2	32, 96
+	scrypt_core_macro2	36, 100
+	scrypt_core_macro2	40, 104
+	scrypt_core_macro2	44, 108
+	scrypt_core_macro2	48, 112
+	scrypt_core_macro2	52, 116
+	scrypt_core_macro2	56, 120
+	scrypt_core_macro2	60, 124
 	
-	call gen_salsa8_core
+	call salsa8_core_gen
 	
 	movl	92(%esp), %edi
 	movl	96(%esp), %esi
-	scrypt_core_macro3(0, 64)
-	scrypt_core_macro3(4, 68)
-	scrypt_core_macro3(8, 72)
-	scrypt_core_macro3(12, 76)
-	scrypt_core_macro3(16, 80)
-	scrypt_core_macro3(20, 84)
-	scrypt_core_macro3(24, 88)
-	scrypt_core_macro3(28, 92)
-	scrypt_core_macro3(32, 96)
-	scrypt_core_macro3(36, 100)
-	scrypt_core_macro3(40, 104)
-	scrypt_core_macro3(44, 108)
-	scrypt_core_macro3(48, 112)
-	scrypt_core_macro3(52, 116)
-	scrypt_core_macro3(56, 120)
-	scrypt_core_macro3(60, 124)
+	scrypt_core_macro3	0, 64
+	scrypt_core_macro3	4, 68
+	scrypt_core_macro3	8, 72
+	scrypt_core_macro3	12, 76
+	scrypt_core_macro3	16, 80
+	scrypt_core_macro3	20, 84
+	scrypt_core_macro3	24, 88
+	scrypt_core_macro3	28, 92
+	scrypt_core_macro3	32, 96
+	scrypt_core_macro3	36, 100
+	scrypt_core_macro3	40, 104
+	scrypt_core_macro3	44, 108
+	scrypt_core_macro3	48, 112
+	scrypt_core_macro3	52, 116
+	scrypt_core_macro3	56, 120
+	scrypt_core_macro3	60, 124
 	
 	movl	68(%esp), %ecx
 	subl	$1, %ecx
-	ja gen_scrypt_core_loop2
+	ja scrypt_core_gen_loop2
 	
 	addl	$72, %esp
 	popl	%esi
@@ -561,167 +605,116 @@ gen_scrypt_core_loop2:
 	ret
 
 
-#define xmm_salsa8_core_doubleround() \
-	movdqa	%xmm1, %xmm4; \
-	paddd	%xmm0, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$7, %xmm4; \
-	psrld	$25, %xmm5; \
-	pxor	%xmm4, %xmm3; \
-	pxor	%xmm5, %xmm3; \
-	movdqa	%xmm0, %xmm4; \
-	paddd	%xmm3, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$9, %xmm4; \
-	psrld	$23, %xmm5; \
-	pxor	%xmm4, %xmm2; \
-	movdqa	%xmm3, %xmm4; \
-	pshufd	$0x93, %xmm3, %xmm3; \
-	pxor	%xmm5, %xmm2; \
-	paddd	%xmm2, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$13, %xmm4; \
-	psrld	$19, %xmm5; \
-	pxor	%xmm4, %xmm1; \
-	movdqa	%xmm2, %xmm4; \
-	pshufd	$0x4e, %xmm2, %xmm2; \
-	pxor	%xmm5, %xmm1; \
-	paddd	%xmm1, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$18, %xmm4; \
-	psrld	$14, %xmm5; \
-	pxor	%xmm4, %xmm0; \
-	pshufd	$0x39, %xmm1, %xmm1; \
-	pxor	%xmm5, %xmm0; \
-	movdqa	%xmm3, %xmm4; \
-	paddd	%xmm0, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$7, %xmm4; \
-	psrld	$25, %xmm5; \
-	pxor	%xmm4, %xmm1; \
-	pxor	%xmm5, %xmm1; \
-	movdqa	%xmm0, %xmm4; \
-	paddd	%xmm1, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$9, %xmm4; \
-	psrld	$23, %xmm5; \
-	pxor	%xmm4, %xmm2; \
-	movdqa	%xmm1, %xmm4; \
-	pshufd	$0x93, %xmm1, %xmm1; \
-	pxor	%xmm5, %xmm2; \
-	paddd	%xmm2, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$13, %xmm4; \
-	psrld	$19, %xmm5; \
-	pxor	%xmm4, %xmm3; \
-	movdqa	%xmm2, %xmm4; \
-	pshufd	$0x4e, %xmm2, %xmm2; \
-	pxor	%xmm5, %xmm3; \
-	paddd	%xmm3, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$18, %xmm4; \
-	psrld	$14, %xmm5; \
-	pxor	%xmm4, %xmm0; \
-	pshufd	$0x39, %xmm3, %xmm3; \
-	pxor	%xmm5, %xmm0; \
-
-
-#define xmm_salsa8_core() \
-	xmm_salsa8_core_doubleround(); \
-	xmm_salsa8_core_doubleround(); \
-	xmm_salsa8_core_doubleround(); \
-	xmm_salsa8_core_doubleround(); \
-
+.macro salsa8_core_sse2_doubleround
+	movdqa	%xmm1, %xmm4
+	paddd	%xmm0, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$7, %xmm4
+	psrld	$25, %xmm5
+	pxor	%xmm4, %xmm3
+	movdqa	%xmm0, %xmm4
+	pxor	%xmm5, %xmm3
 	
-	.align 32
-xmm_scrypt_core:
+	paddd	%xmm3, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$9, %xmm4
+	psrld	$23, %xmm5
+	pxor	%xmm4, %xmm2
+	movdqa	%xmm3, %xmm4
+	pxor	%xmm5, %xmm2
+	pshufd	$0x93, %xmm3, %xmm3
+	
+	paddd	%xmm2, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$13, %xmm4
+	psrld	$19, %xmm5
+	pxor	%xmm4, %xmm1
+	movdqa	%xmm2, %xmm4
+	pxor	%xmm5, %xmm1
+	pshufd	$0x4e, %xmm2, %xmm2
+	
+	paddd	%xmm1, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$18, %xmm4
+	psrld	$14, %xmm5
+	pxor	%xmm4, %xmm0
+	movdqa	%xmm3, %xmm4
+	pxor	%xmm5, %xmm0
+	pshufd	$0x39, %xmm1, %xmm1
+	
+	paddd	%xmm0, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$7, %xmm4
+	psrld	$25, %xmm5
+	pxor	%xmm4, %xmm1
+	movdqa	%xmm0, %xmm4
+	pxor	%xmm5, %xmm1
+	
+	paddd	%xmm1, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$9, %xmm4
+	psrld	$23, %xmm5
+	pxor	%xmm4, %xmm2
+	movdqa	%xmm1, %xmm4
+	pxor	%xmm5, %xmm2
+	pshufd	$0x93, %xmm1, %xmm1
+	
+	paddd	%xmm2, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$13, %xmm4
+	psrld	$19, %xmm5
+	pxor	%xmm4, %xmm3
+	movdqa	%xmm2, %xmm4
+	pxor	%xmm5, %xmm3
+	pshufd	$0x4e, %xmm2, %xmm2
+	
+	paddd	%xmm3, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$18, %xmm4
+	psrld	$14, %xmm5
+	pxor	%xmm4, %xmm0
+	pshufd	$0x39, %xmm3, %xmm3
+	pxor	%xmm5, %xmm0
+.endm
+
+.macro salsa8_core_sse2
+	salsa8_core_sse2_doubleround
+	salsa8_core_sse2_doubleround
+	salsa8_core_sse2_doubleround
+	salsa8_core_sse2_doubleround
+.endm
+	
+	.p2align 5
+scrypt_core_sse2:
 	movl	20(%esp), %edi
 	movl	24(%esp), %esi
 	movl	%esp, %ebp
 	subl	$128, %esp
 	andl	$-16, %esp
 	
-	# shuffle 1st block to (%esp)
-	movl	60(%edi), %edx
-	movl	44(%edi), %ecx
-	movl	28(%edi), %ebx
-	movl	12(%edi), %eax
-	movl	%edx, 12(%esp)
-	movl	%ecx, 28(%esp)
-	movl	%ebx, 44(%esp)
-	movl	%eax, 60(%esp)
-	movl	40(%edi), %ecx
-	movl	24(%edi), %ebx
-	movl	8(%edi), %eax
-	movl	56(%edi), %edx
-	movl	%ecx, 8(%esp)
-	movl	%ebx, 24(%esp)
-	movl	%eax, 40(%esp)
-	movl	%edx, 56(%esp)
-	movl	20(%edi), %ebx
-	movl	4(%edi), %eax
-	movl	52(%edi), %edx
-	movl	36(%edi), %ecx
-	movl	%ebx, 4(%esp)
-	movl	%eax, 20(%esp)
-	movl	%edx, 36(%esp)
-	movl	%ecx, 52(%esp)
-	movl	0(%edi), %eax
-	movl	48(%edi), %edx
-	movl	32(%edi), %ecx
-	movl	16(%edi), %ebx
-	movl	%eax, 0(%esp)
-	movl	%edx, 16(%esp)
-	movl	%ecx, 32(%esp)
-	movl	%ebx, 48(%esp)
+	scrypt_shuffle %edi, 0, %esp, 0
+	scrypt_shuffle %edi, 64, %esp, 64
 	
-	# shuffle 2nd block to 64(%esp)
-	movl	124(%edi), %edx
-	movl	108(%edi), %ecx
-	movl	92(%edi), %ebx
-	movl	76(%edi), %eax
-	movl	%edx, 76(%esp)
-	movl	%ecx, 92(%esp)
-	movl	%ebx, 108(%esp)
-	movl	%eax, 124(%esp)
-	movl	104(%edi), %ecx
-	movl	88(%edi), %ebx
-	movl	72(%edi), %eax
-	movl	120(%edi), %edx
-	movl	%ecx, 72(%esp)
-	movl	%ebx, 88(%esp)
-	movl	%eax, 104(%esp)
-	movl	%edx, 120(%esp)
-	movl	84(%edi), %ebx
-	movl	68(%edi), %eax
-	movl	116(%edi), %edx
-	movl	100(%edi), %ecx
-	movl	%ebx, 68(%esp)
-	movl	%eax, 84(%esp)
-	movl	%edx, 100(%esp)
-	movl	%ecx, 116(%esp)
-	movl	64(%edi), %eax
-	movl	112(%edi), %edx
-	movl	96(%edi), %ecx
-	movl	80(%edi), %ebx
-	movl	%eax, 64(%esp)
-	movl	%edx, 80(%esp)
-	movl	%ecx, 96(%esp)
-	movl	%ebx, 112(%esp)
+	movdqa	96(%esp), %xmm6
+	movdqa	112(%esp), %xmm7
 	
 	movl	%esi, %edx
-	leal	131072(%esi), %ecx
-xmm_scrypt_core_loop1:
+	movl	28(%ebp), %ecx
+	shll	$7, %ecx
+	addl	%esi, %ecx
+scrypt_core_sse2_loop1:
 	movdqa	0(%esp), %xmm0
 	movdqa	16(%esp), %xmm1
 	movdqa	32(%esp), %xmm2
 	movdqa	48(%esp), %xmm3
 	movdqa	64(%esp), %xmm4
 	movdqa	80(%esp), %xmm5
-	movdqa	96(%esp), %xmm6
-	movdqa	112(%esp), %xmm7
+	pxor	%xmm4, %xmm0
+	pxor	%xmm5, %xmm1
 	movdqa	%xmm0, 0(%edx)
 	movdqa	%xmm1, 16(%edx)
+	pxor	%xmm6, %xmm2
+	pxor	%xmm7, %xmm3
 	movdqa	%xmm2, 32(%edx)
 	movdqa	%xmm3, 48(%edx)
 	movdqa	%xmm4, 64(%edx)
@@ -729,19 +722,11 @@ xmm_scrypt_core_loop1:
 	movdqa	%xmm6, 96(%edx)
 	movdqa	%xmm7, 112(%edx)
 	
-	pxor	%xmm4, %xmm0
-	pxor	%xmm5, %xmm1
-	pxor	%xmm6, %xmm2
-	pxor	%xmm7, %xmm3
-	movdqa	%xmm0, 0(%esp)
-	movdqa	%xmm1, 16(%esp)
-	movdqa	%xmm2, 32(%esp)
-	movdqa	%xmm3, 48(%esp)
-	xmm_salsa8_core()
-	paddd	0(%esp), %xmm0
-	paddd	16(%esp), %xmm1
-	paddd	32(%esp), %xmm2
-	paddd	48(%esp), %xmm3
+	salsa8_core_sse2
+	paddd	0(%edx), %xmm0
+	paddd	16(%edx), %xmm1
+	paddd	32(%edx), %xmm2
+	paddd	48(%edx), %xmm3
 	movdqa	%xmm0, 0(%esp)
 	movdqa	%xmm1, 16(%esp)
 	movdqa	%xmm2, 32(%esp)
@@ -749,61 +734,52 @@ xmm_scrypt_core_loop1:
 	
 	pxor	64(%esp), %xmm0
 	pxor	80(%esp), %xmm1
-	pxor	96(%esp), %xmm2
-	pxor	112(%esp), %xmm3
+	pxor	%xmm6, %xmm2
+	pxor	%xmm7, %xmm3
 	movdqa	%xmm0, 64(%esp)
 	movdqa	%xmm1, 80(%esp)
-	movdqa	%xmm2, 96(%esp)
-	movdqa	%xmm3, 112(%esp)
-	xmm_salsa8_core()
+	movdqa	%xmm2, %xmm6
+	movdqa	%xmm3, %xmm7
+	salsa8_core_sse2
 	paddd	64(%esp), %xmm0
 	paddd	80(%esp), %xmm1
-	paddd	96(%esp), %xmm2
-	paddd	112(%esp), %xmm3
+	paddd	%xmm2, %xmm6
+	paddd	%xmm3, %xmm7
 	movdqa	%xmm0, 64(%esp)
 	movdqa	%xmm1, 80(%esp)
-	movdqa	%xmm2, 96(%esp)
-	movdqa	%xmm3, 112(%esp)
 	
 	addl	$128, %edx
 	cmpl	%ecx, %edx
-	jne xmm_scrypt_core_loop1
+	jne scrypt_core_sse2_loop1
 	
-	movl	$1024, %ecx
-xmm_scrypt_core_loop2:
+	movdqa	64(%esp), %xmm4
+	movdqa	80(%esp), %xmm5
+	
+	movl	28(%ebp), %ecx
+	movl	%ecx, %eax
+	subl	$1, %eax
+scrypt_core_sse2_loop2:
+	movd	%xmm4, %edx
 	movdqa	0(%esp), %xmm0
 	movdqa	16(%esp), %xmm1
 	movdqa	32(%esp), %xmm2
 	movdqa	48(%esp), %xmm3
-	movdqa	64(%esp), %xmm4
-	movdqa	80(%esp), %xmm5
-	movdqa	96(%esp), %xmm6
-	movdqa	112(%esp), %xmm7
-	movd	%xmm4, %edx
-	andl	$1023, %edx
+	andl	%eax, %edx
 	shll	$7, %edx
 	pxor	0(%esi, %edx), %xmm0
 	pxor	16(%esi, %edx), %xmm1
 	pxor	32(%esi, %edx), %xmm2
 	pxor	48(%esi, %edx), %xmm3
-	pxor	64(%esi, %edx), %xmm4
-	pxor	80(%esi, %edx), %xmm5
-	pxor	96(%esi, %edx), %xmm6
-	pxor	112(%esi, %edx), %xmm7
-	movdqa	%xmm4, 64(%esp)
-	movdqa	%xmm5, 80(%esp)
-	movdqa	%xmm6, 96(%esp)
-	movdqa	%xmm7, 112(%esp)
 	
 	pxor	%xmm4, %xmm0
 	pxor	%xmm5, %xmm1
-	pxor	%xmm6, %xmm2
-	pxor	%xmm7, %xmm3
 	movdqa	%xmm0, 0(%esp)
 	movdqa	%xmm1, 16(%esp)
+	pxor	%xmm6, %xmm2
+	pxor	%xmm7, %xmm3
 	movdqa	%xmm2, 32(%esp)
 	movdqa	%xmm3, 48(%esp)
-	xmm_salsa8_core()
+	salsa8_core_sse2
 	paddd	0(%esp), %xmm0
 	paddd	16(%esp), %xmm1
 	paddd	32(%esp), %xmm2
@@ -813,94 +789,36 @@ xmm_scrypt_core_loop2:
 	movdqa	%xmm2, 32(%esp)
 	movdqa	%xmm3, 48(%esp)
 	
+	pxor	64(%esi, %edx), %xmm0
+	pxor	80(%esi, %edx), %xmm1
+	pxor	96(%esi, %edx), %xmm2
+	pxor	112(%esi, %edx), %xmm3
 	pxor	64(%esp), %xmm0
 	pxor	80(%esp), %xmm1
-	pxor	96(%esp), %xmm2
-	pxor	112(%esp), %xmm3
+	pxor	%xmm6, %xmm2
+	pxor	%xmm7, %xmm3
 	movdqa	%xmm0, 64(%esp)
 	movdqa	%xmm1, 80(%esp)
-	movdqa	%xmm2, 96(%esp)
-	movdqa	%xmm3, 112(%esp)
-	xmm_salsa8_core()
+	movdqa	%xmm2, %xmm6
+	movdqa	%xmm3, %xmm7
+	salsa8_core_sse2
 	paddd	64(%esp), %xmm0
 	paddd	80(%esp), %xmm1
-	paddd	96(%esp), %xmm2
-	paddd	112(%esp), %xmm3
+	paddd	%xmm2, %xmm6
+	paddd	%xmm3, %xmm7
+	movdqa	%xmm0, %xmm4
+	movdqa	%xmm1, %xmm5
 	movdqa	%xmm0, 64(%esp)
 	movdqa	%xmm1, 80(%esp)
-	movdqa	%xmm2, 96(%esp)
-	movdqa	%xmm3, 112(%esp)
 	
 	subl	$1, %ecx
-	ja xmm_scrypt_core_loop2
+	ja scrypt_core_sse2_loop2
 	
-	# re-shuffle 1st block back
-	movl	60(%esp), %edx
-	movl	44(%esp), %ecx
-	movl	28(%esp), %ebx
-	movl	12(%esp), %eax
-	movl	%edx, 12(%edi)
-	movl	%ecx, 28(%edi)
-	movl	%ebx, 44(%edi)
-	movl	%eax, 60(%edi)
-	movl	40(%esp), %ecx
-	movl	24(%esp), %ebx
-	movl	8(%esp), %eax
-	movl	56(%esp), %edx
-	movl	%ecx, 8(%edi)
-	movl	%ebx, 24(%edi)
-	movl	%eax, 40(%edi)
-	movl	%edx, 56(%edi)
-	movl	20(%esp), %ebx
-	movl	4(%esp), %eax
-	movl	52(%esp), %edx
-	movl	36(%esp), %ecx
-	movl	%ebx, 4(%edi)
-	movl	%eax, 20(%edi)
-	movl	%edx, 36(%edi)
-	movl	%ecx, 52(%edi)
-	movl	0(%esp), %eax
-	movl	48(%esp), %edx
-	movl	32(%esp), %ecx
-	movl	16(%esp), %ebx
-	movl	%eax, 0(%edi)
-	movl	%edx, 16(%edi)
-	movl	%ecx, 32(%edi)
-	movl	%ebx, 48(%edi)
+	movdqa	%xmm6, 96(%esp)
+	movdqa	%xmm7, 112(%esp)
 	
-	# re-shuffle 2nd block back
-	movl	124(%esp), %edx
-	movl	108(%esp), %ecx
-	movl	92(%esp), %ebx
-	movl	76(%esp), %eax
-	movl	%edx, 76(%edi)
-	movl	%ecx, 92(%edi)
-	movl	%ebx, 108(%edi)
-	movl	%eax, 124(%edi)
-	movl	104(%esp), %ecx
-	movl	88(%esp), %ebx
-	movl	72(%esp), %eax
-	movl	120(%esp), %edx
-	movl	%ecx, 72(%edi)
-	movl	%ebx, 88(%edi)
-	movl	%eax, 104(%edi)
-	movl	%edx, 120(%edi)
-	movl	84(%esp), %ebx
-	movl	68(%esp), %eax
-	movl	116(%esp), %edx
-	movl	100(%esp), %ecx
-	movl	%ebx, 68(%edi)
-	movl	%eax, 84(%edi)
-	movl	%edx, 100(%edi)
-	movl	%ecx, 116(%edi)
-	movl	64(%esp), %eax
-	movl	112(%esp), %edx
-	movl	96(%esp), %ecx
-	movl	80(%esp), %ebx
-	movl	%eax, 64(%edi)
-	movl	%edx, 80(%edi)
-	movl	%ecx, 96(%edi)
-	movl	%ebx, 112(%edi)
+	scrypt_shuffle %esp, 0, %edi, 0
+	scrypt_shuffle %esp, 64, %edi, 64
 	
 	movl	%ebp, %esp
 	popl	%esi

--- a/src/scrypt-x86_64.S
+++ b/src/scrypt-x86_64.S
@@ -1,191 +1,288 @@
-# Copyright 2011-2012 pooler@litecoinpool.org
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-# SUCH DAMAGE.
+/*
+ * Copyright 2011-2014 pooler@litecoinpool.org
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 
-
-#if defined(OPTIMIZED_SALSA) && defined(__x86_64__)
+#include <config/gridcoin-config.h>
 
 #if defined(__linux__) && defined(__ELF__)
 	.section .note.GNU-stack,"",%progbits
 #endif
 
-#define scrypt_shuffle(src, so, dest, do) \
-	movl	so+60(src), %r8d; \
-	movl	so+44(src), %r9d; \
-	movl	so+28(src), %r10d; \
-	movl	so+12(src), %r11d; \
-	movl	%r8d, do+12(dest); \
-	movl	%r9d, do+28(dest); \
-	movl	%r10d, do+44(dest); \
-	movl	%r11d, do+60(dest); \
-	movl	so+40(src), %r8d; \
-	movl	so+8(src), %r9d; \
-	movl	so+48(src), %r10d; \
-	movl	so+16(src), %r11d; \
-	movl	%r8d, do+8(dest); \
-	movl	%r9d, do+40(dest); \
-	movl	%r10d, do+16(dest); \
-	movl	%r11d, do+48(dest); \
-	movl	so+20(src), %r8d; \
-	movl	so+4(src), %r9d; \
-	movl	so+52(src), %r10d; \
-	movl	so+36(src), %r11d; \
-	movl	%r8d, do+4(dest); \
-	movl	%r9d, do+20(dest); \
-	movl	%r10d, do+36(dest); \
-	movl	%r11d, do+52(dest); \
-	movl	so+0(src), %r8d; \
-	movl	so+24(src), %r9d; \
-	movl	so+32(src), %r10d; \
-	movl	so+56(src), %r11d; \
-	movl	%r8d, do+0(dest); \
-	movl	%r9d, do+24(dest); \
-	movl	%r10d, do+32(dest); \
-	movl	%r11d, do+56(dest); \
+#if defined(USE_ASM) && defined(__x86_64__)
+	.text
+	.p2align 6
+	.globl scrypt_best_throughput
+	.globl _scrypt_best_throughput
+scrypt_best_throughput:
+_scrypt_best_throughput:
+	pushq	%rbx
+#if defined(ENABLE_AVX2)
+	/* Check for AVX and OSXSAVE support */
+	movl	$1, %eax
+	cpuid
+	andl	$0x18000000, %ecx
+	cmpl	$0x18000000, %ecx
+	jne scrypt_best_throughput_no_avx2
+	/* Check for AVX2 support */
+	movl	$7, %eax
+	xorl	%ecx, %ecx
+	cpuid
+	andl	$0x00000020, %ebx
+	cmpl	$0x00000020, %ebx
+	jne scrypt_best_throughput_no_avx2
+	/* Check for XMM and YMM state support */
+	xorl	%ecx, %ecx
+	xgetbv
+	andl	$0x00000006, %eax
+	cmpl	$0x00000006, %eax
+	jne scrypt_best_throughput_no_avx2
+	movl	$6, %eax
+	jmp scrypt_best_throughput_exit
+scrypt_best_throughput_no_avx2:
+#endif
+	/* Check for AuthenticAMD */
+	xorq	%rax, %rax
+	cpuid
+	movl	$3, %eax
+	cmpl	$0x444d4163, %ecx
+	jne scrypt_best_throughput_not_amd
+	cmpl	$0x69746e65, %edx
+	jne scrypt_best_throughput_not_amd
+	cmpl	$0x68747541, %ebx
+	jne scrypt_best_throughput_not_amd
+	/* Check for AMD K8 or Bobcat */
+	movl	$1, %eax
+	cpuid
+	andl	$0x0ff00000, %eax
+	jz scrypt_best_throughput_one
+	cmpl	$0x00500000, %eax
+	je scrypt_best_throughput_one
+	movl	$3, %eax
+	jmp scrypt_best_throughput_exit
+scrypt_best_throughput_not_amd:
+	/* Check for GenuineIntel */
+	cmpl	$0x6c65746e, %ecx
+	jne scrypt_best_throughput_exit
+	cmpl	$0x49656e69, %edx
+	jne scrypt_best_throughput_exit
+	cmpl	$0x756e6547, %ebx
+	jne scrypt_best_throughput_exit
+	/* Check for Intel Atom */
+	movl	$1, %eax
+	cpuid
+	movl	%eax, %edx
+	andl	$0x0ff00f00, %eax
+	cmpl	$0x00000600, %eax
+	movl	$3, %eax
+	jnz scrypt_best_throughput_exit
+	andl	$0x000f00f0, %edx
+	cmpl	$0x000100c0, %edx
+	je scrypt_best_throughput_one
+	cmpl	$0x00020060, %edx
+	je scrypt_best_throughput_one
+	cmpl	$0x00030060, %edx
+	jne scrypt_best_throughput_exit
+scrypt_best_throughput_one:
+	movl	$1, %eax
+scrypt_best_throughput_exit:
+	popq	%rbx
+	ret
+	
+	
+.macro scrypt_shuffle src, so, dest, do
+	movl	\so+60(\src), %eax
+	movl	\so+44(\src), %ebx
+	movl	\so+28(\src), %ecx
+	movl	\so+12(\src), %edx
+	movl	%eax, \do+12(\dest)
+	movl	%ebx, \do+28(\dest)
+	movl	%ecx, \do+44(\dest)
+	movl	%edx, \do+60(\dest)
+	movl	\so+40(\src), %eax
+	movl	\so+8(\src), %ebx
+	movl	\so+48(\src), %ecx
+	movl	\so+16(\src), %edx
+	movl	%eax, \do+8(\dest)
+	movl	%ebx, \do+40(\dest)
+	movl	%ecx, \do+16(\dest)
+	movl	%edx, \do+48(\dest)
+	movl	\so+20(\src), %eax
+	movl	\so+4(\src), %ebx
+	movl	\so+52(\src), %ecx
+	movl	\so+36(\src), %edx
+	movl	%eax, \do+4(\dest)
+	movl	%ebx, \do+20(\dest)
+	movl	%ecx, \do+36(\dest)
+	movl	%edx, \do+52(\dest)
+	movl	\so+0(\src), %eax
+	movl	\so+24(\src), %ebx
+	movl	\so+32(\src), %ecx
+	movl	\so+56(\src), %edx
+	movl	%eax, \do+0(\dest)
+	movl	%ebx, \do+24(\dest)
+	movl	%ecx, \do+32(\dest)
+	movl	%edx, \do+56(\dest)
+.endm
 
 
-#define gen_salsa8_core_doubleround() \
-	movq	72(%rsp), %r15; \
-	leaq	(%r14, %rdx), %rbp; \
-	roll	$7, %ebp; \
-	xorq	%rbp, %r9; \
-	leaq	(%rdi, %r15), %rbp; \
-	roll	$7, %ebp; \
-	xorq	%rbp, %r10; \
-	leaq	(%rdx, %r9), %rbp; \
-	roll	$9, %ebp; \
-	xorq	%rbp, %r11; \
-	leaq	(%r15, %r10), %rbp; \
-	roll	$9, %ebp; \
-	xorq	%rbp, %r13; \
-	leaq	(%r9, %r11), %rbp; \
-	roll	$13, %ebp; \
-	xorq	%rbp, %r14; \
-	leaq	(%r10, %r13), %rbp; \
-	roll	$13, %ebp; \
-	xorq	%rbp, %rdi; \
-	leaq	(%r11, %r14), %rbp; \
-	roll	$18, %ebp; \
-	xorq	%rbp, %rdx; \
-	leaq	(%r13, %rdi), %rbp; \
-	roll	$18, %ebp; \
-	xorq	%rbp, %r15; \
-	movq	48(%rsp), %rbp; \
-	movq	%r15, 72(%rsp); \
-	leaq	(%rax, %rbp), %r15; \
-	roll	$7, %r15d; \
-	xorq	%r15, %rbx; \
-	leaq	(%rbp, %rbx), %r15; \
-	roll	$9, %r15d; \
-	xorq	%r15, %rcx; \
-	leaq	(%rbx, %rcx), %r15; \
-	roll	$13, %r15d; \
-	xorq	%r15, %rax; \
-	leaq	(%rcx, %rax), %r15; \
-	roll	$18, %r15d; \
-	xorq	%r15, %rbp; \
-	movq	88(%rsp), %r15; \
-	movq	%rbp, 48(%rsp); \
-	leaq	(%r12, %r15), %rbp; \
-	roll	$7, %ebp; \
-	xorq	%rbp, %rsi; \
-	leaq	(%r15, %rsi), %rbp; \
-	roll	$9, %ebp; \
-	xorq	%rbp, %r8; \
-	leaq	(%rsi, %r8), %rbp; \
-	roll	$13, %ebp; \
-	xorq	%rbp, %r12; \
-	leaq	(%r8, %r12), %rbp; \
-	roll	$18, %ebp; \
-	xorq	%rbp, %r15; \
-	movq	%r15, 88(%rsp); \
-	movq	72(%rsp), %r15; \
-	leaq	(%rsi, %rdx), %rbp; \
-	roll	$7, %ebp; \
-	xorq	%rbp, %rdi; \
-	leaq	(%r9, %r15), %rbp; \
-	roll	$7, %ebp; \
-	xorq	%rbp, %rax; \
-	leaq	(%rdx, %rdi), %rbp; \
-	roll	$9, %ebp; \
-	xorq	%rbp, %rcx; \
-	leaq	(%r15, %rax), %rbp; \
-	roll	$9, %ebp; \
-	xorq	%rbp, %r8; \
-	leaq	(%rdi, %rcx), %rbp; \
-	roll	$13, %ebp; \
-	xorq	%rbp, %rsi; \
-	leaq	(%rax, %r8), %rbp; \
-	roll	$13, %ebp; \
-	xorq	%rbp, %r9; \
-	leaq	(%rcx, %rsi), %rbp; \
-	roll	$18, %ebp; \
-	xorq	%rbp, %rdx; \
-	leaq	(%r8, %r9), %rbp; \
-	roll	$18, %ebp; \
-	xorq	%rbp, %r15; \
-	movq	48(%rsp), %rbp; \
-	movq	%r15, 72(%rsp); \
-	leaq	(%r10, %rbp), %r15; \
-	roll	$7, %r15d; \
-	xorq	%r15, %r12; \
-	leaq	(%rbp, %r12), %r15; \
-	roll	$9, %r15d; \
-	xorq	%r15, %r11; \
-	leaq	(%r12, %r11), %r15; \
-	roll	$13, %r15d; \
-	xorq	%r15, %r10; \
-	leaq	(%r11, %r10), %r15; \
-	roll	$18, %r15d; \
-	xorq	%r15, %rbp; \
-	movq	88(%rsp), %r15; \
-	movq	%rbp, 48(%rsp); \
-	leaq	(%rbx, %r15), %rbp; \
-	roll	$7, %ebp; \
-	xorq	%rbp, %r14; \
-	leaq	(%r15, %r14), %rbp; \
-	roll	$9, %ebp; \
-	xorq	%rbp, %r13; \
-	leaq	(%r14, %r13), %rbp; \
-	roll	$13, %ebp; \
-	xorq	%rbp, %rbx; \
-	leaq	(%r13, %rbx), %rbp; \
-	roll	$18, %ebp; \
-	xorq	%rbp, %r15; \
-	movq	%r15, 88(%rsp); \
-
+.macro salsa8_core_gen_doubleround
+	movq	72(%rsp), %r15
+	
+	leaq	(%r14, %rdx), %rbp
+	roll	$7, %ebp
+	xorl	%ebp, %r9d
+	leaq	(%rdi, %r15), %rbp
+	roll	$7, %ebp
+	xorl	%ebp, %r10d
+	leaq	(%rdx, %r9), %rbp
+	roll	$9, %ebp
+	xorl	%ebp, %r11d
+	leaq	(%r15, %r10), %rbp
+	roll	$9, %ebp
+	xorl	%ebp, %r13d
+	
+	leaq	(%r9, %r11), %rbp
+	roll	$13, %ebp
+	xorl	%ebp, %r14d
+	leaq	(%r10, %r13), %rbp
+	roll	$13, %ebp
+	xorl	%ebp, %edi
+	leaq	(%r11, %r14), %rbp
+	roll	$18, %ebp
+	xorl	%ebp, %edx
+	leaq	(%r13, %rdi), %rbp
+	roll	$18, %ebp
+	xorl	%ebp, %r15d
+	
+	movq	48(%rsp), %rbp
+	movq	%r15, 72(%rsp)
+	
+	leaq	(%rax, %rbp), %r15
+	roll	$7, %r15d
+	xorl	%r15d, %ebx
+	leaq	(%rbp, %rbx), %r15
+	roll	$9, %r15d
+	xorl	%r15d, %ecx
+	leaq	(%rbx, %rcx), %r15
+	roll	$13, %r15d
+	xorl	%r15d, %eax
+	leaq	(%rcx, %rax), %r15
+	roll	$18, %r15d
+	xorl	%r15d, %ebp
+	
+	movq	88(%rsp), %r15
+	movq	%rbp, 48(%rsp)
+	
+	leaq	(%r12, %r15), %rbp
+	roll	$7, %ebp
+	xorl	%ebp, %esi
+	leaq	(%r15, %rsi), %rbp
+	roll	$9, %ebp
+	xorl	%ebp, %r8d
+	leaq	(%rsi, %r8), %rbp
+	roll	$13, %ebp
+	xorl	%ebp, %r12d
+	leaq	(%r8, %r12), %rbp
+	roll	$18, %ebp
+	xorl	%ebp, %r15d
+	
+	movq	%r15, 88(%rsp)
+	movq	72(%rsp), %r15
+	
+	leaq	(%rsi, %rdx), %rbp
+	roll	$7, %ebp
+	xorl	%ebp, %edi
+	leaq	(%r9, %r15), %rbp
+	roll	$7, %ebp
+	xorl	%ebp, %eax
+	leaq	(%rdx, %rdi), %rbp
+	roll	$9, %ebp
+	xorl	%ebp, %ecx
+	leaq	(%r15, %rax), %rbp
+	roll	$9, %ebp
+	xorl	%ebp, %r8d
+	
+	leaq	(%rdi, %rcx), %rbp
+	roll	$13, %ebp
+	xorl	%ebp, %esi
+	leaq	(%rax, %r8), %rbp
+	roll	$13, %ebp
+	xorl	%ebp, %r9d
+	leaq	(%rcx, %rsi), %rbp
+	roll	$18, %ebp
+	xorl	%ebp, %edx
+	leaq	(%r8, %r9), %rbp
+	roll	$18, %ebp
+	xorl	%ebp, %r15d
+	
+	movq	48(%rsp), %rbp
+	movq	%r15, 72(%rsp)
+	
+	leaq	(%r10, %rbp), %r15
+	roll	$7, %r15d
+	xorl	%r15d, %r12d
+	leaq	(%rbp, %r12), %r15
+	roll	$9, %r15d
+	xorl	%r15d, %r11d
+	leaq	(%r12, %r11), %r15
+	roll	$13, %r15d
+	xorl	%r15d, %r10d
+	leaq	(%r11, %r10), %r15
+	roll	$18, %r15d
+	xorl	%r15d, %ebp
+	
+	movq	88(%rsp), %r15
+	movq	%rbp, 48(%rsp)
+	
+	leaq	(%rbx, %r15), %rbp
+	roll	$7, %ebp
+	xorl	%ebp, %r14d
+	leaq	(%r15, %r14), %rbp
+	roll	$9, %ebp
+	xorl	%ebp, %r13d
+	leaq	(%r14, %r13), %rbp
+	roll	$13, %ebp
+	xorl	%ebp, %ebx
+	leaq	(%r13, %rbx), %rbp
+	roll	$18, %ebp
+	xorl	%ebp, %r15d
+	
+	movq	%r15, 88(%rsp)
+.endm
 
 	.text
-	.align 32
-gen_salsa8_core:
-	# 0: %rdx, %rdi, %rcx, %rsi
+	.p2align 6
+salsa8_core_gen:
+	/* 0: %rdx, %rdi, %rcx, %rsi */
 	movq	8(%rsp), %rdi
 	movq	%rdi, %rdx
 	shrq	$32, %rdi
 	movq	16(%rsp), %rsi
 	movq	%rsi, %rcx
 	shrq	$32, %rsi
-	# 1: %r9, 72(%rsp), %rax, %r8
+	/* 1: %r9, 72(%rsp), %rax, %r8 */
 	movq	24(%rsp), %r8
 	movq	%r8, %r9
 	shrq	$32, %r8
@@ -193,15 +290,15 @@ gen_salsa8_core:
 	movq	32(%rsp), %r8
 	movq	%r8, %rax
 	shrq	$32, %r8
-	# 2: %r11, %r10, 48(%rsp), %r12
+	/* 2: %r11, %r10, 48(%rsp), %r12 */
 	movq	40(%rsp), %r10
 	movq	%r10, %r11
 	shrq	$32, %r10
 	movq	48(%rsp), %r12
-	#movq	%r12, %r13
-	#movq	%r13, 48(%rsp)
+	/* movq	%r12, %r13 */
+	/* movq	%r13, 48(%rsp) */
 	shrq	$32, %r12
-	# 3: %r14, %r13, %rbx, 88(%rsp)
+	/* 3: %r14, %r13, %rbx, 88(%rsp) */
 	movq	56(%rsp), %r13
 	movq	%r13, %r14
 	shrq	$32, %r13
@@ -209,73 +306,57 @@ gen_salsa8_core:
 	movq	%r15, %rbx
 	shrq	$32, %r15
 	movq	%r15, 88(%rsp)
-
-	gen_salsa8_core_doubleround()
-	gen_salsa8_core_doubleround()
-	gen_salsa8_core_doubleround()
-	gen_salsa8_core_doubleround()
-
-	movl	%edx, %edx
+	
+	salsa8_core_gen_doubleround
+	salsa8_core_gen_doubleround
+	salsa8_core_gen_doubleround
+	salsa8_core_gen_doubleround
+	
 	shlq	$32, %rdi
-	addq	%rdi, %rdx
-	movd	%rdx, %xmm0
-
-	movl	%ecx, %ecx
+	xorq	%rdi, %rdx
+	movq	%rdx, 24(%rsp)
+	
 	shlq	$32, %rsi
-	addq	%rsi, %rcx
-	movd	%rcx, %xmm4
-
-	movq	72(%rsp), %rdi
-	movl	%r9d, %r9d
+	xorq	%rsi, %rcx
+	movq	%rcx, 32(%rsp)
+	
+	movl	72(%rsp), %edi
 	shlq	$32, %rdi
-	addq	%rdi, %r9
-	movd	%r9, %xmm1
-
-	movl	%eax, %eax
+	xorq	%rdi, %r9
+	movq	%r9, 40(%rsp)
+	
+	movl	48(%rsp), %ebp
 	shlq	$32, %r8
-	addq	%r8, %rax
-	movd	%rax, %xmm5
-
-	movl	%r11d, %r11d
+	xorq	%r8, %rax
+	movq	%rax, 48(%rsp)
+	
 	shlq	$32, %r10
-	addq	%r10, %r11
-	movd	%r11, %xmm2
-
-	movl	48(%rsp), %r8d
+	xorq	%r10, %r11
+	movq	%r11, 56(%rsp)
+	
 	shlq	$32, %r12
-	addq	%r12, %r8
-	movd	%r8, %xmm6
-
-	movl	%r14d, %r14d
+	xorq	%r12, %rbp
+	movq	%rbp, 64(%rsp)
+	
 	shlq	$32, %r13
-	addq	%r13, %r14
-	movd	%r14, %xmm3
-
-	movq	88(%rsp), %rdi
-	movl	%ebx, %ebx
-	shlq	$32, %rdi
-	addq	%rdi, %rbx
-	movd	%rbx, %xmm7
-
-	punpcklqdq	%xmm4, %xmm0
-	punpcklqdq	%xmm5, %xmm1
-	punpcklqdq	%xmm6, %xmm2
-	punpcklqdq	%xmm7, %xmm3
-
-	#movq	%rdx, 8(%rsp)
-	#movq	%rcx, 16(%rsp)
-	#movq	%r9, 24(%rsp)
-	#movq	%rax, 32(%rsp)
-	#movq	%r11, 40(%rsp)
-	#movq	%r8, 48(%rsp)
-	#movq	%r14, 56(%rsp)
-	#movq	%rbx, 64(%rsp)
-
+	xorq	%r13, %r14
+	movq	%r14, 72(%rsp)
+	
+	movdqa	24(%rsp), %xmm0
+	
+	shlq	$32, %r15
+	xorq	%r15, %rbx
+	movq	%rbx, 80(%rsp)
+	
+	movdqa	40(%rsp), %xmm1
+	movdqa	56(%rsp), %xmm2
+	movdqa	72(%rsp), %xmm3
+	
 	ret
-
-
+	
+	
 	.text
-	.align 32
+	.p2align 6
 	.globl scrypt_core
 	.globl _scrypt_core
 scrypt_core:
@@ -286,7 +367,7 @@ _scrypt_core:
 	pushq	%r13
 	pushq	%r14
 	pushq	%r15
-#if defined(WIN64)
+#if defined(_WIN64) || defined(__CYGWIN__)
 	subq	$176, %rsp
 	movdqa	%xmm6, 8(%rsp)
 	movdqa	%xmm7, 24(%rsp)
@@ -302,28 +383,46 @@ _scrypt_core:
 	pushq	%rsi
 	movq	%rcx, %rdi
 	movq	%rdx, %rsi
+#else
+	movq	%rdx, %r8
 #endif
 
-#define scrypt_core_cleanup() \
-	popq	%r15; \
-	popq	%r14; \
-	popq	%r13; \
-	popq	%r12; \
-	popq	%rbp; \
-	popq	%rbx; \
-
-
-	# GenuineIntel processors have fast SIMD
+.macro scrypt_core_cleanup
+#if defined(_WIN64) || defined(__CYGWIN__)
+	popq	%rsi
+	popq	%rdi
+	movdqa	8(%rsp), %xmm6
+	movdqa	24(%rsp), %xmm7
+	movdqa	40(%rsp), %xmm8
+	movdqa	56(%rsp), %xmm9
+	movdqa	72(%rsp), %xmm10
+	movdqa	88(%rsp), %xmm11
+	movdqa	104(%rsp), %xmm12
+	movdqa	120(%rsp), %xmm13
+	movdqa	136(%rsp), %xmm14
+	movdqa	152(%rsp), %xmm15
+	addq	$176, %rsp
+#endif
+	popq	%r15
+	popq	%r14
+	popq	%r13
+	popq	%r12
+	popq	%rbp
+	popq	%rbx
+.endm
+	
+	/* GenuineIntel processors have fast SIMD */
 	xorl	%eax, %eax
 	cpuid
 	cmpl	$0x6c65746e, %ecx
-	jne gen_scrypt_core
+	jne scrypt_core_gen
 	cmpl	$0x49656e69, %edx
-	jne gen_scrypt_core
+	jne scrypt_core_gen
 	cmpl	$0x756e6547, %ebx
-	je xmm_scrypt_core
-
-gen_scrypt_core:
+	je scrypt_core_xmm
+	
+	.p2align 6
+scrypt_core_gen:
 	subq	$136, %rsp
 	movdqa	0(%rdi), %xmm8
 	movdqa	16(%rdi), %xmm9
@@ -333,12 +432,15 @@ gen_scrypt_core:
 	movdqa	80(%rdi), %xmm13
 	movdqa	96(%rdi), %xmm14
 	movdqa	112(%rdi), %xmm15
-
-	leaq	131072(%rsi), %rcx
+	
+	movq	%r8, %rcx
+	shlq	$7, %rcx
+	addq	%rsi, %rcx
+	movq	%r8, 96(%rsp)
 	movq	%rdi, 104(%rsp)
 	movq	%rsi, 112(%rsp)
 	movq	%rcx, 120(%rsp)
-gen_scrypt_core_loop1:
+scrypt_core_gen_loop1:
 	movdqa	%xmm8, 0(%rsi)
 	movdqa	%xmm9, 16(%rsi)
 	movdqa	%xmm10, 32(%rsi)
@@ -347,7 +449,7 @@ gen_scrypt_core_loop1:
 	movdqa	%xmm13, 80(%rsi)
 	movdqa	%xmm14, 96(%rsi)
 	movdqa	%xmm15, 112(%rsi)
-
+	
 	pxor	%xmm12, %xmm8
 	pxor	%xmm13, %xmm9
 	pxor	%xmm14, %xmm10
@@ -357,12 +459,12 @@ gen_scrypt_core_loop1:
 	movdqa	%xmm10, 32(%rsp)
 	movdqa	%xmm11, 48(%rsp)
 	movq	%rsi, 128(%rsp)
-	call gen_salsa8_core
+	call salsa8_core_gen
 	paddd	%xmm0, %xmm8
 	paddd	%xmm1, %xmm9
 	paddd	%xmm2, %xmm10
 	paddd	%xmm3, %xmm11
-
+	
 	pxor	%xmm8, %xmm12
 	pxor	%xmm9, %xmm13
 	pxor	%xmm10, %xmm14
@@ -371,32 +473,36 @@ gen_scrypt_core_loop1:
 	movdqa	%xmm13, 16(%rsp)
 	movdqa	%xmm14, 32(%rsp)
 	movdqa	%xmm15, 48(%rsp)
-	call gen_salsa8_core
+	call salsa8_core_gen
 	movq	128(%rsp), %rsi
 	paddd	%xmm0, %xmm12
 	paddd	%xmm1, %xmm13
 	paddd	%xmm2, %xmm14
 	paddd	%xmm3, %xmm15
-
+	
 	addq	$128, %rsi
 	movq	120(%rsp), %rcx
 	cmpq	%rcx, %rsi
-	jne gen_scrypt_core_loop1
-
-	movq	$1024, %rcx
-gen_scrypt_core_loop2:
-	movq	112(%rsp), %rsi
+	jne scrypt_core_gen_loop1
+	
+	movq	96(%rsp), %r8
+	movq	%r8, %rcx
+	subl	$1, %r8d
+	movq	%r8, 96(%rsp)
 	movd	%xmm12, %edx
-	andl	$1023, %edx
+scrypt_core_gen_loop2:
+	movq	112(%rsp), %rsi
+	andl	%r8d, %edx
 	shll	$7, %edx
-	movdqa	0(%rsi, %rdx), %xmm0
-	movdqa	16(%rsi, %rdx), %xmm1
-	movdqa	32(%rsi, %rdx), %xmm2
-	movdqa	48(%rsi, %rdx), %xmm3
-	movdqa	64(%rsi, %rdx), %xmm4
-	movdqa	80(%rsi, %rdx), %xmm5
-	movdqa	96(%rsi, %rdx), %xmm6
-	movdqa	112(%rsi, %rdx), %xmm7
+	addq	%rsi, %rdx
+	movdqa	0(%rdx), %xmm0
+	movdqa	16(%rdx), %xmm1
+	movdqa	32(%rdx), %xmm2
+	movdqa	48(%rdx), %xmm3
+	movdqa	64(%rdx), %xmm4
+	movdqa	80(%rdx), %xmm5
+	movdqa	96(%rdx), %xmm6
+	movdqa	112(%rdx), %xmm7
 	pxor	%xmm0, %xmm8
 	pxor	%xmm1, %xmm9
 	pxor	%xmm2, %xmm10
@@ -405,7 +511,7 @@ gen_scrypt_core_loop2:
 	pxor	%xmm5, %xmm13
 	pxor	%xmm6, %xmm14
 	pxor	%xmm7, %xmm15
-
+	
 	pxor	%xmm12, %xmm8
 	pxor	%xmm13, %xmm9
 	pxor	%xmm14, %xmm10
@@ -415,12 +521,12 @@ gen_scrypt_core_loop2:
 	movdqa	%xmm10, 32(%rsp)
 	movdqa	%xmm11, 48(%rsp)
 	movq	%rcx, 128(%rsp)
-	call gen_salsa8_core
+	call salsa8_core_gen
 	paddd	%xmm0, %xmm8
 	paddd	%xmm1, %xmm9
 	paddd	%xmm2, %xmm10
 	paddd	%xmm3, %xmm11
-
+	
 	pxor	%xmm8, %xmm12
 	pxor	%xmm9, %xmm13
 	pxor	%xmm10, %xmm14
@@ -429,16 +535,18 @@ gen_scrypt_core_loop2:
 	movdqa	%xmm13, 16(%rsp)
 	movdqa	%xmm14, 32(%rsp)
 	movdqa	%xmm15, 48(%rsp)
-	call gen_salsa8_core
+	call salsa8_core_gen
+	movq	96(%rsp), %r8
 	movq	128(%rsp), %rcx
+	addl	0(%rsp), %edx
 	paddd	%xmm0, %xmm12
 	paddd	%xmm1, %xmm13
 	paddd	%xmm2, %xmm14
 	paddd	%xmm3, %xmm15
-
+	
 	subq	$1, %rcx
-	ja gen_scrypt_core_loop2
-
+	ja scrypt_core_gen_loop2
+	
 	movq	104(%rsp), %rdi
 	movdqa	%xmm8, 0(%rdi)
 	movdqa	%xmm9, 16(%rdi)
@@ -448,205 +556,157 @@ gen_scrypt_core_loop2:
 	movdqa	%xmm13, 80(%rdi)
 	movdqa	%xmm14, 96(%rdi)
 	movdqa	%xmm15, 112(%rdi)
-
+	
 	addq	$136, %rsp
-	scrypt_core_cleanup()
+	scrypt_core_cleanup
 	ret
 
 
-#define xmm_salsa8_core_doubleround() \
-	movdqa	%xmm1, %xmm4; \
-	paddd	%xmm0, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$7, %xmm4; \
-	psrld	$25, %xmm5; \
-	pxor	%xmm4, %xmm3; \
-	pxor	%xmm5, %xmm3; \
-	movdqa	%xmm0, %xmm4; \
-	paddd	%xmm3, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$9, %xmm4; \
-	psrld	$23, %xmm5; \
-	pxor	%xmm4, %xmm2; \
-	movdqa	%xmm3, %xmm4; \
-	pshufd	$0x93, %xmm3, %xmm3; \
-	pxor	%xmm5, %xmm2; \
-	paddd	%xmm2, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$13, %xmm4; \
-	psrld	$19, %xmm5; \
-	pxor	%xmm4, %xmm1; \
-	movdqa	%xmm2, %xmm4; \
-	pshufd	$0x4e, %xmm2, %xmm2; \
-	pxor	%xmm5, %xmm1; \
-	paddd	%xmm1, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$18, %xmm4; \
-	psrld	$14, %xmm5; \
-	pxor	%xmm4, %xmm0; \
-	pshufd	$0x39, %xmm1, %xmm1; \
-	pxor	%xmm5, %xmm0; \
-	movdqa	%xmm3, %xmm4; \
-	paddd	%xmm0, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$7, %xmm4; \
-	psrld	$25, %xmm5; \
-	pxor	%xmm4, %xmm1; \
-	pxor	%xmm5, %xmm1; \
-	movdqa	%xmm0, %xmm4; \
-	paddd	%xmm1, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$9, %xmm4; \
-	psrld	$23, %xmm5; \
-	pxor	%xmm4, %xmm2; \
-	movdqa	%xmm1, %xmm4; \
-	pshufd	$0x93, %xmm1, %xmm1; \
-	pxor	%xmm5, %xmm2; \
-	paddd	%xmm2, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$13, %xmm4; \
-	psrld	$19, %xmm5; \
-	pxor	%xmm4, %xmm3; \
-	movdqa	%xmm2, %xmm4; \
-	pshufd	$0x4e, %xmm2, %xmm2; \
-	pxor	%xmm5, %xmm3; \
-	paddd	%xmm3, %xmm4; \
-	movdqa	%xmm4, %xmm5; \
-	pslld	$18, %xmm4; \
-	psrld	$14, %xmm5; \
-	pxor	%xmm4, %xmm0; \
-	pshufd	$0x39, %xmm3, %xmm3; \
-	pxor	%xmm5, %xmm0; \
-
-
-#define xmm_salsa8_core() \
-	xmm_salsa8_core_doubleround(); \
-	xmm_salsa8_core_doubleround(); \
-	xmm_salsa8_core_doubleround(); \
-	xmm_salsa8_core_doubleround(); \
-
-
-	.align 32
-xmm_scrypt_core:
-	# shuffle 1st block into %xmm8-%xmm11
-	movl	60(%rdi), %edx
-	movl	44(%rdi), %ecx
-	movl	28(%rdi), %ebx
-	movl	12(%rdi), %eax
-	movd	%edx, %xmm0
-	movd	%ecx, %xmm1
-	movd	%ebx, %xmm2
-	movd	%eax, %xmm3
-	movl	40(%rdi), %ecx
-	movl	24(%rdi), %ebx
-	movl	8(%rdi), %eax
-	movl	56(%rdi), %edx
-	pshufd	$0x93, %xmm0, %xmm0
-	pshufd	$0x93, %xmm1, %xmm1
-	pshufd	$0x93, %xmm2, %xmm2
+.macro salsa8_core_xmm_doubleround
+	movdqa	%xmm1, %xmm4
+	paddd	%xmm0, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$7, %xmm4
+	psrld	$25, %xmm5
+	pxor	%xmm4, %xmm3
+	movdqa	%xmm0, %xmm4
+	pxor	%xmm5, %xmm3
+	
+	paddd	%xmm3, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$9, %xmm4
+	psrld	$23, %xmm5
+	pxor	%xmm4, %xmm2
+	movdqa	%xmm3, %xmm4
+	pxor	%xmm5, %xmm2
 	pshufd	$0x93, %xmm3, %xmm3
-	movd	%ecx, %xmm4
-	movd	%ebx, %xmm5
-	movd	%eax, %xmm6
-	movd	%edx, %xmm7
-	paddd	%xmm4, %xmm0
-	paddd	%xmm5, %xmm1
-	paddd	%xmm6, %xmm2
-	paddd	%xmm7, %xmm3
-	movl	20(%rdi), %ebx
-	movl	4(%rdi), %eax
-	movl	52(%rdi), %edx
-	movl	36(%rdi), %ecx
-	pshufd	$0x93, %xmm0, %xmm0
+	
+	paddd	%xmm2, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$13, %xmm4
+	psrld	$19, %xmm5
+	pxor	%xmm4, %xmm1
+	movdqa	%xmm2, %xmm4
+	pxor	%xmm5, %xmm1
+	pshufd	$0x4e, %xmm2, %xmm2
+	
+	paddd	%xmm1, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$18, %xmm4
+	psrld	$14, %xmm5
+	pxor	%xmm4, %xmm0
+	movdqa	%xmm3, %xmm4
+	pxor	%xmm5, %xmm0
+	pshufd	$0x39, %xmm1, %xmm1
+	
+	paddd	%xmm0, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$7, %xmm4
+	psrld	$25, %xmm5
+	pxor	%xmm4, %xmm1
+	movdqa	%xmm0, %xmm4
+	pxor	%xmm5, %xmm1
+	
+	paddd	%xmm1, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$9, %xmm4
+	psrld	$23, %xmm5
+	pxor	%xmm4, %xmm2
+	movdqa	%xmm1, %xmm4
+	pxor	%xmm5, %xmm2
 	pshufd	$0x93, %xmm1, %xmm1
-	pshufd	$0x93, %xmm2, %xmm2
-	pshufd	$0x93, %xmm3, %xmm3
-	movd	%ebx, %xmm4
-	movd	%eax, %xmm5
-	movd	%edx, %xmm6
-	movd	%ecx, %xmm7
-	paddd	%xmm4, %xmm0
-	paddd	%xmm5, %xmm1
-	paddd	%xmm6, %xmm2
-	paddd	%xmm7, %xmm3
-	movl	0(%rdi), %eax
-	movl	48(%rdi), %edx
-	movl	32(%rdi), %ecx
-	movl	16(%rdi), %ebx
-	pshufd	$0x93, %xmm0, %xmm0
-	pshufd	$0x93, %xmm1, %xmm1
-	pshufd	$0x93, %xmm2, %xmm2
-	pshufd	$0x93, %xmm3, %xmm3
-	movd	%eax, %xmm8
-	movd	%edx, %xmm9
-	movd	%ecx, %xmm10
-	movd	%ebx, %xmm11
-	paddd	%xmm0, %xmm8
-	paddd	%xmm1, %xmm9
-	paddd	%xmm2, %xmm10
-	paddd	%xmm3, %xmm11
+	
+	paddd	%xmm2, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$13, %xmm4
+	psrld	$19, %xmm5
+	pxor	%xmm4, %xmm3
+	movdqa	%xmm2, %xmm4
+	pxor	%xmm5, %xmm3
+	pshufd	$0x4e, %xmm2, %xmm2
+	
+	paddd	%xmm3, %xmm4
+	movdqa	%xmm4, %xmm5
+	pslld	$18, %xmm4
+	psrld	$14, %xmm5
+	pxor	%xmm4, %xmm0
+	pshufd	$0x39, %xmm3, %xmm3
+	pxor	%xmm5, %xmm0
+.endm
 
-	# shuffle 2nd block into %xmm12-%xmm15
-	movl	124(%rdi), %edx
-	movl	108(%rdi), %ecx
-	movl	92(%rdi), %ebx
-	movl	76(%rdi), %eax
-	movd	%edx, %xmm0
-	movd	%ecx, %xmm1
-	movd	%ebx, %xmm2
-	movd	%eax, %xmm3
-	movl	104(%rdi), %ecx
-	movl	88(%rdi), %ebx
-	movl	72(%rdi), %eax
-	movl	120(%rdi), %edx
-	pshufd	$0x93, %xmm0, %xmm0
-	pshufd	$0x93, %xmm1, %xmm1
-	pshufd	$0x93, %xmm2, %xmm2
-	pshufd	$0x93, %xmm3, %xmm3
-	movd	%ecx, %xmm4
-	movd	%ebx, %xmm5
-	movd	%eax, %xmm6
-	movd	%edx, %xmm7
-	paddd	%xmm4, %xmm0
-	paddd	%xmm5, %xmm1
-	paddd	%xmm6, %xmm2
-	paddd	%xmm7, %xmm3
-	movl	84(%rdi), %ebx
-	movl	68(%rdi), %eax
-	movl	116(%rdi), %edx
-	movl	100(%rdi), %ecx
-	pshufd	$0x93, %xmm0, %xmm0
-	pshufd	$0x93, %xmm1, %xmm1
-	pshufd	$0x93, %xmm2, %xmm2
-	pshufd	$0x93, %xmm3, %xmm3
-	movd	%ebx, %xmm4
-	movd	%eax, %xmm5
-	movd	%edx, %xmm6
-	movd	%ecx, %xmm7
-	paddd	%xmm4, %xmm0
-	paddd	%xmm5, %xmm1
-	paddd	%xmm6, %xmm2
-	paddd	%xmm7, %xmm3
-	movl	64(%rdi), %eax
-	movl	112(%rdi), %edx
-	movl	96(%rdi), %ecx
-	movl	80(%rdi), %ebx
-	pshufd	$0x93, %xmm0, %xmm0
-	pshufd	$0x93, %xmm1, %xmm1
-	pshufd	$0x93, %xmm2, %xmm2
-	pshufd	$0x93, %xmm3, %xmm3
-	movd	%eax, %xmm12
-	movd	%edx, %xmm13
-	movd	%ecx, %xmm14
-	movd	%ebx, %xmm15
-	paddd	%xmm0, %xmm12
-	paddd	%xmm1, %xmm13
-	paddd	%xmm2, %xmm14
-	paddd	%xmm3, %xmm15
-
+.macro salsa8_core_xmm
+	salsa8_core_xmm_doubleround
+	salsa8_core_xmm_doubleround
+	salsa8_core_xmm_doubleround
+	salsa8_core_xmm_doubleround
+.endm
+	
+	.p2align 6
+scrypt_core_xmm:
+	pcmpeqw	%xmm1, %xmm1
+	psrlq	$32, %xmm1
+	
+	movdqa	0(%rdi), %xmm8
+	movdqa	16(%rdi), %xmm11
+	movdqa	32(%rdi), %xmm10
+	movdqa	48(%rdi), %xmm9
+	movdqa	%xmm8, %xmm0
+	pxor	%xmm11, %xmm8
+	pand	%xmm1, %xmm8
+	pxor	%xmm11, %xmm8
+	pxor	%xmm10, %xmm11
+	pand	%xmm1, %xmm11
+	pxor	%xmm10, %xmm11
+	pxor	%xmm9, %xmm10
+	pand	%xmm1, %xmm10
+	pxor	%xmm9, %xmm10
+	pxor	%xmm0, %xmm9
+	pand	%xmm1, %xmm9
+	pxor	%xmm0, %xmm9
+	movdqa	%xmm8, %xmm0
+	pshufd	$0x4e, %xmm10, %xmm10
+	punpcklqdq	%xmm10, %xmm8
+	punpckhqdq	%xmm0, %xmm10
+	movdqa	%xmm11, %xmm0
+	pshufd	$0x4e, %xmm9, %xmm9
+	punpcklqdq	%xmm9, %xmm11
+	punpckhqdq	%xmm0, %xmm9
+	
+	movdqa	64(%rdi), %xmm12
+	movdqa	80(%rdi), %xmm15
+	movdqa	96(%rdi), %xmm14
+	movdqa	112(%rdi), %xmm13
+	movdqa	%xmm12, %xmm0
+	pxor	%xmm15, %xmm12
+	pand	%xmm1, %xmm12
+	pxor	%xmm15, %xmm12
+	pxor	%xmm14, %xmm15
+	pand	%xmm1, %xmm15
+	pxor	%xmm14, %xmm15
+	pxor	%xmm13, %xmm14
+	pand	%xmm1, %xmm14
+	pxor	%xmm13, %xmm14
+	pxor	%xmm0, %xmm13
+	pand	%xmm1, %xmm13
+	pxor	%xmm0, %xmm13
+	movdqa	%xmm12, %xmm0
+	pshufd	$0x4e, %xmm14, %xmm14
+	punpcklqdq	%xmm14, %xmm12
+	punpckhqdq	%xmm0, %xmm14
+	movdqa	%xmm15, %xmm0
+	pshufd	$0x4e, %xmm13, %xmm13
+	punpcklqdq	%xmm13, %xmm15
+	punpckhqdq	%xmm0, %xmm13
+	
 	movq	%rsi, %rdx
-	leaq	131072(%rsi), %rcx
-xmm_scrypt_core_loop1:
+	movq	%r8, %rcx
+	shlq	$7, %rcx
+	addq	%rsi, %rcx
+scrypt_core_xmm_loop1:
+	pxor	%xmm12, %xmm8
+	pxor	%xmm13, %xmm9
+	pxor	%xmm14, %xmm10
+	pxor	%xmm15, %xmm11
 	movdqa	%xmm8, 0(%rdx)
 	movdqa	%xmm9, 16(%rdx)
 	movdqa	%xmm10, 32(%rdx)
@@ -655,21 +715,17 @@ xmm_scrypt_core_loop1:
 	movdqa	%xmm13, 80(%rdx)
 	movdqa	%xmm14, 96(%rdx)
 	movdqa	%xmm15, 112(%rdx)
-
-	pxor	%xmm12, %xmm8
-	pxor	%xmm13, %xmm9
-	pxor	%xmm14, %xmm10
-	pxor	%xmm15, %xmm11
+	
 	movdqa	%xmm8, %xmm0
 	movdqa	%xmm9, %xmm1
 	movdqa	%xmm10, %xmm2
 	movdqa	%xmm11, %xmm3
-	xmm_salsa8_core()
+	salsa8_core_xmm
 	paddd	%xmm0, %xmm8
 	paddd	%xmm1, %xmm9
 	paddd	%xmm2, %xmm10
 	paddd	%xmm3, %xmm11
-
+	
 	pxor	%xmm8, %xmm12
 	pxor	%xmm9, %xmm13
 	pxor	%xmm10, %xmm14
@@ -678,38 +734,27 @@ xmm_scrypt_core_loop1:
 	movdqa	%xmm13, %xmm1
 	movdqa	%xmm14, %xmm2
 	movdqa	%xmm15, %xmm3
-	xmm_salsa8_core()
+	salsa8_core_xmm
 	paddd	%xmm0, %xmm12
 	paddd	%xmm1, %xmm13
 	paddd	%xmm2, %xmm14
 	paddd	%xmm3, %xmm15
-
+	
 	addq	$128, %rdx
 	cmpq	%rcx, %rdx
-	jne xmm_scrypt_core_loop1
-
-	movq	$1024, %rcx
-xmm_scrypt_core_loop2:
+	jne scrypt_core_xmm_loop1
+	
+	movq	%r8, %rcx
+	subl	$1, %r8d
+scrypt_core_xmm_loop2:
 	movd	%xmm12, %edx
-	andl	$1023, %edx
+	andl	%r8d, %edx
 	shll	$7, %edx
-	movdqa	0(%rsi, %rdx), %xmm0
-	movdqa	16(%rsi, %rdx), %xmm1
-	movdqa	32(%rsi, %rdx), %xmm2
-	movdqa	48(%rsi, %rdx), %xmm3
-	movdqa	64(%rsi, %rdx), %xmm4
-	movdqa	80(%rsi, %rdx), %xmm5
-	movdqa	96(%rsi, %rdx), %xmm6
-	movdqa	112(%rsi, %rdx), %xmm7
-	pxor	%xmm0, %xmm8
-	pxor	%xmm1, %xmm9
-	pxor	%xmm2, %xmm10
-	pxor	%xmm3, %xmm11
-	pxor	%xmm4, %xmm12
-	pxor	%xmm5, %xmm13
-	pxor	%xmm6, %xmm14
-	pxor	%xmm7, %xmm15
-
+	pxor	0(%rsi, %rdx), %xmm8
+	pxor	16(%rsi, %rdx), %xmm9
+	pxor	32(%rsi, %rdx), %xmm10
+	pxor	48(%rsi, %rdx), %xmm11
+	
 	pxor	%xmm12, %xmm8
 	pxor	%xmm13, %xmm9
 	pxor	%xmm14, %xmm10
@@ -718,12 +763,16 @@ xmm_scrypt_core_loop2:
 	movdqa	%xmm9, %xmm1
 	movdqa	%xmm10, %xmm2
 	movdqa	%xmm11, %xmm3
-	xmm_salsa8_core()
+	salsa8_core_xmm
 	paddd	%xmm0, %xmm8
 	paddd	%xmm1, %xmm9
 	paddd	%xmm2, %xmm10
 	paddd	%xmm3, %xmm11
-
+	
+	pxor	64(%rsi, %rdx), %xmm12
+	pxor	80(%rsi, %rdx), %xmm13
+	pxor	96(%rsi, %rdx), %xmm14
+	pxor	112(%rsi, %rdx), %xmm15
 	pxor	%xmm8, %xmm12
 	pxor	%xmm9, %xmm13
 	pxor	%xmm10, %xmm14
@@ -732,112 +781,263 @@ xmm_scrypt_core_loop2:
 	movdqa	%xmm13, %xmm1
 	movdqa	%xmm14, %xmm2
 	movdqa	%xmm15, %xmm3
-	xmm_salsa8_core()
+	salsa8_core_xmm
 	paddd	%xmm0, %xmm12
 	paddd	%xmm1, %xmm13
 	paddd	%xmm2, %xmm14
 	paddd	%xmm3, %xmm15
-
+	
 	subq	$1, %rcx
-	ja xmm_scrypt_core_loop2
-
-	# re-shuffle 1st block back
-	movd	%xmm8, %eax
-	movd	%xmm9, %edx
-	movd	%xmm10, %ecx
-	movd	%xmm11, %ebx
-	pshufd	$0x39, %xmm8, %xmm8
-	pshufd	$0x39, %xmm9, %xmm9
-	pshufd	$0x39, %xmm10, %xmm10
-	pshufd	$0x39, %xmm11, %xmm11
-	movl	%eax, 0(%rdi)
-	movl	%edx, 48(%rdi)
-	movl	%ecx, 32(%rdi)
-	movl	%ebx, 16(%rdi)
-	movd	%xmm8, %ebx
-	movd	%xmm9, %eax
-	movd	%xmm10, %edx
-	movd	%xmm11, %ecx
-	pshufd	$0x39, %xmm8, %xmm8
-	pshufd	$0x39, %xmm9, %xmm9
-	pshufd	$0x39, %xmm10, %xmm10
-	pshufd	$0x39, %xmm11, %xmm11
-	movl	%ebx, 20(%rdi)
-	movl	%eax, 4(%rdi)
-	movl	%edx, 52(%rdi)
-	movl	%ecx, 36(%rdi)
-	movd	%xmm8, %ecx
-	movd	%xmm9, %ebx
-	movd	%xmm10, %eax
-	movd	%xmm11, %edx
-	pshufd	$0x39, %xmm8, %xmm8
-	pshufd	$0x39, %xmm9, %xmm9
-	pshufd	$0x39, %xmm10, %xmm10
-	pshufd	$0x39, %xmm11, %xmm11
-	movl	%ecx, 40(%rdi)
-	movl	%ebx, 24(%rdi)
-	movl	%eax, 8(%rdi)
-	movl	%edx, 56(%rdi)
-	movd	%xmm8, %edx
-	movd	%xmm9, %ecx
-	movd	%xmm10, %ebx
-	movd	%xmm11, %eax
-	movl	%edx, 60(%rdi)
-	movl	%ecx, 44(%rdi)
-	movl	%ebx, 28(%rdi)
-	movl	%eax, 12(%rdi)
-
-	# re-shuffle 2nd block back
-	movd	%xmm12, %eax
-	movd	%xmm13, %edx
-	movd	%xmm14, %ecx
-	movd	%xmm15, %ebx
-	pshufd	$0x39, %xmm12, %xmm12
-	pshufd	$0x39, %xmm13, %xmm13
-	pshufd	$0x39, %xmm14, %xmm14
-	pshufd	$0x39, %xmm15, %xmm15
-	movl	%eax, 64(%rdi)
-	movl	%edx, 112(%rdi)
-	movl	%ecx, 96(%rdi)
-	movl	%ebx, 80(%rdi)
-	movd	%xmm12, %ebx
-	movd	%xmm13, %eax
-	movd	%xmm14, %edx
-	movd	%xmm15, %ecx
-	pshufd	$0x39, %xmm12, %xmm12
-	pshufd	$0x39, %xmm13, %xmm13
-	pshufd	$0x39, %xmm14, %xmm14
-	pshufd	$0x39, %xmm15, %xmm15
-	movl	%ebx, 84(%rdi)
-	movl	%eax, 68(%rdi)
-	movl	%edx, 116(%rdi)
-	movl	%ecx, 100(%rdi)
-	movd	%xmm12, %ecx
-	movd	%xmm13, %ebx
-	movd	%xmm14, %eax
-	movd	%xmm15, %edx
-	pshufd	$0x39, %xmm12, %xmm12
-	pshufd	$0x39, %xmm13, %xmm13
-	pshufd	$0x39, %xmm14, %xmm14
-	pshufd	$0x39, %xmm15, %xmm15
-	movl	%ecx, 104(%rdi)
-	movl	%ebx, 88(%rdi)
-	movl	%eax, 72(%rdi)
-	movl	%edx, 120(%rdi)
-	movd	%xmm12, %edx
-	movd	%xmm13, %ecx
-	movd	%xmm14, %ebx
-	movd	%xmm15, %eax
-	movl	%edx, 124(%rdi)
-	movl	%ecx, 108(%rdi)
-	movl	%ebx, 92(%rdi)
-	movl	%eax, 76(%rdi)
-
-	scrypt_core_cleanup()
+	ja scrypt_core_xmm_loop2
+	
+	pcmpeqw	%xmm1, %xmm1
+	psrlq	$32, %xmm1
+	
+	movdqa	%xmm8, %xmm0
+	pxor	%xmm9, %xmm8
+	pand	%xmm1, %xmm8
+	pxor	%xmm9, %xmm8
+	pxor	%xmm10, %xmm9
+	pand	%xmm1, %xmm9
+	pxor	%xmm10, %xmm9
+	pxor	%xmm11, %xmm10
+	pand	%xmm1, %xmm10
+	pxor	%xmm11, %xmm10
+	pxor	%xmm0, %xmm11
+	pand	%xmm1, %xmm11
+	pxor	%xmm0, %xmm11
+	movdqa	%xmm8, %xmm0
+	pshufd	$0x4e, %xmm10, %xmm10
+	punpcklqdq	%xmm10, %xmm8
+	punpckhqdq	%xmm0, %xmm10
+	movdqa	%xmm9, %xmm0
+	pshufd	$0x4e, %xmm11, %xmm11
+	punpcklqdq	%xmm11, %xmm9
+	punpckhqdq	%xmm0, %xmm11
+	movdqa	%xmm8, 0(%rdi)
+	movdqa	%xmm11, 16(%rdi)
+	movdqa	%xmm10, 32(%rdi)
+	movdqa	%xmm9, 48(%rdi)
+	
+	movdqa	%xmm12, %xmm0
+	pxor	%xmm13, %xmm12
+	pand	%xmm1, %xmm12
+	pxor	%xmm13, %xmm12
+	pxor	%xmm14, %xmm13
+	pand	%xmm1, %xmm13
+	pxor	%xmm14, %xmm13
+	pxor	%xmm15, %xmm14
+	pand	%xmm1, %xmm14
+	pxor	%xmm15, %xmm14
+	pxor	%xmm0, %xmm15
+	pand	%xmm1, %xmm15
+	pxor	%xmm0, %xmm15
+	movdqa	%xmm12, %xmm0
+	pshufd	$0x4e, %xmm14, %xmm14
+	punpcklqdq	%xmm14, %xmm12
+	punpckhqdq	%xmm0, %xmm14
+	movdqa	%xmm13, %xmm0
+	pshufd	$0x4e, %xmm15, %xmm15
+	punpcklqdq	%xmm15, %xmm13
+	punpckhqdq	%xmm0, %xmm15
+	movdqa	%xmm12, 64(%rdi)
+	movdqa	%xmm15, 80(%rdi)
+	movdqa	%xmm14, 96(%rdi)
+	movdqa	%xmm13, 112(%rdi)
+	
+	scrypt_core_cleanup
 	ret
+	
+	
+#if defined(ENABLE_AVX)
+.macro salsa8_core_3way_avx_doubleround
+	vpaddd	%xmm0, %xmm1, %xmm4
+	vpaddd	%xmm8, %xmm9, %xmm6
+	vpaddd	%xmm12, %xmm13, %xmm7
+	vpslld	$7, %xmm4, %xmm5
+	vpsrld	$25, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm3, %xmm3
+	vpxor	%xmm4, %xmm3, %xmm3
+	vpslld	$7, %xmm6, %xmm5
+	vpsrld	$25, %xmm6, %xmm6
+	vpxor	%xmm5, %xmm11, %xmm11
+	vpxor	%xmm6, %xmm11, %xmm11
+	vpslld	$7, %xmm7, %xmm5
+	vpsrld	$25, %xmm7, %xmm7
+	vpxor	%xmm5, %xmm15, %xmm15
+	vpxor	%xmm7, %xmm15, %xmm15
+	
+	vpaddd	%xmm3, %xmm0, %xmm4
+	vpaddd	%xmm11, %xmm8, %xmm6
+	vpaddd	%xmm15, %xmm12, %xmm7
+	vpslld	$9, %xmm4, %xmm5
+	vpsrld	$23, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm2, %xmm2
+	vpxor	%xmm4, %xmm2, %xmm2
+	vpslld	$9, %xmm6, %xmm5
+	vpsrld	$23, %xmm6, %xmm6
+	vpxor	%xmm5, %xmm10, %xmm10
+	vpxor	%xmm6, %xmm10, %xmm10
+	vpslld	$9, %xmm7, %xmm5
+	vpsrld	$23, %xmm7, %xmm7
+	vpxor	%xmm5, %xmm14, %xmm14
+	vpxor	%xmm7, %xmm14, %xmm14
+	
+	vpaddd	%xmm2, %xmm3, %xmm4
+	vpaddd	%xmm10, %xmm11, %xmm6
+	vpaddd	%xmm14, %xmm15, %xmm7
+	vpslld	$13, %xmm4, %xmm5
+	vpsrld	$19, %xmm4, %xmm4
+	vpshufd	$0x93, %xmm3, %xmm3
+	vpshufd	$0x93, %xmm11, %xmm11
+	vpshufd	$0x93, %xmm15, %xmm15
+	vpxor	%xmm5, %xmm1, %xmm1
+	vpxor	%xmm4, %xmm1, %xmm1
+	vpslld	$13, %xmm6, %xmm5
+	vpsrld	$19, %xmm6, %xmm6
+	vpxor	%xmm5, %xmm9, %xmm9
+	vpxor	%xmm6, %xmm9, %xmm9
+	vpslld	$13, %xmm7, %xmm5
+	vpsrld	$19, %xmm7, %xmm7
+	vpxor	%xmm5, %xmm13, %xmm13
+	vpxor	%xmm7, %xmm13, %xmm13
+	
+	vpaddd	%xmm1, %xmm2, %xmm4
+	vpaddd	%xmm9, %xmm10, %xmm6
+	vpaddd	%xmm13, %xmm14, %xmm7
+	vpslld	$18, %xmm4, %xmm5
+	vpsrld	$14, %xmm4, %xmm4
+	vpshufd	$0x4e, %xmm2, %xmm2
+	vpshufd	$0x4e, %xmm10, %xmm10
+	vpshufd	$0x4e, %xmm14, %xmm14
+	vpxor	%xmm5, %xmm0, %xmm0
+	vpxor	%xmm4, %xmm0, %xmm0
+	vpslld	$18, %xmm6, %xmm5
+	vpsrld	$14, %xmm6, %xmm6
+	vpxor	%xmm5, %xmm8, %xmm8
+	vpxor	%xmm6, %xmm8, %xmm8
+	vpslld	$18, %xmm7, %xmm5
+	vpsrld	$14, %xmm7, %xmm7
+	vpxor	%xmm5, %xmm12, %xmm12
+	vpxor	%xmm7, %xmm12, %xmm12
+	
+	vpaddd	%xmm0, %xmm3, %xmm4
+	vpaddd	%xmm8, %xmm11, %xmm6
+	vpaddd	%xmm12, %xmm15, %xmm7
+	vpslld	$7, %xmm4, %xmm5
+	vpsrld	$25, %xmm4, %xmm4
+	vpshufd	$0x39, %xmm1, %xmm1
+	vpxor	%xmm5, %xmm1, %xmm1
+	vpxor	%xmm4, %xmm1, %xmm1
+	vpslld	$7, %xmm6, %xmm5
+	vpsrld	$25, %xmm6, %xmm6
+	vpshufd	$0x39, %xmm9, %xmm9
+	vpxor	%xmm5, %xmm9, %xmm9
+	vpxor	%xmm6, %xmm9, %xmm9
+	vpslld	$7, %xmm7, %xmm5
+	vpsrld	$25, %xmm7, %xmm7
+	vpshufd	$0x39, %xmm13, %xmm13
+	vpxor	%xmm5, %xmm13, %xmm13
+	vpxor	%xmm7, %xmm13, %xmm13
+	
+	vpaddd	%xmm1, %xmm0, %xmm4
+	vpaddd	%xmm9, %xmm8, %xmm6
+	vpaddd	%xmm13, %xmm12, %xmm7
+	vpslld	$9, %xmm4, %xmm5
+	vpsrld	$23, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm2, %xmm2
+	vpxor	%xmm4, %xmm2, %xmm2
+	vpslld	$9, %xmm6, %xmm5
+	vpsrld	$23, %xmm6, %xmm6
+	vpxor	%xmm5, %xmm10, %xmm10
+	vpxor	%xmm6, %xmm10, %xmm10
+	vpslld	$9, %xmm7, %xmm5
+	vpsrld	$23, %xmm7, %xmm7
+	vpxor	%xmm5, %xmm14, %xmm14
+	vpxor	%xmm7, %xmm14, %xmm14
+	
+	vpaddd	%xmm2, %xmm1, %xmm4
+	vpaddd	%xmm10, %xmm9, %xmm6
+	vpaddd	%xmm14, %xmm13, %xmm7
+	vpslld	$13, %xmm4, %xmm5
+	vpsrld	$19, %xmm4, %xmm4
+	vpshufd	$0x93, %xmm1, %xmm1
+	vpshufd	$0x93, %xmm9, %xmm9
+	vpshufd	$0x93, %xmm13, %xmm13
+	vpxor	%xmm5, %xmm3, %xmm3
+	vpxor	%xmm4, %xmm3, %xmm3
+	vpslld	$13, %xmm6, %xmm5
+	vpsrld	$19, %xmm6, %xmm6
+	vpxor	%xmm5, %xmm11, %xmm11
+	vpxor	%xmm6, %xmm11, %xmm11
+	vpslld	$13, %xmm7, %xmm5
+	vpsrld	$19, %xmm7, %xmm7
+	vpxor	%xmm5, %xmm15, %xmm15
+	vpxor	%xmm7, %xmm15, %xmm15
+	
+	vpaddd	%xmm3, %xmm2, %xmm4
+	vpaddd	%xmm11, %xmm10, %xmm6
+	vpaddd	%xmm15, %xmm14, %xmm7
+	vpslld	$18, %xmm4, %xmm5
+	vpsrld	$14, %xmm4, %xmm4
+	vpshufd	$0x4e, %xmm2, %xmm2
+	vpshufd	$0x4e, %xmm10, %xmm10
+	vpxor	%xmm5, %xmm0, %xmm0
+	vpxor	%xmm4, %xmm0, %xmm0
+	vpslld	$18, %xmm6, %xmm5
+	vpsrld	$14, %xmm6, %xmm6
+	vpshufd	$0x4e, %xmm14, %xmm14
+	vpshufd	$0x39, %xmm11, %xmm11
+	vpxor	%xmm5, %xmm8, %xmm8
+	vpxor	%xmm6, %xmm8, %xmm8
+	vpslld	$18, %xmm7, %xmm5
+	vpsrld	$14, %xmm7, %xmm7
+	vpshufd	$0x39, %xmm3, %xmm3
+	vpshufd	$0x39, %xmm15, %xmm15
+	vpxor	%xmm5, %xmm12, %xmm12
+	vpxor	%xmm7, %xmm12, %xmm12
+.endm
 
+.macro salsa8_core_3way_avx
+	salsa8_core_3way_avx_doubleround
+	salsa8_core_3way_avx_doubleround
+	salsa8_core_3way_avx_doubleround
+	salsa8_core_3way_avx_doubleround
+.endm
+#endif /* USE_AVX */
+	
+	.text
+	.p2align 6
+	.globl scrypt_core_3way
+	.globl _scrypt_core_3way
+scrypt_core_3way:
+_scrypt_core_3way:
+	pushq	%rbx
+	pushq	%rbp
+#if defined(_WIN64) || defined(__CYGWIN__)
+	subq	$176, %rsp
+	movdqa	%xmm6, 8(%rsp)
+	movdqa	%xmm7, 24(%rsp)
+	movdqa	%xmm8, 40(%rsp)
+	movdqa	%xmm9, 56(%rsp)
+	movdqa	%xmm10, 72(%rsp)
+	movdqa	%xmm11, 88(%rsp)
+	movdqa	%xmm12, 104(%rsp)
+	movdqa	%xmm13, 120(%rsp)
+	movdqa	%xmm14, 136(%rsp)
+	movdqa	%xmm15, 152(%rsp)
+	pushq	%rdi
+	pushq	%rsi
+	movq	%rcx, %rdi
+	movq	%rdx, %rsi
+#else
+	movq	%rdx, %r8
+#endif
+	subq	$392, %rsp
+	
+.macro scrypt_core_3way_cleanup
 	addq	$392, %rsp
-#if defined(WIN64)
+#if defined(_WIN64) || defined(__CYGWIN__)
 	popq	%rsi
 	popq	%rdi
 	movdqa	8(%rsp), %xmm6
@@ -854,6 +1054,1853 @@ xmm_scrypt_core_loop2:
 #endif
 	popq	%rbp
 	popq	%rbx
+.endm
+	
+#if !defined(ENABLE_AVX)
+	jmp scrypt_core_3way_xmm
+#else
+	/* Check for AVX and OSXSAVE support */
+	movl	$1, %eax
+	cpuid
+	andl	$0x18000000, %ecx
+	cmpl	$0x18000000, %ecx
+	jne scrypt_core_3way_xmm
+	/* Check for XMM and YMM state support */
+	xorl	%ecx, %ecx
+	xgetbv
+	andl	$0x00000006, %eax
+	cmpl	$0x00000006, %eax
+	jne scrypt_core_3way_xmm
+#if defined(ENABLE_XOP)
+	/* Check for XOP support */
+	movl	$0x80000001, %eax
+	cpuid
+	andl	$0x00000800, %ecx
+	jnz scrypt_core_3way_xop
+#endif
+	
+scrypt_core_3way_avx:
+	scrypt_shuffle %rdi, 0, %rsp, 0
+	scrypt_shuffle %rdi, 64, %rsp, 64
+	scrypt_shuffle %rdi, 128, %rsp, 128
+	scrypt_shuffle %rdi, 192, %rsp, 192
+	scrypt_shuffle %rdi, 256, %rsp, 256
+	scrypt_shuffle %rdi, 320, %rsp, 320
+	
+	movdqa	64(%rsp), %xmm0
+	movdqa	80(%rsp), %xmm1
+	movdqa	96(%rsp), %xmm2
+	movdqa	112(%rsp), %xmm3
+	movdqa	128+64(%rsp), %xmm8
+	movdqa	128+80(%rsp), %xmm9
+	movdqa	128+96(%rsp), %xmm10
+	movdqa	128+112(%rsp), %xmm11
+	movdqa	256+64(%rsp), %xmm12
+	movdqa	256+80(%rsp), %xmm13
+	movdqa	256+96(%rsp), %xmm14
+	movdqa	256+112(%rsp), %xmm15
+	
+	movq	%rsi, %rbx
+	leaq	(%r8, %r8, 2), %rax
+	shlq	$7, %rax
+	addq	%rsi, %rax
+scrypt_core_3way_avx_loop1:
+	movdqa	%xmm0, 64(%rbx)
+	movdqa	%xmm1, 80(%rbx)
+	movdqa	%xmm2, 96(%rbx)
+	movdqa	%xmm3, 112(%rbx)
+	pxor	0(%rsp), %xmm0
+	pxor	16(%rsp), %xmm1
+	pxor	32(%rsp), %xmm2
+	pxor	48(%rsp), %xmm3
+	movdqa	%xmm8, 128+64(%rbx)
+	movdqa	%xmm9, 128+80(%rbx)
+	movdqa	%xmm10, 128+96(%rbx)
+	movdqa	%xmm11, 128+112(%rbx)
+	pxor	128+0(%rsp), %xmm8
+	pxor	128+16(%rsp), %xmm9
+	pxor	128+32(%rsp), %xmm10
+	pxor	128+48(%rsp), %xmm11
+	movdqa	%xmm12, 256+64(%rbx)
+	movdqa	%xmm13, 256+80(%rbx)
+	movdqa	%xmm14, 256+96(%rbx)
+	movdqa	%xmm15, 256+112(%rbx)
+	pxor	256+0(%rsp), %xmm12
+	pxor	256+16(%rsp), %xmm13
+	pxor	256+32(%rsp), %xmm14
+	pxor	256+48(%rsp), %xmm15
+	movdqa	%xmm0, 0(%rbx)
+	movdqa	%xmm1, 16(%rbx)
+	movdqa	%xmm2, 32(%rbx)
+	movdqa	%xmm3, 48(%rbx)
+	movdqa	%xmm8, 128+0(%rbx)
+	movdqa	%xmm9, 128+16(%rbx)
+	movdqa	%xmm10, 128+32(%rbx)
+	movdqa	%xmm11, 128+48(%rbx)
+	movdqa	%xmm12, 256+0(%rbx)
+	movdqa	%xmm13, 256+16(%rbx)
+	movdqa	%xmm14, 256+32(%rbx)
+	movdqa	%xmm15, 256+48(%rbx)
+	
+	salsa8_core_3way_avx
+	paddd	0(%rbx), %xmm0
+	paddd	16(%rbx), %xmm1
+	paddd	32(%rbx), %xmm2
+	paddd	48(%rbx), %xmm3
+	paddd	128+0(%rbx), %xmm8
+	paddd	128+16(%rbx), %xmm9
+	paddd	128+32(%rbx), %xmm10
+	paddd	128+48(%rbx), %xmm11
+	paddd	256+0(%rbx), %xmm12
+	paddd	256+16(%rbx), %xmm13
+	paddd	256+32(%rbx), %xmm14
+	paddd	256+48(%rbx), %xmm15
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	
+	pxor	64(%rbx), %xmm0
+	pxor	80(%rbx), %xmm1
+	pxor	96(%rbx), %xmm2
+	pxor	112(%rbx), %xmm3
+	pxor	128+64(%rbx), %xmm8
+	pxor	128+80(%rbx), %xmm9
+	pxor	128+96(%rbx), %xmm10
+	pxor	128+112(%rbx), %xmm11
+	pxor	256+64(%rbx), %xmm12
+	pxor	256+80(%rbx), %xmm13
+	pxor	256+96(%rbx), %xmm14
+	pxor	256+112(%rbx), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	salsa8_core_3way_avx
+	paddd	64(%rsp), %xmm0
+	paddd	80(%rsp), %xmm1
+	paddd	96(%rsp), %xmm2
+	paddd	112(%rsp), %xmm3
+	paddd	128+64(%rsp), %xmm8
+	paddd	128+80(%rsp), %xmm9
+	paddd	128+96(%rsp), %xmm10
+	paddd	128+112(%rsp), %xmm11
+	paddd	256+64(%rsp), %xmm12
+	paddd	256+80(%rsp), %xmm13
+	paddd	256+96(%rsp), %xmm14
+	paddd	256+112(%rsp), %xmm15
+	
+	addq	$3*128, %rbx
+	cmpq	%rax, %rbx
+	jne scrypt_core_3way_avx_loop1
+	
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	
+	movq	%r8, %rcx
+	subq	$1, %r8
+scrypt_core_3way_avx_loop2:
+	movd	%xmm0, %ebp
+	movd	%xmm8, %ebx
+	movd	%xmm12, %eax
+	pxor	0(%rsp), %xmm0
+	pxor	16(%rsp), %xmm1
+	pxor	32(%rsp), %xmm2
+	pxor	48(%rsp), %xmm3
+	pxor	128+0(%rsp), %xmm8
+	pxor	128+16(%rsp), %xmm9
+	pxor	128+32(%rsp), %xmm10
+	pxor	128+48(%rsp), %xmm11
+	pxor	256+0(%rsp), %xmm12
+	pxor	256+16(%rsp), %xmm13
+	pxor	256+32(%rsp), %xmm14
+	pxor	256+48(%rsp), %xmm15
+	andl	%r8d, %ebp
+	leaq	(%rbp, %rbp, 2), %rbp
+	shll	$7, %ebp
+	andl	%r8d, %ebx
+	leaq	1(%rbx, %rbx, 2), %rbx
+	shll	$7, %ebx
+	andl	%r8d, %eax
+	leaq	2(%rax, %rax, 2), %rax
+	shll	$7, %eax
+	pxor	0(%rsi, %rbp), %xmm0
+	pxor	16(%rsi, %rbp), %xmm1
+	pxor	32(%rsi, %rbp), %xmm2
+	pxor	48(%rsi, %rbp), %xmm3
+	pxor	0(%rsi, %rbx), %xmm8
+	pxor	16(%rsi, %rbx), %xmm9
+	pxor	32(%rsi, %rbx), %xmm10
+	pxor	48(%rsi, %rbx), %xmm11
+	pxor	0(%rsi, %rax), %xmm12
+	pxor	16(%rsi, %rax), %xmm13
+	pxor	32(%rsi, %rax), %xmm14
+	pxor	48(%rsi, %rax), %xmm15
+	
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	salsa8_core_3way_avx
+	paddd	0(%rsp), %xmm0
+	paddd	16(%rsp), %xmm1
+	paddd	32(%rsp), %xmm2
+	paddd	48(%rsp), %xmm3
+	paddd	128+0(%rsp), %xmm8
+	paddd	128+16(%rsp), %xmm9
+	paddd	128+32(%rsp), %xmm10
+	paddd	128+48(%rsp), %xmm11
+	paddd	256+0(%rsp), %xmm12
+	paddd	256+16(%rsp), %xmm13
+	paddd	256+32(%rsp), %xmm14
+	paddd	256+48(%rsp), %xmm15
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	
+	pxor	64(%rsi, %rbp), %xmm0
+	pxor	80(%rsi, %rbp), %xmm1
+	pxor	96(%rsi, %rbp), %xmm2
+	pxor	112(%rsi, %rbp), %xmm3
+	pxor	64(%rsi, %rbx), %xmm8
+	pxor	80(%rsi, %rbx), %xmm9
+	pxor	96(%rsi, %rbx), %xmm10
+	pxor	112(%rsi, %rbx), %xmm11
+	pxor	64(%rsi, %rax), %xmm12
+	pxor	80(%rsi, %rax), %xmm13
+	pxor	96(%rsi, %rax), %xmm14
+	pxor	112(%rsi, %rax), %xmm15
+	pxor	64(%rsp), %xmm0
+	pxor	80(%rsp), %xmm1
+	pxor	96(%rsp), %xmm2
+	pxor	112(%rsp), %xmm3
+	pxor	128+64(%rsp), %xmm8
+	pxor	128+80(%rsp), %xmm9
+	pxor	128+96(%rsp), %xmm10
+	pxor	128+112(%rsp), %xmm11
+	pxor	256+64(%rsp), %xmm12
+	pxor	256+80(%rsp), %xmm13
+	pxor	256+96(%rsp), %xmm14
+	pxor	256+112(%rsp), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	salsa8_core_3way_avx
+	paddd	64(%rsp), %xmm0
+	paddd	80(%rsp), %xmm1
+	paddd	96(%rsp), %xmm2
+	paddd	112(%rsp), %xmm3
+	paddd	128+64(%rsp), %xmm8
+	paddd	128+80(%rsp), %xmm9
+	paddd	128+96(%rsp), %xmm10
+	paddd	128+112(%rsp), %xmm11
+	paddd	256+64(%rsp), %xmm12
+	paddd	256+80(%rsp), %xmm13
+	paddd	256+96(%rsp), %xmm14
+	paddd	256+112(%rsp), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	
+	subq	$1, %rcx
+	ja scrypt_core_3way_avx_loop2
+	
+	scrypt_shuffle %rsp, 0, %rdi, 0
+	scrypt_shuffle %rsp, 64, %rdi, 64
+	scrypt_shuffle %rsp, 128, %rdi, 128
+	scrypt_shuffle %rsp, 192, %rdi, 192
+	scrypt_shuffle %rsp, 256, %rdi, 256
+	scrypt_shuffle %rsp, 320, %rdi, 320
+	
+	scrypt_core_3way_cleanup
 	ret
+
+#if defined(ENABLE_XOP)
+.macro salsa8_core_3way_xop_doubleround
+	vpaddd	%xmm0, %xmm1, %xmm4
+	vpaddd	%xmm8, %xmm9, %xmm6
+	vpaddd	%xmm12, %xmm13, %xmm7
+	vprotd	$7, %xmm4, %xmm4
+	vprotd	$7, %xmm6, %xmm6
+	vprotd	$7, %xmm7, %xmm7
+	vpxor	%xmm4, %xmm3, %xmm3
+	vpxor	%xmm6, %xmm11, %xmm11
+	vpxor	%xmm7, %xmm15, %xmm15
+	
+	vpaddd	%xmm3, %xmm0, %xmm4
+	vpaddd	%xmm11, %xmm8, %xmm6
+	vpaddd	%xmm15, %xmm12, %xmm7
+	vprotd	$9, %xmm4, %xmm4
+	vprotd	$9, %xmm6, %xmm6
+	vprotd	$9, %xmm7, %xmm7
+	vpxor	%xmm4, %xmm2, %xmm2
+	vpxor	%xmm6, %xmm10, %xmm10
+	vpxor	%xmm7, %xmm14, %xmm14
+	
+	vpaddd	%xmm2, %xmm3, %xmm4
+	vpaddd	%xmm10, %xmm11, %xmm6
+	vpaddd	%xmm14, %xmm15, %xmm7
+	vprotd	$13, %xmm4, %xmm4
+	vprotd	$13, %xmm6, %xmm6
+	vprotd	$13, %xmm7, %xmm7
+	vpshufd	$0x93, %xmm3, %xmm3
+	vpshufd	$0x93, %xmm11, %xmm11
+	vpshufd	$0x93, %xmm15, %xmm15
+	vpxor	%xmm4, %xmm1, %xmm1
+	vpxor	%xmm6, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm13, %xmm13
+	
+	vpaddd	%xmm1, %xmm2, %xmm4
+	vpaddd	%xmm9, %xmm10, %xmm6
+	vpaddd	%xmm13, %xmm14, %xmm7
+	vprotd	$18, %xmm4, %xmm4
+	vprotd	$18, %xmm6, %xmm6
+	vprotd	$18, %xmm7, %xmm7
+	vpshufd	$0x4e, %xmm2, %xmm2
+	vpshufd	$0x4e, %xmm10, %xmm10
+	vpshufd	$0x4e, %xmm14, %xmm14
+	vpxor	%xmm6, %xmm8, %xmm8
+	vpxor	%xmm4, %xmm0, %xmm0
+	vpxor	%xmm7, %xmm12, %xmm12
+	
+	vpaddd	%xmm0, %xmm3, %xmm4
+	vpaddd	%xmm8, %xmm11, %xmm6
+	vpaddd	%xmm12, %xmm15, %xmm7
+	vprotd	$7, %xmm4, %xmm4
+	vprotd	$7, %xmm6, %xmm6
+	vprotd	$7, %xmm7, %xmm7
+	vpshufd	$0x39, %xmm1, %xmm1
+	vpshufd	$0x39, %xmm9, %xmm9
+	vpshufd	$0x39, %xmm13, %xmm13
+	vpxor	%xmm4, %xmm1, %xmm1
+	vpxor	%xmm6, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm13, %xmm13
+	
+	vpaddd	%xmm1, %xmm0, %xmm4
+	vpaddd	%xmm9, %xmm8, %xmm6
+	vpaddd	%xmm13, %xmm12, %xmm7
+	vprotd	$9, %xmm4, %xmm4
+	vprotd	$9, %xmm6, %xmm6
+	vprotd	$9, %xmm7, %xmm7
+	vpxor	%xmm4, %xmm2, %xmm2
+	vpxor	%xmm6, %xmm10, %xmm10
+	vpxor	%xmm7, %xmm14, %xmm14
+	
+	vpaddd	%xmm2, %xmm1, %xmm4
+	vpaddd	%xmm10, %xmm9, %xmm6
+	vpaddd	%xmm14, %xmm13, %xmm7
+	vprotd	$13, %xmm4, %xmm4
+	vprotd	$13, %xmm6, %xmm6
+	vprotd	$13, %xmm7, %xmm7
+	vpshufd	$0x93, %xmm1, %xmm1
+	vpshufd	$0x93, %xmm9, %xmm9
+	vpshufd	$0x93, %xmm13, %xmm13
+	vpxor	%xmm4, %xmm3, %xmm3
+	vpxor	%xmm6, %xmm11, %xmm11
+	vpxor	%xmm7, %xmm15, %xmm15
+	
+	vpaddd	%xmm3, %xmm2, %xmm4
+	vpaddd	%xmm11, %xmm10, %xmm6
+	vpaddd	%xmm15, %xmm14, %xmm7
+	vprotd	$18, %xmm4, %xmm4
+	vprotd	$18, %xmm6, %xmm6
+	vprotd	$18, %xmm7, %xmm7
+	vpshufd	$0x4e, %xmm2, %xmm2
+	vpshufd	$0x4e, %xmm10, %xmm10
+	vpshufd	$0x4e, %xmm14, %xmm14
+	vpxor	%xmm4, %xmm0, %xmm0
+	vpxor	%xmm6, %xmm8, %xmm8
+	vpxor	%xmm7, %xmm12, %xmm12
+	vpshufd	$0x39, %xmm3, %xmm3
+	vpshufd	$0x39, %xmm11, %xmm11
+	vpshufd	$0x39, %xmm15, %xmm15
+.endm
+
+.macro salsa8_core_3way_xop
+	salsa8_core_3way_xop_doubleround
+	salsa8_core_3way_xop_doubleround
+	salsa8_core_3way_xop_doubleround
+	salsa8_core_3way_xop_doubleround
+.endm
+	
+	.p2align 6
+scrypt_core_3way_xop:
+	scrypt_shuffle %rdi, 0, %rsp, 0
+	scrypt_shuffle %rdi, 64, %rsp, 64
+	scrypt_shuffle %rdi, 128, %rsp, 128
+	scrypt_shuffle %rdi, 192, %rsp, 192
+	scrypt_shuffle %rdi, 256, %rsp, 256
+	scrypt_shuffle %rdi, 320, %rsp, 320
+	
+	movdqa	64(%rsp), %xmm0
+	movdqa	80(%rsp), %xmm1
+	movdqa	96(%rsp), %xmm2
+	movdqa	112(%rsp), %xmm3
+	movdqa	128+64(%rsp), %xmm8
+	movdqa	128+80(%rsp), %xmm9
+	movdqa	128+96(%rsp), %xmm10
+	movdqa	128+112(%rsp), %xmm11
+	movdqa	256+64(%rsp), %xmm12
+	movdqa	256+80(%rsp), %xmm13
+	movdqa	256+96(%rsp), %xmm14
+	movdqa	256+112(%rsp), %xmm15
+	
+	movq	%rsi, %rbx
+	leaq	(%r8, %r8, 2), %rax
+	shlq	$7, %rax
+	addq	%rsi, %rax
+scrypt_core_3way_xop_loop1:
+	movdqa	%xmm0, 64(%rbx)
+	movdqa	%xmm1, 80(%rbx)
+	movdqa	%xmm2, 96(%rbx)
+	movdqa	%xmm3, 112(%rbx)
+	pxor	0(%rsp), %xmm0
+	pxor	16(%rsp), %xmm1
+	pxor	32(%rsp), %xmm2
+	pxor	48(%rsp), %xmm3
+	movdqa	%xmm8, 128+64(%rbx)
+	movdqa	%xmm9, 128+80(%rbx)
+	movdqa	%xmm10, 128+96(%rbx)
+	movdqa	%xmm11, 128+112(%rbx)
+	pxor	128+0(%rsp), %xmm8
+	pxor	128+16(%rsp), %xmm9
+	pxor	128+32(%rsp), %xmm10
+	pxor	128+48(%rsp), %xmm11
+	movdqa	%xmm12, 256+64(%rbx)
+	movdqa	%xmm13, 256+80(%rbx)
+	movdqa	%xmm14, 256+96(%rbx)
+	movdqa	%xmm15, 256+112(%rbx)
+	pxor	256+0(%rsp), %xmm12
+	pxor	256+16(%rsp), %xmm13
+	pxor	256+32(%rsp), %xmm14
+	pxor	256+48(%rsp), %xmm15
+	movdqa	%xmm0, 0(%rbx)
+	movdqa	%xmm1, 16(%rbx)
+	movdqa	%xmm2, 32(%rbx)
+	movdqa	%xmm3, 48(%rbx)
+	movdqa	%xmm8, 128+0(%rbx)
+	movdqa	%xmm9, 128+16(%rbx)
+	movdqa	%xmm10, 128+32(%rbx)
+	movdqa	%xmm11, 128+48(%rbx)
+	movdqa	%xmm12, 256+0(%rbx)
+	movdqa	%xmm13, 256+16(%rbx)
+	movdqa	%xmm14, 256+32(%rbx)
+	movdqa	%xmm15, 256+48(%rbx)
+	
+	salsa8_core_3way_xop
+	paddd	0(%rbx), %xmm0
+	paddd	16(%rbx), %xmm1
+	paddd	32(%rbx), %xmm2
+	paddd	48(%rbx), %xmm3
+	paddd	128+0(%rbx), %xmm8
+	paddd	128+16(%rbx), %xmm9
+	paddd	128+32(%rbx), %xmm10
+	paddd	128+48(%rbx), %xmm11
+	paddd	256+0(%rbx), %xmm12
+	paddd	256+16(%rbx), %xmm13
+	paddd	256+32(%rbx), %xmm14
+	paddd	256+48(%rbx), %xmm15
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	
+	pxor	64(%rbx), %xmm0
+	pxor	80(%rbx), %xmm1
+	pxor	96(%rbx), %xmm2
+	pxor	112(%rbx), %xmm3
+	pxor	128+64(%rbx), %xmm8
+	pxor	128+80(%rbx), %xmm9
+	pxor	128+96(%rbx), %xmm10
+	pxor	128+112(%rbx), %xmm11
+	pxor	256+64(%rbx), %xmm12
+	pxor	256+80(%rbx), %xmm13
+	pxor	256+96(%rbx), %xmm14
+	pxor	256+112(%rbx), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	salsa8_core_3way_xop
+	paddd	64(%rsp), %xmm0
+	paddd	80(%rsp), %xmm1
+	paddd	96(%rsp), %xmm2
+	paddd	112(%rsp), %xmm3
+	paddd	128+64(%rsp), %xmm8
+	paddd	128+80(%rsp), %xmm9
+	paddd	128+96(%rsp), %xmm10
+	paddd	128+112(%rsp), %xmm11
+	paddd	256+64(%rsp), %xmm12
+	paddd	256+80(%rsp), %xmm13
+	paddd	256+96(%rsp), %xmm14
+	paddd	256+112(%rsp), %xmm15
+	
+	addq	$3*128, %rbx
+	cmpq	%rax, %rbx
+	jne scrypt_core_3way_xop_loop1
+	
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	
+	movq	%r8, %rcx
+	subq	$1, %r8
+scrypt_core_3way_xop_loop2:
+	movd	%xmm0, %ebp
+	movd	%xmm8, %ebx
+	movd	%xmm12, %eax
+	pxor	0(%rsp), %xmm0
+	pxor	16(%rsp), %xmm1
+	pxor	32(%rsp), %xmm2
+	pxor	48(%rsp), %xmm3
+	pxor	128+0(%rsp), %xmm8
+	pxor	128+16(%rsp), %xmm9
+	pxor	128+32(%rsp), %xmm10
+	pxor	128+48(%rsp), %xmm11
+	pxor	256+0(%rsp), %xmm12
+	pxor	256+16(%rsp), %xmm13
+	pxor	256+32(%rsp), %xmm14
+	pxor	256+48(%rsp), %xmm15
+	andl	%r8d, %ebp
+	leaq	(%rbp, %rbp, 2), %rbp
+	shll	$7, %ebp
+	andl	%r8d, %ebx
+	leaq	1(%rbx, %rbx, 2), %rbx
+	shll	$7, %ebx
+	andl	%r8d, %eax
+	leaq	2(%rax, %rax, 2), %rax
+	shll	$7, %eax
+	pxor	0(%rsi, %rbp), %xmm0
+	pxor	16(%rsi, %rbp), %xmm1
+	pxor	32(%rsi, %rbp), %xmm2
+	pxor	48(%rsi, %rbp), %xmm3
+	pxor	0(%rsi, %rbx), %xmm8
+	pxor	16(%rsi, %rbx), %xmm9
+	pxor	32(%rsi, %rbx), %xmm10
+	pxor	48(%rsi, %rbx), %xmm11
+	pxor	0(%rsi, %rax), %xmm12
+	pxor	16(%rsi, %rax), %xmm13
+	pxor	32(%rsi, %rax), %xmm14
+	pxor	48(%rsi, %rax), %xmm15
+	
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	salsa8_core_3way_xop
+	paddd	0(%rsp), %xmm0
+	paddd	16(%rsp), %xmm1
+	paddd	32(%rsp), %xmm2
+	paddd	48(%rsp), %xmm3
+	paddd	128+0(%rsp), %xmm8
+	paddd	128+16(%rsp), %xmm9
+	paddd	128+32(%rsp), %xmm10
+	paddd	128+48(%rsp), %xmm11
+	paddd	256+0(%rsp), %xmm12
+	paddd	256+16(%rsp), %xmm13
+	paddd	256+32(%rsp), %xmm14
+	paddd	256+48(%rsp), %xmm15
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	
+	pxor	64(%rsi, %rbp), %xmm0
+	pxor	80(%rsi, %rbp), %xmm1
+	pxor	96(%rsi, %rbp), %xmm2
+	pxor	112(%rsi, %rbp), %xmm3
+	pxor	64(%rsi, %rbx), %xmm8
+	pxor	80(%rsi, %rbx), %xmm9
+	pxor	96(%rsi, %rbx), %xmm10
+	pxor	112(%rsi, %rbx), %xmm11
+	pxor	64(%rsi, %rax), %xmm12
+	pxor	80(%rsi, %rax), %xmm13
+	pxor	96(%rsi, %rax), %xmm14
+	pxor	112(%rsi, %rax), %xmm15
+	pxor	64(%rsp), %xmm0
+	pxor	80(%rsp), %xmm1
+	pxor	96(%rsp), %xmm2
+	pxor	112(%rsp), %xmm3
+	pxor	128+64(%rsp), %xmm8
+	pxor	128+80(%rsp), %xmm9
+	pxor	128+96(%rsp), %xmm10
+	pxor	128+112(%rsp), %xmm11
+	pxor	256+64(%rsp), %xmm12
+	pxor	256+80(%rsp), %xmm13
+	pxor	256+96(%rsp), %xmm14
+	pxor	256+112(%rsp), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	salsa8_core_3way_xop
+	paddd	64(%rsp), %xmm0
+	paddd	80(%rsp), %xmm1
+	paddd	96(%rsp), %xmm2
+	paddd	112(%rsp), %xmm3
+	paddd	128+64(%rsp), %xmm8
+	paddd	128+80(%rsp), %xmm9
+	paddd	128+96(%rsp), %xmm10
+	paddd	128+112(%rsp), %xmm11
+	paddd	256+64(%rsp), %xmm12
+	paddd	256+80(%rsp), %xmm13
+	paddd	256+96(%rsp), %xmm14
+	paddd	256+112(%rsp), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	
+	subq	$1, %rcx
+	ja scrypt_core_3way_xop_loop2
+	
+	scrypt_shuffle %rsp, 0, %rdi, 0
+	scrypt_shuffle %rsp, 64, %rdi, 64
+	scrypt_shuffle %rsp, 128, %rdi, 128
+	scrypt_shuffle %rsp, 192, %rdi, 192
+	scrypt_shuffle %rsp, 256, %rdi, 256
+	scrypt_shuffle %rsp, 320, %rdi, 320
+	
+	scrypt_core_3way_cleanup
+	ret
+#endif /* USE_XOP */
+#endif /* USE_AVX */
+	
+.macro salsa8_core_3way_xmm_doubleround
+	movdqa	%xmm1, %xmm4
+	movdqa	%xmm9, %xmm6
+	movdqa	%xmm13, %xmm7
+	paddd	%xmm0, %xmm4
+	paddd	%xmm8, %xmm6
+	paddd	%xmm12, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$7, %xmm4
+	psrld	$25, %xmm5
+	pxor	%xmm4, %xmm3
+	pxor	%xmm5, %xmm3
+	movdqa	%xmm0, %xmm4
+	movdqa	%xmm6, %xmm5
+	pslld	$7, %xmm6
+	psrld	$25, %xmm5
+	pxor	%xmm6, %xmm11
+	pxor	%xmm5, %xmm11
+	movdqa	%xmm8, %xmm6
+	movdqa	%xmm7, %xmm5
+	pslld	$7, %xmm7
+	psrld	$25, %xmm5
+	pxor	%xmm7, %xmm15
+	pxor	%xmm5, %xmm15
+	movdqa	%xmm12, %xmm7
+	
+	paddd	%xmm3, %xmm4
+	paddd	%xmm11, %xmm6
+	paddd	%xmm15, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$9, %xmm4
+	psrld	$23, %xmm5
+	pxor	%xmm4, %xmm2
+	movdqa	%xmm3, %xmm4
+	pshufd	$0x93, %xmm3, %xmm3
+	pxor	%xmm5, %xmm2
+	movdqa	%xmm6, %xmm5
+	pslld	$9, %xmm6
+	psrld	$23, %xmm5
+	pxor	%xmm6, %xmm10
+	movdqa	%xmm11, %xmm6
+	pshufd	$0x93, %xmm11, %xmm11
+	pxor	%xmm5, %xmm10
+	movdqa	%xmm7, %xmm5
+	pslld	$9, %xmm7
+	psrld	$23, %xmm5
+	pxor	%xmm7, %xmm14
+	movdqa	%xmm15, %xmm7
+	pxor	%xmm5, %xmm14
+	pshufd	$0x93, %xmm15, %xmm15
+	
+	paddd	%xmm2, %xmm4
+	paddd	%xmm10, %xmm6
+	paddd	%xmm14, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$13, %xmm4
+	psrld	$19, %xmm5
+	pxor	%xmm4, %xmm1
+	movdqa	%xmm2, %xmm4
+	pshufd	$0x4e, %xmm2, %xmm2
+	pxor	%xmm5, %xmm1
+	movdqa	%xmm6, %xmm5
+	pslld	$13, %xmm6
+	psrld	$19, %xmm5
+	pxor	%xmm6, %xmm9
+	movdqa	%xmm10, %xmm6
+	pshufd	$0x4e, %xmm10, %xmm10
+	pxor	%xmm5, %xmm9
+	movdqa	%xmm7, %xmm5
+	pslld	$13, %xmm7
+	psrld	$19, %xmm5
+	pxor	%xmm7, %xmm13
+	movdqa	%xmm14, %xmm7
+	pshufd	$0x4e, %xmm14, %xmm14
+	pxor	%xmm5, %xmm13
+	
+	paddd	%xmm1, %xmm4
+	paddd	%xmm9, %xmm6
+	paddd	%xmm13, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$18, %xmm4
+	psrld	$14, %xmm5
+	pxor	%xmm4, %xmm0
+	pshufd	$0x39, %xmm1, %xmm1
+	pxor	%xmm5, %xmm0
+	movdqa	%xmm3, %xmm4
+	movdqa	%xmm6, %xmm5
+	pslld	$18, %xmm6
+	psrld	$14, %xmm5
+	pxor	%xmm6, %xmm8
+	pshufd	$0x39, %xmm9, %xmm9
+	pxor	%xmm5, %xmm8
+	movdqa	%xmm11, %xmm6
+	movdqa	%xmm7, %xmm5
+	pslld	$18, %xmm7
+	psrld	$14, %xmm5
+	pxor	%xmm7, %xmm12
+	movdqa	%xmm15, %xmm7
+	pxor	%xmm5, %xmm12
+	pshufd	$0x39, %xmm13, %xmm13
+	
+	paddd	%xmm0, %xmm4
+	paddd	%xmm8, %xmm6
+	paddd	%xmm12, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$7, %xmm4
+	psrld	$25, %xmm5
+	pxor	%xmm4, %xmm1
+	pxor	%xmm5, %xmm1
+	movdqa	%xmm0, %xmm4
+	movdqa	%xmm6, %xmm5
+	pslld	$7, %xmm6
+	psrld	$25, %xmm5
+	pxor	%xmm6, %xmm9
+	pxor	%xmm5, %xmm9
+	movdqa	%xmm8, %xmm6
+	movdqa	%xmm7, %xmm5
+	pslld	$7, %xmm7
+	psrld	$25, %xmm5
+	pxor	%xmm7, %xmm13
+	pxor	%xmm5, %xmm13
+	movdqa	%xmm12, %xmm7
+	
+	paddd	%xmm1, %xmm4
+	paddd	%xmm9, %xmm6
+	paddd	%xmm13, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$9, %xmm4
+	psrld	$23, %xmm5
+	pxor	%xmm4, %xmm2
+	movdqa	%xmm1, %xmm4
+	pshufd	$0x93, %xmm1, %xmm1
+	pxor	%xmm5, %xmm2
+	movdqa	%xmm6, %xmm5
+	pslld	$9, %xmm6
+	psrld	$23, %xmm5
+	pxor	%xmm6, %xmm10
+	movdqa	%xmm9, %xmm6
+	pshufd	$0x93, %xmm9, %xmm9
+	pxor	%xmm5, %xmm10
+	movdqa	%xmm7, %xmm5
+	pslld	$9, %xmm7
+	psrld	$23, %xmm5
+	pxor	%xmm7, %xmm14
+	movdqa	%xmm13, %xmm7
+	pshufd	$0x93, %xmm13, %xmm13
+	pxor	%xmm5, %xmm14
+	
+	paddd	%xmm2, %xmm4
+	paddd	%xmm10, %xmm6
+	paddd	%xmm14, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$13, %xmm4
+	psrld	$19, %xmm5
+	pxor	%xmm4, %xmm3
+	movdqa	%xmm2, %xmm4
+	pshufd	$0x4e, %xmm2, %xmm2
+	pxor	%xmm5, %xmm3
+	movdqa	%xmm6, %xmm5
+	pslld	$13, %xmm6
+	psrld	$19, %xmm5
+	pxor	%xmm6, %xmm11
+	movdqa	%xmm10, %xmm6
+	pshufd	$0x4e, %xmm10, %xmm10
+	pxor	%xmm5, %xmm11
+	movdqa	%xmm7, %xmm5
+	pslld	$13, %xmm7
+	psrld	$19, %xmm5
+	pxor	%xmm7, %xmm15
+	movdqa	%xmm14, %xmm7
+	pshufd	$0x4e, %xmm14, %xmm14
+	pxor	%xmm5, %xmm15
+	
+	paddd	%xmm3, %xmm4
+	paddd	%xmm11, %xmm6
+	paddd	%xmm15, %xmm7
+	movdqa	%xmm4, %xmm5
+	pslld	$18, %xmm4
+	psrld	$14, %xmm5
+	pxor	%xmm4, %xmm0
+	pshufd	$0x39, %xmm3, %xmm3
+	pxor	%xmm5, %xmm0
+	movdqa	%xmm6, %xmm5
+	pslld	$18, %xmm6
+	psrld	$14, %xmm5
+	pxor	%xmm6, %xmm8
+	pshufd	$0x39, %xmm11, %xmm11
+	pxor	%xmm5, %xmm8
+	movdqa	%xmm7, %xmm5
+	pslld	$18, %xmm7
+	psrld	$14, %xmm5
+	pxor	%xmm7, %xmm12
+	pshufd	$0x39, %xmm15, %xmm15
+	pxor	%xmm5, %xmm12
+.endm
+
+.macro salsa8_core_3way_xmm
+	salsa8_core_3way_xmm_doubleround
+	salsa8_core_3way_xmm_doubleround
+	salsa8_core_3way_xmm_doubleround
+	salsa8_core_3way_xmm_doubleround
+.endm
+	
+	.p2align 6
+scrypt_core_3way_xmm:
+	scrypt_shuffle %rdi, 0, %rsp, 0
+	scrypt_shuffle %rdi, 64, %rsp, 64
+	scrypt_shuffle %rdi, 128, %rsp, 128
+	scrypt_shuffle %rdi, 192, %rsp, 192
+	scrypt_shuffle %rdi, 256, %rsp, 256
+	scrypt_shuffle %rdi, 320, %rsp, 320
+	
+	movdqa	64(%rsp), %xmm0
+	movdqa	80(%rsp), %xmm1
+	movdqa	96(%rsp), %xmm2
+	movdqa	112(%rsp), %xmm3
+	movdqa	128+64(%rsp), %xmm8
+	movdqa	128+80(%rsp), %xmm9
+	movdqa	128+96(%rsp), %xmm10
+	movdqa	128+112(%rsp), %xmm11
+	movdqa	256+64(%rsp), %xmm12
+	movdqa	256+80(%rsp), %xmm13
+	movdqa	256+96(%rsp), %xmm14
+	movdqa	256+112(%rsp), %xmm15
+	
+	movq	%rsi, %rbx
+	leaq	(%r8, %r8, 2), %rax
+	shlq	$7, %rax
+	addq	%rsi, %rax
+scrypt_core_3way_xmm_loop1:
+	movdqa	%xmm0, 64(%rbx)
+	movdqa	%xmm1, 80(%rbx)
+	movdqa	%xmm2, 96(%rbx)
+	movdqa	%xmm3, 112(%rbx)
+	pxor	0(%rsp), %xmm0
+	pxor	16(%rsp), %xmm1
+	pxor	32(%rsp), %xmm2
+	pxor	48(%rsp), %xmm3
+	movdqa	%xmm8, 128+64(%rbx)
+	movdqa	%xmm9, 128+80(%rbx)
+	movdqa	%xmm10, 128+96(%rbx)
+	movdqa	%xmm11, 128+112(%rbx)
+	pxor	128+0(%rsp), %xmm8
+	pxor	128+16(%rsp), %xmm9
+	pxor	128+32(%rsp), %xmm10
+	pxor	128+48(%rsp), %xmm11
+	movdqa	%xmm12, 256+64(%rbx)
+	movdqa	%xmm13, 256+80(%rbx)
+	movdqa	%xmm14, 256+96(%rbx)
+	movdqa	%xmm15, 256+112(%rbx)
+	pxor	256+0(%rsp), %xmm12
+	pxor	256+16(%rsp), %xmm13
+	pxor	256+32(%rsp), %xmm14
+	pxor	256+48(%rsp), %xmm15
+	movdqa	%xmm0, 0(%rbx)
+	movdqa	%xmm1, 16(%rbx)
+	movdqa	%xmm2, 32(%rbx)
+	movdqa	%xmm3, 48(%rbx)
+	movdqa	%xmm8, 128+0(%rbx)
+	movdqa	%xmm9, 128+16(%rbx)
+	movdqa	%xmm10, 128+32(%rbx)
+	movdqa	%xmm11, 128+48(%rbx)
+	movdqa	%xmm12, 256+0(%rbx)
+	movdqa	%xmm13, 256+16(%rbx)
+	movdqa	%xmm14, 256+32(%rbx)
+	movdqa	%xmm15, 256+48(%rbx)
+	
+	salsa8_core_3way_xmm
+	paddd	0(%rbx), %xmm0
+	paddd	16(%rbx), %xmm1
+	paddd	32(%rbx), %xmm2
+	paddd	48(%rbx), %xmm3
+	paddd	128+0(%rbx), %xmm8
+	paddd	128+16(%rbx), %xmm9
+	paddd	128+32(%rbx), %xmm10
+	paddd	128+48(%rbx), %xmm11
+	paddd	256+0(%rbx), %xmm12
+	paddd	256+16(%rbx), %xmm13
+	paddd	256+32(%rbx), %xmm14
+	paddd	256+48(%rbx), %xmm15
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	
+	pxor	64(%rbx), %xmm0
+	pxor	80(%rbx), %xmm1
+	pxor	96(%rbx), %xmm2
+	pxor	112(%rbx), %xmm3
+	pxor	128+64(%rbx), %xmm8
+	pxor	128+80(%rbx), %xmm9
+	pxor	128+96(%rbx), %xmm10
+	pxor	128+112(%rbx), %xmm11
+	pxor	256+64(%rbx), %xmm12
+	pxor	256+80(%rbx), %xmm13
+	pxor	256+96(%rbx), %xmm14
+	pxor	256+112(%rbx), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	salsa8_core_3way_xmm
+	paddd	64(%rsp), %xmm0
+	paddd	80(%rsp), %xmm1
+	paddd	96(%rsp), %xmm2
+	paddd	112(%rsp), %xmm3
+	paddd	128+64(%rsp), %xmm8
+	paddd	128+80(%rsp), %xmm9
+	paddd	128+96(%rsp), %xmm10
+	paddd	128+112(%rsp), %xmm11
+	paddd	256+64(%rsp), %xmm12
+	paddd	256+80(%rsp), %xmm13
+	paddd	256+96(%rsp), %xmm14
+	paddd	256+112(%rsp), %xmm15
+	
+	addq	$3*128, %rbx
+	cmpq	%rax, %rbx
+	jne scrypt_core_3way_xmm_loop1
+	
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	
+	movq	%r8, %rcx
+	subq	$1, %r8
+scrypt_core_3way_xmm_loop2:
+	movd	%xmm0, %ebp
+	movd	%xmm8, %ebx
+	movd	%xmm12, %eax
+	pxor	0(%rsp), %xmm0
+	pxor	16(%rsp), %xmm1
+	pxor	32(%rsp), %xmm2
+	pxor	48(%rsp), %xmm3
+	pxor	128+0(%rsp), %xmm8
+	pxor	128+16(%rsp), %xmm9
+	pxor	128+32(%rsp), %xmm10
+	pxor	128+48(%rsp), %xmm11
+	pxor	256+0(%rsp), %xmm12
+	pxor	256+16(%rsp), %xmm13
+	pxor	256+32(%rsp), %xmm14
+	pxor	256+48(%rsp), %xmm15
+	andl	%r8d, %ebp
+	leaq	(%rbp, %rbp, 2), %rbp
+	shll	$7, %ebp
+	andl	%r8d, %ebx
+	leaq	1(%rbx, %rbx, 2), %rbx
+	shll	$7, %ebx
+	andl	%r8d, %eax
+	leaq	2(%rax, %rax, 2), %rax
+	shll	$7, %eax
+	pxor	0(%rsi, %rbp), %xmm0
+	pxor	16(%rsi, %rbp), %xmm1
+	pxor	32(%rsi, %rbp), %xmm2
+	pxor	48(%rsi, %rbp), %xmm3
+	pxor	0(%rsi, %rbx), %xmm8
+	pxor	16(%rsi, %rbx), %xmm9
+	pxor	32(%rsi, %rbx), %xmm10
+	pxor	48(%rsi, %rbx), %xmm11
+	pxor	0(%rsi, %rax), %xmm12
+	pxor	16(%rsi, %rax), %xmm13
+	pxor	32(%rsi, %rax), %xmm14
+	pxor	48(%rsi, %rax), %xmm15
+	
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	salsa8_core_3way_xmm
+	paddd	0(%rsp), %xmm0
+	paddd	16(%rsp), %xmm1
+	paddd	32(%rsp), %xmm2
+	paddd	48(%rsp), %xmm3
+	paddd	128+0(%rsp), %xmm8
+	paddd	128+16(%rsp), %xmm9
+	paddd	128+32(%rsp), %xmm10
+	paddd	128+48(%rsp), %xmm11
+	paddd	256+0(%rsp), %xmm12
+	paddd	256+16(%rsp), %xmm13
+	paddd	256+32(%rsp), %xmm14
+	paddd	256+48(%rsp), %xmm15
+	movdqa	%xmm0, 0(%rsp)
+	movdqa	%xmm1, 16(%rsp)
+	movdqa	%xmm2, 32(%rsp)
+	movdqa	%xmm3, 48(%rsp)
+	movdqa	%xmm8, 128+0(%rsp)
+	movdqa	%xmm9, 128+16(%rsp)
+	movdqa	%xmm10, 128+32(%rsp)
+	movdqa	%xmm11, 128+48(%rsp)
+	movdqa	%xmm12, 256+0(%rsp)
+	movdqa	%xmm13, 256+16(%rsp)
+	movdqa	%xmm14, 256+32(%rsp)
+	movdqa	%xmm15, 256+48(%rsp)
+	
+	pxor	64(%rsi, %rbp), %xmm0
+	pxor	80(%rsi, %rbp), %xmm1
+	pxor	96(%rsi, %rbp), %xmm2
+	pxor	112(%rsi, %rbp), %xmm3
+	pxor	64(%rsi, %rbx), %xmm8
+	pxor	80(%rsi, %rbx), %xmm9
+	pxor	96(%rsi, %rbx), %xmm10
+	pxor	112(%rsi, %rbx), %xmm11
+	pxor	64(%rsi, %rax), %xmm12
+	pxor	80(%rsi, %rax), %xmm13
+	pxor	96(%rsi, %rax), %xmm14
+	pxor	112(%rsi, %rax), %xmm15
+	pxor	64(%rsp), %xmm0
+	pxor	80(%rsp), %xmm1
+	pxor	96(%rsp), %xmm2
+	pxor	112(%rsp), %xmm3
+	pxor	128+64(%rsp), %xmm8
+	pxor	128+80(%rsp), %xmm9
+	pxor	128+96(%rsp), %xmm10
+	pxor	128+112(%rsp), %xmm11
+	pxor	256+64(%rsp), %xmm12
+	pxor	256+80(%rsp), %xmm13
+	pxor	256+96(%rsp), %xmm14
+	pxor	256+112(%rsp), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	salsa8_core_3way_xmm
+	paddd	64(%rsp), %xmm0
+	paddd	80(%rsp), %xmm1
+	paddd	96(%rsp), %xmm2
+	paddd	112(%rsp), %xmm3
+	paddd	128+64(%rsp), %xmm8
+	paddd	128+80(%rsp), %xmm9
+	paddd	128+96(%rsp), %xmm10
+	paddd	128+112(%rsp), %xmm11
+	paddd	256+64(%rsp), %xmm12
+	paddd	256+80(%rsp), %xmm13
+	paddd	256+96(%rsp), %xmm14
+	paddd	256+112(%rsp), %xmm15
+	movdqa	%xmm0, 64(%rsp)
+	movdqa	%xmm1, 80(%rsp)
+	movdqa	%xmm2, 96(%rsp)
+	movdqa	%xmm3, 112(%rsp)
+	movdqa	%xmm8, 128+64(%rsp)
+	movdqa	%xmm9, 128+80(%rsp)
+	movdqa	%xmm10, 128+96(%rsp)
+	movdqa	%xmm11, 128+112(%rsp)
+	movdqa	%xmm12, 256+64(%rsp)
+	movdqa	%xmm13, 256+80(%rsp)
+	movdqa	%xmm14, 256+96(%rsp)
+	movdqa	%xmm15, 256+112(%rsp)
+	
+	subq	$1, %rcx
+	ja scrypt_core_3way_xmm_loop2
+	
+	scrypt_shuffle %rsp, 0, %rdi, 0
+	scrypt_shuffle %rsp, 64, %rdi, 64
+	scrypt_shuffle %rsp, 128, %rdi, 128
+	scrypt_shuffle %rsp, 192, %rdi, 192
+	scrypt_shuffle %rsp, 256, %rdi, 256
+	scrypt_shuffle %rsp, 320, %rdi, 320
+	
+	scrypt_core_3way_cleanup
+	ret
+
+
+#if defined(ENABLE_AVX2)
+
+.macro salsa8_core_6way_avx2_doubleround
+	vpaddd	%ymm0, %ymm1, %ymm4
+	vpaddd	%ymm8, %ymm9, %ymm6
+	vpaddd	%ymm12, %ymm13, %ymm7
+	vpslld	$7, %ymm4, %ymm5
+	vpsrld	$25, %ymm4, %ymm4
+	vpxor	%ymm5, %ymm3, %ymm3
+	vpxor	%ymm4, %ymm3, %ymm3
+	vpslld	$7, %ymm6, %ymm5
+	vpsrld	$25, %ymm6, %ymm6
+	vpxor	%ymm5, %ymm11, %ymm11
+	vpxor	%ymm6, %ymm11, %ymm11
+	vpslld	$7, %ymm7, %ymm5
+	vpsrld	$25, %ymm7, %ymm7
+	vpxor	%ymm5, %ymm15, %ymm15
+	vpxor	%ymm7, %ymm15, %ymm15
+	
+	vpaddd	%ymm3, %ymm0, %ymm4
+	vpaddd	%ymm11, %ymm8, %ymm6
+	vpaddd	%ymm15, %ymm12, %ymm7
+	vpslld	$9, %ymm4, %ymm5
+	vpsrld	$23, %ymm4, %ymm4
+	vpxor	%ymm5, %ymm2, %ymm2
+	vpxor	%ymm4, %ymm2, %ymm2
+	vpslld	$9, %ymm6, %ymm5
+	vpsrld	$23, %ymm6, %ymm6
+	vpxor	%ymm5, %ymm10, %ymm10
+	vpxor	%ymm6, %ymm10, %ymm10
+	vpslld	$9, %ymm7, %ymm5
+	vpsrld	$23, %ymm7, %ymm7
+	vpxor	%ymm5, %ymm14, %ymm14
+	vpxor	%ymm7, %ymm14, %ymm14
+	
+	vpaddd	%ymm2, %ymm3, %ymm4
+	vpaddd	%ymm10, %ymm11, %ymm6
+	vpaddd	%ymm14, %ymm15, %ymm7
+	vpslld	$13, %ymm4, %ymm5
+	vpsrld	$19, %ymm4, %ymm4
+	vpshufd	$0x93, %ymm3, %ymm3
+	vpshufd	$0x93, %ymm11, %ymm11
+	vpshufd	$0x93, %ymm15, %ymm15
+	vpxor	%ymm5, %ymm1, %ymm1
+	vpxor	%ymm4, %ymm1, %ymm1
+	vpslld	$13, %ymm6, %ymm5
+	vpsrld	$19, %ymm6, %ymm6
+	vpxor	%ymm5, %ymm9, %ymm9
+	vpxor	%ymm6, %ymm9, %ymm9
+	vpslld	$13, %ymm7, %ymm5
+	vpsrld	$19, %ymm7, %ymm7
+	vpxor	%ymm5, %ymm13, %ymm13
+	vpxor	%ymm7, %ymm13, %ymm13
+	
+	vpaddd	%ymm1, %ymm2, %ymm4
+	vpaddd	%ymm9, %ymm10, %ymm6
+	vpaddd	%ymm13, %ymm14, %ymm7
+	vpslld	$18, %ymm4, %ymm5
+	vpsrld	$14, %ymm4, %ymm4
+	vpshufd	$0x4e, %ymm2, %ymm2
+	vpshufd	$0x4e, %ymm10, %ymm10
+	vpshufd	$0x4e, %ymm14, %ymm14
+	vpxor	%ymm5, %ymm0, %ymm0
+	vpxor	%ymm4, %ymm0, %ymm0
+	vpslld	$18, %ymm6, %ymm5
+	vpsrld	$14, %ymm6, %ymm6
+	vpxor	%ymm5, %ymm8, %ymm8
+	vpxor	%ymm6, %ymm8, %ymm8
+	vpslld	$18, %ymm7, %ymm5
+	vpsrld	$14, %ymm7, %ymm7
+	vpxor	%ymm5, %ymm12, %ymm12
+	vpxor	%ymm7, %ymm12, %ymm12
+	
+	vpaddd	%ymm0, %ymm3, %ymm4
+	vpaddd	%ymm8, %ymm11, %ymm6
+	vpaddd	%ymm12, %ymm15, %ymm7
+	vpslld	$7, %ymm4, %ymm5
+	vpsrld	$25, %ymm4, %ymm4
+	vpshufd	$0x39, %ymm1, %ymm1
+	vpxor	%ymm5, %ymm1, %ymm1
+	vpxor	%ymm4, %ymm1, %ymm1
+	vpslld	$7, %ymm6, %ymm5
+	vpsrld	$25, %ymm6, %ymm6
+	vpshufd	$0x39, %ymm9, %ymm9
+	vpxor	%ymm5, %ymm9, %ymm9
+	vpxor	%ymm6, %ymm9, %ymm9
+	vpslld	$7, %ymm7, %ymm5
+	vpsrld	$25, %ymm7, %ymm7
+	vpshufd	$0x39, %ymm13, %ymm13
+	vpxor	%ymm5, %ymm13, %ymm13
+	vpxor	%ymm7, %ymm13, %ymm13
+	
+	vpaddd	%ymm1, %ymm0, %ymm4
+	vpaddd	%ymm9, %ymm8, %ymm6
+	vpaddd	%ymm13, %ymm12, %ymm7
+	vpslld	$9, %ymm4, %ymm5
+	vpsrld	$23, %ymm4, %ymm4
+	vpxor	%ymm5, %ymm2, %ymm2
+	vpxor	%ymm4, %ymm2, %ymm2
+	vpslld	$9, %ymm6, %ymm5
+	vpsrld	$23, %ymm6, %ymm6
+	vpxor	%ymm5, %ymm10, %ymm10
+	vpxor	%ymm6, %ymm10, %ymm10
+	vpslld	$9, %ymm7, %ymm5
+	vpsrld	$23, %ymm7, %ymm7
+	vpxor	%ymm5, %ymm14, %ymm14
+	vpxor	%ymm7, %ymm14, %ymm14
+	
+	vpaddd	%ymm2, %ymm1, %ymm4
+	vpaddd	%ymm10, %ymm9, %ymm6
+	vpaddd	%ymm14, %ymm13, %ymm7
+	vpslld	$13, %ymm4, %ymm5
+	vpsrld	$19, %ymm4, %ymm4
+	vpshufd	$0x93, %ymm1, %ymm1
+	vpshufd	$0x93, %ymm9, %ymm9
+	vpshufd	$0x93, %ymm13, %ymm13
+	vpxor	%ymm5, %ymm3, %ymm3
+	vpxor	%ymm4, %ymm3, %ymm3
+	vpslld	$13, %ymm6, %ymm5
+	vpsrld	$19, %ymm6, %ymm6
+	vpxor	%ymm5, %ymm11, %ymm11
+	vpxor	%ymm6, %ymm11, %ymm11
+	vpslld	$13, %ymm7, %ymm5
+	vpsrld	$19, %ymm7, %ymm7
+	vpxor	%ymm5, %ymm15, %ymm15
+	vpxor	%ymm7, %ymm15, %ymm15
+	
+	vpaddd	%ymm3, %ymm2, %ymm4
+	vpaddd	%ymm11, %ymm10, %ymm6
+	vpaddd	%ymm15, %ymm14, %ymm7
+	vpslld	$18, %ymm4, %ymm5
+	vpsrld	$14, %ymm4, %ymm4
+	vpshufd	$0x4e, %ymm2, %ymm2
+	vpshufd	$0x4e, %ymm10, %ymm10
+	vpxor	%ymm5, %ymm0, %ymm0
+	vpxor	%ymm4, %ymm0, %ymm0
+	vpslld	$18, %ymm6, %ymm5
+	vpsrld	$14, %ymm6, %ymm6
+	vpshufd	$0x4e, %ymm14, %ymm14
+	vpshufd	$0x39, %ymm11, %ymm11
+	vpxor	%ymm5, %ymm8, %ymm8
+	vpxor	%ymm6, %ymm8, %ymm8
+	vpslld	$18, %ymm7, %ymm5
+	vpsrld	$14, %ymm7, %ymm7
+	vpshufd	$0x39, %ymm3, %ymm3
+	vpshufd	$0x39, %ymm15, %ymm15
+	vpxor	%ymm5, %ymm12, %ymm12
+	vpxor	%ymm7, %ymm12, %ymm12
+.endm
+
+.macro salsa8_core_6way_avx2
+	salsa8_core_6way_avx2_doubleround
+	salsa8_core_6way_avx2_doubleround
+	salsa8_core_6way_avx2_doubleround
+	salsa8_core_6way_avx2_doubleround
+.endm
+	
+	.text
+	.p2align 6
+	.globl scrypt_core_6way
+	.globl _scrypt_core_6way
+scrypt_core_6way:
+_scrypt_core_6way:
+	pushq	%rbx
+	pushq	%rbp
+#if defined(_WIN64) || defined(__CYGWIN__)
+	subq	$176, %rsp
+	vmovdqa	%xmm6, 8(%rsp)
+	vmovdqa	%xmm7, 24(%rsp)
+	vmovdqa	%xmm8, 40(%rsp)
+	vmovdqa	%xmm9, 56(%rsp)
+	vmovdqa	%xmm10, 72(%rsp)
+	vmovdqa	%xmm11, 88(%rsp)
+	vmovdqa	%xmm12, 104(%rsp)
+	vmovdqa	%xmm13, 120(%rsp)
+	vmovdqa	%xmm14, 136(%rsp)
+	vmovdqa	%xmm15, 152(%rsp)
+	pushq	%rdi
+	pushq	%rsi
+	movq	%rcx, %rdi
+	movq	%rdx, %rsi
+#else
+	movq	%rdx, %r8
+#endif
+	movq	%rsp, %rdx
+	subq	$768, %rsp
+	andq	$-128, %rsp
+	
+.macro scrypt_core_6way_cleanup
+	movq	%rdx, %rsp
+#if defined(_WIN64) || defined(__CYGWIN__)
+	popq	%rsi
+	popq	%rdi
+	vmovdqa	8(%rsp), %xmm6
+	vmovdqa	24(%rsp), %xmm7
+	vmovdqa	40(%rsp), %xmm8
+	vmovdqa	56(%rsp), %xmm9
+	vmovdqa	72(%rsp), %xmm10
+	vmovdqa	88(%rsp), %xmm11
+	vmovdqa	104(%rsp), %xmm12
+	vmovdqa	120(%rsp), %xmm13
+	vmovdqa	136(%rsp), %xmm14
+	vmovdqa	152(%rsp), %xmm15
+	addq	$176, %rsp
+#endif
+	popq	%rbp
+	popq	%rbx
+.endm
+
+.macro scrypt_shuffle_pack2 src, so, dest, do
+	vmovdqa	\so+0*16(\src), %xmm0
+	vmovdqa	\so+1*16(\src), %xmm1
+	vmovdqa	\so+2*16(\src), %xmm2
+	vmovdqa	\so+3*16(\src), %xmm3
+	vinserti128	$1, \so+128+0*16(\src), %ymm0, %ymm0
+	vinserti128	$1, \so+128+1*16(\src), %ymm1, %ymm1
+	vinserti128	$1, \so+128+2*16(\src), %ymm2, %ymm2
+	vinserti128	$1, \so+128+3*16(\src), %ymm3, %ymm3
+	vpblendd	$0x33, %ymm0, %ymm2, %ymm4
+	vpblendd	$0xcc, %ymm1, %ymm3, %ymm5
+	vpblendd	$0x33, %ymm2, %ymm0, %ymm6
+	vpblendd	$0xcc, %ymm3, %ymm1, %ymm7
+	vpblendd	$0x55, %ymm7, %ymm6, %ymm3
+	vpblendd	$0x55, %ymm6, %ymm5, %ymm2
+	vpblendd	$0x55, %ymm5, %ymm4, %ymm1
+	vpblendd	$0x55, %ymm4, %ymm7, %ymm0
+	vmovdqa	%ymm0, \do+0*32(\dest)
+	vmovdqa	%ymm1, \do+1*32(\dest)
+	vmovdqa	%ymm2, \do+2*32(\dest)
+	vmovdqa	%ymm3, \do+3*32(\dest)
+.endm
+
+.macro scrypt_shuffle_unpack2 src, so, dest, do
+	vmovdqa	\so+0*32(\src), %ymm0
+	vmovdqa	\so+1*32(\src), %ymm1
+	vmovdqa	\so+2*32(\src), %ymm2
+	vmovdqa	\so+3*32(\src), %ymm3
+	vpblendd	$0x33, %ymm0, %ymm2, %ymm4
+	vpblendd	$0xcc, %ymm1, %ymm3, %ymm5
+	vpblendd	$0x33, %ymm2, %ymm0, %ymm6
+	vpblendd	$0xcc, %ymm3, %ymm1, %ymm7
+	vpblendd	$0x55, %ymm7, %ymm6, %ymm3
+	vpblendd	$0x55, %ymm6, %ymm5, %ymm2
+	vpblendd	$0x55, %ymm5, %ymm4, %ymm1
+	vpblendd	$0x55, %ymm4, %ymm7, %ymm0
+	vmovdqa	%xmm0, \do+0*16(\dest)
+	vmovdqa	%xmm1, \do+1*16(\dest)
+	vmovdqa	%xmm2, \do+2*16(\dest)
+	vmovdqa	%xmm3, \do+3*16(\dest)
+	vextracti128	$1, %ymm0, \do+128+0*16(\dest)
+	vextracti128	$1, %ymm1, \do+128+1*16(\dest)
+	vextracti128	$1, %ymm2, \do+128+2*16(\dest)
+	vextracti128	$1, %ymm3, \do+128+3*16(\dest)
+.endm
+	
+scrypt_core_6way_avx2:
+	scrypt_shuffle_pack2 %rdi, 0*256+0, %rsp, 0*128
+	scrypt_shuffle_pack2 %rdi, 0*256+64, %rsp, 1*128
+	scrypt_shuffle_pack2 %rdi, 1*256+0, %rsp, 2*128
+	scrypt_shuffle_pack2 %rdi, 1*256+64, %rsp, 3*128
+	scrypt_shuffle_pack2 %rdi, 2*256+0, %rsp, 4*128
+	scrypt_shuffle_pack2 %rdi, 2*256+64, %rsp, 5*128
+	
+	vmovdqa	0*256+4*32(%rsp), %ymm0
+	vmovdqa	0*256+5*32(%rsp), %ymm1
+	vmovdqa	0*256+6*32(%rsp), %ymm2
+	vmovdqa	0*256+7*32(%rsp), %ymm3
+	vmovdqa	1*256+4*32(%rsp), %ymm8
+	vmovdqa	1*256+5*32(%rsp), %ymm9
+	vmovdqa	1*256+6*32(%rsp), %ymm10
+	vmovdqa	1*256+7*32(%rsp), %ymm11
+	vmovdqa	2*256+4*32(%rsp), %ymm12
+	vmovdqa	2*256+5*32(%rsp), %ymm13
+	vmovdqa	2*256+6*32(%rsp), %ymm14
+	vmovdqa	2*256+7*32(%rsp), %ymm15
+	
+	movq	%rsi, %rbx
+	leaq	(%r8, %r8, 2), %rax
+	shlq	$8, %rax
+	addq	%rsi, %rax
+scrypt_core_6way_avx2_loop1:
+	vmovdqa	%ymm0, 0*256+4*32(%rbx)
+	vmovdqa	%ymm1, 0*256+5*32(%rbx)
+	vmovdqa	%ymm2, 0*256+6*32(%rbx)
+	vmovdqa	%ymm3, 0*256+7*32(%rbx)
+	vpxor	0*256+0*32(%rsp), %ymm0, %ymm0
+	vpxor	0*256+1*32(%rsp), %ymm1, %ymm1
+	vpxor	0*256+2*32(%rsp), %ymm2, %ymm2
+	vpxor	0*256+3*32(%rsp), %ymm3, %ymm3
+	vmovdqa	%ymm8, 1*256+4*32(%rbx)
+	vmovdqa	%ymm9, 1*256+5*32(%rbx)
+	vmovdqa	%ymm10, 1*256+6*32(%rbx)
+	vmovdqa	%ymm11, 1*256+7*32(%rbx)
+	vpxor	1*256+0*32(%rsp), %ymm8, %ymm8
+	vpxor	1*256+1*32(%rsp), %ymm9, %ymm9
+	vpxor	1*256+2*32(%rsp), %ymm10, %ymm10
+	vpxor	1*256+3*32(%rsp), %ymm11, %ymm11
+	vmovdqa	%ymm12, 2*256+4*32(%rbx)
+	vmovdqa	%ymm13, 2*256+5*32(%rbx)
+	vmovdqa	%ymm14, 2*256+6*32(%rbx)
+	vmovdqa	%ymm15, 2*256+7*32(%rbx)
+	vpxor	2*256+0*32(%rsp), %ymm12, %ymm12
+	vpxor	2*256+1*32(%rsp), %ymm13, %ymm13
+	vpxor	2*256+2*32(%rsp), %ymm14, %ymm14
+	vpxor	2*256+3*32(%rsp), %ymm15, %ymm15
+	vmovdqa	%ymm0, 0*256+0*32(%rbx)
+	vmovdqa	%ymm1, 0*256+1*32(%rbx)
+	vmovdqa	%ymm2, 0*256+2*32(%rbx)
+	vmovdqa	%ymm3, 0*256+3*32(%rbx)
+	vmovdqa	%ymm8, 1*256+0*32(%rbx)
+	vmovdqa	%ymm9, 1*256+1*32(%rbx)
+	vmovdqa	%ymm10, 1*256+2*32(%rbx)
+	vmovdqa	%ymm11, 1*256+3*32(%rbx)
+	vmovdqa	%ymm12, 2*256+0*32(%rbx)
+	vmovdqa	%ymm13, 2*256+1*32(%rbx)
+	vmovdqa	%ymm14, 2*256+2*32(%rbx)
+	vmovdqa	%ymm15, 2*256+3*32(%rbx)
+	
+	salsa8_core_6way_avx2
+	vpaddd	0*256+0*32(%rbx), %ymm0, %ymm0
+	vpaddd	0*256+1*32(%rbx), %ymm1, %ymm1
+	vpaddd	0*256+2*32(%rbx), %ymm2, %ymm2
+	vpaddd	0*256+3*32(%rbx), %ymm3, %ymm3
+	vpaddd	1*256+0*32(%rbx), %ymm8, %ymm8
+	vpaddd	1*256+1*32(%rbx), %ymm9, %ymm9
+	vpaddd	1*256+2*32(%rbx), %ymm10, %ymm10
+	vpaddd	1*256+3*32(%rbx), %ymm11, %ymm11
+	vpaddd	2*256+0*32(%rbx), %ymm12, %ymm12
+	vpaddd	2*256+1*32(%rbx), %ymm13, %ymm13
+	vpaddd	2*256+2*32(%rbx), %ymm14, %ymm14
+	vpaddd	2*256+3*32(%rbx), %ymm15, %ymm15
+	vmovdqa	%ymm0, 0*256+0*32(%rsp)
+	vmovdqa	%ymm1, 0*256+1*32(%rsp)
+	vmovdqa	%ymm2, 0*256+2*32(%rsp)
+	vmovdqa	%ymm3, 0*256+3*32(%rsp)
+	vmovdqa	%ymm8, 1*256+0*32(%rsp)
+	vmovdqa	%ymm9, 1*256+1*32(%rsp)
+	vmovdqa	%ymm10, 1*256+2*32(%rsp)
+	vmovdqa	%ymm11, 1*256+3*32(%rsp)
+	vmovdqa	%ymm12, 2*256+0*32(%rsp)
+	vmovdqa	%ymm13, 2*256+1*32(%rsp)
+	vmovdqa	%ymm14, 2*256+2*32(%rsp)
+	vmovdqa	%ymm15, 2*256+3*32(%rsp)
+	
+	vpxor	0*256+4*32(%rbx), %ymm0, %ymm0
+	vpxor	0*256+5*32(%rbx), %ymm1, %ymm1
+	vpxor	0*256+6*32(%rbx), %ymm2, %ymm2
+	vpxor	0*256+7*32(%rbx), %ymm3, %ymm3
+	vpxor	1*256+4*32(%rbx), %ymm8, %ymm8
+	vpxor	1*256+5*32(%rbx), %ymm9, %ymm9
+	vpxor	1*256+6*32(%rbx), %ymm10, %ymm10
+	vpxor	1*256+7*32(%rbx), %ymm11, %ymm11
+	vpxor	2*256+4*32(%rbx), %ymm12, %ymm12
+	vpxor	2*256+5*32(%rbx), %ymm13, %ymm13
+	vpxor	2*256+6*32(%rbx), %ymm14, %ymm14
+	vpxor	2*256+7*32(%rbx), %ymm15, %ymm15
+	vmovdqa	%ymm0, 0*256+4*32(%rsp)
+	vmovdqa	%ymm1, 0*256+5*32(%rsp)
+	vmovdqa	%ymm2, 0*256+6*32(%rsp)
+	vmovdqa	%ymm3, 0*256+7*32(%rsp)
+	vmovdqa	%ymm8, 1*256+4*32(%rsp)
+	vmovdqa	%ymm9, 1*256+5*32(%rsp)
+	vmovdqa	%ymm10, 1*256+6*32(%rsp)
+	vmovdqa	%ymm11, 1*256+7*32(%rsp)
+	vmovdqa	%ymm12, 2*256+4*32(%rsp)
+	vmovdqa	%ymm13, 2*256+5*32(%rsp)
+	vmovdqa	%ymm14, 2*256+6*32(%rsp)
+	vmovdqa	%ymm15, 2*256+7*32(%rsp)
+	salsa8_core_6way_avx2
+	vpaddd	0*256+4*32(%rsp), %ymm0, %ymm0
+	vpaddd	0*256+5*32(%rsp), %ymm1, %ymm1
+	vpaddd	0*256+6*32(%rsp), %ymm2, %ymm2
+	vpaddd	0*256+7*32(%rsp), %ymm3, %ymm3
+	vpaddd	1*256+4*32(%rsp), %ymm8, %ymm8
+	vpaddd	1*256+5*32(%rsp), %ymm9, %ymm9
+	vpaddd	1*256+6*32(%rsp), %ymm10, %ymm10
+	vpaddd	1*256+7*32(%rsp), %ymm11, %ymm11
+	vpaddd	2*256+4*32(%rsp), %ymm12, %ymm12
+	vpaddd	2*256+5*32(%rsp), %ymm13, %ymm13
+	vpaddd	2*256+6*32(%rsp), %ymm14, %ymm14
+	vpaddd	2*256+7*32(%rsp), %ymm15, %ymm15
+	
+	addq	$6*128, %rbx
+	cmpq	%rax, %rbx
+	jne scrypt_core_6way_avx2_loop1
+	
+	vmovdqa	%ymm0, 0*256+4*32(%rsp)
+	vmovdqa	%ymm1, 0*256+5*32(%rsp)
+	vmovdqa	%ymm2, 0*256+6*32(%rsp)
+	vmovdqa	%ymm3, 0*256+7*32(%rsp)
+	vmovdqa	%ymm8, 1*256+4*32(%rsp)
+	vmovdqa	%ymm9, 1*256+5*32(%rsp)
+	vmovdqa	%ymm10, 1*256+6*32(%rsp)
+	vmovdqa	%ymm11, 1*256+7*32(%rsp)
+	vmovdqa	%ymm12, 2*256+4*32(%rsp)
+	vmovdqa	%ymm13, 2*256+5*32(%rsp)
+	vmovdqa	%ymm14, 2*256+6*32(%rsp)
+	vmovdqa	%ymm15, 2*256+7*32(%rsp)
+	
+	movq	%r8, %rcx
+	leaq	-1(%r8), %r11
+scrypt_core_6way_avx2_loop2:
+	vmovd	%xmm0, %ebp
+	vmovd	%xmm8, %ebx
+	vmovd	%xmm12, %eax
+	vextracti128	$1, %ymm0, %xmm4
+	vextracti128	$1, %ymm8, %xmm5
+	vextracti128	$1, %ymm12, %xmm6
+	vmovd	%xmm4, %r8d
+	vmovd	%xmm5, %r9d
+	vmovd	%xmm6, %r10d
+	vpxor	0*256+0*32(%rsp), %ymm0, %ymm0
+	vpxor	0*256+1*32(%rsp), %ymm1, %ymm1
+	vpxor	0*256+2*32(%rsp), %ymm2, %ymm2
+	vpxor	0*256+3*32(%rsp), %ymm3, %ymm3
+	vpxor	1*256+0*32(%rsp), %ymm8, %ymm8
+	vpxor	1*256+1*32(%rsp), %ymm9, %ymm9
+	vpxor	1*256+2*32(%rsp), %ymm10, %ymm10
+	vpxor	1*256+3*32(%rsp), %ymm11, %ymm11
+	vpxor	2*256+0*32(%rsp), %ymm12, %ymm12
+	vpxor	2*256+1*32(%rsp), %ymm13, %ymm13
+	vpxor	2*256+2*32(%rsp), %ymm14, %ymm14
+	vpxor	2*256+3*32(%rsp), %ymm15, %ymm15
+	andl	%r11d, %ebp
+	leaq	0(%rbp, %rbp, 2), %rbp
+	shll	$8, %ebp
+	andl	%r11d, %ebx
+	leaq	1(%rbx, %rbx, 2), %rbx
+	shll	$8, %ebx
+	andl	%r11d, %eax
+	leaq	2(%rax, %rax, 2), %rax
+	shll	$8, %eax
+	andl	%r11d, %r8d
+	leaq	0(%r8, %r8, 2), %r8
+	shll	$8, %r8d
+	andl	%r11d, %r9d
+	leaq	1(%r9, %r9, 2), %r9
+	shll	$8, %r9d
+	andl	%r11d, %r10d
+	leaq	2(%r10, %r10, 2), %r10
+	shll	$8, %r10d
+	vmovdqa	0*32(%rsi, %rbp), %xmm4
+	vinserti128	$1, 0*32+16(%rsi, %r8), %ymm4, %ymm4
+	vmovdqa	1*32(%rsi, %rbp), %xmm5
+	vinserti128	$1, 1*32+16(%rsi, %r8), %ymm5, %ymm5
+	vmovdqa	2*32(%rsi, %rbp), %xmm6
+	vinserti128	$1, 2*32+16(%rsi, %r8), %ymm6, %ymm6
+	vmovdqa	3*32(%rsi, %rbp), %xmm7
+	vinserti128	$1, 3*32+16(%rsi, %r8), %ymm7, %ymm7
+	vpxor	%ymm4, %ymm0, %ymm0
+	vpxor	%ymm5, %ymm1, %ymm1
+	vpxor	%ymm6, %ymm2, %ymm2
+	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqa	0*32(%rsi, %rbx), %xmm4
+	vinserti128	$1, 0*32+16(%rsi, %r9), %ymm4, %ymm4
+	vmovdqa	1*32(%rsi, %rbx), %xmm5
+	vinserti128	$1, 1*32+16(%rsi, %r9), %ymm5, %ymm5
+	vmovdqa	2*32(%rsi, %rbx), %xmm6
+	vinserti128	$1, 2*32+16(%rsi, %r9), %ymm6, %ymm6
+	vmovdqa	3*32(%rsi, %rbx), %xmm7
+	vinserti128	$1, 3*32+16(%rsi, %r9), %ymm7, %ymm7
+	vpxor	%ymm4, %ymm8, %ymm8
+	vpxor	%ymm5, %ymm9, %ymm9
+	vpxor	%ymm6, %ymm10, %ymm10
+	vpxor	%ymm7, %ymm11, %ymm11
+	vmovdqa	0*32(%rsi, %rax), %xmm4
+	vinserti128	$1, 0*32+16(%rsi, %r10), %ymm4, %ymm4
+	vmovdqa	1*32(%rsi, %rax), %xmm5
+	vinserti128	$1, 1*32+16(%rsi, %r10), %ymm5, %ymm5
+	vmovdqa	2*32(%rsi, %rax), %xmm6
+	vinserti128	$1, 2*32+16(%rsi, %r10), %ymm6, %ymm6
+	vmovdqa	3*32(%rsi, %rax), %xmm7
+	vinserti128	$1, 3*32+16(%rsi, %r10), %ymm7, %ymm7
+	vpxor	%ymm4, %ymm12, %ymm12
+	vpxor	%ymm5, %ymm13, %ymm13
+	vpxor	%ymm6, %ymm14, %ymm14
+	vpxor	%ymm7, %ymm15, %ymm15
+	
+	vmovdqa	%ymm0, 0*256+0*32(%rsp)
+	vmovdqa	%ymm1, 0*256+1*32(%rsp)
+	vmovdqa	%ymm2, 0*256+2*32(%rsp)
+	vmovdqa	%ymm3, 0*256+3*32(%rsp)
+	vmovdqa	%ymm8, 1*256+0*32(%rsp)
+	vmovdqa	%ymm9, 1*256+1*32(%rsp)
+	vmovdqa	%ymm10, 1*256+2*32(%rsp)
+	vmovdqa	%ymm11, 1*256+3*32(%rsp)
+	vmovdqa	%ymm12, 2*256+0*32(%rsp)
+	vmovdqa	%ymm13, 2*256+1*32(%rsp)
+	vmovdqa	%ymm14, 2*256+2*32(%rsp)
+	vmovdqa	%ymm15, 2*256+3*32(%rsp)
+	salsa8_core_6way_avx2
+	vpaddd	0*256+0*32(%rsp), %ymm0, %ymm0
+	vpaddd	0*256+1*32(%rsp), %ymm1, %ymm1
+	vpaddd	0*256+2*32(%rsp), %ymm2, %ymm2
+	vpaddd	0*256+3*32(%rsp), %ymm3, %ymm3
+	vpaddd	1*256+0*32(%rsp), %ymm8, %ymm8
+	vpaddd	1*256+1*32(%rsp), %ymm9, %ymm9
+	vpaddd	1*256+2*32(%rsp), %ymm10, %ymm10
+	vpaddd	1*256+3*32(%rsp), %ymm11, %ymm11
+	vpaddd	2*256+0*32(%rsp), %ymm12, %ymm12
+	vpaddd	2*256+1*32(%rsp), %ymm13, %ymm13
+	vpaddd	2*256+2*32(%rsp), %ymm14, %ymm14
+	vpaddd	2*256+3*32(%rsp), %ymm15, %ymm15
+	vmovdqa	%ymm0, 0*256+0*32(%rsp)
+	vmovdqa	%ymm1, 0*256+1*32(%rsp)
+	vmovdqa	%ymm2, 0*256+2*32(%rsp)
+	vmovdqa	%ymm3, 0*256+3*32(%rsp)
+	vmovdqa	%ymm8, 1*256+0*32(%rsp)
+	vmovdqa	%ymm9, 1*256+1*32(%rsp)
+	vmovdqa	%ymm10, 1*256+2*32(%rsp)
+	vmovdqa	%ymm11, 1*256+3*32(%rsp)
+	vmovdqa	%ymm12, 2*256+0*32(%rsp)
+	vmovdqa	%ymm13, 2*256+1*32(%rsp)
+	vmovdqa	%ymm14, 2*256+2*32(%rsp)
+	vmovdqa	%ymm15, 2*256+3*32(%rsp)
+	
+	vmovdqa	4*32(%rsi, %rbp), %xmm4
+	vinserti128	$1, 4*32+16(%rsi, %r8), %ymm4, %ymm4
+	vmovdqa	5*32(%rsi, %rbp), %xmm5
+	vinserti128	$1, 5*32+16(%rsi, %r8), %ymm5, %ymm5
+	vmovdqa	6*32(%rsi, %rbp), %xmm6
+	vinserti128	$1, 6*32+16(%rsi, %r8), %ymm6, %ymm6
+	vmovdqa	7*32(%rsi, %rbp), %xmm7
+	vinserti128	$1, 7*32+16(%rsi, %r8), %ymm7, %ymm7
+	vpxor	%ymm4, %ymm0, %ymm0
+	vpxor	%ymm5, %ymm1, %ymm1
+	vpxor	%ymm6, %ymm2, %ymm2
+	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqa	4*32(%rsi, %rbx), %xmm4
+	vinserti128	$1, 4*32+16(%rsi, %r9), %ymm4, %ymm4
+	vmovdqa	5*32(%rsi, %rbx), %xmm5
+	vinserti128	$1, 5*32+16(%rsi, %r9), %ymm5, %ymm5
+	vmovdqa	6*32(%rsi, %rbx), %xmm6
+	vinserti128	$1, 6*32+16(%rsi, %r9), %ymm6, %ymm6
+	vmovdqa	7*32(%rsi, %rbx), %xmm7
+	vinserti128	$1, 7*32+16(%rsi, %r9), %ymm7, %ymm7
+	vpxor	%ymm4, %ymm8, %ymm8
+	vpxor	%ymm5, %ymm9, %ymm9
+	vpxor	%ymm6, %ymm10, %ymm10
+	vpxor	%ymm7, %ymm11, %ymm11
+	vmovdqa	4*32(%rsi, %rax), %xmm4
+	vinserti128	$1, 4*32+16(%rsi, %r10), %ymm4, %ymm4
+	vmovdqa	5*32(%rsi, %rax), %xmm5
+	vinserti128	$1, 5*32+16(%rsi, %r10), %ymm5, %ymm5
+	vmovdqa	6*32(%rsi, %rax), %xmm6
+	vinserti128	$1, 6*32+16(%rsi, %r10), %ymm6, %ymm6
+	vmovdqa	7*32(%rsi, %rax), %xmm7
+	vinserti128	$1, 7*32+16(%rsi, %r10), %ymm7, %ymm7
+	vpxor	%ymm4, %ymm12, %ymm12
+	vpxor	%ymm5, %ymm13, %ymm13
+	vpxor	%ymm6, %ymm14, %ymm14
+	vpxor	%ymm7, %ymm15, %ymm15
+	vpxor	0*256+4*32(%rsp), %ymm0, %ymm0
+	vpxor	0*256+5*32(%rsp), %ymm1, %ymm1
+	vpxor	0*256+6*32(%rsp), %ymm2, %ymm2
+	vpxor	0*256+7*32(%rsp), %ymm3, %ymm3
+	vpxor	1*256+4*32(%rsp), %ymm8, %ymm8
+	vpxor	1*256+5*32(%rsp), %ymm9, %ymm9
+	vpxor	1*256+6*32(%rsp), %ymm10, %ymm10
+	vpxor	1*256+7*32(%rsp), %ymm11, %ymm11
+	vpxor	2*256+4*32(%rsp), %ymm12, %ymm12
+	vpxor	2*256+5*32(%rsp), %ymm13, %ymm13
+	vpxor	2*256+6*32(%rsp), %ymm14, %ymm14
+	vpxor	2*256+7*32(%rsp), %ymm15, %ymm15
+	vmovdqa	%ymm0, 0*256+4*32(%rsp)
+	vmovdqa	%ymm1, 0*256+5*32(%rsp)
+	vmovdqa	%ymm2, 0*256+6*32(%rsp)
+	vmovdqa	%ymm3, 0*256+7*32(%rsp)
+	vmovdqa	%ymm8, 1*256+4*32(%rsp)
+	vmovdqa	%ymm9, 1*256+5*32(%rsp)
+	vmovdqa	%ymm10, 1*256+6*32(%rsp)
+	vmovdqa	%ymm11, 1*256+7*32(%rsp)
+	vmovdqa	%ymm12, 2*256+4*32(%rsp)
+	vmovdqa	%ymm13, 2*256+5*32(%rsp)
+	vmovdqa	%ymm14, 2*256+6*32(%rsp)
+	vmovdqa	%ymm15, 2*256+7*32(%rsp)
+	salsa8_core_6way_avx2
+	vpaddd	0*256+4*32(%rsp), %ymm0, %ymm0
+	vpaddd	0*256+5*32(%rsp), %ymm1, %ymm1
+	vpaddd	0*256+6*32(%rsp), %ymm2, %ymm2
+	vpaddd	0*256+7*32(%rsp), %ymm3, %ymm3
+	vpaddd	1*256+4*32(%rsp), %ymm8, %ymm8
+	vpaddd	1*256+5*32(%rsp), %ymm9, %ymm9
+	vpaddd	1*256+6*32(%rsp), %ymm10, %ymm10
+	vpaddd	1*256+7*32(%rsp), %ymm11, %ymm11
+	vpaddd	2*256+4*32(%rsp), %ymm12, %ymm12
+	vpaddd	2*256+5*32(%rsp), %ymm13, %ymm13
+	vpaddd	2*256+6*32(%rsp), %ymm14, %ymm14
+	vpaddd	2*256+7*32(%rsp), %ymm15, %ymm15
+	vmovdqa	%ymm0, 0*256+4*32(%rsp)
+	vmovdqa	%ymm1, 0*256+5*32(%rsp)
+	vmovdqa	%ymm2, 0*256+6*32(%rsp)
+	vmovdqa	%ymm3, 0*256+7*32(%rsp)
+	vmovdqa	%ymm8, 1*256+4*32(%rsp)
+	vmovdqa	%ymm9, 1*256+5*32(%rsp)
+	vmovdqa	%ymm10, 1*256+6*32(%rsp)
+	vmovdqa	%ymm11, 1*256+7*32(%rsp)
+	vmovdqa	%ymm12, 2*256+4*32(%rsp)
+	vmovdqa	%ymm13, 2*256+5*32(%rsp)
+	vmovdqa	%ymm14, 2*256+6*32(%rsp)
+	vmovdqa	%ymm15, 2*256+7*32(%rsp)
+	
+	subq	$1, %rcx
+	ja scrypt_core_6way_avx2_loop2
+	
+	scrypt_shuffle_unpack2 %rsp, 0*128, %rdi, 0*256+0
+	scrypt_shuffle_unpack2 %rsp, 1*128, %rdi, 0*256+64
+	scrypt_shuffle_unpack2 %rsp, 2*128, %rdi, 1*256+0
+	scrypt_shuffle_unpack2 %rsp, 3*128, %rdi, 1*256+64
+	scrypt_shuffle_unpack2 %rsp, 4*128, %rdi, 2*256+0
+	scrypt_shuffle_unpack2 %rsp, 5*128, %rdi, 2*256+64
+	
+	scrypt_core_6way_cleanup
+	ret
+
+#endif /* ENABLE_AVX2 */
 
 #endif


### PR DESCRIPTION
Enable old scrypt assembler implementations and update them with ones from cpuminer-opt. Posting this PR prematurely to get help with testing. A quick test showed a 50% performance increase on the scrypt blocks when syncing on a 3.1GHz i5 which should spill over to an almost equal boost when loading the blocks from disk.

Tested:
- x64 sync from 0
- ARM sync, ~20% (66 vs 83 minutes) speed increase on the first 50k blocks (@G-UK)

Needs testing:
- Loading any existing chain (I can do that)
- x86 sync (I can do that)

Changes needed:
- Cleanup in configure.ac. Not all changes are needed.