### PR TITLE
Add warning in help for blockchain scan for importprivkey

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -112,6 +112,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
         "\n"
         "[label] -------> Optional; Label for imported address\n"
         "[bool:rescan] -> Optional; Default true\n"
+        "WARNING: if true rescan of blockchain will occur. This could take up to 20 minutes.\n"
         "\n"
         "Adds a private key (as returned by dumpprivkey) to your wallet\n");
 


### PR DESCRIPTION
The easiest thing to do here is to simply add a warning about the long time for the rescan in the help. addresses #1399.