### PR TITLE
Refactor QT UI variable names to be more consistent, Fix Difficulty default

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -78,18 +78,18 @@ CoinControlDialog::CoinControlDialog(QWidget *parent) :
     connect(clipboardLowOutputAction, SIGNAL(triggered()), this, SLOT(clipboardLowOutput()));
     connect(clipboardChangeAction, SIGNAL(triggered()), this, SLOT(clipboardChange()));
 
-    ui->labelCoinControlQuantity->addAction(clipboardQuantityAction);
-    ui->labelCoinControlAmount->addAction(clipboardAmountAction);
-    ui->labelCoinControlFee->addAction(clipboardFeeAction);
-    ui->labelCoinControlAfterFee->addAction(clipboardAfterFeeAction);
-    ui->labelCoinControlBytes->addAction(clipboardBytesAction);
-    ui->labelCoinControlPriority->addAction(clipboardPriorityAction);
-    ui->labelCoinControlLowOutput->addAction(clipboardLowOutputAction);
-    ui->labelCoinControlChange->addAction(clipboardChangeAction);
+    ui->coinControlQuantityLabel->addAction(clipboardQuantityAction);
+    ui->coinControlAmountLabel->addAction(clipboardAmountAction);
+    ui->coinControlFeeLabel->addAction(clipboardFeeAction);
+    ui->coinControlAfterFeeLabel->addAction(clipboardAfterFeeAction);
+    ui->coinControlBytesLabel->addAction(clipboardBytesAction);
+    ui->coinControlPriorityLabel->addAction(clipboardPriorityAction);
+    ui->coinControlLowOutputLabel->addAction(clipboardLowOutputAction);
+    ui->coinControlChangeLabel->addAction(clipboardChangeAction);
 
     // toggle tree/list mode
-    connect(ui->radioTreeMode, SIGNAL(toggled(bool)), this, SLOT(radioTreeMode(bool)));
-    connect(ui->radioListMode, SIGNAL(toggled(bool)), this, SLOT(radioListMode(bool)));
+    connect(ui->treeModeRadioButton, SIGNAL(toggled(bool)), this, SLOT(treeModeRadioButton(bool)));
+    connect(ui->listModeRadioButton, SIGNAL(toggled(bool)), this, SLOT(listModeRadioButton(bool)));
 
     // click on checkbox
     connect(ui->treeWidget, SIGNAL(itemChanged( QTreeWidgetItem*, int)), this, SLOT(viewItemChanged( QTreeWidgetItem*, int)));
@@ -102,7 +102,7 @@ CoinControlDialog::CoinControlDialog(QWidget *parent) :
     connect(ui->buttonBox, SIGNAL(clicked( QAbstractButton*)), this, SLOT(buttonBoxClicked(QAbstractButton*)));
 
     // (un)select all
-    connect(ui->pushButtonSelectAll, SIGNAL(clicked()), this, SLOT(buttonSelectAllClicked()));
+    connect(ui->selectAllPushButton, SIGNAL(clicked()), this, SLOT(buttonSelectAllClicked()));
 
     ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 84);
     ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 100);
@@ -217,7 +217,7 @@ void CoinControlDialog::copyAmount()
 // context menu action: copy label
 void CoinControlDialog::copyLabel()
 {
-    if (ui->radioTreeMode->isChecked() && contextMenuItem->text(COLUMN_LABEL).length() == 0 && contextMenuItem->parent())
+    if (ui->treeModeRadioButton->isChecked() && contextMenuItem->text(COLUMN_LABEL).length() == 0 && contextMenuItem->parent())
         QApplication::clipboard()->setText(contextMenuItem->parent()->text(COLUMN_LABEL));
     else
         QApplication::clipboard()->setText(contextMenuItem->text(COLUMN_LABEL));
@@ -226,7 +226,7 @@ void CoinControlDialog::copyLabel()
 // context menu action: copy address
 void CoinControlDialog::copyAddress()
 {
-    if (ui->radioTreeMode->isChecked() && contextMenuItem->text(COLUMN_ADDRESS).length() == 0 && contextMenuItem->parent())
+    if (ui->treeModeRadioButton->isChecked() && contextMenuItem->text(COLUMN_ADDRESS).length() == 0 && contextMenuItem->parent())
         QApplication::clipboard()->setText(contextMenuItem->parent()->text(COLUMN_ADDRESS));
     else
         QApplication::clipboard()->setText(contextMenuItem->text(COLUMN_ADDRESS));
@@ -264,49 +264,49 @@ void CoinControlDialog::copyTransactionHash()
 // copy label "Quantity" to clipboard
 void CoinControlDialog::clipboardQuantity()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlQuantity->text());
+    QApplication::clipboard()->setText(ui->coinControlQuantityLabel->text());
 }
 
 // copy label "Amount" to clipboard
 void CoinControlDialog::clipboardAmount()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlAmount->text().left(ui->labelCoinControlAmount->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlAmountLabel->text().left(ui->coinControlAmountLabel->text().indexOf(" ")));
 }
 
 // copy label "Fee" to clipboard
 void CoinControlDialog::clipboardFee()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlFee->text().left(ui->labelCoinControlFee->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlFeeLabel->text().left(ui->coinControlFeeLabel->text().indexOf(" ")));
 }
 
 // copy label "After fee" to clipboard
 void CoinControlDialog::clipboardAfterFee()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlAfterFee->text().left(ui->labelCoinControlAfterFee->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlAfterFeeLabel->text().left(ui->coinControlAfterFeeLabel->text().indexOf(" ")));
 }
 
 // copy label "Bytes" to clipboard
 void CoinControlDialog::clipboardBytes()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlBytes->text());
+    QApplication::clipboard()->setText(ui->coinControlBytesLabel->text());
 }
 
 // copy label "Priority" to clipboard
 void CoinControlDialog::clipboardPriority()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlPriority->text());
+    QApplication::clipboard()->setText(ui->coinControlPriorityLabel->text());
 }
 
 // copy label "Low output" to clipboard
 void CoinControlDialog::clipboardLowOutput()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlLowOutput->text());
+    QApplication::clipboard()->setText(ui->coinControlLowOutputLabel->text());
 }
 
 // copy label "Change" to clipboard
 void CoinControlDialog::clipboardChange()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlChange->text().left(ui->labelCoinControlChange->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlChangeLabel->text().left(ui->coinControlChangeLabel->text().indexOf(" ")));
 }
 
 // treeview: sort
@@ -346,14 +346,14 @@ void CoinControlDialog::headerSectionClicked(int logicalIndex)
 }
 
 // toggle tree mode
-void CoinControlDialog::radioTreeMode(bool checked)
+void CoinControlDialog::treeModeRadioButton(bool checked)
 {
     if (checked && model)
         updateView();
 }
 
 // toggle list mode
