### PR TITLE
Refactor ThreadSocketHandler2() Inactivity checks

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -207,6 +207,7 @@ std::string HelpMessage()
         "  -dbcache=<n>           " + _("Set database cache size in megabytes (default: 25)") + "\n" +
         "  -dblogsize=<n>         " + _("Set database disk log size in megabytes (default: 100)") + "\n" +
         "  -timeout=<n>           " + _("Specify connection timeout in milliseconds (default: 5000)") + "\n" +
+        "  -peertimeout=<n>       " + _("Specify p2p connection timeout in seconds. This option determines the amount of time a peer may be inactive before the connection to it is dropped. (minimum: 1, default: 45)") + "\n"
         "  -proxy=<ip:port>       " + _("Connect through socks proxy") + "\n" +
         "  -socks=<n>             " + _("Select the version of socks proxy to use (4-5, default: 5)") + "\n" +
         "  -tor=<ip:port>         " + _("Use proxy to reach tor hidden services (default: same as -proxy)") + "\n"
@@ -511,9 +512,19 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     if (mapArgs.count("-timeout"))
     {
-        int nNewTimeout = GetArg("-timeout", 4000);
+        int nNewTimeout = GetArg("-timeout", 5000);
         if (nNewTimeout > 0 && nNewTimeout < 600000)
             nConnectTimeout = nNewTimeout;
+    }
+
+    if (mapArgs.count("-peertimeout"))
+    {
+        int nNewPeerTimeout = GetArg("-timeout", 45);
+
+        if (nNewPeerTimeout <= 0)
+            InitError(strprintf(_("Invalid amount for -peertimeout=<amount>: '%s'"), mapArgs["-peertimeout"]));
+
+        PEER_TIMEOUT = nNewPeerTimeout;
     }
 
     if (mapArgs.count("-paytxfee"))

--- a/src/net.h
+++ b/src/net.h
@@ -33,6 +33,7 @@ static const int PING_INTERVAL = 2 * 60;
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */
 static const int TIMEOUT_INTERVAL = 20 * 60;
 extern int MAX_OUTBOUND_CONNECTIONS;
+extern int PEER_TIMEOUT;
 
 inline unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", 5*1000); }
 inline unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }


### PR DESCRIPTION
Changed:
* Clean up inactivity checks and crowding.
* Remove double checks on lack of socket message response of 24 seconds
* Fix incorrect `-timeout` default value to what is specified in args help
* PEER_TIMEOUT is default 45 seconds
* Add `PEER_TIMEOUT` defaults to 45 however can be set to user-defined `-peertimeout` arg.
* Remove banscore of 1 for no socket message within 24 seconds
* Add continues where appropriate when `pnode->fdisconnect` is set to reduce wasted cycles

Previous:
* if the node did not send a socket message within the 24 seconds it would be set to disconnect and then do various other checks that could/would result in the same end result. We would also check > 24 seconds twice as well. 

Notes:
* 24 seconds could not necessarily be long enough. net code is dated and we have slow downs. 
* bitcoin does 60 seconds with a maparg to set peertimeout if a user chooses a custom number.
* bitcoin does not misbehave in this area for a socket not replying in time.
* bitcoin also does not disconnect a node after 2 hours if 75% of max connections is reached. We should review that portion of code. If a node is connected more then 2 hours and has not been banned then disconnecting a well behaved node might not be so supportive network wise.
* Added some spacing as it was a little clogged up imo.

Add a milestone for a complete refactor of ThreadSocketHandler2() for now this should improve in this area some