### PR TITLE
Refactor hashBoinc for binary claim contexts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,6 +91,7 @@ GRIDCOIN_CORE_H = \
 	main.h \
 	miner.h \
 	mruset.h \
+	neuralnet/claim.h \
 	neuralnet/cpid.h \
 	neuralnet/neuralnet.h \
    neuralnet/neuralnet_native.h \
@@ -158,10 +159,11 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
 	keystore.cpp \
 	main.cpp \
 	miner.cpp \
+	neuralnet/claim.cpp \
+	neuralnet/cpid.cpp \
    neuralnet/neuralnet.cpp \
    neuralnet/neuralnet_native.cpp \
    neuralnet/neuralnet_stub.cpp \
-	neuralnet/cpid.cpp \
 	neuralnet/project.cpp \
 	neuralnet/researcher.cpp \
 	neuralnet/superblock.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -40,6 +40,7 @@ GRIDCOIN_TESTS =\
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \
+  test/neuralnet/claim_tests.cpp \
   test/neuralnet/cpid_tests.cpp \
   test/neuralnet/project_tests.cpp \
   test/neuralnet/researcher_tests.cpp \

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -108,6 +108,29 @@ std::string GetBeaconPublicKey(const std::string& cpid, bool bAdvertisingBeacon)
     return sBeaconPublicKey;
 }
 
+std::set<std::string> GetAlternativeBeaconKeys(const std::string& cpid)
+{
+    int64_t iMaxSeconds = 60 * 24 * 30 * 6 * 60;
+    std::set<std::string> result;
+
+    for(const auto& item : ReadCacheSection(Section::BEACONALT))
+    {
+        const std::string& key = item.first;
+        const std::string& value = item.second.value;
+        if(!std::equal(cpid.begin(), cpid.end(), key.begin()))
+            continue;
+
+        const int64_t iAge = pindexBest != NULL
+            ? pindexBest->nTime - item.second.timestamp
+            : 0;
+        if (iAge > iMaxSeconds)
+            continue;
+
+        result.emplace(value);
+    }
+    return result;
+}
+
 int64_t BeaconTimeStamp(const std::string& cpid, bool bZeroOutAfterPOR)
 {
     if (!IsResearcher(cpid)) {

--- a/src/beacon.h
+++ b/src/beacon.h
@@ -8,6 +8,7 @@
 #include "util.h"
 #include <string>
 #include <map>
+#include <set>
 
 // This is modelled after AppCacheEntry/Section but named separately.
 struct BeaconEntry
@@ -69,6 +70,7 @@ int64_t BeaconAgeAdvertiseThreshold();
 
 void GetBeaconElements(const std::string& sBeacon, std::string& out_cpid, std::string& out_address, std::string& out_publickey);
 std::string GetBeaconPublicKey(const std::string& cpid, bool bAdvertisingBeacon);
+std::set<std::string> GetAlternativeBeaconKeys(const std::string& cpid);
 int64_t BeaconTimeStamp(const std::string& cpid, bool bZeroOutAfterPOR);
 bool HasActiveBeacon(const std::string& cpid);
 

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -93,16 +93,17 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
         std::string acceptable_answers = PollAnswers(sTitle);
         return std::make_pair("Error", "Sorry, Answer " + sAnswer + " is not one of the acceptable answers, allowable answers are: " + acceptable_answers + ".  If you are voting multiple choice, please use a semicolon delimited vote string such as : 'dog;cat'.");
     }
-    std::string sParam = SerializeBoincBlock(GlobalCPUMiningCPID, pindexBest->nVersion);
+
+    const std::string primary_cpid = NN::GetPrimaryCpid();
+
     std::string GRCAddress = DefaultWalletAddress();
-    StructCPID& structMag = GetInitializedStructCPID2(GlobalCPUMiningCPID.cpid, mvMagnitudes);
+    StructCPID& structMag = GetInitializedStructCPID2(primary_cpid, mvMagnitudes);
     double dmag = structMag.Magnitude;
     double poll_duration = PollDuration(sTitle) * 86400;
 
     // Prevent Double Voting
-    std::string cpid1 = GlobalCPUMiningCPID.cpid;
     std::string GRCAddress1 = DefaultWalletAddress();
-    GetEarliestStakeTime(GRCAddress1, cpid1);
+    GetEarliestStakeTime(GRCAddress1, primary_cpid);
     double cpid_age = GetAdjustedTime() - ReadCache(Section::GLOBAL, "nCPIDTime").timestamp;
     double stake_age = GetAdjustedTime() - ReadCache(Section::GLOBAL, "nGRCTime").timestamp;
 
@@ -123,12 +124,12 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
     else
     {
         std::string voter = "<CPID>"
-                + GlobalCPUMiningCPID.cpid + "</CPID><GRCADDRESS>" + GRCAddress + "</GRCADDRESS><RND>"
+                + primary_cpid + "</CPID><GRCADDRESS>" + GRCAddress + "</GRCADDRESS><RND>"
                 + hashRand.GetHex() + "</RND><BALANCE>" + RoundToString(nBalance,2)
                 + "</BALANCE><MAGNITUDE>" + RoundToString(dmag,0) + "</MAGNITUDE>";
         // Add the provable balance and the provable magnitude - this goes into effect July 1 2017
         voter += GetProvableVotingWeightXML();
-        std::string pk = sTitle + ";" + GRCAddress + ";" + GlobalCPUMiningCPID.cpid;
+        std::string pk = sTitle + ";" + GRCAddress + ";" + primary_cpid;
         std::string contract = "<TITLE>" + sTitle + "</TITLE><ANSWER>" + sAnswer + "</ANSWER>" + voter;
         std::string result = SendContract("vote",pk,contract);
         std::string narr = "Your CPID weight is " + RoundToString(dmag,0) + " and your Balance weight is " + RoundToString(nBalance,0) + ".";

--- a/src/fwd.h
+++ b/src/fwd.h
@@ -10,7 +10,6 @@ class CTransaction;
 class CWallet;
 
 // Gridcoin
-struct MiningCPID;
 struct StructCPID;
 
 class ThreadHandler;

--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -40,30 +40,6 @@ struct StructCPID
     std::set<const CBlockIndex*> rewardBlocks;
 };
 
-struct MiningCPID
-{
-    bool initialized;
-    double Magnitude;
-    double LastPaymentTime;
-    double ResearchSubsidy;
-    double ResearchAge;
-    double ResearchMagnitudeUnit;
-    double ResearchAverageMagnitude;
-    double InterestSubsidy;
-
-    std::string cpid;
-    std::string clientversion;
-    std::string GRCAddress;
-    std::string lastblockhash;
-    std::string Organization;
-    std::string NeuralHash;
-    std::string superblock;
-    std::string LastPORBlockHash;
-    std::string CurrentNeuralHash;
-    std::string BoincPublicKey;
-    std::string BoincSignature;
-};
-
 //Network Averages
 extern std::map<std::string, StructCPID> mvNetwork;
 extern std::map<std::string, StructCPID> mvNetworkCopy;

--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -70,9 +70,6 @@ extern std::map<std::string, StructCPID> mvNetworkCopy;
 extern std::map<std::string, StructCPID> mvMagnitudes;
 extern std::map<std::string, StructCPID> mvMagnitudesCopy;
 
-//Global CPU Mining CPID:
-extern MiningCPID GlobalCPUMiningCPID;
-
 // Timers
 extern std::map<std::string, int> mvTimers; // Contains event timers that reset after max ms duration iterator is exceeded
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -392,10 +392,11 @@ bool CalculateLegacyV3HashProof(
 // after the coins mature!
 
 CBigNum CalculateStakeHashV8(
-    const CBlock &CoinBlock, const CTransaction &CoinTx,
-    unsigned CoinTxN, unsigned nTimeTx,
-    uint64_t StakeModifier,
-    const MiningCPID &BoincData)
+    const CBlock &CoinBlock,
+    const CTransaction &CoinTx,
+    unsigned CoinTxN,
+    unsigned nTimeTx,
+    uint64_t StakeModifier)
 {
     CDataStream ss(SER_GETHASH, 0);
     ss << StakeModifier;
@@ -407,9 +408,7 @@ CBigNum CalculateStakeHashV8(
     return hashProofOfStake;
 }
 
-int64_t CalculateStakeWeightV8(
-    const CTransaction &CoinTx, unsigned CoinTxN,
-    const MiningCPID &BoincData)
+int64_t CalculateStakeWeightV8(const CTransaction &CoinTx, unsigned CoinTxN)
 {
     int64_t nValueIn = CoinTx.vout[CoinTxN].nValue;
     nValueIn /= 1250000;
@@ -489,16 +488,13 @@ bool CheckProofOfStakeV8(
     if (blockPrev.nTime + nStakeMinAge > tx.nTime) // Min age requirement
         return error("CheckProofOfStakeV8: min age violation");
 
-    MiningCPID boincblock = DeserializeBoincBlock(Block.vtx[0].hashBoinc,Block.nVersion);
-
-    //
     uint64_t StakeModifier = 0;
     if(!FindStakeModifierRev(StakeModifier,pindexPrev))
         return error("CheckProofOfStakeV8: unable to find stake modifier");
 
     //Stake refactoring TomasBrod
-    int64_t Weight= CalculateStakeWeightV8(txPrev,txin.prevout.n,boincblock);
-    CBigNum bnHashProof= CalculateStakeHashV8(blockPrev,txPrev,txin.prevout.n,tx.nTime,StakeModifier,boincblock);
+    int64_t Weight = CalculateStakeWeightV8(txPrev, txin.prevout.n);
+    CBigNum bnHashProof = CalculateStakeHashV8(blockPrev, txPrev, txin.prevout.n, tx.nTime, StakeModifier);
 
     // Base target
     CBigNum bnTarget;

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -12,7 +12,6 @@
 using namespace std;
 
 StructCPID GetStructCPID();
-extern double GetLastPaymentTimeByCPID(std::string cpid);
 
 namespace {
 //!
@@ -258,39 +257,6 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     nStakeModifier = nStakeModifierNew;
     fGeneratedStakeModifier = true;
     return true;
-}
-
-double GetLastPaymentTimeByCPID(std::string cpid)
-{
-    double lpt = 0;
-    if (mvMagnitudes.size() > 0)
-    {
-            StructCPID UntrustedHost = GetStructCPID();
-            UntrustedHost = mvMagnitudes[cpid]; //Contains Consensus Magnitude
-            if (UntrustedHost.initialized)
-            {
-                        double mag_accuracy = UntrustedHost.Accuracy;
-                        if (mag_accuracy > 0)
-                        {
-                                lpt = UntrustedHost.LastPaymentTime;
-                        }
-            }
-            else
-            {
-                if (IsResearcher(cpid))
-                {
-                        lpt = 0;
-                }
-            }
-    }
-    else
-    {
-        if (IsResearcher(cpid))
-        {
-                lpt=0;
-        }
-    }
-    return lpt;
 }
 
 // Get stake modifier checksum

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -71,12 +71,12 @@ bool FindStakeModifierRev(uint64_t& StakeModifier,CBlockIndex* pindexPrev);
 
 // Kernel for V8
 CBigNum CalculateStakeHashV8(
-    const CBlock &CoinBlock, const CTransaction &CoinTx,
-    unsigned CoinTxN, unsigned nTimeTx,
-    uint64_t StakeModifier,
-    const MiningCPID &BoincData);
-int64_t CalculateStakeWeightV8(
-    const CTransaction &CoinTx, unsigned CoinTxN,
-    const MiningCPID &BoincData);
+    const CBlock &CoinBlock,
+    const CTransaction &CoinTx,
+    unsigned CoinTxN,
+    unsigned nTimeTx,
+    uint64_t StakeModifier);
+
+int64_t CalculateStakeWeightV8(const CTransaction &CoinTx, unsigned CoinTxN);
 
 #endif // PPCOIN_KERNEL_H

--- a/src/key.h
+++ b/src/key.h
@@ -68,7 +68,7 @@ private:
 
 public:
     CPubKey() { }
-    CPubKey(const std::vector<unsigned char> &vchPubKeyIn) : vchPubKey(vchPubKeyIn) { }
+    CPubKey(std::vector<unsigned char> vchPubKeyIn) : vchPubKey(std::move(vchPubKeyIn)) { }
     friend bool operator==(const CPubKey &a, const CPubKey &b) { return a.vchPubKey == b.vchPubKey; }
     friend bool operator!=(const CPubKey &a, const CPubKey &b) { return a.vchPubKey != b.vchPubKey; }
     friend bool operator<(const CPubKey &a, const CPubKey &b) { return a.vchPubKey < b.vchPubKey; }
@@ -79,6 +79,15 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(vchPubKey);
+    }
+
+    static CPubKey Parse(const std::string& input)
+    {
+        if (input.empty()) {
+            return CPubKey();
+        }
+
+        return CPubKey(ParseHex(input));
     }
 
     CKeyID GetID() const {
@@ -99,6 +108,11 @@ public:
 
     std::vector<unsigned char> Raw() const {
         return vchPubKey;
+    }
+
+    std::string ToString() const
+    {
+        return HexStr(vchPubKey);
     }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3716,12 +3716,15 @@ bool CBlock::AcceptBlock(bool generated_by_me)
               || (IsV8Enabled(nHeight) && nVersion < 8)
               || (IsV9Enabled(nHeight) && nVersion < 9)
               || (IsV10Enabled(nHeight) && nVersion < 10)
+              || (IsV11Enabled(nHeight) && nVersion < 11)
               )
         return DoS(20, error("AcceptBlock() : reject too old nVersion = %d", nVersion));
     else if( (!IsProtocolV2(nHeight) && nVersion >= 7)
              ||(!IsV8Enabled(nHeight) && nVersion >= 8)
              ||(!IsV9Enabled(nHeight) && nVersion >= 9)
-             ||(!IsV10Enabled(nHeight) && nVersion >= 10))
+             ||(!IsV10Enabled(nHeight) && nVersion >= 10)
+             ||(!IsV11Enabled(nHeight) && nVersion >= 11)
+             )
         return DoS(100, error("AcceptBlock() : reject too new nVersion = %d", nVersion));
 
     if (IsProofOfWork() && nHeight > LAST_POW_BLOCK)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4557,29 +4557,6 @@ std::string RetrieveMd5(std::string s1)
     }
 }
 
