### PR TITLE
Standardize money values as integers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2598,8 +2598,12 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck, boo
             //sometimes be slightly smaller than we calculate here due to the
             //RA timespan increasing.  So we will allow for time shift before
             //rejecting the block.
-            double nDrift = claim.m_research_subsidy * .15;
-            if (nDrift < 10 * COIN) nDrift = 10 * COIN;
+            int64_t nDrift = 0;
+
+            if (pindex->nVersion <= 10) {
+                nDrift = claim.m_research_subsidy * .15;
+                if (nDrift < 10 * COIN) nDrift = 10 * COIN;
+            }
 
             if ((claim.TotalSubsidy() + nDrift) < nStakeRewardWithoutFees)
             {

--- a/src/main.h
+++ b/src/main.h
@@ -252,8 +252,8 @@ int64_t GetProofOfStakeReward(
     const NN::MiningId mining_id,
     int64_t nTime,
     const CBlockIndex* pindexLast,
-    double& OUT_POR,
-    double& OUT_INTEREST);
+    int64_t& OUT_POR,
+    int64_t& OUT_INTEREST);
 
 bool OutOfSyncByAge();
 bool IsSuperBlock(CBlockIndex* pIndex);
@@ -1344,8 +1344,8 @@ public:
     int64_t nMoneySupply;
     // Gridcoin (7-11-2015) Add new Accrual Fields to block index
     NN::Cpid cpid;
-    double nResearchSubsidy;
-    double nInterestSubsidy;
+    int64_t nResearchSubsidy;
+    int64_t nInterestSubsidy;
     double nMagnitude;
     // Indicators (9-13-2015)
     unsigned int nIsSuperBlock;
@@ -1653,14 +1653,19 @@ public:
 
         //7-11-2015 - Gridcoin - New Accrual Fields (Note, Removing the determinstic block number to make this happen all the time):
         std::string cpid_hex = GetMiningId().ToString();
+        double research_subsidy_grc = nResearchSubsidy / (double)COIN;
+        double interest_subsidy_grc = nInterestSubsidy / (double)COIN;
+
         READWRITE(cpid_hex);
+        READWRITE(research_subsidy_grc);
+        READWRITE(interest_subsidy_grc);
 
         if (ser_action.ForRead()) {
             const_cast<CDiskBlockIndex*>(this)->SetMiningId(NN::MiningId::Parse(cpid_hex));
+            nResearchSubsidy = research_subsidy_grc * COIN;
+            nInterestSubsidy = interest_subsidy_grc * COIN;
         }
 
-        READWRITE(nResearchSubsidy);
-        READWRITE(nInterestSubsidy);
         READWRITE(nMagnitude);
 
         //9-13-2015 - Indicators

