### PR TITLE
Fix deadlock in log archiver when rename fails

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -403,7 +403,7 @@ bool BCLog::Logger::archive(bool fImmediate, fs::path pfile_out)
 
             plogfile = m_file_path;
 
-            pfile_temp = static_cast<fs::path>(m_file_path.stem().string() + "-" + DateTimeStrFormat("%Y%m%d%H%M%S", nTime) + m_file_path.extension().string());
+            pfile_temp = LogArchiveDir / static_cast<fs::path>(m_file_path.stem().string() + "-" + DateTimeStrFormat("%Y%m%d%H%M%S", nTime) + m_file_path.extension().string());
 
             pfile_out = LogArchiveDir / static_cast<fs::path>((m_file_path.filename().stem().string() + "-" + DateTimeStrFormat("%Y%m%d%H%M%S", nTime)
                                          + m_file_path.filename().extension().string() + ".gz"));


### PR DESCRIPTION
The non-recursive mutex used for `BCLog::Logger::m_cs` prevents the `BCLog::Logger::archive()` method from returning when the log file rename operation fails because this method calls `LogPrintf()` that attempts to engage the same mutex in the locked scope.