### PR TITLE
Remove old research age checks (rebase #1365)

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -18,20 +18,14 @@ struct StructCPID
     bool initialized;
 
     double Magnitude;
-    double owed;
     double payments;
-    double interestPayments;
     double TotalMagnitude;
     uint32_t LowLockTime;
-    uint32_t HighLockTime;
     double Accuracy;
-    double totalowed;
-    double LastPaymentTime;
     double ResearchSubsidy;
     /* double ResearchAverageMagnitude; TotalMagnitude / (Accuracy+0.01) */
     double EarliestPaymentTime;
     double InterestSubsidy;
-    double PaymentTimespan;
     int32_t LastBlock;
     double NetworkMagnitude;
     double NetworkAvgMagnitude;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1727,42 +1727,6 @@ int64_t GetProofOfStakeMaxReward(uint64_t nCoinAge, int64_t nFees, int64_t lockt
     return nSubsidy + nFees;
 }
 
-double GetProofOfResearchReward(std::string cpid, bool VerifyingBlock)
-{
-
-        StructCPID& mag = GetInitializedStructCPID2(cpid,mvMagnitudes);
-
-        if (!mag.initialized) return 0;
-        double owed = (mag.owed*1.0);
-        if (owed < 0) owed = 0;
-        // Coarse Payment Rule (helps prevent sync problems):
-        if (!VerifyingBlock)
-        {
-            //If owed less than 4% of max subsidy, assess at 0:
-            if (owed < (GetMaximumBoincSubsidy(GetAdjustedTime())/50))
-            {
-                owed = 0;
-            }
-            //Coarse payment rule:
-            if (mag.totalowed > (GetMaximumBoincSubsidy(GetAdjustedTime())*2))
-            {
-                //If owed more than 2* Max Block, pay normal amount
-                owed = (owed*1);
-            }
-            else
-            {
-                owed = owed/2;
-            }
-
-            if (owed > (GetMaximumBoincSubsidy(GetAdjustedTime()))) owed = GetMaximumBoincSubsidy(GetAdjustedTime());
-
-
-        }
-        //End of Coarse Payment Rule
-        return owed * COIN;
-}
-
-
 // miner's coin stake reward based on coin age spent (coin-days)
 int64_t GetConstantBlockReward(const CBlockIndex* index)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1717,16 +1717,6 @@ double GetMagnitudeMultiplier(int64_t nTime)
     return magnitude_multiplier;
 }
 
