### PR TITLE
Add support for paths with special characters on Windows

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -15,6 +15,7 @@ define $(package)_set_vars
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)
   $(package)_cflags_arm_linux = $(GCCFLAGS)
+  $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 
 define $(package)_preprocess_cmds

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -114,7 +114,7 @@ bool BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::string&
     filesystem::path PrivateKeysTarget = GetBackupFilename("keys.dat");
     filesystem::create_directories(PrivateKeysTarget.parent_path());
     sTarget = PrivateKeysTarget.string();
-    std::ofstream myBackup;
+    fsbridge::ofstream myBackup;
     myBackup.open (PrivateKeysTarget.string().c_str());
     std::string sError;
     for(const auto& keyPair : wallet.GetAllPrivateKeys(sError))

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -91,7 +91,7 @@ bool CDBEnv::Open(boost::filesystem::path pathEnv_)
     dbenv.set_lk_max_locks(537000);
 
     dbenv.set_lk_max_objects(10000);
-    dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
+    dbenv.set_errfile(fsbridge::fopen(pathErrorFile, "a")); /// debug
     dbenv.set_flags(DB_AUTO_COMMIT, 1);
     dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
 #ifdef DB_LOG_AUTO_REMOVE
@@ -513,7 +513,7 @@ bool CAddrDB::Write(const CAddrMan& addr)
 
     // open temp output file, and associate with CAutoFile
     boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
-    FILE *file = fopen(pathTmp.string().c_str(), "wb");
+    FILE *file = fsbridge::fopen(pathTmp.string().c_str(), "wb");
     CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
     if (fileout.IsNull())
         return error("CAddrman::Write() : open failed");
@@ -538,7 +538,7 @@ bool CAddrDB::Write(const CAddrMan& addr)
 bool CAddrDB::Read(CAddrMan& addr)
 {
     // open input file, and associate with CAutoFile
-    FILE *file = fopen(pathAddr.string().c_str(), "rb");
+    FILE *file = fsbridge::fopen(pathAddr.string().c_str(), "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
     if (filein.IsNull())
         return error("CAddrman::Read() : open failed");

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -44,6 +44,13 @@
 //
 bool AppInit(int argc, char* argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
+#endif
+
+    SetupEnvironment();
+
     ThreadHandlerPtr threads = std::make_shared<ThreadHandler>();
     bool fRet = false;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -563,15 +563,14 @@ bool AppInit2(ThreadHandlerPtr threads)
     std::string sha256_algo = SHA256AutoDetect();
     LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);                                                                                      
 
-    std::string strDataDir = GetDataDir().string();
-    std::string strWalletFileName = GetArg("-wallet", "wallet.dat");
+    fs::path datadir = GetDataDir();
+    fs::path walletFileName = GetArg("-wallet", "wallet.dat");
 
-    // strWalletFileName must be a plain filename without a directory
-    if (strWalletFileName != boost::filesystem::basename(strWalletFileName) + boost::filesystem::extension(strWalletFileName))
-        return InitError(strprintf(_("Wallet %s resides outside data directory %s."), strWalletFileName, strDataDir));
+    // WalletFileName must be a plain filename without a directory
+    if (walletFileName != walletFileName.filename())
+        return InitError(strprintf(_("Wallet %s resides outside data directory %s."), walletFileName.string(), datadir.string()));
 
     // Make sure only a single Bitcoin process is using the data directory.
-    boost::filesystem::path datadir = GetDataDir();
     if (!DirIsWritable(datadir)) {
         return InitError(strprintf(_("Cannot write to data directory '%s'; check permissions."), datadir.string()));
     }
@@ -613,7 +612,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (!fLogTimestamps)
         LogPrintf("Startup time: %s", DateTimeStrFormat("%x %H:%M:%S",  GetAdjustedTime()));
     LogPrintf("Default data directory %s", GetDefaultDataDir().string());
-    LogPrintf("Used data directory %s", strDataDir);
+    LogPrintf("Used data directory %s", datadir.string());
     std::ostringstream strErrors;
 
     fDevbuildCripple = false;
@@ -648,26 +647,26 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
          string msg = strprintf(_("Error initializing database environment %s!"
                                  " To recover, BACKUP THAT DIRECTORY, then remove"
-                                 " everything from it except for wallet.dat."), strDataDir);
+                                 " everything from it except for wallet.dat."), datadir.string());
         return InitError(msg);
     }
 
     if (GetBoolArg("-salvagewallet"))
     {
         // Recover readable keypairs:
-        if (!CWalletDB::Recover(bitdb, strWalletFileName, true))
+        if (!CWalletDB::Recover(bitdb, walletFileName.string(), true))
             return false;
     }
 
