### PR TITLE
Fix lingering beacon warning after advertisement

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -468,6 +468,9 @@ bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::str
             // This prevents repeated beacons
             nLastBeaconAdvertised = nBestHeight;
 
+            // Clear "unable to send beacon" warning message (if any):
+            msMiningErrors6.clear();
+
             return true;
         }
         catch(UniValue& objError)


### PR DESCRIPTION
The "Unable to send beacon..." warning message lingers in the GUI and in RPC output even after advertisement. This clears the warning message when it succeeds.