-
-int64_t GetProofOfStakeMaxReward(uint64_t nCoinAge, int64_t nFees, int64_t locktime)
-{
-    int64_t nInterest = nCoinAge * GetCoinYearReward(locktime) * 33 / (365 * 33 + 8);
-    nInterest += 10*COIN;
-    int64_t nBoinc    = (GetMaximumBoincSubsidy(locktime)+1) * COIN;
-    int64_t nSubsidy  = nInterest + nBoinc;
-    return nSubsidy + nFees;
-}
-
 // miner's coin stake reward based on coin age spent (coin-days)
 int64_t GetConstantBlockReward(const CBlockIndex* index)
 {
@@ -2623,8 +2613,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
         // ppcoin: coin stake tx earns reward instead of paying fee
         if (!vtx[1].GetCoinAge(txdb, nCoinAge))
             return error("ConnectBlock[] : %s unable to get coin age for coinstake", vtx[1].GetHash().ToString().substr(0,10).c_str());
-
-        double dCalcStakeReward = CoinToDouble(GetProofOfStakeMaxReward(nCoinAge, nFees, nTime));
 
         //9-3-2015
         double dMaxResearchAgeReward = CoinToDouble(GetMaximumBoincSubsidy(nTime) * COIN * 255);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1793,40 +1793,6 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
     bool VerifyingBlock, int VerificationPhase, int64_t nTime, CBlockIndex* pindexLast,
     double& OUT_POR, double& OUT_INTEREST, double& dAccrualAge, double& dMagnitudeUnit, double& AvgMagnitude)
 {
-
-    // Non Research Age - RSA Mode - Legacy (before 10-20-2015)
-    if (!IsResearchAgeEnabled(pindexLast->nHeight))
-    {
-            int64_t nInterest = nCoinAge * GetCoinYearReward(nTime) * 33 / (365 * 33 + 8);
-            int64_t nBoinc    = GetProofOfResearchReward(cpid,VerifyingBlock);
-            int64_t nSubsidy  = nInterest + nBoinc;
-            if (fDebug10 || GetBoolArg("-printcreation"))
-            {
-                LogPrintf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRIu64 " nBoinc=%" PRId64 "   ",
-                FormatMoney(nSubsidy), nCoinAge, nBoinc);
-            }
-            int64_t maxStakeReward1 = GetProofOfStakeMaxReward(nCoinAge, nFees, nTime);
-            int64_t maxStakeReward2 = GetProofOfStakeMaxReward(nCoinAge, nFees, GetAdjustedTime());
-            int64_t maxStakeReward = std::min(maxStakeReward1, maxStakeReward2);
-            if ((nSubsidy+nFees) > maxStakeReward) nSubsidy = maxStakeReward-nFees;
-            int64_t nTotalSubsidy = nSubsidy + nFees;
-            // This rule does not apply in v11
-            if (nBoinc > 1 && pindexLast->nVersion <= 10)
-            {
-                std::string sTotalSubsidy = RoundToString(CoinToDouble(nTotalSubsidy)+.00000123,8);
-
-                if (sTotalSubsidy.length() > 7)
-                {
-                    sTotalSubsidy = sTotalSubsidy.substr(0,sTotalSubsidy.length()-4) + "0124";
-                    nTotalSubsidy = RoundFromString(sTotalSubsidy,8)*COIN;
-                }
-            }
-            OUT_POR = CoinToDouble(nBoinc);
-            OUT_INTEREST = CoinToDouble(nInterest);
-            return nTotalSubsidy;
-    }
-    else
-    {
             // Research Age Subsidy - PROD
             int64_t nBoinc = ComputeResearchAccrual(nTime, cpid, pindexLast, VerifyingBlock, VerificationPhase, dAccrualAge, dMagnitudeUnit, AvgMagnitude);
             int64_t nInterest = 0;
@@ -1869,7 +1835,6 @@ int64_t GetProofOfStakeReward(uint64_t nCoinAge, int64_t nFees, std::string cpid
             OUT_INTEREST = CoinToDouble(nInterest);
             return nTotalSubsidy;
     }
-}
 
 
 
@@ -1959,8 +1924,7 @@ bool CheckProofOfResearch(
      * which does not matter, because this one is no longer used */
     if(block.vtx.size() == 0 ||
        !block.IsProofOfStake() ||
-       pindexPrev->nHeight <= nGrandfather ||
-       !IsResearchAgeEnabled(pindexPrev->nHeight))
+       pindexPrev->nHeight <= nGrandfather)
         return true;
 
     const NN::Claim& claim = block.GetClaim();
@@ -2627,7 +2591,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                 nStakeReward = nTxValueOut - nTxValueIn;
                 if (tx.vout.size() > 3 && pindex->nHeight > nGrandfather) bIsDPOR = true;
                 // ResearchAge: Verify vouts cannot contain any other payments except coinstake: PASS (GetValueOut returns the sum of all spent coins in the coinstake)
