### PR TITLE
Fix missing poll in GUI when most recent poll expired

### DIFF
--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -165,6 +165,22 @@ bool PollExpired(std::string pollname)
     return (expiration < (double)GetAdjustedTime()) ? true : false;
 }
 
+// Like PollExpired() except that it doesn't load the entire Section::POLL
+// AppCache section for every call:
+bool PollIsActive(const std::string& poll_contract)
+{
+    try
+    {
+        uint64_t expires = stoll(ExtractXML(poll_contract, "<EXPIRATION>", "</EXPIRATION>"));
+
+        return expires > GetAdjustedTime();
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+}
+
 bool PollCreatedAfterSecurityUpgrade(std::string pollname)
 {
     // If the expiration is after July 1 2017, use the new security features.

--- a/src/contract/polls.h
+++ b/src/contract/polls.h
@@ -40,6 +40,10 @@ bool PollExists(std::string pollname);
 
 bool PollExpired(std::string pollname);
 
+// Like PollExpired() except that it doesn't load the entire Section::POLL
+// AppCache section for every call:
+bool PollIsActive(const std::string& poll_contract);
+
 bool PollCreatedAfterSecurityUpgrade(std::string pollname);
 
 double PollDuration(std::string pollname);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -42,6 +42,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.pushKV("blocks",        nBestHeight);
     diff.pushKV("proof-of-stake",    GetDifficulty(GetLastBlockIndex(pindexBest, true)));
 
+    std::string current_poll;
     { LOCK(MinerStatus.lock);
         // not using real weigh to not break calculation
         bool staking = MinerStatus.nLastCoinStakeSearchInterval && MinerStatus.WeightSum;
@@ -65,6 +66,8 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         obj.pushKV("mining-kernels-found", MinerStatus.KernelsFound);
         obj.pushKV("kernel-diff-best",MinerStatus.KernelDiffMax);
         obj.pushKV("kernel-diff-sum",MinerStatus.KernelDiffSum);
+
+        current_poll = GetCurrentOverviewTabPoll();
     }
 
     int64_t nMinStakeSplitValue = 0;
@@ -128,8 +131,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     }
 
     obj.pushKV("MiningInfo 1", msMiningErrors);
-    std::string sMessageKey = ExtractXML(msPoll, "<MK>", "</MK>");
-    obj.pushKV("MiningInfo 2", "Poll: " + sMessageKey.substr(0,80));
+    obj.pushKV("MiningInfo 2", "Poll: " + current_poll);
     obj.pushKV("MiningInfo 5", msMiningErrors5);
     obj.pushKV("MiningInfo 6", msMiningErrors6);
     obj.pushKV("MiningInfo 7", msMiningErrors7);


### PR DESCRIPTION
This fixes #1454 by fetching the next most recent active poll from the `AppCache` when the poll stored in `msPoll` expired. The most recent poll published to the network is not necessarily the poll that expires last--an earlier poll could exist that expires later.

Also updates the RPC output from #1437.