### PR TITLE
Fix lock order debugging and potential deadlocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5267,13 +5267,24 @@ bool ProcessMessages(CNode* pfrom)
     return fOk;
 }
 
+// Note: this function requires a lock on cs_main before calling. (See below comments.)
 bool SendMessages(CNode* pto, bool fSendTrickle)
 {
+    // Some comments and TODOs in order...
+    // 1. This function never returns anything but true... (try to find a return other than true).
+    // 2. The try lock inside this function causes a potential deadlock due to a lock order reversal in main.
+    // 3. The reason for the interior lock is vacated by 1. So the below is commented out, and moved to
+    //    the ThreadMessageHandler2 in net.cpp.
+    // 4. We need to research why we never return false at all, and subordinately, why we never consume
+    //    the value of this function.
+
+    /*
     // Treat lock failures as send successes in case the caller disconnects
     // the node based on the return value.
     TRY_LOCK(cs_main, lockMain);
     if(!lockMain)
         return true;
+    */
 
     // Don't send anything until we get their version message
     if (pto->nVersion == 0)

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -93,7 +93,6 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
         }
         LogPrintf(" %s", i.second.ToString());
     }
-    assert(false);
 }
 
 static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)


### PR DESCRIPTION
This address #779.

Some serious comments are in order here.

An assert should NEVER have been put in the potential_deadlock_detected to begin with. It is totally wrongheaded. The whole idea of that function, which is activated when a debug build is done, is to detect and provide to developers potential deadlocks. ASSERTs should only be used for an error condition so severe that the program should be stopped immediately. A potential deadlock condition is not one of those! In fact, in many cases the potential deadlock may not ever be encountered in practice. If you stop the program at the first one, it makes trying to find the universe of potential deadlocks almost impossible. You would have to troubleshoot and resolve them one at a time, recompiling and rerunning after each one. And that is assuming that you could actually fix them all.

Instead it is much better to just log the potential deadlock and keep going, so that all of them can be collected and analyzed in the debug log. Some of them may not be important and not affect program execution at all.

Because of this ASSERT, we have not been able to run debug builds which hampers the debugging information available to the developers.

Now the debug build works fine and just logs potential deadlocks.

I have also fixed the deadlock in #779, so I will close that issue. It turns out we have a few more left.