### PR TITLE
Implement new transaction fees for block version 11

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1251,7 +1251,7 @@ int64_t CTransaction::GetBaseFee(enum GetMinFee_mode mode) const
 
     // For block version 11 onwards, which corresponds to CTransaction::CURRENT_VERSION 2,
     // a multiplier is used on top of MIN_TX_FEE and MIN_RELAY_TX_FEE
-    if (CURRENT_VERSION >= 2)
+    if (nVersion >= 2)
     {
         nBaseFee *= 10;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,7 +119,11 @@ CScript COINBASE_FLAGS;
 const string strMessageMagic = "Gridcoin Signed Message:\n";
 
 // Settings
-int64_t nTransactionFee = MIN_TX_FEE;
+// This is changed to MIN_TX_FEE * 10 for block version 11 (CTransaction::CURRENT_VERSION 2).
+// Note that this is an early init value and will result in overpayment of the fee per kbyte
+// if this code is run on a wallet prior to the v11 mandatory switchover unless a manual value
+// of -paytxfee is specified as an argument.
+int64_t nTransactionFee = MIN_TX_FEE * 10;
 int64_t nReserveBalance = 0;
 int64_t nMinimumInputValue = 0;
 
@@ -1240,10 +1244,24 @@ bool CTransaction::CheckTransaction() const
     return true;
 }
 
-int64_t CTransaction::GetMinFee(unsigned int nBlockSize, enum GetMinFee_mode mode, unsigned int nBytes) const
+int64_t CTransaction::GetBaseFee(enum GetMinFee_mode mode) const
 {
     // Base fee is either MIN_TX_FEE or MIN_RELAY_TX_FEE
     int64_t nBaseFee = (mode == GMF_RELAY) ? MIN_RELAY_TX_FEE : MIN_TX_FEE;
+
+    // For block version 11 onwards, which corresponds to CTransaction::CURRENT_VERSION 2,
+    // a multiplier is used on top of MIN_TX_FEE and MIN_RELAY_TX_FEE
+    if (CURRENT_VERSION >= 2)
+    {
+        nBaseFee *= 10;
+    }
+
+    return nBaseFee;
+}
+
+int64_t CTransaction::GetMinFee(unsigned int nBlockSize, enum GetMinFee_mode mode, unsigned int nBytes) const
+{
+    int64_t nBaseFee = GetBaseFee(mode);
 
     unsigned int nNewBlockSize = nBlockSize + nBytes;
     int64_t nMinFee = (1 + (int64_t)nBytes / 1000) * nBaseFee;
@@ -1371,7 +1389,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         // Continuously rate-limit free transactions
         // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
         // be annoying or make others' transactions take longer to confirm.
-        if (nFees < MIN_RELAY_TX_FEE)
+        if (nFees < tx.GetBaseFee(GMF_RELAY))
         {
             static CCriticalSection cs;
             static double dFreeCount;

--- a/src/main.h
+++ b/src/main.h
@@ -744,6 +744,8 @@ public:
      */
     int64_t GetValueIn(const MapPrevTx& mapInputs) const;
 
+    int64_t GetBaseFee(enum GetMinFee_mode mode=GMF_BLOCK) const;
+
     int64_t GetMinFee(unsigned int nBlockSize=1, enum GetMinFee_mode mode=GMF_BLOCK, unsigned int nBytes = 0) const;
 
     bool ReadFromDisk(CDiskTxPos pos, FILE** pfileRet=NULL)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -236,7 +236,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
     // a transaction spammer can cheaply fill blocks using
     // 1-satoshi-fee transactions. It should be set above the real
     // cost to you of processing a transaction.
-    int64_t nMinTxFee = MIN_TX_FEE;
+    int64_t nMinTxFee = CoinBase.GetBaseFee();
     if (mapArgs.count("-mintxfee"))
         ParseMoney(mapArgs["-mintxfee"], nMinTxFee);
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -88,7 +88,19 @@ static bool ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption
 {
     if(!guiref)
         return false;
-    if(nFeeRequired < MIN_TX_FEE || nFeeRequired <= nTransactionFee || fDaemon)
+
+    int64_t nMinFee;
+
+    {
+        LOCK(cs_main);
+
+        CTransaction txDummy;
+
+        // Min Fee
+        nMinFee = txDummy.GetBaseFee(GMF_SEND);
+    }
+
+    if(nFeeRequired < nMinFee || nFeeRequired <= nTransactionFee || fDaemon)
         return true;
     bool payFee = false;
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -261,18 +261,22 @@ UniValue getdifficulty(const UniValue& params, bool fHelp)
 
 UniValue settxfee(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 1 || AmountFromValue(params[0]) < MIN_TX_FEE)
+    LOCK(cs_main);
+
+    CTransaction txDummy;
+
+    // Min Fee
+    int64_t nMinFee = txDummy.GetBaseFee(GMF_SEND);
+
+    if (fHelp || params.size() < 1 || params.size() > 1 || AmountFromValue(params[0]) < nMinFee)
         throw runtime_error(
                 "settxfee <amount>\n"
                 "\n"
-                "<amount> is a real and is rounded to the nearest 0.01\n"
+                "<amount> is a real and is rounded to the nearest 0.00000001\n"
                 "\n"
                 "Sets the txfee for transactions\n");
 
-    LOCK(cs_main);
-
     nTransactionFee = AmountFromValue(params[0]);
-    nTransactionFee = (nTransactionFee / CENT) * CENT;  // round to cent
 
     return true;
 }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1643,12 +1643,12 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
                 }
 
                 int64_t nChange = nValueIn - nValueOut - nFeeRet;
-                // if sub-cent change is required, the fee must be raised to at least MIN_TX_FEE
+                // if sub-cent change is required, the fee must be raised to at least GetBaseFee
                 // or until nChange becomes zero
                 // NOTE: this depends on the exact behaviour of GetMinFee
-                if (nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < CENT)
+                if (nFeeRet < wtxNew.GetBaseFee() && nChange > 0 && nChange < CENT)
                 {
-                    int64_t nMoveToFee = min(nChange, MIN_TX_FEE - nFeeRet);
+                    int64_t nMoveToFee = min(nChange, wtxNew.GetBaseFee() - nFeeRet);
                     nChange -= nMoveToFee;
                     nFeeRet += nMoveToFee;
                 }


### PR DESCRIPTION
This is an early stab at adjusting the fees for block version 11 onwards.

Some serious issues to ponder. nTransactionFee needs to be updated every block. I have updated it in init later after the intial block load, but it is going to have to be updated from now on per block. But maybe it shouldn't. Note that nTransactionFee can be specified by the user on the command line, or in the optionsmodel (in the GUI). In the static situation prior to v11, it was initialized to MIN_TX_FEE early and then overridden by GetArg, with a clamp at 0.25 GRC.

If nTransactionFee needs to be continuously updated, should we make nTransactionFee a std::atomic<uint64_t> to avoid more locking problems?

Note I implemented CTransaction::GetBaseFee which now makes min fee essentially conditional. and changed the places that referred directly to MIN_TX_FEE and MIN_RELAY_TX_FEE.

Related to the nTransactionFee and std::atomic question, I have created dummy transactions in certain areas to provide the context to call GetBaseFee and get the min transaction fee. This implicitly pulls pindexBest, which is also global.

There is also a bunch of stuff to ensure fees are increased to avoid any UTXO being less than one CENT to ensure there is no dust in transactions. I have left this in place but would like comments.

Comments/thoughts welcome...