-    if (filesystem::exists(GetDataDir() / strWalletFileName))
+    if (filesystem::exists(GetDataDir() / walletFileName))
     {
-        CDBEnv::VerifyResult r = bitdb.Verify(strWalletFileName, CWalletDB::Recover);
+        CDBEnv::VerifyResult r = bitdb.Verify(walletFileName.string(), CWalletDB::Recover);
         if (r == CDBEnv::RECOVER_OK)
         {
             string msg = strprintf(_("Warning: wallet.dat corrupt, data salvaged!"
                                      " Original wallet.dat saved as wallet.{timestamp}.bak in %s; if"
                                      " your balance or transactions are incorrect you should"
-                                     " restore from a backup."), strDataDir);
+                                     " restore from a backup."), datadir.string());
             uiInterface.ThreadSafeMessageBox(msg, _("Gridcoin"),
                 CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION | CClientUIInterface::MODAL);
         }
@@ -789,7 +788,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
         string msg = strprintf(_("Error initializing database environment %s!"
                                  " To recover, BACKUP THAT DIRECTORY, then remove"
-                                 " everything from it except for wallet.dat."), strDataDir);
+                                 " everything from it except for wallet.dat."), datadir.string());
         return InitError(msg);
     }
 
@@ -852,7 +851,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     LogPrintf("Loading wallet...");
     nStart = GetTimeMillis();
     bool fFirstRun = true;
