### PR TITLE
Remove legacy quorum messaging system (neural network)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,11 +43,9 @@ extern std::string NodeAddress(CNode* pfrom);
 extern bool WalletOutOfSync();
 bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage);
 extern void CleanInboundConnections(bool bClearAll);
-bool RequestSupermajorityNeuralData();
 extern bool AskForOutstandingBlocks(uint256 hashStart);
 extern void ResetTimerMain(std::string timer_name);
 extern void IncrementCurrentNeuralNetworkSupermajority(const NN::QuorumHash& quorum_hash, std::string GRCAddress, double distance);
-extern double ExtractMagnitudeFromExplainMagnitude();
 extern void GridcoinServices();
 extern bool StrLessThanReferenceHash(std::string rh);
 extern bool IsContract(CBlockIndex* pIndex);
@@ -56,9 +54,6 @@ int64_t GetEarliestWalletTransaction();
 extern void IncrementVersionCount(const std::string& Version);
 extern bool LoadAdminMessages(bool bFullTableScan,std::string& out_errors);
 extern std::string GetCurrentNeuralNetworkSupermajorityHash(double& out_popularity);
-
-bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit);
-extern bool FullSyncWithDPORNodes();
 
 extern bool GetEarliestStakeTime(std::string grcaddress, std::string cpid);
 extern double GetTotalBalance();
@@ -181,7 +176,6 @@ std::string    msMiningErrors7;
 std::string    msMiningErrors8;
 std::string    msMiningErrorsIncluded;
 std::string    msMiningErrorsExcluded;
-std::string    msNeuralResponse;
 std::string    msHDDSerial;
 //When syncing, we grandfather block rejection rules up to this block, as rules became stricter over time and fields changed
 
@@ -225,28 +219,6 @@ bool TimerMain(std::string timer_name, int max_ms)
         return true;
     }
     return false;
-}
-
-bool FullSyncWithDPORNodes()
-{
-    if(!NN::GetInstance()->IsEnabled())
-        return false;
-    // 3-30-2016 : First try to get the master database from another neural network node if these conditions occur:
-    // The foreign node is fully synced.  The foreign nodes quorum hash matches the supermajority hash.  My hash != supermajority hash.
-    double dCurrentPopularity = 0;
-    std::string sCurrentNeuralSupermajorityHash = GetCurrentNeuralNetworkSupermajorityHash(dCurrentPopularity);
-    std::string sMyNeuralHash = NN::GetInstance()->GetNeuralHash();
-    if (!sMyNeuralHash.empty() && sMyNeuralHash != sCurrentNeuralSupermajorityHash)
-    {
-        bool bNodeOnline = RequestSupermajorityNeuralData();
-        if (bNodeOnline)
-            return false;  // Async call to another node will continue after the node responds.
-    }
-
-    std::string errors1;
-    LoadAdminMessages(false,errors1);
-    NN::GetInstance()->SynchronizeDPOR(GetConsensusBeaconList());
-    return true;
 }
 
 double GetEstimatedNetworkWeight(unsigned int nPoSInterval)
@@ -3620,57 +3592,6 @@ void GridcoinServices()
         LogPrintf("Daily backup results: Wallet -> %s Config -> %s", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
     }
 
