### PR TITLE
Implement project level rain for rainbymagnitude

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -142,7 +142,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "consolidateunspent"     , 2 },
     { "move"                   , 2 },
     { "move"                   , 3 },
-    { "rainbymagnitude"        , 0 },
+    { "rainbymagnitude"        , 1 },
     { "reservebalance"         , 0 },
     { "reservebalance"         , 1 },
     { "scanforunspent"         , 1 },


### PR DESCRIPTION
This switches rainbymagnitude to use the scraper statistics map and enables the choice of either network-wide or by-project rain.

The command syntax is now

`rainbymagnitude <project> <amount> [comment]`

Where "*" for project means network-wide.