### PR TITLE
Support boost 1.70

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -45,10 +45,10 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
 
     // Connect to localhost
     bool fUseSSL = GetBoolArg("-rpcssl");
-    asio::io_service io_service;
+    ioContext io_context;
     ssl::context context(ssl::context::sslv23);
     context.set_options(ssl::context::no_sslv2);
-    asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_service, context);
+    asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_context, context);
     SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);
     iostreams::stream< SSLIOStreamDevice<asio::ip::tcp> > stream(d);
     if (!d.connect(GetArg("-rpcconnect", "127.0.0.1"), GetArg("-rpcport", ToString(GetDefaultRPCPort()))))

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -36,7 +36,7 @@ void ThreadRPCServer2(void* parg);
 static std::string strRPCUserColonPass;
 
 // These are created by StartRPCThreads, destroyed in StopRPCThreads
-static asio::io_service* rpc_io_service = NULL;
+static ioContext* rpc_io_service = NULL;
 static ssl::context* rpc_ssl_context = NULL;
 static boost::thread_group* rpc_worker_group = NULL;
 
@@ -509,7 +509,7 @@ static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol> > accep
                       const bool fUseSSL)
 {
     // Accept connection
-    AcceptedConnectionImpl<Protocol>* conn = new AcceptedConnectionImpl<Protocol>(acceptor->get_io_service(), context, fUseSSL);
+    AcceptedConnectionImpl<Protocol>* conn = new AcceptedConnectionImpl<Protocol>(GetIOServiceFromPtr(acceptor), context, fUseSSL);
 
     acceptor->async_accept(
                 conn->sslStream.lowest_layer(),
@@ -592,7 +592,7 @@ void StartRPCThreads()
     const bool fUseSSL = GetBoolArg("-rpcssl");
 
     assert(rpc_io_service == NULL);
-    rpc_io_service = new asio::io_service();
+    rpc_io_service = new ioContext();
     rpc_ssl_context = new ssl::context(ssl::context::sslv23);
 
     if (fUseSSL)
@@ -675,7 +675,7 @@ void StartRPCThreads()
     
     rpc_worker_group = new boost::thread_group();
     for (int i = 0; i < GetArg("-rpcthreads", 4); i++)
-        rpc_worker_group->create_thread(boost::bind(&asio::io_service::run, rpc_io_service));
+        rpc_worker_group->create_thread(boost::bind(&ioContext::run, rpc_io_service));
 }
 
 void StopRPCThreads()


### PR DESCRIPTION
Support boost 1.70

tACK on depends boost 1.65 and boost 1.70

This will allow support depending on which boost version is used. in boost 1.70 get_io_context and get_io_service were removed in favour of get_executor().context()

io_context is the favoured in latest boost. eventually io_service itself will be removed as well as per boost notes. This make compatibility forward more simple. We can move to boost 1.70 in depends with this and eventually remove the defines.