### PR TITLE
Add precision to support magnitudes less than 1

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -100,6 +100,7 @@ GRIDCOIN_CORE_H = \
 	neuralnet/accrual/research_age.h \
 	neuralnet/claim.h \
 	neuralnet/cpid.h \
+	neuralnet/magnitude.h \
 	neuralnet/project.h \
 	neuralnet/quorum.h \
 	neuralnet/researcher.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -43,6 +43,7 @@ GRIDCOIN_TESTS =\
   test/netbase_tests.cpp \
   test/neuralnet/claim_tests.cpp \
   test/neuralnet/cpid_tests.cpp \
+  test/neuralnet/magnitude_tests.cpp \
   test/neuralnet/project_tests.cpp \
   test/neuralnet/researcher_tests.cpp \
   test/neuralnet/superblock_tests.cpp \

--- a/src/appcache.cpp
+++ b/src/appcache.cpp
@@ -1,5 +1,4 @@
 #include "appcache.h"
-#include "main.h"
 #include "util.h"
 
 #include <boost/algorithm/string.hpp>

--- a/src/beacon.cpp
+++ b/src/beacon.cpp
@@ -78,7 +78,7 @@ int64_t MaxBeaconAge()
 int64_t BeaconAgeAdvertiseThreshold()
 {
     // 5 months in seconds.
-    return 3600 * 24 * 30 * 5;    
+    return 3600 * 24 * 30 * 5;
 }
 
 void GetBeaconElements(const std::string& sBeacon, std::string& out_cpid, std::string& out_address, std::string& out_publickey)
@@ -101,7 +101,7 @@ std::string GetBeaconPublicKey(const std::string& cpid, bool bAdvertisingBeacon)
     std::string sBeacon = RetrieveBeaconValueWithMaxAge(cpid, iMaxSeconds);
     if (sBeacon.empty())
         return "";
-    
+
     // Beacon data structure: CPID,hashRand,Address,beacon public key: base64 encoded
     std::string sContract = DecodeBase64(sBeacon);
     std::vector<std::string> vContract = split(sContract.c_str(),";");
@@ -244,14 +244,14 @@ bool VerifyBeaconContractTx(const CTransaction& tx)
 }
 
 bool ImportBeaconKeysFromConfig(const std::string& cpid, CWallet* wallet)
-{    
+{
     if(cpid.empty())
         return error("Empty CPID");
 
     std::string strSecret = GetArgument("privatekey" + cpid + (fTestNet ? "testnet" : ""), "");
     if(strSecret.empty())
         return false;
-    
+
     auto vecsecret = ParseHex(strSecret);
 
     CKey key;
@@ -335,7 +335,7 @@ BeaconStatus GetBeaconStatus(std::string& sCPID)
     beacon_status.iBeaconTimestamp = BeaconTimeStamp(sCPID);
     beacon_status.timestamp = TimestampToHRDate(beacon_status.iBeaconTimestamp);
     beacon_status.hasBeacon = HasActiveBeacon(sCPID);
-    beacon_status.dPriorSBMagnitude = NN::Tally::GetMagnitude(NN::MiningId::Parse(sCPID));
+    beacon_status.dPriorSBMagnitude = NN::Tally::GetMagnitude(NN::MiningId::Parse(sCPID)).Floating();
     beacon_status.is_mine = (sCPID == NN::GetPrimaryCpid());
 
     return beacon_status;

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -6,9 +6,6 @@
 #include <boost/range/adaptor/reversed.hpp>
 
 #include "checkpoints.h"
-
-#include "txdb.h"
-#include "main.h"
 #include "uint256.h"
 
 

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -99,7 +99,7 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
     const std::string primary_cpid = NN::GetPrimaryCpid();
 
     std::string GRCAddress = DefaultWalletAddress();
-    double dmag = NN::Tally::MyMagnitude();
+    double dmag = NN::Tally::MyMagnitude().Floating();
     double poll_duration = PollDuration(sTitle) * 86400;
 
     // Prevent Double Voting

--- a/src/db.h
+++ b/src/db.h
@@ -6,8 +6,9 @@
 #define BITCOIN_DB_H
 
 #include "fs.h"
-#include "main.h"
 #include "streams.h"
+#include "sync.h"
+#include "version.h"
 
 #include <map>
 #include <string>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -569,7 +569,7 @@ void GetGlobalStatus()
 
     try
     {
-        double boincmagnitude = NN::Tally::MyMagnitude();
+        double boincmagnitude = NN::Tally::MyMagnitude().Floating();
         uint64_t nWeight = 0;
         pwalletMain->GetStakeWeight(nWeight);
         nBoincUtilization = boincmagnitude; //Legacy Support for the about screen
@@ -2601,7 +2601,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
             {
                 // 6-4-2017 - Verify researchers stored block magnitude
                 // 2018 02 04 - Moved here for better effect.
-                double dNeuralNetworkMagnitude = NN::Tally::GetMagnitude(claim.m_mining_id);
+                double dNeuralNetworkMagnitude = NN::Tally::GetMagnitude(claim.m_mining_id).Floating();
                 if (claim.m_magnitude > (dNeuralNetworkMagnitude * 1.25)
                     && (fTestNet || (!fTestNet && (pindex->nHeight-1) > 947000)))
                 {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1031,7 +1031,7 @@ bool CreateGridcoinReward(CBlock &blocknew, CBlockIndex* pindexPrev, int64_t &nR
     }
 
     if (const NN::CpidOption cpid = claim.m_mining_id.TryCpid()) {
-        claim.m_magnitude = NN::Tally::GetMagnitude(*cpid);
+        claim.m_magnitude = NN::Tally::GetMagnitude(*cpid).Floating();
     }
 
     LogPrintf(

--- a/src/neuralnet/magnitude.h
+++ b/src/neuralnet/magnitude.h
@@ -1,0 +1,289 @@
+#pragma once
+
+#include <tinyformat.h>
+
+#include <cmath>
+#include <stdint.h>
+#include <string>
+
+namespace NN {
+//!
+//! \brief Represents a CPID's computing power at a point in time relative to
+//! the other CPIDs in the network.
+//!
+//! Gridcoin uses units of magnitude to quantify a BOINC participant's computing
+//! power. Magnitude values are one of the primary variables in the formula that
+//! calculates research rewards. The protocol derives these values using BOINC's
+//! recent average credit (RAC) metric by calculating the ratios of a CPID's RAC
+//! at each BOINC project to the sum of the RAC of all the participants at these
+//! projects.
+//!
+//! With block version 11 and later, the network tracks magnitudes with decaying
+//! precision as the magnitude values increase. These manifest in three tiers:
+//!
+//!   - Less than 1: two fractional places
+//!   - Between 1 and 10: one fractional place
+//!   - 10 and greater: whole numbers only
+//!
+//! This improves representation of participants with less computing power while
+//! retaining the superblock compactness of the earlier, integer-only format. To
+//! present these values to the rest of the application uniformly, the Magnitude
+//! type stores normalized magnitudes as integers scaled by a factor of 100.
+//!
+class Magnitude
+{
+public:
+    //!
+    //! \brief The largest magnitude value that a CPID may obtain.
+    //!
+    static constexpr uint16_t MAX = 32767;
+
+    //!
+    //! \brief The smallest magnitude value that the network can represent as
+    //! a non-zero magnitude is just greater than this value.
+    //!
+    //! Note: magnitudes less than 0.01 are rounded-up to 0.01.
+    //!
+    static constexpr double ZERO_THRESHOLD = 0.005;
+
+    //!
+    //! \brief The largest possible magnitude stored with two fractional places
+    //! is just less than this value.
+    //!
+    static constexpr double MIN_MEDIUM = 0.995;
+
+    //!
+    //! \brief The largest possible magnitude stored with one fractional place
+    //! is just less than this value.
+    //!
+    static constexpr double MIN_LARGE = 9.95;
+
+    //!
+    //! \brief Factor by which a canonical magnitude is scaled for storage in
+    //! this type.
+    //!
+    static constexpr size_t SCALE_FACTOR = 100;
+
+    //!
+    //! \brief Factor by which a magnitude with a value less than 10 is scaled
+    //! from compact storage.
+    //!
+    static constexpr size_t MEDIUM_SCALE_FACTOR = 10;
+
+    //!
+    //! \brief Factor by which a magnitude with a value less than 1 is scaled
+    //! from compact storage.
+    //!
+    static constexpr size_t SMALL_SCALE_FACTOR = 1;
+
+    //!
+    //! \brief Describes the size of the magnitude value for the purpose of
+    //! assigning the number of fractional places.
+    //!
+    enum class Kind
+    {
+        ZERO,   //!< A zero magnitude.
+        SMALL,  //!< Less than 1 with two fractional places.
+        MEDIUM, //!< 1 or greater and less than 10 with one fractional place.
+        LARGE,  //!< 10 or greater with no fractional places.
+    };
+
+    //!
+    //! \brief Initialize a magnitude with a value of zero.
+    //!
+    //! \return A magnitude with a value of zero.
+    //!
+    static Magnitude Zero()
+    {
+        return Magnitude(0);
+    }
+
+    //!
+    //! \brief Initialize a magnitude directly from its scaled representation.
+    //!
+    //! \param scaled A magnitude value scaled by a factor of 100.
+    //!
+    //! \return The wrapped magnitude value.
+    //!
+    static Magnitude FromScaled(const uint32_t scaled)
+    {
+        return Magnitude(scaled);
+    }
+
+    //!
+    //! \brief Initialize a magnitude from a floating-point number.
+    //!
+    //! \param value An unscaled magnitude.
+    //!
+    //! \return The wrapped magnitude value appropriately rounded and scaled.
+    //!
+    static Magnitude RoundFrom(const double value)
+    {
+        if (value <= ZERO_THRESHOLD || value > MAX) {
+            return Zero();
+        }
+
+        if (value < MIN_MEDIUM) {
+            return Magnitude(RoundAndScale(value, SMALL_SCALE_FACTOR));
+        }
+
+        if (value < MIN_LARGE) {
+            return Magnitude(RoundAndScale(value, MEDIUM_SCALE_FACTOR));
+        }
+
+        return Magnitude(RoundAndScale(value, SCALE_FACTOR));
+    }
+
+    bool operator==(const Magnitude other) const
+    {
+        return m_scaled == other.m_scaled;
+    }
+
+    bool operator!=(const Magnitude other) const
+    {
+        return m_scaled != other.m_scaled;
+    }
+
+    bool operator==(const int64_t other) const
+    {
+        return static_cast<int64_t>(m_scaled) == other * SCALE_FACTOR;
+    }
+
+    bool operator!=(const int64_t other) const
+    {
+        return !(*this == other);
+    }
+
+    bool operator==(const int32_t other) const
+    {
+        return *this == static_cast<int64_t>(other);
+    }
+
+    bool operator!=(const int32_t other) const
+    {
+        return !(*this == other);
+    }
+
+    bool operator==(const double other) const
+    {
+        return *this == RoundFrom(other);
+    }
+
+    bool operator!=(const double other) const
+    {
+        return !(*this == other);
+    }
+
+    //!
+    //! \brief Describe the size of the magnitude value for the purpose of
+    //! categorizing it for serialization.
+    //!
+    //! \return A value that represents the size of the magnitude.
+    //!
+    Kind Which() const
+    {
+        if (m_scaled == 0) {
+            return Kind::ZERO;
+        }
+
+        if (m_scaled < (MIN_MEDIUM * SCALE_FACTOR)) {
+            return Kind::SMALL;
+        }
+
+        if (m_scaled < (MIN_LARGE * SCALE_FACTOR)) {
+            return Kind::MEDIUM;
+        }
+
+        return Kind::LARGE;
+    }
+
+    //!
+    //! \brief Get the scaled representation of the magnitude.
+    //!
+    //! Use the scaled value instead of the floating-point representation when
+    //! appropriate to avoid floating-point errors.
+    //!
+    //! \return Magnitude scaled by a factor of 100.
+    //!
+    uint32_t Scaled() const
+    {
+        return m_scaled;
+    }
+
+    //!
+    //! \brief Get the compact representation of the magnitude.
+    //!
+    //! This produces an integer value that matches the format of the magnitude
+    //! as a superblock stores it.
+    //!
+    //! \return Magnitude scaled-down as needed for its size category.
+    //!
+    uint16_t Compact() const
+    {
+        switch (Which()) {
+            case Kind::ZERO:   return 0;
+            case Kind::SMALL:  return m_scaled / SMALL_SCALE_FACTOR;
+            case Kind::MEDIUM: return m_scaled / MEDIUM_SCALE_FACTOR;
+            case Kind::LARGE:  return m_scaled / SCALE_FACTOR;
+        }
+
+        return 0;
+    }
+
+    //!
+    //! \brief Get the floating-point representation of the magnitude.
+    //!
+    //! Use the scaled value instead of the floating-point representation when
+    //! appropriate to avoid floating-point errors.
+    //!
+    //! \return Floating-point magnitude at canonical scale.
+    //!
+    double Floating() const
+    {
+        return static_cast<double>(m_scaled) / SCALE_FACTOR;
+    }
+
+    //!
+    //! \brief Get the string representation of the magnitude.
+    //!
+    //! \return The magnitude's floating-point representation as a string.
+    //!
+    std::string ToString() const
+    {
+        return strprintf("%g", Floating());
+    }
+
+private:
+    uint32_t m_scaled; //!< Magnitude scaled by a factor of 100.
+
+    //!
+    //! \brief Initialize a magnitude with a value of zero.
+    //!
+    Magnitude() : Magnitude(0)
+    {
+    }
+
+    //!
+    //! \brief Initialize a magnitude directly from its scaled representation.
+    //!
+    //! \param scaled A magnitude value scaled by a factor of 100.
+    //!
+    explicit Magnitude(const uint32_t scaled) : m_scaled(scaled)
+    {
+    }
+
+    //!
+    //! \brief Scale a floating-point magnitude by the specified factor and
+    //! round the result.
+    //!
+    //! \param magnitude An unscaled magnitude.
+    //! \param scale     Scale factor of the magnitude's size category.
+    //!
+    //! \return The scaled integer representation of the rounded magnitude.
+    //!
+    static uint32_t RoundAndScale(const double magnitude, const double scale)
+    {
+        return std::nearbyint(magnitude * (SCALE_FACTOR / scale)) * scale;
+    }
+}; // Magnitude
+}

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -1611,18 +1611,6 @@ uint16_t Superblock::CpidIndex::MagnitudeOf(const Cpid& cpid) const
     return iter->second;
 }
 
-size_t Superblock::CpidIndex::OffsetOf(const Cpid& cpid) const
-{
-    const auto iter = m_magnitudes.find(cpid);
-
-    if (iter == m_magnitudes.end()) {
-        return m_magnitudes.size();
-    }
-
-    // Not very efficient--we can optimize this if needed:
-    return std::distance(m_magnitudes.begin(), iter);
-}
-
 Superblock::CpidIndex::const_iterator
 Superblock::CpidIndex::At(const size_t offset) const
 {

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -1197,7 +1197,8 @@ public:
         try {
             m_zero_mags = std::stoi(ExtractXML(packed, "<ZERO>", "</ZERO>"));
         } catch (...) {
-            LogPrintf("LegacySuperblock: Failed to parse zero mag CPIDs");
+            LogPrint(BCLog::LogFlags::SB,
+                "LegacySuperblock: Failed to parse zero mag CPIDs.\n");
         }
     }
 
@@ -1233,7 +1234,8 @@ public:
                     parts.size() > 2 ? std::stoi(parts[2]) : 0)); // RAC
 
             } catch (...) {
-                LogPrintf("ExtractProjects(): Failed to parse project RAC.");
+                LogPrint(BCLog::LogFlags::SB,
+                    "LegacySuperblock: Failed to parse project RAC.\n");
             }
         }
 
@@ -1302,7 +1304,8 @@ private:
             try {
                 magnitudes.Add(MiningId::Parse(parts[0]), std::stoi(parts[1]));
             } catch(...) {
-                LogPrintf("ExtractTextMagnitude(): Failed to parse magnitude.");
+                LogPrint(BCLog::LogFlags::SB,
+                    "LegacySuperblock: Failed to parse magnitude.\n");
             }
         }
 

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -351,17 +351,6 @@ public:
         uint16_t MagnitudeOf(const Cpid& cpid) const;
 
         //!
