### PR TITLE
Remove PrimaryCPID check from diagnostics dialog

### DIFF
--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -42,13 +42,6 @@ bool DiagnosticsDialog::VerifyBoincPath()
     return boost::filesystem::exists(boincPath) ? true : false;
 }
 
-bool DiagnosticsDialog::FindCPID()
-{
-    std::string cpid = GetArgument("PrimaryCPID", "");
-
-    return IsResearcher(cpid) ? true : false;
-}
-
 bool DiagnosticsDialog::VerifyIsCPIDValid()
 {
     boost::filesystem::path clientStatePath = GetBoincDataDir();
@@ -216,19 +209,6 @@ void DiagnosticsDialog::on_testButton_clicked()
     else
         ui->boincPathResultLabel->setText("Failed");
 
-    //find cpid
-#ifndef WIN32
-    ui->findCPIDResultLabel->setText("N/A");
-#else
-    ui->findCPIDResultLabel->setText("Testing...");
-    this->repaint();
-
-    if (FindCPID())
-        ui->findCPIDResultLabel->setText(QString::fromStdString("Passed CPID: " + GetArgument("PrimaryCPID", "")));
-
-    else
-        ui->findCPIDResultLabel->setText("Failed (Is PrimaryCPID in gridcoinresearch.conf?)");
-#endif
     //cpid valid
     ui->verifyCPIDValidResultLabel->setText("Testing...");
     this->repaint();

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -27,7 +27,6 @@ private:
     bool VerifyCPIDIsInNeuralNetwork();
     bool VerifyWalletIsSynced();
     bool VerifyIsCPIDValid();
-    bool FindCPID();
     bool VerifyCPIDHasRAC();
     int VerifyCountSeedNodes();
     int VerifyCountConnections();

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -162,28 +162,6 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="findCPIDResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="1">
       <widget class="QLabel" name="verifyCPIDHasRACResultLabel">
        <property name="sizePolicy">


### PR DESCRIPTION
Nothing uses this configuration directive anymore, and the check is only performed on Windows. It confuses a lot of users, so let's get rid of it.