### PR TITLE
Select smallest coins for contracts

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -78,7 +78,7 @@ public:
 class CWallet : public CCryptoKeyStore
 {
 private:
-    bool SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, const CCoinControl *coinControl=NULL) const;
+    bool SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, const CCoinControl *coinControl=NULL, bool contract = false) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -144,7 +144,7 @@ public:
 	void AvailableCoinsForStaking(std::vector<COutput>& vCoins, unsigned int nSpendTime) const;
     bool SelectCoinsForStaking(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, bool fIncludeStakingCoins=false) const;
-    bool SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
+    bool SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, bool contract = false) const;
 
     // keystore implementation
     // Generate a new key


### PR DESCRIPTION
From previous PR #1289;

I've reworked this a bit and made it a lot smaller and taken into account your request @denravonska for .sort() and .random.

We still have to use a comparator as std::sort cannot compare COutput.
The reason the std::random_shuffle works with it because its just randomly shifting the contents.

This is more simple approach as I can tell and tested on testnet. If its a contract it will use the smallest for sure as even the subset function will favor the smallest to larger since its already sorted and not randomly shuffled. this is minimal impact in the code area with the desired effect.

Desired effect of this with regards to votes, polls and beacons is to make sure we use the smallest utxos when possible and not end up using a biggest utxo that a user has been staking with and delaying that staking for the 16 hour maturing window.