### PR TITLE
Add back informational magnitude to generated blocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4751,17 +4751,6 @@ std::string RetrieveMd5(std::string s1)
     }
 }
 
-int GetFilesize(FILE* file)
-{
-    int nSavePos = ftell(file);
-    int nFilesize = -1;
-    if (fseek(file, 0, SEEK_END) == 0)
-        nFilesize = ftell(file);
-    fseek(file, nSavePos, SEEK_SET);
-    return nFilesize;
-}
-
-
 std::set<std::string> GetAlternativeBeaconKeys(const std::string& cpid)
 {
     int64_t iMaxSeconds = 60 * 24 * 30 * 6 * 60;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -30,6 +30,7 @@ double CoinToDouble(double surrogate);
 
 void ThreadTopUpKeyPool(void* parg);
 
+double CalculatedMagnitude(int64_t locktime, bool bUseLederstrumpf);
 bool HasActiveBeacon(const std::string& cpid);
 std::string SerializeBoincBlock(MiningCPID mcpid);
 bool LessVerbose(int iMax1000);
@@ -973,6 +974,7 @@ bool CreateGridcoinReward(CBlock &blocknew, MiningCPID& miningcpid, uint64_t &nC
     pbh=pindexPrev->GetBlockHash();
 
     miningcpid.lastblockhash = pbh.GetHex();
+    miningcpid.Magnitude = CalculatedMagnitude(blocknew.nTime, false);
     miningcpid.ResearchSubsidy = OUT_POR;
     miningcpid.ResearchAge = dAccrualAge;
     miningcpid.ResearchMagnitudeUnit = dAccrualMagnitudeUnit;

--- a/src/test/neuralnet/researcher_tests.cpp
+++ b/src/test/neuralnet/researcher_tests.cpp
@@ -600,7 +600,7 @@ BOOST_AUTO_TEST_CASE(it_ignores_the_team_requirement_when_set_by_protocol)
     }
 
     // Clean up:
-    SetArgument("email", "researcher@example.com");
+    SetArgument("email", "");
     DeleteCache(Section::PROTOCOL, "REQUIRE_TEAM_WHITELIST_MEMBERSHIP");
     NN::Researcher::Reload({ });
 }

--- a/src/util.h
+++ b/src/util.h
@@ -192,8 +192,6 @@ bool WildcardMatch(const char* psz, const char* mask);
 bool WildcardMatch(const std::string& str, const std::string& mask);
 void FileCommit(FILE *fileout);
 
-int GetFilesize(FILE* file);
-
 std::string TimestampToHRDate(double dtm);
 
 bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);


### PR DESCRIPTION
The changes from #1480 did not set the wallet's current magnitude on `GlobalCPUMiningCPID` with each miner loop as `GetNextProject()` did before, so the informational magnitude embedded in each generated block always equals zero. This fixes the regression by adding the magnitude while preparing a new block.