-std::set<std::string> GetAlternativeBeaconKeys(const std::string& cpid)
-{
-    int64_t iMaxSeconds = 60 * 24 * 30 * 6 * 60;
-    std::set<std::string> result;
-
-    for(const auto& item : ReadCacheSection(Section::BEACONALT))
-    {
-        const std::string& key = item.first;
-        const std::string& value = item.second.value;
-        if(!std::equal(cpid.begin(), cpid.end(), key.begin()))
-            continue;
-
-        const int64_t iAge = pindexBest != NULL
-            ? pindexBest->nTime - item.second.timestamp
-            : 0;
-        if (iAge > iMaxSeconds)
-            continue;
-
-        result.emplace(value);
-    }
-    return result;
-}
-
 bool IsCPIDValidv2(MiningCPID& mc, int height)
 {
     //09-25-2016: Transition to CPID Keypairs.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -594,7 +594,7 @@ void GetGlobalStatus()
         GlobalStatusStruct.magnitude = RoundToString(boincmagnitude,2);
         GlobalStatusStruct.ETTS = RoundToString(dETTS,3);
         GlobalStatusStruct.ERRperday = RoundToString(boincmagnitude * GRCMagnitudeUnit(GetAdjustedTime()),2);
-        GlobalStatusStruct.cpid = NN::Researcher::Get()->Id().ToString();
+        GlobalStatusStruct.cpid = NN::GetPrimaryCpid();
         try
         {
             GlobalStatusStruct.poll = GetCurrentOverviewTabPoll();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,7 @@ extern void IncrementVersionCount(const std::string& Version);
 double GetSuperblockAvgMag(std::string data,double& out_beacon_count,double& out_participant_count,double& out_avg,bool bIgnoreBeacons, int nHeight);
 extern bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 extern std::string GetCurrentNeuralNetworkSupermajorityHash(double& out_popularity);
-extern double CalculatedMagnitude2(std::string cpid, int64_t locktime,bool bUseLederstrumpf);
+extern double CalculatedMagnitude2(std::string cpid, int64_t locktime);
 
 bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit);
 extern bool FullSyncWithDPORNodes();
@@ -114,7 +114,7 @@ std::string msMasterMessagePrivateKey = "308201130201010420fbd45ffb02ff05a3322c0
 std::string msMasterMessagePublicKey  = "044b2938fbc38071f24bede21e838a0758a52a0085f2e034e7f971df445436a252467f692ec9c5ba7e5eaa898ab99cbd9949496f7e3cafbf56304b1cc2e5bdf06e";
 
 int64_t GetMaximumBoincSubsidy(int64_t nTime);
-extern double CalculatedMagnitude(int64_t locktime,bool bUseLederstrumpf);
+extern double CalculatedMagnitude(int64_t locktime);
 extern int64_t GetCoinYearReward(int64_t nTime);
 
 BlockMap mapBlockIndex;
@@ -567,7 +567,7 @@ void GetGlobalStatus()
 
     try
     {
-        double boincmagnitude = CalculatedMagnitude(GetAdjustedTime(),false);
+        double boincmagnitude = CalculatedMagnitude(GetAdjustedTime());
         uint64_t nWeight = 0;
         pwalletMain->GetStakeWeight(nWeight);
         nBoincUtilization = boincmagnitude; //Legacy Support for the about screen
@@ -1654,18 +1654,18 @@ static CBigNum GetProofOfStakeLimit(int nHeight)
 }
 
 
-double CalculatedMagnitude(int64_t locktime,bool bUseLederstrumpf)
+double CalculatedMagnitude(int64_t locktime)
 {
     // Get neural network magnitude:
     StructCPID& stDPOR = GetInitializedStructCPID2(NN::GetPrimaryCpid(), mvDPOR);
-    return bUseLederstrumpf ? LederstrumpfMagnitude2(stDPOR.Magnitude,locktime) : stDPOR.Magnitude;
+    return stDPOR.Magnitude;
 }
 
-double CalculatedMagnitude2(std::string cpid, int64_t locktime,bool bUseLederstrumpf)
+double CalculatedMagnitude2(std::string cpid, int64_t locktime)
 {
     // Get neural network magnitude:
     StructCPID& stDPOR = GetInitializedStructCPID2(cpid,mvDPOR);
-    return bUseLederstrumpf ? LederstrumpfMagnitude2(stDPOR.Magnitude,locktime) : stDPOR.Magnitude;
+    return stDPOR.Magnitude;
 }
 
 //Survey Results: Start inflation rate: 9%, end=1%, 30 day steps, 9 steps, mag multiplier start: 2, mag end .3, 9 steps
@@ -1985,7 +1985,7 @@ bool CheckProofOfResearch(
         return true;
 
     // 6-4-2017 - Verify researchers stored block magnitude
-    double dNeuralNetworkMagnitude = CalculatedMagnitude2(cpid, block.nTime, false);
+    double dNeuralNetworkMagnitude = CalculatedMagnitude2(cpid, block.nTime);
 
     if (claim.m_magnitude > (dNeuralNetworkMagnitude*1.25)
         && (fTestNet || (!fTestNet && pindexPrev->nHeight > 947000)))
@@ -2790,7 +2790,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
 
                 // 6-4-2017 - Verify researchers stored block magnitude
                 // 2018 02 04 - Moved here for better effect.
-                double dNeuralNetworkMagnitude = CalculatedMagnitude2(cpid, nTime, false);
+                double dNeuralNetworkMagnitude = CalculatedMagnitude2(cpid, nTime);
                 if (claim.m_magnitude > (dNeuralNetworkMagnitude * 1.25)
                     && (fTestNet || (!fTestNet && (pindex->nHeight-1) > 947000)))
                 {
@@ -6997,7 +6997,7 @@ int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, CBlockIndex* pin
     if (!IsResearcher(cpid))
         return 0;
 
-    double dCurrentMagnitude = CalculatedMagnitude2(cpid, nTime, false);
+    double dCurrentMagnitude = CalculatedMagnitude2(cpid, nTime);
     if(pindexLast->nVersion>=9)
     {
         // Bugfix for newbie rewards always being around 1 GRC

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3556,8 +3556,13 @@ bool CBlock::CheckBlock(std::string sCaller, int height1, int64_t Mint, bool fCh
     // that can be verified before saving an orphan block.
 
     // Size limits
-    if (vtx.empty() || vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    if (vtx.empty()
+        || vtx.size() > MAX_BLOCK_SIZE
+        || ::GetSerializeSize(*this, (SER_NETWORK & SER_SKIPSUPERBLOCK), PROTOCOL_VERSION) > MAX_BLOCK_SIZE
+        || ::GetSerializeSize(GetSuperblock(), SER_NETWORK, PROTOCOL_VERSION) > NN::Superblock::MAX_SIZE)
+    {
         return DoS(100, error("CheckBlock[] : size limits failed"));
+    }
 
     // Check proof of work matches claimed amount
     if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetPoWHash(), nBits))

--- a/src/main.h
+++ b/src/main.h
@@ -273,8 +273,6 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
 	bool VerifyingBlock, int VerificationPhase, int64_t nTime, CBlockIndex* pindexLast,
 	double& OUT_POR, double& OUT_INTEREST, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude);
 
-MiningCPID DeserializeBoincBlock(std::string block, int BlockVersion);
-std::string SerializeBoincBlock(MiningCPID mcpid, int BlockVersion);
 bool OutOfSyncByAge();
 bool NeedASuperblock();
 std::string GetQuorumHash(const std::string& data);
@@ -292,7 +290,7 @@ double GetAverageDifficulty(unsigned int nPoSInterval = 40);
 double GetEstimatedTimetoStake(double dDiff = 0.0, double dConfidence = 0.8);
 
 void AddRARewardBlock(const CBlockIndex* pIndex);
-MiningCPID GetBoincBlockByIndex(CBlockIndex* pblockindex);
+NN::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex);
 
 int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();

--- a/src/main.h
+++ b/src/main.h
@@ -113,7 +113,9 @@ inline bool IsV10Enabled(int nHeight)
 inline bool IsV11Enabled(int nHeight)
 {
     // Returns false before planned intro of bv11.
-    return false;
+    return fTestNet
+            ? false
+            : false;
 }
 
 inline int GetSuperblockAgeSpacing(int nHeight)

--- a/src/main.h
+++ b/src/main.h
@@ -266,9 +266,9 @@ bool CheckProofOfResearch(
 
 unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast);
 int64_t GetConstantBlockReward(const CBlockIndex* index);
-int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, std::string operation, CBlockIndex* pindexLast, bool bVerifyingBlock, int VerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude);
+int64_t ComputeResearchAccrual(int64_t nTime, std::string cpid, CBlockIndex* pindexLast, bool bVerifyingBlock, int VerificationPhase, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude);
 int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid,
-	bool VerifyingBlock, int VerificationPhase, int64_t nTime, CBlockIndex* pindexLast, std::string operation,
+	bool VerifyingBlock, int VerificationPhase, int64_t nTime, CBlockIndex* pindexLast,
 	double& OUT_POR, double& OUT_INTEREST, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude);
 
 MiningCPID DeserializeBoincBlock(std::string block, int BlockVersion);

--- a/src/main.h
+++ b/src/main.h
@@ -7,6 +7,7 @@
 
 #include "util.h"
 #include "net.h"
+#include "neuralnet/claim.h"
 #include "sync.h"
 #include "script.h"
 #include "scrypt.h"
@@ -149,7 +150,6 @@ extern std::map<std::string, StructCPID> mvDPORCopy;
 
 
 extern std::map<std::string, StructCPID> mvResearchAge;
-extern std::map<std::string, MiningCPID> mvBlockIndex;
 
 struct BlockHasher
 {
@@ -1049,8 +1049,8 @@ public:
     // ppcoin: block signature - signed by one of the coin base txout[N]'s owner
     std::vector<unsigned char> vchBlockSig;
 
-
-
+    // Gridcoin Research Reward Context
+    NN::Claim m_claim;
 
     // memory only
     mutable std::vector<uint256> vMerkleTree;
@@ -1058,10 +1058,6 @@ public:
     // Denial-of-service detection:
     mutable int nDoS;
     bool DoS(int nDoSIn, bool fIn) const { nDoS += nDoSIn; return fIn; }
-
-	//Gridcoin - 7/27/2014
-	/////////////////////////////////////////
-
 
     CBlock()
     {
@@ -1080,9 +1076,26 @@ public:
         READWRITE(nBits);
         READWRITE(nNonce);
 
+        // ConnectBlock depends on vtx following header to generate CDiskTxPos
         if (!(s.GetType() & (SER_GETHASH|SER_BLOCKHEADERONLY))) {
             READWRITE(vtx);
             READWRITE(vchBlockSig);
+
+            // Before block version 11, the Gridcoin reward claim context is
+            // stored in the first transaction of the block. Versions 11 and
+            // above place a claim in the block to facilitate the submission
+            // of superblocks with a greater quantity of participant data.
+            //
+            // Because version 11+ blocks store a claim directly in a member
+            // field, the claim must be included as input to a block hash to
+            // protect its integrity. Previous versions hashed a claim along
+            // with the transactions. Block versions 11 and above must store
+            // the hash of the claim within the hashBoinc field of the first
+            // transaction and validation shall check that the hash matches.
+            //
+            if (nVersion >= 11) {
+                READWRITE(m_claim);
+            }
         } else if (ser_action.ForRead()) {
             const_cast<CBlock*>(this)->vtx.clear();
             const_cast<CBlock*>(this)->vchBlockSig.clear();
@@ -1101,6 +1114,7 @@ public:
         vchBlockSig.clear();
 	    vMerkleTree.clear();
         nDoS = 0;
+        m_claim = NN::Claim();
     }
 
     bool IsNull() const
@@ -1119,6 +1133,38 @@ public:
     uint256 GetPoWHash() const
     {
         return scrypt_blockhash(CVOIDBEGIN(nVersion));
+    }
+
+    const NN::Claim& GetClaim() const
+    {
+        if (nVersion >= 11 || m_claim.m_mining_id.Valid() || vtx.empty()) {
+            return m_claim;
+        }
+
+        // Before block version 11, the Gridcoin reward claim context is
+        // stored in the first transaction of the block. We'll store the
+        // parsed representation here to speed up subsequent access:
+        //
+        REF(m_claim) = NN::Claim::Parse(vtx[0].hashBoinc, nVersion);
+
+        return m_claim;
+    }
+
+    NN::Claim PullClaim()
+    {
+        if (nVersion >= 11 || m_claim.m_mining_id.Valid() || vtx.empty()) {
+            return std::move(m_claim);
+        }
+
+        // Before block version 11, the Gridcoin reward claim context is
+        // stored in the first transaction of the block.
+        //
+        return NN::Claim::Parse(vtx[0].hashBoinc, nVersion);
+    }
+
+    const NN::Superblock& GetSuperblock() const
+    {
+        return GetClaim().m_superblock;
     }
 
     int64_t GetBlockTime() const

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -29,7 +29,6 @@ using namespace std;
 unsigned int nMinerSleep;
 double CoinToDouble(double surrogate);
 double CalculatedMagnitude2(std::string cpid, int64_t locktime);
-double GetLastPaymentTimeByCPID(std::string cpid);
 std::string GetLastPORBlockHash(std::string cpid);
 bool HasActiveBeacon(const std::string& cpid);
 bool LessVerbose(int iMax1000);
@@ -983,7 +982,6 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
 
     claim.m_client_version = FormatFullVersion();
     claim.m_organization = GetArgument("org", "");
-    claim.m_last_payment_time = GetLastPaymentTimeByCPID(claim.m_mining_id.ToString());
     claim.m_last_block_hash = pindexPrev->GetBlockHash();
     claim.m_last_por_block_hash = uint256(GetLastPORBlockHash(claim.m_mining_id.ToString()));
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -29,7 +29,6 @@ using namespace std;
 unsigned int nMinerSleep;
 double CoinToDouble(double surrogate);
 double CalculatedMagnitude2(std::string cpid, int64_t locktime);
-std::string GetLastPORBlockHash(std::string cpid);
 bool HasActiveBeacon(const std::string& cpid);
 bool LessVerbose(int iMax1000);
 
@@ -983,7 +982,6 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
     claim.m_client_version = FormatFullVersion();
     claim.m_organization = GetArgument("org", "");
     claim.m_last_block_hash = pindexPrev->GetBlockHash();
-    claim.m_last_por_block_hash = uint256(GetLastPORBlockHash(claim.m_mining_id.ToString()));
 
     if (const NN::CpidOption cpid = claim.m_mining_id.TryCpid()) {
         claim.m_magnitude = CalculatedMagnitude2(cpid->ToString(), blocknew.nTime);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -963,6 +963,8 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
     NN::Claim& claim = blocknew.m_claim;
     claim.m_mining_id = NN::Researcher::Get()->Id();
 
+    double out_unused; // Drop currently unused values
+
     // Note: Since research age must be exact, we need to transmit the block
     // nTime here so it matches AcceptBlock():
     nReward = GetProofOfStakeReward(
@@ -975,7 +977,7 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
         pindexPrev,
         claim.m_research_subsidy,
         claim.m_block_subsidy,
-        claim.m_research_age,
+        out_unused,
         claim.m_magnitude_unit,
         claim.m_average_magnitude);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -996,8 +996,8 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
         claim.m_magnitude_unit,
         out_unused);
 
-    claim.m_client_version = FormatFullVersion();
-    claim.m_organization = GetArgument("org", "");
+    claim.m_client_version = FormatFullVersion().substr(0, NN::Claim::MAX_VERSION_SIZE);
+    claim.m_organization = GetArgument("org", "").substr(0, NN::Claim::MAX_ORGANIZATION_SIZE);
 
     if (const NN::CpidOption cpid = claim.m_mining_id.TryCpid()) {
         claim.m_magnitude = CalculatedMagnitude2(cpid->ToString(), blocknew.nTime);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 unsigned int nMinerSleep;
 double CoinToDouble(double surrogate);
-double CalculatedMagnitude2(std::string cpid, int64_t locktime, bool bUseLederstrumpf);
+double CalculatedMagnitude2(std::string cpid, int64_t locktime);
 double GetLastPaymentTimeByCPID(std::string cpid);
 std::string GetLastPORBlockHash(std::string cpid);
 bool HasActiveBeacon(const std::string& cpid);
@@ -988,7 +988,7 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
     claim.m_last_por_block_hash = uint256(GetLastPORBlockHash(claim.m_mining_id.ToString()));
 
     if (const NN::CpidOption cpid = claim.m_mining_id.TryCpid()) {
-        claim.m_magnitude = CalculatedMagnitude2(cpid->ToString(), blocknew.nTime, false);
+        claim.m_magnitude = CalculatedMagnitude2(cpid->ToString(), blocknew.nTime);
     }
 
     LogPrintf(

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1012,6 +1012,21 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
         claim.m_magnitude_unit,
         out_unused);
 
+    // If no pending research subsidy value exists, build an investor claim.
+    // This avoids polluting the block index with non-research reward blocks
+    // that contain CPIDs which increases the effort needed to load research
+    // age context at start-up:
+    //
+    if (claim.m_mining_id.Which() == NN::MiningId::Kind::CPID
+        && claim.m_research_subsidy <= 0)
+    {
+        LogPrintf(
+            "CreateGridcoinReward: No positive research reward pending at "
+            "time of stake. Staking as investor.");
+
+        claim.m_mining_id = NN::MiningId::ForInvestor();
+    }
+
     claim.m_client_version = FormatFullVersion().substr(0, NN::Claim::MAX_VERSION_SIZE);
     claim.m_organization = GetArgument("org", "").substr(0, NN::Claim::MAX_ORGANIZATION_SIZE);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -979,7 +979,7 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
         claim.m_block_subsidy,
         out_unused,
         claim.m_magnitude_unit,
-        claim.m_average_magnitude);
+        out_unused);
 
     claim.m_client_version = FormatFullVersion();
     claim.m_organization = GetArgument("org", "");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1193,13 +1193,12 @@ void StakeMiner(CWallet *pwallet)
             MinerStatus.ReasonNotStaking="";
 
             //New versions
-            StakeBlock.nVersion = 7;
-            if(IsV8Enabled(pindexPrev->nHeight+1))
-                StakeBlock.nVersion = 8;
-            if(IsV9Enabled(pindexPrev->nHeight+1))
-                StakeBlock.nVersion = 9;
-            if(IsV10Enabled(pindexPrev->nHeight + 1))
+            if (IsV11Enabled(pindexPrev->nHeight + 1)) {
+                StakeBlock.nVersion = 11;
+            } else {
                 StakeBlock.nVersion = 10;
+                StakeBlock.m_claim.m_version = 1;
+            }
 
             MinerStatus.Version= StakeBlock.nVersion;
         }

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -81,7 +81,6 @@ Claim::Claim(uint32_t version)
     , m_research_subsidy(0)
     , m_magnitude(0)
     , m_magnitude_unit(0)
