### PR TITLE
Clean up compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -496,6 +496,19 @@ case $host in
      ;;
 esac
 
+dnl Suppress ABI compatibility warnings for ARM:
+dnl
+dnl   "note: parameter passing for argument of type [...] changed in GCC 7.1"
+dnl
+dnl These notices remind that code compiled with GCC 7.1+ are not ABI compatible
+dnl with environments built with previous GCC versions. We can remove this block
+dnl when the compiler no longer emits these warnings.
+dnl
+case "$host" in arm-*)
+    AC_MSG_WARN([Disabled ARM warnings for GCC 7.1 ABI compatibility.])
+    CXXFLAGS="$CXXFLAGS -Wno-psabi"
+esac
+
 if test "x$enable_debug" = xyes; then
     if test "x$GCC" = xyes; then
         if test x$TARGET_OS = xwindows; then

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -106,7 +106,6 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
     double cpid_age = GetAdjustedTime() - ReadCache(Section::GLOBAL, "nCPIDTime").timestamp;
     double stake_age = GetAdjustedTime() - ReadCache(Section::GLOBAL, "nGRCTime").timestamp;
 
-    StructCPID& structGRC = GetInitializedStructCPID2(GRCAddress, mvMagnitudes);
     LogPrintf("CPIDAge %f, StakeAge %f, Poll Duration %f", cpid_age, stake_age, poll_duration);
     double dShareType= RoundFromString(GetPollXMLElementByPollTitle(sTitle, "<SHARETYPE>", "</SHARETYPE>"), 0);
 
@@ -168,7 +167,7 @@ bool PollIsActive(const std::string& poll_contract)
 {
     try
     {
-        uint64_t expires = stoll(ExtractXML(poll_contract, "<EXPIRATION>", "</EXPIRATION>"));
+        int64_t expires = stoll(ExtractXML(poll_contract, "<EXPIRATION>", "</EXPIRATION>"));
 
         return expires > GetAdjustedTime();
     }
@@ -293,7 +292,7 @@ std::string GetProvableVotingWeightXML()
     //Retrieve the historical magnitude
     if (IsResearcher(primary_cpid))
     {
-        StructCPID& st1 = GetLifetimeCPID(primary_cpid);
+        GetLifetimeCPID(primary_cpid); // Rescan...
         CBlockIndex* pHistorical = GetHistoricalMagnitude(primary_cpid);
         if (pHistorical->nHeight > 1 && pHistorical->nMagnitude > 0)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2831,7 +2831,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
 
                 if(!is_claim_valid(nStakeReward, OUT_POR, OUT_INTEREST, nFees))
                 {
-                    StructCPID& st1 = GetLifetimeCPID(pindex->GetCPID());
+                    GetLifetimeCPID(pindex->GetCPID()); // Rescan...
                     GetProofOfStakeReward(nCoinAge, nFees, bb.cpid, true, 2, nTime,
                                           pindex, "connectblock_researcher_doublecheck", OUT_POR, OUT_INTEREST, dAccrualAge, dMagnitudeUnit, dAvgMagnitude);
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -385,6 +385,12 @@ int main(int argc, char *argv[])
     threads->removeAll();
     threads.reset();
 
+    // Current exit code was previously introduced to trigger a wallet restart
+    // when set to the value of 42. This feature was removed.
+    if (fDebug) {
+        LogPrintf("Exit code: %d", currentExitCode);
+    }
+
     return 0;
 }
 #endif // BITCOIN_QT_TEST

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -616,7 +616,7 @@ bool TallyMagnitudesInSuperblock()
                 if (vProjects[i].length() > 1)
                 {
                     std::string project = ExtractValue(vProjects[i],",",0);
-                    double avg = RoundFromString(ExtractValue("0" + vProjects[i],",",1),0);
+
                     if (project.length() > 1)
                     {
                         StructCPID& stProject = GetInitializedStructCPID2(project,mvNetworkCopy);
@@ -2376,7 +2376,7 @@ UniValue MagnitudeReport(std::string cpid)
 
                     if (IsResearchAgeEnabled(pindexBest->nHeight))
                     {
-                        StructCPID& stCPID = GetLifetimeCPID(structMag.cpid);
+                        StructCPID& stCPID = GetLifetimeCPID(structMag.cpid); // Rescan...
                         double days = (GetAdjustedTime() - stCPID.LowLockTime) / 86400.0;
                         entry.pushKV("CPID",structMag.cpid);
                         entry.pushKV("Earliest Payment Time",TimestampToHRDate(stCPID.LowLockTime));
@@ -2481,7 +2481,7 @@ UniValue GetJsonUnspentReport()
     //Retrieve the historical magnitude
     if (IsResearcher(primary_cpid))
     {
-        StructCPID& st1 = GetLifetimeCPID(primary_cpid);
+        GetLifetimeCPID(primary_cpid); // Rescan...
         CBlockIndex* pHistorical = GetHistoricalMagnitude(primary_cpid);
         UniValue entry1(UniValue::VOBJ);
         entry1.pushKV("Researcher Magnitude",pHistorical->nMagnitude);

--- a/src/scraper_net.h
+++ b/src/scraper_net.h
@@ -58,7 +58,7 @@ public:
     /* We could store the parts in mapRelay and have getdata service for free. */
     /** map from part hash to scraper Index, so we can attach incoming Part in Index */
     static std::map<uint256,CPart> mapParts;
-    int cntPartsRcvd =0;
+    size_t cntPartsRcvd =0;
 
 };
 


### PR DESCRIPTION
This includes trivial changes to the lines that generate compiler warnings in Gridcoin-layer code. It also suppresses GCC 7.1 ABI compatibility reminders for ARM builds. 

I did not modify the LevelDB code that generates warnings to avoid conflicts if the library is updated in the future.