### PR TITLE
Create zero-credit days structure for automated greylisting

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,7 @@ GRIDCOIN_CORE_H = \
 	mruset.h \
 	neuralnet/claim.h \
 	neuralnet/cpid.h \
+	neuralnet/greylist.h \
 	neuralnet/project.h \
 	neuralnet/quorum.h \
 	neuralnet/researcher.h \
@@ -168,6 +169,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
 	miner.cpp \
 	neuralnet/claim.cpp \
 	neuralnet/cpid.cpp \
+	neuralnet/greylist.cpp \
 	neuralnet/project.cpp \
 	neuralnet/quorum.cpp \
 	neuralnet/researcher.cpp \

--- a/src/neuralnet/greylist.cpp
+++ b/src/neuralnet/greylist.cpp
@@ -1,0 +1,35 @@
+#include "neuralnet/greylist.h"
+
+using namespace NN;
+
+GreylistSnapshot Greylist::Filter(WhitelistSnapshot projects)
+{
+    GreylistSnapshot::ActiveProjectSet active_projects;
+    GreylistSnapshot::GreylistedProjectSet greylisted_projects;
+
+    for (const auto& project : projects) {
+        const GreylistReason reason = Check(project);
+
+        if (reason == GreylistReason::NONE) {
+            active_projects.emplace_back(&project);
+        } else {
+            greylisted_projects.emplace_back(&project, reason);
+        }
+    }
+
+    return GreylistSnapshot(
+        std::move(projects),
+        std::move(active_projects),
+        std::move(greylisted_projects));
+}
+
+GreylistReason Greylist::Check(const Project& project)
+{
+    return Check(project.m_name);
+}
+
+GreylistReason Greylist::Check(const std::string& project_name)
+{
+    // TODO: implement greylist rules
+    return GreylistReason::NONE;
+}

