### PR TITLE
Add back in the in sync check in ScraperGetNeuralContract

### DIFF
--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -105,7 +105,7 @@ bool LoadScraperFileManifest(const fs::path& file);
 bool InsertScraperFileManifestEntry(ScraperFileManifestEntry& entry);
 unsigned int DeleteScraperFileManifestEntry(ScraperFileManifestEntry& entry);
 bool MarkScraperFileManifestEntryNonCurrent(ScraperFileManifestEntry& entry);
-bool AlignScraperFileManifestEntries(const fs::path& file, const std::string& filetype, const std::string& sProject, const bool& excludefromcsmanifest);
+void AlignScraperFileManifestEntries(const fs::path& file, const std::string& filetype, const std::string& sProject, const bool& excludefromcsmanifest);
 ScraperStats GetScraperStatsByConsensusBeaconList();
 bool LoadProjectFileToStatsByCPID(const std::string& project, const fs::path& file, const double& projectmag, const BeaconMap& mBeaconMap, ScraperStats& mScraperStats);
 bool LoadProjectObjectToStatsByCPID(const std::string& project, const CSerializeData& ProjectData, const double& projectmag, const BeaconMap& mBeaconMap, ScraperStats& mScraperStats);
@@ -2354,7 +2354,7 @@ bool MarkScraperFileManifestEntryNonCurrent(ScraperFileManifestEntry& entry)
 }
 
 
-bool AlignScraperFileManifestEntries(const fs::path& file, const std::string& filetype, const std::string& sProject, const bool& excludefromcsmanifest)
+void AlignScraperFileManifestEntries(const fs::path& file, const std::string& filetype, const std::string& sProject, const bool& excludefromcsmanifest)
 {
     ScraperFileManifestEntry NewRecord;
 

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -100,6 +100,9 @@ AppCacheSectionExt mScrapersExt = {};
 
 // Lets try to start using some lockless synchronization.
 std::atomic<int64_t> nSyncTime {0};
+// Starting state is always out of sync. This atomic is to avoid multiple threads calling
+// OutOfSyncByAge(), which takes a lock on cs_main and can cause deadlocks.
+std::atomic<bool> fOutOfSyncByAge {true};
 
 CCriticalSection cs_mScrapersExt;
 


### PR DESCRIPTION
Also fixes a return type issue for AlignScraperFileManifestEntries.

This is a subset of #1488 and has already been reviewed.