### PR TITLE
Notify when wallet locked in beaconstatus RPC method

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1055,25 +1055,30 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
 
     res.pushKV("Magnitude (As of last superblock)", dMagnitude);
 
-    if (dMagnitude==0)
+    const bool is_mine = sCPID == NN::GetPrimaryCpid();
+    res.pushKV("Mine", is_mine);
+
+    if (is_mine && dMagnitude == 0)
         res.pushKV("Warning","Your magnitude is 0 as of the last superblock: this may keep you from staking POR blocks.");
 
-    // Staking Test 10-15-2016 - Simulate signing an actual block to verify this CPID keypair will work.
-    uint256 hashBlock = GetRandHash();
-
-    if (!sPubKey.empty())
+    if (!sPubKey.empty() && is_mine)
     {
+        EnsureWalletIsUnlocked();
+
         bool bResult;
         std::string sSignature;
         std::string sError;
+
+        // Staking Test 10-15-2016 - Simulate signing an actual block to verify this CPID keypair will work.
+        uint256 hashBlock = GetRandHash();
 
         bResult = SignBlockWithCPID(sCPID, hashBlock.GetHex(), sSignature, sError);
 
         if (!bResult)
         {
-            sErr += "Failed to sign block with cpid ";
+            sErr += "Failed to sign block with cpid: ";
             sErr += sError;
-            sErr += ";";
+            sErr += "; ";
         }
 
         bool fResult = VerifyCPIDSignature(sCPID, hashBlock.GetHex(), sSignature);


### PR DESCRIPTION
 - Actually resolve #1503 (last PR--#1504--was `advertisebeacon`, not `beaconstatus`)
 - Only try the block signing test when the beacon belongs to the wallet 
 - Add output field that indicates whether the beacon belongs to the wallet

The last two changes fix support for calling `beaconstatus` with someone else's CPID.