### PR TITLE
adds an rpc call convergencereport

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -395,6 +395,7 @@ static const CRPCCommand vRPCCommands[] =
     { "deletecscrapermanifest",  &deletecscrapermanifest,  cat_developer     },
     { "archivelog",              &archivelog,              cat_developer     },
     { "testnewsb",               &testnewsb,               cat_developer     },
+    { "convergencereport",       &convergencereport,       cat_developer     },
 
   // Network commands
     { "addnode",                 &addnode,                 cat_network       },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -213,6 +213,7 @@ extern UniValue savescraperfilemanifest(const UniValue& params, bool fHelp);
 extern UniValue deletecscrapermanifest(const UniValue& params, bool fHelp);
 extern UniValue archivelog(const UniValue& params, bool fHelp);
 extern UniValue testnewsb(const UniValue& params, bool fHelp);
+extern UniValue convergencereport(const UniValue& params, bool fHelp);
 
 // Network
 extern UniValue addnode(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Provides the same information that is obtained from the graphical tooltip from
the scraper icon in the GUI with debug3 set in JSON format.

I realized people running headless might want the same status information.