### PR TITLE
Fix diagnostics failed to make connection to NTP server

### DIFF
--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -326,7 +326,7 @@ void DiagnosticsDialog::clkStateChanged(QAbstractSocket::SocketState state)
 
         char NTPMessage[48] = {0x1b, 0, 0, 0 ,0, 0, 0, 0, 0};
 
-        udpSocket->writeDatagram(NTPMessage, sizeof(NTPMessage), udpSocket->peerAddress(), udpSocket->peerPort());
+        udpSocket->write(NTPMessage, sizeof(NTPMessage));
     }
 
     return;


### PR DESCRIPTION
This fixes: https://github.com/gridcoin-community/Gridcoin-Research/issues/1404
QT does not allow to call QUdpSocket::writeDatagram on a "connected" UDP socket.
Details here: https://doc.qt.io/qt-5/qudpsocket.html#writeDatagram