-                if (IsResearchAgeEnabled(pindex->nHeight) && fDebug10)
+                if (fDebug10)
                 {
                     int64_t nTotalCoinstake = 0;
                     for (unsigned int i = 0; i < tx.vout.size(); i++)
@@ -2698,13 +2662,10 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
 
         double dCalcStakeReward = CoinToDouble(GetProofOfStakeMaxReward(nCoinAge, nFees, nTime));
 
-        if (dStakeReward > dCalcStakeReward+1 && !IsResearchAgeEnabled(pindex->nHeight))
-            return DoS(1, error("ConnectBlock[] : coinstake pays above maximum (actual= %f, vs calculated=%f )", dStakeReward, dCalcStakeReward));
-
         //9-3-2015
         double dMaxResearchAgeReward = CoinToDouble(GetMaximumBoincSubsidy(nTime) * COIN * 255);
 
-        if (claim.m_research_subsidy > dMaxResearchAgeReward && IsResearchAgeEnabled(pindex->nHeight))
+        if (claim.m_research_subsidy > dMaxResearchAgeReward)
             return DoS(1, error("ConnectBlock[ResearchAge] : Coinstake pays above maximum (actual= %f, vs calculated=%f )", dStakeRewardWithoutFees, dMaxResearchAgeReward));
 
         if (!claim.HasResearchReward() && dStakeReward > 1)
@@ -2773,8 +2734,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
         if (claim.HasResearchReward())
         {
             //ResearchAge: Since the best block may increment before the RA is connected but After the RA is computed, the ResearchSubsidy can sometimes be slightly smaller than we calculate here due to the RA timespan increasing.  So we will allow for time shift before rejecting the block.
-            double dDrift = IsResearchAgeEnabled(pindex->nHeight) ? claim.m_research_subsidy * .15 : 1;
-            if (IsResearchAgeEnabled(pindex->nHeight) && dDrift < 10) dDrift = 10;
+            double dDrift = claim.m_research_subsidy * .15;
+            if (dDrift < 10) dDrift = 10;
 
             if ((claim.TotalSubsidy() + dDrift) < dStakeRewardWithoutFees)
             {
@@ -2783,10 +2744,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                                      dStakeRewardWithoutFees, mint, OUT_INTEREST, OUT_POR, CoinToDouble(nFees), cpid));
             }
 
-            if (IsResearchAgeEnabled(pindex->nHeight)
-                && (BlockNeedsChecked(nTime) || nVersion>=9))
+            if (BlockNeedsChecked(nTime) || nVersion>=9)
             {
-
                 // 6-4-2017 - Verify researchers stored block magnitude
                 // 2018 02 04 - Moved here for better effect.
                 double dNeuralNetworkMagnitude = CalculatedMagnitude2(cpid, nTime);
@@ -2827,31 +2786,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                             else
                                 LogPrintf("WARNING ConnectBlock[ResearchAge] : Researchers Reward Pays too much : bad block ignored: Interest %f and Research %f and StakeReward %f, OUT_POR %f, with Out_Interest %f for CPID %s ",
                                                     claim.m_block_subsidy, claim.m_research_subsidy, dStakeReward, OUT_POR, OUT_INTEREST, cpid);
-                    }
-                }
-            }
-        }
-
-        //Approve first coinstake in DPOR block
-        if (claim.HasResearchReward() && IsLockTimeWithinMinutes(GetBlockTime(), 15, GetAdjustedTime()) && !IsResearchAgeEnabled(pindex->nHeight))
-        {
-            if (claim.m_research_subsidy > (GetOwedAmount(cpid) + 1))
-            {
-                StructCPID& strUntrustedHost = GetInitializedStructCPID2(cpid, mvMagnitudes);
-                if (claim.m_research_subsidy > strUntrustedHost.totalowed)
-                {
-                    double deficit = strUntrustedHost.totalowed - claim.m_research_subsidy;
-                    if ( (deficit < -500 && strUntrustedHost.Accuracy > 10) || (deficit < -150 && strUntrustedHost.Accuracy > 5) || deficit < -50)
-                    {
-                        LogPrintf("ConnectBlock[] : Researchers Reward results in deficit of %f for CPID %s with trust level of %f - (Submitted Research Subsidy %f vs calculated=%f) Hash: %s",
-                                  deficit, cpid, (double)strUntrustedHost.Accuracy, claim.m_research_subsidy,
-                                  OUT_POR, vtx[0].hashBoinc.c_str());
-                    }
-                    else
-                    {
-                        return error("ConnectBlock[] : Researchers Reward for CPID %s pays too much - (Submitted Research Subsidy %f vs calculated=%f) Hash: %s",
-                                     cpid, claim.m_research_subsidy,
-                                     OUT_POR, vtx[0].hashBoinc.c_str());
                     }
                 }
             }
@@ -2912,31 +2846,19 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
                     return error("ConnectBlock[] : Superblock avg mag below 10; SuperblockHash: %s, Consensus Hash: %s",
                                  neural_hash.c_str(), consensus_hash.c_str());
                 }