-    if (TimerMain("MyNeuralMagnitudeReport",30))
-    {
-        try
-        {
-            std::string primary_cpid = NN::GetPrimaryCpid();
-
-            if (msNeuralResponse.length() < 25 && IsResearcher(primary_cpid))
-            {
-                AsyncNeuralRequest("explainmag", primary_cpid, 5);
-                if (fDebug3) LogPrintf("Async explainmag sent for %s.", primary_cpid);
-            }
-            if (fDebug3) LogPrintf("MR Complete");
-        }
-        catch (std::exception &e)
-        {
-            LogPrintf("Error in MyNeuralMagnitudeReport1.");
-        }
-        catch(...)
-        {
-            LogPrintf("Error in MyNeuralMagnitudeReport.");
-        }
-    }
-
-    // Every N blocks as a Synchronized TEAM:
-    if ((nBestHeight % 30) == 0)
-    {
-        //Sync RAC with neural network IF superblock is over 24 hours Old, Or if we have No superblock (in case of the latter, age will be 45 years old)
-        // Note that nodes will NOT accept superblocks without a supermajority hash, so the last block will not be in memory unless it is a good superblock.
-        // Let's start syncing the neural network as soon as the LAST superblock is over 12 hours old.
-        // Also, lets do this as a TEAM exactly every 30 blocks (~30 minutes) to try to reach an EXACT consensus every half hour:
-        // For effeciency, the network sleeps for 20 hours after a good superblock is accepted
-        if (NN::Tally::SuperblockNeeded() && IsNeuralNodeParticipant(DefaultWalletAddress(), GetAdjustedTime()))
-        {
-            if (fDebug3) LogPrintf("FSWDPOR ");
-            FullSyncWithDPORNodes();
-        }
-    }
-
-    if (( (nBestHeight-10) % 30 ) == 0)
-    {
-        // 10 Blocks after the network started syncing the neural network as a team, ask the neural network to come to a quorum
-        if (NN::Tally::SuperblockNeeded() && IsNeuralNodeParticipant(DefaultWalletAddress(), GetAdjustedTime()))
-        {
-            // First verify my node has a synced contract
-            if (NN::GetInstance()->GetSuperblockContract().WellFormed())
-            {
-                AsyncNeuralRequest("quorum","gridcoin",25);
-            }
-        }
-    }
-
     /* Do this only for users with valid CPID */
     if (TimerMain("send_beacon", 180)) {
         if (const NN::CpidOption cpid = NN::Researcher::Get()->Id().TryCpid()) {
@@ -3690,9 +3611,6 @@ void GridcoinServices()
             }
         }
     }
-
-    if (TimerMain("gather_cpids",480))
-        msNeuralResponse.clear();
 }
 
 bool AskForOutstandingBlocks(uint256 hashStart)
@@ -4521,47 +4439,6 @@ std::string NodeAddress(CNode* pfrom)
     return ip;
 }
 
-double ExtractMagnitudeFromExplainMagnitude()
-{
-        if (msNeuralResponse.empty()) return 0;
-        try
-        {
-            std::vector<std::string> vMag = split(msNeuralResponse.c_str(),"<ROW>");
-            for (unsigned int i = 0; i < vMag.size(); i++)
-            {
-                if (Contains(vMag[i],"Total Mag:"))
-                {
-                    std::vector<std::string> vMyMag = split(vMag[i].c_str(),":");
-                    if (vMyMag.size() > 0)
-                    {
-                        std::string sSubMag = vMyMag[1];
-                        boost::replace_all(sSubMag, " ", "");
-                        double dMag = RoundFromString("0"+sSubMag,0);
-                        return dMag;
-                    }
-                }
-            }
-            return 0;
-        }
-        catch(...)
-        {
-            return 0;
-        }
-        return 0;
-}
-
-bool VerifyExplainMagnitudeResponse()
-{
-    if (msNeuralResponse.empty())
-        return false;
-
-            double dMag = ExtractMagnitudeFromExplainMagnitude();
-            if (dMag==0)
-        msNeuralResponse.clear();
-
-    return dMag != 0;
-            }
-
 bool SecurityTest(CNode* pfrom, bool acid_test)
 {
     if (pfrom->nStartingHeight > (nBestHeight*.5) && acid_test) return true;
@@ -5267,33 +5144,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (!tracker.IsNull())
             tracker.fn(tracker.param1, vRecv);
     }