-    , m_average_magnitude(0)
 {
 }
 
@@ -101,7 +100,7 @@ Claim Claim::Parse(const std::string& claim, int block_version)
         case 29: c.m_public_key = CPubKey::Parse(s[29]);
         case 28: c.m_quorum_hash = QuorumHash::Parse(s[28]);
         case 27: //c.m_last_por_block_hash = uint256(s[27]);
-        case 26: c.m_average_magnitude = RoundFromString(s[26], 2);
+        case 26: //c.m_average_magnitude = RoundFromString(s[26], 2);
         case 25: c.m_magnitude_unit = RoundFromString(s[25], MAG_UNIT_PLACES);
         case 24: //c.m_research_age = RoundFromString(s[24], 6);
         case 23: //c.ResearchSubsidy2 = RoundFromString(s[23], subsidy_places);
@@ -254,7 +253,7 @@ std::string Claim::ToString(const int block_version) const
         + delim // + RoundToString(mcpid.ResearchSubsidy2,2)
         + delim // + RoundToString(m_research_age, 6)
         + delim + RoundToString(m_magnitude_unit, MAG_UNIT_PLACES)
-        + delim + RoundToString(m_average_magnitude, 2)
+        + delim // + RoundToString(m_average_magnitude, 2)
         + delim // + BlockHashToString(m_last_por_block_hash)
         + delim // + mcpid.CurrentNeuralHash
         + delim + m_public_key.ToString()

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -78,7 +78,6 @@ Claim::Claim() : Claim(CURRENT_VERSION)
 Claim::Claim(uint32_t version)
     : m_version(version)
     , m_block_subsidy(0)
-    , m_last_payment_time(0)
     , m_research_subsidy(0)
     , m_magnitude(0)
     , m_research_age(0)
@@ -119,7 +118,7 @@ Claim Claim::Parse(const std::string& claim, int block_version)
         case 15: c.m_magnitude = RoundFromString(s[15], 0);
         case 14: //c.cpidv2 = s[14];
         case 13: //c.m_rsa_weight = RoundFromString(s[13], 0);
-        case 12: c.m_last_payment_time = RoundFromString(s[12], 0);
+        case 12: //c.m_last_payment_time = RoundFromString(s[12], 0);
         case 11: c.m_research_subsidy = RoundFromString(s[11], 2);
         case 10: c.m_client_version = std::move(s[10]);
         case  9: //c.NetworkRAC = RoundFromString(s[9], 0);
@@ -243,7 +242,7 @@ std::string Claim::ToString(const int block_version) const
         + delim // + RoundToString(mcpid.NetworkRAC, 0)
         + delim + m_client_version
         + delim + RoundToString(m_research_subsidy, subsidy_places)
-        + delim + std::to_string(m_last_payment_time)
+        + delim // + std::to_string(m_last_payment_time)
         + delim // + std::to_string(m_rsa_weight)
         + delim // + mcpid.cpidv2
         + delim + std::to_string(m_magnitude)

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -170,8 +170,8 @@ bool Claim::WellFormed() const
         && (m_version == 1
             || (m_mining_id.Valid()
                 && !m_client_version.empty()
-                && m_client_version.size() <= 30
-                && m_organization.size() <= 50
+                && m_client_version.size() <= MAX_VERSION_SIZE
+                && m_organization.size() <= MAX_ORGANIZATION_SIZE
                 && m_block_subsidy > 0
                 && (m_mining_id.Which() == MiningId::Kind::INVESTOR
                     || (m_research_subsidy > 0 && m_signature.size() > 0))

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -80,7 +80,6 @@ Claim::Claim(uint32_t version)
     , m_block_subsidy(0)
     , m_research_subsidy(0)
     , m_magnitude(0)
-    , m_research_age(0)
     , m_magnitude_unit(0)
     , m_average_magnitude(0)
 {
@@ -104,7 +103,6 @@ Claim Claim::Parse(const std::string& claim, int block_version)
         case 27: //c.m_last_por_block_hash = uint256(s[27]);
         case 26: c.m_average_magnitude = RoundFromString(s[26], 2);
         case 25: c.m_magnitude_unit = RoundFromString(s[25], MAG_UNIT_PLACES);
-        case 24: c.m_research_age = RoundFromString(s[24], 6);
         case 24: //c.m_research_age = RoundFromString(s[24], 6);
         case 23: //c.ResearchSubsidy2 = RoundFromString(s[23], subsidy_places);
         case 22: c.m_superblock = Superblock::UnpackLegacy(s[22]);
@@ -254,7 +252,7 @@ std::string Claim::ToString(const int block_version) const
         + delim + m_quorum_hash.ToString()
         + delim + (m_superblock.WellFormed() ? m_superblock.PackLegacy() : "")
         + delim // + RoundToString(mcpid.ResearchSubsidy2,2)
-        + delim + RoundToString(m_research_age, 6)
+        + delim // + RoundToString(m_research_age, 6)
         + delim + RoundToString(m_magnitude_unit, MAG_UNIT_PLACES)
         + delim + RoundToString(m_average_magnitude, 2)
         + delim // + BlockHashToString(m_last_por_block_hash)

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -101,7 +101,7 @@ Claim Claim::Parse(const std::string& claim, int block_version)
         case 30: c.m_signature = DecodeBase64(s[30].c_str());
         case 29: c.m_public_key = CPubKey::Parse(s[29]);
         case 28: c.m_quorum_hash = QuorumHash::Parse(s[28]);
-        case 27: c.m_last_por_block_hash = uint256(s[27]);
+        case 27: //c.m_last_por_block_hash = uint256(s[27]);
         case 26: c.m_average_magnitude = RoundFromString(s[26], 2);
         case 25: c.m_magnitude_unit = RoundFromString(s[25], MAG_UNIT_PLACES);
         case 24: c.m_research_age = RoundFromString(s[24], 6);
@@ -257,7 +257,7 @@ std::string Claim::ToString(const int block_version) const
         + delim + RoundToString(m_research_age, 6)
         + delim + RoundToString(m_magnitude_unit, MAG_UNIT_PLACES)
         + delim + RoundToString(m_average_magnitude, 2)
-        + delim + BlockHashToString(m_last_por_block_hash)
+        + delim // + BlockHashToString(m_last_por_block_hash)
         + delim // + mcpid.CurrentNeuralHash
         + delim + m_public_key.ToString()
         + delim + EncodeBase64(m_signature.data(), m_signature.size());

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -1,0 +1,265 @@
+#include "beacon.h"
+#include "key.h"
+#include "neuralnet/claim.h"
+#include "util.h"
+
+using namespace NN;
+
+namespace {
+//!
+//! \brief Convert a block hash to a hex-encoded string for legacy serialized
+//! claims.
+//!
+//! \param block_hash SHA256 hash of the block to format a string for.
+//!
+//! \return Hex-encoded bytes in the hash, or "0" for a blank hash to conserve
+//! space.
+//!
+std::string BlockHashToString(uint256 block_hash)
+{
+    if (block_hash == 0) {
+        return "0";
+    }
+
+    return block_hash.ToString();
+}
+} // anonymous namespace
+
+// -----------------------------------------------------------------------------
+// Functions
+// -----------------------------------------------------------------------------
+
+bool NN::VerifyClaim(const Claim& claim)
+{
+    if (!claim.m_mining_id.Valid()) {
+        return error("VerifyClaim(): Invalid mining ID.");
+    }
+
+    const CpidOption cpid = claim.m_mining_id.TryCpid();
+
+    if (!cpid) {
+        // Investor claims are not signed by a beacon key.
+        return true;
+    }
+
+    const std::string cpid_str = cpid->ToString();
+    const std::string beacon_key = GetBeaconPublicKey(cpid_str, false);
+
+    CKey key;
+
+    if (key.SetPubKey(ParseHex(beacon_key)) && claim.VerifySignature(key)) {
+        return true;
+    }
+
+    for (const auto& beacon_alt_key : GetAlternativeBeaconKeys(cpid_str)) {
+        if (!key.SetPubKey(ParseHex(beacon_alt_key))) {
+            continue;
+        }
+
+        if (claim.VerifySignature(key)) {
+            LogPrintf("WARNING: VerifyClaim(): Good signature with alternative key.");
+            return true;
+        }
+    }
+
+    LogPrintf("WARNING: VerifyClaim(): Block key mismatch.");
+
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+// Class: Claim
+// -----------------------------------------------------------------------------
+
+Claim::Claim() : Claim(CURRENT_VERSION)
+{
+}
+
+Claim::Claim(uint32_t version)
+    : m_version(version)
+    , m_block_subsidy(0)
+    , m_last_payment_time(0)
+    , m_research_subsidy(0)
+    , m_magnitude(0)
+    , m_research_age(0)
+    , m_magnitude_unit(0)
+    , m_average_magnitude(0)
+{
+}
+
+Claim Claim::Parse(const std::string& claim, int block_version)
+{
+    const int subsidy_places = block_version < 8 ? 2 : 8;
+    std::vector<std::string> s = split(claim, "<|>");
+
+    // Legacy string claims (BoincBlocks) always parse to version 1:
+    //
+    Claim c(1);
+
+    // Note: Commented-out items recorded to document removed fields:
+    //
+    switch (std::min<size_t>(s.size() - 1, 30)) {
+        case 30: c.m_signature = DecodeBase64(s[30].c_str());
+        case 29: c.m_public_key = CPubKey::Parse(s[29]);
+        case 28: c.m_quorum_hash = QuorumHash::Parse(s[28]);
+        case 27: c.m_last_por_block_hash = uint256(s[27]);
+        case 26: c.m_average_magnitude = RoundFromString(s[26], 2);
+        case 25: c.m_magnitude_unit = RoundFromString(s[25], MAG_UNIT_PLACES);
+        case 24: c.m_research_age = RoundFromString(s[24], 6);
+        case 24: //c.m_research_age = RoundFromString(s[24], 6);
+        case 23: //c.ResearchSubsidy2 = RoundFromString(s[23], subsidy_places);
+        case 22: c.m_superblock = Superblock::UnpackLegacy(s[22]);
+        case 21: if (!c.m_quorum_hash.Valid())
+                    c.m_quorum_hash = QuorumHash::Parse(s[21]);
+        case 20: //c.OrganizationKey = s[20];
+        case 19: c.m_organization = std::move(s[19]);
+        case 18: c.m_block_subsidy = RoundFromString(s[18], subsidy_places);
+        case 17: c.m_last_block_hash = uint256(s[17]);
+        case 16: c.m_quorum_address = s[16];
+        case 15: c.m_magnitude = RoundFromString(s[15], 0);
+        case 14: //c.cpidv2 = s[14];
+        case 13: //c.m_rsa_weight = RoundFromString(s[13], 0);
+        case 12: c.m_last_payment_time = RoundFromString(s[12], 0);
+        case 11: c.m_research_subsidy = RoundFromString(s[11], 2);
+        case 10: c.m_client_version = std::move(s[10]);
+        case  9: //c.NetworkRAC = RoundFromString(s[9], 0);
+        case  8:
+            c.m_mining_id = MiningId::Parse(s[0]);
+            //c.projectname = s[1];
+            //boost::to_lower(c.projectname);
+            //c.aesskein = s[2];
+            //c.rac = RoundFromString(s[3],0);
+            //c.pobdifficulty = RoundFromString(s[4],6);
+            //c.diffbytes = (unsigned int)RoundFromString(s[5],0);
+            //c.enccpid = s[6];
+            //c.encboincpublickey = s[6];
+            //c.encaes = s[7];
+            //c.nonce = RoundFromString(s[8],0);
+            break;
+    }
+
+    return c;
+}
+
+bool Claim::WellFormed() const
+{
+    return m_version > 0 && m_version <= Claim::CURRENT_VERSION
+        && (m_version == 1
+            || (m_mining_id.Valid()
+                && !m_client_version.empty()
+                && m_client_version.size() <= 30
+                && m_organization.size() <= 50
+                && m_block_subsidy > 0
+                && m_last_block_hash > 0
+                && (m_mining_id.Which() == MiningId::Kind::INVESTOR
+                    || (m_research_subsidy > 0 && m_signature.size() > 0))
+                && (!m_quorum_hash.Valid() || m_quorum_address.size() > 0)
+            )
+        );
+}
+
+bool Claim::HasResearchReward() const
+{
+    return m_mining_id.Which() == MiningId::Kind::CPID;
+}
+
+bool Claim::ContainsSuperblock() const
+{
+    return m_superblock.WellFormed();
+}
+
+double Claim::TotalSubsidy() const
+{
+    return m_block_subsidy + m_research_subsidy;
+}
+
+bool Claim::Sign(CKey& beacon_private_key)
+{
+    const CpidOption cpid = m_mining_id.TryCpid();
+
+    if (!cpid) {
+        return false;
+    }
+
+    if (!beacon_private_key.Sign(GetVerificationHash(), m_signature)) {
+        m_signature.clear();
+        return false;
+    }
+
+    m_public_key = beacon_private_key.GetPubKey();
+
+    return true;
+}
+
+bool Claim::VerifySignature(CKey& beacon_public_key) const
+{
+    return beacon_public_key.Verify(GetVerificationHash(), m_signature);
+}
+
+uint256 Claim::GetVerificationHash() const
+{
+    const CpidOption cpid = m_mining_id.TryCpid();
+
+    if (!cpid) {
+        return uint256(0);
+    }
+
+    if (m_version > 1) {
+        return Hash(
+            cpid->Raw().begin(),
+            cpid->Raw().end(),
+            m_last_block_hash.begin(),
+            m_last_block_hash.end());
+    }
+
+    const std::string cpid_hex = cpid->ToString();
+    const std::string hash_hex = BlockHashToString(m_last_block_hash);
+
+    return Hash(cpid_hex.begin(), cpid_hex.end(), hash_hex.begin(), hash_hex.end());
+}
+
+uint256 Claim::GetHash() const
+{
+    return SerializeHash(*this);
+}
+
+std::string Claim::ToString(const int block_version) const
+{
+    constexpr char delim[] = "<|>";
+
+    const int subsidy_places = block_version < 8 ? 2 : 8;
+
+    // Note: Commented-out items recorded to document removed fields:
+    //
+    return m_mining_id.ToString()
+        + delim // + mcpid.projectname
+        + delim // + mcpid.aesskein
+        + delim // + RoundToString(mcpid.rac, 0)
+        + delim // + RoundToString(mcpid.pobdifficulty, 5)
+        + delim // + RoundToString((double)mcpid.diffbytes, 0)
+        + delim // + mcpid.enccpid
+        + delim // + mcpid.encaes
+        + delim // + RoundToString(mcpid.nonce, 0)
+        + delim // + RoundToString(mcpid.NetworkRAC, 0)
+        + delim + m_client_version
+        + delim + RoundToString(m_research_subsidy, subsidy_places)
+        + delim + std::to_string(m_last_payment_time)
+        + delim // + std::to_string(m_rsa_weight)
+        + delim // + mcpid.cpidv2
+        + delim + std::to_string(m_magnitude)
+        + delim + m_quorum_address
+        + delim + BlockHashToString(m_last_block_hash)
+        + delim + RoundToString(m_block_subsidy, subsidy_places)
+        + delim + m_organization
+        + delim // + mcpid.OrganizationKey
+        + delim + m_quorum_hash.ToString()
+        + delim + (m_superblock.WellFormed() ? m_superblock.PackLegacy() : "")
+        + delim // + RoundToString(mcpid.ResearchSubsidy2,2)
+        + delim + RoundToString(m_research_age, 6)
+        + delim + RoundToString(m_magnitude_unit, MAG_UNIT_PLACES)
+        + delim + RoundToString(m_average_magnitude, 2)
+        + delim + BlockHashToString(m_last_por_block_hash)
+        + delim // + mcpid.CurrentNeuralHash
+        + delim + m_public_key.ToString()
+        + delim + EncodeBase64(m_signature.data(), m_signature.size());
+}

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -97,7 +97,7 @@ Claim Claim::Parse(const std::string& claim, int block_version)
     //
     switch (std::min<size_t>(s.size() - 1, 30)) {
         case 30: c.m_signature = DecodeBase64(s[30].c_str());
-        case 29: c.m_public_key = CPubKey::Parse(s[29]);
+        case 29: //c.m_public_key = CPubKey::Parse(s[29]);
         case 28: c.m_quorum_hash = QuorumHash::Parse(s[28]);
         case 27: //c.m_last_por_block_hash = uint256(s[27]);
         case 26: //c.m_average_magnitude = RoundFromString(s[26], 2);
@@ -182,8 +182,6 @@ bool Claim::Sign(CKey& beacon_private_key)
         return false;
     }
 
-    m_public_key = beacon_private_key.GetPubKey();
-
     return true;
 }
 
@@ -256,6 +254,6 @@ std::string Claim::ToString(const int block_version) const
         + delim // + RoundToString(m_average_magnitude, 2)
         + delim // + BlockHashToString(m_last_por_block_hash)
         + delim // + mcpid.CurrentNeuralHash
-        + delim + m_public_key.ToString()
+        + delim // + m_public_key.ToString()
         + delim + EncodeBase64(m_signature.data(), m_signature.size());
 }

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -230,13 +230,6 @@ struct Claim
     double m_magnitude_unit; // MiningCPID::ResearchMagnitudeUnit
 
     //!
-    //! \brief Average magnitude over the research accrual period.
-    //!
-    //! Informational.
-    //!
-    double m_average_magnitude; // MiningCPID::ResearchAverageMagnitude
-
-    //!
     //! \brief The public key of the beacon associated with the CPID.
     //!
     //! Informational. The protocol checks that this key matches the beacon
@@ -418,7 +411,6 @@ struct Claim
             READWRITE(VarDouble<COIN_PLACES>(m_research_subsidy));
             READWRITE(m_magnitude);
             READWRITE(VarDouble<MAG_UNIT_PLACES>(m_magnitude_unit));
-            READWRITE(VarDouble<2>(m_average_magnitude));
 
             READWRITE(m_public_key);
             READWRITE(m_signature);

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -195,6 +195,8 @@ struct Claim
     //! The significance of the last block is embedded into the claim signature
     //! for researchers so we can consider this field informational.
     //!
+    //! TODO: Remove this field after the switch to block version 11.
+    //!
     uint256 m_last_block_hash; // MiningCPID::lastblockhash
 
     //!
@@ -326,32 +328,30 @@ struct Claim
     //!
     //! \brief Sign an instance that claims research rewards.
     //!
-    //! \param beacon_private_key The private key of the beacon to sign the
-    //! claim with.
+    //! \param private_key     The private key of the beacon to sign the claim
+    //! with.
+    //! \param last_block_hash Hash of the block that preceeds the block that
+    //! contains the claim.
     //!
     //! \return \c false if the claim does not contain a valid CPID or if the
     //! signing fails.
     //!
-    bool Sign(CKey& beacon_private_key);
+    bool Sign(CKey& private_key, const uint256& last_block_hash);
 
     //!
     //! \brief Validate the authenticity of a research reward claim by verifying
     //! the digital signature.
     //!
-    //! \param beacon_public_key The public key of the beacon that signed the
+    //! \param public_key      The public key of the beacon that signed the
     //! claim.
+    //! \param last_block_hash Hash of the block that preceeds the block that
+    //! contains the claim.
     //!
     //! \return \c true if the signature check passes using the supplied key.
     //!
-    bool VerifySignature(CKey& beacon_public_key) const;
-
-    //!
-    //! \brief Get the hash of a subset of the data in the object used as input
-    //! to sign or verify a research reward claim.
-    //!
-    //! \return Hash of the CPID and last block hash contained in the claim.
-    //!
-    uint256 GetVerificationHash() const;
+    bool VerifySignature(
+        const CPubKey& public_key,
+        const uint256& last_block_hash) const;
 
     //!
     //! \brief Compute a hash of the claim data.
@@ -393,7 +393,6 @@ struct Claim
         READWRITE(m_organization);
 
         READWRITE(VarDouble<COIN_PLACES>(m_block_subsidy));
-        READWRITE(m_last_block_hash);
 
         // Serialize research-related fields only for researcher claims:
         //
@@ -423,9 +422,11 @@ typedef boost::optional<Claim> ClaimOption;
 //! \brief Check the authenticity of a research reward claim by verifying the
 //! signature against a matching beacon public key.
 //!
-//! \brief claim Contains the claim data to verify.
+//! \brief claim           Contains the claim data to verify.
+//! \param last_block_hash Hash of the block that preceeds the block that
+//! contains the claim.
 //!
 //! \return \c true if the signature check passes.
 //!
-bool VerifyClaim(const Claim& claim);
+bool VerifyClaim(const Claim& claim, const uint256& last_block_hash);
 }

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -418,7 +418,10 @@ struct Claim
 
         if (!(s.GetType() & SER_GETHASH) && m_quorum_hash.Valid()) {
             READWRITE(m_quorum_address);
-            READWRITE(m_superblock);
+
+            if (!(s.GetType() & SER_SKIPSUPERBLOCK)) {
+                READWRITE(m_superblock);
+            }
         }
     }
 }; // Claim

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -198,14 +198,6 @@ struct Claim
     uint256 m_last_block_hash; // MiningCPID::lastblockhash
 
     //!