-                if (!IsResearchAgeEnabled(pindex->nHeight))
-                {
-                    if (consensus_hash != neural_hash && consensus_hash != legacy_neural_hash)
-                    {
-                        return error("ConnectBlock[] : Superblock hash does not match consensus hash; SuperblockHash: %s, Consensus Hash: %s",
-                                     neural_hash.c_str(), consensus_hash.c_str());
-                    }
-                }
-                else
-                {
                     if (consensus_hash != neural_hash)
                     {
                         return error("ConnectBlock[] : Superblock hash does not match consensus hash; SuperblockHash: %s, Consensus Hash: %s",
                                      neural_hash.c_str(), consensus_hash.c_str());
                     }
                 }
-
-            }
         }
 
         if(nVersion<9)
         {
             //If we are out of sync, and research age is enabled, and the superblock is valid, load it now, so we can continue checking blocks accurately
             // I would suggest to NOT bother with superblock at all here. It will be loaded in tally.
-            if ((OutOfSyncByAge() || fColdBoot || fReorganizing) && IsResearchAgeEnabled(pindex->nHeight) && pindex->nHeight > nGrandfather)
+            if ((OutOfSyncByAge() || fColdBoot || fReorganizing) && pindex->nHeight > nGrandfather)
             {
                 if (claim.ContainsSuperblock())
                 {
@@ -2977,13 +2899,13 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
 
     // Slow down Retallying when in RA mode so we minimize disruption of the network
     // TODO: Remove this if we can sync to v9 without it.
-    if ( (pindex->nHeight % 60 == 0) && IsResearchAgeEnabled(pindex->nHeight) && BlockNeedsChecked(pindex->nTime))
+    if ( (pindex->nHeight % 60 == 0) && BlockNeedsChecked(pindex->nTime))
     {
         if(!IsV9Enabled_Tally(pindexBest->nHeight))
             TallyResearchAverages(pindexBest);
     }
 
-    if (IsResearchAgeEnabled(pindex->nHeight) && !OutOfSyncByAge())
+    if (!OutOfSyncByAge())
     {
         fColdBoot = false;
     }
@@ -4930,10 +4852,8 @@ bool TallyResearchAverages(CBlockIndex* index)
 {
     if(IsV9Enabled_Tally(index->nHeight))
         return TallyResearchAverages_v9(index);
-    else if(IsResearchAgeEnabled(index->nHeight) && !IsV9Enabled_Tally(index->nHeight))
-        return TallyResearchAverages_retired(index);
     else
-        return false;
+        return TallyResearchAverages_retired(index);
 }
 
 bool TallyResearchAverages_retired(CBlockIndex* index)
@@ -5521,7 +5441,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-        if (!fTestNet && pfrom->nVersion < 180314 && IsResearchAgeEnabled(pindexBest->nHeight))
+        if (!fTestNet && pfrom->nVersion < 180314)
         {
             // disconnect from peers older than this proto version
             if (fDebug10) LogPrintf("ResearchAge: partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
@@ -6724,7 +6644,7 @@ void IncrementCurrentNeuralNetworkSupermajority(
         //This node has already voted, throw away the vote
         return;
     }
-
+    
     WriteCache(Section::CURRENTNEURALSECURITY, GRCAddress,NeuralHash,GetAdjustedTime());
 
     double multiplier = distance < 40 ? 400 : 200;
@@ -6774,7 +6694,7 @@ void IncrementNeuralNetworkSupermajority(
         //This node has already voted, throw away the vote
         return;
     }
-
+    
     WriteCache(Section::NEURALSECURITY, GRCAddress,NeuralHash,GetAdjustedTime());
 
     double multiplier = distance < 40 ? 400 : 200;
@@ -7263,21 +7183,11 @@ bool IsNeuralNodeParticipant(const std::string& addr, int64_t locktime)
 
     // For now, let's call for a 25% participation rate (approx. 125 nodes):
     // When RA is enabled, 25% of the neural network nodes will work on a quorum at any given time to alleviate stress on the project sites:
-    uint256 uRef;
-    if (IsResearchAgeEnabled(pindexBest->nHeight))
-    {
-        uRef = fTestNet
-               ? uint256S("0x00000000000000000000000000000000ed182f81388f317df738fd9994e7020b")
-               : uint256S("0x000000000000000000000000000000004d182f81388f317df738fd9994e7020b"); //This hash is approx 25% of the md5 range (90% for testnet)
-    }
-    else
-    {
-        uRef = fTestNet
-               ? uint256S("0x00000000000000000000000000000000ed182f81388f317df738fd9994e7020b")
-               : uint256S("0x00000000000000000000000000000000fd182f81388f317df738fd9994e7020b"); //This hash is approx 25% of the md5 range (90% for testnet)
-    }
+    arith_uint256 uRef = fTestNet
+       ? arith_uint256("0x00000000000000000000000000000000ed182f81388f317df738fd9994e7020b")
+       : arith_uint256("0x000000000000000000000000000000004d182f81388f317df738fd9994e7020b"); //This hash is approx 25% of the md5 range (90% for testnet)
 
-    uint256 uADH = uint256S("0x" + address_day_hash);
+    arith_uint256 uADH("0x" + address_day_hash);
     return (uADH < uRef);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,8 +74,6 @@ extern void IncrementNeuralNetworkSupermajority(const NN::QuorumHash& NeuralHash
 
 extern CBlockIndex* GetHistoricalMagnitude(std::string cpid);
 
-extern double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime, double& total_owed, double block_magnitude);
-
 bool TallyMagnitudesInSuperblock();
 std::string GetCommandNonce(std::string command);
 
@@ -4430,45 +4428,6 @@ std::string RetrieveMd5(std::string s1)
     {
         LogPrintf("MD5 INVALID!");
         return "";
-    }
-}
-
-double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime,
-    double& total_owed, double block_magnitude)
-{
-    // Gridcoin Payment Magnitude Unit in RSA Owed calculation ensures rewards are capped at MaxBlockSubsidy*BLOCKS_PER_DAY
-    // Payment date range is stored in HighLockTime-LowLockTime
-    // If newbie has not participated for 14 days, use earliest payment in chain to assess payment window
-    // (Important to prevent e-mail change attacks) - Calculate payment timespan window in days
-    try
-    {
-        double payment_timespan = (GetAdjustedTime() - mag.EarliestPaymentTime)/38400;
-        if (payment_timespan < 2) payment_timespan =  2;
-        if (payment_timespan > 10) payment_timespan = 14;
-        mag.PaymentTimespan = Round(payment_timespan,0);
-        double research_magnitude = 0;
-        // Get neural network magnitude:
-        StructCPID stDPOR = GetInitializedStructCPID2(cpid,mvDPOR);
-        research_magnitude = LederstrumpfMagnitude2(stDPOR.Magnitude,locktime);
-        double owed_standard = payment_timespan * std::min(research_magnitude*GetMagnitudeMultiplier(locktime),
-            GetMaximumBoincSubsidy(locktime)*5.0);
-        double owed_network_cap = payment_timespan * GRCMagnitudeUnit(locktime) * research_magnitude;
-        double owed = std::min(owed_standard, owed_network_cap);
-        double paid = mag.payments;
-        double outstanding = std::min(owed-paid, GetMaximumBoincSubsidy(locktime) * 5.0);
-        total_owed = owed;
-        //if (outstanding < 0) outstanding=0;
-        return outstanding;
-    }
-    catch (std::exception &e)
-    {
-            LogPrintf("Error while Getting outstanding amount owed.");
-            return 0;
-    }
-    catch(...)
-    {
-            LogPrintf("Error while Getting outstanding amount owed.");
-            return 0;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,6 @@ extern CBlockIndex* GetHistoricalMagnitude(std::string cpid);
 
 extern double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime, double& total_owed, double block_magnitude);
 
-extern double GetOwedAmount(std::string cpid);
 bool TallyMagnitudesInSuperblock();
 std::string GetCommandNonce(std::string command);
 
@@ -4433,18 +4432,6 @@ std::string RetrieveMd5(std::string s1)
         return "";
     }
 }
-
-double GetOwedAmount(std::string cpid)
-{
-    if (mvMagnitudes.size() > 1)
-    {
-        StructCPID& m = GetInitializedStructCPID2(cpid,mvMagnitudes);
-        if (m.initialized) return m.owed;
-        return 0;
-    }
-    return 0;
-}
-
 
 double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime,
     double& total_owed, double block_magnitude)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,7 +177,6 @@ bool bForceUpdate = false;
 bool fQtActive = false;
 bool bGridcoinGUILoaded = false;
 
-extern double LederstrumpfMagnitude2(double Magnitude, int64_t locktime);
 extern void GetGlobalStatus();
 bool PollIsActive(const std::string& poll_contract);
 
@@ -6269,25 +6268,6 @@ bool ProcessMessages(CNode* pfrom)
         pfrom->vRecvMsg.erase(pfrom->vRecvMsg.begin(), it);
 
     return fOk;
-}
-
-double LederstrumpfMagnitude2(double Magnitude, int64_t locktime)
-{
-    //2-1-2015 - Halford - The MagCap is 2000
-    double MagCap = 2000;
-    double out_mag = Magnitude;
-    if (Magnitude >= MagCap*.90 && Magnitude <= MagCap*1.0) out_mag = MagCap*.90;
-    if (Magnitude >= MagCap*1.0 && Magnitude <= MagCap*1.1) out_mag = MagCap*.91;
-    if (Magnitude >= MagCap*1.1 && Magnitude <= MagCap*1.2) out_mag = MagCap*.92;
-    if (Magnitude >= MagCap*1.2 && Magnitude <= MagCap*1.3) out_mag = MagCap*.93;
-    if (Magnitude >= MagCap*1.3 && Magnitude <= MagCap*1.4) out_mag = MagCap*.94;
-    if (Magnitude >= MagCap*1.4 && Magnitude <= MagCap*1.5) out_mag = MagCap*.95;
-    if (Magnitude >= MagCap*1.5 && Magnitude <= MagCap*1.6) out_mag = MagCap*.96;
-    if (Magnitude >= MagCap*1.6 && Magnitude <= MagCap*1.7) out_mag = MagCap*.97;
-    if (Magnitude >= MagCap*1.7 && Magnitude <= MagCap*1.8) out_mag = MagCap*.98;
-    if (Magnitude >= MagCap*1.8 && Magnitude <= MagCap*1.9) out_mag = MagCap*.99;
-    if (Magnitude >= MagCap*1.9)                            out_mag = MagCap*1.0;
-    return out_mag;
 }
 
 std::string GetLastPORBlockHash(std::string cpid)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2765,7 +2765,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             // 12-20-2015 : Add support for Binary Superblocks
             std::string superblock = UnpackBinarySuperblock(claim.m_superblock.PackLegacy());
             std::string neural_hash = GetQuorumHash(superblock);
