### PR TITLE
Add missing condition for newbie accrual computer

### DIFF
--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -445,6 +445,10 @@ public:
         constexpr int64_t six_months = ONE_DAY_IN_SECONDS * 30 * 6;
 
         if (AccrualAge(account) >= six_months) {
+            if (account.m_magnitude <= 0) {
+                return 0;
+            }
+
             if (fDebug) {
                 LogPrintf(
                     "Accrual: %s Invalid Beacon, Using 0.01 age bootstrap",


### PR DESCRIPTION
The refactor from `ComputeResearchAccrual()` to the new tally system is missing the condition for new CPIDs that verifies magnitude for those without a current beacon in the `NewbieAccrualComputer`. 