-        //! \brief Get the offset of the provided CPID in the index.
-        //!
-        //! \param cpid The CPID to look-up the offset for.
-        //!
-        //! \return The CPID's zero-based offset if it exists in the index, or
-        //! the offset after the last element in the index (the index size) if
-        //! it doesn't.
-        //!
-        size_t OffsetOf(const Cpid& cpid) const;
-
-        //!
         //! \brief Get the CPID indexed at the specified offset.
         //!
         //! \param offset Zero-based offset of the CPID to fetch.

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -127,7 +127,10 @@ public:
             const Cpid& cpid = account_pair.first;
             ResearchAccount& account = account_pair.second;
 
-            account.m_magnitude = m_current_superblock->m_cpids.MagnitudeOf(cpid);
+            // TODO: this only supports legacy magnitudes, but the upcoming
+            // superblock window accrual changes remove these shenanigans:
+            //
+            account.m_magnitude = m_current_superblock->m_cpids.MagnitudeOf(cpid).Compact();
         }
 
         return ResearchAccountRange(m_researchers);
@@ -143,7 +146,10 @@ public:
     //!
     const ResearchAccount& GetAccount(const Cpid cpid)
     {
-        const uint16_t magnitude = m_current_superblock->m_cpids.MagnitudeOf(cpid);
+        // TODO: this only supports legacy magnitudes, but the upcoming
+        // superblock window accrual changes remove these shenanigans:
+        //
+        const uint16_t magnitude = m_current_superblock->m_cpids.MagnitudeOf(cpid).Compact();
         auto iter = m_researchers.find(cpid);
 
         if (iter == m_researchers.end()) {
@@ -299,13 +305,13 @@ double Tally::GetMagnitudeUnit(const int64_t payment_time)
     return g_network_tally.GetMagnitudeUnit(payment_time);
 }
 
-uint16_t Tally::MyMagnitude()
+Magnitude Tally::MyMagnitude()
 {
     if (const auto cpid_option = NN::Researcher::Get()->Id().TryCpid()) {
         return Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(*cpid_option);
     }
 
-    return 0;
+    return Magnitude::Zero();
 }
 
 ResearchAccountRange Tally::Accounts()
@@ -341,18 +347,18 @@ AccrualComputer Tally::GetComputer(
         last_block_ptr->nHeight);
 }
 
-uint16_t Tally::GetMagnitude(const Cpid cpid)
+Magnitude Tally::GetMagnitude(const Cpid cpid)
 {
     return Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(cpid);
 }
 
-uint16_t Tally::GetMagnitude(const MiningId mining_id)
+Magnitude Tally::GetMagnitude(const MiningId mining_id)
 {
     if (const auto cpid_option = mining_id.TryCpid()) {
         return GetMagnitude(*cpid_option);
     }
 
-    return 0;
+    return Magnitude::Zero();
 }
 
 void Tally::RecordRewardBlock(const CBlockIndex* const pindex)

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -66,7 +66,7 @@ public:
     //! \return The wallet user's magnitude or zero if the wallet started in
     //! investor mode.
     //!
-    static uint16_t MyMagnitude();
+    static Magnitude MyMagnitude();
 
     //!
     //! \brief Get a traversable object for the research accounts stored in
@@ -107,7 +107,7 @@ public:
     //!
     //! \return Magnitude as of the last tallied superblock.
     //!
-    static uint16_t GetMagnitude(const Cpid cpid);
+    static Magnitude GetMagnitude(const Cpid cpid);
 
     //!
     //! \brief Get the current magnitude for the specified mining ID.
@@ -117,7 +117,7 @@ public:
     //! \return Magnitude as of the last tallied superblock or zero if the
     //! mining ID represents an investor.
     //!
-    static uint16_t GetMagnitude(const MiningId mining_id);
+    static Magnitude GetMagnitude(const MiningId mining_id);
 
     //!
     //! \brief Record a block's research reward data in the tally.

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -15,6 +15,7 @@
 #include "transactiontablemodel.h"
 #include "addressbookpage.h"
 
+#include "global_objects_noui.hpp"
 #include "diagnosticsdialog.h"
 #include "sendcoinsdialog.h"
 #include "signverifymessagedialog.h"

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -3,7 +3,6 @@
 
 #include <QObject>
 #include "scraper/fwd.h"
-#include "neuralnet/superblock.h"
 
 class OptionsModel;
 class AddressTableModel;
@@ -11,6 +10,7 @@ class TransactionTableModel;
 class BanTableModel;
 class PeerTableModel;
 
+class ConvergedScraperStats;
 class CWallet;
 
 QT_BEGIN_NAMESPACE

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -1,8 +1,5 @@
 #include "upgradeqt.h"
 #include "upgrade.h"
-#include "util.h"
-#include "db.h"
-#include "txdb-leveldb.h"
 #include <QtWidgets>
 #include <QProgressDialog>
 #include <QMessageBox>
@@ -136,7 +133,7 @@ bool UpgradeQt::SnapshotMain()
             Msg(_("Snapshot operation canceled."), _("The wallet will not shutdown."));
 
             return false;
-        }       
+        }
     }
 
     // Make it seen

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -8,6 +8,7 @@
 #include "rpcprotocol.h"
 #include "init.h" // for pwalletMain
 #include "block.h"
