### PR TITLE
Change spacer minimum height hint

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -453,8 +453,6 @@ void BitcoinGUI::createToolBars()
     toolbar->addAction(addressBookAction);
     toolbar->addAction(votingAction);
 
-    // Prevent Lock from falling off the page
-
     QWidget* spacer = new QWidget();
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     toolbar->addWidget(spacer);
@@ -462,13 +460,6 @@ void BitcoinGUI::createToolBars()
     // Unlock Wallet
     toolbar->addAction(unlockWalletAction);
     toolbar->addAction(lockWalletAction);
-    QWidget* webSpacer = new QWidget();
-
-    webSpacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    webSpacer->setMaximumHeight(10);
-    toolbar->addWidget(webSpacer);
-    webSpacer->setObjectName("WebSpacer");
-
 
     // Status bar notification icons
     QFrame *frameBlocks = new QFrame();

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -255,7 +255,7 @@
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
-              <height>20</height>
+              <height>40</height>
              </size>
             </property>
            </spacer>
@@ -413,7 +413,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>10</height>
+           <height>40</height>
           </size>
          </property>
         </spacer>


### PR DESCRIPTION
This changes the minimum height hint of the spacer between
the Status fields and the Poll and Error fields. This seems to
fix the Lock Wallet button disappearing when the window is resized
to the minimum.