-            std::string legacy_neural_hash = RetrieveMd5(superblock);
             double popularity = 0;
             std::string consensus_hash = GetNeuralNetworkSupermajorityHash(popularity);
             // Only reject superblock when it is new And when QuorumHash of Block != the Popular Quorum Hash:

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -79,7 +79,6 @@ double GetTotalBalance();
 
 double CoinToDouble(double surrogate);
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
-double LederstrumpfMagnitude2(double mag,int64_t locktime);
 
 BlockFinder RPCBlockFinder;
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -605,18 +605,12 @@ bool TallyMagnitudesInSuperblock()
                     stCPID.Magnitude = magnitude;
                     stCPID.cpid = cpid;
                     mvDPORCopy[cpid]=stCPID;
+
                     StructCPID& stMagg = GetInitializedStructCPID2(cpid,mvMagnitudesCopy);
                     stMagg.cpid = cpid;
                     stMagg.Magnitude = stCPID.Magnitude;
-                    //Adjust total owed - in case they are a newbie:
-                    if (true)
-                    {
-                        double total_owed = 0;
-                        stMagg.owed = GetOutstandingAmountOwed(stMagg,cpid,(double)GetAdjustedTime(),total_owed,stCPID.Magnitude);
-                        stMagg.totalowed = total_owed;
-                    }
-
                     mvMagnitudesCopy[cpid] = stMagg;