+#include "checkpoints.h"
 #include "txdb.h"
 #include "beacon.h"
 #include "neuralnet/project.h"

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -84,8 +84,8 @@ UniValue SuperblockToJson(const NN::Superblock& superblock)
 {
     UniValue magnitudes(UniValue::VOBJ);
 
-    for (const auto& cpid_pair : superblock.m_cpids) {
-        magnitudes.pushKV(cpid_pair.first.ToString(), cpid_pair.second);
+    for (const auto& cpid_iter : superblock.m_cpids) {
+        magnitudes.pushKV(cpid_iter.Cpid().ToString(), cpid_iter.Magnitude().Floating());
     }
 
     UniValue projects(UniValue::VOBJ);
@@ -1897,7 +1897,7 @@ UniValue SuperblockReport(int lookback, bool displaycontract, std::string cpid)
 
                 if (cpid_parsed)
                 {
-                    c.pushKV("Magnitude", superblock.m_cpids.MagnitudeOf(*cpid_parsed));
+                    c.pushKV("Magnitude", superblock.m_cpids.MagnitudeOf(*cpid_parsed).Floating());
                 }
 
                 if (displaycontract)

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -10,11 +10,9 @@
 #include <map>
 
 class CBlockIndex;
+class uint256;
 
 #include <univalue.h>
-
-#include "global_objects_noui.hpp"
-#include "checkpoints.h"
 
 void StartRPCThreads();
 void StopRPCThreads();

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -70,7 +70,7 @@ int64_t SCRAPER_CMANIFEST_RETENTION_TIME = 48 * 3600;
 bool SCRAPER_CMANIFEST_INCLUDE_NONCURRENT_PROJ_FILES = false;
 double MAG_ROUND = 0.01;
 double NEURALNETWORKMULTIPLIER = 115000;
-double CPID_MAG_LIMIT = 32767;
+double CPID_MAG_LIMIT = NN::Magnitude::MAX;
 // This settings below are important. This sets the minimum number of scrapers
 // that must be available to form a convergence. Above this minimum, the ratio
 // is followed. For example, if there are 4 scrapers, a ratio of 0.6 would require

--- a/src/scraper_net.cpp
+++ b/src/scraper_net.cpp
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <atomic>
+#include "main.h"
 #include "net.h"
 #include "rpcserver.h"
 #include "rpcprotocol.h"
@@ -14,8 +15,8 @@
 #include "scraper_net.h"
 #include "appcache.h"
 #include "scraper/fwd.h"
-#include "neuralnet/superblock.h"
 #include "neuralnet/project.h"
+#include "neuralnet/superblock.h"
 
 //Globals
 std::map<uint256,CSplitBlob::CPart> CSplitBlob::mapParts;

--- a/src/test/neuralnet/claim_tests.cpp
+++ b/src/test/neuralnet/claim_tests.cpp
@@ -61,7 +61,7 @@ NN::Superblock GetTestSuperblock(uint32_t version = NN::Superblock::CURRENT_VERS
     NN::Superblock superblock;
 
     superblock.m_version = version;
-    superblock.m_cpids.Add(NN::Cpid(), 123);
+    superblock.m_cpids.Add(NN::Cpid(), NN::Magnitude::RoundFrom(123));
     superblock.m_projects.Add("project", NN::Superblock::ProjectStats());
 
     return superblock;

--- a/src/test/neuralnet/magnitude_tests.cpp
+++ b/src/test/neuralnet/magnitude_tests.cpp
@@ -1,0 +1,174 @@
+#include "neuralnet/magnitude.h"
+#include "streams.h"
+
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+
+// -----------------------------------------------------------------------------
+// Magnitude
+// -----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Magnitude)
+
+BOOST_AUTO_TEST_CASE(it_initializes_to_zero_magnitude)
+{
+    const NN::Magnitude mag = NN::Magnitude::Zero();
+
+    BOOST_CHECK_EQUAL(mag.Scaled(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(it_initializes_to_zero_when_rounding_invalid_magnitudes)
+{
+    // Negative
+    const NN::Magnitude negative = NN::Magnitude::RoundFrom(-1.234);
+    BOOST_CHECK_EQUAL(negative.Scaled(), 0);
+
+    // Rounds-down to zero
+    const NN::Magnitude effectivly_zero = NN::Magnitude::RoundFrom(0.005);
+    BOOST_CHECK_EQUAL(effectivly_zero.Scaled(), 0);
+
+    // Exceeded maximum
+    const NN::Magnitude overflow = NN::Magnitude::RoundFrom(32767.123);
+    BOOST_CHECK_EQUAL(overflow.Scaled(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(it_rounds_a_small_magnitude_to_two_places)
+{
+    const NN::Magnitude min = NN::Magnitude::RoundFrom(0.0051);
+    BOOST_CHECK_EQUAL(min.Scaled(), 1);
+
+    const NN::Magnitude max = NN::Magnitude::RoundFrom(0.994);
+    BOOST_CHECK_EQUAL(max.Scaled(), 99);
+}
+
+BOOST_AUTO_TEST_CASE(it_rounds_a_medium_magnitude_to_one_place)
+{
+    const NN::Magnitude min = NN::Magnitude::RoundFrom(0.995);
+    BOOST_CHECK_EQUAL(min.Scaled(), 100);
+
+    const NN::Magnitude max = NN::Magnitude::RoundFrom(9.94);
+    BOOST_CHECK_EQUAL(max.Scaled(), 990);
+}
+
+BOOST_AUTO_TEST_CASE(it_rounds_a_large_magnitude_to_a_whole)
+{
+    const NN::Magnitude min = NN::Magnitude::RoundFrom(9.95);
+    BOOST_CHECK_EQUAL(min.Scaled(), 1000);
+
+    const NN::Magnitude max = NN::Magnitude::RoundFrom(32767.0);
+    BOOST_CHECK_EQUAL(max.Scaled(), 3276700);
+}
+
+BOOST_AUTO_TEST_CASE(it_compares_another_magnitude_for_equality)
+{
+    const NN::Magnitude magnitude1 = NN::Magnitude::RoundFrom(1.23);
+    const NN::Magnitude magnitude2 = NN::Magnitude::RoundFrom(1.23);
+
+    BOOST_CHECK(magnitude1 == magnitude2);
+    BOOST_CHECK(magnitude1 != NN::Magnitude::Zero());
+}
+
+BOOST_AUTO_TEST_CASE(it_compares_an_integer_for_equality)
+{
+    const NN::Magnitude magnitude = NN::Magnitude::RoundFrom(123);
+
+    BOOST_CHECK(magnitude == 123);
+    BOOST_CHECK(magnitude != 999);
+}
+
+BOOST_AUTO_TEST_CASE(it_compares_a_floating_point_number_for_equality)
+{
+    const NN::Magnitude magnitude = NN::Magnitude::RoundFrom(1.23);
+
+    // Floating-point comparisons round the other value according to the size
+    // for the precision tiers before checking equality:
+    BOOST_CHECK(magnitude == 1.23);
+    BOOST_CHECK(magnitude == 1.2);
+    BOOST_CHECK(magnitude == 1.25);
+    BOOST_CHECK(magnitude != 1.26);
+}
+
+BOOST_AUTO_TEST_CASE(it_reports_its_size_category)
+{
+    using Kind = NN::Magnitude::Kind;
+
+    const NN::Magnitude zero = NN::Magnitude::Zero();
+    BOOST_CHECK(zero.Which() == Kind::ZERO);
+
+    const NN::Magnitude effectively_zero = NN::Magnitude::RoundFrom(0.005);
+    BOOST_CHECK(effectively_zero.Which() == Kind::ZERO);
+
+    const NN::Magnitude min_small = NN::Magnitude::RoundFrom(0.0051);
+    BOOST_CHECK(min_small.Which() == Kind::SMALL);
+
+    const NN::Magnitude max_small = NN::Magnitude::RoundFrom(0.994);
+    BOOST_CHECK(max_small.Which() == Kind::SMALL);
+
+    const NN::Magnitude min_medium = NN::Magnitude::RoundFrom(0.995);
+    BOOST_CHECK(min_medium.Which() == Kind::MEDIUM);
+
+    const NN::Magnitude max_medium = NN::Magnitude::RoundFrom(9.94);
+    BOOST_CHECK(max_medium.Which() == Kind::MEDIUM);
+
+    const NN::Magnitude min_large = NN::Magnitude::RoundFrom(9.95);
+    BOOST_CHECK(min_large.Which() == Kind::LARGE);
+
+    const NN::Magnitude max_large = NN::Magnitude::RoundFrom(32767.0);
+    BOOST_CHECK(max_large.Which() == Kind::LARGE);
+}
+
+BOOST_AUTO_TEST_CASE(it_presents_the_scaled_magnitude_representation)
+{
+    const NN::Magnitude small = NN::Magnitude::RoundFrom(0.11);
+    BOOST_CHECK_EQUAL(small.Scaled(), 11);
+
+    const NN::Magnitude medium = NN::Magnitude::RoundFrom(1.1);
+    BOOST_CHECK_EQUAL(medium.Scaled(), 110);
+
+    const NN::Magnitude large = NN::Magnitude::RoundFrom(11.0);
+    BOOST_CHECK_EQUAL(large.Scaled(), 1100);
+}
+
+BOOST_AUTO_TEST_CASE(it_presents_the_compact_magnitude_representation)
+{
+    const NN::Magnitude small = NN::Magnitude::RoundFrom(0.11);
+    BOOST_CHECK_EQUAL(small.Compact(), 11);
+
+    const NN::Magnitude medium = NN::Magnitude::RoundFrom(1.1);
+    BOOST_CHECK_EQUAL(medium.Compact(), 11);
+
+    const NN::Magnitude large = NN::Magnitude::RoundFrom(11.0);
+    BOOST_CHECK_EQUAL(large.Compact(), 11);
+}
+
+BOOST_AUTO_TEST_CASE(it_presents_the_floatng_point_magnitude_representation)
+{
+    const NN::Magnitude small = NN::Magnitude::RoundFrom(0.11);
+    BOOST_CHECK_EQUAL(small.Floating(), 0.11);
+
+    const NN::Magnitude medium = NN::Magnitude::RoundFrom(1.1);
+    BOOST_CHECK_EQUAL(medium.Floating(), 1.1);
+
+    const NN::Magnitude large = NN::Magnitude::RoundFrom(11.0);
+    BOOST_CHECK_EQUAL(large.Floating(), 11.0);
+}
+
+BOOST_AUTO_TEST_CASE(it_represents_itself_as_a_string)
+{
+    const NN::Magnitude zero = NN::Magnitude::Zero();
+    BOOST_CHECK_EQUAL(zero.ToString(), "0");
+
+    const NN::Magnitude small = NN::Magnitude::RoundFrom(0.11);
+    BOOST_CHECK_EQUAL(small.ToString(), "0.11");
+
+    const NN::Magnitude medium = NN::Magnitude::RoundFrom(1.1);
+    BOOST_CHECK_EQUAL(medium.ToString(), "1.1");
+
+    const NN::Magnitude large = NN::Magnitude::RoundFrom(11.0);
+    BOOST_CHECK_EQUAL(large.ToString(), "11");
+
+    const NN::Magnitude max = NN::Magnitude::RoundFrom(32767.0);
+    BOOST_CHECK_EQUAL(max.ToString(), "32767");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -170,94 +170,225 @@ struct Legacy
     }
 }; // Legacy
 
-ScraperStats GetTestScraperStats()
+//!
+//! \brief Common values shared by tests that produce superblocks from scraper
+//! statistics and convergences.
+//!
+struct ScraperStatsMeta
 {
-    ScraperStats stats;
-    std::string cpid1 = "00010203040506070809101112131415";
-    std::string cpid2 = "15141312111009080706050403020100";
+    // Make clang happy
+    ScraperStatsMeta()
+    {
+    }
+
+    std::string cpid1_str = "00010203040506070809101112131415";
+    NN::Cpid cpid1 = NN::Cpid::Parse(cpid1_str);
+
+    std::string cpid2_str = "15141312111009080706050403020100";
+    NN::Cpid cpid2 = NN::Cpid::Parse(cpid2_str);
+
+    std::string cpid3_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    NN::Cpid cpid3 = NN::Cpid::Parse(cpid3_str);
+
     std::string project1 = "project_1";
     std::string project2 = "project_2";
 
+    // Project 1, CPID 1
+    double p1c1_tc = 1000;
+    double p1c1_rac = 101;
+    double p1c1_avg_rac = 1003;
+    double p1c1_mag = 1004;
+
+    // Project 2, CPID 1
+    double p2c1_tc = 2000;
+    double p2c1_rac = 102;
+    double p2c1_avg_rac = 2003;
+    double p2c1_mag = 2004;
+
+    // Project 1, CPID 2
+    double p1c2_tc = 3000;
+    double p1c2_rac = 103;
+    double p1c2_avg_rac = 3003;
+    double p1c2_mag = 1.3;
+
+    // Project 2, CPID 2
+    double p2c2_tc = 4000;
+    double p2c2_rac = 402;
+    double p2c2_avg_rac = 4003;
+    double p2c2_mag = 1.4;
+
+    // Project 1, CPID 3
+    double p1c3_tc = 5000;
+    double p1c3_rac = 105;
+    double p1c3_avg_rac = 5003;
+    double p1c3_mag = 0.3;
+
+    // Project 2, CPID 3
+    double p2c3_tc = 6000;
+    double p2c3_rac = 602;
+    double p2c3_avg_rac = 6003;
+    double p2c3_mag = 0.4;
+
+    double c1_tc = p1c1_tc + p2c1_tc;
+    double c1_rac = p1c1_rac + p2c1_rac;
+    double c1_mag = p1c1_mag + p2c1_mag;
+    NN::Magnitude c1_mag_obj = NN::Magnitude::RoundFrom(c1_mag);
+
+    double c2_tc = p1c2_tc + p2c2_tc;
+    double c2_rac = p1c2_rac + p2c2_rac;
+    double c2_mag = p1c2_mag + p2c2_mag;
+    NN::Magnitude c2_mag_obj = NN::Magnitude::RoundFrom(c2_mag);
+
+    double c3_tc = p1c3_tc + p2c3_tc;
+    double c3_rac = p1c3_rac + p2c3_rac;
+    double c3_mag = p1c3_mag + p2c3_mag;
+    NN::Magnitude c3_mag_obj = NN::Magnitude::RoundFrom(c3_mag);
+
+    double p1_tc = p1c1_tc + p1c2_tc + p1c3_tc;
+    double p1_rac = p1c1_rac + p1c2_rac + p1c3_rac;
+    double p1_avg_rac = p1_rac / 3;
+    double p1_avg_rac_rounded = std::nearbyint(p1_avg_rac);
+    double p1_mag = p1c1_mag + p1c2_mag + p1c3_mag;
+
+    double p2_tc = p2c1_tc + p2c2_tc + p2c3_tc;
+    double p2_rac = p2c1_rac + p2c2_rac + p2c3_rac;
+    double p2_avg_rac = p2_rac / 3;
+    double p2_avg_rac_rounded = std::nearbyint(p2_avg_rac);
+    double p2_mag = p2c1_mag + p2c2_mag + p2c3_mag;
+
+    uint64_t cpid_count = 3;
+    double cpid_total_mag = (c1_mag_obj.Scaled() + c2_mag_obj.Scaled() + c3_mag_obj.Scaled()) / 100.0;
+    double cpid_average_mag = cpid_total_mag / cpid_count;
+
+    uint64_t project_count = 2;
+    double project_total_rac = p1_rac + p2_rac;
+    double project_average_rac = project_total_rac / project_count;
+};
+
+//!
+//! \brief Build a mock scraper statistics data object.
+//!
+//! \param meta Contains the values to initialize the scraper stats object with.
+//!
+ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
+{
+    ScraperStats stats;
+
     ScraperObjectStats p1c1;
     p1c1.statskey.objecttype = statsobjecttype::byCPIDbyProject;
-    p1c1.statskey.objectID = project1 + "," + cpid1;
-    p1c1.statsvalue.dTC = 1000;
-    p1c1.statsvalue.dRAC = 101;
-    p1c1.statsvalue.dAvgRAC = 1003;
-    p1c1.statsvalue.dMag = 1004;
+    p1c1.statskey.objectID = meta.project1 + "," + meta.cpid1_str;
+    p1c1.statsvalue.dTC = meta.p1c1_tc;
+    p1c1.statsvalue.dRAC = meta.p1c1_rac;
+    p1c1.statsvalue.dAvgRAC = meta.p1c1_avg_rac;
+    p1c1.statsvalue.dMag = meta.p1c1_mag;
     stats.emplace(p1c1.statskey, p1c1);
 
     ScraperObjectStats p1c2;
     p1c2.statskey.objecttype = statsobjecttype::byCPIDbyProject;
-    p1c2.statskey.objectID = project1 + "," + cpid2;
-    p1c2.statsvalue.dTC = 2000;
-    p1c2.statsvalue.dRAC = 102;
-    p1c2.statsvalue.dAvgRAC = 2003;
-    p1c2.statsvalue.dMag = 2004;
+    p1c2.statskey.objectID = meta.project1 + "," + meta.cpid2_str;
+    p1c2.statsvalue.dTC = meta.p1c2_tc;
+    p1c2.statsvalue.dRAC = meta.p1c2_rac;
+    p1c2.statsvalue.dAvgRAC = meta.p1c2_avg_rac;
+    p1c2.statsvalue.dMag = meta.p1c2_mag;
     stats.emplace(p1c2.statskey, p1c2);
 
     ScraperObjectStats p2c1;
     p2c1.statskey.objecttype = statsobjecttype::byCPIDbyProject;
-    p2c1.statskey.objectID = project2 + "," + cpid1;
-    p2c1.statsvalue.dTC = 3000;
-    p2c1.statsvalue.dRAC = 103;
-    p2c1.statsvalue.dAvgRAC = 3003;
-    p2c1.statsvalue.dMag = 3004;
+    p2c1.statskey.objectID = meta.project2 + "," + meta.cpid1_str;
+    p2c1.statsvalue.dTC = meta.p2c1_tc;
+    p2c1.statsvalue.dRAC = meta.p2c1_rac;
+    p2c1.statsvalue.dAvgRAC = meta.p2c1_avg_rac;
+    p2c1.statsvalue.dMag = meta.p2c1_mag;
     stats.emplace(p2c1.statskey, p2c1);
 
     ScraperObjectStats p2c2;
     p2c2.statskey.objecttype = statsobjecttype::byCPIDbyProject;
-    p2c2.statskey.objectID = project2 + "," + cpid2;
-    p2c2.statsvalue.dTC = 4000;
-    p2c2.statsvalue.dRAC = 104;
-    p2c2.statsvalue.dAvgRAC = 4003;
-    p2c2.statsvalue.dMag = 4004;
+    p2c2.statskey.objectID = meta.project2 + "," + meta.cpid2_str;
+    p2c2.statsvalue.dTC = meta.p2c2_tc;
+    p2c2.statsvalue.dRAC = meta.p2c2_rac;
+    p2c2.statsvalue.dAvgRAC = meta.p2c2_avg_rac;
+    p2c2.statsvalue.dMag = meta.p2c2_mag;
     stats.emplace(p2c2.statskey, p2c2);
+
+    ScraperObjectStats p1c3;
+    p1c3.statskey.objecttype = statsobjecttype::byCPIDbyProject;
+    p1c3.statskey.objectID = meta.project1 + "," + meta.cpid3_str;
+    p1c3.statsvalue.dTC = meta.p1c3_tc;
+    p1c3.statsvalue.dRAC = meta.p1c3_rac;
+    p1c3.statsvalue.dAvgRAC = meta.p1c3_avg_rac;
+    p1c3.statsvalue.dMag = meta.p1c3_mag;
+    stats.emplace(p1c2.statskey, p1c3);
+
+    ScraperObjectStats p2c3;
+    p2c3.statskey.objecttype = statsobjecttype::byCPIDbyProject;
+    p2c3.statskey.objectID = meta.project2 + "," + meta.cpid3_str;
+    p2c3.statsvalue.dTC = meta.p2c3_tc;
+    p2c3.statsvalue.dRAC = meta.p2c3_rac;
+    p2c3.statsvalue.dAvgRAC = meta.p2c3_avg_rac;
+    p2c3.statsvalue.dMag = meta.p2c3_mag;
+    stats.emplace(p2c2.statskey, p2c3);
 
     ScraperObjectStats c1;
     c1.statskey.objecttype = statsobjecttype::byCPID;
-    c1.statskey.objectID = cpid1;
-    c1.statsvalue.dTC = p1c1.statsvalue.dTC + p2c1.statsvalue.dTC;
-    c1.statsvalue.dRAC = p1c1.statsvalue.dRAC + p2c1.statsvalue.dRAC;
-    c1.statsvalue.dAvgRAC = c1.statsvalue.dRAC;
-    c1.statsvalue.dMag = p1c1.statsvalue.dMag + p2c1.statsvalue.dMag;
+    c1.statskey.objectID = meta.cpid1_str;
+    c1.statsvalue.dTC = meta.c1_tc;
+    c1.statsvalue.dRAC = meta.c1_rac;
+    c1.statsvalue.dAvgRAC = meta.c1_rac;
+    c1.statsvalue.dMag = meta.c1_mag;
     stats.emplace(c1.statskey, c1);
 
     ScraperObjectStats c2;
     c2.statskey.objecttype = statsobjecttype::byCPID;
-    c2.statskey.objectID = cpid2;
-    c2.statsvalue.dTC = p1c2.statsvalue.dTC + p2c2.statsvalue.dTC;
-    c2.statsvalue.dRAC = p1c2.statsvalue.dRAC + p2c2.statsvalue.dRAC;
-    c2.statsvalue.dAvgRAC = c2.statsvalue.dRAC;
-    c2.statsvalue.dMag = p1c2.statsvalue.dMag + p2c2.statsvalue.dMag;
+    c2.statskey.objectID = meta.cpid2_str;
+    c2.statsvalue.dTC = meta.c2_tc;
+    c2.statsvalue.dRAC = meta.c2_rac;
+    c2.statsvalue.dAvgRAC = meta.c2_rac;
+    c2.statsvalue.dMag = meta.c2_mag;
     stats.emplace(c2.statskey, c2);
+
+    ScraperObjectStats c3;
+    c3.statskey.objecttype = statsobjecttype::byCPID;
+    c3.statskey.objectID = meta.cpid3_str;
+    c3.statsvalue.dTC = meta.c3_tc;
+    c3.statsvalue.dRAC = meta.c3_rac;
+    c3.statsvalue.dAvgRAC = meta.c3_rac;
+    c3.statsvalue.dMag = meta.c3_mag;
+    stats.emplace(c3.statskey, c3);
 
     ScraperObjectStats p1;
     p1.statskey.objecttype = statsobjecttype::byProject;
-    p1.statskey.objectID = project1;
-    p1.statsvalue.dTC = p1c1.statsvalue.dTC + p1c2.statsvalue.dTC;
-    p1.statsvalue.dRAC = p1c1.statsvalue.dRAC + p1c2.statsvalue.dRAC;
-    p1.statsvalue.dAvgRAC = p1.statsvalue.dRAC / 2;
-    p1.statsvalue.dMag = p1c1.statsvalue.dMag + p1c2.statsvalue.dMag;
+    p1.statskey.objectID = meta.project1;
+    p1.statsvalue.dTC = meta.p1_tc;
+    p1.statsvalue.dRAC = meta.p1_rac;
+    p1.statsvalue.dAvgRAC = meta.p1_avg_rac;
+    p1.statsvalue.dMag = meta.p1_mag;
     stats.emplace(p1.statskey, p1);
 
     ScraperObjectStats p2;
     p2.statskey.objecttype = statsobjecttype::byProject;
-    p2.statskey.objectID = project2;
-    p2.statsvalue.dTC = p2c1.statsvalue.dTC + p2c2.statsvalue.dTC;
-    p2.statsvalue.dRAC = p2c1.statsvalue.dRAC + p2c2.statsvalue.dRAC;
-    p2.statsvalue.dAvgRAC = p2.statsvalue.dRAC / 2;
-    p2.statsvalue.dMag = p2c1.statsvalue.dMag + p2c2.statsvalue.dMag;
+    p2.statskey.objectID = meta.project2;
+    p2.statsvalue.dTC = meta.p2_tc;
+    p2.statsvalue.dRAC = meta.p2_rac;
+    p2.statsvalue.dAvgRAC = meta.p2_avg_rac;
+    p2.statsvalue.dMag = meta.p2_mag;
     stats.emplace(p2.statskey, p2);
 
     return stats;
 }
 
-ConvergedScraperStats GetTestConvergence(const bool by_parts = false)
+//!
+//! \brief Build a mock scraper convergence object.
+//!
+//! \param meta Contains the values to initialize the scraper stats object with.
+//! \param by_parts If \c true, build it as a by-project fallback convergence.
+//!
+ConvergedScraperStats GetTestConvergence(
+    const ScraperStatsMeta& meta,
+    const bool by_parts = false)
 {
     ConvergedScraperStats convergence;
 
-    convergence.mScraperConvergedStats = GetTestScraperStats();
+    convergence.mScraperConvergedStats = GetTestScraperStats(meta);
 
     convergence.Convergence.bByParts = by_parts;
     convergence.Convergence.nContentHash
@@ -290,8 +421,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_superblock)
     BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     BOOST_CHECK(superblock.m_cpids.empty() == true);
-    BOOST_CHECK(superblock.m_cpids.TotalMagnitude() == 0);
-    BOOST_CHECK(superblock.m_cpids.AverageMagnitude() == 0);
+    BOOST_CHECK(superblock.m_cpids.TotalMagnitude() == 0.0);
+    BOOST_CHECK(superblock.m_cpids.AverageMagnitude() == 0.0);
 
     BOOST_CHECK(superblock.m_projects.empty() == true);
     BOOST_CHECK(superblock.m_projects.TotalRac() == 0);
@@ -310,8 +441,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_the_specified_version)
     BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     BOOST_CHECK(superblock.m_cpids.empty() == true);
-    BOOST_CHECK(superblock.m_cpids.TotalMagnitude() == 0);
-    BOOST_CHECK(superblock.m_cpids.AverageMagnitude() == 0);
+    BOOST_CHECK(superblock.m_cpids.TotalMagnitude() == 0.0);
+    BOOST_CHECK(superblock.m_cpids.AverageMagnitude() == 0.0);
 
     BOOST_CHECK(superblock.m_projects.empty() == true);
     BOOST_CHECK(superblock.m_projects.TotalRac() == 0);
@@ -323,39 +454,40 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_the_specified_version)
 
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
 {
-    NN::Superblock superblock = NN::Superblock::FromStats(GetTestScraperStats());
+    const ScraperStatsMeta meta;
+    NN::Superblock superblock = NN::Superblock::FromStats(GetTestScraperStats(meta));
 
     BOOST_CHECK(superblock.m_version == NN::Superblock::CURRENT_VERSION);
     BOOST_CHECK(superblock.m_convergence_hint == 0);
     BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     auto& cpids = superblock.m_cpids;
-    BOOST_CHECK(cpids.size() == 2);
-    BOOST_CHECK(cpids.TotalMagnitude() == 10016);
-    BOOST_CHECK(cpids.AverageMagnitude() == 5008);
-    BOOST_CHECK(cpids.At(0)->first.ToString() == "00010203040506070809101112131415");
-    BOOST_CHECK(cpids.At(0)->second == 4008);
-    BOOST_CHECK(cpids.At(1)->first.ToString() == "15141312111009080706050403020100");
-    BOOST_CHECK(cpids.At(1)->second == 6008);
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
+    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
+    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
 
     auto& projects = superblock.m_projects;
-    BOOST_CHECK(projects.size() == 2);
-    BOOST_CHECK(projects.TotalRac() == 410);
-    BOOST_CHECK(projects.AverageRac() == 205.0);
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
 
-    if (const auto project_1 = projects.Try("project_1")) {
-        BOOST_CHECK(project_1->m_total_credit == 3000);
-        BOOST_CHECK(project_1->m_average_rac == 102);
-        BOOST_CHECK(project_1->m_rac == 203);
+    if (const auto project_1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project_1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project_1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project_1->m_rac == meta.p1_rac);
         BOOST_CHECK(project_1->m_convergence_hint == 0);
     } else {
         BOOST_FAIL("Project 1 not found in superblock.");
     }
 
-    if (const auto project_2 = projects.Try("project_2")) {
-        BOOST_CHECK(project_2->m_total_credit == 7000);
-        BOOST_CHECK(project_2->m_average_rac == 104);
-        BOOST_CHECK(project_2->m_rac == 207);
+    if (const auto project_2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project_2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project_2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project_2->m_rac == meta.p2_rac);
         BOOST_CHECK(project_2->m_convergence_hint == 0);
     } else {
         BOOST_FAIL("Project 2 not found in superblock.");
@@ -364,7 +496,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
 
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergnce)
 {
-    NN::Superblock superblock = NN::Superblock::FromConvergence(GetTestConvergence());
+    const ScraperStatsMeta meta;
+    NN::Superblock superblock = NN::Superblock::FromConvergence(GetTestConvergence(meta));
 
     BOOST_CHECK(superblock.m_version == NN::Superblock::CURRENT_VERSION);
 
@@ -374,33 +507,33 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergnce)
     BOOST_CHECK(superblock.m_manifest_content_hint == 0x22222222);
 
     auto& cpids = superblock.m_cpids;
-    BOOST_CHECK(cpids.size() == 2);
-    BOOST_CHECK(cpids.TotalMagnitude() == 10016);
-    BOOST_CHECK(cpids.AverageMagnitude() == 5008);
-    BOOST_CHECK(cpids.At(0)->first.ToString() == "00010203040506070809101112131415");
-    BOOST_CHECK(cpids.At(0)->second == 4008);
-    BOOST_CHECK(cpids.At(1)->first.ToString() == "15141312111009080706050403020100");
-    BOOST_CHECK(cpids.At(1)->second == 6008);
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
+    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
+    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
 
     auto& projects = superblock.m_projects;
     BOOST_CHECK(projects.m_converged_by_project == false);
-    BOOST_CHECK(projects.size() == 2);
-    BOOST_CHECK(projects.TotalRac() == 410);
-    BOOST_CHECK(projects.AverageRac() == 205.0);
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
 
-    if (const auto project_1 = projects.Try("project_1")) {
-        BOOST_CHECK(project_1->m_total_credit == 3000);
-        BOOST_CHECK(project_1->m_average_rac == 102);
-        BOOST_CHECK(project_1->m_rac == 203);
+    if (const auto project_1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project_1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project_1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project_1->m_rac == meta.p1_rac);
         BOOST_CHECK(project_1->m_convergence_hint == 0);
     } else {
         BOOST_FAIL("Project 1 not found in superblock.");
     }
 
-    if (const auto project_2 = projects.Try("project_2")) {
-        BOOST_CHECK(project_2->m_total_credit == 7000);
-        BOOST_CHECK(project_2->m_average_rac == 104);
-        BOOST_CHECK(project_2->m_rac == 207);
+    if (const auto project_2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project_2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project_2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project_2->m_rac == meta.p2_rac);
         BOOST_CHECK(project_2->m_convergence_hint == 0);
     } else {
         BOOST_FAIL("Project 2 not found in superblock.");
@@ -409,8 +542,9 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergnce)
 
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergnce)
 {
+    const ScraperStatsMeta meta;
     NN::Superblock superblock = NN::Superblock::FromConvergence(
-        GetTestConvergence(true)); // Set fallback by project flag
+        GetTestConvergence(meta, true)); // Set fallback by project flag
 
     BOOST_CHECK(superblock.m_version == NN::Superblock::CURRENT_VERSION);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
@@ -418,26 +552,26 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergnc
     BOOST_CHECK(superblock.m_manifest_content_hint == 0x00000000);
 
     auto& cpids = superblock.m_cpids;
-    BOOST_CHECK(cpids.size() == 2);
-    BOOST_CHECK(cpids.TotalMagnitude() == 10016);
-    BOOST_CHECK(cpids.AverageMagnitude() == 5008);
-    BOOST_CHECK(cpids.At(0)->first.ToString() == "00010203040506070809101112131415");
-    BOOST_CHECK(cpids.At(0)->second == 4008);
-    BOOST_CHECK(cpids.At(1)->first.ToString() == "15141312111009080706050403020100");
-    BOOST_CHECK(cpids.At(1)->second == 6008);
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
+    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
+    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
 
     auto& projects = superblock.m_projects;
 
     // By project flag must be true in a fallback-to-project convergence:
     BOOST_CHECK(projects.m_converged_by_project == true);
-    BOOST_CHECK(projects.size() == 2);
-    BOOST_CHECK(projects.TotalRac() == 410);
-    BOOST_CHECK(projects.AverageRac() == 205.0);
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
 
-    if (const auto project_1 = projects.Try("project_1")) {
-        BOOST_CHECK(project_1->m_total_credit == 3000);
-        BOOST_CHECK(project_1->m_average_rac == 102);
-        BOOST_CHECK(project_1->m_rac == 203);
+    if (const auto project_1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project_1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project_1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project_1->m_rac == meta.p1_rac);
 
         // The convergence hint must be set in fallback-to-project convergence.
         // This is derived from the hash of an empty part data:
@@ -446,10 +580,10 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergnc
         BOOST_FAIL("Project 1 not found in superblock.");
     }
 
-    if (const auto project_2 = projects.Try("project_2")) {
-        BOOST_CHECK(project_2->m_total_credit == 7000);
-        BOOST_CHECK(project_2->m_average_rac == 104);
-        BOOST_CHECK(project_2->m_rac == 207);
+    if (const auto project_2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project_2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project_2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project_2->m_rac == meta.p2_rac);
 
         // The convergence hint must be set in fallback-to-project convergence.
         // This is derived from the hash of an empty part data:
@@ -494,12 +628,12 @@ BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_binary_contract)
 
     BOOST_CHECK(superblock.m_cpids.size() == 3);
     BOOST_CHECK(superblock.m_cpids.Zeros() == 5);
-    BOOST_CHECK(superblock.m_cpids.At(0)->first.ToString() == cpid1);
-    BOOST_CHECK(superblock.m_cpids.At(0)->second == 0);
-    BOOST_CHECK(superblock.m_cpids.At(1)->first.ToString() == cpid2);
-    BOOST_CHECK(superblock.m_cpids.At(1)->second == 100);
-    BOOST_CHECK(superblock.m_cpids.At(2)->first.ToString() == cpid3);
-    BOOST_CHECK(superblock.m_cpids.At(2)->second == 200);
+    BOOST_CHECK(superblock.m_cpids.At(0)->Cpid().ToString() == cpid1);
+    BOOST_CHECK(superblock.m_cpids.At(0)->Magnitude() == 0);
+    BOOST_CHECK(superblock.m_cpids.At(1)->Cpid().ToString() == cpid2);
+    BOOST_CHECK(superblock.m_cpids.At(1)->Magnitude() == 100);
+    BOOST_CHECK(superblock.m_cpids.At(2)->Cpid().ToString() == cpid3);
+    BOOST_CHECK(superblock.m_cpids.At(2)->Magnitude() == 200);
 
     BOOST_CHECK(superblock.m_projects.m_converged_by_project == false);
     BOOST_CHECK(superblock.m_projects.size() == 2);
@@ -558,12 +692,12 @@ BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_text_contract)
 
     BOOST_CHECK(superblock.m_cpids.size() == 3);
     BOOST_CHECK(superblock.m_cpids.Zeros() == 0);
-    BOOST_CHECK(superblock.m_cpids.At(0)->first.ToString() == cpid1);
-    BOOST_CHECK(superblock.m_cpids.At(0)->second == 0);
-    BOOST_CHECK(superblock.m_cpids.At(1)->first.ToString() == cpid2);
-    BOOST_CHECK(superblock.m_cpids.At(1)->second == 100);
-    BOOST_CHECK(superblock.m_cpids.At(2)->first.ToString() == cpid3);
-    BOOST_CHECK(superblock.m_cpids.At(2)->second == 200);
+    BOOST_CHECK(superblock.m_cpids.At(0)->Cpid().ToString() == cpid1);
+    BOOST_CHECK(superblock.m_cpids.At(0)->Magnitude() == 0);
+    BOOST_CHECK(superblock.m_cpids.At(1)->Cpid().ToString() == cpid2);
+    BOOST_CHECK(superblock.m_cpids.At(1)->Magnitude() == 100);
+    BOOST_CHECK(superblock.m_cpids.At(2)->Cpid().ToString() == cpid3);
+    BOOST_CHECK(superblock.m_cpids.At(2)->Magnitude() == 200);
 
     BOOST_CHECK(superblock.m_projects.m_converged_by_project == false);
     BOOST_CHECK(superblock.m_projects.size() == 2);
@@ -616,10 +750,10 @@ BOOST_AUTO_TEST_CASE(it_provides_backward_compatibility_for_legacy_contracts)
     // Check the first few CPIDs:
     auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == 1906);
-    BOOST_CHECK(cpids.At(0)->first.ToString() == "002a9d6f3832d0b0028606d907e09d97");
-    BOOST_CHECK(cpids.At(0)->second == 1);
-    BOOST_CHECK(cpids.At(1)->first.ToString() == "002d383a19b63d698a3201793e7e3750");
-    BOOST_CHECK(cpids.At(1)->second == 24);
+    BOOST_CHECK(cpids.At(0)->Cpid().ToString() == "002a9d6f3832d0b0028606d907e09d97");
+    BOOST_CHECK(cpids.At(0)->Magnitude() == 1);
+    BOOST_CHECK(cpids.At(1)->Cpid().ToString() == "002d383a19b63d698a3201793e7e3750");
+    BOOST_CHECK(cpids.At(1)->Magnitude() == 24);
 
     const std::string expected_packed(
         superblock_packed_bin,
@@ -641,7 +775,7 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_it_represents_a_complete_superblock)
 {
     NN::Superblock valid;
 
-    valid.m_cpids.Add(NN::Cpid(), 123);
+    valid.m_cpids.Add(NN::Cpid(), NN::Magnitude::RoundFrom(123));
     valid.m_projects.Add("name", NN::Superblock::ProjectStats());
 
     BOOST_CHECK(valid.WellFormed() == true);
@@ -702,7 +836,7 @@ BOOST_AUTO_TEST_CASE(it_caches_its_quorum_hash)
     NN::QuorumHash original_hash = superblock.GetHash();
 
     // Change the resulting hash:
-    superblock.m_cpids.Add(NN::Cpid(), 123);
+    superblock.m_cpids.Add(NN::Cpid(), NN::Magnitude::RoundFrom(123));
 
     // The cached hash should not change:
     BOOST_CHECK(superblock.GetHash() == original_hash);
@@ -716,7 +850,7 @@ BOOST_AUTO_TEST_CASE(it_regenerates_its_cached_quorum_hash)
     superblock.GetHash();
 
     // Change the resulting hash:
-    superblock.m_cpids.Add(NN::Cpid(), 123);
+    superblock.m_cpids.Add(NN::Cpid(), NN::Magnitude::RoundFrom(123));
 
     // Regenrate the hash:
     BOOST_CHECK(superblock.GetHash(true) == NN::QuorumHash::Hash(superblock));
@@ -724,74 +858,79 @@ BOOST_AUTO_TEST_CASE(it_regenerates_its_cached_quorum_hash)
 
 BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
 {
-    std::vector<unsigned char> expected {
-        0x02, 0x00, 0x00, 0x00,                         // Version
-        0x11, 0x11, 0x11, 0x11,                         // Convergence hint
-        0x22, 0x22, 0x22, 0x22,                         // Manifest content hint
-        0x02,                                           // CPIDs size
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
-        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
-        0xfd, 0xa8, 0x0f,                               // Magnitude
-        0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08, // CPID 2
-        0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, // ...
-        0xfd, 0x78, 0x17,                               // Magnitude
-        0x00,                                           // Zero count (VARINT)
-        0x00,                                           // By-project flag
-        0x02,                                           // Projects size
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_1" key
-        0x5f, 0x31,                                     // ...
-        0x96, 0x38,                                     // Total credit (VARINT)
-        0x66,                                           // Average RAC (VARINT)
-        0x80, 0x4b,                                     // Total RAC (VARINT)
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_2" key
-        0x5f, 0x32,                                     // ...
-        0xb5, 0x58,                                     // Total credit (VARINT)
-        0x68,                                           // Average RAC (VARINT)
-        0x80, 0x4f,                                     // Total RAC (VARINT)
-    };
+    const ScraperStatsMeta meta;
+    CDataStream expected(SER_NETWORK, PROTOCOL_VERSION);
 
-    NN::Superblock superblock = NN::Superblock::FromConvergence(GetTestConvergence());
+    expected
+        << uint32_t{2}                                  // Version
+        << uint32_t{0x11111111}                         // Convergence hint
+        << uint32_t{0x22222222}                         // Manifest content hint
+        << COMPACTSIZE(uint64_t{1})                     // Small magnitudes
+        << meta.cpid3
+        << static_cast<uint8_t>(meta.c3_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Medium magnitudes
+        << meta.cpid2
+        << static_cast<uint8_t>(meta.c2_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Large magnitudes
+        << meta.cpid1
+        << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()})
+        << VARINT(uint32_t{0})                          // Zero count
+        << uint8_t{0}                                   // By-project flag
+        << COMPACTSIZE(meta.project_count)              // Project stats
+        << meta.project1
+        << VARINT((uint64_t)std::nearbyint(meta.p1_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_rac))
+        << meta.project2
+        << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
+
+    NN::Superblock superblock = NN::Superblock::FromConvergence(GetTestConvergence(meta));
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 
     CDataStream stream(SER_NETWORK, 1);
     stream << superblock;
-    std::vector<unsigned char> output(stream.begin(), stream.end());
 
-    BOOST_CHECK(output == expected);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
 }
 
 BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
 {
-    std::vector<unsigned char> bytes {
-        0x02, 0x00, 0x00, 0x00,                         // Version
-        0x11, 0x11, 0x11, 0x11,                         // Convergence hint
-        0x22, 0x22, 0x22, 0x22,                         // Manifest content hint
-        0x02,                                           // CPIDs size
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
-        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
-        0xfd, 0xa8, 0x0f,                               // Magnitude
-        0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08, // CPID 2
-        0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, // ...
-        0xfd, 0x78, 0x17,                               // Magnitude
-        0x00,                                           // Zero count (VARINT)
-        0x00,                                           // By-project flag
-        0x02,                                           // Projects size
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_1" key
-        0x5f, 0x31,                                     // ...
-        0x96, 0x38,                                     // Total credit (VARINT)
-        0x66,                                           // Average RAC (VARINT)
-        0x80, 0x4b,                                     // Total RAC (VARINT)
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_2" key
-        0x5f, 0x32,                                     // ...
-        0xb5, 0x58,                                     // Total credit (VARINT)
-        0x68,                                           // Average RAC (VARINT)
-        0x80, 0x4f,                                     // Total RAC (VARINT)
-    };
+    const ScraperStatsMeta meta;
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+
+    stream
+        << uint32_t{2}                                  // Version
+        << uint32_t{0x11111111}                         // Convergence hint
+        << uint32_t{0x22222222}                         // Manifest content hint
+        << COMPACTSIZE(uint64_t{1})                     // Small magnitudes
+        << meta.cpid3
+        << static_cast<uint8_t>(meta.c3_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Medium magnitudes
+        << meta.cpid2
+        << static_cast<uint8_t>(meta.c2_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Large magnitudes
+        << meta.cpid1
+        << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()})
+        << VARINT(uint32_t{0})                          // Zero count
+        << uint8_t{0}                                   // By-project flag
+        << COMPACTSIZE(meta.project_count)              // Project stats
+        << meta.project1
+        << VARINT((uint64_t)std::nearbyint(meta.p1_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_rac))
+        << meta.project2
+        << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
 
     NN::Superblock superblock;
-
-    CDataStream stream(bytes, SER_NETWORK, 1);
     stream >> superblock;
 
     BOOST_CHECK(superblock.m_version == 2);
@@ -799,34 +938,34 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     BOOST_CHECK(superblock.m_manifest_content_hint == 0x22222222);
 
     const auto& cpids = superblock.m_cpids;
-    BOOST_CHECK(cpids.size() == 2);
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
     BOOST_CHECK(cpids.Zeros() == 0);
-    BOOST_CHECK(cpids.TotalMagnitude() == 10016);
-    BOOST_CHECK(cpids.AverageMagnitude() == 5008.0);
-    BOOST_CHECK(cpids.At(0)->first.ToString() == "00010203040506070809101112131415");
-    BOOST_CHECK(cpids.At(0)->second == 4008);
-    BOOST_CHECK(cpids.At(1)->first.ToString() == "15141312111009080706050403020100");
-    BOOST_CHECK(cpids.At(1)->second == 6008);
+    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
+    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
 
     const auto& projects = superblock.m_projects;
     BOOST_CHECK(projects.m_converged_by_project == false);
-    BOOST_CHECK(projects.size() == 2);
-    BOOST_CHECK(projects.TotalRac() == 410);
-    BOOST_CHECK(projects.AverageRac() == 205.0);
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
 
-    if (const auto project1 = projects.Try("project_1")) {
-        BOOST_CHECK(project1->m_total_credit == 3000);
-        BOOST_CHECK(project1->m_average_rac == 102);
-        BOOST_CHECK(project1->m_rac == 203);
+    if (const auto project1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project1->m_rac == meta.p1_rac);
         BOOST_CHECK(project1->m_convergence_hint == 0);
     } else {
         BOOST_FAIL("Project 1 not found in index.");
     }
 
-    if (const auto project2 = projects.Try("project_2")) {
-        BOOST_CHECK(project2->m_total_credit == 7000);
-        BOOST_CHECK(project2->m_average_rac == 104);
-        BOOST_CHECK(project2->m_rac == 207);
+    if (const auto project2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project2->m_rac == meta.p2_rac);
         BOOST_CHECK(project2->m_convergence_hint == 0);
     } else {
         BOOST_FAIL("Project 2 not found in index.");
@@ -835,120 +974,125 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
 
 BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_fallback_convergences)
 {
+    const ScraperStatsMeta meta;
+    CDataStream expected(SER_NETWORK, PROTOCOL_VERSION);
+
     // Superblocks generated from fallback-by-project convergences include
     // convergence hints with a by-project flag set to 1:
     //
-    std::vector<unsigned char> expected {
-        0x02, 0x00, 0x00, 0x00,                         // Version
-        0x11, 0x11, 0x11, 0x11,                         // Convergence hint
-        0x00, 0x00, 0x00, 0x00,                         // Manifest content hint
-        0x02,                                           // CPIDs size
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
-        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
-        0xfd, 0xa8, 0x0f,                               // Magnitude
-        0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08, // CPID 2
-        0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, // ...
-        0xfd, 0x78, 0x17,                               // Magnitude
-        0x00,                                           // Zero count (VARINT)
-        0x01,                                           // By-project flag
-        0x02,                                           // Projects size
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_1" key
-        0x5f, 0x31,                                     // ...
-        0x96, 0x38,                                     // Total credit (VARINT)
-        0x66,                                           // Average RAC (VARINT)
-        0x80, 0x4b,                                     // Total RAC (VARINT)
-        0x76, 0x13, 0x59, 0xd3,                         // Convergence hint
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_2" key
-        0x5f, 0x32,                                     // ...
-        0xb5, 0x58,                                     // Total credit (VARINT)
-        0x68,                                           // Average RAC (VARINT)
-        0x80, 0x4f,                                     // Total RAC (VARINT)
-        0x76, 0x13, 0x59, 0xd3,                         // Convergence hint
-    };
+    expected
+        << uint32_t{2}                                  // Version
+        << uint32_t{0x11111111}                         // Convergence hint
+        << uint32_t{0x00000000}                         // Manifest content hint
+        << COMPACTSIZE(uint64_t{1})                     // Small magnitudes
+        << meta.cpid3
+        << static_cast<uint8_t>(meta.c3_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Medium magnitudes
+        << meta.cpid2
+        << static_cast<uint8_t>(meta.c2_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Large magnitudes
+        << meta.cpid1
+        << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()})
+        << VARINT(uint32_t{0})                          // Zero count
+        << uint8_t{1}                                   // By-project flag
+        << COMPACTSIZE(meta.project_count)              // Project stats
+        << meta.project1
+        << VARINT((uint64_t)std::nearbyint(meta.p1_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_rac))
+        << uint32_t{0xd3591376}                         // Convergence hint
+        << meta.project2
+        << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << uint32_t{0xd3591376};                        // Convergence hint
 
     NN::Superblock superblock = NN::Superblock::FromConvergence(
-        GetTestConvergence(true)); // Set fallback by project flag
+        GetTestConvergence(meta, true)); // Set fallback by project flag
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 
     CDataStream stream(SER_NETWORK, 1);
     stream << superblock;
-    std::vector<unsigned char> output(stream.begin(), stream.end());
 
-    BOOST_CHECK(output == expected);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
 }
 
 BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_fallback_convergence)
 {
+    const ScraperStatsMeta meta;
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+
     // Superblocks generated from fallback-by-project convergences include
     // convergence hints with a by-project flag set to 1:
     //
-    std::vector<unsigned char> bytes {
-        0x02, 0x00, 0x00, 0x00,                         // Version
-        0x11, 0x11, 0x11, 0x11,                         // Convergence hint
-        0x22, 0x22, 0x22, 0x22,                         // Manifest content hint
-        0x02,                                           // CPIDs size
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
-        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
-        0xfd, 0xa8, 0x0f,                               // Magnitude
-        0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08, // CPID 2
-        0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, // ...
-        0xfd, 0x78, 0x17,                               // Magnitude
-        0x00,                                           // Zero count (VARINT)
-        0x01,                                           // By-project flag
-        0x02,                                           // Projects size
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_1" key
-        0x5f, 0x31,                                     // ...
-        0x96, 0x38,                                     // Total credit (VARINT)
-        0x66,                                           // Average RAC (VARINT)
-        0x80, 0x4b,                                     // Total RAC (VARINT)
-        0x76, 0x13, 0x59, 0xd3,                         // Convergence hint
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, // "project_2" key
-        0x5f, 0x32,                                     // ...
-        0xb5, 0x58,                                     // Total credit (VARINT)
-        0x68,                                           // Average RAC (VARINT)
-        0x80, 0x4f,                                     // Total RAC (VARINT)
-        0x76, 0x13, 0x59, 0xd3,                         // Convergence hint
-    };
+    stream
+        << uint32_t{2}                                  // Version
+        << uint32_t{0x11111111}                         // Convergence hint
+        << uint32_t{0x00000000}                         // Manifest content hint
+        << COMPACTSIZE(uint64_t{1})                     // Small magnitudes
+        << meta.cpid3
+        << static_cast<uint8_t>(meta.c3_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Medium magnitudes
+        << meta.cpid2
+        << static_cast<uint8_t>(meta.c2_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Large magnitudes
+        << meta.cpid1
+        << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()})
+        << VARINT(uint32_t{0})                          // Zero count
+        << uint8_t{1}                                   // By-project flag
+        << COMPACTSIZE(meta.project_count)              // Project stats
+        << meta.project1
+        << VARINT((uint64_t)std::nearbyint(meta.p1_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_rac))
+        << uint32_t{0xd3591376}                         // Convergence hint
+        << meta.project2
+        << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << uint32_t{0xd3591376};                        // Convergence hint
 
     NN::Superblock superblock;
-
-    CDataStream stream(bytes, SER_NETWORK, 1);
     stream >> superblock;
 
     BOOST_CHECK(superblock.m_version == 2);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
-    BOOST_CHECK(superblock.m_manifest_content_hint == 0x22222222);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0x00000000);
 
     const auto& cpids = superblock.m_cpids;
-    BOOST_CHECK(cpids.size() == 2);
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
     BOOST_CHECK(cpids.Zeros() == 0);
-    BOOST_CHECK(cpids.TotalMagnitude() == 10016);
-    BOOST_CHECK(cpids.AverageMagnitude() == 5008.0);
-    BOOST_CHECK(cpids.At(0)->first.ToString() == "00010203040506070809101112131415");
-    BOOST_CHECK(cpids.At(0)->second == 4008);
-    BOOST_CHECK(cpids.At(1)->first.ToString() == "15141312111009080706050403020100");
-    BOOST_CHECK(cpids.At(1)->second == 6008);
+    BOOST_CHECK_EQUAL(cpids.TotalMagnitude(), meta.cpid_total_mag);
+    BOOST_CHECK_EQUAL(cpids.AverageMagnitude(), meta.cpid_average_mag);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
 
     const auto& projects = superblock.m_projects;
     BOOST_CHECK(projects.m_converged_by_project == true);
-    BOOST_CHECK(projects.size() == 2);
-    BOOST_CHECK(projects.TotalRac() == 410);
-    BOOST_CHECK(projects.AverageRac() == 205.0);
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
 
-    if (const auto project1 = projects.Try("project_1")) {
-        BOOST_CHECK(project1->m_total_credit == 3000);
-        BOOST_CHECK(project1->m_average_rac == 102);
-        BOOST_CHECK(project1->m_rac == 203);
+    if (const auto project1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project1->m_rac == meta.p1_rac);
         BOOST_CHECK(project1->m_convergence_hint == 0xd3591376);
     } else {
         BOOST_FAIL("Project 1 not found in index.");
     }
 
-    if (const auto project2 = projects.Try("project_2")) {
-        BOOST_CHECK(project2->m_total_credit == 7000);
-        BOOST_CHECK(project2->m_average_rac == 104);
-        BOOST_CHECK(project2->m_rac == 207);
+    if (const auto project2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project2->m_rac == meta.p2_rac);
         BOOST_CHECK(project2->m_convergence_hint == 0xd3591376);
     } else {
         BOOST_FAIL("Project 2 not found in index.");
@@ -986,7 +1130,7 @@ BOOST_AUTO_TEST_CASE(it_adds_a_cpid_magnitude_to_the_index)
 
     BOOST_CHECK(cpids.size() == 0);
 
-    cpids.Add(NN::Cpid(), 123);
+    cpids.Add(NN::Cpid(), NN::Magnitude::RoundFrom(123));
 
     BOOST_CHECK(cpids.size() == 1);
 }
@@ -1048,8 +1192,8 @@ BOOST_AUTO_TEST_CASE(it_ignores_insertion_of_a_duplicate_cpid)
     NN::Superblock::CpidIndex cpids;
     NN::Cpid cpid = NN::Cpid::Parse("00010203040506070809101112131415");
 
-    cpids.Add(cpid, 123);
-    cpids.Add(cpid, 456);
+    cpids.Add(cpid, NN::Magnitude::RoundFrom(123));
+    cpids.Add(cpid, NN::Magnitude::RoundFrom(123));
 
     BOOST_CHECK(cpids.size() == 1);
 }
@@ -1061,13 +1205,15 @@ BOOST_AUTO_TEST_CASE(it_fetches_a_cpid_pair_by_offset)
     NN::Cpid cpid1 = NN::Cpid::Parse("00010203040506070809101112131415");
     NN::Cpid cpid2 = NN::Cpid::Parse("15141312111009080706050403020100");
 
-    cpids.Add(cpid1, 123);
-    cpids.Add(cpid2, 456);
+    cpids.Add(cpid1, NN::Magnitude::RoundFrom(123));
+    cpids.Add(cpid2, NN::Magnitude::RoundFrom(456));
 
-    BOOST_CHECK(cpids.At(0)->first == cpid1);
-    BOOST_CHECK(cpids.At(0)->second == 123);
-    BOOST_CHECK(cpids.At(1)->first == cpid2);
-    BOOST_CHECK(cpids.At(1)->second == 456);
+    BOOST_CHECK(cpids.At(0)->Cpid() == cpid1);
+    BOOST_CHECK(cpids.At(0)->Magnitude() == 123);
+    BOOST_CHECK(cpids.At(1)->Cpid() == cpid2);
+    BOOST_CHECK(cpids.At(1)->Magnitude() == 456);
+
+    BOOST_CHECK(cpids.At(cpids.size()) == cpids.end());
 }
 
 BOOST_AUTO_TEST_CASE(it_fetches_the_magnitude_of_a_specific_cpid)
@@ -1075,7 +1221,7 @@ BOOST_AUTO_TEST_CASE(it_fetches_the_magnitude_of_a_specific_cpid)
     NN::Superblock::CpidIndex cpids;
     NN::Cpid cpid = NN::Cpid::Parse("00010203040506070809101112131415");
 
-    cpids.Add(cpid, 123);
+    cpids.Add(cpid, NN::Magnitude::RoundFrom(123));
 
     BOOST_CHECK(cpids.MagnitudeOf(cpid) == 123);
 }
@@ -1099,16 +1245,16 @@ BOOST_AUTO_TEST_CASE(it_stores_cpids_in_lexicographical_order)
     NN::Cpid cpid2 = NN::Cpid::Parse("ffffffffffffffffffffffffffffffff");
     NN::Cpid cpid3 = NN::Cpid::Parse("00000000000000000000000000000000");
 
-    cpids.Add(cpid1, 123);
-    cpids.Add(cpid2, 456);
-    cpids.Add(cpid3, 789);
+    cpids.Add(cpid1, NN::Magnitude::RoundFrom(123));
+    cpids.Add(cpid2, NN::Magnitude::RoundFrom(456));
+    cpids.Add(cpid3, NN::Magnitude::RoundFrom(789));
 
-    BOOST_CHECK(cpids.At(0)->first == cpid3);
-    BOOST_CHECK(cpids.At(0)->second == 789);
-    BOOST_CHECK(cpids.At(1)->first == cpid1);
-    BOOST_CHECK(cpids.At(1)->second == 123);
-    BOOST_CHECK(cpids.At(2)->first == cpid2);
-    BOOST_CHECK(cpids.At(2)->second == 456);
+    BOOST_CHECK(cpids.At(0)->Cpid() == cpid3);
+    BOOST_CHECK(cpids.At(0)->Magnitude() == 789);
+    BOOST_CHECK(cpids.At(1)->Cpid() == cpid1);
+    BOOST_CHECK(cpids.At(1)->Magnitude() == 123);
+    BOOST_CHECK(cpids.At(2)->Cpid() == cpid2);
+    BOOST_CHECK(cpids.At(2)->Magnitude() == 456);
 }
 
 BOOST_AUTO_TEST_CASE(it_counts_the_number_of_active_cpids)
