### PR TITLE
Fix a spurious segmentation fault during client load on Windows with fast CPUs

### DIFF
--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -10,7 +10,7 @@ extern int nBoincUtilization;
 extern std::string sRegVer;
 extern bool bForceUpdate;
 extern bool fQtActive;
-extern bool bGridcoinGUILoaded;
+extern bool bGridcoinCoreInitComplete;
 
 // Timers
 extern std::map<std::string, int> mvTimers; // Contains event timers that reset after max ms duration iterator is exceeded

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -52,6 +52,8 @@ bool AppInit(int argc, char* argv[])
 
     SetupEnvironment();
 
+    // Note every function above the InitLogging() call must use fprintf or similar.
+
     ThreadHandlerPtr threads = std::make_shared<ThreadHandler>();
     bool fRet = false;
 
@@ -94,6 +96,9 @@ bool AppInit(int argc, char* argv[])
 
         /** Check here config file incase TestNet is set there and not in mapArgs **/
         ReadConfigFile(mapArgs, mapMultiArgs);
+
+        // Initialize logging as early as possible.
+        InitLogging();
 
         // Check to see if the user requested a snapshot and we are not running TestNet!
         if (mapArgs.count("-snapshotdownload") && !mapArgs.count("-testnet"))
@@ -142,8 +147,6 @@ bool AppInit(int argc, char* argv[])
             int ret = CommandLineRPC(argc, argv);
             exit(ret);
         }