-    else if (strCommand == "neural")
-    {
-        std::string neural_request = "";
-        std::string neural_request_id = "";
-        vRecv >> neural_request >> neural_request_id;  // foreign node issued neural request with request ID:
-        std::string neural_response = "generic_response";
-
-        if (neural_request=="neural_data")
-        {
-            pfrom->PushMessage("ndata_nresp", NN::GetInstance()->GetNeuralContract());
-        }
-        else if (neural_request=="neural_hash")
-        {
-            pfrom->PushMessage("hash_nresp", NN::GetInstance()->GetNeuralHash());
-        }
-        else if (neural_request=="explainmag")
-        {
-            pfrom->PushMessage(
-                        "expmag_nresp",
-                        NN::GetInstance()->ExplainMagnitude(neural_request_id));
-        }
-        else if (neural_request=="quorum")
-        {
-            // 7-12-2015 Resolve discrepencies in w nodes to speak to each other
-            pfrom->PushMessage("quorum_nresp", NN::GetInstance()->GetNeuralContract());
-        }
-    }
     else if (strCommand == "ping")
     {
         std::string acid = "";
@@ -5370,41 +5220,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (bPingFinished) {
             pfrom->nPingNonceSent = 0;
         }
-    }
-    else if (strCommand == "hash_nresp")
-    {
-        std::string neural_response = "";
-        vRecv >> neural_response;
-        // if (pfrom->nNeuralRequestSent != 0)
-        // nNeuralNonce must match request ID
-        pfrom->NeuralHash = neural_response;
-        if (fDebug10) LogPrintf("hash_Neural Response %s ",neural_response);
-    }
-    else if (strCommand == "expmag_nresp")
-    {
-            std::string neural_response = "";
-            vRecv >> neural_response;
-            if (neural_response.length() > 10)
-            {
-                msNeuralResponse=neural_response;
-                //If invalid, try again 10-20-2015
-                VerifyExplainMagnitudeResponse();
-            }
-            if (fDebug10) LogPrintf("expmag_Neural Response %s ",neural_response);
-    }
-    else if (strCommand == "quorum_nresp")
-    {
-        std::string neural_contract = "";
-        vRecv >> neural_contract;
-        if (fDebug && neural_contract.length() > 100) LogPrintf("Quorum contract received %s",neural_contract.substr(0,80));
-    }
-    else if (strCommand == "ndata_nresp")
-    {
-        std::string neural_contract;
-        vRecv >> neural_contract;
-        if (fDebug3 && neural_contract.length() > 100) LogPrintf("Quorum contract received %s",neural_contract.substr(0,80));
-        if (neural_contract.length() > 10)
-            FullSyncWithDPORNodes();
     }
     else if (strCommand == "alert")
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4482,13 +4482,20 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CAddress addrMe;
         CAddress addrFrom;
         uint64_t nNonce = 1;
-        std::string acid = "";
-        vRecv >> pfrom->nVersion >> pfrom->boinchashnonce >> pfrom->boinchashpw >> pfrom->cpid >> pfrom->enccpid >> acid >> pfrom->nServices >> nTime >> addrMe;
+        std::string legacy_dummy;
+
+        vRecv >> pfrom->nVersion
+            >> legacy_dummy      // pfrom->boinchashnonce
+            >> legacy_dummy      // pfrom->boinchashpw
+            >> legacy_dummy      // pfrom->cpid
+            >> legacy_dummy      // pfrom->enccpid
+            >> legacy_dummy      // acid
+            >> pfrom->nServices
+            >> nTime
+            >> addrMe;
 
         if (fDebug10)
-            LogPrintf("received aries version %i boinchashnonce %s boinchashpw %s cpid %s enccpid %s acid %s ..."
-                      ,pfrom->nVersion, pfrom->boinchashnonce, pfrom->boinchashpw
-                      ,pfrom->cpid.c_str(), pfrom->enccpid, acid);
+            LogPrintf("received aries version %i ...", pfrom->nVersion);
 
         int64_t timedrift = std::abs(GetAdjustedTime() - nTime);
 
@@ -4546,7 +4553,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // 12-5-2015 - Append Trust fields
         pfrom->nTrust = 0;
 
-        if (!vRecv.empty())         vRecv >> pfrom->sGRCAddress;
+        if (!vRecv.empty())         vRecv >> legacy_dummy; // pfrom->sGRCAddress;
 
 
         // Allow newbies to connect easily with 0 blocks

--- a/src/main.h
+++ b/src/main.h
@@ -198,7 +198,6 @@ extern std::string  msMiningErrors8;
 extern std::string  msMiningErrorsIncluded;
 extern std::string  msMiningErrorsExcluded;
 