-    //! \brief The hash of the block at which a node submitted a claim as a
-    //! researcher prior to this claim.
-    //!
-    //! Informational.
-    //!
-    uint256 m_last_por_block_hash; // MiningCPID::LastPORBlockHash
-
-    //!
     //! \brief The GRC value of the research rewards claimed by the node.
     //!
     //! Contains a value of zero for investor claims.
@@ -428,7 +420,6 @@ struct Claim
 
         READWRITE(VarDouble<COIN_PLACES>(m_block_subsidy));
         READWRITE(m_last_block_hash);
-        READWRITE(m_last_por_block_hash);
 
         // Serialize research-related fields only for researcher claims:
         //

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -186,18 +186,6 @@ struct Claim
     double m_block_subsidy; // MiningCPID::InterestSubsidy
 
     //!
-    //! \brief Previous payment time of the claim prior to this claim.
-    //!
-    //! Informational.
-    //!
-    //! Previous protocol versions used the last payment time to determine
-    //! payment age for reward calculations. An investor's advertised last
-    //! payment time resets when restarting the wallet. Researcher payment
-    //! times are tracked by CPID.
-    //!
-    uint64_t m_last_payment_time; // MiningCPID::LastPaymentTime
-
-    //!
     //! \brief Hash of the block below the block containing this claim.
     //!
     //! Nodes check that this hash matches the hash of block that preceeds the
@@ -439,7 +427,6 @@ struct Claim
         READWRITE(m_organization);
 
         READWRITE(VarDouble<COIN_PLACES>(m_block_subsidy));
