### PR TITLE
Implement zapwallettxes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1051,6 +1051,23 @@ bool AppInit2(ThreadHandlerPtr threads)
     LogPrintf("%s", strErrors.str());
     LogPrintf(" wallet      %15" PRId64 "ms", GetTimeMillis() - nStart);
 
+    // Zap wallet transactions if specified as a command line argument.
+    if (GetBoolArg("-zapwallettxes", false))
+    {
+        std::vector<CWalletTx> vWtx;
+
+        LogPrintf("Zapping wallet transactions.");
+
+        DBErrors nZapWalletTxRet = pwalletMain->ZapWalletTx(vWtx);
+
+        LogPrintf("%u transactions zapped.", vWtx.size());
+
+        if (nZapWalletTxRet != DBErrors::DB_LOAD_OK)
+        {
+            strErrors << _("Error loading %s: Wallet corrupted") << walletFileName.string() << "\n";
+        }
+    }
+
     RegisterWallet(pwalletMain);
 
     CBlockIndex *pindexRescan = pindexBest;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -273,7 +273,7 @@ std::string HelpMessage()
         "  -keypool=<n>           " + _("Set key pool size to <n> (default: 100)") + "\n" +
         "  -rescan                " + _("Rescan the block chain for missing wallet transactions") + "\n" +
         "  -salvagewallet         " + _("Attempt to recover private keys from a corrupt wallet.dat") + "\n" +
-        "  -zapwallettxes=<mode>  " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") + "\n" +
+        "  -zapwallettxes         " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") + "\n" +
         "  -checkblocks=<n>       " + _("How many blocks to check at startup (default: 2500, 0 = all)") + "\n" +
         "  -checklevel=<n>        " + _("How thorough the block verification is (0-6, default: 1)") + "\n" +
         "  -loadblock=<file>      " + _("Imports blocks from external blk000?.dat file") + "\n" +


### PR DESCRIPTION
This is a simple PR to implement the -zapwallettxes switch, which for some reason was never implemented. The implied -rescan portion was done but not the zap transactions call itself, so prior to this PR, if -zapwallettxes was called, all that would happen is a -rescan. This was probably as a result of a botched porting early in Gridcoin's history and was never addressed. The implementation here is much simpler than in current Bitcoin, because we only have one wallet, and do not have to catch multi-wallet setups.

Note this was built for and tested by @barton2526 on a very large testnet wallet and worked very well. I also tested it on a large testnet node and it worked very well.