### PR TITLE
Add support for generating legacy superblocks from scraper stats

### DIFF
--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -73,9 +73,9 @@ public:
                     continue;
 
                 case statsobjecttype::byCPID:
-                    m_superblock.m_cpids.Add(
+                    m_superblock.m_cpids.RoundAndAdd(
                         Cpid::Parse(object_id),
-                        std::round(entry.second.statsvalue.dMag));
+                        entry.second.statsvalue.dMag);
 
                     break;
 
@@ -83,9 +83,9 @@ public:
                     m_superblock.m_projects.Add(
                         object_id,
                         Superblock::ProjectStats(
-                            std::round(entry.second.statsvalue.dTC),
-                            std::round(entry.second.statsvalue.dAvgRAC),
-                            std::round(entry.second.statsvalue.dRAC))
+                            std::nearbyint(entry.second.statsvalue.dTC),
+                            std::nearbyint(entry.second.statsvalue.dAvgRAC),
+                            std::nearbyint(entry.second.statsvalue.dRAC))
                     );
 
                     break;
@@ -113,6 +113,10 @@ private:
 //! compute a matching superblock hash directly from scraper statistics. This
 //! class generates quorum hashes from scraper statistics that will match the
 //! hashes of corresponding superblock objects.
+//!
+//! CONSENSUS: This class will only produce a SHA256 quorum hash for versions
+//! 2+ superblocks. Do not use it to produce hashes of scraper statistics for
+//! legacy superblocks.
 //!
 class ScraperStatsQuorumHasher
 {
@@ -196,6 +200,18 @@ private:
                 } else {
                     m_zero_magnitude_count++;
                 }
+            }
+
+            //!
+            //! \brief Round and hash a CPID/magnitude pair as it would exist
+            //! in the Superblock::CpidIndex container.
+            //!
+            //! \param cpid      The CPID value to hash.
+            //! \param magnitude The magnitude value to hash.
+            //!
+            void RoundAndAdd(Cpid cpid, double magnitude)
+            {
+                Add(cpid, std::nearbyint(magnitude));
             }
 
             //!
@@ -1402,9 +1418,11 @@ Superblock::Superblock(uint32_t version)
 {
 }
 
-Superblock Superblock::FromConvergence(const ConvergedScraperStats& stats)
+Superblock Superblock::FromConvergence(
+    const ConvergedScraperStats& stats,
+    const uint32_t version)
 {
-    Superblock superblock = Superblock::FromStats(stats.mScraperConvergedStats);
+    Superblock superblock = Superblock::FromStats(stats.mScraperConvergedStats, version);
 
     superblock.m_convergence_hint = stats.Convergence.nContentHash.GetUint64() >> 32;
 
@@ -1430,10 +1448,19 @@ Superblock Superblock::FromConvergence(const ConvergedScraperStats& stats)
     return superblock;
 }
 
-Superblock Superblock::FromStats(const ScraperStats& stats)
+Superblock Superblock::FromStats(const ScraperStats& stats, const uint32_t version)
 {
-    Superblock superblock;
+    Superblock superblock(version);
     ScraperStatsSuperblockBuilder<Superblock> builder(superblock);
+
+    if (version == 1) {
+        // Force the CPID index into legacy mode to capture zero-magnitude
+        // CPIDs that result from rounding.
+        //
+        // TODO: encapsulate this
+        //
+        superblock.m_cpids = Superblock::CpidIndex(0);
+    }
 
     builder.BuildFromStats(stats);
 
@@ -1621,6 +1648,25 @@ void Superblock::CpidIndex::Add(const MiningId id, const uint16_t magnitude)
     if (const CpidOption cpid = id.TryCpid()) {
         Add(*cpid, magnitude);
     } else if (!m_legacy) {
+        m_zero_magnitude_count++;
+    }
+}
+
+void Superblock::CpidIndex::RoundAndAdd(const MiningId id, const double magnitude)
+{
+    // The ScraperGetNeuralContract() function that these classes replace
+    // rounded magnitude values using a half-away-from-zero rounding mode
+    // to determine whether floating-point magnitudes round-down to zero,
+    // but it added the magnitude values to the superblock with half-even
+    // rounding. This caused legacy superblock contracts to contain CPIDs
+    // with zero magnitude when the rounding results differed.
+    //
+    // To create legacy superblocks from scraper statistics with matching
+    // hashes, we filter magnitudes using the same rounding rules:
+    //
+    if (!m_legacy || std::round(magnitude) > 0) {
+        Add(id, std::nearbyint(magnitude));
+    } else {
         m_zero_magnitude_count++;
     }
 }

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -318,7 +318,7 @@ public:
             return Result::UNKNOWN;
         }
 