-void CoinControlDialog::radioListMode(bool checked)
+void CoinControlDialog::listModeRadioButton(bool checked)
 {
     if (checked && model)
         updateView();
@@ -526,20 +526,20 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     if (model && model->getOptionsModel())
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
 
-    QLabel *l1 = dialog->findChild<QLabel *>("labelCoinControlQuantity");
-    QLabel *l2 = dialog->findChild<QLabel *>("labelCoinControlAmount");
-    QLabel *l3 = dialog->findChild<QLabel *>("labelCoinControlFee");
-    QLabel *l4 = dialog->findChild<QLabel *>("labelCoinControlAfterFee");
-    QLabel *l5 = dialog->findChild<QLabel *>("labelCoinControlBytes");
-    QLabel *l6 = dialog->findChild<QLabel *>("labelCoinControlPriority");
-    QLabel *l7 = dialog->findChild<QLabel *>("labelCoinControlLowOutput");
-    QLabel *l8 = dialog->findChild<QLabel *>("labelCoinControlChange");
+    QLabel *l1 = dialog->findChild<QLabel *>("coinControlQuantityLabel");
+    QLabel *l2 = dialog->findChild<QLabel *>("coinControlAmountLabel");
+    QLabel *l3 = dialog->findChild<QLabel *>("coinControlFeeLabel");
+    QLabel *l4 = dialog->findChild<QLabel *>("coinControlAfterFeeLabel");
+    QLabel *l5 = dialog->findChild<QLabel *>("coinControlBytesLabel");
+    QLabel *l6 = dialog->findChild<QLabel *>("coinControlPriorityLabel");
+    QLabel *l7 = dialog->findChild<QLabel *>("coinControlLowOutputLabel");
+    QLabel *l8 = dialog->findChild<QLabel *>("coinControlChangeLabel");
 
     // enable/disable "low output" and "change"
-    dialog->findChild<QLabel *>("labelCoinControlLowOutputText")->setEnabled(nPayAmount > 0);
-    dialog->findChild<QLabel *>("labelCoinControlLowOutput")    ->setEnabled(nPayAmount > 0);
-    dialog->findChild<QLabel *>("labelCoinControlChangeText")   ->setEnabled(nPayAmount > 0);
-    dialog->findChild<QLabel *>("labelCoinControlChange")       ->setEnabled(nPayAmount > 0);
+    dialog->findChild<QLabel *>("coinControlLowOutputLabelText")->setEnabled(nPayAmount > 0);
+    dialog->findChild<QLabel *>("coinControlLowOutputLabel")    ->setEnabled(nPayAmount > 0);
+    dialog->findChild<QLabel *>("coinControlChangeLabelText")   ->setEnabled(nPayAmount > 0);
+    dialog->findChild<QLabel *>("coinControlChangeLabel")       ->setEnabled(nPayAmount > 0);
 
     // stats
     l1->setText(QString::number(nQuantity));                                 // Quantity
@@ -562,20 +562,20 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     l6->setToolTip(tr("Transactions with higher priority get more likely into a block.\n\nThis label turns red, if the priority is smaller than \"medium\".\n\n This means a fee of at least %1 per kb is required.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
     l7->setToolTip(tr("This label turns red, if any recipient receives an amount smaller than %1.\n\n This means a fee of at least %2 is required. \n\n Amounts below 0.546 times the minimum relay fee are shown as DUST.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)).arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
     l8->setToolTip(tr("This label turns red, if the change is smaller than %1.\n\n This means a fee of at least %2 is required.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)).arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
-    dialog->findChild<QLabel *>("labelCoinControlBytesText")    ->setToolTip(l5->toolTip());
-    dialog->findChild<QLabel *>("labelCoinControlPriorityText") ->setToolTip(l6->toolTip());
-    dialog->findChild<QLabel *>("labelCoinControlLowOutputText")->setToolTip(l7->toolTip());
-    dialog->findChild<QLabel *>("labelCoinControlChangeText")   ->setToolTip(l8->toolTip());
+    dialog->findChild<QLabel *>("coinControlBytesLabelText")    ->setToolTip(l5->toolTip());
+    dialog->findChild<QLabel *>("coinControlPriorityLabelText") ->setToolTip(l6->toolTip());
+    dialog->findChild<QLabel *>("coinControlLowOutputLabelText")->setToolTip(l7->toolTip());
+    dialog->findChild<QLabel *>("coinControlChangeLabelText")   ->setToolTip(l8->toolTip());
 
     // Insufficient funds
-    QLabel *label = dialog->findChild<QLabel *>("labelCoinControlInsuffFunds");
+    QLabel *label = dialog->findChild<QLabel *>("coinControlInsuffFundsLabel");
     if (label)
         label->setVisible(nChange < 0);
 }
 
 void CoinControlDialog::updateView()
 {
-    bool treeMode = ui->radioTreeMode->isChecked();
+    bool treeMode = ui->treeModeRadioButton->isChecked();
 
     ui->treeWidget->clear();
     ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -80,8 +80,8 @@ private slots:
     void clipboardPriority();
     void clipboardLowOutput();
     void clipboardChange();
-    void radioTreeMode(bool);
-    void radioListMode(bool);
+    void treeModeRadioButton(bool);
+    void listModeRadioButton(bool);
     void viewItemChanged(QTreeWidgetItem*, int);
     void headerSectionClicked(int);
     void buttonBoxClicked(QAbstractButton*);

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -23,7 +23,7 @@
       <number>10</number>
      </property>
      <item>
-      <layout class="QFormLayout" name="formLayoutCoinControl1">
+      <layout class="QFormLayout" name="formLayoutCoinControlQuantity">
        <property name="horizontalSpacing">
         <number>10</number>
        </property>
@@ -37,14 +37,14 @@
         <number>6</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="labelCoinControlQuantityText">
+        <widget class="QLabel" name="coinControlQuantityTextLabel">
          <property name="text">
           <string>Quantity:</string>
          </property>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QLabel" name="labelCoinControlQuantity">
+        <widget class="QLabel" name="coinControlQuantityLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -60,14 +60,14 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="labelCoinControlBytesText">
+        <widget class="QLabel" name="coinControlBytesTextLabel">
          <property name="text">
           <string>Bytes:</string>
          </property>
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QLabel" name="labelCoinControlBytes">
+        <widget class="QLabel" name="coinControlBytesLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -85,7 +85,7 @@
       </layout>
      </item>
      <item>
-      <layout class="QFormLayout" name="formLayoutCoinControl2">
+      <layout class="QFormLayout" name="formLayoutCoinControlAmount">
        <property name="horizontalSpacing">
         <number>10</number>
        </property>
@@ -99,14 +99,14 @@
         <number>6</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="labelCoinControlAmountText">
+        <widget class="QLabel" name="coinControlAmountTextLabel">
          <property name="text">
           <string>Amount:</string>
          </property>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QLabel" name="labelCoinControlAmount">
+        <widget class="QLabel" name="coinControlAmountLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -122,14 +122,14 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="labelCoinControlPriorityText">
+        <widget class="QLabel" name="coinControlPriorityTextLabel">
          <property name="text">
           <string>Priority:</string>
          </property>
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QLabel" name="labelCoinControlPriority">
+        <widget class="QLabel" name="coinControlPriorityLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -147,7 +147,7 @@
       </layout>
      </item>
      <item>
-      <layout class="QFormLayout" name="formLayoutCoinControl3">
+      <layout class="QFormLayout" name="formLayoutCoinControlFee">
        <property name="horizontalSpacing">
         <number>10</number>
        </property>
@@ -161,14 +161,14 @@
         <number>6</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="labelCoinControlFeeText">
+        <widget class="QLabel" name="coinControlFeeTextLabel">
          <property name="text">
           <string>Fee:</string>
          </property>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QLabel" name="labelCoinControlFee">
+        <widget class="QLabel" name="coinControlFeeLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -184,7 +184,7 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="labelCoinControlLowOutputText">
+        <widget class="QLabel" name="coinControlLowOutputTextLabel">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -194,7 +194,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QLabel" name="labelCoinControlLowOutput">
+        <widget class="QLabel" name="coinControlLowOutputLabel">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -215,7 +215,7 @@
       </layout>
      </item>
      <item>
-      <layout class="QFormLayout" name="formLayoutCoinControl4">
+      <layout class="QFormLayout" name="formLayoutCoinControlChange">
        <property name="horizontalSpacing">
         <number>10</number>
        </property>
@@ -229,14 +229,14 @@
         <number>6</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="labelCoinControlAfterFeeText">
+        <widget class="QLabel" name="coinControlAfterFeeTextLabel">
          <property name="text">
           <string>After Fee:</string>
          </property>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QLabel" name="labelCoinControlAfterFee">
+        <widget class="QLabel" name="coinControlAfterFeeLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -252,7 +252,7 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="labelCoinControlChangeText">
+        <widget class="QLabel" name="coinControlChangeTextLabel">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -262,7 +262,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QLabel" name="labelCoinControlChange">
+        <widget class="QLabel" name="coinControlChangeLabel">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -312,7 +312,7 @@
         <number>14</number>
        </property>
        <item>
-        <widget class="QPushButton" name="pushButtonSelectAll">
+        <widget class="QPushButton" name="selectAllPushButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -325,7 +325,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QRadioButton" name="radioTreeMode">
+        <widget class="QRadioButton" name="treeModeRadioButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -341,7 +341,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QRadioButton" name="radioListMode">
+        <widget class="QRadioButton" name="listModeRadioButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -406,7 +406,7 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QPushButton" name="cancelButton">
+      <widget class="QPushButton" name="closeButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -441,7 +441,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>cancelButton</sender>
+   <sender>closeButton</sender>
    <signal>clicked()</signal>
    <receiver>DiagnosticsDialog</receiver>
    <slot>close()</slot>

--- a/src/qt/forms/editaddressdialog.ui
+++ b/src/qt/forms/editaddressdialog.ui
@@ -20,7 +20,7 @@
       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
      </property>
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelTextLabel">
        <property name="text">
         <string>&amp;Label</string>
        </property>
@@ -37,7 +37,7 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="addressLabel">
+      <widget class="QLabel" name="addressTextLabel">
        <property name="text">
         <string>&amp;Address</string>
        </property>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -382,7 +382,7 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
-          <widget class="QLabel" name="StyleLabel">
+          <widget class="QLabel" name="styleLabel">
            <property name="text">
             <string>Style:</string>
            </property>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -66,7 +66,7 @@
              <number>7</number>
             </property>
             <item>
-             <widget class="QLabel" name="labelOverviewWallet">
+             <widget class="QLabel" name="overviewWalletLabel">
               <property name="text">
                <string>Wallet</string>
               </property>
@@ -76,7 +76,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="labelWalletStatus">
+             <widget class="QLabel" name="walletStatusLabel">
               <property name="toolTip">
                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Gridcoin network after a connection is established, but this process has not completed yet.</string>
               </property>
@@ -89,7 +89,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_2">
+             <spacer name="horizontalSpacer">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -115,14 +115,14 @@
              <number>12</number>
             </property>
             <item row="0" column="0">
-             <widget class="QLabel" name="labelAvailable">
+             <widget class="QLabel" name="availableLabel">
               <property name="text">
                <string>Available:</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLabel" name="labelBalance">
+             <widget class="QLabel" name="balanceLabel">
               <property name="cursor">
                <cursorShape>IBeamCursor</cursorShape>
               </property>
@@ -138,14 +138,14 @@
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_10">
+             <widget class="QLabel" name="stakeTextLabel">
               <property name="text">
                <string>Stake</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QLabel" name="labelStake">
+             <widget class="QLabel" name="stakeLabel">
               <property name="cursor">
                <cursorShape>IBeamCursor</cursorShape>
               </property>
@@ -161,14 +161,14 @@
              </widget>
             </item>
             <item row="2" column="0">
-             <widget class="QLabel" name="label_3">
+             <widget class="QLabel" name="unconfirmedTextLabel">
               <property name="text">
                <string>Unconfirmed</string>
               </property>
              </widget>
             </item>
             <item row="2" column="1">
-             <widget class="QLabel" name="labelUnconfirmed">
+             <widget class="QLabel" name="unconfirmedLabel">
               <property name="cursor">
                <cursorShape>IBeamCursor</cursorShape>
               </property>
@@ -184,14 +184,14 @@
              </widget>
             </item>
             <item row="3" column="0">
-             <widget class="QLabel" name="labelImmatureText">
+             <widget class="QLabel" name="immatureTextLabel">
               <property name="text">
                <string>Immature:</string>
               </property>
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QLabel" name="labelImmature">
+             <widget class="QLabel" name="immatureLabel">
               <property name="toolTip">
                <string>Total mined coins that have not yet matured.</string>
               </property>
@@ -204,7 +204,7 @@
              </widget>
             </item>
             <item row="4" column="0" colspan="2">
-             <widget class="Line" name="line">
+             <widget class="Line" name="balanceDividerLine">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -223,19 +223,19 @@
              </widget>
             </item>
             <item row="5" column="0">
-             <widget class="QLabel" name="labelTotalBalance">
+             <widget class="QLabel" name="totalBalanceLabel">
               <property name="text">
                <string>Total:</string>
               </property>
              </widget>
             </item>
             <item row="5" column="1">
-             <widget class="QLabel" name="labelTotal">
+             <widget class="QLabel" name="totalLabel">
               <property name="toolTip">
                <string>Your current total balance</string>
               </property>
               <property name="text">
-               <string notr="true">0</string>
+               <string notr="true">0 GRC</string>
               </property>
               <property name="textInteractionFlags">
                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -261,7 +261,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="Line" name="line_2">
+           <widget class="Line" name="dividerLine">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -279,14 +279,14 @@
              <number>12</number>
             </property>
             <item row="0" column="0">
-             <widget class="QLabel" name="label_2">
+             <widget class="QLabel" name="blocksTextLabel">
               <property name="text">
                <string>Blocks:</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLabel" name="labelBlocks">
+             <widget class="QLabel" name="blocksLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -296,14 +296,14 @@
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_8">
+             <widget class="QLabel" name="difficultyTextLabel">
               <property name="text">
                <string>Difficulty:</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QLabel" name="labelDifficulty">
+             <widget class="QLabel" name="difficultyLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -313,14 +313,14 @@
              </widget>
             </item>
             <item row="2" column="0">
-             <widget class="QLabel" name="label_11">
+             <widget class="QLabel" name="netWeightTextLabel">
               <property name="text">
                <string>Net Weight:</string>
               </property>
              </widget>
             </item>
             <item row="2" column="1">
-             <widget class="QLabel" name="labelNetWeight">
+             <widget class="QLabel" name="netWeightLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -330,35 +330,35 @@
              </widget>
             </item>
             <item row="3" column="0">
-             <widget class="QLabel" name="label_7">
+             <widget class="QLabel" name="coinWeightTextLabel">
               <property name="text">
                <string>Coin Weight:</string>
               </property>
              </widget>
             </item>
             <item row="4" column="0">
-             <widget class="QLabel" name="label_13">
+             <widget class="QLabel" name="magnitudeTextLabel">
               <property name="text">
                <string>Magnitude:</string>
               </property>
              </widget>
             </item>
             <item row="5" column="0">
-             <widget class="QLabel" name="label_15">
+             <widget class="QLabel" name="cpidTextLabel">
               <property name="text">
                <string>CPID:</string>
               </property>
              </widget>
             </item>
             <item row="6" column="0">
-             <widget class="QLabel" name="label_16">
+             <widget class="QLabel" name="statusTextLabel">
               <property name="text">
                <string>Status:</string>
               </property>
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QLabel" name="labelCoinWeight">
+             <widget class="QLabel" name="coinWeightLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -368,7 +368,7 @@
              </widget>
             </item>
             <item row="4" column="1">
-             <widget class="QLabel" name="labelMagnitude">
+             <widget class="QLabel" name="magnitudeLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -378,7 +378,7 @@
              </widget>
             </item>
             <item row="5" column="1">
-             <widget class="QLabel" name="labelCpid">
+             <widget class="QLabel" name="cpidLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -388,7 +388,7 @@
              </widget>
             </item>
             <item row="6" column="1">
-             <widget class="QLabel" name="labelStatus">
+             <widget class="QLabel" name="statusLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -403,7 +403,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_3">
+        <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -446,7 +446,7 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QLabel" name="labelRecentTrans">
+             <widget class="QLabel" name="recentTransLabel">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -465,7 +465,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="labelTransactionsStatus">
+             <widget class="QLabel" name="transactionsStatusLabel">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -490,7 +490,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_4">
+             <spacer name="horizontalSpacer_2">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -554,14 +554,14 @@
       <number>12</number>
      </property>
      <item row="0" column="0">
-      <widget class="QLabel" name="label_9">
+      <widget class="QLabel" name="pollTextLabel">
        <property name="text">
         <string>Current Poll:</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="ClickLabel" name="labelPoll">
+      <widget class="ClickLabel" name="pollLabel">
        <property name="text">
         <string notr="true"/>
        </property>
@@ -571,14 +571,14 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_17">
+      <widget class="QLabel" name="errorsTextLabel">
        <property name="text">
         <string>Error Messages:</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLabel" name="labelErrors">
+      <widget class="QLabel" name="errorsLabel">
        <property name="text">
         <string/>
        </property>

--- a/src/qt/forms/qrcodedialog.ui
+++ b/src/qt/forms/qrcodedialog.ui
@@ -18,7 +18,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QLabel" name="lblQRCode">
+    <widget class="QLabel" name="qrCodeLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -43,7 +43,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPlainTextEdit" name="outUri">
+    <widget class="QPlainTextEdit" name="outUriEdit">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
@@ -68,7 +68,7 @@
     <widget class="QWidget" name="widget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QCheckBox" name="chkReqPayment">
+       <widget class="QCheckBox" name="requestPaymentCheckBox">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -83,7 +83,7 @@
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelLabel">
+         <widget class="QLabel" name="labelTextLabel">
           <property name="text">
            <string>Label:</string>
           </property>
@@ -102,7 +102,7 @@
          <widget class="QLineEdit" name="labelEdit"/>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="labelMessage">
+         <widget class="QLabel" name="messageTextLabel">
           <property name="text">
            <string>Message:</string>
           </property>
@@ -121,7 +121,7 @@
          <widget class="QLineEdit" name="messageEdit"/>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="labelAmount">
+         <widget class="QLabel" name="amountTextLabel">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
             <horstretch>0</horstretch>
@@ -173,7 +173,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="buttonSaveAs">
+         <widget class="QPushButton" name="saveAsButton">
           <property name="text">
            <string>&amp;Save As...</string>
           </property>
@@ -196,7 +196,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>chkReqPayment</sender>
+   <sender>requestPaymentCheckBox</sender>
    <signal>clicked(bool)</signal>
    <receiver>lnReqAmount</receiver>
    <slot>setEnabled(bool)</slot>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -484,7 +484,7 @@
            <item>
             <widget class="QPushButton" name="btnClearTrafficGraph">
              <property name="text">
-              <string>&amp;Clear</string>
+              <string>&amp;Reset</string>
              </property>
             </widget>
            </item>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -450,7 +450,7 @@
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
-            <widget class="QSlider" name="sldGraphRange">
+            <widget class="QSlider" name="graphRangeSlider">
              <property name="minimum">
               <number>1</number>
              </property>
@@ -469,7 +469,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="lblGraphRange">
+            <widget class="QLabel" name="graphRangeLabel">
              <property name="minimumSize">
               <size>
                <width>100</width>
@@ -482,7 +482,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="btnClearTrafficGraph">
+            <widget class="QPushButton" name="clearTrafficGraphButton">
              <property name="text">
               <string>&amp;Reset</string>
              </property>
@@ -559,14 +559,14 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_17">
+               <widget class="QLabel" name="bytesInTextLabel">
                 <property name="text">
                  <string>In:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="lblBytesIn">
+               <widget class="QLabel" name="bytesInLabel">
                 <property name="minimumSize">
                  <size>
                   <width>50</width>
@@ -639,14 +639,14 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_18">
+               <widget class="QLabel" name="bytesOutTextLabel">
                 <property name="text">
                  <string>Out:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="lblBytesOut">
+               <widget class="QLabel" name="bytesOutLabel">
                 <property name="minimumSize">
                  <size>
                   <width>50</width>
@@ -1171,7 +1171,7 @@
                 </widget>
                </item>
                <item row="14" column="0">
-                <widget class="QLabel" name="peerPingTime_2">
+                <widget class="QLabel" name="peerPingTimeLabel">
                  <property name="text">
                   <string>Ping Time</string>
                  </property>
@@ -1266,7 +1266,7 @@
                 </widget>
                </item>
                <item row="18" column="0">
-                <spacer name="verticalSpacer_3">
+                <spacer name="verticalSpacer_5">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -484,7 +484,7 @@
            <item>
             <widget class="QPushButton" name="clearTrafficGraphButton">
              <property name="text">
-              <string>&amp;Reset</string>
+              <string>&amp;Clear</string>
              </property>
             </widget>
            </item>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -55,7 +55,7 @@
        <item row="37" column="2">
         <widget class="QLabel" name="porDiff">
          <property name="text">
-          <string>1</string>
+          <string>N/A</string>
          </property>
         </widget>
        </item>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -70,7 +70,7 @@
            <number>15</number>
           </property>
           <item>
-           <widget class="QLabel" name="labelCoinControlFeatures">
+           <widget class="QLabel" name="coinControlFeaturesLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
               <horstretch>0</horstretch>
@@ -93,7 +93,7 @@
            <number>10</number>
           </property>
           <item>
-           <widget class="QPushButton" name="pushButtonCoinControl">
+           <widget class="QPushButton" name="coinControlPushButton">
             <property name="styleSheet">
              <string notr="true"/>
             </property>
@@ -103,7 +103,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="labelCoinControlAutomaticallySelected">
+           <widget class="QLabel" name="coinControlAutomaticallySelectedLabel">
             <property name="text">
              <string>automatically selected</string>
             </property>
@@ -113,7 +113,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="labelCoinControlInsuffFunds">
+           <widget class="QLabel" name="coinControlInsuffFundsLabel">
             <property name="text">
              <string>Insufficient funds!</string>
             </property>
@@ -123,7 +123,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacerCoinControl">
+           <spacer name="coinControlHorizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -196,7 +196,7 @@
                 <number>6</number>
                </property>
                <item row="0" column="0">
-                <widget class="QLabel" name="labelCoinControlQuantityText">
+                <widget class="QLabel" name="coinControlQuantityTextLabel">
                  <property name="text">
                   <string>Quantity:</string>
                  </property>
@@ -206,7 +206,7 @@
                 </widget>
                </item>
                <item row="0" column="1">
-                <widget class="QLabel" name="labelCoinControlQuantity">
+                <widget class="QLabel" name="coinControlQuantityLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -225,14 +225,14 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="labelCoinControlBytesText">
+                <widget class="QLabel" name="coinControlBytesTextLabel">
                  <property name="text">
                   <string>Bytes:</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLabel" name="labelCoinControlBytes">
+                <widget class="QLabel" name="coinControlBytesLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -267,7 +267,7 @@
                 <number>6</number>
                </property>
                <item row="0" column="0">
-                <widget class="QLabel" name="labelCoinControlAmountText">
+                <widget class="QLabel" name="coinControlAmountTextLabel">
                  <property name="text">
                   <string>Amount:</string>
                  </property>
@@ -277,7 +277,7 @@
                 </widget>
                </item>
                <item row="0" column="1">
-                <widget class="QLabel" name="labelCoinControlAmount">
+                <widget class="QLabel" name="coinControlAmountLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -293,14 +293,14 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="labelCoinControlPriorityText">
+                <widget class="QLabel" name="coinControlPriorityTextLabel">
                  <property name="text">
                   <string>Priority:</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLabel" name="labelCoinControlPriority">
+                <widget class="QLabel" name="coinControlPriorityLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -335,7 +335,7 @@
                 <number>6</number>
                </property>
                <item row="0" column="0">
-                <widget class="QLabel" name="labelCoinControlFeeText">
+                <widget class="QLabel" name="coinControlFeeTextLabel">
                  <property name="text">
                   <string>Fee:</string>
                  </property>
@@ -345,7 +345,7 @@
                 </widget>
                </item>
                <item row="0" column="1">
-                <widget class="QLabel" name="labelCoinControlFee">
+                <widget class="QLabel" name="coinControlFeeLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -361,14 +361,14 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="labelCoinControlLowOutputText">
+                <widget class="QLabel" name="coinControlLowOutputTextLabel">
                  <property name="text">
                   <string>Low Output:</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLabel" name="labelCoinControlLowOutput">
+                <widget class="QLabel" name="coinControlLowOutputLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -403,7 +403,7 @@
                 <number>6</number>
                </property>
                <item row="0" column="0">
-                <widget class="QLabel" name="labelCoinControlAfterFeeText">
+                <widget class="QLabel" name="coinControlAfterFeeTextLabel">
                  <property name="text">
                   <string>After Fee:</string>
                  </property>
@@ -413,7 +413,7 @@
                 </widget>
                </item>
                <item row="0" column="1">
-                <widget class="QLabel" name="labelCoinControlAfterFee">
+                <widget class="QLabel" name="coinControlAfterFeeLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -429,14 +429,14 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="labelCoinControlChangeText">
+                <widget class="QLabel" name="coinControlChangeTextLabel">
                  <property name="text">
                   <string>Change</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLabel" name="labelCoinControlChange">
+                <widget class="QLabel" name="coinControlChangeLabel_2">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -473,14 +473,14 @@
            <number>5</number>
           </property>
           <item>
-           <widget class="QCheckBox" name="checkBoxCoinControlChange">
+           <widget class="QCheckBox" name="coinControlChangeCheckBox">
             <property name="text">
              <string>custom change address</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QLineEdit" name="lineEditCoinControlChange">
+           <widget class="QLineEdit" name="coinControlChangeEdit">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -496,7 +496,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="labelCoinControlChangeLabel">
+           <widget class="QLabel" name="coinControlChangeLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -639,7 +639,7 @@
         <number>3</number>
        </property>
        <item>
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="balanceTextLabel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -652,7 +652,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="labelBalance">
+        <widget class="QLabel" name="balanceLabel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -129,7 +129,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
      <property name="buddy">
-      <cstring>txtMessage</cstring>
+      <cstring>messageText</cstring>
      </property>
     </widget>
    </item>
@@ -137,7 +137,7 @@
     <widget class="BitcoinAmountField" name="payAmount"/>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="labelLabel">
+    <widget class="QLabel" name="labelTextLabel">
      <property name="text">
       <string>&amp;Label:</string>
      </property>
@@ -150,7 +150,7 @@
     </widget>
    </item>
    <item row="6" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="amountLabel">
      <property name="text">
       <string>A&amp;mount:</string>
      </property>
@@ -168,7 +168,7 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QValidatedLineEdit" name="txtMessage">
+      <widget class="QValidatedLineEdit" name="messageText">
        <property name="enabled">
         <bool>true</bool>
        </property>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -46,7 +46,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QValidatedLineEdit" name="addressIn_SM">
+          <widget class="QValidatedLineEdit" name="addressInEdit_SM">
            <property name="toolTip">
             <string>The address to sign the message with (e.g. Sjz75uKHzUQJnSdzvpiigEGxseKkDhQToX)</string>
            </property>
@@ -101,7 +101,7 @@
         </layout>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="messageIn_SM">
+        <widget class="QPlainTextEdit" name="messageInEdit_SM">
          <property name="toolTip">
           <string>Enter the message you want to sign here</string>
          </property>
@@ -113,7 +113,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLineEdit" name="signatureOut_SM">
+          <widget class="QLineEdit" name="signatureOutEdit_SM">
            <property name="readOnly">
             <bool>true</bool>
            </property>
@@ -244,7 +244,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QValidatedLineEdit" name="addressIn_VM">
+          <widget class="QValidatedLineEdit" name="addressInEdit_VM">
            <property name="toolTip">
             <string>The address the message was signed with (e.g. Sjz75uKHzUQJnSdzvpiigEGxseKkDhQToX)</string>
            </property>
@@ -279,10 +279,10 @@
         </layout>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="messageIn_VM"/>
+        <widget class="QPlainTextEdit" name="messageInEdit_VM"/>
        </item>
        <item>
-        <widget class="QValidatedLineEdit" name="signatureIn_VM">
+        <widget class="QValidatedLineEdit" name="signatureInEdit_VM">
          <property name="placeholderText">
           <string>Enter Gridcoin signature</string>
          </property>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -194,7 +194,7 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
     // for the non-mining users
     bool showImmature = immatureBalance != 0;
     ui->immatureLabel->setVisible(showImmature);
-    ui->immatureLabelText->setVisible(showImmature);
+    ui->immatureTextLabel->setVisible(showImmature);
 	OverviewPage::UpdateBoincUtilization();
 
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -122,11 +122,11 @@ OverviewPage::OverviewPage(QWidget *parent) :
 
     connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));
 
-    connect(ui->labelPoll, SIGNAL(clicked()), this, SLOT(handlePollLabelClicked()));
+    connect(ui->pollLabel, SIGNAL(clicked()), this, SLOT(handlePollLabelClicked()));
 
     // init "out of sync" warning labels
-    ui->labelWalletStatus->setText("(" + tr("out of sync") + ")");
-    ui->labelTransactionsStatus->setText("(" + tr("out of sync") + ")");
+    ui->walletStatusLabel->setText("(" + tr("out of sync") + ")");
+    ui->transactionsStatusLabel->setText("(" + tr("out of sync") + ")");
 
     // start with displaying the "out of sync" warnings
     showOutOfSyncWarning(true);
@@ -184,17 +184,17 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
     currentStake = stake;
     currentUnconfirmedBalance = unconfirmedBalance;
     currentImmatureBalance = immatureBalance;
-    ui->labelBalance->setText(BitcoinUnits::formatWithUnit(unit, balance));
-    ui->labelStake->setText(BitcoinUnits::formatWithUnit(unit, stake));
-    ui->labelUnconfirmed->setText(BitcoinUnits::formatWithUnit(unit, unconfirmedBalance));
-    ui->labelImmature->setText(BitcoinUnits::formatWithUnit(unit, immatureBalance));
-    ui->labelTotal->setText(BitcoinUnits::formatWithUnit(unit, balance + stake + unconfirmedBalance + immatureBalance));
+    ui->balanceLabel->setText(BitcoinUnits::formatWithUnit(unit, balance));
+    ui->stakeLabel->setText(BitcoinUnits::formatWithUnit(unit, stake));
+    ui->unconfirmedLabel->setText(BitcoinUnits::formatWithUnit(unit, unconfirmedBalance));
+    ui->immatureLabel->setText(BitcoinUnits::formatWithUnit(unit, immatureBalance));
+    ui->totalLabel->setText(BitcoinUnits::formatWithUnit(unit, balance + stake + unconfirmedBalance + immatureBalance));
 
     // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
     // for the non-mining users
     bool showImmature = immatureBalance != 0;
-    ui->labelImmature->setVisible(showImmature);
-    ui->labelImmatureText->setVisible(showImmature);
+    ui->immatureLabel->setVisible(showImmature);
+    ui->immatureLabelText->setVisible(showImmature);
 	OverviewPage::UpdateBoincUtilization();
 
 }
@@ -202,15 +202,15 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
 void OverviewPage::UpdateBoincUtilization()
 {
     LOCK(GlobalStatusStruct.lock);
-    ui->labelBlocks->setText(QString::fromUtf8(GlobalStatusStruct.blocks.c_str()));
-    ui->labelDifficulty->setText(QString::fromUtf8(GlobalStatusStruct.difficulty.c_str()));
-    ui->labelNetWeight->setText(QString::fromUtf8(GlobalStatusStruct.netWeight.c_str()));
-    ui->labelCoinWeight->setText(QString::fromUtf8(GlobalStatusStruct.coinWeight.c_str()));
-    ui->labelMagnitude->setText(QString::fromUtf8(GlobalStatusStruct.magnitude.c_str()));
-    ui->labelCpid->setText(QString::fromUtf8(GlobalStatusStruct.cpid.c_str()));
-    ui->labelStatus->setText(QString::fromUtf8(GlobalStatusStruct.status.c_str()));
-    ui->labelPoll->setText(QString::fromUtf8(GlobalStatusStruct.poll.c_str()).replace(QChar('_'),QChar(' '), Qt::CaseSensitive));
-    ui->labelErrors->setText(QString::fromUtf8(GlobalStatusStruct.errors.c_str()));
+    ui->blocksLabel->setText(QString::fromUtf8(GlobalStatusStruct.blocks.c_str()));
+    ui->difficultyLabel->setText(QString::fromUtf8(GlobalStatusStruct.difficulty.c_str()));
+    ui->netWeightLabel->setText(QString::fromUtf8(GlobalStatusStruct.netWeight.c_str()));
+    ui->coinWeightLabel->setText(QString::fromUtf8(GlobalStatusStruct.coinWeight.c_str()));
+    ui->magnitudeLabel->setText(QString::fromUtf8(GlobalStatusStruct.magnitude.c_str()));
+    ui->cpidLabel->setText(QString::fromUtf8(GlobalStatusStruct.cpid.c_str()));
+    ui->statusLabel->setText(QString::fromUtf8(GlobalStatusStruct.status.c_str()));
+    ui->pollLabel->setText(QString::fromUtf8(GlobalStatusStruct.poll.c_str()).replace(QChar('_'),QChar(' '), Qt::CaseSensitive));
+    ui->errorsLabel->setText(QString::fromUtf8(GlobalStatusStruct.errors.c_str()));
 }
 
 void OverviewPage::setModel(WalletModel *model)
@@ -257,8 +257,8 @@ void OverviewPage::updateDisplayUnit()
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)
 {
-    ui->labelWalletStatus->setVisible(fShow);
-    ui->labelTransactionsStatus->setVisible(fShow);
+    ui->walletStatusLabel->setVisible(fShow);
+    ui->transactionsStatusLabel->setVisible(fShow);
 	OverviewPage::UpdateBoincUtilization();
 }
 

--- a/src/qt/qrcodedialog.cpp
+++ b/src/qt/qrcodedialog.cpp
@@ -22,7 +22,7 @@ QRCodeDialog::QRCodeDialog(const QString &addr, const QString &label, bool enabl
     setWindowTitle(QString("%1").arg(address));
 
     ui->requestPaymentCheckBox->setVisible(enableReq);
-    ui->labelAmount->setVisible(enableReq);
+    ui->amountTextLabel->setVisible(enableReq);
     ui->lnReqAmount->setVisible(enableReq);
 
     ui->labelEdit->setText(label);

--- a/src/qt/qrcodedialog.cpp
+++ b/src/qt/qrcodedialog.cpp
@@ -21,13 +21,13 @@ QRCodeDialog::QRCodeDialog(const QString &addr, const QString &label, bool enabl
 
     setWindowTitle(QString("%1").arg(address));
 
-    ui->chkReqPayment->setVisible(enableReq);
+    ui->requestPaymentCheckBox->setVisible(enableReq);
     ui->labelAmount->setVisible(enableReq);
     ui->lnReqAmount->setVisible(enableReq);
 
     ui->labelEdit->setText(label);
 
-    ui->buttonSaveAs->setEnabled(false);
+    ui->saveAsButton->setEnabled(false);
 
     genCode();
 }
@@ -54,12 +54,12 @@ void QRCodeDialog::genCode()
 
     if (uri != "")
     {
-        ui->lblQRCode->setText("");
+        ui->qrCodeLabel->setText("");
 
         QRcode *code = QRcode_encodeString(uri.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
         if (!code)
         {
-            ui->lblQRCode->setText(tr("Error encoding URI into QR Code."));
+            ui->qrCodeLabel->setText(tr("Error encoding URI into QR Code."));
             return;
         }
         myImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
@@ -75,9 +75,9 @@ void QRCodeDialog::genCode()
         }
         QRcode_free(code);
 
-        ui->lblQRCode->setPixmap(QPixmap::fromImage(myImage).scaled(300, 300));
+        ui->qrCodeLabel->setPixmap(QPixmap::fromImage(myImage).scaled(300, 300));
 
-        ui->outUri->setPlainText(uri);
+        ui->outUriEdit->setPlainText(uri);
     }
 }
 
@@ -86,9 +86,9 @@ QString QRCodeDialog::getURI()
     QString ret = QString("gridcoin:%1").arg(address);
     int paramCount = 0;
 
-    ui->outUri->clear();
+    ui->outUriEdit->clear();
 
-    if (ui->chkReqPayment->isChecked())
+    if (ui->requestPaymentCheckBox->isChecked())
     {
         if (ui->lnReqAmount->validate())
         {
@@ -98,8 +98,8 @@ QString QRCodeDialog::getURI()
         }
         else
         {
-            ui->buttonSaveAs->setEnabled(false);
-            ui->lblQRCode->setText(tr("The entered amount is invalid, please check."));
+            ui->saveAsButton->setEnabled(false);
+            ui->qrCodeLabel->setText(tr("The entered amount is invalid, please check."));
             return QString("");
         }
     }
@@ -121,12 +121,12 @@ QString QRCodeDialog::getURI()
     // limit URI length to prevent a DoS against the QR-Code dialog
     if (ret.length() > MAX_URI_LENGTH)
     {
-        ui->buttonSaveAs->setEnabled(false);
-        ui->lblQRCode->setText(tr("Resulting URI too long, try to reduce the text for label / message."));
+        ui->saveAsButton->setEnabled(false);
+        ui->qrCodeLabel->setText(tr("Resulting URI too long, try to reduce the text for label / message."));
         return QString("");
     }
 
-    ui->buttonSaveAs->setEnabled(true);
+    ui->saveAsButton->setEnabled(true);
     return ret;
 }
 
@@ -145,17 +145,17 @@ void QRCodeDialog::on_messageEdit_textChanged()
     genCode();
 }
 
-void QRCodeDialog::on_buttonSaveAs_clicked()
+void QRCodeDialog::on_saveAsButton_clicked()
 {
     QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Images (*.png)"));
     if (!fn.isEmpty())
         myImage.scaled(EXPORT_IMAGE_SIZE, EXPORT_IMAGE_SIZE).save(fn);
 }
 
-void QRCodeDialog::on_chkReqPayment_toggled(bool fChecked)
+void QRCodeDialog::on_requestPaymentCheckBox_toggled(bool fChecked)
 {
     if (!fChecked)
-        // if chkReqPayment is not active, don't display lnReqAmount as invalid
+        // if requestPaymentCheckBox is not active, don't display lnReqAmount as invalid
         ui->lnReqAmount->setValid(true);
 
     genCode();

--- a/src/qt/qrcodedialog.h
+++ b/src/qt/qrcodedialog.h
@@ -23,8 +23,8 @@ private slots:
     void on_lnReqAmount_textChanged();
     void on_labelEdit_textChanged();
     void on_messageEdit_textChanged();
-    void on_buttonSaveAs_clicked();
-    void on_chkReqPayment_toggled(bool fChecked);
+    void on_saveAsButton_clicked();
+    void on_requestPaymentCheckBox_toggled(bool fChecked);
 
     void updateDisplayUnit();
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -550,7 +550,7 @@ void RPCConsole::startExecutor()
 }
 
 
-void RPCConsole::on_sldGraphRange_valueChanged(int value)
+void RPCConsole::on_graphRangeSlider_valueChanged(int value)
 {
     const int multiplier = 5; // each position on the slider represents 5 min
     int mins = value * multiplier;
@@ -573,25 +573,25 @@ void RPCConsole::setTrafficGraphRange(int mins)
 {
     ui->trafficGraph->setGraphRangeMins(mins);
     if(mins < 60) {
-        ui->lblGraphRange->setText(QString(tr("%1 m")).arg(mins));
+        ui->graphRangeLabel->setText(QString(tr("%1 m")).arg(mins));
     } else {
         int hours = mins / 60;
         int minsLeft = mins % 60;
         if(minsLeft == 0) {
-            ui->lblGraphRange->setText(QString(tr("%1 h")).arg(hours));
+            ui->graphRangeLabel->setText(QString(tr("%1 h")).arg(hours));
         } else {
-            ui->lblGraphRange->setText(QString(tr("%1 h %2 m")).arg(hours).arg(minsLeft));
+            ui->graphRangeLabel->setText(QString(tr("%1 h %2 m")).arg(hours).arg(minsLeft));
         }
     }
 }
 
 void RPCConsole::updateTrafficStats(quint64 totalBytesIn, quint64 totalBytesOut)
 {
-    ui->lblBytesIn->setText(FormatBytes(totalBytesIn));
-    ui->lblBytesOut->setText(FormatBytes(totalBytesOut));
+    ui->bytesInLabel->setText(FormatBytes(totalBytesIn));
+    ui->bytesOutLabel->setText(FormatBytes(totalBytesOut));
 }
 
-void RPCConsole::on_btnClearTrafficGraph_clicked()
+void RPCConsole::on_clearTrafficGraphButton_clicked()
 {
     ui->trafficGraph->clear();
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -50,14 +50,14 @@ private slots:
     /** display messagebox with program parameters (same as bitcoin-qt --help) */
     void on_showCLOptionsButton_clicked();
     /** change the time range of the network traffic graph */
-    void on_sldGraphRange_valueChanged(int value);
+    void on_graphRangeSlider_valueChanged(int value);
     /** update traffic statistics */
     void updateTrafficStats(quint64 totalBytesIn, quint64 totalBytesOut);
     void resizeEvent(QResizeEvent *event);
     void showEvent(QShowEvent *event);
     void hideEvent(QHideEvent *event);
     /** clear traffic graph */
-    void on_btnClearTrafficGraph_clicked();
+    void on_clearTrafficGraphButton_clicked();
     /** Show custom context menu on Peers tab */
     void showPeersTableContextMenu(const QPoint& point);
     /** Show custom context menu on Bans tab */

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -34,10 +34,10 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
 
     // Coin Control
-    ui->lineEditCoinControlChange->setFont(GUIUtil::bitcoinAddressFont());
-    connect(ui->pushButtonCoinControl, SIGNAL(clicked()), this, SLOT(coinControlButtonClicked()));
-    connect(ui->checkBoxCoinControlChange, SIGNAL(stateChanged(int)), this, SLOT(coinControlChangeChecked(int)));
-    connect(ui->lineEditCoinControlChange, SIGNAL(textEdited(const QString &)), this, SLOT(coinControlChangeEdited(const QString &)));
+    ui->coinControlChangeEdit->setFont(GUIUtil::bitcoinAddressFont());
+    connect(ui->coinControlPushButton, SIGNAL(clicked()), this, SLOT(coinControlButtonClicked()));
+    connect(ui->coinControlChangeCheckBox, SIGNAL(stateChanged(int)), this, SLOT(coinControlChangeChecked(int)));
+    connect(ui->coinControlChangeEdit, SIGNAL(textEdited(const QString &)), this, SLOT(coinControlChangeEdited(const QString &)));
 
     // Coin Control: clipboard actions
     QAction *clipboardQuantityAction = new QAction(tr("Copy quantity"), this);
@@ -56,14 +56,14 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     connect(clipboardPriorityAction, SIGNAL(triggered()), this, SLOT(coinControlClipboardPriority()));
     connect(clipboardLowOutputAction, SIGNAL(triggered()), this, SLOT(coinControlClipboardLowOutput()));
     connect(clipboardChangeAction, SIGNAL(triggered()), this, SLOT(coinControlClipboardChange()));
-    ui->labelCoinControlQuantity->addAction(clipboardQuantityAction);
-    ui->labelCoinControlAmount->addAction(clipboardAmountAction);
-    ui->labelCoinControlFee->addAction(clipboardFeeAction);
-    ui->labelCoinControlAfterFee->addAction(clipboardAfterFeeAction);
-    ui->labelCoinControlBytes->addAction(clipboardBytesAction);
-    ui->labelCoinControlPriority->addAction(clipboardPriorityAction);
-    ui->labelCoinControlLowOutput->addAction(clipboardLowOutputAction);
-    ui->labelCoinControlChange->addAction(clipboardChangeAction);
+    ui->coinControlQuantityLabel->addAction(clipboardQuantityAction);
+    ui->coinControlAmountLabel->addAction(clipboardAmountAction);
+    ui->coinControlFeeLabel->addAction(clipboardFeeAction);
+    ui->coinControlAfterFeeLabel->addAction(clipboardAfterFeeAction);
+    ui->coinControlBytesLabel->addAction(clipboardBytesAction);
+    ui->coinControlPriorityLabel->addAction(clipboardPriorityAction);
+    ui->coinControlLowOutputLabel->addAction(clipboardLowOutputAction);
+    ui->coinControlChangeLabel->addAction(clipboardChangeAction);
 
     fNewRecipientAllowed = true;
 }
@@ -350,64 +350,64 @@ void SendCoinsDialog::setBalance(qint64 balance, qint64 stake, qint64 unconfirme
         return;
 
     int unit = model->getOptionsModel()->getDisplayUnit();
-    ui->labelBalance->setText(BitcoinUnits::formatWithUnit(unit, balance));
+    ui->balanceLabel->setText(BitcoinUnits::formatWithUnit(unit, balance));
 }
 
 void SendCoinsDialog::updateDisplayUnit()
 {
     if(model && model->getOptionsModel())
     {
-        // Update labelBalance with the current balance and the current unit
-        ui->labelBalance->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), model->getBalance()));
+        // Update balanceLabel with the current balance and the current unit
+        ui->balanceLabel->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), model->getBalance()));
     }
 }
 
 // Coin Control: copy label "Quantity" to clipboard
 void SendCoinsDialog::coinControlClipboardQuantity()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlQuantity->text());