--- a/src/main.h
+++ b/src/main.h
@@ -252,8 +252,8 @@ int64_t GetProofOfStakeReward(
     const NN::MiningId mining_id,
     int64_t nTime,
     const CBlockIndex* pindexLast,
-    int64_t& OUT_POR,
-    int64_t& OUT_INTEREST);
+    int64_t& out_research_subsidy,
+    int64_t& out_block_subsidy);
 
 bool OutOfSyncByAge();
 bool IsSuperBlock(CBlockIndex* pIndex);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1045,12 +1045,12 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
     }
 
     LogPrintf(
-        "CreateGridcoinReward: for %s mint %f magnitude %d Research %f, Interest %f ",
+        "CreateGridcoinReward: for %s mint %s magnitude %d Research %s, Interest %s",
         claim.m_mining_id.ToString(),
-        CoinToDouble(nReward),
+        FormatMoney(nReward),
         claim.m_magnitude,
-        claim.m_research_subsidy,
-        claim.m_block_subsidy);
+        FormatMoney(claim.m_research_subsidy),
+        FormatMoney(claim.m_block_subsidy));
 
     blocknew.vtx[1].vout[1].nValue += nReward;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1038,7 +1038,10 @@ bool CreateGridcoinReward(CBlock &blocknew, uint64_t &nCoinAge, CBlockIndex* pin
 
     claim.m_client_version = FormatFullVersion().substr(0, NN::Claim::MAX_VERSION_SIZE);
     claim.m_organization = GetArgument("org", "").substr(0, NN::Claim::MAX_ORGANIZATION_SIZE);
-    claim.m_magnitude_unit = NN::Tally::GetMagnitudeUnit(pindexPrev->nTime);
+
+    if (blocknew.nVersion <= 10) {
+        claim.m_magnitude_unit = NN::Tally::GetMagnitudeUnit(pindexPrev->nTime);
+    }
 
     if (const NN::CpidOption cpid = claim.m_mining_id.TryCpid()) {
         claim.m_magnitude = NN::Tally::GetMagnitude(*cpid);

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -135,14 +135,14 @@ Claim Claim::Parse(const std::string& claim, int block_version)
                     c.m_quorum_hash = QuorumHash::Parse(s[21]);
         case 20: //c.OrganizationKey = s[20];
         case 19: c.m_organization = std::move(s[19]);
-        case 18: c.m_block_subsidy = RoundFromString(s[18], subsidy_places);
+        case 18: c.m_block_subsidy = RoundFromString(s[18], subsidy_places) * COIN;
         case 17: //c.m_last_block_hash = uint256(s[17]);
         case 16: c.m_quorum_address = s[16];
         case 15: c.m_magnitude = RoundFromString(s[15], 0);
         case 14: //c.cpidv2 = s[14];
         case 13: //c.m_rsa_weight = RoundFromString(s[13], 0);
         case 12: //c.m_last_payment_time = RoundFromString(s[12], 0);
-        case 11: c.m_research_subsidy = RoundFromString(s[11], 2);
+        case 11: c.m_research_subsidy = RoundFromString(s[11], 2) * COIN;
         case 10: c.m_client_version = std::move(s[10]);
         case  9: //c.NetworkRAC = RoundFromString(s[9], 0);
         case  8:
@@ -187,7 +187,7 @@ bool Claim::ContainsSuperblock() const
     return m_superblock.WellFormed();
 }
 
-double Claim::TotalSubsidy() const
+int64_t Claim::TotalSubsidy() const
 {
     return m_block_subsidy + m_research_subsidy;
 }
@@ -245,14 +245,14 @@ std::string Claim::ToString(const int block_version) const
         + delim // + RoundToString(mcpid.nonce, 0)
         + delim // + RoundToString(mcpid.NetworkRAC, 0)
         + delim + m_client_version
-        + delim + RoundToString(m_research_subsidy, subsidy_places)
+        + delim + RoundToString((double)m_research_subsidy / COIN, subsidy_places)
         + delim // + std::to_string(m_last_payment_time)
         + delim // + std::to_string(m_rsa_weight)
         + delim // + mcpid.cpidv2
         + delim + std::to_string(m_magnitude)
         + delim + m_quorum_address
         + delim + BlockHashToString(m_last_block_hash)
-        + delim + RoundToString(m_block_subsidy, subsidy_places)
+        + delim + RoundToString((double)m_block_subsidy / COIN, subsidy_places)
         + delim + m_organization
         + delim // + mcpid.OrganizationKey
         + delim + m_quorum_hash.ToString()

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -182,7 +182,8 @@ struct Claim
     std::string m_organization; // MiningCPID::Organization
 
     //!
-    //! \brief The GRC value minted for generating the new block.
+    //! \brief The value minted for generating the new block in units of
+    //! 1/100000000 GRC.
     //!
     //! Below the switch to constant block rewards, this field contains the
     //! amount of accrued interest claimed by the staking node. It contains
@@ -193,7 +194,7 @@ struct Claim
     //! incoming reward claims and can index those calculated values without
     //! this field. It can be considered informational.
     //!
-    double m_block_subsidy; // MiningCPID::InterestSubsidy
+    int64_t m_block_subsidy; // MiningCPID::InterestSubsidy
 
     //!
     //! \brief Hash of the block below the block containing this claim.
@@ -210,7 +211,8 @@ struct Claim
     uint256 m_last_block_hash; // MiningCPID::lastblockhash
 
     //!
-    //! \brief The GRC value of the research rewards claimed by the node.
+    //! \brief The value of the research rewards claimed by the node in units
+    //! of 1/100000000 GRC.
     //!
     //! Contains a value of zero for investor claims.
     //!
@@ -219,7 +221,7 @@ struct Claim
     //! incoming reward claims and can index those calculated values without
     //! this field. It can be considered informational.
     //!
-    double m_research_subsidy; // MiningCPID::ResearchSubsidy
+    int64_t m_research_subsidy; // MiningCPID::ResearchSubsidy
 
     //!
     //! \brief The researcher magnitude value from the superblock at the time
@@ -333,7 +335,7 @@ struct Claim
     //! \return The sum of the block subsidy and research subsidy declared in
     //! the claim.
     //!
-    double TotalSubsidy() const;
+    int64_t TotalSubsidy() const;
 
     //!
     //! \brief Sign an instance that claims research rewards.
@@ -402,12 +404,12 @@ struct Claim
         READWRITE(LIMITED_STRING(m_client_version, MAX_VERSION_SIZE));
         READWRITE(LIMITED_STRING(m_organization, MAX_ORGANIZATION_SIZE));
 
-        READWRITE(VarDouble<COIN_PLACES>(m_block_subsidy));
+        READWRITE(m_block_subsidy);
 
         // Serialize research-related fields only for researcher claims:
         //
         if (m_mining_id.Which() == MiningId::Kind::CPID) {
-            READWRITE(VarDouble<COIN_PLACES>(m_research_subsidy));
+            READWRITE(m_research_subsidy);
             READWRITE(m_magnitude);
             READWRITE(VarDouble<MAG_UNIT_PLACES>(m_magnitude_unit));
 

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -40,7 +40,7 @@ struct BlockIndexHeightComparator
 class ResearchAccount
 {
 public:
-    double m_total_research_subsidy;     //!< Total lifetime research paid.
+    int64_t m_total_research_subsidy;    //!< Total lifetime research paid.
 
     uint16_t m_magnitude;                //!< Current magnitude in superblock.
     uint32_t m_total_magnitude;          //!< Total lifetime magnitude sum.
@@ -59,7 +59,7 @@ public:
     //!
     //! \return \c true if no block contains a reward for the account's CPID.
     //!
-    double IsNew() const;
+    bool IsNew() const;
 
     //!
     //! \brief Get a pointer to the last block with a research reward earned by
@@ -210,16 +210,16 @@ public:
     //! \brief Get the average daily research payment over the lifetime of the
     //! account.
     //!
-    //! \return Average research payment in units of GRC (not COIN).
+    //! \return Average research payment in units of 1/100000000 GRC.
     //!
-    virtual double PaymentPerDay(const ResearchAccount& account) const = 0;
+    virtual int64_t PaymentPerDay(const ResearchAccount& account) const = 0;
 
     //!
     //! \brief Get the average daily research payment limit of the account.
     //!
-    //! \return Payment per day limit in units of GRC (not COIN).
+    //! \return Payment per day limit in units of 1/100000000 GRC.
     //!
-    virtual double PaymentPerDayLimit(const ResearchAccount& account) const = 0;
+    virtual int64_t PaymentPerDayLimit(const ResearchAccount& account) const = 0;
 
     //!
     //! \brief Determine whether the account exceeded the daily payment limit.
@@ -233,15 +233,15 @@ public:
     //! \brief Get the expected daily research payment for the account based on
     //! the current network payment conditions.
     //!
-    //! \return Expected daily payment in units of GRC (not COIN).
+    //! \return Expected daily payment in units of 1/100000000 GRC.
     //!
-    virtual double ExpectedDaily(const ResearchAccount& account) const = 0;
+    virtual int64_t ExpectedDaily(const ResearchAccount& account) const = 0;
 
     //!
     //! \brief Get the pending research reward for the account without applying
     //! any limit rules.
     //!
-    //! \return Pending payment in units of COIN.
+    //! \return Pending payment in units of 1/100000000 GRC.
     //!
     virtual int64_t RawAccrual(const ResearchAccount& account) const = 0;
 
@@ -249,7 +249,7 @@ public:
     //! \brief Get the pending research reward for the account as expected by
     //! the network.
     //!
-    //! \return Pending payment in units of COIN.
+    //! \return Pending payment in units of 1/100000000 GRC.
     //!
     virtual int64_t Accrual(const ResearchAccount& account) const = 0;
 };
@@ -285,7 +285,7 @@ public:
     //!
     //! \param payment_time Time of payment to calculate rewards for.
     //!
-    //! \return Max reward allowed in units of COIN.
+    //! \return Max reward allowed in units of 1/100000000 GRC.
     //!
     static int64_t MaxReward(const int64_t payment_time);
 
@@ -321,16 +321,16 @@ public:
     //! \brief Get the average daily research payment over the lifetime of the
     //! account.
     //!
-    //! \return Average research payment in units of GRC (not COIN).
+    //! \return Average research payment in units of 1/100000000 GRC.
     //!
-    double PaymentPerDay(const ResearchAccount& account) const override;
+    int64_t PaymentPerDay(const ResearchAccount& account) const override;
 
     //!
     //! \brief Get the average daily research payment limit of the account.
     //!
-    //! \return Payment per day limit in units of GRC (not COIN).
+    //! \return Payment per day limit in units of 1/100000000 GRC.
     //!
-    double PaymentPerDayLimit(const ResearchAccount& account) const override;
+    int64_t PaymentPerDayLimit(const ResearchAccount& account) const override;
 
     //!
     //! \brief Determine whether the account exceeded the daily payment limit.
@@ -344,15 +344,15 @@ public:
     //! \brief Get the expected daily research payment for the account based on
     //! the current network payment conditions.
     //!
-    //! \return Expected daily payment in units of GRC (not COIN).
+    //! \return Expected daily payment in units of 1/100000000 GRC.
     //!
-    double ExpectedDaily(const ResearchAccount& account) const override;
+    int64_t ExpectedDaily(const ResearchAccount& account) const override;
 
     //!
     //! \brief Get the pending research reward for the account without applying
     //! any limit rules.
     //!
-    //! \return Pending payment in units of COIN.
+    //! \return Pending payment in units of 1/100000000 GRC.
     //!
     int64_t RawAccrual(const ResearchAccount& account) const override;
 
@@ -360,7 +360,7 @@ public:
     //! \brief Get the pending research reward for the account as expected by
     //! the network.
     //!
-    //! \return Pending payment in units of COIN.
+    //! \return Pending payment in units of 1/100000000 GRC.
     //!
     int64_t Accrual(const ResearchAccount& account) const override;
 
@@ -409,9 +409,9 @@ public:
     //!
     //! \param payment_time Determines the max reward based on a schedule.
     //!
-    //! \return Maximum daily emission in units of GRC (not COIN).
+    //! \return Maximum daily emission in units of 1/100000000 GRC.
     //!
-    static double MaxEmission(const int64_t payment_time);
+    static int64_t MaxEmission(const int64_t payment_time);
 
     //!
     //! \brief Get the current network magnitude unit.

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -80,8 +80,8 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
     std::map<std::string,long> c_cpid;
     std::map<std::string,long> c_org;
     int64_t researchcount = 0;
-    double researchtotal = 0;
-    double interesttotal = 0;
+    int64_t researchtotal = 0;
+    int64_t interesttotal = 0;
     int64_t minttotal = 0;
     //int64_t stakeinputtotal = 0;
     int64_t poscount = 0;
@@ -146,7 +146,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
         c_version[claim.m_client_version]++;
         researchtotal += claim.m_research_subsidy;
         interesttotal += claim.m_block_subsidy;
-        researchcount += (claim.m_research_subsidy > 0.001);
+        researchcount += (claim.m_research_subsidy > 10000); // 0.001
         minttotal+=cur->nMint;
         unsigned sizeblock = GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
         size_min_blk=std::min(size_min_blk,sizeblock);
@@ -182,9 +182,9 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
     {
         UniValue result(UniValue::VOBJ);
         result.pushKV("block", blockcount);
-        result.pushKV("research", researchtotal);
-        result.pushKV("interest", interesttotal);
-        result.pushKV("mint", minttotal/(double)COIN);
+        result.pushKV("research", ValueFromAmount(researchtotal));
+        result.pushKV("interest", ValueFromAmount(interesttotal));
+        result.pushKV("mint", ValueFromAmount(minttotal));
         //result.pushKV("stake_input", stakeinputtotal/(double)COIN);
         result.pushKV("blocksizek", size_sum_blk/(double)1024);
         result.pushKV("posdiff", diff_sum);
@@ -192,9 +192,9 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
     }
     {
         UniValue result(UniValue::VOBJ);
-        result.pushKV("research", researchtotal/(double)researchcount);
-        result.pushKV("interest", interesttotal/(double)blockcount);
-        result.pushKV("mint", (minttotal/(double)blockcount)/(double)COIN);
+        result.pushKV("research", ValueFromAmount(researchtotal / researchcount));
+        result.pushKV("interest", ValueFromAmount(interesttotal / blockcount));
+        result.pushKV("mint", ValueFromAmount(minttotal / blockcount));
         //result.pushKV("stake_input", (stakeinputtotal/(double)poscount)/(double)COIN);
         result.pushKV("spacing_sec", ((double)l_last_time-(double)l_first_time)/(double)blockcount);
         result.pushKV("block_per_day", ((double)blockcount*86400.0)/((double)l_last_time-(double)l_first_time));
@@ -675,8 +675,8 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             if(detail>=2 && detail<20)
             {
                 line+="<|>"+cur->GetMiningId().ToString()
-                    + "<|>"+RoundToString(cur->nResearchSubsidy,4)
-                    + "<|>"+RoundToString(cur->nInterestSubsidy,4);
+                    + "<|>"+FormatMoney(cur->nResearchSubsidy)
+                    + "<|>"+FormatMoney(cur->nInterestSubsidy);
             }
         }
         else
@@ -688,8 +688,8 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             result2.pushKV("iscontract", (bool)cur->nIsContract );
             result2.pushKV("ismodifier", (bool)cur->GeneratedStakeModifier() );
             result2.pushKV("cpid", cur->GetMiningId().ToString() );
-            result2.pushKV("research", cur->nResearchSubsidy );
-            result2.pushKV("interest", cur->nInterestSubsidy );
+            result2.pushKV("research", ValueFromAmount(cur->nResearchSubsidy));
+            result2.pushKV("interest", ValueFromAmount(cur->nInterestSubsidy));
             result2.pushKV("magnitude", cur->nMagnitude );
         }
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -123,7 +123,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         const NN::AccrualComputer calc = NN::Tally::GetComputer(*cpid, nTime, pindexBest);
 
         obj.pushKV("Magnitude Unit", calc->MagnitudeUnit());
-        obj.pushKV("BoincRewardPending", FormatMoney(calc->Accrual(account)));
+        obj.pushKV("BoincRewardPending", ValueFromAmount(calc->Accrual(account)));
     }
 
     std::string current_poll = "Poll: ";

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -61,11 +61,11 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
     res.push_back(std::make_pair(_("Block Version"), ToString(block.nVersion)));
     res.push_back(std::make_pair(_("Difficulty"), RoundToString(GetBlockDifficulty(block.nBits),8)));
     res.push_back(std::make_pair(_("CPID"), claim.m_mining_id.ToString()));