-extern std::string  msNeuralResponse;
 extern std::string  msHDDSerial;
 extern bool         mbBlocksDownloaded;
 extern int nGrandfather;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -724,8 +724,8 @@ void CNode::PushVersion()
     std::string sboinchashargs;
     std::string nonce;
     std::string pw1;
-    std::string mycpid = "INVESTOR";
-    std::string acid = GetCommandNonce("aries");
+    std::string mycpid;
+    std::string acid;
 
     PushMessage("aries", PROTOCOL_VERSION, nonce, pw1,
                 mycpid, mycpid, acid, nLocalServices, nTime, addrYou, addrMe,
@@ -809,7 +809,6 @@ void CNode::copyStats(CNodeStats &stats)
     stats.strSubVer = strSubVer;
     stats.fInbound = fInbound;
     stats.nStartingHeight = nStartingHeight;
-    stats.sGRCAddress = sGRCAddress;
     stats.nTrust = nTrust;
     stats.nMisbehavior = GetMisbehavior();
 

--- a/src/net.h
+++ b/src/net.h
@@ -149,8 +149,6 @@ public:
     double dPingWait;
 	std::string addrLocal;
 	int nTrust;
-	std::string sGRCAddress;
-	//std::string securityversion;
 };
 
 
@@ -226,13 +224,6 @@ public:
     CService addrLocal;
     int nVersion;
     std::string strSubVer;
-	std::string boinchashnonce;
-	std::string boinchashpw;
-	//12-10-2014 CPID Support
-	std::string cpid;
-	std::string enccpid;
-	std::string NeuralHash;
-	std::string sGRCAddress;
 	int nTrust;
 	////////////////////////
 
@@ -307,7 +298,6 @@ public:
         addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
         nVersion = 0;
         strSubVer = "";
-		//securityversion = "";
         fOneShot = false;
         fClient = false; // set by version message
         fInbound = fInboundIn;
@@ -326,8 +316,6 @@ public:
 		nLastOrphan=0;
 		nOrphanCount=0;
 		nOrphanCountViolations=0;
-		NeuralHash = "";
-		sGRCAddress = "";
 		nTrust = 0;
         hashCheckpointKnown.SetNull();
         setInventoryKnown.max_size(SendBufferSize() / 1000);

--- a/src/neuralnet/neuralnet.h
+++ b/src/neuralnet/neuralnet.h
@@ -34,16 +34,6 @@ namespace NN
         virtual bool IsEnabled() = 0;
 
         //!
-        //! \brief Get application neural version.
-        //!
-        //! Fetches the application version with the neural network magic suffix
-        //! (\c 1999) if the neural net is enabled.
-        //!
-        //! \return Current application version with proper neural suffix.
-        //!
-        virtual std::string GetNeuralVersion() = 0;
-
-        //!
         //! \brief Get current neural hash from neural net.
         //!
         //! \note This is a synchoronous operation.
@@ -95,8 +85,6 @@ namespace NN
         virtual bool SynchronizeDPOR(const BeaconConsensus& beacons) = 0;
 
         virtual std::string ExplainMagnitude(const std::string& cpid) = 0;
-
-        virtual int64_t IsNeuralNet() = 0;
     };
 
     //!

--- a/src/neuralnet/neuralnet_native.cpp
+++ b/src/neuralnet/neuralnet_native.cpp
@@ -17,13 +17,6 @@ bool NeuralNetNative::IsEnabled()
     return GetArgument("disableneuralnetwork", "false") == "false";
 }
 