+    QApplication::clipboard()->setText(ui->coinControlQuantityLabel->text());
 }
 
 // Coin Control: copy label "Amount" to clipboard
 void SendCoinsDialog::coinControlClipboardAmount()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlAmount->text().left(ui->labelCoinControlAmount->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlAmountLabel->text().left(ui->coinControlAmountLabel->text().indexOf(" ")));
 }
 
 // Coin Control: copy label "Fee" to clipboard
 void SendCoinsDialog::coinControlClipboardFee()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlFee->text().left(ui->labelCoinControlFee->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlFeeLabel->text().left(ui->coinControlFeeLabel->text().indexOf(" ")));
 }
 
 // Coin Control: copy label "After fee" to clipboard
 void SendCoinsDialog::coinControlClipboardAfterFee()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlAfterFee->text().left(ui->labelCoinControlAfterFee->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlAfterFeeLabel->text().left(ui->coinControlAfterFeeLabel->text().indexOf(" ")));
 }
 
 // Coin Control: copy label "Bytes" to clipboard
 void SendCoinsDialog::coinControlClipboardBytes()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlBytes->text());
+    QApplication::clipboard()->setText(ui->coinControlBytesLabel->text());
 }
 
 // Coin Control: copy label "Priority" to clipboard
 void SendCoinsDialog::coinControlClipboardPriority()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlPriority->text());