-        READWRITE(m_last_payment_time);
         READWRITE(m_last_block_hash);
         READWRITE(m_last_por_block_hash);
 

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -1,0 +1,482 @@
+#pragma once
+
+#include "neuralnet/cpid.h"
+#include "neuralnet/superblock.h"
+#include "serialize.h"
+#include "uint256.h"
+
+#include <boost/optional.hpp>
+
+class CPubKey;
+
+namespace NN {
+//!
+//! \brief Converts non-negative \c double values to unsigned integers and
+//! serializes or deserializes them using variable-width integer encoding.
+//!
+//! The Claim class contains \c double type floating-point values to match
+//! the representation expected by legacy code. To improve the portability
+//! of these values, we serialize these values as unsigned integers scaled
+//! to store the appropriate accuracy.
+//!
+//! \tparam scale Accuracy of the floating-point number to store.
+//!
+template<size_t scale>
+class ClaimDoubleCompressor
+{
+public:
+    //!
+    //! \brief Wrap the supplied double reference for serialization operations.
+    //!
+    //! \param value The double value to serialize as a variable-width integer.
+    //!
+    explicit ClaimDoubleCompressor(double& value) : m_value(value)
+    {
+    }
+
+    //!
+    //! \brief Wrap the supplied double reference for serialization operations.
+    //!
+    //! \param value The double value to serialize as a variable-width integer.
+    //!
+    explicit ClaimDoubleCompressor(const double& value) : m_value(REF(value))
+    {
+    }
+
+    //!
+    //! \brief Serialize the object to the provided stream.
+    //!
+    //! \param stream   The output stream.
+    //!
+    template<typename Stream>
+    void Serialize(Stream& stream) const
+    {
+        VARINT(GetUnsigned()).Serialize(stream);
+    }
+
+    //!
+    //! \brief Deserialize the object from the provided stream.
+    //!
+    //! \param stream   The input stream.
+    //!
+    template<typename Stream>
+    void Unserialize(Stream& stream)
+    {
+        uint64_t packed;
+
+        VARINT(packed).Unserialize(stream);
+
+        m_value = static_cast<double>(packed) / std::pow(10, scale);
+    }
+
+private:
+    double& m_value; //!< The target value to serialize or deserialize.
+
+    //!
+    //! \brief Calculate the integer value of the wrapped floating-point number.
+    //!
+    //! \return Unsigned integer representation scaled to the specified number
+    //! of places (half-even rounding).
+    //!
+    uint64_t GetUnsigned() const
+    {
+        // Claim objects should never contain negative floating-point values
+        // at serialization time.
+        //
+        assert(m_value >= 0);
+
+        // Round using the same mode as RoundToString() (half-even; banker's
+        // rounding) to match the behavior:
+        //
+        return std::nearbyint(m_value * std::pow(10, scale));
+    }
+}; // ClaimDoubleCompressor
+
+//!
+//! \brief An alias for use within \c SerializationOp blocks.
+//!
+template<size_t scale>
+using VarDouble = ClaimDoubleCompressor<scale>;
+
+//!
+//! \brief Contains the reward claim context embedded in each generated block.
+//!
+//! Gridcoin blocks require some auxiliary information about claimed rewards to
+//! facilitate and secure the reward protocol. Nodes embed the data represented
+//! by a \c Claim instance in generated blocks to provide this context.
+//!
+struct Claim
+{
+    //!
+    //! \brief Version number of the current format for a serialized reward
+    //! claim block.
+    //!
+    //! CONSENSUS: Increment this value when introducing a breaking change and
+    //! ensure that the serialization/deserialization routines also handle all
+    //! of the previous versions.
+    //!
+    static constexpr uint32_t CURRENT_VERSION = 2;
+
+    //!
+    //! \brief Number of places after the decimal point of serialized magnitude
+    //! unit values.
+    //!
+    static constexpr size_t MAG_UNIT_PLACES = 6;
+
+    //!
+    //! \brief Version number of the serialized reward claim format.
+    //!
+    //! Defaults to the most recent version for a new claim instance.
+    //!
+    //! Version 1: Parsed from legacy "BoincBlock"-formatted string data stored
+    //! in the \c hashBoinc field of a coinbase transaction.
+    //!
+    //! Version 2: Claim data serializable in binary format. Stored in a block's
+    //! \c m_claim field to enable submission of larger superblocks.
+    //!
+    uint32_t m_version = CURRENT_VERSION;
+
+    //!
+    //! \brief Indicates whether the claim is for a researcher or investor.
+    //!
+    //! If the claim declares research rewards, this field shall contain the
+    //! external CPID of the researcher. For this case, it must match a CPID
+    //! advertised in a verified beacon.
+    //!
+    MiningId m_mining_id; // MiningCPID::cpid
+
+    //!
+    //! \brief The version string of the wallet software running on the node
+    //! that submits the claim.
+    //!
+    //! Informational. This provides a rough metric of the distribution of
+    //! the software versions installed on staking nodes. No protocol rule
+    //! exists that depends on this value.
+    //!
+    //! Max length: 30 bytes. Blocks that contain a claim structure with a
+    //! version field longer than 30 characters are rejected.
+    //!
+    std::string m_client_version; // MiningCPID::clientversion
+
+    //!
+    //! \brief A user-customizable field that may contain any arbitrary data.
+    //!
+    //! Informational. This field is intended to demonstrate an affiliation of
+    //! a staked block with the staking party. For example, testnet guidelines
+    //! recommend that participants set the organization value to recognizable
+    //! identities to facilitate communication when needed.
+    //!
+    //! Max length: 50 bytes. Blocks that contain a claim structure with an
+    //! organization field longer than 50 characters are rejected.
+    //!
+    std::string m_organization; // MiningCPID::Organization
+
+    //!
+    //! \brief The GRC value minted for generating the new block.
+    //!
+    //! Below the switch to constant block rewards, this field contains the
+    //! amount of accrued interest claimed by the staking node. It contains
+    //! the constant block reward rate after the switch.
+    //!
+    //! Claims do not strictly need to contain the block subsidy or research
+    //! subsidy values. Nodes will calculate these values anyway to validate
+    //! incoming reward claims and can index those calculated values without
+    //! this field. It can be considered informational.
+    //!
+    double m_block_subsidy; // MiningCPID::InterestSubsidy
+
+    //!
+    //! \brief Previous payment time of the claim prior to this claim.
+    //!
+    //! Informational.
+    //!
+    //! Previous protocol versions used the last payment time to determine
+    //! payment age for reward calculations. An investor's advertised last
+    //! payment time resets when restarting the wallet. Researcher payment
+    //! times are tracked by CPID.
+    //!
+    uint64_t m_last_payment_time; // MiningCPID::LastPaymentTime
+
+    //!
+    //! \brief Hash of the block below the block containing this claim.
+    //!
+    //! Nodes check that this hash matches the hash of block that preceeds the
+    //! block that contains the claim. This hash is signed along with the CPID
+    //! to prevent replay of the research reward subsidy.
+    //!
+    //! The significance of the last block is embedded into the claim signature
+    //! for researchers so we can consider this field informational.
+    //!
+    uint256 m_last_block_hash; // MiningCPID::lastblockhash
+
+    //!
+    //! \brief The hash of the block at which a node submitted a claim as a
+    //! researcher prior to this claim.
+    //!
+    //! Informational.
+    //!
+    uint256 m_last_por_block_hash; // MiningCPID::LastPORBlockHash
+
+    //!
+    //! \brief The GRC value of the research rewards claimed by the node.
+    //!
+    //! Contains a value of zero for investor claims.
+    //!
+    //! Claims do not strictly need to contain the block subsidy or research
+    //! subsidy values. Nodes will calculate these values anyway to validate
+    //! incoming reward claims and can index those calculated values without
+    //! this field. It can be considered informational.
+    //!
+    double m_research_subsidy; // MiningCPID::ResearchSubsidy
+
+    //!
+    //! \brief The researcher magnitude value from the superblock at the time
+    //! of the claim.
+    //!
+    //! Informational. The magnitude value may better enable off-chain services
+    //! like explorers to more easily produce historical logs of the researcher
+    //! magnitudes over time. The protocol only checks that this magnitude does
+    //! not exceed the magnitude in a superblock for the same CPID.
+    //!
+    //! Previous protocol versions used the magnitude in reward calculations.
+    //!
+    uint16_t m_magnitude; // MiningCPID::Magnitude
+
+    //!
+    //! \brief Duration in seconds between the block that contains this claim
+    //! and a block that contains the previous research reward claim for this
+    //! CPID.
+    //!
+    //! Informational.
+    //!
+    double m_research_age; // MiningCPID::ResearchAge
+
+    //!
+    //! \brief The magnitude ratio of the network at the time of the claim.
+    //!
+    //! Informational.
+    //!
+    double m_magnitude_unit; // MiningCPID::ResearchMagnitudeUnit
+
+    //!
+    //! \brief Average magnitude over the research accrual period.
+    //!
+    //! Informational.
+    //!
+    double m_average_magnitude; // MiningCPID::ResearchAverageMagnitude
+
+    //!
+    //! \brief The public key of the beacon associated with the CPID.
+    //!
+    //! Informational. The protocol checks that this key matches the beacon
+    //! public key stored locally for the CPID. This check affords no added
+    //! security, so this value only exists for historical record. We might
+    //! remove it in the future.
+    //!
+    CPubKey m_public_key; // MiningCPID::BoincPublicKey
+
+    //!
+    //! \brief Produced by signing the CPID and last block hash with a beacon
+    //! public key.
+    //!
+    //! Nodes verify this signature with the CPID's stored beacon key to prevent
+    //! unauthorized claim or replay of the research reward subsidy.
+    //!
+    std::vector<unsigned char> m_signature; // MiningCPID::BoincSignature
+
+    //!
+    //! \brief Hash of the superblock to vote for.
+    //!
+    //! When a superblock is due for a day, nodes will vote for a particular
+    //! superblock contract by submitting in this field the contract hash of
+    //! the pending superblock that the node caches locally.
+    //!
+    QuorumHash m_quorum_hash; // MiningCPID::NeuralHash
+
+    //!
+    //! \brief The default wallet address of the node submitting the claim.
+    //!
+    //! This address matches the address advertised in the beacon for the CPID
+    //! owned by the node. It will determine whether a node may participate in
+    //! the superblock quorum for a particular day.
+    //!
+    std::string m_quorum_address; // MiningCPID::GRCAddress
+
+    //!
+    //! \brief The complete superblock data when the node submitting the claim
+    //! also publishes the daily superblock in the generated block.
+    //!
+    //! Must be accompanied by a valid superblock hash in the \c m_quorum_hash
+    //! field.
+    //!
+    Superblock m_superblock; // MiningCPID::superblock
+
+    //!
+    //! \brief Initialize an empty, invalid reward claim object.
+    //!
+    Claim();
+
+    //!
+    //! \brief Initialize an empty, invalid reward claim object of the specified
+    //! version.
+    //!
+    //! \param version Version number of the serialized reward claim format.
+    //!
+    Claim(uint32_t version);
+
+    //!
+    //! \brief Parse a claim object from a legacy, delimited string (hashBoinc).
+    //!
+    //! \param claim         Legacy "BoincBlock"-formatted claim string data.
+    //! \param block_version Format version of the block that contains the claim
+    //! to parse.
+    //!
+    //! \return A new claim instance that contains the parsed reward context.
+    //!
+    static Claim Parse(const std::string& claim, int block_version);
+
+    //!
+    //! \brief Determine whether the instance represents a complete claim.
+    //!
+    //! The result of this method call does NOT guarantee that the claim is
+    //! valid. The return value of \c true only indicates that the instance
+    //! received each of the pieces of data needed for a well-formed claim.
+    //!
+    //! \return \c true if the claim contains each of the required elements.
+    //!
+    bool WellFormed() const;
+
+    //!
+    //! \brief Determine whether the instance represents a claim that includes
+    //! accrued research rewards.
+    //!
+    //! \return \c true if the claim contains a valid CPID.
+    //!
+    bool HasResearchReward() const;
+
+    //!
+    //! \brief Determine whether the claim instance includes a superblock.
+    //!
+    //! \return \c true if the claim contains a valid superblock object.
+    //!
+    bool ContainsSuperblock() const;
+
+    //!
+    //! \brief Get the sum of the claimed block and research rewards.
+    //!
+    //! \return The sum of the block subsidy and research subsidy declared in
+    //! the claim.
+    //!
+    double TotalSubsidy() const;
+
+    //!
+    //! \brief Sign an instance that claims research rewards.
+    //!
+    //! \param beacon_private_key The private key of the beacon to sign the
+    //! claim with.
+    //!
+    //! \return \c false if the claim does not contain a valid CPID or if the
+    //! signing fails.
+    //!
+    bool Sign(CKey& beacon_private_key);
+
+    //!
+    //! \brief Validate the authenticity of a research reward claim by verifying
+    //! the digital signature.
+    //!
+    //! \param beacon_public_key The public key of the beacon that signed the
+    //! claim.
+    //!
+    //! \return \c true if the signature check passes using the supplied key.
+    //!
+    bool VerifySignature(CKey& beacon_public_key) const;
+
+    //!
+    //! \brief Get the hash of a subset of the data in the object used as input
+    //! to sign or verify a research reward claim.
+    //!
+    //! \return Hash of the CPID and last block hash contained in the claim.
+    //!
+    uint256 GetVerificationHash() const;
+
+    //!
+    //! \brief Compute a hash of the claim data.
+    //!
+    //! \return Hash of the data in the claim.
+    //!
+    uint256 GetHash() const;
+
+    //!
+    //! \brief Get the legacy string representation of the claim.
+    //!
+    //! CONSENSUS: Although this method produces a legacy string compatible
+    //! with older protocols, it does not guarantee that the string matches
+    //! exactly to legacy input string versions imported by Claim::Parse().
+    //! Use this method to produce a new claim context for generated legacy
+    //! blocks or for informational output. Do not reproduce existing claim
+    //! data with this routine if it will be retransmitted to other nodes.
+    //!
+    //! \param block_version Determines the number of subsidy places.
+    //!
+    //! \return A "BoincBlock"-formatted string that contains the claim data.
+    //!
+    std::string ToString(const int block_version) const;
+
+    //
+    // Serialize and deserialize the claim in binary format instead of parsing
+    // and formatting the legacy delimited string representation.
+    //
+    // For Claim::m_version >= 2.
+    //
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(m_version);
+        READWRITE(m_mining_id);
+        READWRITE(m_client_version);
+        READWRITE(m_organization);
+
+        READWRITE(VarDouble<COIN_PLACES>(m_block_subsidy));
+        READWRITE(m_last_payment_time);
+        READWRITE(m_last_block_hash);
+        READWRITE(m_last_por_block_hash);
+
+        // Serialize research-related fields only for researcher claims:
+        //
+        if (m_mining_id.Which() == MiningId::Kind::CPID) {
+            READWRITE(VarDouble<COIN_PLACES>(m_research_subsidy));
+            READWRITE(m_magnitude);
+            READWRITE(VarDouble<6>(m_research_age));
+            READWRITE(VarDouble<MAG_UNIT_PLACES>(m_magnitude_unit));
+            READWRITE(VarDouble<2>(m_average_magnitude));
+
+            READWRITE(m_public_key);
+            READWRITE(m_signature);
+        }
+
+        READWRITE(m_quorum_hash);
+
+        if (!(s.GetType() & SER_GETHASH) && m_quorum_hash.Valid()) {
+            READWRITE(m_quorum_address);
+            READWRITE(m_superblock);
+        }
+    }
+}; // Claim
+
+//!
+//! \brief An optional type that either contains some claim object or does not.
+//!
+typedef boost::optional<Claim> ClaimOption;
+
+//!
+//! \brief Check the authenticity of a research reward claim by verifying the
+//! signature against a matching beacon public key.
+//!
+//! \brief claim Contains the claim data to verify.
+//!
+//! \return \c true if the signature check passes.
+//!
+bool VerifyClaim(const Claim& claim);
+}

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -223,15 +223,6 @@ struct Claim
     uint16_t m_magnitude; // MiningCPID::Magnitude
 
     //!
-    //! \brief Duration in seconds between the block that contains this claim
-    //! and a block that contains the previous research reward claim for this
-    //! CPID.
-    //!
-    //! Informational.
-    //!
-    double m_research_age; // MiningCPID::ResearchAge
-
-    //!
     //! \brief The magnitude ratio of the network at the time of the claim.
     //!
     //! Informational.
@@ -426,7 +417,6 @@ struct Claim
         if (m_mining_id.Which() == MiningId::Kind::CPID) {
             READWRITE(VarDouble<COIN_PLACES>(m_research_subsidy));
             READWRITE(m_magnitude);
-            READWRITE(VarDouble<6>(m_research_age));
             READWRITE(VarDouble<MAG_UNIT_PLACES>(m_magnitude_unit));
             READWRITE(VarDouble<2>(m_average_magnitude));
 

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -118,6 +118,16 @@ struct Claim
     static constexpr uint32_t CURRENT_VERSION = 2;
 
     //!
+    //! \brief The maximum length of a serialized client version in a claim.
+    //!
+    static constexpr size_t MAX_VERSION_SIZE = 30;
+
+    //!
+    //! \brief The maximum length of a serialized organization value in a claim.
+    //!
+    static constexpr size_t MAX_ORGANIZATION_SIZE = 50;
+
+    //!
     //! \brief Number of places after the decimal point of serialized magnitude
     //! unit values.
     //!

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -230,16 +230,6 @@ struct Claim
     double m_magnitude_unit; // MiningCPID::ResearchMagnitudeUnit
 
     //!
-    //! \brief The public key of the beacon associated with the CPID.
-    //!
-    //! Informational. The protocol checks that this key matches the beacon
-    //! public key stored locally for the CPID. This check affords no added
-    //! security, so this value only exists for historical record. We might
-    //! remove it in the future.
-    //!
-    CPubKey m_public_key; // MiningCPID::BoincPublicKey
-
-    //!
     //! \brief Produced by signing the CPID and last block hash with a beacon
     //! public key.
     //!
@@ -412,7 +402,6 @@ struct Claim
             READWRITE(m_magnitude);
             READWRITE(VarDouble<MAG_UNIT_PLACES>(m_magnitude_unit));
 
-            READWRITE(m_public_key);
             READWRITE(m_signature);
         }
 

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -17,7 +17,6 @@ using namespace NN;
 std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 // Used to build the legacy global mining context after reloading projects:
-MiningCPID GetMiningCPID();
 extern std::string msMiningErrors;
 
 namespace {
@@ -284,28 +283,14 @@ void DetectSplitCpid(const MiningProjectMap& projects)
 }
 
 //!
-//! \brief Set up the legacy global mining context variables after reloading
-//! researcher context.
+//! \brief Set the global BOINC researcher context.
 //!
-//! \param researcher Contains the context to export.
+//! \param context Contains the CPID and local projects loaded from BOINC.
 //!
