### PR TITLE
Side Stake Allocation Percentage

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -99,7 +99,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         for (const auto& alloc : vSideStakeAlloc)
         {
             sidestakingalloc.pushKV("address", alloc.first);
-            sidestakingalloc.pushKV("allocation-pct", alloc.second);
+            sidestakingalloc.pushKV("allocation-pct", alloc.second * 100);
 
             vsidestakingalloc.push_back(sidestakingalloc);
         }


### PR DESCRIPTION
Show as percentage rather then decimal form to avoid potential confusion with future wallet users.