+    QApplication::clipboard()->setText(ui->coinControlPriorityLabel->text());
 }
 
 // Coin Control: copy label "Low output" to clipboard
 void SendCoinsDialog::coinControlClipboardLowOutput()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlLowOutput->text());
+    QApplication::clipboard()->setText(ui->coinControlLowOutputLabel->text());
 }
 
 // Coin Control: copy label "Change" to clipboard
 void SendCoinsDialog::coinControlClipboardChange()
 {
-    QApplication::clipboard()->setText(ui->labelCoinControlChange->text().left(ui->labelCoinControlChange->text().indexOf(" ")));
+    QApplication::clipboard()->setText(ui->coinControlChangeLabel->text().left(ui->coinControlChangeLabel->text().indexOf(" ")));
 }
 
 // Coin Control: settings menu - coin control enabled/disabled by user
@@ -434,13 +434,13 @@ void SendCoinsDialog::coinControlChangeChecked(int state)
     if (model)
     {
         if (state == Qt::Checked)
-            CoinControlDialog::coinControl->destChange = CBitcoinAddress(ui->lineEditCoinControlChange->text().toStdString()).Get();
+            CoinControlDialog::coinControl->destChange = CBitcoinAddress(ui->coinControlChangeEdit->text().toStdString()).Get();
         else
             CoinControlDialog::coinControl->destChange = CNoDestination();
     }
 