-    res.push_back(std::make_pair(_("Interest"), RoundToString(claim.m_block_subsidy, 8)));
+    res.push_back(std::make_pair(_("Interest"), FormatMoney(claim.m_block_subsidy)));
 
     if (claim.m_magnitude > 0)
     {
-        res.push_back(std::make_pair(_("Boinc Reward"), RoundToString(claim.m_research_subsidy, 8)));
+        res.push_back(std::make_pair(_("Boinc Reward"), FormatMoney(claim.m_research_subsidy)));
         res.push_back(std::make_pair(_("Magnitude"), RoundToString(claim.m_magnitude, 8)));
     }
 

--- a/src/test/neuralnet/claim_tests.cpp
+++ b/src/test/neuralnet/claim_tests.cpp
@@ -353,7 +353,6 @@ BOOST_AUTO_TEST_CASE(it_generates_a_hash_for_a_research_reward_claim)
         << claim.m_block_subsidy
         << claim.m_research_subsidy
         << claim.m_magnitude
-        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(claim.m_magnitude_unit)
         << claim.m_signature
         << claim.m_quorum_hash;
 
@@ -563,7 +562,6 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_researcher)
         << claim.m_block_subsidy
         << claim.m_research_subsidy
         << claim.m_magnitude
-        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(claim.m_magnitude_unit)
         << claim.m_signature
         << claim.m_quorum_hash;
 