@@ -1117,7 +1263,7 @@ BOOST_AUTO_TEST_CASE(it_counts_the_number_of_active_cpids)
 
     BOOST_CHECK(cpids.size() == 0);
 
-    cpids.Add(NN::Cpid(), 123);
+    cpids.Add(NN::Cpid(), NN::Magnitude::RoundFrom(123));
 
     BOOST_CHECK(cpids.size() == 1);
 }
@@ -1128,7 +1274,7 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_it_contains_any_active_cpids)
 
     BOOST_CHECK(cpids.empty() == true);
 
-    cpids.Add(NN::Cpid(), 123);
+    cpids.Add(NN::Cpid(), NN::Magnitude::RoundFrom(123));
 
     BOOST_CHECK(cpids.empty() == false);
 }
@@ -1140,8 +1286,12 @@ BOOST_AUTO_TEST_CASE(it_tallies_the_number_of_zero_magnitude_cpids)
     BOOST_CHECK(cpids.Zeros() == 0);
 
     // Add only one zero-magnitude CPID:
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 0);
-    cpids.Add(NN::Cpid::Parse("15141312111009080706050403020100"), 123);
+    cpids.Add(
+        NN::Cpid::Parse("00010203040506070809101112131415"),
+        NN::Magnitude::Zero());
+    cpids.Add(
+        NN::Cpid::Parse("15141312111009080706050403020100"),
+        NN::Magnitude::RoundFrom(123));
 
     BOOST_CHECK(cpids.Zeros() == 1);
 }
