### PR TITLE
Add missing fstream include for daemon compile

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <boost/assign/list_of.hpp>
+#include <fstream>
 
 #include "base58.h"
 #include "rpcserver.h"


### PR DESCRIPTION
This affects only compiling of daemon without gui. normally I compile both at same time in which this issue did not show itself.