### PR TITLE
 Add next target difficulty to RPC output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,6 @@ extern double GetTotalBalance();
 extern std::string PubKeyToAddress(const CScript& scriptPubKey);
 extern const CBlockIndex* GetHistoricalMagnitude(const NN::MiningId mining_id);
 std::string GetCommandNonce(std::string command);
-double GetDifficulty(const CBlockIndex* blockindex);
 
 unsigned int nNodeLifespan;
 
@@ -238,6 +237,60 @@ double GetEstimatedNetworkWeight(unsigned int nPoSInterval)
     if (fDebug10) LogPrintf("GetEstimatedNetworkWeight debug: Network Weight in GRC = %f", result / 80.0);
 
     return result;
+}
+
+double GetDifficulty(const CBlockIndex* blockindex)
+{
+    // Floating point number that is a multiple of the minimum difficulty,
+    // minimum difficulty = 1.0.
+    if (blockindex == NULL)
+    {
+        if (pindexBest == NULL)
+            return 1.0;
+        else
+            blockindex = GetLastBlockIndex(pindexBest, false);
+    }
+
+    int nShift = (blockindex->nBits >> 24) & 0xff;
+
+    double dDiff =
+            (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
+
+    while (nShift < 29)
+    {
+        dDiff *= 256.0;
+        nShift++;
+    }
+    while (nShift > 29)
+    {
+        dDiff /= 256.0;
+        nShift--;
+    }
+
+    return dDiff;
+}
+
+double GetBlockDifficulty(unsigned int nBits)
+{
+    // Floating point number that is a multiple of the minimum difficulty,
+    // minimum difficulty = 1.0.
+    int nShift = (nBits >> 24) & 0xff;
+
+    double dDiff =
+            (double)0x0000ffff / (double)(nBits & 0x00ffffff);
+
+    while (nShift < 29)
+    {
+        dDiff *= 256.0;
+        nShift++;
+    }
+    while (nShift > 29)
+    {
+        dDiff /= 256.0;
+        nShift--;
+    }
+
+    return dDiff;
 }
 
 double GetAverageDifficulty(unsigned int nPoSInterval)

--- a/src/main.h
+++ b/src/main.h
@@ -232,7 +232,6 @@ void PrintBlockTree();
 bool ProcessMessages(CNode* pfrom);
 bool SendMessages(CNode* pto, bool fSendTrickle);
 bool LoadExternalBlockFile(FILE* fileIn);
-double GetBlockDifficulty(unsigned int nBits);
 std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 std::string GetCurrentOverviewTabPoll();
@@ -259,6 +258,8 @@ bool OutOfSyncByAge();
 bool IsSuperBlock(CBlockIndex* pIndex);
 
 double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40);
+double GetDifficulty(const CBlockIndex* blockindex = NULL);
+double GetBlockDifficulty(unsigned int nBits);
 double GetAverageDifficulty(unsigned int nPoSInterval = 40);
 // Note that dDiff cannot be = 0 normally. This is set as default because you can't specify the output of
 // GetAverageDifficulty(nPosInterval) = to dDiff here.

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -16,7 +16,6 @@
 #include <QTimer>
 
 static const int64_t nClientStartupTime = GetTime();
-double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern ConvergedScraperStats ConvergedScraperStatsCache;
 extern CCriticalSection cs_ConvergedScraperStatsCache;
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -55,63 +55,6 @@ extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& 
 
 BlockFinder RPCBlockFinder;
 
