### PR TITLE
ETTS and staking icon enhancements

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -270,6 +270,7 @@ RES_ICONS = \
   qt/res/icons/rsz_chat.png \
   qt/res/icons/staking_off.svg \
   qt/res/icons/staking_on.svg \
+  qt/res/icons/staking_unable.svg \
   qt/res/icons/statistics.png \
   qt/res/icons/toolbar.png \
   qt/res/icons/transaction_conflicted.png \

--- a/src/miner.h
+++ b/src/miner.h
@@ -9,23 +9,7 @@
 #include "main.h"
 #include "wallet.h"
 
-struct CMinerStatus
-{
-    CCriticalSection lock;
-    std::string ReasonNotStaking;
-    uint64_t WeightSum,WeightMin,WeightMax;
-    double ValueSum;
-    int Version;
-    uint64_t CreatedCnt;
-    uint64_t AcceptedCnt;
-    uint64_t KernelsFound;
-    int64_t nLastCoinStakeSearchInterval;
-    double KernelDiffMax;
-    double KernelDiffSum;
-
-    void Clear();
-    CMinerStatus();
-};
+// struct CMinerStatus is in wallet.h to prevent a circular header reference issue
 
 typedef std::vector< std::pair<std::string, double> > SideStakeAlloc;
 

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -71,6 +71,7 @@
         <file alias="notsynced">res/icons/notsynced.svg</file>
         <file alias="synced">res/icons/green_check.svg</file>
         <file alias="white_and_red_x">res/icons/white_and_red_x.svg</file>
+        <file alias="staking_unable">res/icons/staking_unable.svg</file>
     </qresource>
     <qresource prefix="/images">
         <file alias="splash">res/images/splash3.png</file>

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -52,7 +52,6 @@ public:
     */
     void setWalletModel(WalletModel *walletModel);
 
-
 protected:
     void changeEvent(QEvent *e);
     void closeEvent(QCloseEvent *event);

--- a/src/qt/res/icons/staking_unable.svg
+++ b/src/qt/res/icons/staking_unable.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="110"
+   height="110"
+   xml:space="preserve"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="staking_unable.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"><metadata
+   id="metadata27"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><sodipodi:namedview
+   inkscape:window-height="1859"
+   inkscape:window-width="3840"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0"
+   guidetolerance="10.0"
+   gridtolerance="10.0"
+   objecttolerance="10.0"
+   borderopacity="1.0"
+   bordercolor="#666666"
+   pagecolor="#ffffff"
+   id="base"
+   showgrid="false"
+   inkscape:zoom="8.8"
+   inkscape:cx="-2.4740502"
+   inkscape:cy="66.7047"
+   inkscape:current-layer="svg2"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:pagecheckerboard="true" />
+ <defs
+   id="defs4"><linearGradient
+   inkscape:collect="always"
+   id="linearGradient864"><stop
+     style="stop-color:#ff0000;stop-opacity:1;"
+     offset="0"
+     id="stop860" /><stop
+     style="stop-color:#858585;stop-opacity:1"
+     offset="1"
+     id="stop862" /></linearGradient><inkscape:perspective
+   sodipodi:type="inkscape:persp3d"
+   inkscape:vp_x="0 : 55 : 1"
+   inkscape:vp_y="0 : 1000 : 0"
+   inkscape:vp_z="110 : 55 : 1"
+   inkscape:persp3d-origin="55 : 36.666667 : 1"
+   id="perspective29" />
+  <linearGradient
+   id="linGrad"
+   x1="55"
+   y1="12.5"
+   x2="55"
+   y2="55"
+   gradientUnits="userSpaceOnUse"
+   gradientTransform="rotate(-29.999995,52.415693,54.42123)">
+   <stop
+   offset="0"
+   style="stop-color:white;stop-opacity:1"
+   id="stop7" />
+   <stop
+   offset="1"
+   style="stop-color:white;stop-opacity:0"
+   id="stop9" />
+  </linearGradient>
+  <radialGradient
+   id="radGrad"
+   cx="55"
+   cy="55"
+   r="101"
+   fx="55"
+   fy="80.25"
+   gradientUnits="userSpaceOnUse"
+   gradientTransform="translate(0.11363636)">
+   <stop
+   offset="0"
+   style="stop-color:#d5fc00;"
+   id="stop12" />
+   <stop
+   offset="0.45"
+   style="stop-color:#6bbb03;"
+   id="stop14" />
+   <stop
+   offset="1"
+   style="stop-color:#589903;"
+   id="stop16" />
+  </radialGradient>
+ <radialGradient
+   inkscape:collect="always"
+   xlink:href="#linearGradient864"
+   id="radialGradient866"
+   cx="55.113636"
+   cy="55"
+   fx="55.113636"
+   fy="55"
+   r="50.5"
+   gradientUnits="userSpaceOnUse" /></defs>
+ <circle
+   cx="55.113636"
+   cy="55"
+   r="47.5"
+   style="fill:url(#radialGradient866);stroke:#020802;stroke-width:6;stroke-opacity:1;fill-opacity:1"
+   id="circle18" />
+ <circle
+   cx="-55"
+   cy="-55"
+   r="44"
+   style="fill:none;stroke:#b4b4b4;stroke-width:1;stroke-opacity:0.75"
+   id="circle20"
+   transform="scale(-1)" />
+ <polygon
+   style="fill:#010101;fill-opacity:1"
+   points="60.3839,61.4181 42.6864,79.1156 60.8844,79.1156 85,55 60.8844,30.8844 42.6864,30.8844 60.3839,48.5819 25,48.5819 25,61.4181 "
+   id="polygon22"
+   transform="rotate(90,55,55)" />
+ <path
+   style="fill:url(#linGrad)"
+   d="m 33.693164,16.82422 c 13.620415,-7.8637497 29.788048,-7.3279887 42.503988,-0.0025 -0.01394,14.675021 -7.633523,28.944917 -21.253938,36.808666 -13.620415,7.863751 -29.788297,7.327555 -42.50424,0.0021 0.01394,-14.675055 7.633775,-28.944517 21.25419,-36.808266 z"
+   id="path24"
+   inkscape:connector-curvature="0"
+   inkscape:label="path24" />
+</svg>