--- a/src/neuralnet/greylist.h
+++ b/src/neuralnet/greylist.h
@@ -1,0 +1,225 @@
+#pragma once
+
+#include "neuralnet/project.h"
+
+namespace NN {
+//!
+//! \brief Describes why a BOINC project is temporarily greylisted.
+//!
+enum class GreylistReason
+{
+    NONE,              //!< Project is not greylisted.
+    WORK_AVAILABILITY, //!< Failed to supply a reasonable quantity of work.
+    ZERO_CREDIT_DAYS,  //!< Exported too many recent zero-credit days.
+};
+
+//!
+//! \brief Associates a project on the Gridcoin whitelist with a reason for
+//! why the protocol automatically placed it on the greylist.
+//!
+class GreylistProject
+{
+public:
+    const Project* const m_project; //!< Refers to the greylisted project.
+    const GreylistReason m_reason;  //!< Describes why a project is greylisted.
+
+    //!
+    //! \brief Initialize a new greylisted project context.
+    //!
+    //! \param project Refers to the greylisted project.
+    //! \param reason  Describes why a project is greylisted.
+    //!
+    GreylistProject(const Project* const project, const GreylistReason reason)
+        : m_project(project)
+        , m_reason(reason)
+    {
+    }
+
+    const Project& operator*() const
+    {
+        return *m_project;
+    }
+
+    const Project* operator->() const
+    {
+        return m_project;
+    }
+};
+
+//!
+//! \brief Contains a snapshot of projects on the Gridcoin whitelist grouped
+//! by greylisted status.
+//!
+class GreylistSnapshot
+{
+public:
+    typedef std::vector<const Project*> ActiveProjectSet;
+    typedef std::vector<GreylistProject> GreylistedProjectSet;
+
+    //!
+    //! \brief Initialize a new greylist snapshot instance.
+    //!
+    //! \param projects            A snapshot of the projects on the whitelist.
+    //! \param active_projects     Groups non-greylisted projects.
+    //! \param greylisted_projects Groups greylisted projects.
+    //!
+    GreylistSnapshot(
+        WhitelistSnapshot projects,
+        ActiveProjectSet active_projects,
+        GreylistedProjectSet greylisted_projects)
+        : m_projects(std::move(projects))
+        , m_active_projects(std::move(active_projects))
+        , m_greylisted_projects(std::move(greylisted_projects))
+    {
+    }
+
+    //!
+    //! \brief Get the set of non-greylisted projects on the whitelist.
+    //!
+    //! \return Projects that did not trigger an automated greylisting rule.
+    //!
+    const ActiveProjectSet& ActiveProjects() const
+    {
+        return m_active_projects;
+    }
+
+    //!
+    //! \brief Get the set of greylisted projects on the whitelist.
+    //!
+    //! \return Projects that triggered automated greylisting rules, if any.
+    //!
+    const GreylistedProjectSet& GreylistedProjects() const
+    {
+        return m_greylisted_projects;
+    }
+
+    //!
+    //! \brief Determine whether the snapshot contains an active or greylisted
+    //! project with the specified name.
+    //!
+    //! \param project_name Identifies the project to check for.
+    //!
+    //! \return \c true if either the active set or greylisted set of projects
+    //! contains the project identified by \p project_name.
+    //!
+    bool Contains(const std::string& project_name) const
+    {
+        return m_projects.Contains(project_name);
+    }
+
+    //!
+    //! \brief Determine whether the specified project triggered an automated
+    //! greylisting rule.
+    //!
+    //! \param project_name Identifies the project to check for.
+    //!
+    //! \return A value that describes the greylist status of the project.
+    //!
+    GreylistReason Check(const std::string& project_name) const
+    {
+        for (const auto& project : m_greylisted_projects) {
+            if (project->m_name == project_name) {
+                return project.m_reason;
+            }
+        }
+
+        return GreylistReason::NONE;
+    }
+
+    //!
+    //! \brief Determine whether the specified project is not greylisted.
+    //!
+    //! \param project_name Identifies the project to check for.
+    //!
+    //! \return \c true if the project did not trigger an automated greylisting
+    //! rule.
+    //!
+    bool CheckActive(const std::string& project_name) const
+    {
+        return Check(project_name) == GreylistReason::NONE;
+    }
+
+    //!
+    //! \brief Determine whether the specified project is greylisted.
+    //!
+    //! \param project_name Identifies the project to check for.
+    //!
+    //! \return \c true if the project triggered an automated greylisting rule.
+    //!
+    bool CheckGreylisted(const std::string& project_name) const
+    {
+        return Check(project_name) != GreylistReason::NONE;
+    }
+
+private:
+    //!
+    //! \brief Contains a snapshot of the full set of whitelisted projects.
+    //!
+    //! This snapshot contains both active and greylisted projects. By storing
+    //! the snapshot here, \c GreylistSnapshot objects inherit the thread-safe
+    //! design of \c WhitelistSnapshot. The active and greylisted groups point
+    //! to project objects contained in this field.
+    //!
+    const WhitelistSnapshot m_projects;
+
+    //!
+    //! \brief Projects not associated with a greylist status.
+    //!
+    //! Pointers in this set refer to objects in \c m_projects. Dereferencing
+    //! these is always safe.
+    //!
+    const ActiveProjectSet m_active_projects;
+
+    //!
+    //! \brief Projects associated with a greylist status.
+    //!
+    //! Pointers in this set refer to objects in \c m_projects. Dereferencing
+    //! these is always safe.
+    //!
+    const GreylistedProjectSet m_greylisted_projects;
+};
+
+//!
+//! \brief Manages automated greylisting of projects on the Gridcoin whitelist.
+//!
+//! The network may temporarily disqualify whitelisted BOINC projects from the
+//! reward protocol because of conditions that render a project unsuitable for
+//! participation. For these cases, a project is placed onto the "greylist" to
+//! classify the project as ineligible for reward until it resolves short-term
+//! operational issues. This class manages the state used to identify projects
+//! in a greylisted status for the rules compatible with automation.
+//!
+class Greylist
+{
+public:
+    //!
+    //! \brief Filter the supplied set of whitelisted projects into active
+    //! and greylisted statuses.
+    //!
+    //! \param projects A snapshot of projects on the whitelist to filter.
+    //!
+    //! \return A snapshot of projects categorized by greylist status.
+    //!
+    GreylistSnapshot Filter(WhitelistSnapshot projects);
+
+    //!
+    //! \brief Determine whether the supplied project triggered an automated
+    //! greylisting rule.
+    //!
+    //! \param project The whitelisted project to check for.
+    //!
+    //! \return A value that describes the greylist status of the project.
+    //!
+    GreylistReason Check(const Project& project);
+
+    //!
+    //! \brief Determine whether the specified project triggered an automated
+    //! greylisting rule.
+    //!
+    //! \param project_name The name of the whitelisted project to check for.
+    //!
+    //! \return A value that describes the greylist status of the project.
+    //!
+    GreylistReason Check(const std::string& project_name);
+};
+}

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -194,6 +194,7 @@ public:
             pindexLast = pindexLast->pprev;
         }
     }
+
 private:
     //!
     //! \brief A set of recently-added superblocks not yet activated by the
@@ -520,6 +521,11 @@ SuperblockIndex g_superblock_index;
 //!
 LegacyConsensus g_legacy_consensus;
 
+//!
+//! \brief Manages automated greylisting of projects on the Gridcoin whitelist.
+//!
+Greylist g_greylist;
+
 } // anonymous namespace
 
 
