### PR TITLE
Fix diagnostics, add ETTS test, fix tooltipcolor, add missing lock, and add email=investor check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,7 +341,7 @@ double GetAverageDifficulty(unsigned int nPoSInterval)
     return result;
 }
 
-double GetEstimatedTimetoStake(double dDiff, double dConfidence)
+double GetEstimatedTimetoStake(bool ignore_staking_status, double dDiff, double dConfidence)
 {
     /*
      * The algorithm below is an attempt to come up with a more accurate way of estimating Time to Stake (ETTS) based on
@@ -378,8 +378,8 @@ double GetEstimatedTimetoStake(double dDiff, double dConfidence)
     }
 
     bool staking = MinerStatus.nLastCoinStakeSearchInterval && MinerStatus.WeightSum;
-    // Get out early if not staking and set return value of 0.
-    if (!staking)
+    // Get out early if not staking and ignore_staking_status is false and set return value of 0.
+    if (!staking && !ignore_staking_status)
     {
         if (fDebug10) LogPrintf("GetEstimatedTimetoStake debug: Not staking: ETTS = %f", result);
         return result;

--- a/src/main.h
+++ b/src/main.h
@@ -256,12 +256,12 @@ double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40);
 double GetDifficulty(const CBlockIndex* blockindex = NULL);
 double GetBlockDifficulty(unsigned int nBits);
 double GetAverageDifficulty(unsigned int nPoSInterval = 40);
+
 // Note that dDiff cannot be = 0 normally. This is set as default because you can't specify the output of
 // GetAverageDifficulty(nPosInterval) = to dDiff here.
-// The defeult confidence is 1-1/e which is the mean for the geometric distribution.
-
-const double DEFAULT_ETTS_CONFIDENCE = 0.632120558829;
-double GetEstimatedTimetoStake(double dDiff = 0.0, double dConfidence = DEFAULT_ETTS_CONFIDENCE);
+// The defeult confidence is 1-1/e which is the mean for the geometric distribution for small probabilities.
+const double DEFAULT_ETTS_CONFIDENCE = 1.0 - 1.0 / exp(1.0);
+double GetEstimatedTimetoStake(bool ignore_staking_status = false, double dDiff = 0.0, double dConfidence = DEFAULT_ETTS_CONFIDENCE);
 
 NN::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex);
 

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -484,7 +484,7 @@ std::string Researcher::Email()
 
 bool Researcher::ConfiguredForInvestorMode(bool log)
 {
-    if (GetBoolArg("-investor", false)) {
+    if (GetBoolArg("-investor", false) || Researcher::Email() == "investor") {
         if (log) LogPrintf("Investor mode configured. Skipping CPID import.");
         return true;
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -722,10 +722,10 @@ void BitcoinGUI::aboutClicked()
     dlg.exec();
 }
 
-void BitcoinGUI::setNumConnections(int count)
+void BitcoinGUI::setNumConnections(int n)
 {
     QString icon;
-    switch(count)
+    switch (n)
     {
     case 0: icon = ":/icons/connect_0"; break;
     case 1: case 2: case 3: icon = ":/icons/connect_1"; break;
@@ -735,19 +735,15 @@ void BitcoinGUI::setNumConnections(int count)
     }
     labelConnectionsIcon->setPixmap(QIcon(icon).pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
 
-    if (count == 0)
+    if (n == 0)
     {
         labelConnectionsIcon->setToolTip(tr("No active connections to the Gridcoin network. "
                                             "If this persists more than a few minutes, please check your configuration "
-                                            "and your network connectivity.").arg(count));
-    }
-    else if (count == 1)
-    {
-        labelConnectionsIcon->setToolTip(tr("%1 active connection to the Gridcoin network").arg(count));
+                                            "and your network connectivity."));
     }
     else
     {
-        labelConnectionsIcon->setToolTip(tr("%1 active connections to the Gridcoin network").arg(count));
+        labelConnectionsIcon->setToolTip(tr("%n active connection(s) to the Gridcoin network", "", n));
     }
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -553,12 +553,12 @@ void BitcoinGUI::createToolBars()
     // Use a red color for the toolbars background if on testnet.
     if (GetBoolArg("-testnet"))
     {
-        toolbar2->setStyleSheet("background-color:qlineargradient(x1: 0, y1: 0, x2: 0.5, y2: 0.5,stop: 0 darkRed, stop: 1 darkRed)");
+        toolbar2->setStyleSheet("background-color:darkRed");
         toolbar3->setStyleSheet("background-color:darkRed");
     }
     else
     {
-        toolbar2->setStyleSheet("background-color:qlineargradient(x1: 0, y1: 0, x2: 0.5, y2: 0.5,stop: 0 rgb(65,0,127), stop: 1 rgb(65,0,127))");
+        toolbar2->setStyleSheet("background-color:rgb(65,0,127)");
         toolbar3->setStyleSheet("background-color:rgb(65,0,127)");
     }
 
@@ -734,7 +734,21 @@ void BitcoinGUI::setNumConnections(int count)
     default: icon = ":/icons/connect_4"; break;
     }
     labelConnectionsIcon->setPixmap(QIcon(icon).pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
-    labelConnectionsIcon->setToolTip(tr("%1 active connection(s) to Gridcoin network").arg(count));
+
+    if (count == 0)
+    {
+        labelConnectionsIcon->setToolTip(tr("No active connections to the Gridcoin network. "
+                                            "If this persists more than a few minutes, please check your configuration "
+                                            "and your network connectivity.").arg(count));
+    }
+    else if (count == 1)
+    {
+        labelConnectionsIcon->setToolTip(tr("%1 active connection to the Gridcoin network").arg(count));
+    }
+    else
+    {
+        labelConnectionsIcon->setToolTip(tr("%1 active connections to the Gridcoin network").arg(count));
+    }
 }
 
 void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -476,7 +476,15 @@ void DiagnosticsDialog::on_testButton_clicked()
             rounded_ETTS = RoundToString(ETTS, 2);
         }
 
-        if (ETTS > 90.0 || ETTS == 0.0)
+        // ETTS of zero actually means no coins, i.e. infinite.
+        if (ETTS == 0.0)
+        {
+            ui->checkETTSResultLabel->setText(tr("Failed: ETTS is infinite. No coins to stake."));
+            ui->checkETTSResultLabel->setStyleSheet("color:white;background-color:red");
+            UpdateTestStatus("checkETTS", completed);
+            UpdateOverallDiagnosticResult(failed);
+        }
+        else if (ETTS > 90.0)
         {
             ui->checkETTSResultLabel->setText(tr("Failed: ETTS = %1 > 90 days")
                                               .arg(QString(rounded_ETTS.c_str())));

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -15,8 +15,6 @@
 #include <numeric>
 #include <fstream>
 
-extern std::unique_ptr<Upgrade> g_UpdateChecker;
-
 namespace NN { std::string GetPrimaryCpid(); }
 
 DiagnosticsDialog::DiagnosticsDialog(QWidget *parent) :
@@ -43,6 +41,22 @@ unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
     }
 
     return pending_count;
+}
+
+DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetTestStatus(std::string test_name)
+{
+    LOCK(cs_diagnostictests);
+
+    auto entry = test_status_map.find(test_name);
+
+    if (entry != test_status_map.end())
+    {
+        return entry->second;
+    }
+    else
+    {
+        return unknown;
+    }
 }
 
 unsigned int DiagnosticsDialog::UpdateTestStatus(std::string test_name, DiagnosticTestStatus test_status)
@@ -82,7 +96,7 @@ void DiagnosticsDialog::UpdateOverallDiagnosticResult(DiagnosticResult diagnosti
         diagnostic_result_status = pending;
     }
 
-    diagnostic_result = (DiagnosticResult) std::max((int) diagnostic_result_in, (int) diagnostic_result);
+    diagnostic_result = (DiagnosticResult) std::max<int>(diagnostic_result_in,  diagnostic_result);
 
     // If diagnostic_result_status is still set to completed, then at least all tests
     // are registered. Walk through the map of tests one by one and check the status.
@@ -134,7 +148,7 @@ void DiagnosticsDialog::DisplayOverallDiagnosticResult()
 
         case passed:
             ui->overallResultResultLabel->setText(tr("Passed"));
-            ui->overallResultResultLabel->setStyleSheet("color:black;background-color:green");
+            ui->overallResultResultLabel->setStyleSheet("color:white;background-color:green");
             break;
 
         case warning:
@@ -144,7 +158,7 @@ void DiagnosticsDialog::DisplayOverallDiagnosticResult()
 
         case failed:
             ui->overallResultResultLabel->setText(tr("Failed"));
-            ui->overallResultResultLabel->setStyleSheet("color:black;background-color:red");
+            ui->overallResultResultLabel->setStyleSheet("color:white;background-color:red");
         }
     }
 
@@ -300,7 +314,7 @@ void DiagnosticsDialog::on_testButton_clicked()
 
     if (GetNumberOfTestsPending())
     {
-        LogPrintf("INFO: on_testButton_clicked: Tests still in progress from a prior run: %u", GetNumberOfTestsPending());
+        LogPrintf("INFO: DiagnosticsDialog::on_testButton_clicked: Tests still in progress from a prior run: %u", GetNumberOfTestsPending());
         this->repaint();
         return;
     }
@@ -342,14 +356,14 @@ void DiagnosticsDialog::on_testButton_clicked()
         if (VerifyBoincPath())
         {
             ui->boincPathResultLabel->setText(tr("Passed"));
-            ui->boincPathResultLabel->setStyleSheet("color:black;background-color:green");
+            ui->boincPathResultLabel->setStyleSheet("color:white;background-color:green");
             UpdateTestStatus("boincPath", completed);
             UpdateOverallDiagnosticResult(passed);
         }
         else
         {
             ui->boincPathResultLabel->setText(tr("Failed"));
-            ui->boincPathResultLabel->setStyleSheet("color:black;background-color:red");
+            ui->boincPathResultLabel->setStyleSheet("color:white;background-color:red");
             UpdateTestStatus("boincPath", completed);
             UpdateOverallDiagnosticResult(failed);
         }
@@ -363,14 +377,14 @@ void DiagnosticsDialog::on_testButton_clicked()
         if (VerifyIsCPIDValid())
         {
             ui->verifyCPIDValidResultLabel->setText(tr("Passed"));
-            ui->verifyCPIDValidResultLabel->setStyleSheet("color:black;background-color:green");
+            ui->verifyCPIDValidResultLabel->setStyleSheet("color:white;background-color:green");
             UpdateTestStatus("verifyCPIDValid", completed);
             UpdateOverallDiagnosticResult(passed);
         }
         else
         {
             ui->verifyCPIDValidResultLabel->setText(tr("Failed: BOINC CPID does not match CPID"));
-            ui->verifyCPIDValidResultLabel->setStyleSheet("color:black;background-color:red");
+            ui->verifyCPIDValidResultLabel->setStyleSheet("color:white;background-color:red");
             UpdateTestStatus("verifyCPIDValid", completed);
             UpdateOverallDiagnosticResult(failed);
         }
@@ -384,7 +398,7 @@ void DiagnosticsDialog::on_testButton_clicked()
         if (VerifyCPIDHasRAC())
         {
             ui->verifyCPIDHasRACResultLabel->setText(tr("Passed"));
-            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:black;background-color:green");
+            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:white;background-color:green");
             UpdateTestStatus("verifyCPIDHasRAC", completed);
             UpdateOverallDiagnosticResult(passed);
 
@@ -392,7 +406,7 @@ void DiagnosticsDialog::on_testButton_clicked()
         else
         {
             ui->verifyCPIDHasRACResultLabel->setText(tr("Failed"));
-            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:black;background-color:red");
+            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:white;background-color:red");
             UpdateTestStatus("verifyCPIDHasRAC", completed);
             UpdateOverallDiagnosticResult(failed);
         }
@@ -406,14 +420,14 @@ void DiagnosticsDialog::on_testButton_clicked()
         if (VerifyCPIDIsInNeuralNetwork())
         {
             ui->verifyCPIDIsInNNResultLabel->setText(tr("Passed"));
-            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:black;background-color:green");
+            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:white;background-color:green");
             UpdateTestStatus("verifyCPIDIsInNN", completed);
             UpdateOverallDiagnosticResult(passed);
         }
         else
         {
             ui->verifyCPIDIsInNNResultLabel->setText(tr("Failed"));
-            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:black;background-color:red");
+            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:white;background-color:red");
             UpdateTestStatus("verifyCPIDIsInNN", completed);
             UpdateOverallDiagnosticResult(failed);
         }
@@ -429,7 +443,7 @@ void DiagnosticsDialog::on_testButton_clicked()
     if (VerifyWalletIsSynced())
     {
         ui->verifyWalletIsSyncedResultLabel->setText(tr("Passed"));
-        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:black;background-color:green");
+        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:white;background-color:green");
         UpdateTestStatus("verifyWalletIsSynced", completed);
         UpdateOverallDiagnosticResult(passed);
     }
@@ -437,7 +451,7 @@ void DiagnosticsDialog::on_testButton_clicked()
     else
     {
         ui->verifyWalletIsSyncedResultLabel->setText(tr("Failed"));
-        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:black;background-color:red");
+        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:white;background-color:red");
         UpdateTestStatus("verifyWalletIsSynced", completed);
         UpdateOverallDiagnosticResult(failed);
     }
@@ -468,14 +482,14 @@ void DiagnosticsDialog::on_testButton_clicked()
     else if(seed_node_connections >= 3)
     {
         ui->verifySeedNodesResultLabel->setText(tr("Passed: Count = %1").arg(QString::number(seed_node_connections)));
-        ui->verifySeedNodesResultLabel->setStyleSheet("color:black;background-color:green");
+        ui->verifySeedNodesResultLabel->setStyleSheet("color:white;background-color:green");
         UpdateTestStatus("verifySeedNodes", completed);
         UpdateOverallDiagnosticResult(passed);
     }
     else
     {
         ui->verifySeedNodesResultLabel->setText(tr("Failed: Count = %1").arg(QString::number(seed_node_connections)));
-        ui->verifySeedNodesResultLabel->setStyleSheet("color:black;background-color:red");
+        ui->verifySeedNodesResultLabel->setStyleSheet("color:white;background-color:red");
         UpdateTestStatus("verifySeedNodes", completed);
         UpdateOverallDiagnosticResult(failed);
     }
@@ -498,25 +512,36 @@ void DiagnosticsDialog::on_testButton_clicked()
     else if (connections >= 8)
     {
         ui->verifyConnectionsResultLabel->setText(tr("Passed: Count = %1").arg(QString::number(connections)));
-        ui->verifyConnectionsResultLabel->setStyleSheet("color:black;background-color:green");
+        ui->verifyConnectionsResultLabel->setStyleSheet("color:white;background-color:green");
         UpdateTestStatus("verifyConnections", completed);
         UpdateOverallDiagnosticResult(passed);
     }
     else
     {
         ui->verifyConnectionsResultLabel->setText(tr("Failed: Count = %1").arg(QString::number(connections)));
-        ui->verifyConnectionsResultLabel->setStyleSheet("color:black;background-color:red");
+        ui->verifyConnectionsResultLabel->setStyleSheet("color:white;background-color:red");
         UpdateTestStatus("verifyConnections", completed);
         UpdateOverallDiagnosticResult(failed);
     }
 
     // tcp port
-    ui->verifyTCPPortResultLabel->setStyleSheet("");
-    ui->verifyTCPPortResultLabel->setText(tr("Testing..."));
-    UpdateTestStatus("verifyTCPPort", pending);
-    this->repaint();
+    // Only test this if intention is to run a full node (i.e. listen=1).
+    if(GetArg("-listen", false))
+    {
+        ui->verifyTCPPortResultLabel->setStyleSheet("");
+        ui->verifyTCPPortResultLabel->setText(tr("Testing..."));
+        UpdateTestStatus("verifyTCPPort", pending);
+        this->repaint();
 
-    VerifyTCPPort();
+        VerifyTCPPort();
+    }
+    else
+    {
+        ui->verifyTCPPortResultLabel->setText(tr("NA"));
+        ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:grey");
+        UpdateTestStatus("verifyTCPPort", completed);
+        UpdateOverallDiagnosticResult(NA);
+     }
 
     // client version
     ui->checkClientVersionResultLabel->setStyleSheet("");
@@ -535,7 +560,7 @@ void DiagnosticsDialog::on_testButton_clicked()
     else
     {
         ui->checkClientVersionResultLabel->setText(tr("Passed"));
-        ui->checkClientVersionResultLabel->setStyleSheet("color:black;background-color:green");
+        ui->checkClientVersionResultLabel->setStyleSheet("color:white;background-color:green");
         UpdateTestStatus("checkClientVersion", completed);
         UpdateOverallDiagnosticResult(passed);
     }
@@ -545,13 +570,18 @@ void DiagnosticsDialog::on_testButton_clicked()
 
 void DiagnosticsDialog::VerifyClock()
 {
+    QTimer *timerVerifyClock = new QTimer();
+
+    // Set up a timeout clock of 10 seconds as a fail-safe.
+    connect(timerVerifyClock, SIGNAL(timeout()), this, SLOT(clkFinished()));
+    timerVerifyClock->start(10 * 1000);
+
     QHostInfo NTPHost = QHostInfo::fromName("pool.ntp.org");
     udpSocket = new QUdpSocket(this);
 
     connect(udpSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this, SLOT(clkStateChanged(QAbstractSocket::SocketState)));
-    connect(udpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(clkSocketError(QAbstractSocket::SocketError)));
+    connect(udpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(clkSocketError()));
 
-    udpSocket->bind(QHostAddress(NTPHost.addresses().first()), 123, QAbstractSocket::ShareAddress);
     udpSocket->connectToHost(QHostAddress(NTPHost.addresses().first()), 123, QIODevice::ReadWrite);
 }
 
@@ -569,18 +599,9 @@ void DiagnosticsDialog::clkStateChanged(QAbstractSocket::SocketState state)
     return;
 }
 
-void DiagnosticsDialog::clkSocketError(QAbstractSocket::SocketError error)
+void DiagnosticsDialog::clkSocketError()
 {
     udpSocket->close();
-
-    ui->verifyClockResultLabel->setText(tr("Warning: Cannot connect to NTP server"));
-    ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:yellow");
-    UpdateTestStatus("verifyClockResult", completed);
-
-    // We need this here because there is no return call (callback) to the on_testButton_clicked function
-    UpdateOverallDiagnosticResult(warning);
-
-    DisplayOverallDiagnosticResult();
 
     return;
 }
@@ -589,7 +610,10 @@ void DiagnosticsDialog::clkFinished()
 {
     if (udpSocket->waitForReadyRead())
     {
-        while (udpSocket->hasPendingDatagrams())
+        int64_t start_time = GetAdjustedTime();
+
+        // Only allow this loop to run for 15 seconds maximum.
+        while (udpSocket->hasPendingDatagrams() && GetAdjustedTime() - start_time <= 5)
         {
             QByteArray BufferSocket = udpSocket->readAll();
 
@@ -609,7 +633,7 @@ void DiagnosticsDialog::clkFinished()
                 if (timeDiff.minutes() < 3)
                 {
                     ui->verifyClockResultLabel->setText(tr("Passed"));
-                    ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:green");
+                    ui->verifyClockResultLabel->setStyleSheet("color:white;background-color:green");
                     UpdateTestStatus("verifyClockResult", completed);
 
                     // We need this here because there is no return call (callback) to the on_testButton_clicked function
@@ -618,20 +642,38 @@ void DiagnosticsDialog::clkFinished()
                 else
                 {
                     ui->verifyClockResultLabel->setText(tr("Failed: Sync local time with network"));
-                    ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:red");
+                    ui->verifyClockResultLabel->setStyleSheet("color:white;background-color:red");
                     UpdateTestStatus("verifyClockResult", completed);
 
                     // We need this here because there is no return call (callback) to the on_testButton_clicked function
                     UpdateOverallDiagnosticResult(failed);
                 }
+
+                // We need this here because there is no return call (callback) to the on_testButton_clicked function
+                DisplayOverallDiagnosticResult();
+
+                return;
             }
         }
     }
+    else // The other state here is a socket or other indeterminate error such as a timeout (coming from clkSocketError).
+    {
+        // This is needed to "cancel" the timout timer. Essentially if the test was marked completed via the normal exits
+        // above, then when the timer calls clkFinished again, it will hit this conditional and be a no-op.
+        if (GetTestStatus("verifyClockResult") != completed)
+        {
+            ui->verifyClockResultLabel->setText(tr("Warning: Cannot connect to NTP server"));
+            ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:yellow");
+            UpdateTestStatus("verifyClockResult", completed);
 
-    // We need this here because there is no return call (callback) to the on_testButton_clicked function
-    DisplayOverallDiagnosticResult();
+            // We need this here because there is no return call (callback) to the on_testButton_clicked function
+            UpdateOverallDiagnosticResult(warning);
 
-    return;
+            DisplayOverallDiagnosticResult();
+        }
+
+        return;
+    }
 }
 
 void DiagnosticsDialog::VerifyTCPPort()
@@ -648,7 +690,7 @@ void DiagnosticsDialog::TCPFinished()
 {
     tcpSocket->close();
     ui->verifyTCPPortResultLabel->setText(tr("Passed"));
-    ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:green");
+    ui->verifyTCPPortResultLabel->setStyleSheet("color:white;background-color:green");
 
     // We need this here because there is no return call (callback) to the on_testButton_clicked function
     UpdateTestStatus("verifyTCPPort", completed);
@@ -661,8 +703,8 @@ void DiagnosticsDialog::TCPFinished()
 
 void DiagnosticsDialog::TCPFailed(QAbstractSocket::SocketError socket)
 {
-    ui->verifyTCPPortResultLabel->setText(tr("Failed: Port 32749 may be blocked by your firewall"));
-    ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:red");
+    ui->verifyTCPPortResultLabel->setText(tr("Warning: Port 32749 may be blocked by your firewall"));
+    ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:yellow");
 
     // We need this here because there is no return call (callback) to the on_testButton_clicked function
     UpdateTestStatus("verifyTCPPort", completed);

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -9,9 +9,13 @@
 
 #include "diagnosticsdialog.h"
 #include "ui_diagnosticsdialog.h"
+#include "neuralnet/researcher.h"
+#include "upgrade.h"
 
 #include <numeric>
 #include <fstream>
+
+extern std::unique_ptr<Upgrade> g_UpdateChecker;
 
 namespace NN { std::string GetPrimaryCpid(); }
 
@@ -20,14 +24,131 @@ DiagnosticsDialog::DiagnosticsDialog(QWidget *parent) :
     ui(new Ui::DiagnosticsDialog)
 {
     ui->setupUi(this);
-
-    networkManager = new QNetworkAccessManager(this);
-    connect(networkManager, SIGNAL(finished(QNetworkReply *)), this, SLOT(getGithubVersionFinished(QNetworkReply *)));
 }
 
 DiagnosticsDialog::~DiagnosticsDialog()
 {
     delete ui;
+}
+
+unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
+{
+    LOCK(cs_diagnostictests);
+
+    unsigned int pending_count = 0;
+
+    for (const auto& entry : test_status_map)
+    {
+        if (entry.second == pending) pending_count++;
+    }
+
+    return pending_count;
+}
+
+unsigned int DiagnosticsDialog::UpdateTestStatus(std::string test_name, DiagnosticTestStatus test_status)
+{
+    LOCK(cs_diagnostictests);
+
+    test_status_map[test_name] = test_status;
+
+    return test_status_map.size();
+}
+
+
+void DiagnosticsDialog::ResetOverallDiagnosticResult(unsigned int& number_of_tests_in)
+{
+    LOCK(cs_diagnostictests);
+
+    number_of_tests = number_of_tests_in;
+
+    test_status_map.clear();
+
+    diagnostic_result_status = pending;
+
+    diagnostic_result = NA;
+}
+
+void DiagnosticsDialog::UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in)
+{
+    LOCK(cs_diagnostictests);
+
+    // Set diagnostic_result_status to completed. This is under lock, so noone can snoop.
+    diagnostic_result_status = completed;
+
+    // If the total number of registered tests is less than the initialized number, then
+    // the overall status is pending by default.
+    if (test_status_map.size() < number_of_tests)
+    {
+        diagnostic_result_status = pending;
+    }
+
+    diagnostic_result = (DiagnosticResult) std::max((int) diagnostic_result_in, (int) diagnostic_result);
+
+    // If diagnostic_result_status is still set to completed, then at least all tests
+    // are registered. Walk through the map of tests one by one and check the status.
+    // The first one encountered that is pending means the overall status is pending.
+    if (diagnostic_result_status == completed)
+    {
+        for (const auto& entry : test_status_map)
+        {
+            if (entry.second == pending)
+            {
+                diagnostic_result_status = pending;
+                break;
+            }
+        }
+    }
+}
+
+// Lock should be taken on cs_diagnostictests before calling this function.
+DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetOverallDiagnosticResult()
+{
+    return diagnostic_result;
+}
+
+// Lock should be taken on cs_diagnostictests before calling this function.
+DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetOverallDiagnosticStatus()
+{
+    return diagnostic_result_status;
+}
+
+
+void DiagnosticsDialog::DisplayOverallDiagnosticResult()
+{
+    LOCK(cs_diagnostictests);
+
+    if (GetOverallDiagnosticStatus() == pending)
+    {
+        ui->overallResultResultLabel->setText(tr("Testing..."));
+        ui->overallResultResultLabel->setStyleSheet("");
+    }
+    else
+    {
+        // Overall status must be completed, so display overall result
+        switch (GetOverallDiagnosticResult())
+        {
+        case NA:
+            ui->overallResultResultLabel->clear();
+            ui->overallResultResultLabel->setStyleSheet("");
+            break;
+
+        case passed:
+            ui->overallResultResultLabel->setText(tr("Passed"));
+            ui->overallResultResultLabel->setStyleSheet("color:black;background-color:green");
+            break;
+
+        case warning:
+            ui->overallResultResultLabel->setText(tr("Warning"));
+            ui->overallResultResultLabel->setStyleSheet("color:black;background-color:yellow");
+            break;
+
+        case failed:
+            ui->overallResultResultLabel->setText(tr("Failed"));
+            ui->overallResultResultLabel->setStyleSheet("color:black;background-color:red");
+        }
+    }
+
+    this->repaint();
 }
 
 bool DiagnosticsDialog::VerifyBoincPath()
@@ -172,6 +293,256 @@ int DiagnosticsDialog::VerifyCountConnections()
     return (int)vNodes.size();
 }
 
+void DiagnosticsDialog::on_testButton_clicked()
+{
+    // Check to see if there is already a test run in progress, and if so return.
+    // We do not want overlapping test runs.
+
+    if (GetNumberOfTestsPending())
+    {
+        LogPrintf("INFO: on_testButton_clicked: Tests still in progress from a prior run: %u", GetNumberOfTestsPending());
+        this->repaint();
+        return;
+    }
+
+    // This needs to be updated if there are more tests added.
+    unsigned int number_of_tests = 10;
+
+    ResetOverallDiagnosticResult(number_of_tests);
+    DisplayOverallDiagnosticResult();
+
+    // Tests that are N/A if in investor mode.
+    if (NN::Researcher::ConfiguredForInvestorMode())
+    {
+        // N/A tests for investor mode
+        ui->boincPathResultLabel->setText(tr("N/A"));
+        ui->boincPathResultLabel->setStyleSheet("color:black;background-color:grey");
+        UpdateTestStatus("boincPath", completed);
+
+        ui->verifyCPIDValidResultLabel->setText(tr("N/A"));
+        ui->verifyCPIDValidResultLabel->setStyleSheet("color:black;background-color:grey");
+        UpdateTestStatus("verifyCPIDValid", completed);
+
+        ui->verifyCPIDHasRACResultLabel->setText(tr("N/A"));
+        ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:black;background-color:grey");
+        UpdateTestStatus("verifyCPIDHasRAC", completed);
+
+        ui->verifyCPIDIsInNNResultLabel->setText(tr("N/A"));
+        ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:black;background-color:grey");
+        UpdateTestStatus("verifyCPIDIsInNN", completed);
+    }
+    else
+    {
+        //BOINC path
+        ui->boincPathResultLabel->setStyleSheet("");
+        ui->boincPathResultLabel->setText(tr("Testing..."));
+        UpdateTestStatus("boincPath", pending);
+        this->repaint();
+
+        if (VerifyBoincPath())
+        {
+            ui->boincPathResultLabel->setText(tr("Passed"));
+            ui->boincPathResultLabel->setStyleSheet("color:black;background-color:green");
+            UpdateTestStatus("boincPath", completed);
+            UpdateOverallDiagnosticResult(passed);
+        }
+        else
+        {
+            ui->boincPathResultLabel->setText(tr("Failed"));
+            ui->boincPathResultLabel->setStyleSheet("color:black;background-color:red");
+            UpdateTestStatus("boincPath", completed);
+            UpdateOverallDiagnosticResult(failed);
+        }
+
+        //CPID valid
+        ui->verifyCPIDValidResultLabel->setStyleSheet("");
+        ui->verifyCPIDValidResultLabel->setText(tr("Testing..."));
+        UpdateTestStatus("verifyCPIDValid", pending);
+        this->repaint();
+
+        if (VerifyIsCPIDValid())
+        {
+            ui->verifyCPIDValidResultLabel->setText(tr("Passed"));
+            ui->verifyCPIDValidResultLabel->setStyleSheet("color:black;background-color:green");
+            UpdateTestStatus("verifyCPIDValid", completed);
+            UpdateOverallDiagnosticResult(passed);
+        }
+        else
+        {
+            ui->verifyCPIDValidResultLabel->setText(tr("Failed: BOINC CPID does not match CPID"));
+            ui->verifyCPIDValidResultLabel->setStyleSheet("color:black;background-color:red");
+            UpdateTestStatus("verifyCPIDValid", completed);
+            UpdateOverallDiagnosticResult(failed);
+        }
+
+        //CPID has rac
+        ui->verifyCPIDHasRACResultLabel->setStyleSheet("");
+        ui->verifyCPIDHasRACResultLabel->setText(tr("Testing..."));
+        UpdateTestStatus("verifyCPIDHasRAC", pending);
+        this->repaint();
+
+        if (VerifyCPIDHasRAC())
+        {
+            ui->verifyCPIDHasRACResultLabel->setText(tr("Passed"));
+            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:black;background-color:green");
+            UpdateTestStatus("verifyCPIDHasRAC", completed);
+            UpdateOverallDiagnosticResult(passed);
+
+        }
+        else
+        {
+            ui->verifyCPIDHasRACResultLabel->setText(tr("Failed"));
+            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:black;background-color:red");
+            UpdateTestStatus("verifyCPIDHasRAC", completed);
+            UpdateOverallDiagnosticResult(failed);
+        }
+
+        //cpid is in nn
+        ui->verifyCPIDIsInNNResultLabel->setStyleSheet("");
+        ui->verifyCPIDIsInNNResultLabel->setText(tr("Testing..."));
+        UpdateTestStatus("verifyCPIDIsInNN", pending);
+        this->repaint();
+
+        if (VerifyCPIDIsInNeuralNetwork())
+        {
+            ui->verifyCPIDIsInNNResultLabel->setText(tr("Passed"));
+            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:black;background-color:green");
+            UpdateTestStatus("verifyCPIDIsInNN", completed);
+            UpdateOverallDiagnosticResult(passed);
+        }
+        else
+        {
+            ui->verifyCPIDIsInNNResultLabel->setText(tr("Failed"));
+            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:black;background-color:red");
+            UpdateTestStatus("verifyCPIDIsInNN", completed);
+            UpdateOverallDiagnosticResult(failed);
+        }
+    }
+
+    // Tests that are common to both investor and researcher mode.
+    // wallet synced
+    ui->verifyWalletIsSyncedResultLabel->setStyleSheet("");
+    ui->verifyWalletIsSyncedResultLabel->setText(tr("Testing..."));
+    UpdateTestStatus("verifyWalletIsSynced", pending);
+    this->repaint();
+
+    if (VerifyWalletIsSynced())
+    {
+        ui->verifyWalletIsSyncedResultLabel->setText(tr("Passed"));
+        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:black;background-color:green");
+        UpdateTestStatus("verifyWalletIsSynced", completed);
+        UpdateOverallDiagnosticResult(passed);
+    }
+
+    else
+    {
+        ui->verifyWalletIsSyncedResultLabel->setText(tr("Failed"));
+        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:black;background-color:red");
+        UpdateTestStatus("verifyWalletIsSynced", completed);
+        UpdateOverallDiagnosticResult(failed);
+    }
+
+    // clock
+    ui->verifyClockResultLabel->setStyleSheet("");
+    ui->verifyClockResultLabel->setText(tr("Testing..."));
+    UpdateTestStatus("verifyClockResult", pending);
+    this->repaint();
+
+    VerifyClock();
+
+    // seed nodes
+    ui->verifySeedNodesResultLabel->setStyleSheet("");
+    ui->verifySeedNodesResultLabel->setText(tr("Testing..."));
+    UpdateTestStatus("verifySeedNodes", pending);
+    this->repaint();
+
+    unsigned int seed_node_connections = VerifyCountSeedNodes();
+
+    if (seed_node_connections >= 1 && seed_node_connections < 3)
+    {
+        ui->verifySeedNodesResultLabel->setText(tr("Warning: Count = %1 (Pass = 3+)").arg(QString::number(seed_node_connections)));
+        ui->verifySeedNodesResultLabel->setStyleSheet("color:black;background-color:yellow");
+        UpdateTestStatus("verifySeedNodes", completed);
+        UpdateOverallDiagnosticResult(warning);
+    }
+    else if(seed_node_connections >= 3)
+    {
+        ui->verifySeedNodesResultLabel->setText(tr("Passed: Count = %1").arg(QString::number(seed_node_connections)));
+        ui->verifySeedNodesResultLabel->setStyleSheet("color:black;background-color:green");
+        UpdateTestStatus("verifySeedNodes", completed);
+        UpdateOverallDiagnosticResult(passed);
+    }
+    else
+    {
+        ui->verifySeedNodesResultLabel->setText(tr("Failed: Count = %1").arg(QString::number(seed_node_connections)));
+        ui->verifySeedNodesResultLabel->setStyleSheet("color:black;background-color:red");
+        UpdateTestStatus("verifySeedNodes", completed);
+        UpdateOverallDiagnosticResult(failed);
+    }
+
+    // connection count
+    ui->verifyConnectionsResultLabel->setStyleSheet("");
+    ui->verifyConnectionsResultLabel->setText(tr("Testing..."));
+    UpdateTestStatus("verifyConnections", pending);
+    this->repaint();
+
+    unsigned int connections = VerifyCountConnections();
+
+    if (connections <= 7 && connections >= 1)
+    {
+        ui->verifyConnectionsResultLabel->setText(tr("Warning: Count = %1 (Pass = 8+)").arg(QString::number(connections)));
+        ui->verifyConnectionsResultLabel->setStyleSheet("color:black;background-color:yellow");
+        UpdateTestStatus("verifyConnections", completed);
+        UpdateOverallDiagnosticResult(warning);
+    }
+    else if (connections >= 8)
+    {
+        ui->verifyConnectionsResultLabel->setText(tr("Passed: Count = %1").arg(QString::number(connections)));
+        ui->verifyConnectionsResultLabel->setStyleSheet("color:black;background-color:green");
+        UpdateTestStatus("verifyConnections", completed);
+        UpdateOverallDiagnosticResult(passed);
+    }
+    else
+    {
+        ui->verifyConnectionsResultLabel->setText(tr("Failed: Count = %1").arg(QString::number(connections)));
+        ui->verifyConnectionsResultLabel->setStyleSheet("color:black;background-color:red");
+        UpdateTestStatus("verifyConnections", completed);
+        UpdateOverallDiagnosticResult(failed);
+    }
+
+    // tcp port
+    ui->verifyTCPPortResultLabel->setStyleSheet("");
+    ui->verifyTCPPortResultLabel->setText(tr("Testing..."));
+    UpdateTestStatus("verifyTCPPort", pending);
+    this->repaint();
+
+    VerifyTCPPort();
+
+    // client version
+    ui->checkClientVersionResultLabel->setStyleSheet("");
+    ui->checkClientVersionResultLabel->setText(tr("Testing..."));
+    UpdateTestStatus("checkClientVersion", pending);
+
+    std::string client_message;
+
+    if (g_UpdateChecker->CheckForLatestUpdate(false, client_message))
+    {
+        ui->checkClientVersionResultLabel->setText(tr("Warning: New Client version available:\n %1").arg(QString(client_message.c_str())));
+        ui->checkClientVersionResultLabel->setStyleSheet("color:black;background-color:yellow;height:2em");
+        UpdateTestStatus("checkClientVersion", completed);
+        UpdateOverallDiagnosticResult(warning);
+    }
+    else
+    {
+        ui->checkClientVersionResultLabel->setText(tr("Passed"));
+        ui->checkClientVersionResultLabel->setStyleSheet("color:black;background-color:green");
+        UpdateTestStatus("checkClientVersion", completed);
+        UpdateOverallDiagnosticResult(passed);
+    }
+
+    DisplayOverallDiagnosticResult();
+}
+
 void DiagnosticsDialog::VerifyClock()
 {
     QHostInfo NTPHost = QHostInfo::fromName("pool.ntp.org");
@@ -180,122 +551,8 @@ void DiagnosticsDialog::VerifyClock()
     connect(udpSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this, SLOT(clkStateChanged(QAbstractSocket::SocketState)));
     connect(udpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(clkSocketError(QAbstractSocket::SocketError)));
 
+    udpSocket->bind(QHostAddress(NTPHost.addresses().first()), 123, QAbstractSocket::ShareAddress);
     udpSocket->connectToHost(QHostAddress(NTPHost.addresses().first()), 123, QIODevice::ReadWrite);
-}
-
-
-
-void DiagnosticsDialog::VerifyTCPPort()
-{
-    tcpSocket = new QTcpSocket(this);
-
-    connect(tcpSocket, SIGNAL(connected()), this, SLOT(TCPFinished()));
-    connect(tcpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(TCPFailed(QAbstractSocket::SocketError)));
-
-    tcpSocket->connectToHost("portquiz.net", GetListenPort());
-}
-
-void DiagnosticsDialog::on_testButton_clicked()
-{
-    int result = 0;
-
-    //boin path
-    ui->boincPathResultLabel->setText("Testing...");
-    this->repaint();
-
-    if (VerifyBoincPath())
-        ui->boincPathResultLabel->setText("Passed");
-
-    else
-        ui->boincPathResultLabel->setText("Failed");
-
-    //cpid valid
-    ui->verifyCPIDValidResultLabel->setText("Testing...");
-    this->repaint();
-
-    if (VerifyIsCPIDValid())
-        ui->verifyCPIDValidResultLabel->setText("Passed");
-
-    else
-        ui->verifyCPIDValidResultLabel->setText("Failed (BOINC CPID does not match CPID)");
-
-    //cpid has rac
-    ui->verifyCPIDHasRACResultLabel->setText("Testing...");
-    this->repaint();
-
-    if (VerifyCPIDHasRAC())
-        ui->verifyCPIDHasRACResultLabel->setText(QString::fromStdString("Passed"));
-
-    else
-        ui->verifyCPIDHasRACResultLabel->setText("Failed");
-
-    //cpid is in nn
-    ui->verifyCPIDIsInNNResultLabel->setText("Testing...");
-    this->repaint();
-
-    if (VerifyCPIDIsInNeuralNetwork())
-        ui->verifyCPIDIsInNNResultLabel->setText("Passed");
-
-    else
-        ui->verifyCPIDIsInNNResultLabel->setText("Failed");
-
-    //wallet synced
-    ui->verifyWalletIsSyncedResultLabel->setText("Testing...");
-    this->repaint();
-
-    if (VerifyWalletIsSynced())
-        ui->verifyWalletIsSyncedResultLabel->setText("Passed");
-
-    else
-        ui->verifyWalletIsSyncedResultLabel->setText("Failed");
-
-    //clock
-    ui->verifyClockResultLabel->setText("Testing...");
-    this->repaint();
-
-    VerifyClock();
-
-    //seed nodes
-    ui->verifySeedNodesResultLabel->setText("Testing...");
-    this->repaint();
-
-    result = VerifyCountSeedNodes();
-
-    if (result >= 1 && result < 3)
-        ui->verifySeedNodesResultLabel->setText("Warning: Count=" + QString::number(result) + " (Pass=3+)");
-
-    else if(result >= 3)
-        ui->verifySeedNodesResultLabel->setText("Passed: Count=" + QString::number(result));
-
-    else
-        ui->verifySeedNodesResultLabel->setText("Failed: Count=" + QString::number(result));
-
-    //connection count
-    ui->verifyConnectionsResultLabel->setText("Testing...");
-    this->repaint();
-
-    result = VerifyCountConnections();
-
-    if (result <= 7 && result >= 1)
-        ui->verifyConnectionsResultLabel->setText("Warning: Count=" + QString::number(result) + " (Pass=8+)");
-
-    else if (result >=8)
-        ui->verifyConnectionsResultLabel->setText("Passed: Count=" + QString::number(result));
-
-    else
-        ui->verifyConnectionsResultLabel->setText("Failed: Count=" + QString::number(result));
-
-    //tcp port
-    ui->verifyTCPPortResultLabel->setText("Testing...");
-    this->repaint();
-
-    VerifyTCPPort();
-
-    //client version
-    ui->checkClientVersionResultLabel->setText("Testing...");
-    networkManager->get(QNetworkRequest(QUrl("https://api.github.com/repos/gridcoin-community/Gridcoin-Research/releases/latest")));
-
-    return;
 }
 
 void DiagnosticsDialog::clkStateChanged(QAbstractSocket::SocketState state)
@@ -314,9 +571,16 @@ void DiagnosticsDialog::clkStateChanged(QAbstractSocket::SocketState state)
 
 void DiagnosticsDialog::clkSocketError(QAbstractSocket::SocketError error)
 {
-    ui->verifyClockResultLabel->setText("Failed to make connection to NTP server");
-
     udpSocket->close();
+
+    ui->verifyClockResultLabel->setText(tr("Warning: Cannot connect to NTP server"));
+    ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:yellow");
+    UpdateTestStatus("verifyClockResult", completed);
+
+    // We need this here because there is no return call (callback) to the on_testButton_clicked function
+    UpdateOverallDiagnosticResult(warning);
+
+    DisplayOverallDiagnosticResult();
 
     return;
 }
@@ -343,102 +607,68 @@ void DiagnosticsDialog::clkFinished()
                 boost::posix_time::time_duration timeDiff = networkTime - localTime;
 
                 if (timeDiff.minutes() < 3)
-                    ui->verifyClockResultLabel->setText("Passed");
+                {
+                    ui->verifyClockResultLabel->setText(tr("Passed"));
+                    ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:green");
+                    UpdateTestStatus("verifyClockResult", completed);
 
+                    // We need this here because there is no return call (callback) to the on_testButton_clicked function
+                    UpdateOverallDiagnosticResult(passed);
+                }
                 else
-                    ui->verifyClockResultLabel->setText("Failed (Sync local time with network)");
+                {
+                    ui->verifyClockResultLabel->setText(tr("Failed: Sync local time with network"));
+                    ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:red");
+                    UpdateTestStatus("verifyClockResult", completed);
 
-                this->repaint();
+                    // We need this here because there is no return call (callback) to the on_testButton_clicked function
+                    UpdateOverallDiagnosticResult(failed);
+                }
             }
         }
     }
 
+    // We need this here because there is no return call (callback) to the on_testButton_clicked function
+    DisplayOverallDiagnosticResult();
+
     return;
+}
+
+void DiagnosticsDialog::VerifyTCPPort()
+{
+    tcpSocket = new QTcpSocket(this);
+
+    connect(tcpSocket, SIGNAL(connected()), this, SLOT(TCPFinished()));
+    connect(tcpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(TCPFailed(QAbstractSocket::SocketError)));
+
+    tcpSocket->connectToHost("portquiz.net", GetListenPort());
 }
 
 void DiagnosticsDialog::TCPFinished()
 {
     tcpSocket->close();
-    ui->verifyTCPPortResultLabel->setText("Passed");
-    this->repaint();
+    ui->verifyTCPPortResultLabel->setText(tr("Passed"));
+    ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:green");
+
+    // We need this here because there is no return call (callback) to the on_testButton_clicked function
+    UpdateTestStatus("verifyTCPPort", completed);
+    UpdateOverallDiagnosticResult(passed);
+
+    DisplayOverallDiagnosticResult();
 
     return;
 }
 
 void DiagnosticsDialog::TCPFailed(QAbstractSocket::SocketError socket)
 {
-    ui->verifyTCPPortResultLabel->setText("Failed (Port 32749 may be blocked by your firewall)");
-    this->repaint();
+    ui->verifyTCPPortResultLabel->setText(tr("Failed: Port 32749 may be blocked by your firewall"));
+    ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:red");
 
-    return;
-}
+    // We need this here because there is no return call (callback) to the on_testButton_clicked function
+    UpdateTestStatus("verifyTCPPort", completed);
+    UpdateOverallDiagnosticResult(failed);
 
-void DiagnosticsDialog::getGithubVersionFinished(QNetworkReply *reply)
-{
-    if (reply->error())
-    {
-        // Incase ssl dlls are not present or corrupted; avoid crash
-        ui->checkClientVersionResultLabel->setText("Failed (" + reply->errorString() + ")");
-
-        return;
-    }
-
-    QByteArray data;
-    data = reply->readAll();
-    std::string newVersionString;
-
-    QJsonDocument replyJson = QJsonDocument::fromJson(data);
-    QJsonObject obj = replyJson.object();
-
-    if (!obj.empty())
-    {
-        QJsonValue newVersionJVal = obj.value("name");
-
-        if (!newVersionJVal.isUndefined())
-            newVersionString = newVersionJVal.toString().toStdString();
-    }
-
-    std::vector<std::string> newVersionStringSplit;
-    boost::algorithm::split(newVersionStringSplit, newVersionString, boost::is_any_of("-"));
-    newVersionString = newVersionStringSplit.at(0);
-
-    std::string currentVersionString = FormatFullVersion();
-    std::vector<std::string> currentVersionStringSplit;
-    boost::algorithm::split(currentVersionStringSplit, currentVersionString, boost::is_any_of("-"));
-    currentVersionString = currentVersionStringSplit.at(0);
-    boost::algorithm::split(currentVersionStringSplit, currentVersionString, boost::is_any_of("v"));
-    currentVersionString = currentVersionStringSplit.at(1);
-
-    std::vector<std::string> currentVersionList;
-    std::vector<std::string> newVersionList;
-
-    boost::algorithm::split(currentVersionList, currentVersionString, boost::is_any_of("."));
-    boost::algorithm::split(newVersionList, newVersionString, boost::is_any_of("."));
-
-    int iNew;
-    int iCurrent;
-
-    try
-    {
-        for (unsigned int i=0; i<newVersionList.size(); i++) {
-            iNew = std::stoi(newVersionList.at(i), nullptr, 10);
-            iCurrent = std::stoi(currentVersionList.at(i), nullptr, 10);
-
-            if (iNew > iCurrent) {
-                ui->checkClientVersionResultLabel->setText("Failed (An update is available, please update to " + QString::fromStdString(newVersionString) + ")");
-
-                return;
-            }
-
-            else
-                ui->checkClientVersionResultLabel->setText("Up to date");
-        }
-    }
-
-    catch (std::exception& ex)
-    {
-        ui->checkClientVersionResultLabel->setText("Failed: std exception occurred -> " + QString::fromUtf8(ex.what()));
-    }
+    DisplayOverallDiagnosticResult();
 
     return;
 }

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -594,23 +594,12 @@ void DiagnosticsDialog::on_testButton_clicked()
     }
 
     // tcp port
-    // Only test this if intention is to run a full node (i.e. listen=1).
-    if(GetArg("-listen", false))
-    {
-        ui->verifyTCPPortResultLabel->setStyleSheet("");
-        ui->verifyTCPPortResultLabel->setText(tr("Testing..."));
-        UpdateTestStatus("verifyTCPPort", pending);
-        this->repaint();
+    ui->verifyTCPPortResultLabel->setStyleSheet("");
+    ui->verifyTCPPortResultLabel->setText(tr("Testing..."));
+    UpdateTestStatus("verifyTCPPort", pending);
+    this->repaint();
 
-        VerifyTCPPort();
-    }
-    else
-    {
-        ui->verifyTCPPortResultLabel->setText(tr("NA"));
-        ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:grey");
-        UpdateTestStatus("verifyTCPPort", completed);
-        UpdateOverallDiagnosticResult(NA);
-     }
+    VerifyTCPPort();
 
     // client version
     ui->checkClientVersionResultLabel->setStyleSheet("");

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -48,6 +48,7 @@ private:
     bool VerifyWalletIsSynced();
     bool VerifyIsCPIDValid();
     bool VerifyCPIDHasRAC();
+    double VerifyETTSReasonable();
     int VerifyCountSeedNodes();
     int VerifyCountConnections();
     double GetTotalCPIDRAC(std::string cpid);

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -31,6 +31,7 @@ public:
 
     enum DiagnosticTestStatus
     {
+        unknown,
         pending,
         completed
     };
@@ -75,6 +76,7 @@ private:
 public:
     unsigned int GetNumberOfTestsPending();
     unsigned int UpdateTestStatus(std::string test_name, DiagnosticTestStatus test_status);
+    DiagnosticTestStatus GetTestStatus(std::string test_name);
     void ResetOverallDiagnosticResult(unsigned int& number_of_tests);
     void UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in);
     DiagnosticResult GetOverallDiagnosticResult();
@@ -85,7 +87,7 @@ private slots:
     void on_testButton_clicked();
     void clkFinished();
     void clkStateChanged(QAbstractSocket::SocketState state);
-    void clkSocketError(QAbstractSocket::SocketError error);
+    void clkSocketError();
     void TCPFinished();
     void TCPFailed(QAbstractSocket::SocketError socketError);
 };

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>757</width>
-    <height>413</height>
+    <width>765</width>
+    <height>441</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,7 @@
     <number>20</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowminimumheight="30,20,20,20,20,20,20,20,20,20,20">
+    <layout class="QGridLayout" name="gridLayout" rowminimumheight="30,20,20,20,20,20,20,20,20,20,20,0">
      <property name="sizeConstraint">
       <enum>QLayout::SetMinimumSize</enum>
      </property>
@@ -49,6 +49,121 @@
      <property name="verticalSpacing">
       <number>8</number>
      </property>
+     <item row="3" column="0">
+      <widget class="QLabel" name="verifyCPIDHasRACLabel">
+       <property name="text">
+        <string>Verify CPID has RAC</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="verifyWalletIsSyncedResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="verifyWalletIsSyncedLabel">
+       <property name="text">
+        <string>Verify wallet is synced</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="verifyCPIDValidLabel">
+       <property name="text">
+        <string>Verify CPID is valid</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLabel" name="verifyConnectionsResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="verifyTCPPortLabel">
+       <property name="text">
+        <string>Verify TCP/IP port</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QLabel" name="verifyTCPPortResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="checkClientVersionLabel">
+       <property name="text">
+        <string>Check client version</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="diagnosticsLabel">
+       <property name="font">
+        <font>
+         <pointsize>14</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Diagnostics</string>
+       </property>
+      </widget>
+     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="verifyCPIDIsInNNLabel">
        <property name="sizePolicy">
@@ -64,7 +179,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Verify CPID is in Neural Network</string>
+        <string>Verify CPID has valid beacon</string>
        </property>
       </widget>
      </item>
@@ -119,49 +234,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="verifyCPIDHasRACLabel">
-       <property name="text">
-        <string>Verify CPID has RAC</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="verifyWalletIsSyncedResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="verifyWalletIsSyncedLabel">
-       <property name="text">
-        <string>Verify wallet is synced</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="verifyCPIDValidLabel">
-       <property name="text">
-        <string>Verify CPID is valid</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1">
       <widget class="QLabel" name="verifyCPIDHasRACResultLabel">
        <property name="sizePolicy">
@@ -181,18 +253,6 @@
        </property>
        <property name="wordWrap">
         <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="diagnosticsLabel">
-       <property name="font">
-        <font>
-         <pointsize>14</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>Diagnostics</string>
        </property>
       </widget>
      </item>
@@ -283,64 +343,6 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
-      <widget class="QLabel" name="verifyConnectionsResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="verifyTCPPortLabel">
-       <property name="text">
-        <string>Verify TCP port 32749</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QLabel" name="verifyTCPPortResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="checkClientVersionLabel">
-       <property name="text">
-        <string>Check client version</string>
-       </property>
-      </widget>
-     </item>
      <item row="10" column="1">
       <widget class="QLabel" name="checkClientVersionResultLabel">
        <property name="sizePolicy">
@@ -354,6 +356,37 @@
          <width>200</width>
          <height>0</height>
         </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="overallResultLabel">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Overall Result</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QLabel" name="overallResultResultLabel">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
        </property>
        <property name="text">
         <string/>

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>765</width>
-    <height>441</height>
+    <width>866</width>
+    <height>577</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -117,7 +117,7 @@
      <item row="9" column="0">
       <widget class="QLabel" name="verifyTCPPortLabel">
        <property name="text">
-        <string>Verify TCP/IP port</string>
+        <string>Verify listen port for full node</string>
        </property>
       </widget>
      </item>
@@ -179,7 +179,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Verify CPID has valid beacon</string>
+        <string>Verify CPID has valid beacon </string>
        </property>
       </widget>
      </item>
@@ -339,7 +339,7 @@
      <item row="8" column="0">
       <widget class="QLabel" name="verifyConnectionsLabel">
        <property name="text">
-        <string>Verify connections to network</string>
+        <string>Verify connections to network </string>
        </property>
       </widget>
      </item>
@@ -401,7 +401,7 @@
       <number>6</number>
      </property>
      <property name="leftMargin">
-      <number>550</number>
+      <number>610</number>
      </property>
      <property name="rightMargin">
       <number>0</number>

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>866</width>
-    <height>577</height>
+    <height>623</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,7 @@
     <number>20</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowminimumheight="30,20,20,20,20,20,20,20,20,20,20,0">
+    <layout class="QGridLayout" name="gridLayout">
      <property name="sizeConstraint">
       <enum>QLayout::SetMinimumSize</enum>
      </property>
@@ -49,14 +49,70 @@
      <property name="verticalSpacing">
       <number>8</number>
      </property>
-     <item row="3" column="0">
-      <widget class="QLabel" name="verifyCPIDHasRACLabel">
+     <item row="4" column="1">
+      <widget class="QLabel" name="verifyCPIDIsInNNResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Verify CPID has RAC</string>
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="0">
+      <widget class="QLabel" name="verifyCPIDIsInNNLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Verify CPID has valid beacon </string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLabel" name="verifySeedNodesResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
       <widget class="QLabel" name="verifyWalletIsSyncedResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -78,75 +134,24 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="verifyWalletIsSyncedLabel">
+     <item row="13" column="0">
+      <widget class="QLabel" name="overallResultLabel">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
        <property name="text">
-        <string>Verify wallet is synced</string>
+        <string>Overall Result</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="verifyCPIDValidLabel">
+     <item row="3" column="0">
+      <widget class="QLabel" name="verifyCPIDHasRACLabel">
        <property name="text">
-        <string>Verify CPID is valid</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QLabel" name="verifyConnectionsResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="verifyTCPPortLabel">
-       <property name="text">
-        <string>Verify listen port for full node</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QLabel" name="verifyTCPPortResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="checkClientVersionLabel">
-       <property name="text">
-        <string>Check client version</string>
+        <string>Verify CPID has RAC</string>
        </property>
       </widget>
      </item>
@@ -164,49 +169,22 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="verifyCPIDIsInNNLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>240</width>
-         <height>0</height>
-        </size>
+     <item row="13" column="1">
+      <widget class="QLabel" name="overallResultResultLabel">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
        </property>
        <property name="text">
-        <string>Verify CPID has valid beacon </string>
+        <string/>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
       <widget class="QLabel" name="verifyCPIDValidResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="boincPathResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -234,6 +212,136 @@
        </property>
       </widget>
      </item>
+     <item row="9" column="1">
+      <widget class="QLabel" name="verifyConnectionsResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="verifyTCPPortLabel">
+       <property name="text">
+        <string>Verify listen port for full node</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="verifyClockLabel">
+       <property name="text">
+        <string>Verify clock</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="boincPathResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="verifyConnectionsLabel">
+       <property name="text">
+        <string>Verify connections to network </string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="verifyClockResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="verifyCPIDValidLabel">
+       <property name="text">
+        <string>Verify CPID is valid</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QLabel" name="verifyTCPPortResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="checkClientVersionLabel">
+       <property name="text">
+        <string>Check client version</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="verifySeedNodesLabel">
+       <property name="text">
+        <string>Verify connections to seeds</string>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="1">
       <widget class="QLabel" name="verifyCPIDHasRACResultLabel">
        <property name="sizePolicy">
@@ -256,94 +364,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="verifyCPIDIsInNNResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="6" column="0">
-      <widget class="QLabel" name="verifyClockLabel">
+      <widget class="QLabel" name="verifyWalletIsSyncedLabel">
        <property name="text">
-        <string>Verify clock</string>
+        <string>Verify wallet is synced</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QLabel" name="verifyClockResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="verifySeedNodesLabel">
-       <property name="text">
-        <string>Verify connections to seeds</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QLabel" name="verifySeedNodesResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="verifyConnectionsLabel">
-       <property name="text">
-        <string>Verify connections to network </string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
+     <item row="12" column="1">
       <widget class="QLabel" name="checkClientVersionResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -365,28 +393,26 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="overallResultLabel">
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
+     <item row="5" column="0">
+      <widget class="QLabel" name="checkETTSLabel">
        <property name="text">
-        <string>Overall Result</string>
+        <string>Check estimated time to stake </string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
-      <widget class="QLabel" name="overallResultResultLabel">
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
+     <item row="5" column="1">
+      <widget class="QLabel" name="checkETTSResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
        </property>
        <property name="text">
         <string/>

--- a/src/qt/res/icons/notsynced.svg
+++ b/src/qt/res/icons/notsynced.svg
@@ -8,8 +8,8 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="15"
-   height="15"
+   width="256"
+   height="256"
    version="1.1"
    id="svg6"
    sodipodi:docname="notsynced.svg"
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -43,12 +43,13 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient826"
-       id="linearGradient828"
+       id="linearGradient831"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(16.628351,0,0,16.628351,10,2.531691)"
        x1="7.6090364"
        y1="7.4133701"
-       x2="7.3909645"
-       y2="-14.705274"
-       gradientUnits="userSpaceOnUse" />
+       x2="7.5438585"
+       y2="-0.97540414" />
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -59,28 +60,27 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="2074"
-     inkscape:window-height="1378"
+     inkscape:window-width="3840"
+     inkscape:window-height="1859"
      id="namedview8"
      showgrid="false"
      inkscape:pagecheckerboard="true"
-     inkscape:zoom="15.733333"
-     inkscape:cx="-3.5275425"
-     inkscape:cy="7.4999998"
-     inkscape:window-x="984"
-     inkscape:window-y="296"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg6" />
+     inkscape:zoom="3.9333333"
+     inkscape:cx="-1.2394069"
+     inkscape:cy="298.5367"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     showguides="false" />
   <path
-     fill="none"
-     stroke="#000"
-     stroke-width="2"
-     stroke-dasharray="8,3.5"
-     d="m6,2a5.5,5.5 0 1,0 3,0"
+     d="m 109.77011,35.788371 a 91.455929,91.455929 0 1 0 49.88505,0"
      id="path2"
-     style="stroke:url(#linearGradient828);stroke-opacity:1;fill:none;fill-opacity:1" />
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient831);stroke-width:33.25670242;stroke-dasharray:133.02680605, 58.19922764999999742;stroke-opacity:1"
+     inkscape:connector-curvature="0" />
   <path
-     d="m0,7.4h4.4l-2.2,2.5M9.3,4.6l2.2-3.8-3.4,1M9.3,10.2l2.2,3.8 1-3.4"
+     d="M 10,125.58147 H 83.164743 L 46.582372,167.15234 M 164.64366,79.022083 201.22603,15.83435 144.68964,32.462701 m 19.95402,139.678149 36.58237,63.18773 16.62835,-56.53639"
      id="path4"
-     style="stroke:#ff7f01;stroke-opacity:0;fill-opacity:1;fill:#c07a00" />
+     style="fill:#c07a00;fill-opacity:1;stroke:#ff7f01;stroke-width:16.62835121;stroke-opacity:0"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -145,7 +145,6 @@ QToolTip {
     border: none;
 }
 
-
 QTableView{
     background-color: rgb(49,54,59); 
     color:white;
@@ -369,7 +368,7 @@ QCheckBox{
     border:none;
     padding-top:1.25em;
     min-width:8em;
-    height:100%;    
+    height:100%;
     color: white;
 }
 
@@ -377,6 +376,7 @@ QCheckBox{
     border:none;
     min-width:1.625em;
     max-width:3em;
+    color: white;
 }
 
 #toolbar3 {
@@ -399,6 +399,10 @@ QToolBar#toolbar2 QLabel{
     padding-top:1em;
     padding-bottom:1em;
     qproperty-alignment: AlignCenter;
+}
+
+QToolBar#toolbar2 QToolTip {
+    color:white
 }
 
 QToolBar#toolbar3 QLabel{

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -359,7 +359,7 @@ QListWidget{
     border:none;
     padding-top:1.25em;
     min-width:8em;
-    height:100%;    
+    height:100%;
     color: black;
 }
 
@@ -367,6 +367,7 @@ QListWidget{
     border:none;
     min-width:1.625em;
     max-width:3em;
+    color: white;
 }
 
 #toolbar3 {
@@ -389,6 +390,10 @@ QToolBar#toolbar2 QLabel{
     padding-top:1em;
     padding-bottom:1em;
     qproperty-alignment: AlignCenter;
+}
+
+QToolBar#toolbar2 QToolTip {
+    color:white
 }
 
 QToolBar#toolbar3 QLabel{

--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -7,6 +7,7 @@ QMainWindow {
 /* Main Window*/
 
 #toolbar {
+    border:none;
     padding-top:1.25em;
     min-width:8em;
     height:100%;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -393,7 +393,7 @@ std::string ExtractValue(std::string data, std::string delimiter, int pos)
 bool AdvertiseBeacon(std::string &sOutPrivKey, std::string &sOutPubKey, std::string &sError, std::string &sMessage)
 {
     sOutPrivKey = "BUG! deprecated field used";
-    LOCK(cs_main);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
     {
         const std::string primary_cpid = NN::GetPrimaryCpid();
 

--- a/src/upgrade.h
+++ b/src/upgrade.h
@@ -39,7 +39,7 @@ public:
     //!
     //! \brief Check for latest updates on github.
     //!
-    static void CheckForLatestUpdate();
+    static bool CheckForLatestUpdate(bool ui_dialog = true, std::string client_message_out = "");
 
     //!
     //! \brief Function that will be threaded to download snapshot


### PR DESCRIPTION
A few odds and ends...

1. Fix the tooltip color for the text so that it is readable in native, light, and dark modes.
2. Add missing pwalletMain lock on AdvertiseBeacon
3. Add email=investor check to Researcher::ConfiguredForInvestorMode to allow legacy specification of investor mode by using email=investor to continue to work.
4. Fixed diagnostics. Still have a little more work to do, but it should already behave better in investor mode, and now provides a color coded overall result.