-double GetDifficulty(const CBlockIndex* blockindex)
-{
-    // Floating point number that is a multiple of the minimum difficulty,
-    // minimum difficulty = 1.0.
-    if (blockindex == NULL)
-    {
-        if (pindexBest == NULL)
-            return 1.0;
-        else
-            blockindex = GetLastBlockIndex(pindexBest, false);
-    }
-
-    int nShift = (blockindex->nBits >> 24) & 0xff;
-
-    double dDiff =
-            (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
-
-    while (nShift < 29)
-    {
-        dDiff *= 256.0;
-        nShift++;
-    }
-    while (nShift > 29)
-    {
-        dDiff /= 256.0;
-        nShift--;
-    }
-
-    return dDiff;
-}
-
-
-
-
-double GetBlockDifficulty(unsigned int nBits)
-{
-    // Floating point number that is a multiple of the minimum difficulty,
-    // minimum difficulty = 1.0.
-    int nShift = (nBits >> 24) & 0xff;
-
-    double dDiff =
-            (double)0x0000ffff / (double)(nBits & 0x00ffffff);
-
-    while (nShift < 29)
-    {
-        dDiff *= 256.0;
-        nShift++;
-    }
-    while (nShift > 29)
-    {
-        dDiff /= 256.0;
-        nShift--;
-    }
-
-    return dDiff;
-}
-
 namespace {
 UniValue ClaimToJson(const NN::Claim& claim)
 {

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -253,8 +253,9 @@ UniValue getdifficulty(const UniValue& params, bool fHelp)
     LOCK(cs_main);
 
     UniValue obj(UniValue::VOBJ);
-    obj.pushKV("proof-of-work",        GetDifficulty());
-    obj.pushKV("proof-of-stake",       GetDifficulty(GetLastBlockIndex(pindexBest, true)));
+    obj.pushKV("current", GetDifficulty(GetLastBlockIndex(pindexBest, true)));
+    obj.pushKV("target", GetBlockDifficulty(GetNextTargetRequired(pindexBest)));
+
     return obj;
 }
 
@@ -1786,13 +1787,13 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
 
     UniValue res(UniValue::VOBJ), diff(UniValue::VOBJ);
 
-    res.pushKV("blocks",          nBestHeight);
-    res.pushKV("moneysupply",     ValueFromAmount(pindexBest->nMoneySupply));
-    diff.pushKV("proof-of-work",  GetDifficulty());
-    diff.pushKV("proof-of-stake", GetDifficulty(GetLastBlockIndex(pindexBest, true)));
-    res.pushKV("difficulty",      diff);
-    res.pushKV("testnet",         fTestNet);
-    res.pushKV("errors",          GetWarnings("statusbar"));
+    res.pushKV("blocks", nBestHeight);
+    res.pushKV("moneysupply", ValueFromAmount(pindexBest->nMoneySupply));
+    diff.pushKV("current", GetDifficulty(GetLastBlockIndex(pindexBest, true)));
+    diff.pushKV("target", GetBlockDifficulty(GetNextTargetRequired(pindexBest)));
+    res.pushKV("difficulty", diff);
+    res.pushKV("testnet", fTestNet);
+    res.pushKV("errors", GetWarnings("statusbar"));
 
     return res;
 }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -33,19 +33,22 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     int64_t nTime = GetAdjustedTime();
     uint64_t nWeight = 0;
     double nNetworkWeight = 0;
-    double nDifficulty = 0;
+    double nCurrentDiff = 0;
+    double nTargetDiff = 0;
     uint64_t nExpectedTime = 0;
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
         pwalletMain->GetStakeWeight(nWeight);
 
         nNetworkWeight = GetEstimatedNetworkWeight();
-        nDifficulty = GetDifficulty(GetLastBlockIndex(pindexBest, true));
+        nCurrentDiff = GetDifficulty(GetLastBlockIndex(pindexBest, true));
+        nTargetDiff = GetBlockDifficulty(GetNextTargetRequired(pindexBest));
         nExpectedTime = GetEstimatedTimetoStake();
     }
 
     obj.pushKV("blocks", nBestHeight);
-    diff.pushKV("proof-of-stake", nDifficulty);
+    diff.pushKV("current", nCurrentDiff);
+    diff.pushKV("target", nTargetDiff);
 
     { LOCK(MinerStatus.lock);
         // not using real weigh to not break calculation

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -80,7 +80,6 @@ extern const CRPCTable tableRPC;
 extern int64_t nWalletUnlockTime;
 extern int64_t AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(int64_t amount);
-extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 
 extern std::string HelpRequiringPassphrase();
 extern void EnsureWalletIsUnlocked();

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -117,7 +117,8 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.pushKV("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string()));
     obj.pushKV("ip",            addrSeenByPeer.ToStringIP());
 
-    diff.pushKV("proof-of-stake", GetDifficulty(GetLastBlockIndex(pindexBest, true)));
+    diff.pushKV("current", GetDifficulty(GetLastBlockIndex(pindexBest, true)));
+    diff.pushKV("target", GetBlockDifficulty(GetNextTargetRequired(pindexBest)));
     obj.pushKV("difficulty",    diff);
 
     obj.pushKV("testnet",       fTestNet);
@@ -385,7 +386,7 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp)
     CWalletTx wtx;
     if (params.size() > 2 && !params[2].isNull() && !params[2].get_str().empty())
         wtx.mapValue["comment"] = params[2].get_str();
-    if (params.size() > 3 && !params[3].isNull() && !params[3].get_str().empty())        
+    if (params.size() > 3 && !params[3].isNull() && !params[3].get_str().empty())
         wtx.mapValue["to"]      = params[3].get_str();
     if (params.size() > 4 && !params[4].isNull() && !params[4].get_str().empty())
         wtx.hashBoinc += "<MESSAGE>" + MakeSafeMessage(params[4].get_str()) + "</MESSAGE>";


### PR DESCRIPTION
This adds the target difficulty for the next block to the `difficulty` objects in the output of RPC functions: 
 - `getinfo`
 - `getblockchaininfo`
 - `getmininginfo`
 - `getdifficulty`

...and removes the now invalid proof-of-work difficulty values where those still exist.

```
$ gridcoinresearchd getdifficulty
{
  "current": 18.76489411796287,
  "target": 18.54016695804389
}
```

I'm not sure if we want to add this value to the GUI. I can add a field for it there as well. 