@@ -1155,7 +1305,7 @@ BOOST_AUTO_TEST_CASE(it_skips_tallying_zero_magnitudes_for_legacy_superblocks)
 
     BOOST_CHECK(cpids.Zeros() == 123);
 
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 0);
+    cpids.AddLegacy(NN::Cpid::Parse("00010203040506070809101112131415"), 0);
 
     BOOST_CHECK(cpids.Zeros() == 123);
 }
@@ -1167,8 +1317,12 @@ BOOST_AUTO_TEST_CASE(it_sums_the_count_of_both_active_and_zero_magnitude_cpids)
     BOOST_CHECK(cpids.TotalCount() == 0);
 
     // Add only one zero-magnitude CPID:
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 0);
-    cpids.Add(NN::Cpid::Parse("15141312111009080706050403020100"), 123);
+    cpids.Add(
+        NN::Cpid::Parse("00010203040506070809101112131415"),
+        NN::Magnitude::RoundFrom(0));
+    cpids.Add(
+        NN::Cpid::Parse("15141312111009080706050403020100"),
+        NN::Magnitude::RoundFrom(123));
 
     BOOST_CHECK(cpids.TotalCount() == 2);
 }
@@ -1177,108 +1331,159 @@ BOOST_AUTO_TEST_CASE(it_tallies_the_sum_of_the_magnitudes_of_active_cpids)
 {
     NN::Superblock::CpidIndex cpids;
 
-    BOOST_CHECK(cpids.TotalMagnitude() == 0);
+    BOOST_CHECK(cpids.TotalMagnitude() == 0.0);
 
-    cpids.Add(NN::Cpid(), 0);
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 123);
-    cpids.Add(NN::Cpid::Parse("15141312111009080706050403020100"), 456);
+    cpids.Add(NN::Cpid(), NN::Magnitude::Zero());
+    cpids.Add(
+        NN::Cpid::Parse("00010203040506070809101112131415"),
+        NN::Magnitude::RoundFrom(123));
+    cpids.Add(
+        NN::Cpid::Parse("15141312111009080706050403020100"),
+        NN::Magnitude::RoundFrom(456));
 
