### PR TITLE
Clean up and optimize legacy coin age code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3161,28 +3161,6 @@ bool CTransaction::GetCoinAge(CTxDB& txdb, uint64_t& nCoinAge) const
     return true;
 }
 
-// ppcoin: total coin age spent in block, in the unit of coin-days.
-bool CBlock::GetCoinAge(uint64_t& nCoinAge) const
-{
-    nCoinAge = 0;
-
-    CTxDB txdb("r");
-    for (auto const& tx : vtx)
-    {
-        uint64_t nTxCoinAge;
-        if (tx.GetCoinAge(txdb, nTxCoinAge))
-            nCoinAge += nTxCoinAge;
-        else
-            return false;
-    }
-
-    if (nCoinAge == 0) // block coin age minimum 1 coin-day
-        nCoinAge = 1;
-    if (fDebug && GetBoolArg("-printcoinage"))
-        LogPrintf("block coin age total nCoinDays=%" PRIu64, nCoinAge);
-    return true;
-}
-
 bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos, const uint256& hashProof)
 {
     // Check for duplicate

--- a/src/main.h
+++ b/src/main.h
@@ -1311,7 +1311,6 @@ public:
     bool AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos, const uint256& hashProof);
     bool CheckBlock(std::string sCaller, int height1, int64_t mint, bool fCheckPOW=true, bool fCheckMerkleRoot=true, bool fCheckSig=true, bool fLoadingIndex=false) const;
     bool AcceptBlock(bool generated_by_me);
-    bool GetCoinAge(uint64_t& nCoinAge) const; // ppcoin: calculate total coin age spent in block
     bool CheckBlockSignature() const;
 
 private:

--- a/src/miner.h
+++ b/src/miner.h
@@ -15,7 +15,6 @@ struct CMinerStatus
     std::string ReasonNotStaking;
     uint64_t WeightSum,WeightMin,WeightMax;
     double ValueSum;
-    double CoinAgeSum;
     int Version;
     uint64_t CreatedCnt;
     uint64_t AcceptedCnt;


### PR DESCRIPTION
Coin age was used to calculate interest payments before the switch to constant block rewards in block version 10. This removes remnants of coin age calculations from the miner and conditions the lookup of coin age for validation to blocks version 9 and below to avoid unnecessary disk IO for CBR blocks.

This is the last place that we unnecessarily read blocks from disk besides the upcoming contract improvements. The change shaves off another 15 minutes of sync time from my previous baseline and will continue to benefit sync performance as the number of CBR blocks grows. Collectively, this and the earlier changes to remove needless disk access have eliminated the disk IO scaling concerns that I observed at the beginning of the year. The number disk operations that scaled linearly as a function of the number of blocks is now effectively constant.  