### PR TITLE
Improve the "versionreport" RPC output

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -184,6 +184,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendalert2"             , 4 },
     { "sendalert2"             , 5 },
     { "testnewsb"              , 0 },
+    { "versionreport"          , 0 },
+    { "versionreport"          , 1 },
 
     // Network
     { "addpoll"                , 1 },


### PR DESCRIPTION
This improves the usefulness of the "versionreport" RPC output by
aggregating version strings without the commit ID suffix. It adds
a configurable parameter to specify the number of blocks to count
versions backward from, structures output as pure JSON, and looks
back one day's blocks by default instead of 100 blocks as before.

The changes decouple the RPC method from the old quorum caches as
a step to prepare the application for an upcoming transition away
from the quorum system.