### PR TITLE
Changes the order of calls in gridcoinresearchd.cpp to optimize rpc shunt path

### DIFF
--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -97,6 +97,17 @@ bool AppInit(int argc, char* argv[])
         /** Check here config file incase TestNet is set there and not in mapArgs **/
         ReadConfigFile(mapArgs, mapMultiArgs);
 
+        // Command-line RPC  - Test this - ensure single commands execute and exit please.
+        for (int i = 1; i < argc; i++)
+            if (!IsSwitchChar(argv[i][0]) && !boost::algorithm::istarts_with(argv[i], "gridcoinresearchd"))
+                fCommandLine = true;
+
+        if (fCommandLine)
+        {
+            int ret = CommandLineRPC(argc, argv);
+            exit(ret);
+        }
+
         // Initialize logging as early as possible.
         InitLogging();
 
@@ -136,17 +147,6 @@ bool AppInit(int argc, char* argv[])
         }
 
         LogPrintf("AppInit");
-
-        // Command-line RPC  - Test this - ensure single commands execute and exit please.
-        for (int i = 1; i < argc; i++)
-            if (!IsSwitchChar(argv[i][0]) && !boost::algorithm::istarts_with(argv[i], "gridcoinresearchd"))
-                fCommandLine = true;
-
-        if (fCommandLine)
-        {
-            int ret = CommandLineRPC(argc, argv);
-            exit(ret);
-        }
 
         fRet = AppInit2(threads);
     }


### PR DESCRIPTION
A closer examination of gridcoinresearchd.cpp shows that the order of calls is not optimal. In particular the single rpc command "shunt" was too late in the sequence and was allowing the gridcoinresearchd acting as the rpc relay to log "AppInit" in the same log file as the running instance. While this might work most of the time, it is not really a good idea.

This also corrects a small deficiency created by #1608, which changed the location of the Gridcoin "banner" in the log file, and was causing not only Appinit to appear, but also the initialization "banner" when the rpc relay instance ran.

The rpc relay instance should not put anything to the log file and should report all errors to stdout/stderr.