### PR TITLE
Quick fix for rainbymagnitude

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -929,6 +929,8 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
             std::string sContract = DecodeBase64(scacheContract);
             std::string sGRCAddress = ExtractValue(sContract, ";", 2);
 
+            if (fDebug) LogPrintf("INFO: rainbymagnitude: sGRCaddress = %s.", sGRCAddress);
+
             double dPayout = (structMag.Magnitude / dTotalNetworkMagnitude) * dAmount;
 
             if (dPayout <= 0)
@@ -939,7 +941,10 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
             CBitcoinAddress address(sGRCAddress);
 
             if (!address.IsValid())
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Gridcoin address: ") + sGRCAddress);
+            {
+                LogPrintf("ERROR: rainbymagnitude: Invalid Gridcoin address: %s.", sGRCAddress);
+                continue;
+            }
 
             setAddress.insert(address);
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -936,8 +936,6 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
             if (dPayout <= 0)
                 continue;
 
-            dTotalAmount += dPayout;
-
             CBitcoinAddress address(sGRCAddress);
 
             if (!address.IsValid())
@@ -945,6 +943,8 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
                 LogPrintf("ERROR: rainbymagnitude: Invalid Gridcoin address: %s.", sGRCAddress);
                 continue;
             }
+
+            dTotalAmount += dPayout;
 
             setAddress.insert(address);
 


### PR DESCRIPTION
This ignores the "NA"s and invalid addresses in the beacon section
that correspond to mvMagnitude entries. This is due to an issue with
the beacon publishing process which will be fixed in Elizabeth.