### PR TITLE
Fix deadlock in "getmininginfo" RPC function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -524,6 +524,19 @@ void GetGlobalStatus()
             sWeight = sWeight.substr(0,13) + "E" + RoundToString((double)sWeight.length()-13,0);
         }
 
+        std::string current_poll;
+
+        try
+        {
+            LOCK(cs_main);
+            current_poll = GetCurrentOverviewTabPoll();
+        }
+        catch (std::exception &e)
+        {
+            current_poll = _("No current polls");
+            LogPrintf("Error obtaining last poll: %s", e.what());
+        }
+
         // It is necessary to assign a local variable for ETTS to avoid an occasional deadlock between the lock below,
         // the lock on cs_main in GetEstimateTimetoStake(), and the corresponding lock in the stakeminer.
         double dETTS = GetEstimatedTimetoStake()/86400.0;
@@ -538,15 +551,7 @@ void GetGlobalStatus()
         GlobalStatusStruct.ETTS = RoundToString(dETTS,3);
         GlobalStatusStruct.ERRperday = RoundToString(boincmagnitude * NN::Tally::GetMagnitudeUnit(GetAdjustedTime()),2);
         GlobalStatusStruct.cpid = NN::GetPrimaryCpid();
-        try
-        {
-            GlobalStatusStruct.poll = GetCurrentOverviewTabPoll();
-        }
-        catch (std::exception &e)
-        {
-            GlobalStatusStruct.poll = _("No current polls");
-            LogPrintf("Error obtaining last poll: %s", e.what());
-        }
+        GlobalStatusStruct.poll = std::move(current_poll);
 
         GlobalStatusStruct.status = msMiningErrors;
 
@@ -589,7 +594,7 @@ void GetGlobalStatus()
 
 std::string GetCurrentOverviewTabPoll()
 {
-    AssertLockHeld(MinerStatus.lock);
+    AssertLockHeld(cs_main);
 
     // The global msPoll variable contains the poll most-recently published to
     // the network. If it hasn't expired, return the title of this poll:

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -21,11 +21,6 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
             "\n"
             "Returns an object containing mining-related information\n");
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    uint64_t nWeight = 0;
-    int64_t nTime= GetAdjustedTime();
-    pwalletMain->GetStakeWeight(nWeight);
     UniValue obj(UniValue::VOBJ);
     UniValue diff(UniValue::VOBJ);
     UniValue weight(UniValue::VOBJ);
@@ -35,16 +30,26 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     UniValue sidestakingalloc(UniValue::VOBJ);
     UniValue vsidestakingalloc(UniValue::VARR);
 
-    double nNetworkWeight = GetEstimatedNetworkWeight();
-    double nNetworkValue = nNetworkWeight / 80.0;
-    obj.pushKV("blocks",        nBestHeight);
-    diff.pushKV("proof-of-stake",    GetDifficulty(GetLastBlockIndex(pindexBest, true)));
+    int64_t nTime = GetAdjustedTime();
+    uint64_t nWeight = 0;
+    double nNetworkWeight = 0;
+    double nDifficulty = 0;
+    uint64_t nExpectedTime = 0;
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        pwalletMain->GetStakeWeight(nWeight);
 
-    std::string current_poll;
+        nNetworkWeight = GetEstimatedNetworkWeight();
+        nDifficulty = GetDifficulty(GetLastBlockIndex(pindexBest, true));
+        nExpectedTime = GetEstimatedTimetoStake();
+    }
+
+    obj.pushKV("blocks", nBestHeight);
+    diff.pushKV("proof-of-stake", nDifficulty);
+
     { LOCK(MinerStatus.lock);
         // not using real weigh to not break calculation
         bool staking = MinerStatus.nLastCoinStakeSearchInterval && MinerStatus.WeightSum;
-        uint64_t nExpectedTime = GetEstimatedTimetoStake();
         diff.pushKV("last-search-interval", MinerStatus.nLastCoinStakeSearchInterval);
         weight.pushKV("minimum",    MinerStatus.WeightMin);
         weight.pushKV("maximum",    MinerStatus.WeightMax);
@@ -53,7 +58,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         weight.pushKV("legacy",   nWeight/(double)COIN);
         obj.pushKV("stakeweight", weight);
         obj.pushKV("netstakeweight", nNetworkWeight);
-        obj.pushKV("netstakingGRCvalue", nNetworkValue);
+        obj.pushKV("netstakingGRCvalue", nNetworkWeight / 80.0);
         obj.pushKV("staking", staking);
         obj.pushKV("mining-error", MinerStatus.ReasonNotStaking);
         obj.pushKV("time-to-stake_days", nExpectedTime/86400.0);
@@ -64,14 +69,14 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         obj.pushKV("mining-kernels-found", MinerStatus.KernelsFound);
         obj.pushKV("kernel-diff-best",MinerStatus.KernelDiffMax);
         obj.pushKV("kernel-diff-sum",MinerStatus.KernelDiffSum);
-
-        current_poll = GetCurrentOverviewTabPoll();
     }
 
     int64_t nMinStakeSplitValue = 0;
     double dEfficiency = 0;
     int64_t nDesiredStakeSplitValue = 0;
     SideStakeAlloc vSideStakeAlloc;
+
+    LOCK(cs_main);
 
     // nMinStakeSplitValue, dEfficiency, and nDesiredStakeSplitValue are out parameters.
     bool fEnableStakeSplit = GetStakeSplitStatusAndParams(nMinStakeSplitValue, dEfficiency, nDesiredStakeSplitValue);
@@ -127,8 +132,17 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         obj.pushKV("BoincRewardPending", FormatMoney(calc->Accrual(account)));
     }
 
+    std::string current_poll = "Poll: ";
+
+    try {
+        current_poll += GetCurrentOverviewTabPoll();
+    } catch (std::exception &e) {
+        current_poll += _("No current polls");
+        LogPrintf("Error obtaining last poll: %s", e.what());
+    }
+
     obj.pushKV("MiningInfo 1", msMiningErrors);
-    obj.pushKV("MiningInfo 2", "Poll: " + current_poll);
+    obj.pushKV("MiningInfo 2", current_poll);
     obj.pushKV("MiningInfo 5", msMiningErrors5);
     obj.pushKV("MiningInfo 6", msMiningErrors6);
     obj.pushKV("MiningInfo 7", msMiningErrors7);


### PR DESCRIPTION
This alleviates lock contention between `GetGlobalStatus()`, the miner, and the `getmininginfo` RPC function in an attempt to resolve #1574 and slightly improves the thread safetiness of the `GetCurrentOverviewTabPoll()` function. 