-void SetLegacyResearcherContext(const Researcher& researcher)
+void StoreResearcher(Researcher context)
 {
-    MiningCPID mc = GetMiningCPID();
-
-    mc.initialized = true;
-    mc.cpid = researcher.Id().ToString();
-    mc.Magnitude = 0;
-    mc.clientversion = "";
-    mc.LastPaymentTime = 0;
-    mc.lastblockhash = "0";
-    // Reuse for debugging
-    mc.Organization = GetArg("-org", "");
-
-    GlobalCPUMiningCPID = std::move(mc);
-
     // TODO: this belongs in presentation layer code:
-    switch (researcher.Status()) {
+    switch (context.Status()) {
         case ResearcherStatus::ACTIVE:
             msMiningErrors = _("Eligible for Research Rewards");
             break;
@@ -316,16 +301,6 @@ void SetLegacyResearcherContext(const Researcher& researcher)
             msMiningErrors = _("Staking Only - Investor Mode");
             break;
     }
-}
-
-//!
-//! \brief Set the global BOINC researcher context.
-//!
-//! \param context Contains the CPID and local projects loaded from BOINC.
-//!
-void StoreResearcher(Researcher context)
-{
-    SetLegacyResearcherContext(context);
 
     std::atomic_store(
         &researcher,

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -1506,11 +1506,21 @@ QuorumHash QuorumHash::Hash(const Superblock& superblock)
 
 QuorumHash QuorumHash::Parse(const std::string& hex)
 {
-    if (hex.size() != sizeof(uint256) * 2 && hex.size() != sizeof(Md5Sum) * 2) {
-        return QuorumHash();
+    if (hex.size() == sizeof(uint256) * 2) {
+        return QuorumHash(ParseHex(hex));
     }
 
-    return QuorumHash(ParseHex(hex));
+    if (hex.size() == sizeof(Md5Sum) * 2) {
+        // This is the hash of an empty legacy superblock contract. A bug in
+        // previous versions caused nodes to vote for empty superblocks when
+        // staking a block. We can ignore any quorum hashes with this value:
+        //
+        if (hex != "d41d8cd98f00b204e9800998ecf8427e") {
+            return QuorumHash(ParseHex(hex));
+        }
+    }
+
+    return QuorumHash();
 }
 
 bool QuorumHash::operator==(const QuorumHash& other) const

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -237,6 +237,15 @@ public:
     static constexpr uint32_t CURRENT_VERSION = 2;
 
     //!
+    //! \brief The maximum allowed size of a serialized superblock in bytes.
+    //!
+    //! The bulk of the superblock data is comprised of pairs of CPIDs to
+    //! magnitude values. A value of 4 MB provides space for roughly 200k
+    //! CPIDs that accumulated a non-zero magnitude.
+    //!
+    static constexpr size_t MAX_SIZE = 4 * 1000 * 1000;
+
+    //!
     //! \brief Contains the CPID statistics aggregated for all projects.
     //!
     //! To conserve space in a serialized superblock, other sections refer to

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2419,7 +2419,7 @@ UniValue MagnitudeReport(std::string cpid)
                             int64_t nTime = GetAdjustedTime();
                             double dMagnitudeUnit = GRCMagnitudeUnit(nTime);
                             double dAccrualAge, AvgMagnitude;
-                            int64_t nBoinc = ComputeResearchAccrual(nTime, structMag.cpid, "", pindexBest, false, 69, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
+                            int64_t nBoinc = ComputeResearchAccrual(nTime, structMag.cpid, pindexBest, false, 69, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
                             entry.pushKV("Owed", nBoinc / (double)COIN);
                         }
                         entry.pushKV("Daily Paid",structMag.payments/14);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -157,7 +157,6 @@ UniValue ClaimToJson(const NN::Claim& claim)
     json.pushKV("research_subsidy", claim.m_research_subsidy);
     json.pushKV("magnitude", claim.m_magnitude);
     json.pushKV("magnitude_unit", claim.m_magnitude_unit);
-    json.pushKV("average_magnitude", claim.m_average_magnitude);
 
     json.pushKV("public_key", HexStr(claim.m_public_key.Raw()));
     json.pushKV("signature", EncodeBase64(claim.m_signature.data(), claim.m_signature.size()));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -152,7 +152,6 @@ UniValue ClaimToJson(const NN::Claim& claim)
     json.pushKV("organization", claim.m_organization);
 
     json.pushKV("block_subsidy", claim.m_block_subsidy);
-    json.pushKV("last_payment_time", TimestampToHRDate(claim.m_last_payment_time));
     json.pushKV("last_block_hash", claim.m_last_block_hash.ToString());
     json.pushKV("last_por_block_hash", claim.m_last_por_block_hash.ToString());
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -153,7 +153,6 @@ UniValue ClaimToJson(const NN::Claim& claim)
 
     json.pushKV("block_subsidy", claim.m_block_subsidy);
     json.pushKV("last_block_hash", claim.m_last_block_hash.ToString());
-    json.pushKV("last_por_block_hash", claim.m_last_por_block_hash.ToString());
 
     json.pushKV("research_subsidy", claim.m_research_subsidy);
     json.pushKV("research_age", claim.m_research_age);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -158,7 +158,6 @@ UniValue ClaimToJson(const NN::Claim& claim)
     json.pushKV("magnitude", claim.m_magnitude);
     json.pushKV("magnitude_unit", claim.m_magnitude_unit);
 
-    json.pushKV("public_key", HexStr(claim.m_public_key.Raw()));
     json.pushKV("signature", EncodeBase64(claim.m_signature.data(), claim.m_signature.size()));
 
     json.pushKV("quorum_hash", claim.m_quorum_hash.ToString());

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -152,7 +152,6 @@ UniValue ClaimToJson(const NN::Claim& claim)
     json.pushKV("organization", claim.m_organization);
 
     json.pushKV("block_subsidy", claim.m_block_subsidy);
-    json.pushKV("last_block_hash", claim.m_last_block_hash.ToString());
 
     json.pushKV("research_subsidy", claim.m_research_subsidy);
     json.pushKV("magnitude", claim.m_magnitude);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -155,7 +155,6 @@ UniValue ClaimToJson(const NN::Claim& claim)
     json.pushKV("last_block_hash", claim.m_last_block_hash.ToString());
 
     json.pushKV("research_subsidy", claim.m_research_subsidy);
-    json.pushKV("research_age", claim.m_research_age);
     json.pushKV("magnitude", claim.m_magnitude);
     json.pushKV("magnitude_unit", claim.m_magnitude_unit);
     json.pushKV("average_magnitude", claim.m_average_magnitude);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -127,7 +127,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         {
             double dMagnitudeUnit = GRCMagnitudeUnit(nTime);
             double dAccrualAge,AvgMagnitude;
-            int64_t nBoinc = ComputeResearchAccrual(nTime, primary_cpid, "getmininginfo", pindexBest, false, 69, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
+            int64_t nBoinc = ComputeResearchAccrual(nTime, primary_cpid, pindexBest, false, 69, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
             obj.pushKV("Magnitude Unit",dMagnitudeUnit);
             obj.pushKV("BoincRewardPending",nBoinc/(double)COIN);
         }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -80,7 +80,6 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
         res.push_back(std::make_pair(_("Current Neural Hash"), claim.m_quorum_hash.ToString()));
         res.push_back(std::make_pair(_("Client Version"), claim.m_client_version));
         res.push_back(std::make_pair(_("Organization"), claim.m_organization));
-        res.push_back(std::make_pair(_("Boinc Public Key"), HexStr(claim.m_public_key.Raw())));
     }
 
     return res;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -63,11 +63,10 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
     res.push_back(std::make_pair(_("CPID"), claim.m_mining_id.ToString()));
     res.push_back(std::make_pair(_("Interest"), RoundToString(claim.m_block_subsidy, 8)));
 
-    if (claim.m_average_magnitude > 0)
+    if (claim.m_magnitude > 0)
     {
         res.push_back(std::make_pair(_("Boinc Reward"), RoundToString(claim.m_research_subsidy, 8)));
         res.push_back(std::make_pair(_("Magnitude"), RoundToString(claim.m_magnitude, 8)));
-        res.push_back(std::make_pair(_("Average Magnitude"), RoundToString(claim.m_average_magnitude, 8)));
     }
 
     res.push_back(std::make_pair(_("Is Superblock"), (claim.ContainsSuperblock() ? "Yes" : "No")));

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -55,35 +55,34 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
         }
     }
 
-    //Deserialize
-    MiningCPID bb = DeserializeBoincBlock(block.vtx[0].hashBoinc,block.nVersion);
+    const NN::Claim& claim = block.GetClaim();
 
     res.push_back(std::make_pair(_("Height"), ToString(pindex->nHeight)));
     res.push_back(std::make_pair(_("Block Version"), ToString(block.nVersion)));
     res.push_back(std::make_pair(_("Difficulty"), RoundToString(GetBlockDifficulty(block.nBits),8)));
-    res.push_back(std::make_pair(_("CPID"), bb.cpid));
-    res.push_back(std::make_pair(_("Interest"), RoundToString(bb.InterestSubsidy,8)));
+    res.push_back(std::make_pair(_("CPID"), claim.m_mining_id.ToString()));
+    res.push_back(std::make_pair(_("Interest"), RoundToString(claim.m_block_subsidy, 8)));
 
-    if (bb.ResearchAverageMagnitude > 0)
+    if (claim.m_average_magnitude > 0)
     {
-        res.push_back(std::make_pair(_("Boinc Reward"), RoundToString(bb.ResearchSubsidy,8)));
-        res.push_back(std::make_pair(_("Magnitude"), RoundToString(bb.Magnitude,8)));
-        res.push_back(std::make_pair(_("Average Magnitude"), RoundToString(bb.ResearchAverageMagnitude, 8)));
-        res.push_back(std::make_pair(_("Research Age"), RoundToString(bb.ResearchAge, 8)));
+        res.push_back(std::make_pair(_("Boinc Reward"), RoundToString(claim.m_research_subsidy, 8)));
+        res.push_back(std::make_pair(_("Magnitude"), RoundToString(claim.m_magnitude, 8)));
+        res.push_back(std::make_pair(_("Average Magnitude"), RoundToString(claim.m_average_magnitude, 8)));
+        res.push_back(std::make_pair(_("Research Age"), RoundToString(claim.m_research_age, 8)));
     }
 
-    res.push_back(std::make_pair(_("Is Superblock"), (bb.superblock.length() >= 20 ? "Yes" : "No")));
+    res.push_back(std::make_pair(_("Is Superblock"), (claim.ContainsSuperblock() ? "Yes" : "No")));
 
     if(fDebug)
     {
-        if (bb.superblock.length() >= 20)
-            res.push_back(std::make_pair(_("Neural Contract Binary Size"), ToString(bb.superblock.length())));
+        if (claim.ContainsSuperblock())
+            res.push_back(std::make_pair(_("Neural Contract Binary Size"), ToString(GetSerializeSize(claim.m_superblock, 1, 1))));
 
-        res.push_back(std::make_pair(_("Neural Hash"), bb.NeuralHash));
-        res.push_back(std::make_pair(_("Current Neural Hash"), bb.CurrentNeuralHash));
-        res.push_back(std::make_pair(_("Client Version"), bb.clientversion));
-        res.push_back(std::make_pair(_("Organization"), bb.Organization));
-        res.push_back(std::make_pair(_("Boinc Public Key"), bb.BoincPublicKey));
+        res.push_back(std::make_pair(_("Neural Hash"), claim.m_quorum_hash.ToString()));
+        res.push_back(std::make_pair(_("Current Neural Hash"), claim.m_quorum_hash.ToString()));
+        res.push_back(std::make_pair(_("Client Version"), claim.m_client_version));
+        res.push_back(std::make_pair(_("Organization"), claim.m_organization));
+        res.push_back(std::make_pair(_("Boinc Public Key"), HexStr(claim.m_public_key.Raw())));
     }
 
     return res;
@@ -256,39 +255,10 @@ std::vector<std::pair<std::string, std::string>> GetTxNormalBoincHashInfo(const 
                     if (pblockindex && pblockindex->nIsSuperBlock)
                     {
                         block.ReadFromDisk(pblockindex);
+                        const NN::Superblock& superblock = block.GetSuperblock();
 
-                        std::string sHashBoinc = block.vtx[0].hashBoinc;
-
-                        MiningCPID vbb = DeserializeBoincBlock(sHashBoinc, block.nVersion);
-
-                        std::string sUnpackedSuperblock = UnpackBinarySuperblock(vbb.superblock);
-                        std::string sMagnitudeContract = ExtractXML(sUnpackedSuperblock, "<MAGNITUDES>", "</MAGNITUDES>");
-
-                        // Since Superblockavg function gives avg for mags yes but total cpids we cannot use this function
-                        // We need the rows_above_zero for Total Network Magnitude calculation with Money Supply Factor.
-                        std::vector<std::string> vMagnitudeContract = split(sMagnitudeContract, ";");
-                        int nRowsWithMag = 0;
-                        double dTotalMag = 0;
-
-                        for (auto const& sMag : vMagnitudeContract)
-                        {
-                            const std::vector<std::string>& vFields = split(sMag, ",");
-
-                            if (vFields.size() < 2)
-                                continue;
-
-                            const std::string& sCPID = vFields[0];
-                            double dMAG = std::stoi(vFields[1].c_str());
-
-                            if (sCPID.length() > 10)
-                            {
-                                nRowsWithMag++;
-                                dTotalMag += dMAG;
-                            }
-                        }
-
-                        double dOutAverage = dTotalMag / ((double)nRowsWithMag + .01);
-                        double dTotalNetworkMagnitude = (double)nRowsWithMag * dOutAverage;
+                        double dOutAverage = superblock.m_cpids.AverageMagnitude();
+                        double dTotalNetworkMagnitude = (double)superblock.m_cpids.size() * dOutAverage;
                         double dMoneySupply = DoubleFromAmount(pblockindex->nMoneySupply);
                         double dMoneySupplyFactor = (dMoneySupply/dTotalNetworkMagnitude + .01);
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -68,7 +68,6 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
         res.push_back(std::make_pair(_("Boinc Reward"), RoundToString(claim.m_research_subsidy, 8)));
         res.push_back(std::make_pair(_("Magnitude"), RoundToString(claim.m_magnitude, 8)));
         res.push_back(std::make_pair(_("Average Magnitude"), RoundToString(claim.m_average_magnitude, 8)));
-        res.push_back(std::make_pair(_("Research Age"), RoundToString(claim.m_research_age, 8)));
     }
 
     res.push_back(std::make_pair(_("Is Superblock"), (claim.ContainsSuperblock() ? "Yes" : "No")));

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -23,6 +23,8 @@
 #include <boost/date_time/gregorian/greg_date.hpp>
 #include <random>
 
+namespace NN { std::string GetPrimaryCpid(); }
+
 // These are initialized empty. GetDataDir() cannot be called here. It is too early.
 fs::path pathDataDir = {};
 fs::path pathScraper = {};
@@ -3249,10 +3251,9 @@ std::string ExplainMagnitude(std::string sCPID)
 
     // "Signature"
     // The magic version number of 430 from .NET is there for compatibility with the old NN protocol.
-    // TODO: Should we take a lock on cs_main to read GlobalCPUMiningCPID?
     out.append("NN Host Version: 430, ");
     out.append("NeuralHash: " + ConvergedScraperStatsCache.sContractHash + ", ");
-    out.append("SignatureCPID: " + GlobalCPUMiningCPID.cpid + ", ");
+    out.append("SignatureCPID: " + NN::GetPrimaryCpid() + ", ");
     out.append("Time: " + DateTimeStrFormat("%x %H:%M:%S",  GetAdjustedTime()) + "<ROW>");
 
     //Totals

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -179,6 +179,7 @@ enum
     // modifiers
     SER_SKIPSIG         = (1 << 16),
     SER_BLOCKHEADERONLY = (1 << 17),
+    SER_SKIPSUPERBLOCK  = (1 << 18),
 };
 
 //! Convert the reference base type to X, without changing constness or reference type.

--- a/src/test/neuralnet/claim_tests.cpp
+++ b/src/test/neuralnet/claim_tests.cpp
@@ -1,0 +1,715 @@
+#include "neuralnet/claim.h"
+
+#include "key.h"
+#include "streams.h"
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <vector>
+
+namespace {
+//!
+//! \brief Get a complete, valid claim for an investor.
+//!
+//! \return Investor fields initialized except the superblock-related fields.
+//!
+NN::Claim GetInvestorClaim()
+{
+    NN::Claim claim;
+
+    claim.m_mining_id = NN::MiningId::ForInvestor();
+    claim.m_client_version = "v4.0.4.6-unk";
+    claim.m_organization = "Example Org";
+    claim.m_block_subsidy = 10.0;
+
+    return claim;
+}
+
+//!
+//! \brief Get a complete, valid claim for a researcher.
+//!
+//! \return Researcher fields initialized except the superblock-related fields.
+//!
+NN::Claim GetResearcherClaim()
+{
+    NN::Claim claim;
+
+    claim.m_mining_id = NN::Cpid::Parse("00010203040506070809101112131415");
+    claim.m_client_version = "v4.0.4.6-unk";
+    claim.m_organization = "Example Org";
+    claim.m_block_subsidy = 10.0;
+    claim.m_research_subsidy = 123.456;
+    claim.m_magnitude = 123;
+    claim.m_magnitude_unit = 0.123456;
+    claim.m_signature = {
+        0x7b, 0x85, 0xc8, 0x3c, 0x92, 0xd9, 0x74, 0x8e,
+        0xa3, 0xd2, 0x26, 0x16, 0x6f, 0x9a, 0x00, 0x6c,
+        0x6f, 0x0a, 0x97, 0x97, 0xa9, 0x3a, 0x52, 0xd0,
+        0xb9, 0x4f, 0xbb, 0x29, 0x61, 0xbe, 0xd5, 0xcc,
+    };
+
+    return claim;
+}
+
+//!
+//! \brief Get a basic superblock to use for testing.
+//!
+//! \return A superblock with one CPID/magnitude pair and one project.
+//!
+NN::Superblock GetTestSuperblock(uint32_t version = NN::Superblock::CURRENT_VERSION)
+{
+    NN::Superblock superblock;
+
+    superblock.m_version = version;
+    superblock.m_cpids.Add(NN::Cpid(), 123);
+    superblock.m_projects.Add("project", NN::Superblock::ProjectStats());
+
+    return superblock;
+}
+
+//!
+//! \brief Create a valid private key for tests.
+//!
+//! \return This is actually the shared message private key.
+//!
+static CKey GetTestPrivateKey()
+{
+    std::vector<unsigned char> private_key = ParseHex(
+        "308201130201010420fbd45ffb02ff05a3322c0d77e1e7aea264866c24e81e5ab6"
+        "a8e150666b4dc6d8a081a53081a2020101302c06072a8648ce3d0101022100ffff"
+        "fffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f300604"
+        "010004010704410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959"
+        "f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47"
+        "d08ffb10d4b8022100fffffffffffffffffffffffffffffffebaaedce6af48a03b"
+        "bfd25e8cd0364141020101a144034200044b2938fbc38071f24bede21e838a0758"
+        "a52a0085f2e034e7f971df445436a252467f692ec9c5ba7e5eaa898ab99cbd9949"
+        "496f7e3cafbf56304b1cc2e5bdf06e");
+
+    CKey key;
+    key.SetPrivKey(CPrivKey(private_key.begin(), private_key.end()));
+
+    return key;
+}
+} // anonymous namespace
+
+// -----------------------------------------------------------------------------
+// Claim
+// -----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Claim)
+
+BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_claim)
+{
+    const NN::Claim claim;
+
+    BOOST_CHECK(claim.m_version == NN::Claim::CURRENT_VERSION);
+    BOOST_CHECK(claim.m_mining_id.Valid() == false);
+    BOOST_CHECK(claim.m_client_version.empty() == true);
+    BOOST_CHECK(claim.m_organization.empty() == true);
+
+    BOOST_CHECK(claim.m_block_subsidy == 0.0);
+
+    BOOST_CHECK(claim.m_magnitude == 0);
+    BOOST_CHECK(claim.m_research_subsidy == 0.0);
+    BOOST_CHECK(claim.m_magnitude_unit == 0.0);
+
+    BOOST_CHECK(claim.m_signature.empty() == true);
+
+    BOOST_CHECK(claim.m_quorum_hash.Valid() == false);
+    BOOST_CHECK(claim.m_quorum_address.empty() == true);
+    BOOST_CHECK(claim.m_superblock.m_cpids.empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_initializes_to_the_specified_version)
+{
+    const NN::Claim claim(1);
+
+    BOOST_CHECK(claim.m_version == 1);
+    BOOST_CHECK(claim.m_mining_id.Valid() == false);
+    BOOST_CHECK(claim.m_client_version.empty() == true);
+    BOOST_CHECK(claim.m_organization.empty() == true);
+
+    BOOST_CHECK(claim.m_block_subsidy == 0.0);
+
+    BOOST_CHECK(claim.m_magnitude == 0);
+    BOOST_CHECK(claim.m_research_subsidy == 0.0);
+    BOOST_CHECK(claim.m_magnitude_unit == 0.0);
+
+    BOOST_CHECK(claim.m_signature.empty() == true);
+
+    BOOST_CHECK(claim.m_quorum_hash.Valid() == false);
+    BOOST_CHECK(claim.m_quorum_address.empty() == true);
+    BOOST_CHECK(claim.m_superblock.m_cpids.empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_a_legacy_boincblock_string_for_researcher)
+{
+    const NN::Cpid cpid = NN::Cpid::Parse("00010203040506070809101112131415");
+    const std::string quorum_address = "mk8PmpcTGLCZky8YqFHEEwXs5px3hGfQBG";
+
+    const NN::Superblock superblock = GetTestSuperblock(1);
+
+    // Legacy claims only contain MD5 quorum hashes:
+    const NN::QuorumHash quorum_hash(NN::QuorumHash::Md5Sum {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+    });
+
+    const std::vector<unsigned char> signature {
+        0x7b, 0x85, 0xc8, 0x3c, 0x92, 0xd9, 0x74, 0x8e,
+        0xa3, 0xd2, 0x26, 0x16, 0x6f, 0x9a, 0x00, 0x6c,
+        0x6f, 0x0a, 0x97, 0x97, 0xa9, 0x3a, 0x52, 0xd0,
+        0xb9, 0x4f, 0xbb, 0x29, 0x61, 0xbe, 0xd5, 0xcc,
+    };
+
+    const std::string sig64 = EncodeBase64(signature.data(), signature.size());
+
+    const NN::Claim claim = NN::Claim::Parse(
+        cpid.ToString() +                // Mining ID
+        "<|>"                            // Project name              (obsolete)
+        "<|>"                            // AES Skein                 (obsolete)
+        "<|>"                            // Recent average credit     (obsolete)
+        "<|>"                            // Proof-of-BOINC difficulty (obsolete)
+        "<|>"                            // Difficulty bytes          (obsolete)
+        "<|>"                            // Encrypted CPID            (obsolete)
+        "<|>"                            // For encrypted CPIDs?      (obsolete)
+        "<|>"                            // Nonce                     (obsolete)
+        "<|>"                            // Network RAC               (obsolete)
+        "<|>v4.0.4.6-unk"                // Client version
+        "<|>47.24638888"                 // Research subsidy
+        "<|>"                            // Last payment time         (obsolete)
+        "<|>"                            // RSA weight                (obsolete)
+        "<|>"                            // CPID "v2"                 (obsolete)
+        "<|>123"                         // Magnitude
+        "<|>" + quorum_address +         // Quorum address
+        "<|>"                            // Last block hash           (obsolete)
+        "<|>10.00000000"                 // Block subsidy
+        "<|>Example Org"                 // Organization
+        "<|>"                            // Organization key          (obsolete)
+        "<|>" + quorum_hash.ToString() + // Neural hash
+        "<|>" + superblock.PackLegacy() +// Superblock
+        "<|>"                            // Research subsidy 2        (obsolete)
+        "<|>"                            // Research age              (obsolete)
+        "<|>0.123456"                    // Magnitude unit
+        "<|>"                            // Average magnitude         (obsolete)
+        "<|>"                            // Last PoR block hash       (obsolete)
+        "<|>" + quorum_hash.ToString() + // Current Neural hash       (obsolete)
+        "<|>"                            // Public key                (obsolete)
+        "<|>" + sig64,                   // Beacon signature
+        8 // block version
+    );
+
+    // Legacy string claims (BoincBlocks) always parse to version 1:
+    BOOST_CHECK(claim.m_version == 1);
+    BOOST_CHECK(claim.WellFormed() == true);
+
+    BOOST_CHECK(claim.m_mining_id == cpid);
+    BOOST_CHECK(claim.m_client_version == "v4.0.4.6-unk");
+    BOOST_CHECK(claim.m_organization == "Example Org");
+
+    BOOST_CHECK(claim.m_block_subsidy == 10.0);
+
+    BOOST_CHECK(claim.m_magnitude == 123);
+    BOOST_CHECK(claim.m_research_subsidy == 47.25);
+    BOOST_CHECK(claim.m_magnitude_unit == 0.123456);
+
+    BOOST_CHECK(claim.m_signature == signature);
+
+    BOOST_CHECK(claim.m_quorum_hash == quorum_hash);
+    BOOST_CHECK(claim.m_quorum_address == quorum_address);
+    BOOST_CHECK(claim.m_superblock.GetHash() == superblock.GetHash());
+}
+
+BOOST_AUTO_TEST_CASE(it_determines_whether_a_claim_is_well_formed)
+{
+    const NN::Claim claim = GetInvestorClaim();
+
+    BOOST_CHECK(claim.WellFormed() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_validates_client_version_string_length)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    // 31 characters (max valid: 30)
+    claim.m_client_version.resize(31, 'x');
+
+    BOOST_CHECK(claim.WellFormed() == false);
+}
+
+BOOST_AUTO_TEST_CASE(it_validates_organization_string_length)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    // 51 characters (max valid: 50)
+    claim.m_organization.resize(51, 'x');
+
+    BOOST_CHECK(claim.WellFormed() == false);
+}
+
+BOOST_AUTO_TEST_CASE(it_determines_whether_it_is_a_research_reward_claim)
+{
+    NN::Claim claim = GetResearcherClaim();
+
+    BOOST_CHECK(claim.HasResearchReward() == true);
+
+    claim = GetInvestorClaim();
+
+    BOOST_CHECK(claim.HasResearchReward() == false);
+}
+
+BOOST_AUTO_TEST_CASE(it_determines_whether_it_contains_a_superblock)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    BOOST_CHECK(claim.ContainsSuperblock() == false);
+
+    claim.m_superblock = GetTestSuperblock();
+
+    BOOST_CHECK(claim.ContainsSuperblock() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_sums_the_block_and_research_reward_subsidies)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    BOOST_CHECK(claim.TotalSubsidy() == 10.0);
+
+    claim = GetResearcherClaim();
+
+    // Legacy double format of subsidy fields can cause floating-point errors:
+    BOOST_CHECK(std::round(claim.TotalSubsidy() * 1000.0) / 1000.0 == 133.456);
+}
+
+BOOST_AUTO_TEST_CASE(it_signs_itself_with_the_supplied_beacon_private_key)
+{
+    NN::Claim claim = GetResearcherClaim();
+
+    const uint256 last_block_hash(0);
+    CKey private_key = GetTestPrivateKey();
+
+    BOOST_CHECK(claim.Sign(private_key, last_block_hash) == true);
+
+    const uint256 hashed = Hash(
+        claim.m_mining_id.TryCpid().get().Raw().begin(),
+        claim.m_mining_id.TryCpid().get().Raw().end(),
+        last_block_hash.begin(),
+        last_block_hash.end());
+
+    private_key = GetTestPrivateKey();
+
+    BOOST_CHECK(private_key.Verify(hashed, claim.m_signature));
+}
+
+BOOST_AUTO_TEST_CASE(it_refuses_to_sign_itself_with_an_invalid_private_key)
+{
+    NN::Claim claim = GetResearcherClaim();
+
+    CKey private_key;
+    uint256 last_block_hash(0);
+
+    BOOST_CHECK(claim.Sign(private_key, last_block_hash) == false);
+    BOOST_CHECK(claim.m_signature.empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_refuses_to_sign_an_investor_claim)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    const uint256 last_block_hash(0);
+    CKey private_key = GetTestPrivateKey();
+
+    BOOST_CHECK(claim.Sign(private_key, last_block_hash) == false);
+    BOOST_CHECK(claim.m_signature.empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_verifies_a_signature_for_a_research_reward_claim)
+{
+    NN::Claim claim = GetResearcherClaim();
+
+    const uint256 last_block_hash(0);
+    CKey private_key = GetTestPrivateKey();
+
+    const uint256 hashed = Hash(
+        claim.m_mining_id.TryCpid().get().Raw().begin(),
+        claim.m_mining_id.TryCpid().get().Raw().end(),
+        last_block_hash.begin(),
+        last_block_hash.end());
+
+    private_key.Sign(hashed, claim.m_signature);
+
+    BOOST_CHECK(claim.VerifySignature(private_key.GetPubKey(), last_block_hash));
+}
+
+BOOST_AUTO_TEST_CASE(it_generates_a_hash_for_an_investor_claim)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    CHashWriter hasher(SER_GETHASH, claim.m_version);
+
+    hasher << claim.m_version
+        << claim.m_mining_id
+        << claim.m_client_version
+        << claim.m_organization
+        << NN::VarDouble<COIN_PLACES>(claim.m_block_subsidy)
+        << claim.m_quorum_hash;
+
+    BOOST_CHECK(claim.GetHash() == hasher.GetHash());
+}
+
+BOOST_AUTO_TEST_CASE(it_generates_a_hash_for_a_research_reward_claim)
+{
+    NN::Claim claim = GetResearcherClaim();
+
+    CHashWriter hasher(SER_GETHASH, claim.m_version);
+
+    hasher << claim.m_version
+        << claim.m_mining_id
+        << claim.m_client_version
+        << claim.m_organization
+        << NN::VarDouble<COIN_PLACES>(claim.m_block_subsidy)
+        << NN::VarDouble<COIN_PLACES>(claim.m_research_subsidy)
+        << claim.m_magnitude
+        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(claim.m_magnitude_unit)
+        << claim.m_signature
+        << claim.m_quorum_hash;
+
+    BOOST_CHECK(claim.GetHash() == hasher.GetHash());
+}
+
+BOOST_AUTO_TEST_CASE(it_represents_itself_as_a_legacy_boincblock_string)
+{
+    const NN::Cpid cpid = NN::Cpid::Parse("00010203040506070809101112131415");
+    const std::string quorum_address = "mk8PmpcTGLCZky8YqFHEEwXs5px3hGfQBG";
+
+    const NN::Superblock superblock = GetTestSuperblock(1);
+
+    // Legacy claims only contain MD5 quorum hashes:
+    const NN::QuorumHash quorum_hash(NN::QuorumHash::Md5Sum {
+        0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08,
+        0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00
+    });
+
+    const std::vector<unsigned char> signature {
+        0x7b, 0x85, 0xc8, 0x3c, 0x92, 0xd9, 0x74, 0x8e,
+        0xa3, 0xd2, 0x26, 0x16, 0x6f, 0x9a, 0x00, 0x6c,
+        0x6f, 0x0a, 0x97, 0x97, 0xa9, 0x3a, 0x52, 0xd0,
+        0xb9, 0x4f, 0xbb, 0x29, 0x61, 0xbe, 0xd5, 0xcc,
+    };
+
+    const std::string sig64 = EncodeBase64(signature.data(), signature.size());
+
+    NN::Claim claim;
+
+    claim.m_mining_id = cpid;
+    claim.m_client_version = "v4.0.4.6-unk";
+    claim.m_organization = "Example Org";
+    claim.m_block_subsidy = 10.0;
+    claim.m_research_subsidy = 47.24638888;
+    claim.m_magnitude = 123;
+    claim.m_magnitude_unit = 0.123456;
+    claim.m_signature = signature;
+    claim.m_quorum_hash = quorum_hash;
+    claim.m_quorum_address = quorum_address;
+    claim.m_superblock = superblock;
+
+    BOOST_CHECK(claim.ToString(8) ==
+        cpid.ToString() +                // Mining ID
+        "<|>"                            // Project name              (obsolete)
+        "<|>"                            // AES Skein                 (obsolete)
+        "<|>"                            // Recent average credit     (obsolete)
+        "<|>"                            // Proof-of-BOINC difficulty (obsolete)
+        "<|>"                            // Difficulty bytes          (obsolete)
+        "<|>"                            // Encrypted CPID            (obsolete)
+        "<|>"                            // For encrypted CPIDs?      (obsolete)
+        "<|>"                            // Nonce                     (obsolete)
+        "<|>"                            // Network RAC               (obsolete)
+        "<|>v4.0.4.6-unk"                // Client version
+        "<|>47.24638888"                 // Research subsidy
+        "<|>"                            // Last payment time         (obsolete)
+        "<|>"                            // RSA weight                (obsolete)
+        "<|>"                            // CPID "v2"                 (obsolete)
+        "<|>123"                         // Magnitude
+        "<|>" + quorum_address +         // Quorum address
+        "<|>0"                           // Last block hash           (obsolete)
+        "<|>10.00000000"                 // Block subsidy
+        "<|>Example Org"                 // Organization
+        "<|>"                            // Organization key          (obsolete)
+        "<|>" + quorum_hash.ToString() + // Neural hash
+        "<|>" + superblock.PackLegacy() +// Superblock
+        "<|>"                            // Research subsidy 2        (obsolete)
+        "<|>"                            // Research age              (obsolete)
+        "<|>0.123456"                    // Magnitude unit
+        "<|>"                            // Average magnitude         (obsolete)
+        "<|>"                            // Last PoR block hash       (obsolete)
+        "<|>"                            // Current Neural hash       (obsolete)
+        "<|>"                            // Public key                (obsolete)
+        "<|>" + sig64                    // Beacon signature
+    );
+}
+
+BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_investor)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    CDataStream expected(SER_NETWORK, PROTOCOL_VERSION);
+
+    expected << claim.m_version
+        << claim.m_mining_id
+        << claim.m_client_version
+        << claim.m_organization
+        << NN::VarDouble<COIN_PLACES>(claim.m_block_subsidy)
+        << claim.m_quorum_hash;
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << claim;
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_investor_with_superblock)
+{
+    NN::Claim claim = GetInvestorClaim();
+
+    claim.m_superblock = GetTestSuperblock();
+    claim.m_quorum_hash = claim.m_superblock.GetHash();
+    claim.m_quorum_address = "mk8PmpcTGLCZky8YqFHEEwXs5px3hGfQBG";
+
+    CDataStream expected(SER_NETWORK, PROTOCOL_VERSION);
+
+    expected << claim.m_version
+        << claim.m_mining_id
+        << claim.m_client_version
+        << claim.m_organization
+        << NN::VarDouble<COIN_PLACES>(claim.m_block_subsidy)
+        << claim.m_quorum_hash
+        << claim.m_quorum_address
+        << claim.m_superblock;
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << claim;
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_investor)
+{
+    NN::Claim expected = GetInvestorClaim();
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+
+    stream << expected.m_version
+        << expected.m_mining_id
+        << expected.m_client_version
+        << expected.m_organization
+        << NN::VarDouble<COIN_PLACES>(expected.m_block_subsidy)
+        << expected.m_quorum_hash;
+
+    NN::Claim claim;
+
+    stream >> claim;
+
+    BOOST_CHECK(claim.m_version == expected.m_version);
+    BOOST_CHECK(claim.m_mining_id == expected.m_mining_id);
+    BOOST_CHECK(claim.m_client_version == expected.m_client_version);
+    BOOST_CHECK(claim.m_organization == expected.m_organization);
+    BOOST_CHECK(claim.m_block_subsidy == expected.m_block_subsidy);
+    BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
+
+    BOOST_CHECK(claim.m_research_subsidy == 0.0);
+    BOOST_CHECK(claim.m_magnitude == 0.0);
+    BOOST_CHECK(claim.m_magnitude_unit == 0.0);
+    BOOST_CHECK(claim.m_signature.empty() == true);
+    BOOST_CHECK(claim.m_quorum_address.empty() == true);
+    BOOST_CHECK(claim.m_superblock.WellFormed() == false);
+}
+
+BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_investor_with_superblock)
+{
+    NN::Claim expected = GetInvestorClaim();
+
+    expected.m_superblock = GetTestSuperblock();
+    expected.m_quorum_hash = expected.m_superblock.GetHash();
+    expected.m_quorum_address = "mk8PmpcTGLCZky8YqFHEEwXs5px3hGfQBG";
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+
+    stream << expected.m_version
+        << expected.m_mining_id
+        << expected.m_client_version
+        << expected.m_organization
+        << NN::VarDouble<COIN_PLACES>(expected.m_block_subsidy)
+        << expected.m_quorum_hash
+        << expected.m_quorum_address
+        << expected.m_superblock;
+
+    NN::Claim claim;
+
+    stream >> claim;
+
+    BOOST_CHECK(claim.m_version == expected.m_version);
+    BOOST_CHECK(claim.m_mining_id == expected.m_mining_id);
+    BOOST_CHECK(claim.m_client_version == expected.m_client_version);
+    BOOST_CHECK(claim.m_organization == expected.m_organization);
+    BOOST_CHECK(claim.m_block_subsidy == expected.m_block_subsidy);
+
+    BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
+    BOOST_CHECK(claim.m_quorum_address == expected.m_quorum_address);
+    BOOST_CHECK(claim.m_superblock.WellFormed() == true);
+    BOOST_CHECK(claim.m_superblock.GetHash() == expected.m_superblock.GetHash());
+
+    BOOST_CHECK(claim.m_research_subsidy == 0.0);
+    BOOST_CHECK(claim.m_magnitude == 0.0);
+    BOOST_CHECK(claim.m_magnitude_unit == 0.0);
+    BOOST_CHECK(claim.m_signature.empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_researcher)
+{
+    NN::Claim claim = GetResearcherClaim();
+
+    CDataStream expected(SER_NETWORK, claim.m_version);
+
+    expected << claim.m_version
+        << claim.m_mining_id
+        << claim.m_client_version
+        << claim.m_organization
+        << NN::VarDouble<COIN_PLACES>(claim.m_block_subsidy)
+        << NN::VarDouble<COIN_PLACES>(claim.m_research_subsidy)
+        << claim.m_magnitude
+        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(claim.m_magnitude_unit)
+        << claim.m_signature
+        << claim.m_quorum_hash;
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << claim;
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_researcher_with_superblock)
+{
+    NN::Claim claim = GetResearcherClaim();
+
+    claim.m_superblock = GetTestSuperblock();
+    claim.m_quorum_hash = claim.m_superblock.GetHash();
+    claim.m_quorum_address = "mk8PmpcTGLCZky8YqFHEEwXs5px3hGfQBG";
+
+    CDataStream expected(SER_NETWORK, claim.m_version);
+
+    expected << claim.m_version
+        << claim.m_mining_id
+        << claim.m_client_version
+        << claim.m_organization
+        << NN::VarDouble<COIN_PLACES>(claim.m_block_subsidy)
+        << NN::VarDouble<COIN_PLACES>(claim.m_research_subsidy)
+        << claim.m_magnitude
+        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(claim.m_magnitude_unit)
+        << claim.m_signature
+        << claim.m_quorum_hash
+        << claim.m_quorum_address
+        << claim.m_superblock;
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << claim;
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher)
+{
+    NN::Claim expected = GetResearcherClaim();
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+
+    stream << expected.m_version
+        << expected.m_mining_id
+        << expected.m_client_version
+        << expected.m_organization
+        << NN::VarDouble<COIN_PLACES>(expected.m_block_subsidy)
+        << NN::VarDouble<COIN_PLACES>(expected.m_research_subsidy)
+        << expected.m_magnitude
+        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(expected.m_magnitude_unit)
+        << expected.m_signature
+        << expected.m_quorum_hash;
+
+    NN::Claim claim;
+
+    stream >> claim;
+
+    BOOST_CHECK(claim.m_version == expected.m_version);
+    BOOST_CHECK(claim.m_mining_id == expected.m_mining_id);
+    BOOST_CHECK(claim.m_client_version == expected.m_client_version);
+    BOOST_CHECK(claim.m_organization == expected.m_organization);
+    BOOST_CHECK(claim.m_block_subsidy == expected.m_block_subsidy);
+
+    BOOST_CHECK(claim.m_research_subsidy == expected.m_research_subsidy);
+    BOOST_CHECK(claim.m_magnitude == expected.m_magnitude);
+    BOOST_CHECK(claim.m_magnitude_unit == expected.m_magnitude_unit);
+    BOOST_CHECK(claim.m_signature == expected.m_signature);
+
+    BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
+    BOOST_CHECK(claim.m_quorum_address.empty() == true);
+    BOOST_CHECK(claim.m_superblock.WellFormed() == false);
+}
+
+BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher_with_superblock)
+{
+    NN::Claim expected = GetResearcherClaim();
+
+    expected.m_superblock = GetTestSuperblock();
+    expected.m_quorum_hash = expected.m_superblock.GetHash();
+    expected.m_quorum_address = "mk8PmpcTGLCZky8YqFHEEwXs5px3hGfQBG";
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+
+    stream << expected.m_version
+        << expected.m_mining_id
+        << expected.m_client_version
+        << expected.m_organization
+        << NN::VarDouble<COIN_PLACES>(expected.m_block_subsidy)
+        << NN::VarDouble<COIN_PLACES>(expected.m_research_subsidy)
+        << expected.m_magnitude
+        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(expected.m_magnitude_unit)
+        << expected.m_signature
+        << expected.m_quorum_hash
+        << expected.m_quorum_address
+        << expected.m_superblock;
+
+    NN::Claim claim;
+
+    stream >> claim;
+
+    BOOST_CHECK(claim.m_version == expected.m_version);
+    BOOST_CHECK(claim.m_mining_id == expected.m_mining_id);
+    BOOST_CHECK(claim.m_client_version == expected.m_client_version);
+    BOOST_CHECK(claim.m_organization == expected.m_organization);
+    BOOST_CHECK(claim.m_block_subsidy == expected.m_block_subsidy);
+
+    BOOST_CHECK(claim.m_research_subsidy == expected.m_research_subsidy);
+    BOOST_CHECK(claim.m_magnitude == expected.m_magnitude);
+    BOOST_CHECK(claim.m_magnitude_unit == expected.m_magnitude_unit);
+    BOOST_CHECK(claim.m_signature == expected.m_signature);
+
+    BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
+    BOOST_CHECK(claim.m_quorum_address == expected.m_quorum_address);
+    BOOST_CHECK(claim.m_superblock.WellFormed() == true);
+    BOOST_CHECK(claim.m_superblock.GetHash() == expected.m_superblock.GetHash());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -1958,6 +1958,17 @@ BOOST_AUTO_TEST_CASE(it_parses_an_invalid_quorum_hash_to_an_invalid_variant)
     BOOST_CHECK(hash.Valid() == false);
 }
 