-    BOOST_CHECK(cpids.TotalMagnitude() == 579);
+    BOOST_CHECK(cpids.TotalMagnitude() == 579.0);
 }
 
 BOOST_AUTO_TEST_CASE(it_skips_tallying_the_magnitudes_of_duplicate_cpids)
 {
     NN::Superblock::CpidIndex cpids;
 
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 123);
+    cpids.Add(
+        NN::Cpid::Parse("00010203040506070809101112131415"),
+        NN::Magnitude::RoundFrom(123));
 
-    BOOST_CHECK(cpids.TotalMagnitude() == 123);
+    BOOST_CHECK(cpids.TotalMagnitude() == 123.0);
 
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 456);
+    cpids.Add(
+        NN::Cpid::Parse("00010203040506070809101112131415"),
+        NN::Magnitude::RoundFrom(456));
 
-    BOOST_CHECK(cpids.TotalMagnitude() == 123);
+    BOOST_CHECK(cpids.TotalMagnitude() == 123.0);
 }
 
 BOOST_AUTO_TEST_CASE(it_calculates_the_average_magnitude_of_active_cpids)
 {
     NN::Superblock::CpidIndex cpids;
 
-    BOOST_CHECK(cpids.AverageMagnitude() == 0);
+    BOOST_CHECK(cpids.AverageMagnitude() == 0.0);
 
-    cpids.Add(NN::Cpid(), 0);
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 123);
-    cpids.Add(NN::Cpid::Parse("15141312111009080706050403020100"), 456);
+    cpids.Add(NN::Cpid(), NN::Magnitude::Zero());
+    cpids.Add(
+        NN::Cpid::Parse("00010203040506070809101112131415"),
+        NN::Magnitude::RoundFrom(123));
+    cpids.Add(
+        NN::Cpid::Parse("15141312111009080706050403020100"),
+        NN::Magnitude::RoundFrom(456));
 
     BOOST_CHECK(cpids.AverageMagnitude() == 289.5);
 }
 
 BOOST_AUTO_TEST_CASE(it_is_iterable)
 {
+    const ScraperStatsMeta meta;
     NN::Superblock::CpidIndex cpids;
 
-    const NN::Cpid cpid1 = NN::Cpid::Parse("00010203040506070809101112131415");
-    const NN::Cpid cpid2 = NN::Cpid::Parse("15141312111009080706050403020100");
-
-    cpids.Add(cpid1, 123);
-    cpids.Add(cpid2, 123);
+    cpids.Add(meta.cpid1, meta.c1_mag_obj);
+    cpids.Add(meta.cpid2, meta.c2_mag_obj);
+    cpids.Add(meta.cpid3, meta.c3_mag_obj);
 
     size_t counter = 0;
 
-    for (auto const& cpid : cpids) {
-        BOOST_CHECK(cpid.first == cpid1 || cpid.first == cpid2);
+    for (const auto& cpid : cpids) {
+        // Iteration over CPID-to-magnitude mappings proceeds in order of the
+        // magnitude size segments (small -> medium -> large), so these CPIDs
+        // appear in a different order than inserted:
+        //
+        switch (counter) {
+            case 0:
+                BOOST_CHECK(cpid.Cpid() == meta.cpid3);
+                BOOST_CHECK(cpid.Magnitude() == meta.c3_mag_obj);
+                break;
+            case 1:
+                BOOST_CHECK(cpid.Cpid() == meta.cpid2);
+                BOOST_CHECK(cpid.Magnitude() == meta.c2_mag_obj);
+                break;
+            case 2:
+                BOOST_CHECK(cpid.Cpid() == meta.cpid1);
+                BOOST_CHECK(cpid.Magnitude() == meta.c1_mag_obj);
+                break;
+            default:
+                BOOST_FAIL("Unexpected number of iterations.");
+                break;
+        }
+
         counter++;
     }
 
-    BOOST_CHECK(counter == 2);
+    BOOST_CHECK(counter == 3);
 }
 
 BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
 {
-    const std::vector<unsigned char> expected {
-        0x01,                                            // Active CPID size
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,  // CPID
-        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,  // ...
-        0x7b,                                            // Magnitude (123)
-        0x01,                                            // Zero count (VARINT)
-    };
+    const ScraperStatsMeta meta;
+    CDataStream expected(SER_NETWORK, PROTOCOL_VERSION);
+
+    expected
+        << COMPACTSIZE(uint64_t{1})                     // Small magnitudes
+        << meta.cpid3
+        << static_cast<uint8_t>(meta.c3_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Medium magnitudes
+        << meta.cpid2
+        << static_cast<uint8_t>(meta.c2_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Large magnitudes
+        << meta.cpid1
+        << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()})
+        << VARINT(uint32_t{1});                         // Zero magnitude count
 
     NN::Superblock::CpidIndex cpids;
 
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 123);
-    cpids.Add(NN::Cpid(), 0);
+    cpids.Add(meta.cpid1, NN::Magnitude::RoundFrom(meta.c1_mag));
+    cpids.Add(meta.cpid2, NN::Magnitude::RoundFrom(meta.c2_mag));
+    cpids.Add(meta.cpid3, NN::Magnitude::RoundFrom(meta.c3_mag));
+    cpids.Add(NN::Cpid(), NN::Magnitude::Zero());
 
     BOOST_CHECK(GetSerializeSize(cpids, SER_NETWORK, 1) == expected.size());
 
     CDataStream stream(SER_NETWORK, 1);
     stream << cpids;
-    std::vector<unsigned char> output(stream.begin(), stream.end());
 
-    BOOST_CHECK(output == expected);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
 }
 
 BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
 {
-    const std::vector<unsigned char> bytes {
-        0x01,                                            // Active CPID size
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,  // CPID
-        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,  // ...
-        0x7b,                                            // Magnitude (123)
-        0x01,                                            // Zero count (VARINT)
-    };
+    const ScraperStatsMeta meta;
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+
+    stream
+        << COMPACTSIZE(uint64_t{1})                     // Small magnitudes
+        << meta.cpid3
+        << static_cast<uint8_t>(meta.c3_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Medium magnitudes
+        << meta.cpid2
+        << static_cast<uint8_t>(meta.c2_mag_obj.Compact())
+        << COMPACTSIZE(uint64_t{1})                     // Large magnitudes
+        << meta.cpid1
+        << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()})
+        << VARINT(uint32_t{1});                         // Zero magnitude count
 
     NN::Superblock::CpidIndex cpids;
