### PR TITLE
For voting - if url does not contain http then add it (Quick Fix)

### DIFF
--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -272,11 +272,10 @@ void VotingTableModel::resetData(bool history)
             item->totalParticipants_ = iterPoll.total_participants;
             item->totalShares_ = iterPoll.total_shares;
 
-            if (iterPoll.url.find("http") == std::string::npos)
-                item->url_ = QString::fromStdString("https://" + iterPoll.url);
+            item->url_ = QString::fromStdString(iterPoll.url).trimmed();
 
-            else
-                item->url_ = QString::fromStdString(iterPoll.url);
+            if (!item->url_.startsWith("http://") && !item->url_.startsWith("https://"))
+                item->url_.prepend("http://");
 
             item->bestAnswer_ = QString::fromStdString(iterPoll.best_answer).replace("_"," ");
             items.push_back(item);

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -271,7 +271,13 @@ void VotingTableModel::resetData(bool history)
             item->vectorOfAnswers_ = iterPoll.answers;
             item->totalParticipants_ = iterPoll.total_participants;
             item->totalShares_ = iterPoll.total_shares;
-            item->url_ = QString::fromStdString(iterPoll.url);
+
+            if (iterPoll.url.find("http") == std::string::npos)
+                item->url_ = QString::fromStdString("https://" + iterPoll.url);
+
+            else
+                item->url_ = QString::fromStdString(iterPoll.url);
+
             item->bestAnswer_ = QString::fromStdString(iterPoll.best_answer).replace("_"," ");
             items.push_back(item);
         }


### PR DESCRIPTION
fixes #1513 

Reasoning for placement of fix:
Rather then force a correct formatted http or https to url on contact I chose to do the fix in the voting dialog. I chose this because I don't think forcing a correct http,https,www in poll contract is overall beneficial. https:// is 8 characters and could take 4-5 bytes of transaction size as is. So lets just check if there is no http in the url and if there is not then correct the url to contain https instead in the voting dialog. This also allows for a http url to be set in a poll url in contract in case the said url server does not have https support. leaves this a little more compatible.

tACK with the poll in question on testnet