@@ -593,7 +591,6 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_researcher_with_superblock)
         << claim.m_block_subsidy
         << claim.m_research_subsidy
         << claim.m_magnitude
-        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(claim.m_magnitude_unit)
         << claim.m_signature
         << claim.m_quorum_hash
         << claim.m_superblock;
@@ -621,7 +618,6 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher)
         << expected.m_block_subsidy
         << expected.m_research_subsidy
         << expected.m_magnitude
-        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(expected.m_magnitude_unit)
         << expected.m_signature
         << expected.m_quorum_hash;
 
@@ -637,7 +633,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher)
 
     BOOST_CHECK(claim.m_research_subsidy == expected.m_research_subsidy);
     BOOST_CHECK(claim.m_magnitude == expected.m_magnitude);
-    BOOST_CHECK(claim.m_magnitude_unit == expected.m_magnitude_unit);
+    BOOST_CHECK(claim.m_magnitude_unit == 0.0);
     BOOST_CHECK(claim.m_signature == expected.m_signature);
 
     BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
@@ -661,7 +657,6 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher_with_superbloc
         << expected.m_block_subsidy
         << expected.m_research_subsidy
         << expected.m_magnitude
-        << NN::VarDouble<NN::Claim::MAG_UNIT_PLACES>(expected.m_magnitude_unit)
         << expected.m_signature
         << expected.m_quorum_hash
         << expected.m_superblock;
@@ -678,7 +673,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher_with_superbloc
 
     BOOST_CHECK(claim.m_research_subsidy == expected.m_research_subsidy);
     BOOST_CHECK(claim.m_magnitude == expected.m_magnitude);
-    BOOST_CHECK(claim.m_magnitude_unit == expected.m_magnitude_unit);
+    BOOST_CHECK(claim.m_magnitude_unit == 0.0);
     BOOST_CHECK(claim.m_signature == expected.m_signature);
 
     BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -424,10 +424,6 @@ public:
     std::string strFromAccount;
     std::vector<char> vfSpent; // which outputs are already spent
     int64_t nOrderPos;  // position in ordered transaction list
-	//Add two fields to CWalletTx
-	//int64_t nResearchSubsidy;
-	//int64_t nInterestSubsidy;
-
 
     // memory only
     mutable bool fDebitCached;


### PR DESCRIPTION
Gridcoin-specific additions used floating-point types to represent money values for reward calculations. This changes these values to integers for consistency with the rest of the Bitcoin code base.