### PR TITLE
Move legacy neural vote warnings to debug log level

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7003,12 +7003,12 @@ void IncrementNeuralNetworkSupermajority(const std::string& NeuralHash, const st
             bool validaddresstovote = address.IsValid();
             if (!validaddresstovote)
             {
-                LogPrintf("INNS : Vote found in block with invalid GRC address. HASH: %s GRC: %s", NeuralHash, GRCAddress);
+                if (fDebug) LogPrintf("INNS : Vote found in block with invalid GRC address. HASH: %s GRC: %s", NeuralHash, GRCAddress);
                 return;
             }
             if (!IsNeuralNodeParticipant(GRCAddress, pblockindex->nTime))
             {
-                LogPrintf("INNS : Vote found in block from ineligible neural node participant. HASH: %s GRC: %s", NeuralHash, GRCAddress);
+                if (fDebug) LogPrintf("INNS : Vote found in block from ineligible neural node participant. HASH: %s GRC: %s", NeuralHash, GRCAddress);
                 return;
             }
         }


### PR DESCRIPTION
This suppresses log messages that indicate that a block contains an
invalid superblock vote. A large span of old blocks contain invalid
votes which result in thousands of messages. Sync speed may improve
a bit by showing them in the debug log level only. The messages are
not particularly actionable, so most users don't need to see these.