+
                     TotalNetworkMagnitude += stMagg.Magnitude;
                     TotalNetworkEntries++;
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -47,7 +47,6 @@ extern std::string ExtractValue(std::string data, std::string delimiter, int pos
 extern UniValue SuperblockReport(int lookback = 14, bool displaycontract = false, std::string cpid = "");
 extern double GetSuperblockMagnitudeByCPID(std::string data, std::string cpid);
 std::string GetQuorumHash(const std::string& data);
-double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime, double& total_owed, double block_magnitude);
 bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 int64_t GetMaximumBoincSubsidy(int64_t nTime);
 double GRCMagnitudeUnit(int64_t locktime);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -2385,7 +2385,6 @@ UniValue MagnitudeReport(std::string cpid)
     std::string Narr = ToString(GetAdjustedTime());
     c.pushKV("RSA Report",Narr);
     results.push_back(c);
-    double total_owed = 0;
     double magnitude_unit = GRCMagnitudeUnit(GetAdjustedTime());
     if (!pindexBest) return results;
 

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -9,7 +9,6 @@
 #include <map>
 #include <string>
 
-extern double GetOutstandingAmountOwed(StructCPID &mag, std::string cpid, int64_t locktime, double& total_owed, double block_magnitude);
 extern std::map<std::string, StructCPID> mvDPOR;
 extern bool fTestNet;
 double RoundFromString(std::string s, int place);