-// This is for compatibility
-std::string NeuralNetNative::GetNeuralVersion()
-{
-    int64_t neural_id = IsNeuralNet();
-    return std::to_string(CLIENT_VERSION_MINOR) + "." + std::to_string(neural_id);
-}
-
 std::string NeuralNetNative::GetNeuralHash()
 {
     return GetSuperblockHash().ToString();
@@ -54,12 +47,4 @@ bool NeuralNetNative::SynchronizeDPOR(const BeaconConsensus& beacons)
 std::string NeuralNetNative::ExplainMagnitude(const std::string& cpid)
 {
     return ::ExplainMagnitude(cpid);
-}
-
-int64_t NeuralNetNative::IsNeuralNet()
-{
-    // This is the NN version number. TODO: Consider different number for new NN?
-    int64_t nNeuralNetVersion = 1999;
-
-    return nNeuralNetVersion;
 }

--- a/src/neuralnet/neuralnet_native.h
+++ b/src/neuralnet/neuralnet_native.h
@@ -14,13 +14,11 @@ namespace NN
     private:
         // Documentation in interface.
         bool IsEnabled();
-        std::string GetNeuralVersion();
         std::string GetNeuralHash();
         NN::QuorumHash GetSuperblockHash();
         std::string GetNeuralContract();
         NN::Superblock GetSuperblockContract();
         bool SynchronizeDPOR(const BeaconConsensus& beacons);
         std::string ExplainMagnitude(const std::string& cpid);
-        int64_t IsNeuralNet();
     };
 }

--- a/src/neuralnet/neuralnet_stub.cpp
+++ b/src/neuralnet/neuralnet_stub.cpp
@@ -9,11 +9,6 @@ bool NeuralNetStub::IsEnabled()
     return false;
 }
 
-std::string NeuralNetStub::GetNeuralVersion()
-{
-    return "0";
-}
-
 std::string NeuralNetStub::GetNeuralHash()
 {
     return std::string();
@@ -48,9 +43,4 @@ bool NeuralNetStub::SynchronizeDPOR(const BeaconConsensus& beacons)
 std::string NeuralNetStub::ExplainMagnitude(const std::string& data)
 {
     return std::string();
-}
-
-int64_t NeuralNetStub::IsNeuralNet()
-{
-    return 0;
 }

--- a/src/neuralnet/neuralnet_stub.h
+++ b/src/neuralnet/neuralnet_stub.h
@@ -14,13 +14,11 @@ namespace NN
     private:
         // Documentation in interface.
         bool IsEnabled();
-        std::string GetNeuralVersion();
         std::string GetNeuralHash();
         NN::QuorumHash GetSuperblockHash();
         std::string GetNeuralContract();
         NN::Superblock GetSuperblockContract();
         bool SynchronizeDPOR(const BeaconConsensus& beacons);
         std::string ExplainMagnitude(const std::string& data);
-        int64_t IsNeuralNet();
     };
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -442,9 +442,6 @@ void RPCConsole::clear()
                 "b { color: #006060; } "
                 );
 
-	//Gridcoin:  Find an open neural node for any neural requests from RPC: (7-23-2015)
-
-
     message(CMD_REPLY, (tr("Welcome to the Gridcoin RPC console! ") + "<br>" +
                         tr("Use up and down arrows to navigate history, and <b>Ctrl-L</b> to clear screen.") + "<br>" +
                         tr("Type <b>help</b> for an overview of available commands.")), true);

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -309,22 +309,6 @@ UniValue ping(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
-// Moved to CNode static.
-/*
-static void CopyNodeStats(std::vector<CNodeStats>& vstats)
-{
-    vstats.clear();
-
-    LOCK(cs_vNodes);
-    vstats.reserve(vNodes.size());
-    for (auto const& pnode : vNodes) {
-        CNodeStats stats;
-        pnode->copyStats(stats);
-        vstats.push_back(stats);
-    }
-}
-*/
-
 UniValue getpeerinfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -372,11 +356,7 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
         bool bNeural = false;
         bNeural = Contains(stats.strSubVer, "1999");
         obj.pushKV("Neural Network", bNeural);
-        if (bNeural)
-        {
-            obj.pushKV("Neural Participant", IsNeuralNodeParticipant(stats.sGRCAddress, GetAdjustedTime()));
 
-        }
         ret.push_back(obj);
     }
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -13,12 +13,6 @@
 #include "banman.h"
 
 using namespace std;