--- a/src/scraper/http.cpp
+++ b/src/scraper/http.cpp
@@ -215,6 +215,10 @@ std::string Http::GetEtag(
         {
             etag = line.substr(pos+6, line.size());
             etag = etag.substr(1, etag.size() - 3);
+
+            if (fDebug)
+                _log(logattribute::INFO, "curl_http_header", "Captured ETag for project url <urlfile=" + url + ", ETag=" + etag + ">");
+
             return etag;
         }
     }
@@ -223,10 +227,6 @@ std::string Http::GetEtag(
         throw std::runtime_error("No ETag response from project url <urlfile=" + url + ">");
 
     return std::string();
-
-    // This needs to go away for production along with the above external function declaration and the fixup enum to support _log here.
-    if (fDebug)
-        _log(logattribute::INFO, "curl_http_header", "Captured ETag for project url <urlfile=" + url + ", ETag=" + etag + ">");
 }
 
 std::string Http::GetLatestVersionResponse()

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -1086,7 +1086,7 @@ bool ScraperHousekeeping()
              + std::to_string(CScraperManifest::mapPendingDeletedManifest.size()));
     }
 
-    if (fDebug3 && !superblock.WellFormed())
+    if (fDebug3 && superblock.WellFormed())
     {
         UniValue input_params(UniValue::VARR);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -98,6 +98,10 @@ static std::map<std::string, std::unique_ptr<fsbridge::FileLock>> dir_locks;
 /** Mutex to protect dir_locks. */
 static std::mutex cs_dir_locks;
 
+// An absolute hack but required due to possible bitcoingui early call, and it goes here because it has to be guaranteed
+// to be initialized here with the bitcoingui object.
+std::atomic_bool miner_first_pass_complete {false};
+
 void SetupEnvironment()
 {
     // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale

--- a/src/util.h
+++ b/src/util.h
@@ -139,6 +139,8 @@ extern bool fLogTimestamps;
 extern bool fReopenDebugLog;
 extern bool fDevbuildCripple;
 
+extern std::atomic_bool miner_first_pass_complete;
+
 void RandAddSeed();
 void RandAddSeedPerfmon();
 


### PR DESCRIPTION
This PR corrects/refines the handling of the staking icon and ETTS reported on the tooltip.

Improvements have been made to the miner code to use scoped enums for the miner status rather than a concatenated string. (The string is also retained for legacy purposes for now.)

The old staking icon/tooltip conflated two different states together: "unable to stake" because the wallet is locked or the reserve is set so that no coins can be used for staking, etc. vs. "currently not staking, but able to stake", which is all of the coins currently on cooldown (such as for a new wallet that just received it's first "deposit", or a one UTXO wallet where the UTXO just staked and is on cooldown.

I have introduced a new staking icon, a red down arrow, which indicates "unable to stake", with an appropriate tooltip description. The gray down arrow is now used for "currently not staking" status, where staking will occur without any further operator action (i.e. coins maturing). The green up arrow is used for currently staking status as before.

Some minor improvements were also made, such as minor style cleanups of the code where I was working, along with some lock optimizations.