### PR TITLE
Fix accrual calculation for new, zero-magnitude CPIDs

### DIFF
--- a/src/gridcoin.cpp
+++ b/src/gridcoin.cpp
@@ -35,6 +35,7 @@ namespace
         uint256S("c1aa0511add3bed3f2e366d38b954285a7602cae10a7244e7fe35e4002e90cd5"), //T629408
         uint256S("639756cf39bf12a4a0ab4ea5ec10938fd0f463cc7bc1bd2916529a445ceba2ab"), //T680406
         uint256S("ba1aae8ea37a9c330b298bd2b569448f0249a685bb0a8e85698fe44d1edca774"), //T1145954 (6-month cutoff)
+        uint256S("b05e6c04c7b414a29746b2d642fd19f64e9fdb13dcc4873144233a23138bd419"), //T1154377 (zero-mag newbie)
     };
 
 

--- a/src/neuralnet/accrual/newbie.h
+++ b/src/neuralnet/accrual/newbie.h
@@ -91,13 +91,13 @@ public:
 
     int64_t Accrual(const ResearchAccount& account) const override
     {
+        if (account.m_magnitude <= 0) {
+            return 0;
+        }
+
         constexpr int64_t six_months = 86400 * 30 * 6; // seconds
 
         if (AccrualAge(account) >= six_months) {
-            if (account.m_magnitude <= 0) {
-                return 0;
-            }
-
             if (fDebug) {
                 LogPrintf(
                     "Accrual: %s Invalid Beacon, Using 0.01 age bootstrap",


### PR DESCRIPTION
This corrects a bug introduced in #1583 that causes a new CPID with no magnitude to stake a 1 GRC research reward. The old zero-magnitude rule was buried in the `BeaconTimestamp()` function updated in that PR. This adds an exception for the block that produced the bug on testnet.