-        if (m_superblock.Age() < SCRAPER_CMANIFEST_RETENTION_TIME) {
+        if (m_superblock.Age() > SCRAPER_CMANIFEST_RETENTION_TIME) {
             return Result::HISTORICAL;
         }
 

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -86,6 +86,18 @@ public:
     //!
     static QuorumHash Hash(const Superblock& superblock);
 
+    //!
+    //! \brief Hash the provided scraper statistics to produce the same quorum
+    //! hash that would be generated for a superblock created from the stats.
+    //!
+    //! CONSENSUS: This method will only produce a SHA256 quorum hash matching
+    //! version 2+ superblocks. Do not use it to produce hashes of the scraper
+    //! statistics for legacy superblocks.
+    //!
+    //! \param stats Scraper statistics from a convergence to hash.
+    //!
+    //! \return A SHA256 quorum hash of the scraper statistics.
+    //!
     static QuorumHash Hash(const ScraperStats& stats);
 
     //!
@@ -382,6 +394,18 @@ public:
         //! \param magnitude Total magnitude to associate with the CPID.
         //!
         void Add(const MiningId id, const uint16_t magnitude);
+
+        //!
+        //! \brief Add the supplied mining ID to the index if it represents a
+        //! valid CPID after rounding the magnitude to an integer.
+        //!
+        //! This method ignores an attempt to add a duplicate entry if a CPID
+        //! already exists.
+        //!
+        //! \param id        May contain a CPID.
+        //! \param magnitude Total magnitude to associate with the CPID.
+        //!
+        void RoundAndAdd(const MiningId id, const double magnitude);
 
         //!
         //! \brief Serialize the object to the provided stream.
@@ -772,7 +796,9 @@ public:
     //! \return A new superblock instance that contains the imported scraper
     //! statistics.
     //!
-    static Superblock FromConvergence(const ConvergedScraperStats& stats);
+    static Superblock FromConvergence(
+        const ConvergedScraperStats& stats,
+        const uint32_t version = Superblock::CURRENT_VERSION);
 
     //!
     //! \brief Initialize a superblock from the provided scraper statistics.
@@ -783,7 +809,9 @@ public:
     //! \return A new superblock instance that contains the imported scraper
     //! statistics.
     //!
-    static Superblock FromStats(const ScraperStats& stats);
+    static Superblock FromStats(
+        const ScraperStats& stats,
+        const uint32_t version = Superblock::CURRENT_VERSION);
 
     //!
     //! \brief Initialize a superblock from a legacy superblock contract.

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1528,6 +1528,24 @@ UniValue network(const UniValue& params, bool fHelp)
     return res;
 }
 
+UniValue parselegacysb(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1)
+        throw runtime_error(
+                "parselegacysb\n"
+                "\n"
+                "Convert a legacy superblock contract to JSON.\n");
+
+    UniValue json(UniValue::VOBJ);
+
+    NN::Superblock superblock = NN::Superblock::UnpackLegacy(params[0].get_str());
+
+    json.pushKV("contract", SuperblockToJson(superblock));
+    json.pushKV("legacy_hash", superblock.GetHash().ToString());
+
+    return json;
+}
+
 UniValue projects(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -373,6 +373,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listprojects",            &listprojects,            cat_developer     },
     { "memorizekeys",            &memorizekeys,            cat_developer     },
     { "network",                 &network,                 cat_developer     },
+    { "parselegacysb",           &parselegacysb,           cat_developer     },
     { "projects",                &projects,                cat_developer     },
     { "readconfig",              &readconfig,              cat_developer     },
     { "readdata",                &readdata,                cat_developer     },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -191,6 +191,7 @@ extern UniValue listdata(const UniValue& params, bool fHelp);
 extern UniValue listprojects(const UniValue& params, bool fHelp);
 extern UniValue memorizekeys(const UniValue& params, bool fHelp);
 extern UniValue network(const UniValue& params, bool fHelp);
+extern UniValue parselegacysb(const UniValue& params, bool fHelp);
 extern UniValue projects(const UniValue& params, bool fHelp);
 extern UniValue readconfig(const UniValue& params, bool fHelp);
 extern UniValue readdata(const UniValue& params, bool fHelp);

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -4533,10 +4533,10 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bCon
                     ConvergedScraperStatsCache.nTime = GetAdjustedTime();
                     ConvergedScraperStatsCache.Convergence = StructConvergedManifest;
 
-                    superblock = NN::Superblock::FromConvergence(ConvergedScraperStatsCache);
-
-                    if (!IsV11Enabled(nBestHeight)) {
-                        superblock.m_version = 1;
+                    if (IsV11Enabled(nBestHeight)) {
+                        superblock = NN::Superblock::FromConvergence(ConvergedScraperStatsCache);
+                    } else {
+                        superblock = NN::Superblock::FromConvergence(ConvergedScraperStatsCache, 1);
                     }
 
                     ConvergedScraperStatsCache.NewFormatSuperblock = superblock;


### PR DESCRIPTION
This switches the superblock rounding mode for statistics back from half-away-from-zero to half-even to match the rounding mode used by legacy superblocks. It fixes the ability to generate legacy superblocks from scraper convergences after the removal of the intermediate string contract in #1583. This issue caused some superblocks to contain off-by-one magnitude values for legacy superblocks which produced a different hash value.

I added a utility RPC function, `parselegacysb`, that converts a legacy superblock contract string into JSON and displays the hash, and I fixed a comparison issue for upcoming superblock validation. 