### PR TITLE
Fix lingering peers.dat temp files and clean up remaining paths

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -34,6 +34,7 @@ GRIDCOIN_TESTS =\
   test/beacon_tests.cpp \
   test/bignum_tests.cpp \
   test/block_tests.cpp \
+  test/fs_tests.cpp \
   test/getarg_tests.cpp \
   test/gridcoin_tests.cpp \
   test/key_tests.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -48,18 +48,30 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     fs::path pathTmp = GetDataDir() / tmpfn;
     FILE *file = fsbridge::fopen(pathTmp, "wb");
     CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
-    if (fileout.IsNull())
+    if (fileout.IsNull()) {
+        fileout.fclose();
+        remove(pathTmp);
         return error("%s: Failed to open file %s", __func__, pathTmp.string());
+    }
 
     // Serialize
-    if (!SerializeDB(fileout, data)) return false;
-    if (!FileCommit(fileout.Get()))
+    if (!SerializeDB(fileout, data)) {
+        fileout.fclose();
+        remove(pathTmp);
+        return false;
+    }
+    if (!FileCommit(fileout.Get())) {
+        fileout.fclose();
+        remove(pathTmp);
         return error("%s: Failed to flush file %s", __func__, pathTmp.string());
+    }
     fileout.fclose();
 
     // replace existing file, if any, with new file
-    if (!RenameOver(pathTmp, path))
+    if (!RenameOver(pathTmp, path)) {
+        remove(pathTmp);
         return error("%s: Rename-into-place failed", __func__);
+    }
 
     return true;
 }

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -115,7 +115,7 @@ bool BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::string&
     filesystem::create_directories(PrivateKeysTarget.parent_path());
     sTarget = PrivateKeysTarget.string();
     fsbridge::ofstream myBackup;
