### PR TITLE
Backup appropiate file when client has -conf argument set

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -43,7 +43,7 @@ bool BackupConfigFile(const std::string& strDest)
 {
     // Check to see if there is a parent_path in strDest to support custom locations by ui - bug fix
 
-    filesystem::path ConfigSource = GetDataDir() / "gridcoinresearch.conf";
+    filesystem::path ConfigSource = GetConfigFile();
     filesystem::path ConfigTarget = strDest;
     filesystem::create_directories(ConfigTarget.parent_path());
     try


### PR DESCRIPTION
Fixes issue #974 

When client specifies -conf option for location of configuration we still pulled from GetDaraDir() which was incorrect. backup the proper config file at this location when the argument is set.

Tested ACK