-    ui->lineEditCoinControlChange->setEnabled((state == Qt::Checked));
-    ui->labelCoinControlChangeLabel->setEnabled((state == Qt::Checked));
+    ui->coinControlChangeEdit->setEnabled((state == Qt::Checked));
+    ui->coinControlChangeLabelLabel->setEnabled((state == Qt::Checked));
 }
 
 // Coin Control: custom change address changed
@@ -451,30 +451,30 @@ void SendCoinsDialog::coinControlChangeEdited(const QString & text)
         CoinControlDialog::coinControl->destChange = CBitcoinAddress(text.toStdString()).Get();
 
         // label for the change address
-        ui->labelCoinControlChangeLabel->setStyleSheet("QLabel{color:black;}");
+        ui->coinControlChangeLabelLabel->setStyleSheet("QLabel{color:black;}");
         if (text.isEmpty())
-            ui->labelCoinControlChangeLabel->setText("");
+            ui->coinControlChangeLabelLabel->setText("");
         else if (!CBitcoinAddress(text.toStdString()).IsValid())
         {
-            ui->labelCoinControlChangeLabel->setStyleSheet("QLabel{color:red;}");
-            ui->labelCoinControlChangeLabel->setText(tr("WARNING: Invalid Gridcoin address"));
+            ui->coinControlChangeLabelLabel->setStyleSheet("QLabel{color:red;}");
+            ui->coinControlChangeLabelLabel->setText(tr("WARNING: Invalid Gridcoin address"));
         }
         else
         {
             QString associatedLabel = model->getAddressTableModel()->labelForAddress(text);
             if (!associatedLabel.isEmpty())
-                ui->labelCoinControlChangeLabel->setText(associatedLabel);
+                ui->coinControlChangeLabelLabel->setText(associatedLabel);
             else
             {
                 CPubKey pubkey;
                 CKeyID keyid;
                 CBitcoinAddress(text.toStdString()).GetKeyID(keyid);
                 if (model->getPubKey(keyid, pubkey))
-                    ui->labelCoinControlChangeLabel->setText(tr("(no label)"));
+                    ui->coinControlChangeLabelLabel->setText(tr("(no label)"));
                 else
                 {
-                    ui->labelCoinControlChangeLabel->setStyleSheet("QLabel{color:red;}");
-                    ui->labelCoinControlChangeLabel->setText(tr("WARNING: unknown change address"));
+                    ui->coinControlChangeLabelLabel->setStyleSheet("QLabel{color:red;}");
+                    ui->coinControlChangeLabelLabel->setText(tr("WARNING: unknown change address"));
                 }
             }
         }
