### PR TITLE
Change banlist save interval to 5 minutes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -59,8 +59,8 @@ extern bool fExplorer;
 extern bool fUseFastIndex;
 extern boost::filesystem::path pathScraper;
 
-// Dump addresses to banlist.dat every 15 minutes (900s)
-static constexpr int DUMP_BANS_INTERVAL = 60 * 15;
+// Dump addresses to banlist.dat every 5 minutes (300 s)
+static constexpr int DUMP_BANS_INTERVAL = 300;
 
 std::unique_ptr<BanMan> g_banman;
 


### PR DESCRIPTION
This was originally set to 15 minutes, and also controls
the refresh (removal) of expired bans on the ban pane