### PR TITLE
Have importwallet file path default to datadir

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -184,10 +184,18 @@ UniValue importwallet(const UniValue& params, bool fHelp)
             "\n"
             "<filename> -> filename of the wallet to import\n"
             "\n"
-            "Imports keys from a wallet dump file (see dumpwallet)\n");
+            "Imports keys from a wallet dump file (see dumpwallet)\n"
+            "If a path is not specified in the filename, the data directory is used.");
+
+    boost::filesystem::path PathForImport = boost::filesystem::path(params[0].get_str());
+    boost::filesystem::path DefaultPathDataDir = GetDataDir();
+
+    // If provided filename does not have a path, then append parent path, otherwise leave alone.
+    if (PathForImport.parent_path().empty())
+        PathForImport = DefaultPathDataDir / PathForImport;
 
     ifstream file;
-    file.open(params[0].get_str().c_str());
+    file.open(PathForImport.string().c_str());
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
 


### PR DESCRIPTION
This aligns the behavior with dumpwallet, which was corrected in an earlier commit. This addresses #1505.