### PR TITLE
Change team whitelist delimiter to <> for CPID detection

### DIFF
--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -159,8 +159,14 @@ std::set<std::string> GetTeamWhitelist()
     }
 
     std::set<std::string> teams;
+    std::string delimiter = "<>";
 
-    for (auto&& team_name : split(entry.value, "|")) {
+    // Handle the transition of the team whitelist delimiter from "|" to "<>":
+    if (entry.value.find(delimiter) == std::string::npos) {
+        delimiter = "|";
+    }
+
+    for (auto&& team_name : split(entry.value, delimiter)) {
         if (team_name.empty()) {
             continue;
         }


### PR DESCRIPTION
The CPID detection routine matches project teams against the team whitelist to filter eligible CPIDs. Since the team whitelist delimiter changed in #1632, this routine needs to match. I forgot about it when reviewing that PR. 