### PR TITLE
Fix staked block rejection when active researcher

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -30,6 +30,7 @@ double CoinToDouble(double surrogate);
 
 void ThreadTopUpKeyPool(void* parg);
 
+bool HasActiveBeacon(const std::string& cpid);
 std::string SerializeBoincBlock(MiningCPID mcpid);
 bool LessVerbose(int iMax1000);
 
@@ -832,9 +833,8 @@ unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitVal
 
 bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInputs, CWallet *pwallet, MiningCPID& BoincData)
 {
-    //Append beacon signature to coinbase
-    std::string PublicKey = GlobalCPUMiningCPID.BoincPublicKey;
-    if (!PublicKey.empty())
+    // Append beacon signature to coinbase
+    if (HasActiveBeacon(GlobalCPUMiningCPID.cpid))
     {
         std::string sBoincSignature;
         std::string sError;


### PR DESCRIPTION
This fixes an issue introduced in #1480 when staking a PoR block. `GlobalCPUMiningCPID.BoincPublicKey` is empty which causes the miner to skip signing with the beacon key. The old `GetNextProject()` function set this field but nothing ever used the value except for the conditional check in the miner, so we can replace it with `HasActiveBeacon()`. 