+BOOST_AUTO_TEST_CASE(it_parses_an_empty_superblock_hash_to_an_invalid_variant)
+{
+    // This is the hash of an empty legacy superblock contract. A bug in
+    // previous versions caused nodes to vote for empty superblocks when
+    // staking a block. It should parse to an invalid quorum hash value:
+    //
+    NN::QuorumHash hash = NN::QuorumHash::Parse("d41d8cd98f00b204e9800998ecf8427e");
+
+    BOOST_CHECK(hash.Valid() == false);
+}
+
 BOOST_AUTO_TEST_CASE(it_hashes_cpid_magnitudes_from_a_legacy_superblock)
 {
     // Version 1 superblocks hash with the legacy MD5-based algorithm:

--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,7 @@
 #include <inttypes.h>
 
 static const int64_t COIN = 100000000;
+static const int64_t COIN_PLACES = 8;
 static const int64_t CENT = 1000000;
 
 #define BEGIN(a)            ((char*)&(a))

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -27,9 +27,8 @@
 
 using namespace std;
 
-MiningCPID DeserializeBoincBlock(std::string block);
-
 int64_t GetMaximumBoincSubsidy(int64_t nTime);
+
 bool fConfChange;
 unsigned int nDerivationMethodIndex;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -33,6 +33,8 @@ int64_t GetMaximumBoincSubsidy(int64_t nTime);
 bool fConfChange;
 unsigned int nDerivationMethodIndex;
 
+namespace NN { std::string GetPrimaryCpid(); }
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // mapWallet
@@ -167,7 +169,7 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
                 return false;
             if (CCryptoKeyStore::Unlock(vMasterKey))
             {
-                ImportBeaconKeysFromConfig(GlobalCPUMiningCPID.cpid, this);
+                ImportBeaconKeysFromConfig(NN::GetPrimaryCpid(), this);
                 return true;
             }
         }