-    myBackup.open (PrivateKeysTarget.string().c_str());
+    myBackup.open(PrivateKeysTarget);
     std::string sError;
     for(const auto& keyPair : wallet.GetAllPrivateKeys(sError))
     {

--- a/src/boinc.cpp
+++ b/src/boinc.cpp
@@ -1,13 +1,11 @@
 #include "boinc.h"
 #include "util.h"
 
-#include <boost/filesystem.hpp>
-
-std::string GetBoincDataDir(){
+fs::path GetBoincDataDir(){
 
     std::string path = GetArgument("boincdatadir", "");
     if (!path.empty()){
-        return path;
+        return fs::path(std::move(path));
     }
 
     #ifdef WIN32
@@ -28,37 +26,37 @@ std::string GetBoincDataDir(){
                         (LPBYTE)&szPath,
                         &dwSize) == ERROR_SUCCESS){
             RegCloseKey(hKey);
-            std::wstring wsPath = szPath;
-	    // TODO: Use and return wstring when all file operations use unicode
-            std::string path(wsPath.begin(),wsPath.end());
-            if (boost::filesystem::exists(path)){
+
+            fs::path path = std::wstring(szPath);
+
+            if (fs::exists(path)){
                 return path;
             } else {
-                LogPrintf("Cannot find BOINC data dir %s.", path);
+                LogPrintf("Cannot find BOINC data dir %s.", path.string());
             }
         }
         RegCloseKey(hKey);
     }
 
-    if (boost::filesystem::exists("C:\\ProgramData\\BOINC\\")){
+    if (fs::exists("C:\\ProgramData\\BOINC\\")){
         return "C:\\ProgramData\\BOINC\\";
     }
-    else if(boost::filesystem::exists("C:\\Documents and Settings\\All Users\\Application Data\\BOINC\\")){
+    else if(fs::exists("C:\\Documents and Settings\\All Users\\Application Data\\BOINC\\")){
         return "C:\\Documents and Settings\\All Users\\Application Data\\BOINC\\";
     }
     #endif
 
     #ifdef __linux__
-    if (boost::filesystem::exists("/var/lib/boinc-client/")){
+    if (fs::exists("/var/lib/boinc-client/")){
         return "/var/lib/boinc-client/";
     }
-    else if (boost::filesystem::exists("/var/lib/boinc/")){
+    else if (fs::exists("/var/lib/boinc/")){
         return "/var/lib/boinc/";
     }
     #endif
 
     #ifdef __APPLE__
-    if (boost::filesystem::exists("/Library/Application Support/BOINC Data/")){
+    if (fs::exists("/Library/Application Support/BOINC Data/")){
         return "/Library/Application Support/BOINC Data/";
     }
     #endif

--- a/src/boinc.h
+++ b/src/boinc.h
@@ -1,8 +1,8 @@
 #ifndef GRIDCOIN_BOINC_H
 #define GRIDCOIN_BOINC_H
 
-#include <string>
+#include <fs.h>
 
-std::string GetBoincDataDir();
+fs::path GetBoincDataDir();
 
 #endif

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -9,8 +9,6 @@
 #include "ui_interface.h"
 #include "util.h"
 
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <stdint.h>
 
 #ifndef WIN32
@@ -18,12 +16,8 @@
 #endif
 
 using namespace std;
-using namespace boost;
-
 
 unsigned int nWalletDBUpdated;
-
-
 
 //
 // CDB
@@ -60,7 +54,7 @@ void CDBEnv::Close()
     EnvShutdown();
 }
 
-bool CDBEnv::Open(boost::filesystem::path pathEnv_)
+bool CDBEnv::Open(fs::path pathEnv_)
 {
     if (fDbEnvInit)
         return true;
@@ -69,11 +63,11 @@ bool CDBEnv::Open(boost::filesystem::path pathEnv_)
         return false;
 
     pathEnv = pathEnv_;
-    filesystem::path pathDataDir = pathEnv;
+    fs::path pathDataDir = pathEnv;
     strPath = pathDataDir.string();
-    filesystem::path pathLogDir = pathDataDir / "database";
-    filesystem::create_directory(pathLogDir);
-    filesystem::path pathErrorFile = pathDataDir / "db.log";
+    fs::path pathLogDir = pathDataDir / "database";
+    fs::create_directory(pathLogDir);
+    fs::path pathErrorFile = pathDataDir / "db.log";
     LogPrintf("dbenv.open LogDir=%s ErrorFile=%s", pathLogDir.string(), pathErrorFile.string());
 
     unsigned int nEnvFlags = 0;
@@ -485,107 +479,3 @@ void CDBEnv::Flush(bool fShutdown)
         }
     }
 }
-
-
-//
-// CAddrDB
-//
-
-/*
-CAddrDB::CAddrDB()
-{
-    pathAddr = GetDataDir() / "peers.dat";
-}
-
-bool CAddrDB::Write(const CAddrMan& addr)
-{
-    // Generate random temporary filename
-    unsigned short randv = 0;
-    RAND_bytes((unsigned char *)&randv, sizeof(randv));
-    std::string tmpfn = strprintf("peers.dat.%04x", randv);
-
-    // serialize addresses, checksum data up to that point, then append csum
-    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
-    ssPeers << pchMessageStart;
-    ssPeers << addr;
-    uint256 hash = Hash(ssPeers.begin(), ssPeers.end());
-    ssPeers << hash;
-
-    // open temp output file, and associate with CAutoFile
-    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
-    FILE *file = fsbridge::fopen(pathTmp.string().c_str(), "wb");
-    CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
-    if (fileout.IsNull())
-        return error("CAddrman::Write() : open failed");
-
-    // Write and commit header, data
-    try {
-        fileout << ssPeers;
-    }
-    catch (std::exception &e) {
-        return error("CAddrman::Write() : I/O error");
-    }
-    FileCommit(fileout.Get());
-    fileout.fclose();
-
-    // replace existing peers.dat, if any, with new peers.dat.XXXX
-    if (!RenameOver(pathTmp, pathAddr))
-        return error("CAddrman::Write() : Rename-into-place failed");
-
-    return true;
-}
-
-bool CAddrDB::Read(CAddrMan& addr)
-{
-    // open input file, and associate with CAutoFile
-    FILE *file = fsbridge::fopen(pathAddr.string().c_str(), "rb");
-    CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
-    if (filein.IsNull())
-        return error("CAddrman::Read() : open failed");
-
-    // use file size to size memory buffer
-    int fileSize = boost::filesystem::file_size(pathAddr);
-    int dataSize = fileSize - sizeof(uint256);
-    // Don't try to resize to a negative number if file is small
-    if ( dataSize < 0 ) dataSize = 0;
-    vector<unsigned char> vchData;
-    vchData.resize(dataSize);
-    uint256 hashIn;
-
-    // read data and checksum from file
-    try
-    {
-        filein.read((char *)&vchData[0], dataSize);
-        filein >> hashIn;
-    }
-    catch (std::exception &e) {
-        return error("CAddrman::Read() 2 : I/O error or stream data corrupted");
-    }
-    filein.fclose();
-
-    CDataStream ssPeers(vchData, SER_DISK, CLIENT_VERSION);
-
-    // verify stored checksum matches input data
-    uint256 hashTmp = Hash(ssPeers.begin(), ssPeers.end());
-    if (hashIn != hashTmp)
-        return error("CAddrman::Read() : checksum mismatch; data corrupted");
-
-    unsigned char pchMsgTmp[4];
-    try {
-        // de-serialize file header (pchMessageStart magic number) and
-        ssPeers >> pchMsgTmp;
-
-        // verify the network matches ours
-        if (memcmp(pchMsgTmp, pchMessageStart, sizeof(pchMsgTmp)))
-            return error("CAddrman::Read() : invalid network magic number");
-
-        // de-serialize address data into one CAddrMan object
-        ssPeers >> addr;
-    }
-    catch (std::exception &e) {
-        return error("CAddrman::Read() : I/O error or stream data corrupted");
-    }
-
-    return true;
-}
-*/

--- a/src/db.h
+++ b/src/db.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_DB_H
 #define BITCOIN_DB_H
 
+#include "fs.h"
 #include "main.h"
 #include "streams.h"
 
@@ -34,7 +35,7 @@ class CDBEnv
 private:
     bool fDbEnvInit;
     bool fMockDb;
-    boost::filesystem::path pathEnv;
+    fs::path pathEnv;
     std::string strPath;
 
     void EnvShutdown();
@@ -68,7 +69,7 @@ public:
     typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char> > KeyValPair;
     bool Salvage(std::string strFile, bool fAggressive, std::vector<KeyValPair>& vResult);
 
-    bool Open(boost::filesystem::path pathEnv_);
+    bool Open(fs::path pathEnv_);
     void Close();
     void Flush(bool fShutdown);
     void CheckpointLSN(std::string strFile);
@@ -306,19 +307,5 @@ public:
 
     bool static Rewrite(const std::string& strFile, const char* pszSkip = NULL);
 };
-
-
-/** Access to the (IP) address database (peers.dat) */
-/*
-class CAddrDB
-{
-private:
-    boost::filesystem::path pathAddr;
-public:
-    CAddrDB();
-    bool Write(const CAddrMan& addr);
-    bool Read(CAddrMan& addr);
-};
-*/
 
 #endif // BITCOIN_DB_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -936,7 +936,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 
         for (auto const& strFile : mapMultiArgs["-loadblock"])
         {
-            FILE *file = fsbridge::fopen(strFile.c_str(), "rb");
+            FILE *file = fsbridge::fopen(strFile, "rb");
             if (file)
                 LoadExternalBlockFile(file);
         }
@@ -947,7 +947,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (filesystem::exists(pathBootstrap)) {
         uiInterface.InitMessage(_("Importing bootstrap blockchain data file."));
 
-        FILE *file = fsbridge::fopen(pathBootstrap.string().c_str(), "rb");
+        FILE *file = fsbridge::fopen(pathBootstrap, "rb");
         if (file) {
             filesystem::path pathBootstrapOld = GetDataDir() / "bootstrap.dat.old";
             LoadExternalBlockFile(file);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4221,7 +4221,7 @@ FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszM
 {
     if ((nFile < 1) || (nFile == (unsigned int) -1))
         return NULL;
-    FILE* file = fsbridge::fopen(BlockFilePath(nFile).string().c_str(), pszMode);
+    FILE* file = fsbridge::fopen(BlockFilePath(nFile), pszMode);
     if (!file)
         return NULL;
     if (nBlockPos != 0 && !strchr(pszMode, 'a') && !strchr(pszMode, 'w'))

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -76,8 +76,8 @@ bool ConfiguredForInvestorMode()
 //!
 boost::optional<std::string> ReadClientStateXml()
 {
-    const std::string path = GetBoincDataDir();
-    std::string contents = GetFileContents(path + "client_state.xml");
+    const fs::path path = GetBoincDataDir();
+    std::string contents = GetFileContents(path / "client_state.xml");
 
     if (contents != "-1") {
         return boost::make_optional(std::move(contents));
@@ -86,7 +86,7 @@ boost::optional<std::string> ReadClientStateXml()
     LogPrintf("WARNING: Unable to obtain BOINC CPIDs.");
 
     if (!GetArgument("boincdatadir", "").empty()) {
-        LogPrintf("Could not access configured BOINC data directory %s", path);
+        LogPrintf("Could not access configured BOINC data directory %s", path.string());
     } else {
         LogPrintf(
             "BOINC data directory is not installed in the default location.\n"

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -844,7 +844,7 @@ bool CreateNewConfigFile(std::string boinc_email)
     std::string filename = "gridcoinresearch.conf";
     boost::filesystem::path path = GetDataDir() / filename;
     fsbridge::ofstream myConfig;
-    myConfig.open (path.string().c_str());
+    myConfig.open (path);
     std::string row = "email=" + boinc_email + "\r\n";
     myConfig << row;
     row = "addnode=node.gridcoin.us \r\n";
@@ -883,17 +883,15 @@ void BitcoinGUI::NewUserWizard()
         QString boincemail = "";
         //Typhoon- Check to see if boinc exists in default path - 11-19-2014
 
-        std::string sourcefile = GetBoincDataDir() + "client_state.xml";
-        std::string sout = "";
-        sout = GetFileContents(sourcefile);
+        fs::path sourcefile = GetBoincDataDir() / "client_state.xml";
+        std::string sout = GetFileContents(sourcefile);
         //bool BoincInstalled = true;
         std::string sBoincNarr = "";
         if (sout == "-1")
         {
             LogPrintf("BOINC not installed in default location! ");
             //BoincInstalled=false;
-            std::string nicePath = GetBoincDataDir();
-            sBoincNarr = "BOINC is not installed in the default location " + nicePath + "!  Please set boincdatadir in the gridcoinresearch.conf file to the correct path where the BOINC client_state.xml file resides.";
+            sBoincNarr = "BOINC is not installed in the default location " + sourcefile.string() + "!  Please set boincdatadir in the gridcoinresearch.conf file to the correct path where the BOINC client_state.xml file resides.";
         }
 
         bool ok;

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -51,7 +51,7 @@ bool DiagnosticsDialog::FindCPID()
 
 bool DiagnosticsDialog::VerifyIsCPIDValid()
 {
-    boost::filesystem::path clientStatePath = (boost::filesystem::path) GetBoincDataDir();
+    boost::filesystem::path clientStatePath = GetBoincDataDir();
 
     if (!clientStatePath.empty())
         clientStatePath = clientStatePath / "client_state.xml";
@@ -65,7 +65,7 @@ bool DiagnosticsDialog::VerifyIsCPIDValid()
     fsbridge::ifstream clientStateStream;
     std::string clientState;
 
-    clientStateStream.open(clientStatePath.string());
+    clientStateStream.open(clientStatePath);
     clientState.assign((std::istreambuf_iterator<char>(clientStateStream)), std::istreambuf_iterator<char>());
     clientStateStream.close();
 

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -480,7 +480,7 @@ UniValue rpc_exportstats(const UniValue& params, bool fHelp)
     fsbridge::ofstream Output;
     boost::filesystem::path o_path = GetDataDir() / "reports" / ( "export_" + std::to_string(GetTime()) + ".txt" );
     boost::filesystem::create_directories(o_path.parent_path());
-    Output.open (o_path.string().c_str());
+    Output.open (o_path);
     Output.imbue(std::locale::classic());
     Output << std::fixed << std::setprecision(4);
     Output << "#midheight  ave_diff min_diff max_diff  "

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -195,7 +195,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
         PathForImport = DefaultPathDataDir / PathForImport;
 
     fsbridge::ifstream file;
-    file.open(PathForImport.string().c_str());
+    file.open(PathForImport);
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
 
@@ -328,7 +328,7 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
         PathForDump = DefaultPathDataDir / PathForDump;
 
     fsbridge::ofstream file;
-    file.open(PathForDump.string().c_str());
+    file.open(PathForDump);
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -1251,14 +1251,14 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
             std::string backupdir = GetArg("-backupdir", "");
 
             if (backupdir.empty())
-                exportpath = GetDataDir() / "walletbackups/rpc" / exportfile;
+                exportpath = GetDataDir() / "walletbackups" / "rpc" / exportfile;
 
             else
-                exportpath = backupdir + "/" + exportfile;
+                exportpath = fs::path(backupdir) / exportfile;
 
             boost::filesystem::create_directory(exportpath.parent_path());
 
-            dataout.open(exportpath.string().c_str());
+            dataout.open(exportpath);
 
             if (!dataout)
             {

--- a/src/scraper/http.cpp
+++ b/src/scraper/http.cpp
@@ -65,10 +65,10 @@ Http::~Http()
 
 void Http::Download(
         const std::string &url,
-        const std::string &destination,
+        const fs::path &destination,
         const std::string &userpass)
 {
-    ScopedFile fp(fsbridge::fopen(destination.c_str(), "wb"), &fclose);
+    ScopedFile fp(fsbridge::fopen(destination, "wb"), &fclose);
     if(!fp)
         throw std::runtime_error(
                 tfm::format("Error opening target %s: %s (%d)", destination, strerror(errno), errno));

--- a/src/scraper/http.h
+++ b/src/scraper/http.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <fs.h>
+
 #include <string>
 #include <stdexcept>
 
@@ -48,7 +50,7 @@ public:
     //!
     void Download(
             const std::string& url,
-            const std::string& destination,
+            const fs::path& destination,
             const std::string& userpass = "");
 
     //!

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -1402,7 +1402,7 @@ bool DownloadProjectHostFiles(const NN::WhitelistSnapshot& projectWhitelist)
 
         try
         {
-            http.Download(prjs.StatsUrl("host"), host_file.string(), userpass);
+            http.Download(prjs.StatsUrl("host"), host_file, userpass);
         }
         catch(const std::runtime_error& e)
         {
@@ -1574,7 +1574,7 @@ bool DownloadProjectTeamFiles(const NN::WhitelistSnapshot& projectWhitelist)
         {
             try
             {
-                http.Download(prjs.StatsUrl("team"), team_file.string(), userpass);
+                http.Download(prjs.StatsUrl("team"), team_file, userpass);
             }
             catch(const std::runtime_error& e)
             {
@@ -1825,7 +1825,7 @@ bool DownloadProjectRacFilesByCPID(const NN::WhitelistSnapshot& projectWhitelist
 
         try
         {
-            http.Download(prjs.StatsUrl("user"), rac_file.string(), userpass);
+            http.Download(prjs.StatsUrl("user"), rac_file, userpass);
         }
         catch(const std::runtime_error& e)
         {
@@ -1837,7 +1837,7 @@ bool DownloadProjectRacFilesByCPID(const NN::WhitelistSnapshot& projectWhitelist
         if (fExplorer) AlignScraperFileManifestEntries(rac_file, "user_source", prjs.m_name, true);
 
         // Now that the source file is handled, process the file.
-        ProcessProjectRacFileByCPID(prjs.m_name, rac_file.string(), sRacETag, Consensus);
+        ProcessProjectRacFileByCPID(prjs.m_name, rac_file, sRacETag, Consensus);
     }
 
     // After processing, update global structure with the timestamp of the latest file in the manifest.
@@ -1889,13 +1889,7 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
     in.push(boostio::gzip_decompressor());
     in.push(ingzfile);
 
-    std::string gzetagfile = "";
-
-    gzetagfile = project + "-" + etag + ".csv" + ".gz";
-
-    std::string gzetagfile_no_path = gzetagfile;
-    // Put path in.
-    gzetagfile = ((fs::path)(pathScraper / gzetagfile)).string();
+    fs::path gzetagfile = pathScraper / (project + "-" + etag + ".csv" + ".gz");
 
     fsbridge::ofstream outgzfile(gzetagfile, std::ios_base::out | std::ios_base::binary);
     boostio::filtering_ostream out;
@@ -2040,7 +2034,7 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
 uint256 GetFileHash(const fs::path& inputfile)
 {
     // open input file, and associate with CAutoFile
-    FILE *file = fsbridge::fopen(inputfile.string().c_str(), "rb");
+    FILE *file = fsbridge::fopen(inputfile, "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
     uint256 nHash;
     
@@ -3617,7 +3611,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
     fs::path inputfilewpath = pathScraper / inputfile;
     
     // open input file, and associate with CAutoFile
-    FILE *file = fsbridge::fopen(inputfilewpath.string().c_str(), "rb");
+    FILE *file = fsbridge::fopen(inputfilewpath, "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
 
     if (filein.IsNull())
@@ -3668,7 +3662,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
         fs::path inputfilewpath = pathScraper / inputfile;
 
         // open input file, and associate with CAutoFile
-        FILE *file = fsbridge::fopen(inputfilewpath.string().c_str(), "rb");
+        FILE *file = fsbridge::fopen(inputfilewpath, "rb");
         CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
 
         if (filein.IsNull())

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+#include <fs.h>
+//#include <test/setup_common.h>
+//#include <util/system.h>
+#include <util.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(fs_tests)
+
+BOOST_AUTO_TEST_CASE(fsbridge_fstream)
+{
+    fs::path tmpfolder = GetDataDir();
+    // tmpfile1 should be the same as tmpfile2
+    fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
+    fs::path tmpfile2 = tmpfolder / "fs_tests_₿_🏃";
+    {
+        fsbridge::ofstream file(tmpfile1);
+        file << "bitcoin";
+    }
+    {
+        fsbridge::ifstream file(tmpfile2);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "bitcoin");
+    }
+    {
+        fsbridge::ifstream file(tmpfile1, std::ios_base::in | std::ios_base::ate);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "");
+    }
+    {
+        fsbridge::ofstream file(tmpfile2, std::ios_base::out | std::ios_base::app);
+        file << "tests";
+    }
+    {
+        fsbridge::ifstream file(tmpfile1);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "bitcointests");
+    }
+    {
+        fsbridge::ofstream file(tmpfile2, std::ios_base::out | std::ios_base::trunc);
+        file << "bitcoin";
+    }
+    {
+        fsbridge::ifstream file(tmpfile1);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "bitcoin");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -294,9 +294,15 @@ void LogPrintStr(const std::string &str)
             // reopen the log file, if requested
             if (fReopenDebugLog) {
                 fReopenDebugLog = false;
+
                 fs::path pathDebug = GetDataDir() / "debug.log";
-                if (freopen(pathDebug.string().c_str(),"a",fileout) != NULL)
-                    setbuf(fileout, NULL); // unbuffered
+                FILE* new_fileout = fsbridge::fopen(pathDebug, "a");
+
+                if (new_fileout) {
+                    setbuf(new_fileout, NULL); // unbuffered
+                    fclose(fileout);
+                    fileout = new_fileout;
+                }
             }
 
             // Debug print useful for profiling

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -859,7 +859,7 @@ void CreatePidFile(const fs::path &path, pid_t pid)
 bool RenameOver(fs::path src, fs::path dest)
 {
 #ifdef WIN32
-    return MoveFileExA(src.string().c_str(), dest.string().c_str(),
+    return MoveFileExW(src.wstring().c_str(), dest.wstring().c_str(),
                       MOVEFILE_REPLACE_EXISTING);
 #else
     int rc = std::rename(src.string().c_str(), dest.string().c_str());

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -276,7 +276,7 @@ void LogPrintStr(const std::string &str)
         if (!fileout)
         {
             fs::path pathDebug = GetDataDir() / "debug.log";
-            fileout = fsbridge::fopen(pathDebug.string().c_str(), "a");
+            fileout = fsbridge::fopen(pathDebug, "a");
             if (fileout) setbuf(fileout, NULL); // unbuffered
         }
         if (fileout)
@@ -787,16 +787,12 @@ fs::path GetProgramDir()
 
 }
 
-
-
 fs::path GetConfigFile()
 {
     fs::path pathConfigFile(GetArg("-conf", "gridcoinresearch.conf"));
     if (!pathConfigFile.is_absolute()) pathConfigFile = GetDataDir(false) / pathConfigFile;
     return pathConfigFile;
 }
-
-
 
 bool IsConfigFileEmpty()
 {
@@ -808,10 +804,6 @@ bool IsConfigFileEmpty()
     return false;
 
 }
-
-
-
-
 
 void ReadConfigFile(ArgsMap& mapSettingsRet,
                     ArgsMultiMap& mapMultiSettingsRet)
@@ -847,7 +839,7 @@ fs::path GetPidFile()
 #ifndef WIN32
 void CreatePidFile(const fs::path &path, pid_t pid)
 {
-    FILE* file = fsbridge::fopen(path.string().c_str(), "w");
+    FILE* file = fsbridge::fopen(path, "w");
     if (file)
     {
         fprintf(file, "%d\n", pid);
@@ -866,18 +858,6 @@ bool RenameOver(fs::path src, fs::path dest)
     return (rc == 0);
 #endif /* WIN32 */
 }
-
-/*
-void FileCommit(FILE *fileout)
-{
-    fflush(fileout);                // harmless if redundantly called
-#ifdef WIN32
-    _commit(_fileno(fileout));
-#else
-    fsync(fileno(fileout));
-#endif
-}
-*/
 
 // Newer FileCommit overload from Bitcoin.
 bool FileCommit(FILE *file)
@@ -918,7 +898,7 @@ void ShrinkDebugFile()
 {
     // Scroll debug.log if it's getting too big
     fs::path pathLog = GetDataDir() / "debug.log";
-    FILE* file = fsbridge::fopen(pathLog.string().c_str(), "r");
+    FILE* file = fsbridge::fopen(pathLog, "r");
     if (file && fs::file_size(pathLog) > 1000000)
     {
         // Restart the file with some of the end
@@ -927,7 +907,7 @@ void ShrinkDebugFile()
         int nBytes = fread(pch, 1, sizeof(pch), file);
         fclose(file);
 
-        file = fsbridge::fopen(pathLog.string().c_str(), "w");
+        file = fsbridge::fopen(pathLog, "w");
         if (file)
         {
             fwrite(pch, 1, nBytes, file);
@@ -973,7 +953,7 @@ bool LockDirectory(const fs::path& directory, const std::string lockfile_name, b
     return true;
 }
 
-std::string GetFileContents(std::string filepath)
+std::string GetFileContents(const fs::path filepath)
 {
     if (!fs::exists(filepath)) {
         LogPrintf("GetFileContents: file does not exist %s", filepath);

--- a/src/util.h
+++ b/src/util.h
@@ -223,7 +223,7 @@ bool LockDirectory(const fs::path& directory, const std::string lockfile_name, b
 //!
 //! \return The file contents as a string.
 //!
-std::string GetFileContents(std::string filepath);
+std::string GetFileContents(const fs::path filepath);
 
 int GetRandInt(int nMax);
 uint64_t GetRand(uint64_t nMax);


### PR DESCRIPTION
This fixes a Unicode path problem on Windows that blocks rename operations on peers.dat temporary files and also removes the temporary file if the database encounters a filesystem problem. I cleaned up some remaining Unicode path handling for `fsbridge` that I started in #1571. 