### PR TITLE
Remove old remnants of legacy smart contract experiments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,6 @@ extern bool LessVerbose(int iMax1000);
 double         mdPORNonce = 0;
 double         mdMachineTimerLast = 0;
 // Mining status variables
-std::string    msHashBoinc;
 std::string    msMiningErrors;
 std::string    msPoll;
 std::string    msMiningErrors5;

--- a/src/main.h
+++ b/src/main.h
@@ -187,7 +187,6 @@ static const uint64_t nMinDiskSpace = 52428800;
 extern double       mdPORNonce;
 extern double       mdMachineTimerLast;
 
-extern std::string  msHashBoinc;
 extern std::string  msMiningErrors;
 extern std::string  msPoll;
 extern std::string  msMiningErrors5;

--- a/src/qt/forms/transactiondescdialog.ui
+++ b/src/qt/forms/transactiondescdialog.ui
@@ -49,16 +49,6 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="executeButton">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Execute Contract</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="closeButton">
        <property name="text">
         <string>C&amp;lose</string>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -333,11 +333,6 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
         }
     }
 
-    // Debug view 12-7-2014 - Halford
-	// Smart Contracts
-
-    msHashBoinc = "";
-
     if (fDebug || true)
     {
         strHTML += "<hr><br><b>" + tr("Transaction Debits/Credits") + "</b><br><br>";
@@ -357,18 +352,6 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
 
         CTxDB txdb("r"); // To fetch source txouts
 
-        // Contracts
-		//std::string sContractLength = RoundToString((double)wtx.hashBoinc.length(),0);
-		//std::string sContractInfo = "";
-		//if (wtx.hashBoinc.length() > 255) sContractInfo = ": " + wtx.hashBoinc.substr(0,255);
-
-        //if (fDebug3)
-        //{
-				//Extract contract here from : wtx.hashBoinc - contract key
-				//strHTML += "<br><b>Contracts:</b> " + QString::fromStdString(sContractLength) + "<p><br>";
-        //}
-
-		msHashBoinc += wtx.hashBoinc;
         strHTML += "<br><b>" + tr("Transaction Inputs") + "</b>";
         strHTML += "<ul>";
 

--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -15,8 +15,6 @@ TransactionDescDialog::TransactionDescDialog(const QModelIndex &idx, QWidget *pa
     ui->setupUi(this);
     QString desc = idx.data(TransactionTableModel::LongDescriptionRole).toString();
     ui->detailText->setHtml(desc);
-    //If smart contract is populated
-    ui->executeButton->setVisible(Contains(msHashBoinc,"<CODE>"));
 }
 
 TransactionDescDialog::~TransactionDescDialog()


### PR DESCRIPTION
This is a small clean-up that removes an "execute" button that appears in the transaction description dialog when a transaction contains some (now meaningless) VBScript metadata for what was apparently the beginnings of a smart contract system. The PR cleans up the remaining global state used to marshal the code to the interpreter.