-    pwalletMain = new CWallet(strWalletFileName);
+    pwalletMain = new CWallet(walletFileName.string());
     DBErrors nLoadWalletRet = pwalletMain->LoadWallet(fFirstRun);
     if (nLoadWalletRet != DB_LOAD_OK)
     {
@@ -915,7 +914,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         pindexRescan = pindexGenesisBlock;
     else
     {
-        CWalletDB walletdb(strWalletFileName);
+        CWalletDB walletdb(walletFileName.string());
         CBlockLocator locator;
         if (walletdb.ReadBestBlock(locator))
             pindexRescan = locator.GetBlockIndex();
@@ -937,7 +936,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 
         for (auto const& strFile : mapMultiArgs["-loadblock"])
         {
-            FILE *file = fopen(strFile.c_str(), "rb");
+            FILE *file = fsbridge::fopen(strFile.c_str(), "rb");
             if (file)
                 LoadExternalBlockFile(file);
         }
@@ -948,7 +947,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (filesystem::exists(pathBootstrap)) {
         uiInterface.InitMessage(_("Importing bootstrap blockchain data file."));
 
-        FILE *file = fopen(pathBootstrap.string().c_str(), "rb");
+        FILE *file = fsbridge::fopen(pathBootstrap.string().c_str(), "rb");
         if (file) {
             filesystem::path pathBootstrapOld = GetDataDir() / "bootstrap.dat.old";
             LoadExternalBlockFile(file);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4362,7 +4362,7 @@ FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszM
 {
     if ((nFile < 1) || (nFile == (unsigned int) -1))
         return NULL;
-    FILE* file = fopen(BlockFilePath(nFile).string().c_str(), pszMode);
+    FILE* file = fsbridge::fopen(BlockFilePath(nFile).string().c_str(), pszMode);
     if (!file)
         return NULL;
     if (nBlockPos != 0 && !strchr(pszMode, 'a') && !strchr(pszMode, 'w'))

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -180,6 +180,13 @@ static void handleRunawayException(std::exception *e)
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
+#endif
+
+    SetupEnvironment();
+
     // Set default value to exit properly. Exit code 42 will trigger restart of the wallet.
     int currentExitCode = 0;
  

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -843,7 +843,7 @@ bool CreateNewConfigFile(std::string boinc_email)
 {
     std::string filename = "gridcoinresearch.conf";
     boost::filesystem::path path = GetDataDir() / filename;
-    std::ofstream myConfig;
+    fsbridge::ofstream myConfig;
     myConfig.open (path.string().c_str());
     std::string row = "email=" + boinc_email + "\r\n";
     myConfig << row;

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -62,7 +62,7 @@ bool DiagnosticsDialog::VerifyIsCPIDValid()
     if (clientStatePath.empty())
         return false;
 
-    std::ifstream clientStateStream;
+    fsbridge::ifstream clientStateStream;
     std::string clientState;
 
     clientStateStream.open(clientStatePath.string());
@@ -120,7 +120,7 @@ bool DiagnosticsDialog::VerifyCPIDHasRAC()
     if (clientStatePath.empty())
         return false;
 
-    std::ifstream clientStateStream;
+    fsbridge::ifstream clientStateStream;
     std::string clientState;
     std::vector<std::string> racStrings;
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -447,7 +447,7 @@ boost::filesystem::path static GetAutostartFilePath()
 
 bool GetStartOnSystemStartup()
 {
-    boost::filesystem::ifstream optionFile(GetAutostartFilePath());
+    fsbridge::ifstream optionFile(GetAutostartFilePath());
     if (!optionFile.good())
         return false;
     // Scan through file for "Hidden=true":
@@ -477,7 +477,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
 
         boost::filesystem::create_directories(GetAutostartDir());
 
-        boost::filesystem::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out|std::ios_base::trunc);
+        fsbridge::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out|std::ios_base::trunc);
         if (!optionFile.good())
             return false;
         // Write a bitcoin.desktop file to the autostart directory:

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -475,7 +475,7 @@ UniValue rpc_exportstats(const UniValue& params, bool fHelp)
     int64_t blockcount = 0;
     unsigned long points = 0;
     double samples = 0; /* this is double for easy division */
-    std::ofstream Output;
+    fsbridge::ofstream Output;
     boost::filesystem::path o_path = GetDataDir() / "reports" / ( "export_" + std::to_string(GetTime()) + ".txt" );
     boost::filesystem::create_directories(o_path.parent_path());
     Output.open (o_path.string().c_str());

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -194,7 +194,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
     if (PathForImport.parent_path().empty())
         PathForImport = DefaultPathDataDir / PathForImport;
 
-    ifstream file;
+    fsbridge::ifstream file;
     file.open(PathForImport.string().c_str());
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
@@ -327,7 +327,7 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
     if (PathForDump.parent_path().empty())
         PathForDump = DefaultPathDataDir / PathForDump;
 
-    ofstream file;
+    fsbridge::ofstream file;
     file.open(PathForDump.string().c_str());
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -1267,7 +1267,7 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
             if (nType == 0)
                 exportoutput << "</id>\n";
 
-            std::ofstream dataout;
+            fsbridge::ofstream dataout;
 
             // We will place this in wallet backups as a safer location then in main data directory
             boost::filesystem::path exportpath;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -606,12 +606,12 @@ void StartRPCThreads()
         rpc_ssl_context->set_options(ssl::context::no_sslv2);
 
         filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
-        if (!pathCertFile.is_complete()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
+        if (!pathCertFile.is_absolute()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
         if (filesystem::exists(pathCertFile)) rpc_ssl_context->use_certificate_chain_file(pathCertFile.string());
         else LogPrintf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string());
 
         filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
-        if (!pathPKFile.is_complete()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
+        if (!pathPKFile.is_absolute()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
         if (filesystem::exists(pathPKFile)) rpc_ssl_context->use_private_key_file(pathPKFile.string(), ssl::context::pem);
         else LogPrintf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string());
 

--- a/src/scraper/http.cpp
+++ b/src/scraper/http.cpp
@@ -68,7 +68,7 @@ void Http::Download(
         const std::string &destination,
         const std::string &userpass)
 {
-    ScopedFile fp(fopen(destination.c_str(), "wb"), &fclose);
+    ScopedFile fp(fsbridge::fopen(destination.c_str(), "wb"), &fclose);
     if(!fp)
         throw std::runtime_error(
                 tfm::format("Error opening target %s: %s (%d)", destination, strerror(errno), errno));

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -170,7 +170,7 @@ private:
 
     static boost::gregorian::date PrevArchiveCheckDate;
 
-    fs::ofstream logfile;
+    fsbridge::ofstream logfile;
 
 public:
 
@@ -285,7 +285,7 @@ public:
                 PrevArchiveCheckDate = ArchiveCheckDate;
             }
 
-            std::ifstream infile(pfile_temp.string(), std::ios_base::in | std::ios_base::binary);
+            fsbridge::ifstream infile(pfile_temp, std::ios_base::in | std::ios_base::binary);
 
             if (!infile)
             {
@@ -293,7 +293,7 @@ public:
                 return false;
             }
 
-            std::ofstream outgzfile(pfile_out.string(), std::ios_base::out | std::ios_base::binary);
+            fsbridge::ofstream outgzfile(pfile_out, std::ios_base::out | std::ios_base::binary);
 
             if (!outgzfile)
             {
@@ -492,7 +492,7 @@ class userpass
 {
 private:
 
-    fs::ifstream userpassfile;
+    fsbridge::ifstream userpassfile;
 
 public:
 
@@ -550,7 +550,7 @@ class authdata
 {
 private:
 
-    fs::ofstream oauthdata;
+    fsbridge::ofstream oauthdata;
     stringbuilder outdata;
 
 public:
@@ -1600,7 +1600,7 @@ bool ProcessProjectTeamFile(const std::string& project, const fs::path& file, co
     if (file.string().empty())
         return false;
 
-    std::ifstream ingzfile(file.string(), std::ios_base::in | std::ios_base::binary);
+    fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
 
     if (!ingzfile)
     {
@@ -1864,7 +1864,7 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
     if (file.string().empty())
         return false;
 
-    std::ifstream ingzfile(file.string(), std::ios_base::in | std::ios_base::binary);
+    fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
 
     if (!ingzfile)
     {
@@ -1888,7 +1888,7 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
     // Put path in.
     gzetagfile = ((fs::path)(pathScraper / gzetagfile)).string();
 
-    std::ofstream outgzfile(gzetagfile, std::ios_base::out | std::ios_base::binary);
+    fsbridge::ofstream outgzfile(gzetagfile, std::ios_base::out | std::ios_base::binary);
     boostio::filtering_ostream out;
     out.push(boostio::gzip_compressor());
     out.push(outgzfile);
@@ -2031,7 +2031,7 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
 uint256 GetFileHash(const fs::path& inputfile)
 {
     // open input file, and associate with CAutoFile
-    FILE *file = fopen(inputfile.string().c_str(), "rb");
+    FILE *file = fsbridge::fopen(inputfile.string().c_str(), "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
     uint256 nHash = 0;
     
@@ -2101,7 +2101,7 @@ uint256 GetmScraperFileManifestHash()
 
 bool LoadBeaconList(const fs::path& file, BeaconMap& mBeaconMap)
 {
-    std::ifstream ingzfile(file.string(), std::ios_base::in | std::ios_base::binary);
+    fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
 
     if (!ingzfile)
     {
@@ -2146,7 +2146,7 @@ bool LoadBeaconList(const fs::path& file, BeaconMap& mBeaconMap)
 
 bool LoadTeamIDList(const fs::path& file)
 {
-    std::ifstream ingzfile(file.string(), std::ios_base::in | std::ios_base::binary);
+    fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
 
     if (!ingzfile)
     {
@@ -2263,7 +2263,7 @@ bool StoreBeaconList(const fs::path& file)
     if (fs::exists(file))
         fs::remove(file);
 
-    std::ofstream outgzfile(file.string(), std::ios_base::out | std::ios_base::binary);
+    fsbridge::ofstream outgzfile(file, std::ios_base::out | std::ios_base::binary);
 
     if (!outgzfile)
     {
@@ -2308,7 +2308,7 @@ bool StoreTeamIDList(const fs::path& file)
     if (fs::exists(file))
         fs::remove(file);
 
-    std::ofstream outgzfile(file.string(), std::ios_base::out | std::ios_base::binary);
+    fsbridge::ofstream outgzfile(file, std::ios_base::out | std::ios_base::binary);
 
     if (!outgzfile)
     {
@@ -2531,7 +2531,7 @@ void AlignScraperFileManifestEntries(const fs::path& file, const std::string& fi
 
 bool LoadScraperFileManifest(const fs::path& file)
 {
-    std::ifstream ingzfile(file.string(), std::ios_base::in | std::ios_base::binary);
+    fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
 
     if (!ingzfile)
     {
@@ -2622,7 +2622,7 @@ bool StoreScraperFileManifest(const fs::path& file)
     if (fs::exists(file))
         fs::remove(file);
 
-    std::ofstream outgzfile(file.string(), std::ios_base::out | std::ios_base::binary);
+    fsbridge::ofstream outgzfile(file, std::ios_base::out | std::ios_base::binary);
 
     if (!outgzfile)
     {
@@ -2682,7 +2682,7 @@ bool StoreStats(const fs::path& file, const ScraperStats& mScraperStats)
     if (fs::exists(file))
         fs::remove(file);
 
-    std::ofstream outgzfile(file.string(), std::ios_base::out | std::ios_base::binary);
+    fsbridge::ofstream outgzfile(file, std::ios_base::out | std::ios_base::binary);
 
     if (!outgzfile)
     {
@@ -2760,7 +2760,7 @@ bool StoreStats(const fs::path& file, const ScraperStats& mScraperStats)
 
 bool LoadProjectFileToStatsByCPID(const std::string& project, const fs::path& file, const double& projectmag, const BeaconMap& mBeaconMap, ScraperStats& mScraperStats)
 {
-    std::ifstream ingzfile(file.string(), std::ios_base::in | std::ios_base::binary);
+    fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
 
     if (!ingzfile)
     {
@@ -3347,7 +3347,7 @@ bool ScraperSaveCScraperManifestToFiles(uint256 nManifestHash)
 
         outputfilewpath = savepath / outputfile;
 
-        std::ofstream outfile(outputfilewpath.string(), std::ios_base::out | std::ios_base::binary);
+        fsbridge::ofstream outfile(outputfilewpath, std::ios_base::out | std::ios_base::binary);
 
         if (!outfile)
         {
@@ -3609,7 +3609,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
     fs::path inputfilewpath = pathScraper / inputfile;
     
     // open input file, and associate with CAutoFile
-    FILE *file = fopen(inputfilewpath.string().c_str(), "rb");
+    FILE *file = fsbridge::fopen(inputfilewpath.string().c_str(), "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
 
     if (filein.IsNull())
@@ -3660,7 +3660,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
         fs::path inputfilewpath = pathScraper / inputfile;
 
         // open input file, and associate with CAutoFile
-        FILE *file = fopen(inputfilewpath.string().c_str(), "rb");
+        FILE *file = fsbridge::fopen(inputfilewpath.string().c_str(), "rb");
         CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
 
         if (filein.IsNull())

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,7 +3,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "fs.h"
 #include "netbase.h" // for AddTimeData
 #include "sync.h"
 #include "strlcpy.h"
@@ -277,7 +276,7 @@ void LogPrintStr(const std::string &str)
         if (!fileout)
         {
             fs::path pathDebug = GetDataDir() / "debug.log";
-            fileout = fopen(pathDebug.string().c_str(), "a");
+            fileout = fsbridge::fopen(pathDebug.string().c_str(), "a");
             if (fileout) setbuf(fileout, NULL); // unbuffered
         }
         if (fileout)
@@ -1275,7 +1274,7 @@ fs::path GetConfigFile()
 
 bool IsConfigFileEmpty()
 {
-    fs::ifstream streamConfig(GetConfigFile());
+    fsbridge::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())
     {
         return true;
@@ -1291,7 +1290,7 @@ bool IsConfigFileEmpty()
 void ReadConfigFile(ArgsMap& mapSettingsRet,
                     ArgsMultiMap& mapMultiSettingsRet)
 {
-    fs::ifstream streamConfig(GetConfigFile());
+    fsbridge::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())
         return; // No bitcoin.conf file is OK
 
@@ -1322,7 +1321,7 @@ fs::path GetPidFile()
 #ifndef WIN32
 void CreatePidFile(const fs::path &path, pid_t pid)
 {
-    FILE* file = fopen(path.string().c_str(), "w");
+    FILE* file = fsbridge::fopen(path.string().c_str(), "w");
     if (file)
     {
         fprintf(file, "%d\n", pid);
@@ -1393,7 +1392,7 @@ void ShrinkDebugFile()
 {
     // Scroll debug.log if it's getting too big
     fs::path pathLog = GetDataDir() / "debug.log";
-    FILE* file = fopen(pathLog.string().c_str(), "r");
+    FILE* file = fsbridge::fopen(pathLog.string().c_str(), "r");
     if (file && fs::file_size(pathLog) > 1000000)
     {
         // Restart the file with some of the end
@@ -1402,7 +1401,7 @@ void ShrinkDebugFile()
         int nBytes = fread(pch, 1, sizeof(pch), file);
         fclose(file);
 
-        file = fopen(pathLog.string().c_str(), "w");
+        file = fsbridge::fopen(pathLog.string().c_str(), "w");
         if (file)
         {
             fwrite(pch, 1, nBytes, file);
@@ -1455,7 +1454,7 @@ std::string GetFileContents(std::string filepath)
         return "-1";
     }
 
-    std::ifstream in(filepath, std::ios::in | std::ios::binary);
+    fsbridge::ifstream in(filepath, std::ios::in | std::ios::binary);
 
     if (in.fail()) {
         LogPrintf("GetFileContents: error opening file %s", filepath);

--- a/src/util.h
+++ b/src/util.h
@@ -9,6 +9,7 @@
 #include "attributes.h"
 
 #include "uint256.h"
+#include "fs.h"
 #include "fwd.h"
 #include "hash.h"
 
@@ -206,23 +207,23 @@ bool FileCommit(FILE *fileout);
 
 std::string TimestampToHRDate(double dtm);
 
-bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);
-boost::filesystem::path GetDefaultDataDir();
-boost::filesystem::path GetProgramDir();
+bool RenameOver(fs::path src, fs::path dest);
+fs::path GetDefaultDataDir();
+fs::path GetProgramDir();
 
-const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
-boost::filesystem::path GetConfigFile();
-boost::filesystem::path GetPidFile();
+const fs::path &GetDataDir(bool fNetSpecific = true);
+fs::path GetConfigFile();
+fs::path GetPidFile();
 #ifndef WIN32
-void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
+void CreatePidFile(const fs::path &path, pid_t pid);
 #endif
 void ReadConfigFile(ArgsMap& mapSettingsRet, ArgsMultiMap& mapMultiSettingsRet);
 #ifdef WIN32
-boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 void ShrinkDebugFile();
-bool DirIsWritable(const boost::filesystem::path& directory);
-bool LockDirectory(const boost::filesystem::path& directory, const std::string lockfile_name, bool probe_only=false);
+bool DirIsWritable(const fs::path& directory);
+bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 
 //!
 //! \brief Read the contents of the specified file into memory.

--- a/src/util.h
+++ b/src/util.h
@@ -81,6 +81,8 @@ static const int64_t CENT = 1000000;
 #define MAX_PATH            1024
 #endif
 
+void SetupEnvironment();
+
 //! Substitute for C++14 std::make_unique.
 template <typename T, typename... Args>
 std::unique_ptr<T> MakeUnique(Args&&... args)
@@ -671,6 +673,23 @@ NODISCARD bool ParseUInt64(const std::string& str, uint64_t *out);
  */
 NODISCARD bool ParseDouble(const std::string& str, double *out);
 
+
+namespace util {
+#ifdef WIN32
+class WinCmdLineArgs
+{
+public:
+    WinCmdLineArgs();
+    ~WinCmdLineArgs();
+    std::pair<int, char**> get();
+
+private:
+    int argc;
+    char** argv;
+    std::vector<std::string> args;
+};
+#endif
+} // namespace util
 
 #endif
 

--- a/src/util.h
+++ b/src/util.h
@@ -221,6 +221,8 @@ void ReadConfigFile(ArgsMap& mapSettingsRet, ArgsMultiMap& mapMultiSettingsRet);
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 void ShrinkDebugFile();
+bool DirIsWritable(const boost::filesystem::path& directory);
+bool LockDirectory(const boost::filesystem::path& directory, const std::string lockfile_name, bool probe_only=false);
 
 //!
 //! \brief Read the contents of the specified file into memory.


### PR DESCRIPTION
This is an attempt to fix Unicode path handling on Windows. I enabled the depends `UNICODE` flag for Berkeley DB, backported UTF-8 translation of `boost::filesystem::path` from Bitcoin, and refactored the application to open files through the `fsbridge` wrapper that applies the conversion. This solves an issue @jamescowens discovered after the LevelDB 1.20 upgrade (#1562) where the database expects non-ANSI characters as UTF-8. 

I tried paths that contained these names:

 - GridcoinResearch-šus
 - ḨE_H͠UNGER̢S̴
 - 世世

Potentially related also: #242, #277, #1470, #1520 