### PR DESCRIPTION
The `hashBoinc` field of a coinbase transaction stores delimited strings of data that contain the context that augments each generated block. These changes refactor the storage of this data to allow for binary serialization of the claim contexts. 

Based on discussions in Slack, this PR moves the storage of claim contexts from the coinbase transaction to the block itself to facilitate submission of much larger superblock data than a transaction allows. This accommodation prepares the protocol for the removal of the team requirement and a greater number of users. The application begins to use the binary serialization format after the next mandatory threshold. This format significantly reduces the size overhead of the claim context and eliminates issues with string-based serialization. 

To further reduce the size of claim data, I removed the following legacy fields:
 - last payment time
 - last block hash
 - last PoR block hash
 - research age
 - average magnitude 
 - public key

Although it provides an easy-to-access historical log, this data can be reproduced from blockchain data, so it's not necessary to store it in every block. We can also remove the following informational fields from the claim context, but we agreed to keep them in the short-term for explorers: 
 - block subsidy (interest/CBR)
 - research subsidy 
 - magnitude 
 - magnitude unit

The new `NN::Claim` class replaces `MiningCPID` and abstracts the related functionality. The changes here continue clean-up work from #1480 by removing the pervasive use of the `GlobalCPUMiningCPID` state, and RPC methods now produce structured JSON data for claims and superblocks. Claims now limit the size of version and organization fields to 30 and 50 characters for version 11 blocks. This includes a fix for #525 that enables researchers to stake investor-only blocks with no beacon or one that expired.

A subsequent pull request will hook-up the new `NN::Superblock` class to the main block acceptance and research reward code.