@@ -502,15 +502,15 @@ void SendCoinsDialog::coinControlUpdateLabels()
         CoinControlDialog::updateLabels(model, this);
 
         // show coin control stats
-        ui->labelCoinControlAutomaticallySelected->hide();
+        ui->coinControlAutomaticallySelectedLabel->hide();
         ui->widgetCoinControl->show();
     }
     else
     {
         // hide coin control stats
-        ui->labelCoinControlAutomaticallySelected->show();
+        ui->coinControlAutomaticallySelectedLabel->show();
         ui->widgetCoinControl->hide();
-        ui->labelCoinControlInsuffFunds->hide();
+        ui->coinControlInsuffFundsLabel->hide();
     }
 }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -440,7 +440,7 @@ void SendCoinsDialog::coinControlChangeChecked(int state)
     }
 
     ui->coinControlChangeEdit->setEnabled((state == Qt::Checked));
-    ui->coinControlChangeLabelLabel->setEnabled((state == Qt::Checked));
+    ui->coinControlChangeLabel->setEnabled((state == Qt::Checked));
 }
 
 // Coin Control: custom change address changed
@@ -451,30 +451,30 @@ void SendCoinsDialog::coinControlChangeEdited(const QString & text)
         CoinControlDialog::coinControl->destChange = CBitcoinAddress(text.toStdString()).Get();
 
         // label for the change address
