### PR TITLE
Reenable Travis builds for MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,9 @@ env:
     - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" PACKAGES="python3 nsis g++-mingw-w64-i686" DEP_OPTS="NO_QT=1" RUN_TESTS=false GOAL="" GRIDCOIN_CONFIG="--enable-reduce-exports"
 # ARM
     - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" GCCFLAGS="-fPIC" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" GRIDCOIN_CONFIG="--enable-glibc-back-compat --disable-tests RUN_TESTS=false"
-# Cross-Mac - disabled for now, since we cannot compile QtSVG with the SDK
-    #- HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" GRIDCOIN_CONFIG="--enable-gui --enable-reduce-exports" OSX_SDK=10.11 RUN_TESTS=false GOAL="deploy"
+# Cross-Mac - Qt is disabled for now, since we cannot compile QtSVG with the SDK, also asm optimizations are disabled until we can straighten out scrypt .S files and Clang. Also the deploy stage is disabled until the qt5
+# can be figured out.
+    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" DEP_OPTS="NO_QT=1" GRIDCOIN_CONFIG="--enable-reduce-exports --disable-asm" OSX_SDK=10.11 RUN_TESTS=false GOAL=""
     
 # Note windows builds may need xvfb package and NEED_XVFB=1 if NO_QT=1 is removed (i.e. QT build is enabled again).
 
@@ -52,7 +53,7 @@ before_script:
     - unset CC; unset CXX
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
-    - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
+    - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -zxf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -z "$NO_DEPENDS" ]; then make $MAKEJOBS -C depends HOST=$HOST GCCFLAGS=$GCCFLAGS $DEP_OPTS; fi
     # Start xvfb if needed, as documented at https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
     - if [ "$NEED_XVFB" = 1 ]; then export DISPLAY=:99.0; /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac; fi

--- a/depends/packages/bzip2.mk
+++ b/depends/packages/bzip2.mk
@@ -10,8 +10,8 @@ define $(package)_set_vars
   $(package)_build_opts+=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
   $(package)_build_opts+=RANLIB="$($(package)_ranlib)"
   $(package)_build_opts+=AR="$($(package)_ar)"
-  $(package)_build_opts_darwin+=AR="$($(package)_libtool)"
-  $(package)_build_opts_darwin+=ARFLAGS="-o"
+  # $(package)_build_opts_darwin+=AR="$($(package)_libtool)"
+  # $(package)_build_opts_darwin+=ARFLAGS="-o"
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/libzip.mk
+++ b/depends/packages/libzip.mk
@@ -12,8 +12,6 @@ define $(package)_set_vars
   $(package)_build_opts+=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
   $(package)_build_opts+=RANLIB="$($(package)_ranlib)"
   $(package)_build_opts+=AR="$($(package)_ar)"
-  $(package)_build_opts_darwin+=AR="$($(package)_libtool)"
-  $(package)_build_opts_darwin+=ARFLAGS="-o"
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)
@@ -33,7 +31,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  CFLAGS=$(i686_cflag) ./configure --host=$(host) --prefix=$(host_prefix) --with-zlib=$(host_prefix) --with-bzip2=$(host_prefix) --with-pic --enable-static --enable-shared=no
+  $($(package)_build_opts) CFLAGS=$(i686_cflag)  ./configure --host=$(host) --prefix=$(host_prefix) --with-zlib=$(host_prefix) --with-bzip2=$(host_prefix) --with-pic --enable-static --enable-shared=no
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
This makes adjustments to .travis.yml and depends packages to reenable continuous integration builds. Note that the MacOS build, like all the builds other than the main Linux x86_64 non-depends build, is done with Qt off. For the other builds, this is done because of the 50 min Travis timeout. For MacOS it is for that reason, and also because the SVG module in Qt doesn't compile with the 10.11 SDK currently.

This is better than nothing for now. We really need to move to a container based build approach similar to current Bitcoin.