### PR TITLE
Clean up legacy Proof-of-Work functions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3917,18 +3917,6 @@ uint256 CBlockIndex::GetBlockTrust() const
     return chaintrust;
 }
 
-bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRequired, unsigned int nToCheck)
-{
-    unsigned int nFound = 0;
-    for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)
-    {
-        if (pstart->nVersion >= minVersion)
-            ++nFound;
-        pstart = pstart->pprev;
-    }
-    return (nFound >= nRequired);
-}
-
 bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent)
 {
     // Pre-condition checks.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2077,14 +2077,6 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
       DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()));
 }
 
-
-void CBlock::UpdateTime(const CBlockIndex* pindexPrev)
-{
-    nTime = max(GetBlockTime(), GetAdjustedTime());
-}
-
-
-
 bool CTransaction::DisconnectInputs(CTxDB& txdb)
 {
     // Relinquish previous transactions' spent pointers

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2252,17 +2252,6 @@ bool LessVerbose(int iMax1000)
      return false;
 }
 
-
-bool KeyEnabled(std::string key)
-{
-    if (mapArgs.count("-" + key))
-    {
-            std::string sBool = GetArg("-" + key, "false");
-            if (sBool == "true") return true;
-    }
-    return false;
-}
-
 unsigned int CTransaction::GetP2SHSigOpCount(const MapPrevTx& inputs) const
 {
     if (IsCoinBase())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,6 @@ extern double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_
 
 extern double GetOwedAmount(std::string cpid);
 bool TallyMagnitudesInSuperblock();
-extern std::string GetNeuralNetworkReport();
 std::string GetCommandNonce(std::string command);
 
 extern double GRCMagnitudeUnit(int64_t locktime);
@@ -7153,24 +7152,6 @@ std::string GetCurrentNeuralNetworkSupermajorityHash(double& out_popularity)
     
     out_popularity = highest_popularity;
     return neural_hash;
-}
-
-std::string GetNeuralNetworkReport()
-{
-    //Returns a report of the networks neural hashes in order of popularity
-    std::string neural_hash = "";
-    std::string report = "Neural_hash, Popularity\n";
-    std::string row = "";
-    
-    // Copy to a sorted map.
-    std::map<std::string, double> sorted_hashes(
-                mvNeuralNetworkHash.begin(),
-                mvNeuralNetworkHash.end());
-    
-    for(auto& entry : sorted_hashes)
-        report += entry.first + "," + RoundToString(entry.second, 0) + "\n";
-
-    return report;
 }
 
 bool MemorizeMessage(const CTransaction &tx, double dAmount, std::string sRecipient)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3929,11 +3929,6 @@ bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, uns
     return (nFound >= nRequired);
 }
 
-bool ServicesIncludesNN(CNode* pNode)
-{
-    return (Contains(pNode->strSubVer,"1999")) ? true : false;
-}
-
 bool VerifySuperblock(const std::string& superblock, const CBlockIndex* parent)
 {
     // Pre-condition checks.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4685,12 +4685,6 @@ bool IsCPIDValidv2(MiningCPID& mc, int height)
     return result;
 }
 
-double GetTotalOwedAmount(std::string cpid)
-{
-    StructCPID& o = GetInitializedStructCPID2(cpid,mvMagnitudes);
-    return o.totalowed;
-}
-
 double GetOwedAmount(std::string cpid)
 {
     if (mvMagnitudes.size() > 1)

--- a/src/main.h
+++ b/src/main.h
@@ -1457,14 +1457,6 @@ public:
         return pbegin[(pend - pbegin)/2];
     }
 
-    /**
-     * Returns true if there are nRequired or more blocks of minVersion or above
-     * in the last nToCheck blocks, starting at pstart and going backwards.
-     */
-    static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart,
-                                unsigned int nRequired, unsigned int nToCheck);
-
-
     bool IsProofOfWork() const
     {
         return !(nFlags & BLOCK_PROOF_OF_STAKE);

--- a/src/main.h
+++ b/src/main.h
@@ -1110,8 +1110,6 @@ public:
         return (int64_t)nTime;
     }
 
-    void UpdateTime(const CBlockIndex* pindexPrev);
-
     // entropy bit for stake modifier if chosen by modifier
     unsigned int GetStakeEntropyBit() const
     {

--- a/src/main.h
+++ b/src/main.h
@@ -258,7 +258,7 @@ bool CheckProofOfResearch(
     const CBlockIndex* pindexPrev, //previous block in chain index
     const CBlock &block);    //block to check
 
-unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake);
+unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast);
 int64_t GetConstantBlockReward(const CBlockIndex* index);
 int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string operation, CBlockIndex* pindexLast, bool bVerifyingBlock, int VerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude);
 int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid,
@@ -288,8 +288,6 @@ double GetEstimatedTimetoStake(double dDiff = 0.0, double dConfidence = 0.8);
 void AddRARewardBlock(const CBlockIndex* pIndex);
 MiningCPID GetBoincBlockByIndex(CBlockIndex* pblockindex);
 
-unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime);
-unsigned int ComputeMinStake(unsigned int nBase, int64_t nTime, unsigned int nBlockTime);
 int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1228,7 +1228,7 @@ void StakeMiner(CWallet *pwallet)
         // * Create a bare block
         StakeBlock.nTime= GetAdjustedTime();
         StakeBlock.nNonce= 0;
-        StakeBlock.nBits = GetNextTargetRequired(pindexPrev, true);
+        StakeBlock.nBits = GetNextTargetRequired(pindexPrev);
         StakeBlock.vtx.resize(2);
         //tx 0 is coin_base
         CTransaction &StakeTX= StakeBlock.vtx[1]; //tx 1 is coin_stake

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -434,31 +434,6 @@ UniValue getblockbynumber(const UniValue& params, bool fHelp)
     return blockToJSON(block, pblockindex, params.size() > 1 ? params[1].get_bool() : false);
 }
 
-void filecopy(FILE *dest, FILE *src)
-{
-    const int size = 16384;
-    char buffer[size];
-
-    while (!feof(src))
-    {
-        int n = fread(buffer, 1, size, src);
-        fwrite(buffer, 1, n, dest);
-    }
-
-    fflush(dest);
-}
-
-void fileopen_and_copy(std::string src, std::string dest)
-{
-    FILE * infile  = fopen(src.c_str(),  "rb");
-    FILE * outfile = fopen(dest.c_str(), "wb");
-
-    filecopy(outfile, infile);
-
-    fclose(infile);
-    fclose(outfile);
-}
-
 std::string ExtractValue(std::string data, std::string delimiter, int pos)
 {
     std::vector<std::string> vKeys = split(data.c_str(),delimiter);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -3,10 +3,8 @@
 //
 #include <algorithm>
 
-#include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/foreach.hpp>
 
 #include "main.h"
 #include "wallet.h"
@@ -80,56 +78,6 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     SetMockTime(nStartTime+60*60*24+1);
     BOOST_CHECK(!CNode::IsBanned(addr));
-}
-
-static bool CheckNBits(unsigned int nbits1, int64_t time1, unsigned int nbits2, int64_t time2)\
-{
-    if (time1 > time2)
-        return CheckNBits(nbits2, time2, nbits1, time1);
-    int64_t deltaTime = time2-time1;
-
-    CBigNum required;
-    required.SetCompact(ComputeMinWork(nbits1, deltaTime));
-    CBigNum have;
-    have.SetCompact(nbits2);
-    return (have <= required);
-}
-
-BOOST_AUTO_TEST_CASE(DoS_checknbits)
-{
-    using namespace boost::assign; // for 'map_list_of()'
-
-    // Timestamps,nBits from the bitcoin blockchain.
-    // These are the block-chain checkpoint blocks
-    typedef std::map<int64_t, unsigned int> BlockData;
-    BlockData chainData =
-        map_list_of(1239852051,486604799)(1262749024,486594666)
-        (1279305360,469854461)(1280200847,469830746)(1281678674,469809688)
-        (1296207707,453179945)(1302624061,453036989)(1309640330,437004818)
-        (1313172719,436789733);
-
-    // Make sure CheckNBits considers every combination of block-chain-lock-in-points
-    // "sane":
-    BOOST_FOREACH(const BlockData::value_type& i, chainData)
-    {
-        BOOST_FOREACH(const BlockData::value_type& j, chainData)
-        {
-            BOOST_CHECK(CheckNBits(i.second, i.first, j.second, j.first));
-        }
-    }
-
-    // Test a couple of insane combinations:
-    BlockData::value_type firstcheck = *(chainData.begin());
-    BlockData::value_type lastcheck = *(chainData.rbegin());
-
-    // First checkpoint difficulty at or a while after the last checkpoint time should fail when
-    // compared to last checkpoint
-    BOOST_CHECK(!CheckNBits(firstcheck.second, lastcheck.first+60*10, lastcheck.second, lastcheck.first));
-    BOOST_CHECK(!CheckNBits(firstcheck.second, lastcheck.first+60*60*24*14, lastcheck.second, lastcheck.first));
-
-    // ... but OK if enough time passed for difficulty to adjust downward:
-    BOOST_CHECK(CheckNBits(firstcheck.second, lastcheck.first+60*60*24*365*4, lastcheck.second, lastcheck.first));
-
 }
 
 CTransaction RandomOrphan()

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -33,17 +33,6 @@ int64_t GetMaximumBoincSubsidy(int64_t nTime);
 bool fConfChange;
 unsigned int nDerivationMethodIndex;
 
-namespace
-{
-    int64_t CoinFromValue(double dAmount)
-    {
-        if (dAmount <= 0.0 || dAmount > MAX_MONEY)        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-        int64_t nAmount = roundint64(dAmount * COIN);
-        if (!MoneyRange(nAmount))                         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-        return nAmount;
-    }
-}
-
 //////////////////////////////////////////////////////////////////////////////
 //
 // mapWallet


### PR DESCRIPTION
I had these changes stashed for #1311. Removal of `GetProofOfWorkReward()` snuck into #1480 at 
f7d975f.

Also includes removal of some other unused functions.