-        ui->coinControlChangeLabelLabel->setStyleSheet("QLabel{color:black;}");
+        ui->coinControlChangeLabel->setStyleSheet("QLabel{color:black;}");
         if (text.isEmpty())
-            ui->coinControlChangeLabelLabel->setText("");
+            ui->coinControlChangeLabel->setText("");
         else if (!CBitcoinAddress(text.toStdString()).IsValid())
         {
-            ui->coinControlChangeLabelLabel->setStyleSheet("QLabel{color:red;}");
-            ui->coinControlChangeLabelLabel->setText(tr("WARNING: Invalid Gridcoin address"));
+            ui->coinControlChangeLabel->setStyleSheet("QLabel{color:red;}");
+            ui->coinControlChangeLabel->setText(tr("WARNING: Invalid Gridcoin address"));
         }
         else
         {
             QString associatedLabel = model->getAddressTableModel()->labelForAddress(text);
             if (!associatedLabel.isEmpty())
-                ui->coinControlChangeLabelLabel->setText(associatedLabel);
+                ui->coinControlChangeLabel->setText(associatedLabel);
             else
             {
                 CPubKey pubkey;
                 CKeyID keyid;
                 CBitcoinAddress(text.toStdString()).GetKeyID(keyid);
                 if (model->getPubKey(keyid, pubkey))
-                    ui->coinControlChangeLabelLabel->setText(tr("(no label)"));
+                    ui->coinControlChangeLabel->setText(tr("(no label)"));
                 else
                 {
-                    ui->coinControlChangeLabelLabel->setStyleSheet("QLabel{color:red;}");
-                    ui->coinControlChangeLabelLabel->setText(tr("WARNING: unknown change address"));
+                    ui->coinControlChangeLabel->setStyleSheet("QLabel{color:red;}");
+                    ui->coinControlChangeLabel->setText(tr("WARNING: unknown change address"));
                 }
             }
         }

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -132,7 +132,7 @@ SendCoinsRecipient SendCoinsEntry::getValue()
     rv.address = ui->payTo->text();
     rv.label = ui->addAsLabel->text();
     rv.amount = ui->payAmount->value();