-
-    CDataStream stream(bytes, SER_NETWORK, 1);
     stream >> cpids;
 
-    const NN::Cpid cpid = NN::Cpid::Parse("00010203040506070809101112131415");
-
-    BOOST_CHECK(cpids.size() == 1);
+    BOOST_CHECK(cpids.size() == 3);
     BOOST_CHECK(cpids.Zeros() == 1);
-    BOOST_CHECK(cpids.At(0)->first == cpid);
-    BOOST_CHECK(cpids.MagnitudeOf(cpid) == 123);
-    BOOST_CHECK(cpids.TotalMagnitude() == 123);
-    BOOST_CHECK(cpids.AverageMagnitude() == 123);
+    BOOST_CHECK(cpids.At(0)->Cpid() == meta.cpid3);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
+    BOOST_CHECK(cpids.At(1)->Cpid() == meta.cpid2);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.At(2)->Cpid() == meta.cpid1);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
+    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -1805,42 +2010,46 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_the_supplied_bytes)
 
 BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
 {
-    NN::Superblock superblock;
-
-    auto& cpids = superblock.m_cpids;
-    cpids.Add(NN::Cpid::Parse("00010203040506070809101112131415"), 1);
-    cpids.Add(NN::Cpid::Parse("15141312111009080706050403020100"), 1);
-
-    auto& projects = superblock.m_projects;
-    projects.Add("project_1", NN::Superblock::ProjectStats(0, 0, 0));
-    projects.Add("project_2", NN::Superblock::ProjectStats(0, 0, 0));
+    const ScraperStatsMeta meta;
+    CHashWriter expected_hasher(SER_GETHASH, PROTOCOL_VERSION);
 
     // Note: convergence hints embedded in a superblock are NOT considered
     // when generating the superblock hash, and the container sizes aren't
     // either:
     //
-    std::vector<unsigned char> input {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,  // CPID 1
-        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,  // ...
-        0x01,                                            // Magnitude
-        0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08,  // CPID 2
-        0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00,  // ...
-        0x01,                                            // Magnitude
-        0x00,                                            // Zero-mag count
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74,  // "project_1" key
-        0x5f, 0x31,                                      // ...
-        0x00,                                            // Total credit
-        0x00,                                            // Average RAC
-        0x00,                                            // Total RAC
-        0x09, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74,  // "project_2" key
-        0x5f, 0x32,                                      // ...
-        0x00,                                            // Total credit
-        0x00,                                            // Average RAC
-        0x00,                                            // Total RAC
-    };
+    expected_hasher
+        // To allow for direct hashing of scraper stats data without
+        // allocating a superblock, we generate an intermediate hash
+        // of the segments of CPID-to-magnitude mappings:
+        //
+        << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+            << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+                << meta.cpid3
+                << static_cast<uint8_t>(meta.c3_mag_obj.Compact()))
+                .GetHash()
+            << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+                << meta.cpid2
+                << static_cast<uint8_t>(meta.c2_mag_obj.Compact()))
+                .GetHash()
+            << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+                << meta.cpid1
+                << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()}))
+                .GetHash())
+            .GetHash()
+        << VARINT(uint32_t{0}) // Zero-mag count
+        << meta.project1
+        << VARINT((uint64_t)std::nearbyint(meta.p1_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_rac))
+        << meta.project2
+        << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
 
