### PR TITLE
Implements a global event filter to suppress help question mark

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -329,6 +329,9 @@ int StartGridcoinQt(int argc, char *argv[])
     // Install global event filter that makes sure that long tooltips can be word-wrapped
     app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
 
+    // Install global event filter that suppresses help context question mark
+    app.installEventFilter(new GUIUtil::WindowContextHelpButtonHintFilter(&app));
+
 #if QT_VERSION < 0x050000
     // Install qDebug() message handler to route to debug.log
     qInstallMsgHandler(DebugMessageHandler);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -357,6 +357,25 @@ bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)
     return QObject::eventFilter(obj, evt);
 }
 
+WindowContextHelpButtonHintFilter::WindowContextHelpButtonHintFilter(QObject *parent) :
+    QObject(parent)
+{
+
+}
+
+bool WindowContextHelpButtonHintFilter::eventFilter (QObject *obj, QEvent *event)
+{
+    if (event->type () == QEvent::Create)
+    {
+        if (obj->isWidgetType ())
+        {
+            auto w = static_cast<QWidget *> (obj);
+            w->setWindowFlags (w->windowFlags () & (~Qt::WindowContextHelpButtonHint));
+        }
+    }
+    return QObject::eventFilter (obj, event);
+}
+
 #ifdef WIN32
 boost::filesystem::path static StartupShortcutPath()
 {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -109,6 +109,21 @@ namespace GUIUtil
         int size_threshold;
     };
 
+    /** Qt event filter that suppress context help question mark for all windows.
+     */
+
+    class WindowContextHelpButtonHintFilter : public QObject
+    {
+        Q_OBJECT
+
+    public:
+        explicit WindowContextHelpButtonHintFilter(QObject *parent = 0);
+
+    protected:
+        bool eventFilter(QObject *obj, QEvent *evt);
+    };
+
+
     bool GetStartOnSystemStartup();
     bool SetStartOnSystemStartup(bool fAutoStart);
 


### PR DESCRIPTION
This small commit properly gets rid of the help "question mark" next to the close button for all of the application windows, since we do not currently use it, and pressing it with no context help available results in irritating behavior.

This replaces #1335 since the original fork repo for the PR was removed by the user.