@@ -48,23 +47,6 @@ namespace
 BOOST_GLOBAL_FIXTURE(GridcoinTestsConfig);
 
 BOOST_AUTO_TEST_SUITE(gridcoin_tests)
-
-BOOST_AUTO_TEST_CASE(gridcoin_GetOutstandingAmountOwedShouldReturnCorrectSum)
-{
-   // Update the CPID earliest pay time to 24 hours ago.
-   StructCPID& cpid = GetInitializedStructCPID2(TEST_CPID, mvMagnitudes);
-   cpid.EarliestPaymentTime = GetAdjustedTime() - 24 * 3600;
-   mvMagnitudes[TEST_CPID] = cpid;
-
-   double total_owed;
-   double magnitude = 190;
-   double outstanding = GetOutstandingAmountOwed(cpid, TEST_CPID, GetAdjustedTime(), total_owed, magnitude);
-
-   // Value taken from GetOutstandingAmountOwed prior to refactoring given
-   // the setup in this test and the GridcoinTestsConfig constructor.
-   BOOST_CHECK_CLOSE(total_owed, 140.625, 0.00001);
-   BOOST_CHECK_CLOSE(outstanding, total_owed - cpid.payments, 0.000001);
-}
 
 BOOST_AUTO_TEST_CASE(gridcoin_V8ShouldBeEnabledOnBlock1010000InProduction)
 {


### PR DESCRIPTION
This rebases @denravonska's work in #1365 to remove old code conditioned on the research age switch-over height and removes some additional incumbent legacy code that these checks depended on. 