@@ -667,4 +673,14 @@ void Quorum::PopSuperblock(const CBlockIndex* const pindex)
 bool Quorum::CommitSuperblock(const uint32_t height)
 {
     return g_superblock_index.Commit(height);
+}
+
+GreylistSnapshot Quorum::FilterGreylist(WhitelistSnapshot projects)
+{
+    return g_greylist.Filter(std::move(projects));
+}
+
+GreylistReason Quorum::CheckGreylist(const std::string& project_name)
+{
+    return g_greylist.Check(project_name);
 }

--- a/src/neuralnet/quorum.h
+++ b/src/neuralnet/quorum.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "neuralnet/greylist.h"
+
 #include <string>
 
 class CBlockIndex;
@@ -167,5 +169,25 @@ public:
     //! activated.
     //!
     static bool CommitSuperblock(const uint32_t height);
+
+    //!
+    //! \brief Filter the supplied set of whitelisted projects into active
+    //! and greylisted statuses.
+    //!
+    //! \param projects A snapshot of projects on the whitelist to filter.
+    //!
+    //! \return A snapshot of projects categorized by greylist status.
+    //!
+    static GreylistSnapshot FilterGreylist(WhitelistSnapshot projects);
+
+    //!
+    //! \brief Determine whether the specified project triggered an automated
+    //! greylisting rule.
+    //!
+    //! \param project_name The name of the whitelisted project to check for.
+    //!
+    //! \return A value that describes the greylist status of the project.
+    //!
+    static GreylistReason CheckGreylist(const std::string& project_name);
 };
 }

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -1680,6 +1680,7 @@ Superblock::ProjectStats::ProjectStats()
     : m_total_credit(0)
     , m_average_rac(0)
     , m_rac(0)
+    , m_zcd(0)
     , m_convergence_hint(0)
 {
 }
@@ -1691,6 +1692,7 @@ Superblock::ProjectStats::ProjectStats(
     : m_total_credit(total_credit)
     , m_average_rac(average_rac)
     , m_rac(rac)
+    , m_zcd(0)
     , m_convergence_hint(0)
 {
 }
@@ -1699,8 +1701,20 @@ Superblock::ProjectStats::ProjectStats(uint64_t average_rac, uint64_t rac)
     : m_total_credit(0)
     , m_average_rac(average_rac)
     , m_rac(rac)
+    , m_zcd(0)
     , m_convergence_hint(0)
 {
+}
+
+bool Superblock::ProjectStats::Greylisted() const
+{
+    return m_zcd.Greylisted();
+}
+
+ZeroCreditTally
+Superblock::ProjectStats::AdvanceZcd(const uint64_t next_credit) const
+{
+    return m_zcd.AdvanceByDelta(m_total_credit, next_credit);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -627,6 +627,7 @@ public:
         uint64_t m_total_credit; //!< All-time credit produced by the project.
         uint64_t m_average_rac;  //!< Average project recent average credit.
         uint64_t m_rac;          //!< Sum of the RAC of all the project CPIDs.
+        ZeroCreditTally m_zcd;   //!< Tracks zero-credit days for greylistiing.
 
         //!
         //! \brief A truncated hash of the converged manifest part that forms
@@ -638,6 +639,27 @@ public:
         //!
         uint32_t m_convergence_hint;
 
+        //!
+        //! \brief Determine whether the project triggered automated greylist
+        //! rules.
+        //!
+        //! \return \c true if the zero-credit days exceeded the limit.
+        //!
+        bool Greylisted() const;
+
+        //!
+        //! \brief Produce a new zero-credit day tally for the subsequent
+        //! superblock by calculating the difference in credit.
+        //!
+        //! \param next_credit The projects credit for the upcoming superblock.
+        //! If no greater than the current credit, set the latest day to a zero
+        //! credit day.
+        //!
+        //! \return A zero-credit day tally object for the project in the next
+        //! superblock.
+        //!
+        ZeroCreditTally AdvanceZcd(const uint64_t next_credit) const;
+
         ADD_SERIALIZE_METHODS;
 
         template <typename Stream, typename Operation>
@@ -646,6 +668,7 @@ public:
             READWRITE(VARINT(m_total_credit));
             READWRITE(VARINT(m_average_rac));
             READWRITE(VARINT(m_rac));
+            READWRITE(m_zcd);
 
             // ProjectIndex handles serialization of m_convergence_hint
             // when creating superblocks from fallback-to-project-level


### PR DESCRIPTION
This adds an initial implementation of the superblock data structure used to support automated greylisting based on the zero-credit days rule (7 out of 20 days). 

I did not write code that actually maintains and enforces the greylist status. @jamescowens will pick this up where I left off. 