-extern std::string NeuralRequest(std::string MyNeuralRequest);
-extern bool RequestSupermajorityNeuralData();
-std::string GetCurrentNeuralNetworkSupermajorityHash(double& out_popularity);
-extern void GatherNeuralHashes();
-extern bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit);
-
 
 UniValue getconnectioncount(const UniValue& params, bool fHelp)
 {
@@ -31,60 +25,6 @@ UniValue getconnectioncount(const UniValue& params, bool fHelp)
     LOCK(cs_vNodes);
 
     return (int)vNodes.size();
-}
-
-
-std::string NeuralRequest(std::string MyNeuralRequest)
-{
-    // Find a Neural Network Node that is free
-    LOCK(cs_vNodes);
-    for (auto const& pNode : vNodes)
-    {
-        if (Contains(pNode->strSubVer,"1999"))
-        {
-            std::string reqid = "reqid";
-            pNode->PushMessage("neural", MyNeuralRequest, reqid);
-            if (fDebug3) LogPrintf(" PUSH ");
-        }
-    }
-    return "";
-}
-
-
-void GatherNeuralHashes()
-{
-    // Find a Neural Network Node that is free
-    LOCK(cs_vNodes);
-    for (auto const& pNode : vNodes)
-    {
-        if (Contains(pNode->strSubVer,"1999"))
-        {
-            std::string reqid = "reqid";
-            std::string command_name="neural_hash";
-            pNode->PushMessage("neural", command_name, reqid);
-            if (fDebug10) LogPrintf(" Pushed ");
-        }
-    }
-}
-
-
-bool RequestSupermajorityNeuralData()
-{
-    LOCK(cs_vNodes);
-    double dCurrentPopularity = 0;
-    std::string sCurrentNeuralSupermajorityHash = GetCurrentNeuralNetworkSupermajorityHash(dCurrentPopularity);
-    std::string reqid = DefaultWalletAddress();
-
-    for (auto const& pNode : vNodes)
-    {
-        if (!pNode->NeuralHash.empty() && !sCurrentNeuralSupermajorityHash.empty() && pNode->NeuralHash == sCurrentNeuralSupermajorityHash)
-        {
-            std::string command_name="neural_data";
-            pNode->PushMessage("neural", command_name, reqid);
-            return true;
-        }
-    }
-    return false;
 }
 
 UniValue addnode(const UniValue& params, bool fHelp)