-	rv.Message = ui->txtMessage->text();
+	rv.Message = ui->messageText->text();
     return rv;
 }
 
@@ -151,7 +151,7 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
     ui->payTo->setText(value.address);
     ui->addAsLabel->setText(value.label);
     ui->payAmount->setValue(value.amount);
-	ui->txtMessage->setText(value.Message);
+	ui->messageText->setText(value.Message);
 }
 
 bool SendCoinsEntry::isClear()

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -23,18 +23,18 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    GUIUtil::setupAddressWidget(ui->addressIn_SM, this);
-    GUIUtil::setupAddressWidget(ui->addressIn_VM, this);
+    GUIUtil::setupAddressWidget(ui->addressInEdit_SM, this);
+    GUIUtil::setupAddressWidget(ui->addressInEdit_VM, this);
 
-    ui->addressIn_SM->installEventFilter(this);
-    ui->messageIn_SM->installEventFilter(this);
-    ui->signatureOut_SM->installEventFilter(this);
-    ui->addressIn_VM->installEventFilter(this);
-    ui->messageIn_VM->installEventFilter(this);
-    ui->signatureIn_VM->installEventFilter(this);
+    ui->addressInEdit_SM->installEventFilter(this);
+    ui->messageInEdit_SM->installEventFilter(this);
+    ui->signatureOutEdit_SM->installEventFilter(this);
+    ui->addressInEdit_VM->installEventFilter(this);
+    ui->messageInEdit_VM->installEventFilter(this);
+    ui->signatureInEdit_VM->installEventFilter(this);
 
-    ui->signatureOut_SM->setFont(GUIUtil::bitcoinAddressFont());
-    ui->signatureIn_VM->setFont(GUIUtil::bitcoinAddressFont());
+    ui->signatureOutEdit_SM->setFont(GUIUtil::bitcoinAddressFont());
+    ui->signatureInEdit_VM->setFont(GUIUtil::bitcoinAddressFont());
 }
 
 SignVerifyMessageDialog::~SignVerifyMessageDialog()
@@ -49,14 +49,14 @@ void SignVerifyMessageDialog::setModel(WalletModel *model)
 
 void SignVerifyMessageDialog::setAddress_SM(QString address)
 {
-    ui->addressIn_SM->setText(address);
-    ui->messageIn_SM->setFocus();
+    ui->addressInEdit_SM->setText(address);
+    ui->messageInEdit_SM->setFocus();
 }
 
 void SignVerifyMessageDialog::setAddress_VM(QString address)
 {
-    ui->addressIn_VM->setText(address);
-    ui->messageIn_VM->setFocus();
+    ui->addressInEdit_VM->setText(address);
+    ui->messageInEdit_VM->setFocus();
 }
 
 void SignVerifyMessageDialog::showTab_SM(bool fShow)
@@ -95,12 +95,12 @@ void SignVerifyMessageDialog::on_pasteButton_SM_clicked()
 void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
 {
     /* Clear old signature to ensure users don't get confused on error with an old signature displayed */
-    ui->signatureOut_SM->clear();
+    ui->signatureOutEdit_SM->clear();
 
-    CBitcoinAddress addr(ui->addressIn_SM->text().toStdString());
+    CBitcoinAddress addr(ui->addressInEdit_SM->text().toStdString());
     if (!addr.IsValid())
     {
-        ui->addressIn_SM->setValid(false);
+        ui->addressInEdit_SM->setValid(false);
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
@@ -108,7 +108,7 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
     CKeyID keyID;
     if (!addr.GetKeyID(keyID))
     {
-        ui->addressIn_SM->setValid(false);
+        ui->addressInEdit_SM->setValid(false);
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(tr("The entered address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."));
         return;
@@ -132,7 +132,7 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
 
     CDataStream ss(SER_GETHASH, 0);
     ss << strMessageMagic;
-    ss << ui->messageIn_SM->document()->toPlainText().toStdString();
+    ss << ui->messageInEdit_SM->document()->toPlainText().toStdString();
 
     std::vector<unsigned char> vchSig;
     if (!key.SignCompact(Hash(ss.begin(), ss.end()), vchSig))
@@ -145,22 +145,22 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
     ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
     ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
 
-    ui->signatureOut_SM->setText(QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
+    ui->signatureOutEdit_SM->setText(QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
 }
 
 void SignVerifyMessageDialog::on_copySignatureButton_SM_clicked()
 {
-    QApplication::clipboard()->setText(ui->signatureOut_SM->text());
+    QApplication::clipboard()->setText(ui->signatureOutEdit_SM->text());
 }
 
 void SignVerifyMessageDialog::on_clearButton_SM_clicked()
 {
-    ui->addressIn_SM->clear();
-    ui->messageIn_SM->clear();
-    ui->signatureOut_SM->clear();
+    ui->addressInEdit_SM->clear();
+    ui->messageInEdit_SM->clear();
+    ui->signatureOutEdit_SM->clear();
     ui->statusLabel_SM->clear();
 
-    ui->addressIn_SM->setFocus();
+    ui->addressInEdit_SM->setFocus();
 }
 
 void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
@@ -178,10 +178,10 @@ void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
 
 void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
 {
-    CBitcoinAddress addr(ui->addressIn_VM->text().toStdString());
+    CBitcoinAddress addr(ui->addressInEdit_VM->text().toStdString());
     if (!addr.IsValid())
     {
-        ui->addressIn_VM->setValid(false);
+        ui->addressInEdit_VM->setValid(false);
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_VM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
@@ -189,18 +189,18 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
     CKeyID keyID;
     if (!addr.GetKeyID(keyID))
     {
-        ui->addressIn_VM->setValid(false);
+        ui->addressInEdit_VM->setValid(false);
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_VM->setText(tr("The entered address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."));
         return;
     }
 
     bool fInvalid = false;
-    std::vector<unsigned char> vchSig = DecodeBase64(ui->signatureIn_VM->text().toStdString().c_str(), &fInvalid);
+    std::vector<unsigned char> vchSig = DecodeBase64(ui->signatureInEdit_VM->text().toStdString().c_str(), &fInvalid);
 
     if (fInvalid)
     {
-        ui->signatureIn_VM->setValid(false);
+        ui->signatureInEdit_VM->setValid(false);
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_VM->setText(tr("The signature could not be decoded.") + QString(" ") + tr("Please check the signature and try again."));
         return;
@@ -208,12 +208,12 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
 
     CDataStream ss(SER_GETHASH, 0);
     ss << strMessageMagic;
-    ss << ui->messageIn_VM->document()->toPlainText().toStdString();
+    ss << ui->messageInEdit_VM->document()->toPlainText().toStdString();
 
     CKey key;
     if (!key.SetCompactSignature(Hash(ss.begin(), ss.end()), vchSig))
     {
-        ui->signatureIn_VM->setValid(false);
+        ui->signatureInEdit_VM->setValid(false);
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_VM->setText(tr("The signature did not match the message digest.") + QString(" ") + tr("Please check the signature and try again."));
         return;
@@ -232,12 +232,12 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
 
 void SignVerifyMessageDialog::on_clearButton_VM_clicked()
 {
-    ui->addressIn_VM->clear();
-    ui->signatureIn_VM->clear();
-    ui->messageIn_VM->clear();
+    ui->addressInEdit_VM->clear();
+    ui->signatureInEdit_VM->clear();
+    ui->messageInEdit_VM->clear();
     ui->statusLabel_VM->clear();
 
-    ui->addressIn_VM->setFocus();
+    ui->addressInEdit_VM->setFocus();
 }
 
 bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
@@ -250,9 +250,9 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
             ui->statusLabel_SM->clear();
 
             /* Select generated signature */
-            if (object == ui->signatureOut_SM)
+            if (object == ui->signatureOutEdit_SM)
             {
-                ui->signatureOut_SM->selectAll();
+                ui->signatureOutEdit_SM->selectAll();
                 return true;
             }
         }


### PR DESCRIPTION
Type of widget should always be in variable name

Always attempt to put widget type at end of name

Enforce consistent camelCase

Fix meta variable names (labelLabel)

Many UI variables (payTo, port, lang) were named too generically to be changed by me.  Someone with more expertise in the C++ side of the hooks will need to review which can be safely changed without breaking functionality.

----

Fix Difficulty defaulting to 1

Set to "N/A" like all other default labels