-    uint256 expected = Hash(input.begin(), input.end());
-    NN::QuorumHash hash = NN::QuorumHash::Hash(superblock);
+    const uint256 expected = expected_hasher.GetHash();
+
+    const NN::QuorumHash hash = NN::QuorumHash::Hash(
+        NN::Superblock::FromStats(GetTestScraperStats(meta)));
 
     BOOST_CHECK(hash.Valid() == true);
     BOOST_CHECK(hash.Which() == NN::QuorumHash::Kind::SHA256);
@@ -1850,8 +2059,11 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
 
 BOOST_AUTO_TEST_CASE(it_hashes_a_set_of_scraper_statistics_like_a_superblock)
 {
-    NN::Superblock superblock = NN::Superblock::FromStats(GetTestScraperStats());
-    NN::QuorumHash quorum_hash = NN::QuorumHash::Hash(GetTestScraperStats());
+    const ScraperStatsMeta meta;
+    const ScraperStats stats = GetTestScraperStats(meta);
+
+    NN::Superblock superblock = NN::Superblock::FromStats(stats);
+    NN::QuorumHash quorum_hash = NN::QuorumHash::Hash(stats);
 
     BOOST_CHECK(quorum_hash == superblock.GetHash());
 }
@@ -1945,8 +2157,8 @@ BOOST_AUTO_TEST_CASE(it_hashes_cpid_magnitudes_from_a_legacy_superblock)
     std::string cpid1 = "00010203040506070809101112131415";
     std::string cpid2 = "15141312111009080706050403020100";
 
-    superblock.m_cpids.Add(NN::Cpid::Parse(cpid1), 100);
-    superblock.m_cpids.Add(NN::Cpid::Parse(cpid2), 200);
+    superblock.m_cpids.AddLegacy(NN::Cpid::Parse(cpid1), 100);
+    superblock.m_cpids.AddLegacy(NN::Cpid::Parse(cpid2), 200);
 
     NN::QuorumHash hash = NN::QuorumHash::Hash(superblock);
 
@@ -1982,16 +2194,22 @@ BOOST_AUTO_TEST_CASE(it_compares_another_quorum_hash_for_equality)
 
 BOOST_AUTO_TEST_CASE(it_compares_a_sha256_hash_for_equality)
 {
-    NN::Superblock superblock;
+    const NN::Superblock superblock;
+    CHashWriter expected_hasher(SER_GETHASH, PROTOCOL_VERSION);
+
+    expected_hasher
+        << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+            << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
+            << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
+            << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash())
+            .GetHash()
+        << VARINT(uint32_t{0}); // Zero-magnitude count
 
     // Hashed byte content of an empty superblock. Note that container sizes
     // are not considered in the hash:
-    std::vector<unsigned char> input {
-        0x00, // Zero-mag CPID count
-    };
+    const uint256 expected = expected_hasher.GetHash();
 
     NN::QuorumHash hash = NN::QuorumHash::Hash(superblock);
-    uint256 expected = Hash(input.begin(), input.end());
 
     BOOST_CHECK(hash == expected);
     BOOST_CHECK(hash != uint256());
@@ -2000,10 +2218,24 @@ BOOST_AUTO_TEST_CASE(it_compares_a_sha256_hash_for_equality)
 
 BOOST_AUTO_TEST_CASE(it_compares_a_string_for_equality)
 {
-    NN::Superblock superblock;
+    const NN::Superblock superblock;
     NN::QuorumHash hash = NN::QuorumHash::Hash(superblock);
 
-    BOOST_CHECK(hash == "9a538906e6466ebd2617d321f71bc94e56056ce213d366773699e28158e00614");
+    CHashWriter expected_hasher(SER_GETHASH, PROTOCOL_VERSION);
+
+    expected_hasher
+        << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+            << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
+            << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
+            << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash())
+            .GetHash()
+        << VARINT(uint32_t{0}); // Zero-magnitude count
+
+    // Hashed byte content of an empty superblock. Note that container sizes
+    // are not considered in the hash:
+    const std::string expected = expected_hasher.GetHash().ToString();
+
+    BOOST_CHECK(hash == expected);
     BOOST_CHECK(hash != "invalid");
     BOOST_CHECK(hash != "");
 
@@ -2017,7 +2249,7 @@ BOOST_AUTO_TEST_CASE(it_compares_a_string_for_equality)
     hash = NN::QuorumHash(); // Invalid
 
     BOOST_CHECK(hash == "");
-    BOOST_CHECK(hash != "9a538906e6466ebd2617d321f71bc94e56056ce213d366773699e28158e00614");
+    BOOST_CHECK(hash != expected);
     BOOST_CHECK(hash != Legacy::GetQuorumHash("<MAGNITUDES></MAGNITUDES>"));
 }
 

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -12,11 +12,9 @@
 #endif
 
 #include <string>
-
 #include <stdint.h>
 
 #include "scraper/fwd.h"
-#include "neuralnet/superblock.h"
 
 class CBasicKeyStore;
 class CWallet;
@@ -79,7 +77,7 @@ public:
 
 	/** Ask the user a question */
     boost::signals2::signal<bool (std::string caption, std::string body), boost::signals2::last_value<bool> > ThreadSafeAskQuestion;
-	
+
     /** Handle a URL passed at the command line. */
     boost::signals2::signal<void (const std::string& strURI)> ThreadSafeHandleURI;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -24,6 +24,7 @@
 #include "beacon.h"
 #include "miner.h"
 #include <random>
+#include "global_objects_noui.hpp"
 
 using namespace std;
 


### PR DESCRIPTION
This adds support for superblock storage of magnitude values as small as 0.01 by increasing the precision of lesser magnitude values to better represent smaller crunchers. Currently, a CPID with a magnitude of 0.5 or less will fall out of the superblock because these magnitudes round-down to zero (greater than 0.5 round-up to 1). After the removal of the team requirement, an influx of new participants may affect the magnitude distribution in a way that makes it difficult for participants with less computing power to earn research rewards by preventing those will lower magnitude from appearing in superblocks. 

We discussed several strategies for storing magnitudes with more precision to mitigate this. I kept my initial implementation with these magnitude precision tiers:

 - Less than 1 exhibit two fractional places 
 - 1 or greater and less than 10 exhibit one fractional place
 - 10 or greater are whole numbers only

This balances the fidelity of magnitude values with storage overhead. Magnitude values are currently encoded as 16-bit integers (two bytes), and the new superblock format can compress magnitudes smaller than 253 into one byte. These precision tiers allow us to continue to use this compression for magnitudes up to 253 even with the increased precision on the low end. The majority of magnitudes in the network fall below this threshold. 

More importantly, these tiers allow for more deterministic superblock sizes. With a strategy that uses both bytes to embed more precision, we can support two fractional places for magnitudes up to about 327. However, this severely limits the range of values that fit into one byte (it caps at around 1.27 magnitude). A powerful cruncher that disappears from a superblock can cause a large fluctuation in superblock size as the magnitudes for many smaller crunchers jump up from one to two bytes. If the network reaches capacity, that sudden jump in size will cause thousands of small CPIDs to fall out of a superblock because of the size limit. For better determinism, we can also serialize magnitudes as two bytes always, but using compression allows for over 2800 more participants before reaching the limit and reduces the rate of growth of the blockchain.

To provide a way to identify serialized magnitudes by precision tier, we talked about using a specialized encoding of the integers that designate some of the bits as flags. Instead, I chose to redesign the magnitude collection in the superblock data structure by splitting it into segments--one for each magnitude size category. Each segment contains the compact representations of the magnitudes in that category. This adds a small cost to scale the magnitudes in a superblock for use by the application, but, in return, bulk superblock data serializes/deserializes much more efficiently without the overhead of the special encoding. 

We have room to adjust the thresholds for the proposed precision tiers to something like _0 &rarr; 2.5 &rarr; 25 &rarr; 32767_ to increase the range of values with higher precision. As recommended by @jamescowens, I started with the powers of 10 for simplicity. I'm interested to hear thoughts about these tiers.