-
-        InitLogging();
 
         fRet = AppInit2(threads);
     }

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -123,7 +123,7 @@ bool AppInit(int argc, char* argv[])
 
                 catch (std::runtime_error& e)
                 {
-                    LogPrintf("Snapshot Downloader: Runtime exception occured in SanpshotMain() (%s)", e.what());
+                    LogPrintf("Snapshot Downloader: Runtime exception occured in SnapshotMain() (%s)", e.what());
 
                     Snapshot.DeleteSnapshot();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -340,20 +340,10 @@ void InitLogging()
 
     LogInstance().m_print_to_file = !IsArgNegated("-debuglogfile");
     LogInstance().m_file_path = AbsPathForConfigVal(GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
-
-    //printf("LogInstance().m_file_path = %s\n", LogInstance().m_file_path.c_str());
-    //printf("LogInstance().m_print_to_file = %i\n", LogInstance().m_print_to_file);
-
     LogInstance().m_print_to_console = fPrintToConsole;
     LogInstance().m_log_timestamps = fLogTimestamps;
     LogInstance().m_log_time_micros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     LogInstance().m_log_threadnames = GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
-
-    //BCLog::LogFlags flags = BCLog::LogFlags::ALL;
-
-    //LogInstance().EnableCategory(flags);
-
-    //printf("LogInstance().GetCategoryMask() = %x\n", LogInstance().GetCategoryMask());
 
     fLogIPs = GetBoolArg("-logips", DEFAULT_LOGIPS);
 
@@ -743,8 +733,6 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 #endif
 
-    ShrinkDebugFile();
-    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     LogPrintf("Gridcoin version %s (%s)", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s", SSLeay_version(SSLEAY_VERSION));
     if (!fLogTimestamps)

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -70,7 +70,7 @@ bool BCLog::Logger::StartLogging()
 
         // Add newlines to the logfile to distinguish this execution from the
         // last one.
-        FileWriteStr("\n\n\n\n\n", m_fileout);
+        FileWriteStr("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", m_fileout);
     }
 
     // dump buffered messages from before we opened the log

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4781,7 +4781,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                             unsigned int banscore_out = 0;
 
                             // Also don't send a manifest that is not current.
-                            if (CScraperManifest::IsManifestAuthorized(manifest.pubkey, banscore_out) && manifest.IsManifestCurrent())
+                            if (CScraperManifest::IsManifestAuthorized(manifest.nTime, manifest.pubkey, banscore_out) && manifest.IsManifestCurrent())
                             {
                                 CScraperManifest::SendManifestTo(pfrom, inv.hash);
                             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,7 @@ BlockFinder blockFinder;
 
 bool bForceUpdate = false;
 bool fQtActive = false;
-bool bGridcoinGUILoaded = false;
+bool bGridcoinCoreInitComplete = false;
 
 extern void GetGlobalStatus();
 bool PollIsActive(const std::string& poll_contract);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -213,8 +213,7 @@ int main(int argc, char *argv[])
 
     SetupEnvironment();
 
-    // Do this early as we don't want to bother initializing if we are just calling IPC
-    ipcScanRelay(argc, argv);
+    // Note every function above the InitLogging() call must use fprintf or similar.
 
     // Command-line options take precedence:
     // Before this would of been done in main then config file loaded.
@@ -222,6 +221,12 @@ int main(int argc, char *argv[])
     ParseParameters(argc, argv);
 
     ReadConfigFile(mapArgs, mapMultiArgs);
+
+    // Initialize logging as early as possible.
+    InitLogging();
+
+    // Do this early as we don't want to bother initializing if we are just calling IPC
+    ipcScanRelay(argc, argv);
 
     // Here we do it if it was started with the snapshot argument and we not TestNet
     if (mapArgs.count("-snapshotdownload") && !mapArgs.count("-testnet"))
@@ -245,7 +250,7 @@ int main(int argc, char *argv[])
 
             catch (std::runtime_error& e)
             {
-                LogPrintf("Snapshot Downloader: Runtime exception occured in SanpshotMain() (%s)", e.what());
+                LogPrintf("Snapshot Downloader: Runtime exception occured in SnapshotMain() (%s)", e.what());
 
                 Snapshot.DeleteSnapshot();
 
@@ -354,8 +359,6 @@ int StartGridcoinQt(int argc, char *argv[])
 
     // ... then GUI settings:
     OptionsModel optionsModel;
-
-    InitLogging();
 
     // Get desired locale (e.g. "de_DE") from command line or use system locale
     QString lang_territory = QString::fromStdString(GetArg("-lang", QLocale::system().name().toStdString()));

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -57,7 +57,7 @@ static bool ipcScanCmd(int argc, char *argv[], bool fRelay)
                 // the first start of the first instance
                 if (ex.get_error_code() != boost::interprocess::not_found_error || !fRelay)
                 {
-                    LogPrintf("main() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
+                    fprintf(stderr, "main() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
                     break;
                 }
             }

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -24,12 +24,12 @@ bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pM
 
        // Seed OpenSSL PRNG with Windows event data (e.g.  mouse movements and other user interactions)
        if (RAND_event(pMsg->message, pMsg->wParam, pMsg->lParam) == 0) {
-            // Warn only once as this is performance-critical
-            static bool warned = false;
-            if (!warned) {
-                LogPrintf("%s: OpenSSL RAND_event() failed to seed OpenSSL PRNG with enough data.\n", __func__);
-                warned = true;
-            }
+           // Warn only once as this is performance-critical
+           static bool warned = false;
+           if (!warned) {
+               LogPrintf("%s: OpenSSL RAND_event() failed to seed OpenSSL PRNG with enough data.\n", __func__);
+               warned = true;
+           }
        }
 
        switch(pMsg->message)

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -3516,6 +3516,119 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
 }
 
 
+// This function computes the average time between manifests as a function of the last 10 received manifests
+// plus the nTime provided as the argument. This gives ten intervals for sampling between manifests. If the
+// average time between manifests is less than 50% of the nScraperSleep interval, or the most recent manifest
+// for a scraper is more than five minutes in the future (accounts for clock skew) then the publishing rate
+// of the scraper is deemed too high. This is actually used in CScraperManifest::IsManifestAuthorized to ban
+// a scraper that is abusing the network by sending too many manifests over a very short period of time.
+bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey)
+{
+    mmCSManifestsBinnedByScraper mMapCSManifestBinnedByScraper;
+
+    {
+        LOCK(CScraperManifest::cs_mapManifest);
+
+        mMapCSManifestBinnedByScraper = BinCScraperManifestsByScraper();
+    }
+
+    CKeyID ManifestKeyID = PubKey.GetID();
+
+    CBitcoinAddress ManifestAddress;
+    ManifestAddress.Set(ManifestKeyID);
+
+    // This is the address corresponding to the manifest public key, and is the scraper ID key in the outer map.
+    std::string sManifestAddress = ManifestAddress.ToString();
+
+    const auto& iScraper = mMapCSManifestBinnedByScraper.find(sManifestAddress);
+
+    if (iScraper == mMapCSManifestBinnedByScraper.end())
+    {
+        // There are no previous manifests on this node corresponding to the supplied public key.
+        return false;
+    }
+
+    unsigned int nIntervals = 0;
+    int64_t nCurrentTime = GetAdjustedTime();
+    int64_t nBeginTime = 0;
+    int64_t nEndTime = 0;
+    int64_t nTotalTime = 0;
+    int64_t nAvgTimeBetweenManifests = 0;
+
+    std::multimap<int64_t, ScraperID, std::greater <int64_t>> mScraperManifests;
+
+    // Insert manifest referenced by the argument first (the "incoming" manifest). Note that it may NOT have the most recent time.
+    // This is followed by the rest so that we have a unified map with the incoming in the right order.
+    mScraperManifests.insert(std::make_pair(nTime, sManifestAddress));
+
+    // Insert the rest of the manifests for the scraper matching the public key.
+    for (const auto& iManifest : iScraper->second)
+    {
+        mScraperManifests.insert(std::make_pair(iManifest.first, sManifestAddress));
+    }
+
+    // Remember the map is sorted in descending order of time, so the end comes before the beginning.
+    for (const auto& iManifest : mScraperManifests)
+    {
+        ++nIntervals;
+
+        if (nIntervals == 1)
+        {
+            // Set the end of the measurement interval to the most recent manifest for the scraper.
+            nEndTime = iManifest.first;
+        }
+
+        // Set the beginning time of the interval to the time at this element
+        nBeginTime = iManifest.first;
+
+        // Go till 10 intervals (between samples) OR time interval reaches 5 expected scraper updates at 3 nScraperSleep scraper cycles per update,
+        // whichever occurs first.
+        if (nIntervals == 10 || (nCurrentTime - nBeginTime) >= nScraperSleep * 3 * 5 / 1000) break;
+    }
+
+    // Do not allow the most recent manifest from a scraper to be more than five minutes into the future from GetAdjustedTime. (This takes
+    // into account reasonable clock skew between the scraper and this node, but prevents future dating manifests to try and fool the rate calculation.)
+    // Note that this is regardless of the minimum sample size below.
+    if (nEndTime - nCurrentTime > 300)
+    {
+        _log(logattribute::CRITICAL, "IsScraperMaximumManifestPublishingRateExceeded", "Scraper " + sManifestAddress +
+             " has published a manifest more than 5 minutes in the future. Banning the scraper.");
+
+        return true;
+    }
+
+    // We are not going to allow less than 5 intervals in the sample. If it is less than 5 intervals, it has either passed the break
+    // condition above (or even slower), or there really are very few published total, in which the sample size is too small to judge
+    // the rate.
+    if (nIntervals < 5) return false;
+
+
+    // nTotalTime be negative because of the sort order of mScraperManifests, and nIntervals is protected against being zero by the
+    // above conditional.
+    nTotalTime = nEndTime - nBeginTime;
+    nAvgTimeBetweenManifests = nTotalTime / nIntervals;
+
+    // nScraperSleep is in milliseconds. If the average interval is less than 50% of nScraperSleep in seconds, ban the scraper.
+    // Note that this is at least a factor of 6 faster than the expected rate given usual project update velocity.
+    if (nAvgTimeBetweenManifests < nScraperSleep / 2000)
+    {
+        _log(logattribute::CRITICAL, "IsScraperMaximumManifestPublishingRateExceeded", "Scraper " + sManifestAddress +
+             " has published too many manifests in too short a time:\n" +
+             "Number of manifests sampled = " + std::to_string(nIntervals + 1) + "\n"
+             "nEndTime = " + std::to_string(nEndTime) + "\n" +
+             "nBeginTime = " + std::to_string(nBeginTime) + "\n" +
+             "nTotalTime = " + std::to_string(nTotalTime) + "\n" +
+             "nAvgTimeBetweenManifests = " + std::to_string(nAvgTimeBetweenManifests) +"\n" +
+             "Banning the scraper.\n");
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 // This function is necessary because some CScraperManifest messages are likely to be received before the wallet is in sync. Therefore, they
 // cannot be checked at that time by the deserialize check. Instead, while the wallet is not in sync, the local CScraperManifest flag
 // bCheckedAuthorized will be set to false on any manifests received during that time. Once the wallet is in sync, this function will be
@@ -3536,7 +3649,7 @@ unsigned int ScraperDeleteUnauthorizedCScraperManifests()
         // We are not going to do anything with the banscore here, but it is an out parameter of IsManifestAuthorized.
         unsigned int banscore_out = 0;
 
-        if (CScraperManifest::IsManifestAuthorized(manifest.pubkey, banscore_out))
+        if (CScraperManifest::IsManifestAuthorized(manifest.nTime, manifest.pubkey, banscore_out))
         {
             manifest.bCheckedAuthorized = true;
             ++iter;

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -3603,8 +3603,8 @@ bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& Pub
     if (nIntervals < 5) return false;
 
 
-    // nTotalTime be negative because of the sort order of mScraperManifests, and nIntervals is protected against being zero by the
-    // above conditional.
+    // nTotalTime cannot be negative because of the sort order of mScraperManifests, and nIntervals is protected against being zero
+    // by the above conditional.
     nTotalTime = nEndTime - nBeginTime;
     nAvgTimeBetweenManifests = nTotalTime / nIntervals;
 

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -8,7 +8,6 @@
 #include <cctype>
 #include <vector>
 #include <map>
-//#include <set>
 #include <boost/locale.hpp>
 #include <codecvt>
 #include <boost/filesystem.hpp>

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -8,6 +8,7 @@
 #include <cctype>
 #include <vector>
 #include <map>
+//#include <set>
 #include <boost/locale.hpp>
 #include <codecvt>
 #include <boost/filesystem.hpp>
@@ -119,6 +120,7 @@ ScraperStats GetScraperStatsByConvergedManifest(const ConvergedManifest& StructC
 std::string ExplainMagnitude(std::string sCPID);
 bool IsScraperAuthorized();
 bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& KeyOut);
+bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
 NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
 bool ScraperSynchronizeDPOR();
 scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperblock, bool bUseCache = true, unsigned int nReducedCacheBits = 32);

--- a/src/scraper_net.cpp
+++ b/src/scraper_net.cpp
@@ -15,6 +15,7 @@
 #include "appcache.h"
 #include "scraper/fwd.h"
 #include "neuralnet/superblock.h"
+#include "neuralnet/project.h"
 
 //Globals
 std::map<uint256,CSplitBlob::CPart> CSplitBlob::mapParts;
@@ -25,12 +26,14 @@ CCriticalSection CScraperManifest::cs_mapManifest;
 extern unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE;
 extern int64_t SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD;
 extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME;
+extern double CONVERGENCE_BY_PROJECT_RATIO;
 extern unsigned int nScraperSleep;
 extern AppCacheSectionExt mScrapersExt;
 extern std::atomic<int64_t> nSyncTime;
 extern ConvergedScraperStats ConvergedScraperStatsCache;
 extern CCriticalSection cs_mScrapersExt;
 extern CCriticalSection cs_ConvergedScraperStatsCache;
+extern bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
 
 // A lock needs to be taken on cs_mapParts before calling this function.
 bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
@@ -283,7 +286,7 @@ void CScraperManifest::Serialize(CDataStream& ss) const
 
 // This is the complement to IsScraperAuthorizedToBroadcastManifests in the scraper.
 // It is used to determine whether received manifests are authorized.
-bool CScraperManifest::IsManifestAuthorized(CPubKey& PubKey, unsigned int& banscore_out)
+bool CScraperManifest::IsManifestAuthorized(int64_t& nTime, CPubKey& PubKey, unsigned int& banscore_out)
 {
     bool bIsValid = PubKey.IsValid();
     if (!bIsValid)
@@ -361,6 +364,15 @@ bool CScraperManifest::IsManifestAuthorized(CPubKey& PubKey, unsigned int& bansc
             nLastFalseEntryTime = std::max(nLastFalseEntryTime, entry.second.timestamp);
     }
 
+    // Check for excessive manifest publishing rate by the associated scraper. If the maximum rate is exceeded
+    // Then return false. This is exempt from the grace period below.
+    if (IsScraperMaximumManifestPublishingRateExceeded(nTime, PubKey))
+    {
+        // Immediate ban
+        banscore_out = GetArg("-banscore", 100);
+        return false;
+    }
+
     if (bAuthorized)
         return true;
     else
@@ -387,6 +399,8 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     vector<uint256> vph;
     ss>>vph;
     ss>> pubkey;
+    ss>> sCManifestName;
+    ss>> nTime;
 
     // This will set the bCheckAuthorized flag to false if a message
     // is received while the wallet is not in sync. If in sync and
@@ -395,13 +409,11 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     // which will also result in an increase in banscore, if past the grace period.
     if (OutOfSyncByAge())
         bCheckedAuthorized = false;
-    else if (IsManifestAuthorized(pubkey, banscore_out))
+    else if (IsManifestAuthorized(nTime, pubkey, banscore_out))
         bCheckedAuthorized = true;
     else
         throw error("CScraperManifest::UnserializeCheck: Unapproved scraper ID");
 
-    ss>> sCManifestName;
-    ss>> nTime;
     ss>> ConsensusBlock;
     ss>> BeaconList >> BeaconList_c;
     ss>> projects;
@@ -411,6 +423,42 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     for(const dentry& prj : projects)
         if(prj.part1+prj.partc>vph.size())
             throw error("CScraperManifest::UnserializeCheck: project part out of range");
+
+    // It is not reasonable for a manifest to contain more than nMaxProjects, where this is
+    // calculated by dividing the current whitelist size by the CONVERGENCE_BY_PROJECT_RATIO,
+    // taking the ceiling and then adding 2. The motivation behind this is the corner case where
+    // the whitelist has been reduced in size by that ratio as a corrective action in the situation
+    // where suddenly a number of projects are not available, and a convergence was not able to be formed.
+    // Then existing manifests on the network would have the reciprocol of that ratio projects. I
+    // take the ceiling and add 2 for a safety measure. For a CONVERGENCE_BY_PROJECT_RATIO of 0.75, which
+    // is the network default, and a whitelist count of 20, this would come out to ceil(20.0/0.75)+2 = 29.
+    // Or if the whitelist were suddenly reduced from 20 to 15, then it would be ceil(15.0/0.75)+2 = 22.
+    // Note that this places limits on the change of the whitelist without causing nodes to ban the scrapers
+    // But it is exceedingly unlikely to need to change the whitelist by more than this ratio.
+    // Let's look at several scenarios to see the actual constraints using a
+    // CONVERGENCE_BY_PROJECT_RATIO of 0.75 ...
+
+    // Whitelist = 0 .... nMaxProjects = 2. (So whitelist could be reduced by 2 from 2 to 0 without tripping.)
+    // Whitelist = 1 .... nMaxProjects = 4. (So whitelist could be reduced by 3 from 4 to 1 without tripping.)
+    // Whitelist = 5 .... nMaxProjects = 9. (So whitelist could be reduced by 4 from 9 to 5 without tripping.)
+    // Whitelist = 10 ... nMaxProjects = 16. (So whitelist could be reduced by 6 from 16 to 10 without tripping.)
+    // Whitelist = 15 ... nMaxProjects = 22. (So whitelist could be reduced by 7 from 22 to 15 without tripping.)
+    // Whitelist = 20 ... nMaxProjects = 29. (So whitelist could be reduced by 9 from 29 to 20 without tripping.)
+
+    // There is also a clamp on the divisor to ensure it is never less than 0.5, even if the CONVERGENCE_BY_PROJECT_RATIO
+    // is set to below 0.5, both to prevent a divide by zero exception, and also prevent unreasonably lose limits. So this
+    // means the loosest limit that is allowed is essentially 2 * whitelist + 2.
+
+    unsigned int nMaxProjects = static_cast<unsigned int>(std::ceil(static_cast<double>(NN::GetWhitelist().Snapshot().size()) /
+                                                                    std::max(0.5, CONVERGENCE_BY_PROJECT_RATIO)) + 2);
+
+    if (projects.size() > nMaxProjects)
+    {
+        // Immmediately ban the node from which the manifest was received.
+        banscore_out = GetArg("-banscore", 100);
+
+        throw error("CScraperManifest::UnserializeCheck: Too many projects in the manifest.");
+    }
 
     ss >> nContentHash;
 
@@ -604,10 +652,6 @@ bool CScraperManifest::addManifest(std::unique_ptr<CScraperManifest>&& m, CKey& 
     if (fDebug3) LogPrintf("INFO: CScraperManifest::addManifest: hash of signature = %s", Hash(m->signature.begin(), m->signature.end()).GetHex());
 
     LogPrint("manifest", "adding new local manifest");
-    /* at this point it is easier to pretend like it was received from network */
-    // ^ Yes, but your are creating a new object and pointer that way. It is better to do
-    // a special insert routine below, which forwards the object (pointer).
-    // return CScraperManifest::RecvManifest(0, ss);
 
     /* try inserting into map */
     const auto it = mapManifest.emplace(hash, std::move(m));

--- a/src/scraper_net.cpp
+++ b/src/scraper_net.cpp
@@ -452,7 +452,7 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     unsigned int nMaxProjects = static_cast<unsigned int>(std::ceil(static_cast<double>(NN::GetWhitelist().Snapshot().size()) /
                                                                     std::max(0.5, CONVERGENCE_BY_PROJECT_RATIO)) + 2);
 
-    if (projects.size() > nMaxProjects)
+    if (!OutOfSyncByAge() && projects.size() > nMaxProjects)
     {
         // Immmediately ban the node from which the manifest was received.
         banscore_out = GetArg("-banscore", 100);

--- a/src/scraper_net.h
+++ b/src/scraper_net.h
@@ -111,7 +111,7 @@ public: /* static methods */
     static bool addManifest(std::unique_ptr<CScraperManifest>&& m, CKey& keySign);
 
     /** Validate whether recieved manifest is authorized */
-    static bool IsManifestAuthorized(CPubKey& PubKey, unsigned int& banscore_out);
+    static bool IsManifestAuthorized(int64_t& nTime, CPubKey& PubKey, unsigned int& banscore_out);
 
     /** Delete Manifest (key version) **/
     static bool DeleteManifest(const uint256& nHash, const bool& fImmediate = false);

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -648,17 +648,9 @@ bool CTxDB::LoadBlockIndex()
     CBlockIndex* pindex = BlockFinder().FindByHeight(1);
 
     LogPrintf("RA scan blocks %i-%i", pindex->nHeight, pindexBest->nHeight);
-    nLoaded=pindex->nHeight;
+
     for ( ; pindex ; pindex= pindex->pnext )
     {
-        if(fQtActive && (pindex->nHeight % 10000) == 0)
-        {
-            nLoaded +=10000;
-            if (nLoaded > nHighest) nHighest=nLoaded;
-            if (nHighest < nGrandfather) nHighest=nGrandfather;
-            uiInterface.InitMessage(strprintf("%" PRId64 "/%" PRId64 " %s", nLoaded, nHighest, _("POR Blocks Verified")));
-        }
-
         // Block repair and reward collection only needs to be done after
         // research age has been enabled.
         if(!IsResearchAgeEnabled(pindex->nHeight))

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -791,29 +791,6 @@ bool FileCommit(FILE *file)
     return true;
 }
 
-
-void ShrinkDebugFile()
-{
-    // Scroll debug.log if it's getting too big
-    fs::path pathLog = GetDataDir() / "debug.log";
-    FILE* file = fsbridge::fopen(pathLog, "r");
-    if (file && fs::file_size(pathLog) > 1000000)
-    {
-        // Restart the file with some of the end
-        char pch[200000];
-        fseek(file, -sizeof(pch), SEEK_END);
-        int nBytes = fread(pch, 1, sizeof(pch), file);
-        fclose(file);
-
-        file = fsbridge::fopen(pathLog, "w");
-        if (file)
-        {
-            fwrite(pch, 1, nBytes, file);
-            fclose(file);
-        }
-    }
-}
-
 bool DirIsWritable(const fs::path& directory)
 {
     fs::path tmpFile = directory / fs::unique_path();

--- a/src/util.h
+++ b/src/util.h
@@ -171,7 +171,6 @@ void ReadConfigFile(ArgsMap& mapSettingsRet, ArgsMultiMap& mapMultiSettingsRet);
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
-void ShrinkDebugFile();
 bool DirIsWritable(const fs::path& directory);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1966,6 +1966,9 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
     fFirstRunRet = !vchDefaultKey.IsValid();
 
     NewThread(ThreadFlushWalletDB, &strWalletFile);
+
+    LogPrintf("LoadWallet: started wallet flush thread.");
+
     return DB_LOAD_OK;
 }
 


### PR DESCRIPTION
The sleep for the processEvents while loop in bitcoin.cpp which executes to process events from the core during the init phase was set at 300 ms. This turns out to be too long for fast CPUs and too many events are generated in that 300 ms, which was overflowing the event buffer and causing a crash.

This PR also includes other cleanups in the init code and some minor improvements to the scraper.