### PR TITLE
Fix accuracy of statistics in "network" RPC output

### DIFF
--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -9,6 +9,7 @@
 #include "appcache.h"
 #include "init.h" // for pwalletMain
 #include "block.h"
+#include "neuralnet/quorum.h"
 #include "neuralnet/tally.h"
 
 double GetTotalBalance();
@@ -461,9 +462,9 @@ double ReturnVerifiedVotingMagnitude(std::string sXML, bool bCreatedAfterSecurit
 
 double GetMoneySupplyFactor()
 {
-    const NN::NetworkStats stats = NN::Tally::GetNetworkStats();
+    const NN::SuperblockPtr superblock = NN::Quorum::CurrentSuperblock();
 
-    double TotalNetworkMagnitude = stats.m_total_cpids * stats.m_average_magnitude;
+    double TotalNetworkMagnitude = superblock->m_cpids.TotalMagnitude();
     if (TotalNetworkMagnitude < 100) TotalNetworkMagnitude=100;
     double MoneySupply = DoubleFromAmount(pindexBest->nMoneySupply);
     double Factor = (MoneySupply/TotalNetworkMagnitude+.01);

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -254,7 +254,6 @@ public:
     {
         ResearchAccount& account = m_researchers[cpid];
 
-        account.m_total_block_subsidy += pindex->nInterestSubsidy;
         account.m_total_research_subsidy += pindex->nResearchSubsidy;
 
         if (pindex->nMagnitude > 0) {
@@ -294,7 +293,6 @@ public:
 
         assert(pindex == account.m_last_block_ptr);
 
-        account.m_total_block_subsidy -= pindex->nInterestSubsidy;
         account.m_total_research_subsidy -= pindex->nResearchSubsidy;
 
         if (pindex->nMagnitude > 0) {
@@ -533,8 +531,7 @@ NetworkTally g_network_tally;       //!< Tracks two-week network averages.
 // -----------------------------------------------------------------------------
 
 ResearchAccount::ResearchAccount()
-    : m_total_block_subsidy(0)
-    , m_total_research_subsidy(0)
+    : m_total_research_subsidy(0)
     , m_magnitude(0)
     , m_total_magnitude(0)
     , m_accuracy(0)

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -18,26 +18,6 @@ class Cpid;
 typedef boost::optional<const CBlockIndex*> BlockPtrOption;
 
 //!
-//! \brief A report that contains an overview of network payment statistics
-//! stored in the tally.
-//!
-class NetworkStats
-{
-public:
-    size_t m_total_cpids;       //!< Number of CPIDs as of the last superblock.
-    uint32_t m_total_magnitude; //!< Magnitude as of the last superblock.
-    double m_average_magnitude; //!< Average magnitude as of last superblock.
-    double m_magnitude_unit;    //!< Current magnitude unit.
-
-    double m_two_week_research_subsidy;      //!< Total as of the last tally.
-    double m_average_daily_research_subsidy; //!< Average as of the last tally.
-    double m_max_daily_research_subsidy;     //!< Max research reward constant.
-
-    double m_two_week_block_subsidy;      //!< Total as of the last tally.
-    double m_average_daily_block_subsidy; //!< Average as of the last tally.
-};
-
-//!
 //! \brief Compares CBlockIndex objects by comparing block heights.
 //!
 struct BlockIndexHeightComparator
@@ -425,14 +405,13 @@ public:
     static CBlockIndex* FindTrigger(CBlockIndex* pindex);
 
     //!
-    //! \brief Get a report that contains an overview of the network payment
-    //! statistics stored in the tally.
+    //! \brief Get the maximum network-wide research reward amount per day.
     //!
-    //! \param time If zero, produce a report for the current time.
+    //! \param payment_time Determines the max reward based on a schedule.
     //!
-    //! \return A copy of the current network statistics.
+    //! \return Maximum daily emission in units of GRC (not COIN).
     //!
-    static NetworkStats GetNetworkStats(int64_t time = 0);
+    static double MaxEmission(const int64_t payment_time);
 
     //!
     //! \brief Get the current network magnitude unit.

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -60,7 +60,6 @@ struct BlockIndexHeightComparator
 class ResearchAccount
 {
 public:
-    double m_total_block_subsidy;        //!< Total lifetime block reward paid.
     double m_total_research_subsidy;     //!< Total lifetime research paid.
 
     uint16_t m_magnitude;                //!< Current magnitude in superblock.

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1963,7 +1963,6 @@ UniValue MagnitudeReport(const NN::Cpid cpid)
     json.pushKV("Expected Earnings (14 days)", calc->ExpectedDaily(account) * 14);
     json.pushKV("Expected Earnings (Daily)", calc->ExpectedDaily(account));
 
-    json.pushKV("Lifetime Stake Paid", account.m_total_block_subsidy);
     json.pushKV("Lifetime Research Paid", account.m_total_research_subsidy);
     json.pushKV("Lifetime Magnitude Sum", (int)account.m_total_magnitude);
     json.pushKV("Lifetime Magnitude Average", account.AverageLifetimeMagnitude());


### PR DESCRIPTION
The "network" RPC output shows data based on two-week aggregates of payment amounts. Before, this function pulled the data from the two-week averages periodically collected by the tally. The legacy tally recount routine, however, counts two weeks using the `BLOCKS_PER_DAY` constant that does not accurately reflect variations in the number of blocks generated by the network over two weeks. It also begins counting backward from an offset, so the statistics are never current for the chain tip.

This replaces the use of the tally data for calculating the network statistics with a direct scan of the blockchain and removes code from the tally system that exported those statistics before. The changes update the RPC output with standard money formatting and JSON field names.

This change decouples the network statistics from the tally caches to prepare for updates to the accrual system for superblocks windows that do not store the network payment data that this output depended on. It also removes the tracking of data for the informational total block subsidy ("interest") field shown by the "magnitude" RPC output because the tally cannot produce an accurate value for this as well, so we can save the memory overhead of maintaining these records for each CPID.