@@ -350,31 +290,6 @@ UniValue clearbanned(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
-
-bool AsyncNeuralRequest(std::string command_name,std::string cpid,int NodeLimit)
-{
-    // Find a Neural Network Node that is free
-    LOCK(cs_vNodes);
-    int iContactCount = 0;
-    msNeuralResponse="";
-    for (auto const& pNode : vNodes)
-    {
-        if (Contains(pNode->strSubVer,"1999"))
-        {
-            std::string reqid = cpid;
-            pNode->PushMessage("neural", command_name, reqid);
-            iContactCount++;
-            if (iContactCount >= NodeLimit) return true;
-        }
-    }
-    if (iContactCount==0)
-    {
-        LogPrintf("No neural network nodes online.");
-        return false;
-    }
-    return true;
-}
-
 UniValue ping(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -426,8 +341,6 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
 
         CNode::CopyNodeStats(vstats);
     }
-
-    GatherNeuralHashes();
 
     for (auto const& stats : vstats) {
         UniValue obj(UniValue::VOBJ);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -356,7 +356,6 @@ static const CRPCCommand vRPCCommands[] =
     { "staketime",               &staketime,               cat_mining        },
     { "superblockage",           &superblockage,           cat_mining        },
     { "superblocks",             &superblocks,             cat_mining        },
-    { "syncdpor2",               &syncdpor2,               cat_mining        },
     { "upgradedbeaconreport",    &upgradedbeaconreport,    cat_mining        },
 
   // Developer commands
@@ -369,8 +368,6 @@ static const CRPCCommand vRPCCommands[] =
     { "debug4",                  &debug4,                  cat_developer     },
     { "debugnet",                &debugnet,                cat_developer     },
     { "exportstats1",            &rpc_exportstats,         cat_developer     },
-    { "forcequorum",             &forcequorum,             cat_developer     },
-    { "gatherneuralhashes",      &gatherneuralhashes,      cat_developer     },
     { "getblockstats",           &rpc_getblockstats,       cat_developer     },
     { "getlistof",               &getlistof,               cat_developer     },
     { "getrecentblocks",         &rpc_getrecentblocks,     cat_developer     },
@@ -379,7 +376,6 @@ static const CRPCCommand vRPCCommands[] =
     { "listprojects",            &listprojects,            cat_developer     },
     { "memorizekeys",            &memorizekeys,            cat_developer     },
     { "network",                 &network,                 cat_developer     },
-    { "neuralrequest",           &neuralrequest,           cat_developer     },
     { "projects",                &projects,                cat_developer     },
     { "readconfig",              &readconfig,              cat_developer     },
     { "readdata",                &readdata,                cat_developer     },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -177,7 +177,6 @@ extern UniValue resetcpids(const UniValue& params, bool fHelp);
 extern UniValue staketime(const UniValue& params, bool fHelp);
 extern UniValue superblockage(const UniValue& params, bool fHelp);
 extern UniValue superblocks(const UniValue& params, bool fHelp);
-extern UniValue syncdpor2(const UniValue& params, bool fHelp);
 extern UniValue upgradedbeaconreport(const UniValue& params, bool fHelp);
 
 // Developers
@@ -189,15 +188,12 @@ extern UniValue debug2(const UniValue& params, bool fHelp);
 extern UniValue debug3(const UniValue& params, bool fHelp);
 extern UniValue debug4(const UniValue& params, bool fHelp);
 extern UniValue debugnet(const UniValue& params, bool fHelp);
-extern UniValue forcequorum(const UniValue& params, bool fHelp);
-extern UniValue gatherneuralhashes(const UniValue& params, bool fHelp);
 extern UniValue rpc_getblockstats(const UniValue& params, bool fHelp);
 extern UniValue getlistof(const UniValue& params, bool fHelp);
 extern UniValue listdata(const UniValue& params, bool fHelp);
 extern UniValue listprojects(const UniValue& params, bool fHelp);
 extern UniValue memorizekeys(const UniValue& params, bool fHelp);
 extern UniValue network(const UniValue& params, bool fHelp);
-extern UniValue neuralrequest(const UniValue& params, bool fHelp);
 extern UniValue projects(const UniValue& params, bool fHelp);
 extern UniValue readconfig(const UniValue& params, bool fHelp);
 extern UniValue readdata(const UniValue& params, bool fHelp);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -86,7 +86,6 @@ bool fNoListen = false;
 bool fLogTimestamps = false;
 CMedianFilter<int64_t> vTimeOffsets(200,0);
 bool fReopenDebugLog = false;
-std::string GetNeuralVersion();
 
 bool fDevbuildCripple;
 
@@ -1181,25 +1180,14 @@ std::vector<std::string> split(const std::string& s, const std::string& delim)
     return elems;
 }
 
-std::string GetNeuralVersion()
-{
-    std::string neural_v = "0";
-    int64_t neural_id = NN::GetInstance()->IsNeuralNet();
-    neural_v = ToString(CLIENT_VERSION_MINOR) + "." + ToString(neural_id);
-    return neural_v;
-}
-
 // Format the subversion field according to BIP 14 spec (https://en.bitcoin.it/wiki/BIP_0014)
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
 {
-    std::string neural_v = GetNeuralVersion();
-
     std::ostringstream ss;
     ss << "/";
     ss << name << ":" << FormatVersion(nClientVersion);
 
     if (!comments.empty())         ss << "(" << boost::algorithm::join(comments, "; ") << ")";
-    ss << "(" << neural_v << ")";
 
     ss << "/";
     return ss.str();


### PR DESCRIPTION
This removes the old quorum messaging code superseded by the scraper. The system was used to share superblock contract data between nodes participating in the "neural network". After the release of the scraper with version 4.0.3, this code remained to allow older versions to continue to participate in the superblock formation process.

Today, between 90-95% of nodes run a version of Gridcoin that supports the scraper system, so we can remove the old neural networking code without disrupting superblock formation. Remaining nodes running version 4.0.2 and earlier will gradually lose the ability to use the `explainmagnitude` RPC command as nodes upgrade to the release following this PR. Since this will be a mandatory release, these nodes will need to upgrade anyway. 