### PR TITLE
Increase vote UTXO limit to 200 items

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1249,14 +1249,27 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 				        vCoins.push_back(COutput(pcoin, i, nDepth));
 				   }
 			}
-
         }
     }
 }
 
+void CWallet::AvailableCoinsSorted(
+    vector<COutput>& vCoins,
+    bool fOnlyConfirmed,
+    const CCoinControl *coinControl,
+    bool fIncludeStakedCoins) const
+{
+    AvailableCoins(vCoins, fOnlyConfirmed, coinControl, fIncludeStakedCoins);
+
+    const auto ascending_by_amount = [](const COutput& a, const COutput& b) {
+        return a.tx->vout[a.i].nValue < b.tx->vout[b.i].nValue;
+    };
+
+    std::sort(vCoins.begin(), vCoins.end(), ascending_by_amount);
+}
+
 void CWallet::AvailableCoinsForStaking(vector<COutput>& vCoins, unsigned int nSpendTime) const
 {
-
     vCoins.clear();
     {
         LOCK2(cs_main, cs_wallet);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -143,6 +143,7 @@ public:
 	void AvailableCoinsForStaking(std::vector<COutput>& vCoins, unsigned int nSpendTime) const;
     bool SelectCoinsForStaking(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, bool fIncludeStakingCoins=false) const;
+    void AvailableCoinsSorted(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, bool fIncludeStakingCoins=false) const;
     bool SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
 
     // keystore implementation


### PR DESCRIPTION
The current voting code limits the coin-based portion of voting weight to 50 UTXOs causing misrepresentation of voters with many UTXOs. This change increases the limit to 200--based on analysis of how many UTXOs will fit in the 100 KB transaction--and chooses the largest UTXOs first.

The protocol cannot reasonably accommodate more than 200 UTXOs without changing the consensus-sensitive design of the vote contract. Support for a greater number of UTXOs will come with the next mandatory version.