### PR TITLE
Disable quorum for grandfathered blocks to speed up sync

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3413,11 +3413,7 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew)
         boost::thread t(runCommand, strCmd); // thread runs free
     }
 
-    // Perform Gridcoin services now that w have a new head.
-    // Remove V9 checks after the V9 switch.
-    // TODO: ???
-    if(IsV9Enabled(nBestHeight))
-        GridcoinServices();
+    GridcoinServices();
 
     return true;
 }
@@ -3951,16 +3947,12 @@ bool NeedASuperblock()
 
 void GridcoinServices()
 {
-
     //Dont do this on headless - SeP
-    if(fQtActive)
+    if (fQtActive && (nBestHeight % 125) == 0 && nBestHeight > 0)
     {
-       if ((nBestHeight % 125) == 0)
-       {
-            GetGlobalStatus();
-            bForceUpdate=true;
-            uiInterface.NotifyBlocksChanged();
-       }
+        GetGlobalStatus();
+        bForceUpdate=true;
+        uiInterface.NotifyBlocksChanged();
     }
 
     // Services thread activity
@@ -4303,10 +4295,6 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
         mapOrphanBlocksByPrev.erase(hashPrev);
 
     }
-
-    // Compatiblity while V8 is in use. Can be removed after the V9 switch.
-    if(IsV9Enabled(pindexBest->nHeight) == false)
-        GridcoinServices();
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3812,10 +3812,6 @@ bool CBlock::AcceptBlock(bool generated_by_me)
     //Grandfather
     if (nHeight > nGrandfather)
     {
-        // Check that the block chain matches the known block chain up to a checkpoint
-        if (!Checkpoints::CheckHardened(nHeight, hash))
-            return DoS(100, error("AcceptBlock() : rejected by hardened checkpoint lock-in at %d", nHeight));
-
         // Enforce rule that the coinbase starts with serialized block height
         CScript expect = CScript() << nHeight;
         if (vtx[0].vin[0].scriptSig.size() < expect.size() ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3955,7 +3955,13 @@ void GridcoinServices()
         uiInterface.NotifyBlocksChanged();
     }
 
-    // Services thread activity
+    // Research reward checks are disabled before nGrandfather. There is no
+    // reason to update quorum state for grandfathered blocks since nothing
+    // checks that data until after nGrandfather:
+    //
+    if (pindexBest->nHeight < nGrandfather) {
+        return;
+    }
 
     if(IsV9Enabled_Tally(nBestHeight))
     {
@@ -4005,8 +4011,9 @@ void GridcoinServices()
     }
 
     //Dont perform the following functions if out of sync
-    if (pindexBest->nHeight < nGrandfather || OutOfSyncByAge())
+    if (OutOfSyncByAge()) {
         return;
+    }
 
     //Backup the wallet once per 900 blocks or as specified in config:
     int nWBI = GetArg("-walletbackupinterval", 900);


### PR DESCRIPTION
Small round of cleanup: 
 - Removed duplicate checkpoint validation (it's checked twice in the same function)
 - Removed old `GridcoinServices()` conditions for block version 9 hard-fork transition
 - Avoid scanning for superblock quorum for grandfathered blocks 

Because of the grandfather rule, superblock quorum voting consensus is never applied for blocks before `nGrandfather`. However, the wallet continues to try to rebuild the quorum data even at the very beginning of the chain where none of the checks need to use that data. Skipping the quorum function before `nGrandfather` dramatically speeds up sync time for the first 1m blocks. 

Sync smoke test finished on mainnet and testnet.