### PR TITLE
Remove dynamic CBR

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1792,27 +1792,15 @@ double GetProofOfResearchReward(std::string cpid, bool VerifyingBlock)
 // miner's coin stake reward based on coin age spent (coin-days)
 int64_t GetConstantBlockReward(const CBlockIndex* index)
 {
-    // The constant block reward is set to a default, voted on value, but this can
-    // be overridden using an admin message. This allows us to change the reward
-    // amount without having to release a mandatory with updated rules. In the case
-    // there is a breach or leaked admin keys the rewards are clamped to twice that
-    // of the default value.    
-    const int64_t MIN_CBR = 0;
-    const int64_t MAX_CBR = DEFAULT_CBR * 2;
-
-    int64_t reward = DEFAULT_CBR;
-    AppCacheEntry oCBReward = ReadCache(Section::PROTOCOL, "blockreward1");
-
-    //TODO: refactor the expire checking to subroutine
-    //Note: time constant is same as GetBeaconPublicKey
-    if( (index->nTime - oCBReward.timestamp) <= (60 * 24 * 30 * 6 * 60) )
-    {
-        reward = atoi64(oCBReward.value);
-    }
-
-    reward = std::max(reward, MIN_CBR);
-    reward = std::min(reward, MAX_CBR);
-    return reward;
+    // Constant block reward used to be configurable through an admin message.
+    // While convenient it should probably be more explicit through hard coded
+    // values and poll driven decisions. This also makes the implementation
+    // easier as there is no need for handling abnormal CBR reward values due
+    // to leaked keys.
+    //
+    // If the reward values changes in the future the value can be
+    // conditionally set here based on the version of "index".
+    return CONSTANT_BLOCK_REWARD;
 }
 
 int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid,

--- a/src/main.h
+++ b/src/main.h
@@ -32,7 +32,7 @@ static const int LAST_POW_BLOCK = 2050;
 static const int CONSENSUS_LOOKBACK = 5;  //Amount of blocks to go back from best block, to avoid counting forked blocks
 static const int BLOCK_GRANULARITY = 10;  //Consensus block divisor
 static const int TALLY_GRANULARITY = BLOCK_GRANULARITY;
-static const int64_t DEFAULT_CBR = 10 * COIN;
+static const int64_t CONSTANT_BLOCK_REWARD = 10 * COIN;
 
 extern std::string msMasterProjectPublicKey;
 extern std::string msMasterMessagePublicKey;

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -166,40 +166,19 @@ BOOST_AUTO_TEST_CASE(gridcoin_DefaultCBRShouldBe10)
 {
     CBlockIndex index;
     index.nTime = 1538066417;
-    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), DEFAULT_CBR);
+    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), CONSTANT_BLOCK_REWARD);
 }
 
-BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldOverrideDefault)
+BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldBeIgnored)
 {
     const int64_t time = 123456;
-    const int64_t cbr = 14.9 * COIN;
 
     CBlockIndex index;
     index.nVersion = 10;
     index.nTime = time;
 
-    WriteCache(Section::PROTOCOL, "blockreward1", ToString(cbr), time);
-    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), cbr);
-}
-
-BOOST_AUTO_TEST_CASE(gridcoin_NegativeCBRShouldClampTo0)
-{
-    const int64_t time = 123456;
-    CBlockIndex index;
-    index.nTime = time;
-
-    WriteCache(Section::PROTOCOL, "blockreward1", ToString(-1 * COIN), time);
-    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), 0);
-}
-
-BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldClampTo2xDefault)
-{
-    const int64_t time = 123456;
-    CBlockIndex index;
-    index.nTime = time;
-
-    WriteCache(Section::PROTOCOL, "blockreward1", ToString(DEFAULT_CBR * 2.1), time);
-    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), DEFAULT_CBR * 2);
+    WriteCache(Section::PROTOCOL, "blockreward1", "15", time);
+    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), CONSTANT_BLOCK_REWARD);
 }
 
 BOOST_AUTO_TEST_CASE(gridcoin_ObsoleteConfigurableCBRShouldResortToDefault)
@@ -212,7 +191,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_ObsoleteConfigurableCBRShouldResortToDefault)
     // relative to the block.
     WriteCache(Section::PROTOCOL, "blockreward1", ToString(3 * COIN), index.nTime - max_message_age - 1);
 
-    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), DEFAULT_CBR);
+    BOOST_CHECK_EQUAL(GetConstantBlockReward(&index), CONSTANT_BLOCK_REWARD);
 }
 
 


### PR DESCRIPTION
As mentioned in the comment, this should probably be more explicit and controlled, and it simplifies the implementation.

Currently testing:
- [x] Sync prod from 1624371
- [x] Sync prod from 0
- [x] Sync testnet from 971732
- [ ] Sync testnet from 0

This closes #1310.