### PR TITLE
Replace research accrual calculations with superblock snapshots

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,6 +98,7 @@ GRIDCOIN_CORE_H = \
 	neuralnet/accrual/newbie.h \
 	neuralnet/accrual/null.h \
 	neuralnet/accrual/research_age.h \
+	neuralnet/accrual/snapshot.h \
 	neuralnet/claim.h \
 	neuralnet/cpid.h \
 	neuralnet/magnitude.h \

--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -6,8 +6,6 @@
 #include <map>
 #include <set>
 
-extern int nBoincUtilization;
-extern std::string sRegVer;
 extern bool bForceUpdate;
 extern bool fQtActive;
 extern bool bGridcoinCoreInitComplete;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
+#include "block.h"
 #include "util.h"
 #include "net.h"
 #include "txdb.h"
@@ -156,7 +157,7 @@ static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
     Sleep(INFINITE);
     return true;
 }
-#endif   
+#endif
 
 
 #ifndef WIN32
@@ -322,7 +323,7 @@ bool InitSanityCheck(void)
                   "information, visit https://en.bitcoin.it/wiki/OpenSSL_and_EC_Libraries");
         return false;
     }
-    
+
     return true;
 }
 
@@ -694,7 +695,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     // Initialize internal hashing code with SSE/AVX2 optimizations. In the future we will also have ARM/NEON optimizations.
     std::string sha256_algo = SHA256AutoDetect();
-    LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);                                                                                      
+    LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);
 
     fs::path datadir = GetDataDir();
     fs::path walletFileName = GetArg("-wallet", "wallet.dat");
@@ -712,7 +713,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
 
-#if !defined(WIN32) 
+#if !defined(WIN32)
     if (fDaemon)
     {
         // Daemonize
@@ -941,6 +942,15 @@ bool AppInit2(ThreadHandlerPtr threads)
         uiInterface.InitMessage(_("Loading superblock cache..."));
         LogPrintf("Loading superblock cache...");
         NN::Quorum::LoadSuperblockIndex(pindexBest);
+    }
+
+    // Initialize the Gridcoin research reward tally system from the first
+    // research age block (as defined in main.h):
+    //
+    uiInterface.InitMessage(_("Initializing research reward tally..."));
+    if (!NN::Tally::Initialize(BlockFinder().FindByHeight(fTestNet ? 36501 : 364501)))
+    {
+        return InitError(_("Failed to initialize tally."));
     }
 
     if (GetBoolArg("-printblockindex") || GetBoolArg("-printblocktree"))

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1166,7 +1166,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         uiInterface.InitMessage(_("Loading Network Averages..."));
         if (fDebug3) LogPrintf("Loading network averages");
 
-        NN::Tally::LegacyRecount(NN::Tally::FindTrigger(pindexBest));
+        NN::Tally::LegacyRecount(NN::Tally::FindLegacyTrigger(pindexBest));
     }
 
     if (!threads->createThread(StartNode, NULL, "Start Thread"))

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1162,11 +1162,12 @@ bool AppInit2(ThreadHandlerPtr threads)
         LogPrintf("mapAddressBook.size() = %" PRIszu,  pwalletMain->mapAddressBook.size());
     }
 
+    if (pindexBest->nVersion <= 10) {
+        uiInterface.InitMessage(_("Loading Network Averages..."));
+        if (fDebug3) LogPrintf("Loading network averages");
 
-    uiInterface.InitMessage(_("Loading Network Averages..."));
-    if (fDebug3) LogPrintf("Loading network averages");
-
-    NN::Tally::LegacyRecount(NN::Tally::FindTrigger(pindexBest));
+        NN::Tally::LegacyRecount(NN::Tally::FindTrigger(pindexBest));
+    }
 
     if (!threads->createThread(StartNode, NULL, "Start Thread"))
         InitError(_("Error: could not start node"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -952,7 +952,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     // research age block (as defined in main.h):
     //
     uiInterface.InitMessage(_("Initializing research reward tally..."));
-    if (!NN::Tally::Initialize(BlockFinder().FindByHeight(fTestNet ? 36501 : 364501)))
+    if (!NN::Tally::Initialize(BlockFinder().FindByHeight(GetResearchAgeThreshold())))
     {
         return InitError(_("Failed to initialize tally."));
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -385,6 +385,10 @@ void InitLogging()
         }
     }
 
+    // TODO: enable tally and accrual debug log categories during Fern testing:
+    LogInstance().EnableCategory("tally");
+    LogInstance().EnableCategory("accrual");
+
     std::vector<std::string> excluded_categories;
 
     if (mapArgs.count("-debugexclude") && mapMultiArgs["-debugexclude"].size() > 0)

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -179,6 +179,8 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::MANIFEST, "manifest"},
     {BCLog::SB, "superblock"},
     {BCLog::ALERT, "alert"},
+    {BCLog::TALLY, "tally"},
+    {BCLog::ACCRUAL, "accrual"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -80,6 +80,8 @@ namespace BCLog {
         MANIFEST    = (1 << 22),
         SB          = (1 << 23),
         ALERT       = (1 << 24),
+        TALLY       = (1 << 25),
+        ACCRUAL     = (1 << 26),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1742,10 +1742,9 @@ int64_t GetProofOfStakeReward(
     //
     if (pindexLast->nVersion >= 9) {
         if (const NN::CpidOption cpid = mining_id.TryCpid()) {
-            const NN::ResearchAccount& account = NN::Tally::GetAccount(*cpid);
             const NN::AccrualComputer calc = NN::Tally::GetComputer(*cpid, nTime, pindexLast);
 
-            out_research_subsidy = calc->Accrual(account);
+            out_research_subsidy = calc->Accrual();
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,7 +610,7 @@ void GetGlobalStatus()
         GlobalStatusStruct.coinWeight = sWeight;
         GlobalStatusStruct.magnitude = RoundToString(boincmagnitude,2);
         GlobalStatusStruct.ETTS = RoundToString(dETTS,3);
-        GlobalStatusStruct.ERRperday = RoundToString(boincmagnitude * NN::Tally::GetMagnitudeUnit(GetAdjustedTime()),2);
+        GlobalStatusStruct.ERRperday = RoundToString(boincmagnitude * NN::Tally::GetMagnitudeUnit(pindexBest), 2);
         GlobalStatusStruct.cpid = NN::GetPrimaryCpid();
         GlobalStatusStruct.poll = std::move(current_poll);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,10 +171,6 @@ bool fColdBoot = true;
 bool fEnforceCanonical = true;
 bool fUseFastIndex = false;
 
-// Gridcoin status    *************
-int nBoincUtilization = 0;
-std::string sRegVer;
-
 std::map<std::string, int> mvTimers; // Contains event timers that reset after max ms duration iterator is exceeded
 
 // End of Gridcoin Global vars
@@ -573,7 +569,6 @@ void GetGlobalStatus()
         double boincmagnitude = NN::Quorum::MyMagnitude().Floating();
         uint64_t nWeight = 0;
         pwalletMain->GetStakeWeight(nWeight);
-        nBoincUtilization = boincmagnitude; //Legacy Support for the about screen
         double weight = nWeight/COIN;
         double PORDiff = GetDifficulty(GetLastBlockIndex(pindexBest, true));
         std::string sWeight = RoundToString((double)weight,0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -566,7 +566,6 @@ void GetGlobalStatus()
 
     try
     {
-        double boincmagnitude = NN::Quorum::MyMagnitude().Floating();
         uint64_t nWeight = 0;
         pwalletMain->GetStakeWeight(nWeight);
         double weight = nWeight/COIN;
@@ -592,10 +591,6 @@ void GetGlobalStatus()
             LogPrintf("Error obtaining last poll: %s", e.what());
         }
 
-        // It is necessary to assign a local variable for ETTS to avoid an occasional deadlock between the lock below,
-        // the lock on cs_main in GetEstimateTimetoStake(), and the corresponding lock in the stakeminer.
-        double dETTS = GetEstimatedTimetoStake() / 86400.0;
-
         LOCK(GlobalStatusStruct.lock);
 
         GlobalStatusStruct.blocks = ToString(nBestHeight);
@@ -603,9 +598,7 @@ void GetGlobalStatus()
         GlobalStatusStruct.netWeight = RoundToString(GetEstimatedNetworkWeight() / 80.0,2);
         //todo: use the real weight from miner status (requires scaling)
         GlobalStatusStruct.coinWeight = sWeight;
-        GlobalStatusStruct.magnitude = RoundToString(boincmagnitude,2);
-        GlobalStatusStruct.ETTS = RoundToString(dETTS,3);
-        GlobalStatusStruct.ERRperday = RoundToString(boincmagnitude * NN::Tally::GetMagnitudeUnit(pindexBest), 2);
+        GlobalStatusStruct.magnitude = NN::Quorum::MyMagnitude().ToString();
         GlobalStatusStruct.cpid = NN::GetPrimaryCpid();
         GlobalStatusStruct.poll = std::move(current_poll);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3540,9 +3540,8 @@ void GridcoinServices()
         && IsV9Enabled(nBestHeight + (fTestNet ? 200 : 40))
         && nBestHeight % 20 == 0)
     {
-        if (fDebug) {
-            LogPrintf("GridcoinServices: Priming tally system for v9 threshold.");
-        }
+        LogPrint(BCLog::LogFlags::TALLY,
+            "GridcoinServices: Priming tally system for v9 threshold.");
 
         NN::Tally::LegacyRecount(pindexBest);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1714,55 +1714,15 @@ int64_t GetConstantBlockReward(const CBlockIndex* index)
 }
 
 int64_t GetProofOfStakeReward(
-    uint64_t nCoinAge,
-    int64_t nFees,
-    const NN::MiningId mining_id,
-    int64_t nTime,
-    const CBlockIndex* pindexLast,
-    int64_t& out_research_subsidy,
-    int64_t& out_block_subsidy)
+    const uint64_t nCoinAge,
+    const int64_t nTime,
+    const CBlockIndex* const pindexLast)
 {
-    // Research Age Subsidy - PROD
-    out_research_subsidy = 0;
-    out_block_subsidy = 0;
-
-    // Tally doesn't calculate research age averages until block version 9:
-    //
-    if (pindexLast->nVersion >= 9) {
-        if (const NN::CpidOption cpid = mining_id.TryCpid()) {
-            const NN::AccrualComputer calc = NN::Tally::GetComputer(*cpid, nTime, pindexLast);
-
-            out_research_subsidy = calc->Accrual();
-        }
+    if (pindexLast->nVersion >= 10) {
+        return GetConstantBlockReward(pindexLast);
     }
 
-    /* Constant Block Reward */
-    if (pindexLast->nVersion>=10)
-        out_block_subsidy = GetConstantBlockReward(pindexLast);
-    else
-        out_block_subsidy = nCoinAge * GetCoinYearReward(nTime) * 33 / (365 * 33 + 8);
-
-    int64_t nSubsidy = out_block_subsidy + out_research_subsidy;
-
-    if (fDebug10 || GetBoolArg("-printcreation"))
-    {
-        LogPrintf("GetProofOfStakeReward(): create=%s nCoinAge=%" PRIu64 " research=%s",
-            FormatMoney(nSubsidy), nCoinAge, FormatMoney(out_research_subsidy));
-    }
-
-    int64_t nTotalSubsidy = nSubsidy + nFees;
-    // This rule does not apply in v11
-    if (out_research_subsidy > 1 && pindexLast->nVersion <= 10)
-    {
-        std::string sTotalSubsidy = RoundToString(CoinToDouble(nTotalSubsidy)+.00000123,8);
-        if (sTotalSubsidy.length() > 7)
-        {
-            sTotalSubsidy = sTotalSubsidy.substr(0,sTotalSubsidy.length()-4) + "0124";
-            nTotalSubsidy = RoundFromString(sTotalSubsidy,8)*COIN;
-        }
-    }
-
-    return nTotalSubsidy;
+    return nCoinAge * GetCoinYearReward(nTime) * 33 / (365 * 33 + 8);
 }
 
 
@@ -2300,6 +2260,10 @@ double ClientVersionNew()
     return cv;
 }
 
+//
+// Gridcoin-specific ConnectBlock() routines:
+//
+namespace {
 int64_t ReturnCurrentMoneySupply(CBlockIndex* pindexcurrent)
 {
     if (pindexcurrent->pprev)
@@ -2342,6 +2306,361 @@ int64_t ReturnCurrentMoneySupply(CBlockIndex* pindexcurrent)
     pindexcurrent = pblockMemory;
     return (pindexcurrent->pprev? pindexcurrent->pprev->nMoneySupply : nGenesisSupply);
 }
+
+bool GetCoinstakeAge(CTxDB& txdb, const CBlock& block, uint64_t& out_coin_age)
+{
+    out_coin_age = 0;
+
+    // ppcoin: coin stake tx earns reward instead of paying fee
+    //
+    // With block version 10, Gridcoin switched to constant block rewards
+    // that do not depend on coin age, so we can avoid reading the blocks
+    // and transactions from the disk. The CheckProofOfStake*() functions
+    // of the kernel verify the transaction timestamp and that the staked
+    // inputs exist in the main chain.
+    //
+    if (block.nVersion <= 9 && !block.vtx[1].GetCoinAge(txdb, out_coin_age)) {
+        return error("ConnectBlock[] : %s unable to get coin age for coinstake",
+            block.vtx[1].GetHash().ToString().substr(0,10));
+    }
+
+    return true;
+}
+
+//!
+//! \brief Checks reward claims in generated blocks.
+//!
+class ClaimValidator
+{
+public:
+    ClaimValidator(
+        const CBlock& block,
+        const CBlockIndex* const pindex,
+        const int64_t total_claimed,
+        const int64_t fees,
+        const uint64_t coin_age)
+        : m_block(block)
+        , m_pindex(pindex)
+        , m_claim(block.GetClaim())
+        , m_total_claimed(total_claimed)
+        , m_fees(fees)
+        , m_coin_age(coin_age)
+    {
+    }
+
+    bool Check() const
+    {
+        return m_claim.HasResearchReward()
+            ? CheckResearcherClaim()
+            : CheckInvestorClaim();
+    }
+
+private:
+    const CBlock& m_block;
+    const CBlockIndex* const m_pindex;
+    const NN::Claim& m_claim;
+    const int64_t m_total_claimed;
+    const int64_t m_fees;
+    const uint64_t m_coin_age;
+
+    bool CheckReward(const int64_t research_owed, int64_t& out_stake_owed) const
+    {
+        out_stake_owed = GetProofOfStakeReward(m_coin_age, m_block.nTime, m_pindex);
+
+        if (m_block.nVersion >= 11) {
+            return m_total_claimed <= research_owed + out_stake_owed + m_fees;
+        }
+
+        // Blocks version 10 and below represented rewards as floating-point
+        // values and needed to accomodate floating-point errors so we'll do
+        // the same rounding on the floating-point representations:
+        //
+        double subsidy = ((double)research_owed / COIN) * 1.25;
+        subsidy += (double)out_stake_owed / COIN;
+
+        int64_t max_owed = roundint64(subsidy * COIN) + m_fees;
+
+        // Block version 9 and below allowed a 1 GRC wiggle.
+        if (m_block.nVersion <= 9) {
+            max_owed += 1 * COIN;
+        }
+
+        return m_total_claimed <= max_owed;
+    }
+
+    bool CheckInvestorClaim() const
+    {
+        int64_t out_stake_owed;
+        if (CheckReward(0, out_stake_owed)) {
+            return true;
+        }
+
+        if (GetBadBlocks().count(m_pindex->GetBlockHash())) {
+            LogPrintf(
+                "WARNING: ConnectBlock[%s]: ignored bad investor claim on block %s",
+                __func__,
+                m_pindex->GetBlockHash().ToString());
+
+            return true;
+        }
+
+        return m_block.DoS(10, error(
+            "ConnectBlock[%s]: investor claim %s exceeds %s. Expected %s, fees %s",
+            __func__,
+            FormatMoney(m_total_claimed),
+            FormatMoney(out_stake_owed + m_fees),
+            FormatMoney(out_stake_owed),
+            FormatMoney(m_fees)));
+    }
+
+    bool CheckResearcherClaim() const
+    {
+        // For version 11 blocks and higher, just validate the reward and check
+        // the signature. No need for the rest of these shenanigans.
+        //
+        if (m_block.nVersion >= 11) {
+            return CheckResearchReward() && CheckClaimSignature();
+        }
+
+        if (!CheckResearchRewardLimit()) {
+            return false;
+        }
+
+        if (!CheckResearchRewardDrift()) {
+            return false;
+        }
+
+        if (m_block.nVersion <= 8) {
+            return true;
+        }
+
+        if (!CheckClaimMagnitude()) {
+            return false;
+        }
+
+        if (!CheckClaimSignature()) {
+            return false;
+        }
+
+        if (!CheckResearchReward()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool CheckResearchRewardLimit() const
+    {
+        // TODO: determine max reward from accrual computer implementation:
+        const int64_t max_reward = 12750 * COIN;
+
+        return m_claim.m_research_subsidy <= max_reward
+            || m_block.DoS(1, error(
+                "ConnectBlock[%s]: research claim %s exceeds max %s. CPID %s",
+                __func__,
+                FormatMoney(m_claim.m_research_subsidy),
+                FormatMoney(max_reward),
+                m_claim.m_mining_id.ToString()));
+    }
+
+    bool CheckResearchRewardDrift() const
+    {
+        // ResearchAge: Since the best block may increment before the RA is
+        // connected but After the RA is computed, the ResearchSubsidy can
+        // sometimes be slightly smaller than we calculate here due to the
+        // RA timespan increasing.  So we will allow for time shift before
+        // rejecting the block.
+        const int64_t reward_claimed = m_total_claimed - m_fees;
+        int64_t drift_allowed = m_claim.m_research_subsidy * 0.15;
+
+        if (drift_allowed < 10 * COIN) {
+            drift_allowed = 10 * COIN;
+        }
+
+        return m_claim.TotalSubsidy() + drift_allowed >= reward_claimed
+            || m_block.DoS(20, error(
+                "ConnectBlock[%s]: reward claim %s exceeds allowed %s. CPID %s",
+                __func__,
+                FormatMoney(reward_claimed),
+                FormatMoney(m_claim.TotalSubsidy() + drift_allowed),
+                m_claim.m_mining_id.ToString()));
+    }
+
+    bool CheckClaimMagnitude() const
+    {
+        // Magnitude as of the last superblock:
+        const double mag = NN::Quorum::GetMagnitude(m_claim.m_mining_id).Floating();
+
+        return m_claim.m_magnitude <= (mag * 1.25)
+            || m_block.DoS(20, error(
+                "ConnectBlock[%s]: magnitude claim %f exceeds superblock %f. CPID %s",
+                __func__,
+                m_claim.m_magnitude,
+                mag,
+                m_claim.m_mining_id.ToString()));
+    }
+
+    bool CheckClaimSignature() const
+    {
+        if (NN::VerifyClaim(m_claim, m_pindex->pprev->GetBlockHash())) {
+            return true;
+        }
+
+        if (GetBadBlocks().count(m_pindex->GetBlockHash())) {
+            LogPrintf(
+                "WARNING: ConnectBlock[%s]: ignored invalid signature in %s",
+                __func__,
+                m_pindex->GetBlockHash().ToString());
+
+            return true;
+        }
+
+        return m_block.DoS(20, error(
+            "ConnectBlock[%s]: signature verification failed. CPID %s, LBH %s",
+            __func__,
+            m_claim.m_mining_id.ToString(),
+            m_pindex->pprev->GetBlockHash().ToString()));
+    }
+
+    bool CheckResearchReward() const
+    {
+        int64_t research_owed = 0;
+
+        if (const NN::CpidOption cpid = m_claim.m_mining_id.TryCpid()) {
+            research_owed = NN::Tally::GetComputer(*cpid, m_block.nTime, m_pindex)->Accrual();
+        }
+
+        int64_t out_stake_owed;
+        if (CheckReward(research_owed, out_stake_owed)) {
+            return true;
+        }
+
+        // Testnet contains some blocks with bad interest claims that were masked
+        // by research age short 10-block-span pending accrual:
+        if (fTestNet
+            && m_block.nVersion <= 9
+            && !CheckReward(0, out_stake_owed))
+        {
+            LogPrintf(
+                "WARNING: ConnectBlock[%s]: ignored bad testnet claim in %s",
+                __func__,
+                m_pindex->GetBlockHash().ToString());
+
+            return true;
+        }
+
+        if (GetBadBlocks().count(m_pindex->GetBlockHash())) {
+            LogPrintf(
+                "WARNING: ConnectBlock[%s]: ignored bad research claim in %s",
+                __func__,
+                m_pindex->GetBlockHash().ToString());
+
+            return true;
+        }
+
+        return m_block.DoS(10, error(
+            "ConnectBlock[%s]: researcher claim %s exceeds %s for CPID %s. "
+            "Expected research %s, stake %s, fees %s. "
+            "Claimed research %s, stake %s",
+            __func__,
+            FormatMoney(m_total_claimed),
+            FormatMoney(research_owed + out_stake_owed + m_fees),
+            m_claim.m_mining_id.ToString(),
+            FormatMoney(research_owed),
+            FormatMoney(out_stake_owed),
+            FormatMoney(m_fees),
+            FormatMoney(m_claim.m_research_subsidy),
+            FormatMoney(m_claim.m_block_subsidy)));
+    }
+}; // ClaimValidator
+
+bool TryLoadSuperblock(
+    CBlock& block,
+    const CBlockIndex* const pindex,
+    const NN::Claim& claim)
+{
+    // Note: PullSuperblock() invalidates the m_claim.m_superblock field
+    // by moving it. This must be the last instance where we reference a
+    // superblock in a block's claim field:
+    //
+    NN::SuperblockPtr superblock = NN::SuperblockPtr::BindShared(block.PullSuperblock(), pindex);
+
+    // TODO: find the invalid historical superblocks so we can remove
+    // the fColdBoot condition that skips this check when syncing the
+    // initial chain:
+    //
+    if ((!fColdBoot || block.nVersion >= 11)
+        && !NN::Quorum::ValidateSuperblockClaim(claim, superblock, pindex))
+    {
+        return block.DoS(25, error("ConnectBlock: Rejected invalid superblock."));
+    }
+
+    // Block versions 11+ calculate research rewards from snapshots of
+    // accrual taken at each superblock:
+    //
+    if (block.nVersion >= 11) {
+        if (!NN::Tally::ApplySuperblock(superblock)) {
+            return false;
+        }
+    }
+
+    NN::Quorum::PushSuperblock(std::move(superblock));
+
+    return true;
+}
+
+bool GridcoinConnectBlock(
+    CBlock& block,
+    CBlockIndex* const pindex,
+    CTxDB& txdb,
+    const int64_t total_claimed,
+    const int64_t fees)
+{
+    const NN::Claim& claim = block.GetClaim();
+
+    if (pindex->nHeight > nGrandfather) {
+        uint64_t out_coin_age;
+        if (!GetCoinstakeAge(txdb, block, out_coin_age)) {
+            return false;
+        }
+
+        if (!ClaimValidator(block, pindex, total_claimed, fees, out_coin_age).Check()) {
+            return false;
+        }
+
+        if (claim.ContainsSuperblock()) {
+            if (!TryLoadSuperblock(block, pindex, claim)) {
+                return false;
+            }
+
+            pindex->nIsSuperBlock = 1;
+        } else if (block.nVersion <= 10) {
+            // Block versions 11+ validate superblocks from scraper convergence
+            // instead of the legacy quorum system so we only record votes from
+            // version 10 blocks and below:
+            //
+            NN::Quorum::RecordVote(claim.m_quorum_hash, claim.m_quorum_address, pindex);
+        }
+    }
+
+    // Load contracts:
+    for (auto iter = ++block.vtx.begin(), end = block.vtx.end(); iter != end; ++iter) {
+        if (iter->hashBoinc.length() > 3) {
+            pindex->nIsContract = 1;
+            MemorizeMessage(*iter, 0, ""); // TODO: replace with contract handler
+        }
+    }
+
+    pindex->SetMiningId(claim.m_mining_id);
+    pindex->nMagnitude = claim.m_magnitude;
+    pindex->nResearchSubsidy = claim.m_research_subsidy;
+    pindex->nInterestSubsidy = claim.m_block_subsidy;
+
+    NN::Tally::RecordRewardBlock(pindex);
+
+    return true;
+}
+} // Anonymous namespace
 
 bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 {
@@ -2474,256 +2793,14 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
         mapQueuedChanges[hashTx] = CTxIndex(posThisTx, tx.vout.size());
     }
 
-    const NN::Claim& claim = GetClaim();
-    uint64_t nCoinAge = 0;
-    int64_t nStakeRewardWithoutFees = nStakeReward - nFees;
-
-    // Common coin validator
-    auto is_claim_valid = [this](
-            int64_t claim,
-            int64_t por_owed,
-            int64_t pos_owed,
-            int64_t fees)
+    if (IsResearchAgeEnabled(pindex->nHeight)
+        && !GridcoinConnectBlock(*this, pindex, txdb, nStakeReward, nFees))
     {
-        int64_t max_owed;
-
-        if (nVersion < 11) {
-            // Blocks version 10 and below represented rewards as floating-point
-            // values and needed to accomodate floating-point errors so we'll do
-            // the same rounding on the floating-point representations:
-            //
-            double subsidy = ((double)por_owed / COIN) * 1.25;
-            subsidy += (double)pos_owed / COIN;
-
-            max_owed = roundint64(subsidy * COIN) + fees;
-        } else {
-            max_owed = por_owed + pos_owed + fees;
-        }
-
-        // Block version 9 and below allowed a 1 GRC wiggle.
-        if(nVersion < 10)
-            max_owed += 1 * COIN;
-
-        return claim <= max_owed;
-    };
-
-
-    if (IsProofOfStake() && pindex->nHeight > nGrandfather)
-    {
-        // ppcoin: coin stake tx earns reward instead of paying fee
-        //
-        // With block version 10, Gridcoin switched to constant block rewards
-        // that do not depend on coin age, so we can avoid reading the blocks
-        // and transactions from the disk. The CheckProofOfStake*() functions
-        // of the kernel verify the transaction timestamp and that the staked
-        // inputs exist in the main chain.
-        //
-        if (pindex->nVersion <= 9 && !vtx[1].GetCoinAge(txdb, nCoinAge)) {
-            return error("ConnectBlock[] : %s unable to get coin age for coinstake",
-                vtx[1].GetHash().ToString().substr(0,10));
-        }
-
-        // TODO: determine max reward from accrual computer implementation:
-        int64_t nMaxResearchAgeReward = 12750 * COIN;
-
-        if (claim.m_research_subsidy > nMaxResearchAgeReward)
-            return DoS(1, error("ConnectBlock[ResearchAge] : Coinstake pays above maximum (actual= %s, vs calculated=%s )",
-                FormatMoney(nStakeRewardWithoutFees), FormatMoney(nMaxResearchAgeReward)));
-
-        if (!claim.HasResearchReward() && nStakeReward > 1)
-        {
-            int64_t out_research_subsidy = 0;
-            int64_t out_block_subsidy = 0;
-            int64_t calculatedResearchReward = GetProofOfStakeReward(
-                        nCoinAge, nFees, claim.m_mining_id, nTime,
-                        pindex, out_research_subsidy, out_block_subsidy);
-
-            if(!is_claim_valid(nStakeReward, 0, out_block_subsidy, nFees))
-            {
-                if(GetBadBlocks().count(pindex->GetBlockHash()) == 0)
-                    return DoS(10, error("ConnectBlock[] : Investor Reward pays too much : claimed %s vs calculated %s, Interest %s, Fees %s",
-                        FormatMoney(nStakeReward),
-                        FormatMoney(calculatedResearchReward),
-                        FormatMoney(out_block_subsidy),
-                        FormatMoney(nFees)));
-
-                LogPrintf("WARNING: ignoring invalid invalid claims on block %s", pindex->GetBlockHash().ToString());
-            }
-        }
+        return false;
     }
 
-    // Track money supply and mint amount info
     pindex->nMint = nValueOut - nValueIn + nFees;
-    if (fDebug10) LogPrintf (".TMS.");
-
     pindex->nMoneySupply = ReturnCurrentMoneySupply(pindex) + nValueOut - nValueIn;
-
-    // Gridcoin: Store verified magnitude and CPID in block index (7-11-2015)
-    if(IsResearchAgeEnabled(pindex->nHeight))
-    {
-        pindex->SetMiningId(claim.m_mining_id);
-        pindex->nMagnitude = claim.m_magnitude;
-        pindex->nResearchSubsidy = claim.m_research_subsidy;
-        pindex->nInterestSubsidy = claim.m_block_subsidy;
-        pindex->nIsSuperBlock = claim.ContainsSuperblock() ? 1 : 0;
-    }
-
-    if (pindex->nHeight > nGrandfather)
-    {
-        int64_t out_research_subsidy = 0;
-        int64_t out_block_subsidy = 0;
-
-        // ResearchAge 1:
-        GetProofOfStakeReward(nCoinAge, nFees, claim.m_mining_id, nTime,
-                              pindex, out_research_subsidy, out_block_subsidy);
-
-        if (claim.HasResearchReward())
-        {
-            //ResearchAge: Since the best block may increment before the RA is
-            //connected but After the RA is computed, the ResearchSubsidy can
-            //sometimes be slightly smaller than we calculate here due to the
-            //RA timespan increasing.  So we will allow for time shift before
-            //rejecting the block.
-            int64_t nDrift = 0;
-
-            if (pindex->nVersion <= 10) {
-                nDrift = claim.m_research_subsidy * .15;
-                if (nDrift < 10 * COIN) nDrift = 10 * COIN;
-            }
-
-            if ((claim.TotalSubsidy() + nDrift) < nStakeRewardWithoutFees)
-            {
-                return DoS(20, error("ConnectBlock[] : Researchers Interest %s + Research %s + TimeDrift %s = %s exceeded by StakeRewardWithoutFees %s, with mint %s, stake %s, research %s, Fees %s, for CPID %s",
-                     FormatMoney(claim.m_block_subsidy),
-                     FormatMoney(claim.m_research_subsidy),
-                     FormatMoney(nDrift),
-                     FormatMoney(claim.TotalSubsidy() + nDrift),
-                     FormatMoney(nStakeRewardWithoutFees),
-                     FormatMoney(pindex->nMint),
-                     FormatMoney(out_block_subsidy),
-                     FormatMoney(out_research_subsidy),
-                     FormatMoney(nFees),
-                     claim.m_mining_id.ToString()));
-            }
-
-            if (BlockNeedsChecked(nTime) || nVersion>=9)
-            {
-                // 6-4-2017 - Verify researchers stored block magnitude
-                // 2018 02 04 - Moved here for better effect.
-                double dNeuralNetworkMagnitude = NN::Quorum::GetMagnitude(claim.m_mining_id).Floating();
-                if (claim.m_magnitude > (dNeuralNetworkMagnitude * 1.25)
-                    && (fTestNet || (!fTestNet && (pindex->nHeight-1) > 947000)))
-                {
-                    return DoS(20, error(
-                                   "ConnectBlock[ResearchAge]: Researchers block magnitude > neural network magnitude: Block Magnitude %f, Neural Network Magnitude %f, CPID %s ",
-                                   claim.m_magnitude, dNeuralNetworkMagnitude, claim.m_mining_id.ToString()));
-                }
-
-                // 2018 02 04 - Brod - Move cpid check here for better effect
-                /* Only signature check is sufficient here, but kiss and
-                            call the function. The height is of previous block. */
-                if (!NN::VerifyClaim(claim, pindex->pprev->GetBlockHash()))
-                {
-                    if( GetBadBlocks().count(pindex->GetBlockHash())==0 )
-                        return DoS(20, error(
-                                       "ConnectBlock[ResearchAge]: Bad CPID or Block Signature : CPID %s, LBH %s, Bad Hashboinc [%s]",
-                                       claim.m_mining_id.ToString(),
-                                       pindex->pprev->GetBlockHash().ToString(),
-                                       vtx[0].hashBoinc.c_str()));
-                    else LogPrintf("WARNING: ignoring invalid hashBoinc signature on block %s", pindex->GetBlockHash().ToString());
-                }
-
-                if(!is_claim_valid(nStakeReward, out_research_subsidy, out_block_subsidy, nFees))
-                {
-                    GetProofOfStakeReward(nCoinAge, nFees, claim.m_mining_id, nTime,
-                                          pindex, out_research_subsidy, out_block_subsidy);
-
-                    if (fTestNet && pindex->nVersion <= 9 && !is_claim_valid(nStakeReward, 0, out_block_subsidy, nFees))
-                    {
-                        // Testnet contains some blocks with bad interest claims that were previously masked
-                        // by research age short 10-block-span pending accrual:
-                        LogPrintf("WARNING ConnectBlock[ResearchAge] : Interest Pays too much : bad block ignored: Interest %s and Research %s and StakeReward %s, research %s, with stake %s for CPID %s",
-                            FormatMoney(claim.m_block_subsidy),
-                            FormatMoney(claim.m_research_subsidy),
-                            FormatMoney(nStakeReward),
-                            FormatMoney(out_research_subsidy),
-                            FormatMoney(out_block_subsidy),
-                            claim.m_mining_id.ToString());
-                    }
-                    else if(!is_claim_valid(nStakeReward, out_research_subsidy, out_block_subsidy, nFees))
-                    {
-                        if(GetBadBlocks().count(pindex->GetBlockHash()) == 0)
-                            return DoS(10, error("ConnectBlock[ResearchAge] : Researchers Reward Pays too much : Interest %s and Research %s and StakeReward %s, research %s, with stake %s for CPID %s",
-                                FormatMoney(claim.m_block_subsidy),
-                                FormatMoney(claim.m_research_subsidy),
-                                FormatMoney(nStakeReward),
-                                FormatMoney(out_research_subsidy),
-                                FormatMoney(out_block_subsidy),
-                                claim.m_mining_id.ToString()));
-                        else
-                            LogPrintf("WARNING ConnectBlock[ResearchAge] : Researchers Reward Pays too much : bad block ignored: Interest %s and Research %s and StakeReward %s, research %s, with stake %s for CPID %s",
-                                FormatMoney(claim.m_block_subsidy),
-                                FormatMoney(claim.m_research_subsidy),
-                                FormatMoney(nStakeReward),
-                                FormatMoney(out_research_subsidy),
-                                FormatMoney(out_block_subsidy),
-                                claim.m_mining_id.ToString());
-                    }
-                }
-            }
-        }
-    }
-
-    if (pindex->nHeight > nGrandfather) {
-        if (claim.ContainsSuperblock()) {
-            // Note: PullSuperblock() invalidates the m_claim.m_superblock field
-            // by moving it. This must be the last instance where we reference a
-            // superblock in a block's claim field:
-            //
-            NN::SuperblockPtr superblock = NN::SuperblockPtr::BindShared(PullSuperblock(), pindex);
-
-            // TODO: find the invalid historical superblocks so we can remove
-            // the fColdBoot condition that skips this check when syncing the
-            // initial chain:
-            //
-            if ((!fColdBoot || pindex->nHeight >= 11)
-                && !NN::Quorum::ValidateSuperblockClaim(claim, superblock, pindex))
-            {
-                return DoS(25, error("ConnectBlock : Rejected invalid superblock."));
-            }
-
-            // Block versions 11+ calculate research rewards from snapshots of
-            // accrual taken at each superblock:
-            //
-            if (pindex->nVersion >= 11) {
-                if (!NN::Tally::ApplySuperblock(superblock)) {
-                    return false;
-                }
-            }
-
-            NN::Quorum::PushSuperblock(std::move(superblock));
-        } else if (nVersion <= 10) {
-            // Block versions 11+ validate superblocks from scraper convergence
-            // instead of the legacy quorum system so we only record votes from
-            // version 10 blocks and below:
-            //
-            NN::Quorum::RecordVote(claim.m_quorum_hash, claim.m_quorum_address, pindex);
-        }
-    }
-
-    // Gridcoin: Track payments to CPID, and last block paid
-    NN::Tally::RecordRewardBlock(pindex);
-
-    // Load contracts:
-    auto tx_iter = vtx.begin();
-    ++tx_iter; // skip the first transaction
-
-    for (auto end = vtx.end(); tx_iter != end; ++tx_iter) {
-        if (tx_iter->hashBoinc.length() > 3) {
-            pindex->nIsContract = 1;
-            MemorizeMessage(*tx_iter, 0, ""); // TODO: replace with contract handler
-        }
-    }
 
     if (!txdb.WriteBlockIndex(CDiskBlockIndex(pindex)))
         return error("Connect() : WriteBlockIndex for pindex failed");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2956,7 +2956,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
 
         // Tally research averages.
         if(IsV9Enabled_Tally(nBestHeight) && !IsV11Enabled(nBestHeight)) {
-            assert(NN::Tally::IsTrigger(nBestHeight));
+            assert(NN::Tally::IsLegacyTrigger(nBestHeight));
             NN::Tally::LegacyRecount(pindexBest);
         }
     }
@@ -2998,7 +2998,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
         //
         if (!IsV11Enabled(pcommon->nHeight) && pcommon != pindexBest)
         {
-            pcommon = NN::Tally::FindTrigger(pcommon);
+            pcommon = NN::Tally::FindLegacyTrigger(pcommon);
             if(!pcommon)
                 return error("ReorganizeChain: unable to find fork root with tally point");
         }
@@ -3128,7 +3128,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
 
         if (IsV9Enabled_Tally(nBestHeight)
             && !IsV11Enabled(nBestHeight)
-            && NN::Tally::IsTrigger(nBestHeight))
+            && NN::Tally::IsLegacyTrigger(nBestHeight))
         {
             NN::Tally::LegacyRecount(pindexBest);
         }

--- a/src/main.h
+++ b/src/main.h
@@ -209,8 +209,6 @@ struct globalStatusType
     std::string netWeight;
     std::string coinWeight;
     std::string magnitude;
-    std::string ETTS;
-    std::string ERRperday;
     std::string cpid;
     std::string status;
     std::string poll;

--- a/src/main.h
+++ b/src/main.h
@@ -109,12 +109,17 @@ inline bool IsV10Enabled(int nHeight)
             : nHeight >= 1420000;
 }
 
+inline int32_t GetV11Threshold()
+{
+    // Returns "never" before planned intro of bv11.
+    return fTestNet
+            ? std::numeric_limits<int32_t>::max()
+            : std::numeric_limits<int32_t>::max();
+}
+
 inline bool IsV11Enabled(int nHeight)
 {
-    // Returns false before planned intro of bv11.
-    return fTestNet
-            ? false
-            : false;
+    return nHeight >= GetV11Threshold();
 }
 
 inline int GetSuperblockAgeSpacing(int nHeight)

--- a/src/main.h
+++ b/src/main.h
@@ -245,12 +245,8 @@ int64_t GetConstantBlockReward(const CBlockIndex* index);
 
 int64_t GetProofOfStakeReward(
     uint64_t nCoinAge,
-    int64_t nFees,
-    const NN::MiningId mining_id,
     int64_t nTime,
-    const CBlockIndex* pindexLast,
-    int64_t& out_research_subsidy,
-    int64_t& out_block_subsidy);
+    const CBlockIndex* const pindexLast);
 
 bool OutOfSyncByAge();
 bool IsSuperBlock(CBlockIndex* pIndex);

--- a/src/main.h
+++ b/src/main.h
@@ -76,9 +76,14 @@ inline bool IsProtocolV2(int nHeight)
     return (fTestNet ?  nHeight > 2060 : nHeight > 85400);
 }
 
+inline int32_t GetResearchAgeThreshold()
+{
+    return fTestNet ? 36501 : 364501;
+}
+
 inline bool IsResearchAgeEnabled(int nHeight)
 {
-    return (fTestNet ?  nHeight > 36500 : nHeight > 364500);
+    return nHeight >= GetResearchAgeThreshold();
 }
 
 // TODO: Move this and the other height thresholds to their own files.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1056,7 +1056,7 @@ bool CreateGridcoinReward(CBlock &blocknew, CBlockIndex* pindexPrev, int64_t &nR
     claim.m_organization = GetArgument("org", "").substr(0, NN::Claim::MAX_ORGANIZATION_SIZE);
 
     if (blocknew.nVersion <= 10) {
-        claim.m_magnitude_unit = NN::Tally::GetMagnitudeUnit(pindexPrev->nTime);
+        claim.m_magnitude_unit = NN::Tally::GetMagnitudeUnit(pindexPrev);
     }
 
     if (const NN::CpidOption cpid = claim.m_mining_id.TryCpid()) {

--- a/src/neuralnet/account.h
+++ b/src/neuralnet/account.h
@@ -8,6 +8,12 @@ class CBlockIndex;
 namespace NN {
 
 class Cpid;
+class ResearchAccount;
+
+//!
+//! \brief Maps BOINC CPIDs to the accounts that track research reward accrual.
+//!
+typedef std::unordered_map<Cpid, ResearchAccount> ResearchAccountMap;
 
 //!
 //! \brief An optional type that contains a pointer to a block index object or
@@ -22,6 +28,7 @@ typedef boost::optional<const CBlockIndex*> BlockPtrOption;
 class ResearchAccount
 {
 public:
+    int64_t m_accrual;                    //!< Research accrued last superblock.
     int64_t m_total_research_subsidy;     //!< Total lifetime research paid.
     uint32_t m_total_magnitude;           //!< Total lifetime magnitude sum.
     uint32_t m_accuracy;                  //!< Non-zero magnitude payment count.
@@ -33,7 +40,8 @@ public:
     //! \brief Initialize an empty research account.
     //!
     ResearchAccount()
-        : m_total_research_subsidy(0)
+        : m_accrual(0)
+        , m_total_research_subsidy(0)
         , m_total_magnitude(0)
         , m_accuracy(0)
         , m_first_block_ptr(nullptr)
@@ -245,7 +253,7 @@ public:
 //!
 class ResearchAccountRange
 {
-    typedef std::unordered_map<Cpid, ResearchAccount> StorageType;
+    typedef ResearchAccountMap StorageType;
 
 public:
     typedef StorageType::const_iterator const_iterator;

--- a/src/neuralnet/account.h
+++ b/src/neuralnet/account.h
@@ -23,8 +23,6 @@ class ResearchAccount
 {
 public:
     int64_t m_total_research_subsidy;     //!< Total lifetime research paid.
-
-    uint16_t m_magnitude;                 //!< Current magnitude in superblock.
     uint32_t m_total_magnitude;           //!< Total lifetime magnitude sum.
     uint32_t m_accuracy;                  //!< Non-zero magnitude payment count.
 
@@ -36,7 +34,6 @@ public:
     //!
     ResearchAccount()
         : m_total_research_subsidy(0)
-        , m_magnitude(0)
         , m_total_magnitude(0)
         , m_accuracy(0)
         , m_first_block_ptr(nullptr)

--- a/src/neuralnet/accrual/computer.h
+++ b/src/neuralnet/accrual/computer.h
@@ -27,7 +27,7 @@ public:
     //!
     //! \brief Get the magnitude unit factored into the reward calculation.
     //!
-    //! \return Amount paid per unit of magnitude in units of GRC.
+    //! \return Amount paid per unit of magnitude per day in units of GRC.
     //!
     virtual double MagnitudeUnit() const = 0;
 
@@ -36,19 +36,19 @@ public:
     //!
     //! \return Elapsed time in seconds.
     //!
-    virtual int64_t AccrualAge(const ResearchAccount& account) const = 0;
+    virtual int64_t AccrualAge() const = 0;
 
     //!
     //! \brief Get the number of days since the account's last research reward.
     //!
     //! \return Elapsed time in days.
     //!
-    virtual double AccrualDays(const ResearchAccount& account) const = 0;
+    virtual double AccrualDays() const = 0;
 
     //!
     //! \brief Get the number of blocks since the account's last research reward.
     //!
-    virtual int64_t AccrualBlockSpan(const ResearchAccount& account) const = 0;
+    virtual int64_t AccrualBlockSpan() const = 0;
 
     //!
     //! \brief Get the average daily research payment over the lifetime of the
@@ -56,14 +56,14 @@ public:
     //!
     //! \return Average research payment in units of 1/100000000 GRC.
     //!
-    virtual int64_t PaymentPerDay(const ResearchAccount& account) const = 0;
+    virtual int64_t PaymentPerDay() const = 0;
 
     //!
     //! \brief Get the average daily research payment limit of the account.
     //!
     //! \return Payment per day limit in units of 1/100000000 GRC.
     //!
-    virtual int64_t PaymentPerDayLimit(const ResearchAccount& account) const = 0;
+    virtual int64_t PaymentPerDayLimit() const = 0;
 
     //!
     //! \brief Determine whether the account exceeded the daily payment limit.
@@ -71,7 +71,7 @@ public:
     //! \return \c true if the average daily research payment amount exceeds
     //! the calculated daily payment limit of the account.
     //!
-    virtual bool ExceededRecentPayments(const ResearchAccount& account) const = 0;
+    virtual bool ExceededRecentPayments() const = 0;
 
     //!
     //! \brief Get the expected daily research payment for the account based on
@@ -79,7 +79,7 @@ public:
     //!
     //! \return Expected daily payment in units of 1/100000000 GRC.
     //!
-    virtual int64_t ExpectedDaily(const ResearchAccount& account) const = 0;
+    virtual int64_t ExpectedDaily() const = 0;
 
     //!
     //! \brief Get the pending research reward for the account without applying
@@ -87,7 +87,7 @@ public:
     //!
     //! \return Pending payment in units of 1/100000000 GRC.
     //!
-    virtual int64_t RawAccrual(const ResearchAccount& account) const = 0;
+    virtual int64_t RawAccrual() const = 0;
 
     //!
     //! \brief Get the pending research reward for the account as expected by
@@ -95,7 +95,7 @@ public:
     //!
     //! \return Pending payment in units of 1/100000000 GRC.
     //!
-    virtual int64_t Accrual(const ResearchAccount& account) const = 0;
+    virtual int64_t Accrual() const = 0;
 };
 
 //!

--- a/src/neuralnet/accrual/newbie.h
+++ b/src/neuralnet/accrual/newbie.h
@@ -28,7 +28,7 @@ public:
         const Cpid cpid,
         const int64_t payment_time,
         const double magnitude_unit,
-        const uint16_t magnitude)
+        const double magnitude)
         : m_cpid(cpid)
         , m_payment_time(payment_time)
         , m_magnitude_unit(magnitude_unit)
@@ -107,7 +107,7 @@ public:
                     m_cpid.ToString());
             }
 
-            return ((double)m_magnitude / 100) * COIN + (1 * COIN);
+            return (m_magnitude / 100) * COIN + (1 * COIN);
         }
 
         const int64_t accrual = RawAccrual();
@@ -129,6 +129,6 @@ private:
     const Cpid m_cpid;             //!< CPID to calculate research accrual for.
     const int64_t m_payment_time;  //!< Time of payment to calculate rewards at.
     const double m_magnitude_unit; //!< Network magnitude unit to factor in.
-    const uint16_t m_magnitude;    //!< CPID's magnitude in the last superblock.
+    const double m_magnitude;      //!< CPID's magnitude in the last superblock.
 }; // NewbieAccrualComputer
 } // anonymous namespace

--- a/src/neuralnet/accrual/newbie.h
+++ b/src/neuralnet/accrual/newbie.h
@@ -8,7 +8,7 @@ using namespace NN;
 
 //!
 //! \brief An accrual calculator for a CPID that never earned a research reward
-//! before.
+//! before. Used for legacy accrual calculations in block version 10 and below.
 //!
 class NewbieAccrualComputer : public IAccrualComputer
 {

--- a/src/neuralnet/accrual/newbie.h
+++ b/src/neuralnet/accrual/newbie.h
@@ -22,14 +22,17 @@ public:
     //! \param cpid           CPID to calculate research accrual for.
     //! \param payment_time   Time of payment to calculate rewards at.
     //! \param magnitude_unit Current network magnitude unit to factor in.
+    //! \param magnitude      CPID's magnitude in the last superblock.
     //!
     NewbieAccrualComputer(
         const Cpid cpid,
         const int64_t payment_time,
-        const double magnitude_unit)
+        const double magnitude_unit,
+        const uint16_t magnitude)
         : m_cpid(cpid)
         , m_payment_time(payment_time)
         , m_magnitude_unit(magnitude_unit)
+        , m_magnitude(magnitude)
     {
     }
 
@@ -43,7 +46,7 @@ public:
         return m_magnitude_unit;
     }
 
-    int64_t AccrualAge(const ResearchAccount& account) const override
+    int64_t AccrualAge() const override
     {
         const int64_t beacon_time = BeaconTimeStamp(m_cpid.ToString());
 
@@ -54,60 +57,60 @@ public:
         return m_payment_time - beacon_time;
     }
 
-    double AccrualDays(const ResearchAccount& account) const override
+    double AccrualDays() const override
     {
-        return AccrualAge(account) / 86400.0;
+        return AccrualAge() / 86400.0;
     }
 
-    int64_t AccrualBlockSpan(const ResearchAccount& account) const override
-    {
-        return 0;
-    }
-
-    int64_t PaymentPerDay(const ResearchAccount& account) const override
+    int64_t AccrualBlockSpan() const override
     {
         return 0;
     }
 
-    int64_t PaymentPerDayLimit(const ResearchAccount& account) const override
+    int64_t PaymentPerDay() const override
+    {
+        return 0;
+    }
+
+    int64_t PaymentPerDayLimit() const override
     {
         return MaxReward();
     }
 
-    bool ExceededRecentPayments(const ResearchAccount& account) const override
+    bool ExceededRecentPayments() const override
     {
-        return RawAccrual(account) > PaymentPerDayLimit(account);
+        return RawAccrual() > PaymentPerDayLimit();
     }
 
-    int64_t ExpectedDaily(const ResearchAccount& account) const override
+    int64_t ExpectedDaily() const override
     {
-        return account.m_magnitude * m_magnitude_unit * COIN;
+        return m_magnitude * m_magnitude_unit * COIN;
     }
 
-    int64_t RawAccrual(const ResearchAccount& account) const override
+    int64_t RawAccrual() const override
     {
-        return AccrualDays(account) * ExpectedDaily(account);
+        return AccrualDays() * ExpectedDaily();
     }
 
-    int64_t Accrual(const ResearchAccount& account) const override
+    int64_t Accrual() const override
     {
-        if (account.m_magnitude <= 0) {
+        if (m_magnitude <= 0) {
             return 0;
         }
 
         constexpr int64_t six_months = 86400 * 30 * 6; // seconds
 
-        if (AccrualAge(account) >= six_months) {
+        if (AccrualAge() >= six_months) {
             if (fDebug) {
                 LogPrintf(
                     "Accrual: %s Invalid Beacon, Using 0.01 age bootstrap",
                     m_cpid.ToString());
             }
 
-            return ((double)account.m_magnitude / 100) * COIN + (1 * COIN);
+            return ((double)m_magnitude / 100) * COIN + (1 * COIN);
         }
 
-        const int64_t accrual = RawAccrual(account);
+        const int64_t accrual = RawAccrual();
 
         if (accrual > MaxReward()) {
             if (fDebug) {
@@ -126,5 +129,6 @@ private:
     const Cpid m_cpid;             //!< CPID to calculate research accrual for.
     const int64_t m_payment_time;  //!< Time of payment to calculate rewards at.
     const double m_magnitude_unit; //!< Network magnitude unit to factor in.
+    const uint16_t m_magnitude;    //!< CPID's magnitude in the last superblock.
 }; // NewbieAccrualComputer
 } // anonymous namespace

--- a/src/neuralnet/accrual/newbie.h
+++ b/src/neuralnet/accrual/newbie.h
@@ -101,11 +101,9 @@ public:
         constexpr int64_t six_months = 86400 * 30 * 6; // seconds
 
         if (AccrualAge() >= six_months) {
-            if (fDebug) {
-                LogPrintf(
-                    "Accrual: %s Invalid Beacon, Using 0.01 age bootstrap",
-                    m_cpid.ToString());
-            }
+            LogPrint(BCLog::LogFlags::ACCRUAL,
+                "Accrual: %s Invalid Beacon, Using 0.01 age bootstrap",
+                m_cpid.ToString());
 
             return (m_magnitude / 100) * COIN + (1 * COIN);
         }
@@ -113,11 +111,9 @@ public:
         const int64_t accrual = RawAccrual();
 
         if (accrual > MaxReward()) {
-            if (fDebug) {
-                LogPrintf(
-                    "Accrual: %s Newbie special stake capped to 500 GRC.",
-                    m_cpid.ToString());
-            }
+            LogPrint(BCLog::LogFlags::ACCRUAL,
+                "Accrual: %s Newbie special stake capped to 500 GRC.",
+                m_cpid.ToString());
 
             return MaxReward();
         }

--- a/src/neuralnet/accrual/null.h
+++ b/src/neuralnet/accrual/null.h
@@ -26,47 +26,47 @@ public:
         return 0.0;
     }
 
-    int64_t AccrualAge(const ResearchAccount& account) const override
+    int64_t AccrualAge() const override
     {
         return 0;
     }
 
-    double AccrualDays(const ResearchAccount& account) const override
+    double AccrualDays() const override
     {
         return 0.0;
     }
 
-    int64_t AccrualBlockSpan(const ResearchAccount& account) const override
+    int64_t AccrualBlockSpan() const override
     {
         return 0;
     }
 
-    int64_t PaymentPerDay(const ResearchAccount& account) const override
+    int64_t PaymentPerDay() const override
     {
         return 0;
     }
 
-    int64_t PaymentPerDayLimit(const ResearchAccount& account) const override
+    int64_t PaymentPerDayLimit() const override
     {
         return 0;
     }
 
-    bool ExceededRecentPayments(const ResearchAccount& account) const override
+    bool ExceededRecentPayments() const override
     {
         return false;
     }
 
-    int64_t ExpectedDaily(const ResearchAccount& account) const override
+    int64_t ExpectedDaily() const override
     {
         return 0;
     }
 
-    int64_t RawAccrual(const ResearchAccount& account) const override
+    int64_t RawAccrual() const override
     {
         return 0;
     }
 
-    int64_t Accrual(const ResearchAccount& account) const override
+    int64_t Accrual() const override
     {
         return 0;
     }

--- a/src/neuralnet/accrual/research_age.h
+++ b/src/neuralnet/accrual/research_age.h
@@ -55,7 +55,7 @@ public:
     ResearchAgeComputer(
         const Cpid cpid,
         const ResearchAccount& account,
-        const uint16_t magnitude,
+        const double magnitude,
         const int64_t payment_time,
         const double magnitude_unit,
         const uint32_t last_height)
@@ -261,7 +261,7 @@ public:
 private:
     const Cpid m_cpid;                //!< CPID to calculate research accrual for.
     const ResearchAccount& m_account; //!< CPID's historical accrual context.
-    const uint16_t m_magnitude;       //!< CPID's magnitude last superblock.
+    const double m_magnitude;         //!< CPID's magnitude last superblock.
     const int64_t m_payment_time;     //!< Time of payment to calculate rewards at.
     const double m_magnitude_unit;    //!< Network magnitude unit to factor in.
     const uint32_t m_last_height;     //!< Height of the block for the reward.
@@ -280,7 +280,7 @@ private:
         uint16_t last_magnitude = m_account.LastRewardMagnitude();
 
         if (AccrualBlockSpan() <= BLOCKS_PER_DAY * 20) {
-            return (double)(last_magnitude + m_magnitude) / 2;
+            return (last_magnitude + m_magnitude) / 2;
         }
 
         // If the accrual age is greater than than 20 days, add the midpoint

--- a/src/neuralnet/accrual/research_age.h
+++ b/src/neuralnet/accrual/research_age.h
@@ -211,13 +211,11 @@ public:
         // in the future:
         //
         if (AccrualBlockSpan() < 10) {
-            if (fDebug) {
-                LogPrintf(
-                    "Accrual: %s Block Span < 10 (%d) -> Accrual 0 (would be %s)",
-                    m_cpid.ToString(),
-                    AccrualBlockSpan(),
-                    FormatMoney(RawAccrual()));
-            }
+            LogPrint(BCLog::LogFlags::ACCRUAL,
+                "Accrual: %s Block Span < 10 (%d) -> Accrual 0 (would be %s)",
+                m_cpid.ToString(),
+                AccrualBlockSpan(),
+                FormatMoney(RawAccrual()));
 
             return 0;
         }
@@ -228,22 +226,21 @@ public:
         // per-day falls below 5 days:
         //
         if (ExceededRecentPayments()) {
-            if (fDebug) {
-                LogPrintf("Accrual: %s RA-PPD, "
-                    "PPD=%s, "
-                    "unit=%f, "
-                    "RAAvgMag=%f, "
-                    "RASubsidy=%s, "
-                    "RALowLockTime=%" PRIu64 " "
-                    "-> Accrual 0 (would be %s)",
-                    m_cpid.ToString(),
-                    FormatMoney(PaymentPerDay()),
-                    m_magnitude_unit,
-                    m_account.AverageLifetimeMagnitude(),
-                    FormatMoney(m_account.m_total_research_subsidy),
-                    m_account.FirstRewardTime(),
-                    FormatMoney(RawAccrual()));
-            }
+            LogPrint(BCLog::LogFlags::ACCRUAL,
+                "Accrual: %s RA-PPD, "
+                "PPD=%s, "
+                "unit=%f, "
+                "RAAvgMag=%f, "
+                "RASubsidy=%s, "
+                "RALowLockTime=%" PRIu64 " "
+                "-> Accrual 0 (would be %s)",
+                m_cpid.ToString(),
+                FormatMoney(PaymentPerDay()),
+                m_magnitude_unit,
+                m_account.AverageLifetimeMagnitude(),
+                FormatMoney(m_account.m_total_research_subsidy),
+                m_account.FirstRewardTime(),
+                FormatMoney(RawAccrual()));
 
             return 0;
         }

--- a/src/neuralnet/accrual/research_age.h
+++ b/src/neuralnet/accrual/research_age.h
@@ -46,16 +46,22 @@ public:
     //! \brief Initialze a research age accrual calculator.
     //!
     //! \param cpid           CPID to calculate research accrual for.
+    //! \param account        CPID's historical accrual context.
+    //! \param magnitude      CPID's magnitude in the last superblock.
     //! \param payment_time   Time of payment to calculate rewards at.
     //! \param magnitude_unit Current network magnitude unit to factor in.
     //! \param last_height    Height of the block for the reward.
     //!
     ResearchAgeComputer(
         const Cpid cpid,
+        const ResearchAccount& account,
+        const uint16_t magnitude,
         const int64_t payment_time,
         const double magnitude_unit,
         const uint32_t last_height)
         : m_cpid(cpid)
+        , m_account(account)
+        , m_magnitude(magnitude)
         , m_payment_time(payment_time)
         , m_magnitude_unit(magnitude_unit)
         , m_last_height(last_height)
@@ -75,7 +81,7 @@ public:
     //!
     //! \brief Get the magnitude unit factored into the reward calculation.
     //!
-    //! \return Amount paid per unit of magnitude in units of GRC.
+    //! \return Amount paid per unit of magnitude per day in units of GRC.
     //!
     double MagnitudeUnit() const override
     {
@@ -87,9 +93,9 @@ public:
     //!
     //! \return Elapsed time in seconds.
     //!
-    int64_t AccrualAge(const ResearchAccount& account) const override
+    int64_t AccrualAge() const override
     {
-        if (const BlockPtrOption pindex_option = account.LastRewardBlock()) {
+        if (const BlockPtrOption pindex_option = m_account.LastRewardBlock()) {
             const CBlockIndex* const pindex = *pindex_option;
 
             if (m_payment_time > pindex->nTime) {
@@ -105,17 +111,17 @@ public:
     //!
     //! \return Elapsed time in days.
     //!
-    double AccrualDays(const ResearchAccount& account) const override
+    double AccrualDays() const override
     {
-        return AccrualAge(account) / 86400.0;
+        return AccrualAge() / 86400.0;
     }
 
     //!
     //! \brief Get the number of blocks since the account's last research reward.
     //!
-    int64_t AccrualBlockSpan(const ResearchAccount& account) const override
+    int64_t AccrualBlockSpan() const override
     {
-        return m_last_height - account.LastRewardHeight();
+        return m_last_height - m_account.LastRewardHeight();
     }
 
     //!
@@ -124,13 +130,13 @@ public:
     //!
     //! \return Average research payment in units of 1/100000000 GRC.
     //!
-    int64_t PaymentPerDay(const ResearchAccount& account) const override
+    int64_t PaymentPerDay() const override
     {
-        if (account.IsNew()) {
+        if (m_account.IsNew()) {
             return 0;
         }
 
-        const int64_t elapsed = m_payment_time - account.FirstRewardTime();
+        const int64_t elapsed = m_payment_time - m_account.FirstRewardTime();
         const double lifetime_days = elapsed / 86400.0;
 
         // The extra 0.01 days was used in old code as a lazy way to avoid
@@ -139,7 +145,7 @@ public:
         // keep it. This especially manifests on testnet where CPIDs stake
         // frequently enough to activate the rule:
         //
-        return account.m_total_research_subsidy / (lifetime_days + 0.01);
+        return m_account.m_total_research_subsidy / (lifetime_days + 0.01);
     }
 
     //!
@@ -147,9 +153,9 @@ public:
     //!
     //! \return Payment per day limit in units of 1/100000000 GRC.
     //!
-    int64_t PaymentPerDayLimit(const ResearchAccount& account) const override
+    int64_t PaymentPerDayLimit() const override
     {
-        return account.AverageLifetimeMagnitude() * m_magnitude_unit * COIN * 5;
+        return m_account.AverageLifetimeMagnitude() * m_magnitude_unit * COIN * 5;
     }
 
     //!
@@ -158,9 +164,9 @@ public:
     //! \return \c true if the average daily research payment amount exceeds
     //! the calculated daily payment limit of the account.
     //!
-    bool ExceededRecentPayments(const ResearchAccount& account) const override
+    bool ExceededRecentPayments() const override
     {
-        return PaymentPerDay(account) > PaymentPerDayLimit(account);
+        return PaymentPerDay() > PaymentPerDayLimit();
     }
 
     //!
@@ -169,9 +175,9 @@ public:
     //!
     //! \return Expected daily payment in units of 1/100000000 GRC.
     //!
-    int64_t ExpectedDaily(const ResearchAccount& account) const override
+    int64_t ExpectedDaily() const override
     {
-        return account.m_magnitude * m_magnitude_unit * COIN;
+        return m_magnitude * m_magnitude_unit * COIN;
     }
 
     //!
@@ -180,19 +186,16 @@ public:
     //!
     //! \return Pending payment in units of 1/100000000 GRC.
     //!
-    int64_t RawAccrual(const ResearchAccount& account) const override
+    int64_t RawAccrual() const override
     {
-        double current_avg_magnitude = AverageMagnitude(account);
+        double current_avg_magnitude = AverageMagnitude();
 
         // Legacy sanity check for unlikely magnitude values:
         if (current_avg_magnitude > 20000) {
             current_avg_magnitude = 20000;
         }
 
-        return AccrualDays(account)
-            * current_avg_magnitude
-            * m_magnitude_unit
-            * COIN;
+        return AccrualDays() * current_avg_magnitude * m_magnitude_unit * COIN;
     }
 
     //!
@@ -201,19 +204,19 @@ public:
     //!
     //! \return Pending payment in units of 1/100000000 GRC.
     //!
-    int64_t Accrual(const ResearchAccount& account) const override
+    int64_t Accrual() const override
     {
         // Note that if the RA block span < 10, we want to return 0 for the
         // accrual amount so the CPID can still receive an accurate accrual
         // in the future:
         //
-        if (AccrualBlockSpan(account) < 10) {
+        if (AccrualBlockSpan() < 10) {
             if (fDebug) {
                 LogPrintf(
                     "Accrual: %s Block Span < 10 (%d) -> Accrual 0 (would be %s)",
                     m_cpid.ToString(),
-                    AccrualBlockSpan(account),
-                    FormatMoney(RawAccrual(account)));
+                    AccrualBlockSpan(),
+                    FormatMoney(RawAccrual()));
             }
 
             return 0;
@@ -224,7 +227,7 @@ public:
         // owed GRC continues to accrue and will be paid later after payments-
         // per-day falls below 5 days:
         //
-        if (ExceededRecentPayments(account)) {
+        if (ExceededRecentPayments()) {
             if (fDebug) {
                 LogPrintf("Accrual: %s RA-PPD, "
                     "PPD=%s, "
@@ -234,18 +237,18 @@ public:
                     "RALowLockTime=%" PRIu64 " "
                     "-> Accrual 0 (would be %s)",
                     m_cpid.ToString(),
-                    FormatMoney(PaymentPerDay(account)),
+                    FormatMoney(PaymentPerDay()),
                     m_magnitude_unit,
-                    account.AverageLifetimeMagnitude(),
-                    FormatMoney(account.m_total_research_subsidy),
-                    account.FirstRewardTime(),
-                    FormatMoney(RawAccrual(account)));
+                    m_account.AverageLifetimeMagnitude(),
+                    FormatMoney(m_account.m_total_research_subsidy),
+                    m_account.FirstRewardTime(),
+                    FormatMoney(RawAccrual()));
             }
 
             return 0;
         }
 
-        const int64_t accrual = RawAccrual(account);
+        const int64_t accrual = RawAccrual();
         const int64_t max_reward = MaxReward();
 
         if (accrual > max_reward) {
@@ -256,28 +259,28 @@ public:
     }
 
 private:
-    const Cpid m_cpid;             //!< CPID to calculate research accrual for.
-    const int64_t m_payment_time;  //!< Time of payment to calculate rewards at.
-    const double m_magnitude_unit; //!< Network magnitude unit to factor in.
-    const uint32_t m_last_height;  //!< Height of the block for the reward.
+    const Cpid m_cpid;                //!< CPID to calculate research accrual for.
+    const ResearchAccount& m_account; //!< CPID's historical accrual context.
+    const uint16_t m_magnitude;       //!< CPID's magnitude last superblock.
+    const int64_t m_payment_time;     //!< Time of payment to calculate rewards at.
+    const double m_magnitude_unit;    //!< Network magnitude unit to factor in.
+    const uint32_t m_last_height;     //!< Height of the block for the reward.
 
     //!
     //! \brief Get the average magnitude of the account over the accrual time
     //! span.
-    //!
-    //! \param account Account of the CPID to calculate average magnitude for.
     //!
     //! \return Average of the CPID's current magnitude and the magnitude for
     //! the CPID's last generated block. When the CPID's last staked block is
     //! older than roughly 20 days, this average includes the CPID's lifetime
     //! average magnitude as well.
     //!
-    double AverageMagnitude(const ResearchAccount& account) const
+    double AverageMagnitude() const
     {
-        uint16_t last_magnitude = account.LastRewardMagnitude();
+        uint16_t last_magnitude = m_account.LastRewardMagnitude();
 
-        if (AccrualBlockSpan(account) <= BLOCKS_PER_DAY * 20) {
-            return (double)(last_magnitude + account.m_magnitude) / 2;
+        if (AccrualBlockSpan() <= BLOCKS_PER_DAY * 20) {
+            return (double)(last_magnitude + m_magnitude) / 2;
         }
 
         // If the accrual age is greater than than 20 days, add the midpoint
@@ -287,8 +290,8 @@ private:
         // TODO: use superblock windows to calculate more precise average
         //
         const double total_mag = last_magnitude
-            + account.AverageLifetimeMagnitude()
-            + account.m_magnitude;
+            + m_account.AverageLifetimeMagnitude()
+            + m_magnitude;
 
         return total_mag / 3;
     }

--- a/src/neuralnet/accrual/research_age.h
+++ b/src/neuralnet/accrual/research_age.h
@@ -37,7 +37,8 @@ int64_t GetMaxResearchSubsidy(const int64_t nTime)
 
 //!
 //! \brief A calculator that computes the accrued research rewards for a
-//! research account using research age rules.
+//! research account using legacy research age rules in block version 10
+//! and below.
 //!
 class ResearchAgeComputer : public IAccrualComputer
 {

--- a/src/neuralnet/accrual/snapshot.h
+++ b/src/neuralnet/accrual/snapshot.h
@@ -1,0 +1,1204 @@
+#pragma once
+
+#include "beacon.h"
+#include "fs.h"
+#include "neuralnet/account.h"
+#include "neuralnet/accrual/computer.h"
+#include "neuralnet/cpid.h"
+#include "neuralnet/quorum.h"
+#include "serialize.h"
+#include "streams.h"
+#include "tinyformat.h"
+
+#include <unordered_map>
+
+class CBlockIndex;
+
+namespace {
+using namespace NN;
+using LogFlags = BCLog::LogFlags;
+
+//!
+//! \brief Calculates the current accrual for a CPID by adding the snapshot of
+//! accrued research rewards of the CPID's research account to rewards accrued
+//! since the active superblock.
+//!
+class SnapshotCalculator
+{
+public:
+    //!
+    //! \brief Initialize a new snapshot calculator.
+    //!
+    //! \param payment_time Time of payment to calculate rewards at.
+    //! \param superblock   Determines CPID magnitude and delta accrual age.
+    //!
+    SnapshotCalculator(const int64_t payment_time, SuperblockPtr superblock)
+        : m_payment_time(payment_time)
+        , m_superblock(std::move(superblock))
+    {
+    }
+
+    //!
+    //! \brief Get the magnitude unit factored into the reward calculation.
+    //!
+    //! \return Amount paid per unit of magnitude per day in units of GRC.
+    //!
+    static double MagnitudeUnit()
+    {
+        // Superblock-based accrual calculations do not rely on the rolling
+        // two-week network payment average. Instead, we calculate research
+        // rewards using the magnitude unit that represents the equilibrium
+        // quantity of the formula used to determine the magnitude unit for
+        // the legacy research age accrual calculations.
+        //
+        // Where...
+        //
+        //   blocks_per_day = 960
+        //   grc_per_block = 50
+        //   total_magnitude = 115000
+        //
+        //   max_daily_emission = blocks_per_day * grc_per_block
+        //   daily_emission = (5.0 / 9) * max_daily_emission;
+        //
+        // ...then...
+        //
+        //   daily_emission / total_magnitude = magnitude_unit = 0.23188405...
+        //
+        // ...rounded-up to:
+        //
+        return 0.25;
+    }
+
+    //!
+    //! \brief Get the accrual earned since the start of an account's accrual
+    //! period.
+    //!
+    //! \param cpid    CPID to calculate accrual for.
+    //! \param account Provides historical accrual context.
+    //!
+    //! \return Accrual earned in units of 1/100000000 GRC.
+    //!
+    int64_t AccrualDelta(const Cpid& cpid, const ResearchAccount& account) const
+    {
+        double accrual_days;
+
+        // If the CPID earned a reward on or after the current superblock, we
+        // calculate the reward using plain research age. The CPID carries no
+        // outstanding snapshot accrual.
+        //
+        // For CPIDs that did not stake a block after the current superblock,
+        // we calculate accrual earned since the superblock arrived and apply
+        // that on top of any rewards carried by their snapshot accrual. This
+        // includes newbie accounts which begin to accrue rewards after their
+        // CPIDs first appear in a superblock.
+        //
+        if (account.LastRewardHeight() >= m_superblock.m_height) {
+            accrual_days = AccrualDays(account);
+        } else {
+            accrual_days = SuperblockAgeDays();
+        }
+
+        return accrual_days * CurrentMagnitude(cpid) * MagnitudeUnit() * COIN;
+    }
+
+protected:
+    const int64_t m_payment_time;     //!< Payment time to calculate rewards at.
+    const SuperblockPtr m_superblock; //!< Supplies CPID magnitudes.
+
+    //!
+    //! \brief Get the magnitude of the CPID in the active superblock.
+    //!
+    //! \param cpid CPID to fetch magnitude for.
+    //!
+    //! \return Magnitude of the CPID in the superblock or zero if the CPID
+    //! does not exist in the superblock.
+    //!
+    double CurrentMagnitude(const Cpid& cpid) const
+    {
+        return m_superblock->m_cpids.MagnitudeOf(cpid).Floating();
+    }
+
+    //!
+    //! \brief Get the time elapsed since the account's last research reward.
+    //!
+    //! \return Elapsed time in seconds.
+    //!
+    int64_t AccrualAge(const ResearchAccount& account) const
+    {
+        if (const BlockPtrOption pindex_option = account.LastRewardBlock()) {
+            const CBlockIndex* const pindex = *pindex_option;
+
+            if (m_payment_time > pindex->nTime) {
+                return m_payment_time - pindex->nTime;
+            }
+        }
+
+        return 0;
+    }
+
+    //!
+    //! \brief Get the number of days since the account's last research reward.
+    //!
+    //! \return Elapsed time in days.
+    //!
+    double AccrualDays(const ResearchAccount& account) const
+    {
+        return AccrualAge(account) / 86400.0;
+    }
+
+    //!
+    //! \brief Calculate the age of the active superblock to determine the
+    //! duration of the accrual period.
+    //!
+    //! \return Superblock age as days in until to the payment time.
+    //!
+    double SuperblockAgeDays() const
+    {
+        const int64_t timespan = m_payment_time - m_superblock.m_timestamp;
+
+        if (timespan <= 0) {
+            return 0;
+        }
+
+        return timespan / 86400.0;
+    }
+}; // SnapshotCalculator
+
+//!
+//! \brief A calculator that computes the accrued research rewards for a
+//! research account using delta snapshot rules.
+//!
+class SnapshotAccrualComputer : public IAccrualComputer, SnapshotCalculator
+{
+    // See IAccrualComputer for inherited API documentation.
+
+public:
+    //!
+    //! \brief Initialze a delta snapshot accrual calculator.
+    //!
+    //! \param cpid         CPID to calculate research accrual for.
+    //! \param account      CPID's historical accrual context.
+    //! \param payment_time Time of payment to calculate rewards at.
+    //! \param last_height  Height of the block for the reward.
+    //! \param superblock   Determines CPID magnitude and delta accrual age.
+    //!
+    SnapshotAccrualComputer(
+        const Cpid cpid,
+        const ResearchAccount& account,
+        const int64_t payment_time,
+        const uint32_t last_height,
+        SuperblockPtr superblock)
+        : SnapshotCalculator(payment_time, std::move(superblock))
+        , m_cpid(cpid)
+        , m_account(account)
+        , m_last_height(last_height)
+    {
+    }
+
+    int64_t MaxReward() const override
+    {
+        // The maximum accrual that a CPID can claim in one block is limited to
+        // the amount of accrual that a CPID can collect over two days when the
+        // CPID acheives the maximum magnitude value supported in a superblock.
+        //
+        // Where...
+        //
+        //   max_magnitude = 32767
+        //   magnitude_unit = 0.25
+        //
+        // ...then...
+        //
+        //   max_magnitude * magnitude_unit * 2 = max_accrual = 16383.5
+        //
+        // ...rounded-up to:
+        //
+        return 16384 * COIN;
+    }
+
+    double MagnitudeUnit() const override
+    {
+        return SnapshotCalculator::MagnitudeUnit();
+    }
+
+    int64_t AccrualAge() const override
+    {
+        // For the CPIDs that never staked a block, report the accrual age as
+        // the time since the CPID advertised a beacon. This is not perfectly
+        // accurate since newbie accrual begins when a new CPID first appears
+        // in a superblock, but we don't store or look-up that superblock for
+        // performance. The accrual age requested here is informational since
+        // the SnapshotCalculator performs the real accrual calculation.
+        //
+        // TODO: Update this to base age on timestamp when beacon verifies in
+        // a superblock after contract improvements for more accurate age.
+        //
+        if (m_account.IsNew()) {
+            const int64_t beacon_time = BeaconTimeStamp(m_cpid.ToString());
+
+            if (beacon_time == 0) {
+                return 0;
+            }
+
+            return m_payment_time - beacon_time;
+        }
+
+        return SnapshotCalculator::AccrualAge(m_account);
+    }
+
+    double AccrualDays() const override
+    {
+        return AccrualAge() / 86400.0;
+    }
+
+    int64_t AccrualBlockSpan() const override
+    {
+        // TODO: we can use the height of a beacon verification in a superblock
+        // to report accurate block spans after contract improvements. For now,
+        // this is informational, so we just report zero for newbies:
+        //
+        if (m_account.IsNew()) {
+            return 0;
+        }
+
+        return m_last_height - m_account.LastRewardHeight();
+    }
+
+    int64_t PaymentPerDay() const override
+    {
+        if (m_account.IsNew()) {
+            return 0;
+        }
+
+        const int64_t elapsed = m_payment_time - m_account.FirstRewardTime();
+        const double lifetime_days = elapsed / 86400.0;
+
+        if (lifetime_days <= 0) {
+            return 0;
+        }
+
+        return m_account.m_total_research_subsidy / lifetime_days;
+    }
+
+    int64_t PaymentPerDayLimit() const override
+    {
+        return MaxReward();
+    }
+
+    bool ExceededRecentPayments() const override
+    {
+        return RawAccrual() > PaymentPerDayLimit();
+    }
+
+    int64_t ExpectedDaily() const override
+    {
+        return CurrentMagnitude(m_cpid) * MagnitudeUnit() * COIN;
+    }
+
+    int64_t RawAccrual() const override
+    {
+        if (m_account.LastRewardHeight() >= m_superblock.m_height) {
+            return AccrualDelta(m_cpid, m_account);
+        }
+
+        return m_account.m_accrual + AccrualDelta(m_cpid, m_account);
+    }
+
+    int64_t Accrual() const override
+    {
+        const int64_t accrual = RawAccrual();
+
+        if (accrual > MaxReward()) {
+            return MaxReward();
+        }
+
+        return accrual;
+    }
+
+private:
+    const Cpid m_cpid;                //!< CPID to calculate accrual for.
+    const ResearchAccount& m_account; //!< CPID's historical accrual context.
+    const uint32_t m_last_height;     //!< Height of the block for the reward.
+}; // SnapshotAccrualComputer
+
+//!
+//! \brief Get the path to the accrual snapshot storage directory.
+//!
+fs::path SnapshotDirectory()
+{
+    return GetDataDir() / "accrual";
+}
+
+//!
+//! \brief Get the path to a snapshot file.
+//!
+//! \param height Block height of the snapshot data.
+//!
+//! \return Path to the snapshot file in the snapshot directory.
+//!
+fs::path SnapshotPath(const uint64_t height)
+{
+    return SnapshotDirectory() / strprintf("%" PRIu64 ".dat", height);
+}
+
+//!
+//! \brief Contains a snapshot of pending research reward accrual for CPIDs in
+//! the network at a point in time.
+//!
+//! Except for the first baseline, the wallet creates accrual snapshots when it
+//! receives blocks that contain a superblock. It stores these to disk to avoid
+//! reading superblocks from disk to recalculate accrual upon start-up and when
+//! reorganizing the chain.
+//!
+class AccrualSnapshot
+{
+public:
+    //!
+    //! \brief Version number of the current format for a serialized snapshot.
+    //!
+    static constexpr uint32_t CURRENT_VERSION = 1;
+
+    //!
+    //! \brief Initialize an empty accrual snapshot.
+    //!
+    AccrualSnapshot()
+        : m_version(CURRENT_VERSION)
+        , m_height(0)
+    {
+    }
+
+    //!
+    //! \brief Initialize an accrual snapshot by deserializing it from the
+    //! provided file.
+    //!
+    //! \param s The input stream.
+    //!
+    AccrualSnapshot(deserialize_type, CAutoFile& file)
+    {
+        m_records.clear();
+
+        file >> m_version;
+        file >> m_height;
+
+        while (true) {
+            std::pair<Cpid, int64_t> record;
+
+            try {
+                file >> record;
+            } catch (const std::ios_base::failure& e) {
+                if (feof(file.Get())) {
+                    break;
+                }
+
+                throw;
+            }
+
+            m_records.emplace(record.first, record.second);
+        }
+    }
+
+    //!
+    //! \brief Get the accrual at the time of the snapshot for the specified
+    //! CPID.
+    //!
+    //! \param cpid CPID to fetch accrual for.
+    //!
+    //! \return Accrued research rewards at the time of the snapshot in units
+    //! of 1/100000000 GRC or zero if the CPID does not exist in the snapshot.
+    //!
+    int64_t GetAccrual(const Cpid cpid) const
+    {
+        auto iter = m_records.find(cpid);
+
+        if (iter == m_records.end()) {
+            return 0;
+        }
+
+        return iter->second;
+    }
+
+private:
+    uint32_t m_version; //!< Version of the serialized snapshot format.
+    uint64_t m_height;  //!< Block height of the snapshot.
+
+    //!
+    //! \brief Maps CPIDs to rewards accrued at the time of the snapshot.
+    //!
+    //! Accrual values stored in units of of 1/100000000 GRC.
+    //!
+    std::unordered_map<Cpid, int64_t> m_records;
+}; // AccrualSnapshot
+
+constexpr uint32_t AccrualSnapshot::CURRENT_VERSION; // for clang
+
+//!
+//! \brief Base class for types that read and write accrual snapshot files.
+//!
+class AccrualSnapshotFile
+{
+public:
+    //!
+    //! \brief Initialize an accrual snapshot file.
+    //!
+    //! \param file Handle of the snapshot file to manage.
+    //!
+    AccrualSnapshotFile(FILE* file)
+        : m_file(file, SER_DISK, AccrualSnapshot::CURRENT_VERSION)
+    {
+    }
+
+    //!
+    //! \brief Determine whether the wrapped file handle is \c nullptr .
+    //!
+    //! \return \c true if initialized with a null file handle. This may occur
+    //! when the operating system filesystem API failed to open the file.
+    //!
+    bool IsNull() const
+    {
+        return m_file.IsNull();
+    }
+
+protected:
+    CAutoFile m_file; //!< Abstracts snapshot file operations.
+}; // AccrualSnapshotFile
+
+//!
+//! \brief Reads an accrual snapshot file from disk.
+//!
+class AccrualSnapshotReader : public AccrualSnapshotFile
+{
+public:
+    //!
+    //! \brief Initialize an accrual snapshot file reader.
+    //!
+    //! \param snapshot_path Path to the snapshot file to read.
+    //!
+    AccrualSnapshotReader(const fs::path& snapshot_path)
+        : AccrualSnapshotFile(fsbridge::fopen(snapshot_path, "rb"))
+    {
+    }
+
+    //!
+    //! \brief Deserialize the snapshot file from disk.
+    //!
+    //! \return The contents of the snapshot file.
+    //!
+    AccrualSnapshot Read()
+    {
+        return AccrualSnapshot(deserialize, m_file);
+    }
+}; // AccrualSnapshotReader
+
+//!
+//! \brief Writes an accrual snapshot to a file on disk.
+//!
+class AccrualSnapshotWriter : public AccrualSnapshotFile
+{
+public:
+    //!
+    //! \brief Initialize an accrual snapshot file writer.
+    //!
+    //! \param snapshot_path Path to the snapshot file to write.
+    //!
+    AccrualSnapshotWriter(const fs::path& snapshot_path)
+        : AccrualSnapshotFile(fsbridge::fopen(snapshot_path, "wb"))
+    {
+    }
+
+    //!
+    //! \brief Write the header of an accrual snapshot.
+    //!
+    //! \param height Block height of the snapshot. Usually a superblock.
+    //!
+    void WriteHeader(const uint64_t height)
+    {
+        m_file << AccrualSnapshot::CURRENT_VERSION;
+        m_file << height;
+    }
+
+    //!
+    //! \brief Write a CPID to accrual mapping to the snapshot file.
+    //!
+    //! \param cpid    Identifies the owner of the accrual.
+    //! \param accrual Accrued research rewards in units of 1/100000000 GRC.
+    //!
+    void WriteRecord(const Cpid cpid, const int64_t accrual)
+    {
+        m_file << cpid << accrual;
+    }
+}; // AccrualSnapshotWriter
+
+//!
+//! \brief Maintains context for the set of active accrual snapshots.
+//!
+class AccrualSnapshotRegistry
+{
+public:
+    //!
+    //! \brief Version number of the current format for a serialized registry
+    //! file.
+    //!
+    static constexpr uint32_t CURRENT_VERSION = 1;
+
+    //!
+    //! \brief Load the snapshot registry from disk and prepare it for use.
+    //!
+    //! \return \c false if the registry failed to initialize because of an IO
+    //! error.
+    //!
+    bool Initialize()
+    {
+        LogPrintf("Initializing accrual snapshot registry...");
+
+        try {
+            CAutoFile registry_file(
+                fsbridge::fopen(RegistryPath(), "rb"),
+                SER_DISK,
+                CURRENT_VERSION);
+
+            if (!registry_file.IsNull()) {
+                Unserialize(registry_file);
+            }
+        } catch (const std::exception& e) {
+            return error("%s: %s", __func__, e.what());
+        }
+
+        LogPrintf("Accrual snapshot registry loaded. Compacting...");
+
+        return Rewrite();
+    }
+
+    //!
+    //! \brief Set the height of the block for the accrual snapshot baseline.
+    //!
+    //! The wallet stores the baseline snapshot at the block before the switch
+    //! to version 11 blocks. Testing RPCs may create this baseline at another
+    //! height.
+    //!
+    //! \return \c false if the registry failed to store the baseline because
+    //! of an IO error.
+    //!
+    bool ResetBaseline(const uint64_t height)
+    {
+        if (!WriteEntry(Action::BASELINE, height) && Register(height)) {
+            return error("%s: failed to record baseline snapshot", __func__);
+        }
+
+        LogPrint(LogFlags::TALLY,
+            "Tally: reset new accrual snapshot baseline: %" PRIu64, height);
+
+        m_heights.clear();
+
+        return true;
+    }
+
+    //!
+    //! \brief Get the height of the baseline accrual snapshot.
+    //!
+    //! \return Zero if no baseline snapshot exists yet.
+    //!
+    uint64_t BaselineHeight() const
+    {
+        if (!m_heights.empty()) {
+            return m_heights.front();
+        }
+
+        return 0;
+    }
+
+    //!
+    //! \brief Get the height of the most recent accrual snapshot.
+    //!
+    //! \return Zero if no baseline snapshot exists yet.
+    //!
+    uint64_t LatestHeight() const
+    {
+        if (!m_heights.empty()) {
+            return m_heights.back();
+        }
+
+        return 0;
+    }
+
+    //!
+    //! \brief Add the height of a new accrual snapshot to the registry.
+    //!
+    //! \param height Block height of the new snapshot. Usually a superblock.
+    //!
+    //! \return \c false if the registry failed to store the snapshot context
+    //! because of an IO error.
+    //!
+    bool Register(const uint64_t height)
+    {
+        assert(m_heights.empty() || height > m_heights.back());
+
+        if (!WriteEntry(Action::REGISTER, height)) {
+            return error("%s: failed to add %" PRIu64, __func__, height);
+        }
+
+        LogPrint(LogFlags::TALLY,
+            "Tally: recorded new accrual snapshot %" PRIu64, height);
+
+        m_heights.emplace_back(height);
+
+        return true;
+    }
+
+    //!
+    //! \brief Remove the height of a defunct accrual snapshot from the registry.
+    //!
+    //! \param height Block height of the snapshot. Usually a superblock.
+    //!
+    //! \return \c false if the registry failed to store the snapshot context
+    //! because of an IO error.
+    //!
+    bool Deregister(const uint64_t height)
+    {
+        assert(!m_heights.empty() && height == m_heights.back());
+
+        if (!WriteEntry(Action::DEREGISTER, height)) {
+            return error("%s: failed to remove %" PRIu64, __func__, height);
+        }
+
+        LogPrint(LogFlags::TALLY,
+            "Tally: recorded accrual snapshot removal %" PRIu64, height);
+
+        m_heights.pop_back();
+
+        return true;
+    }
+
+    //!
+    //! \brief Serialize the provided data to the registry file.
+    //!
+    //! \param pch  The bytes to serialize.
+    //! \param size Byte length of the data.
+    //!
+    //! TODO: encapsulate this
+    //!
+    void write(const char* pch, size_t size)
+    {
+        if (!m_file) {
+            throw std::ios_base::failure(
+                strprintf("%s: file handle is nullptr", __func__));
+        }
+
+        if (fwrite(pch, 1, size, m_file) != size) {
+            throw std::ios_base::failure(
+                strprintf("%s: write failed", __func__));
+        }
+    }
+private:
+    //!
+    //! \brief
+    //!
+    enum class Action
+    {
+        BASELINE,    //!< Set the height of the baseline accrual snapshot.
+        REGISTER,    //!< Add a new accrual snapshot.
+        DEREGISTER,  //!< Remove an existing accrual snapshot.
+    };
+
+    //!
+    //! \brief
+    //!
+    struct Entry
+    {
+        Action m_action;
+        uint64_t m_height;
+
+        Entry(const Action action, const uint64_t height)
+            : m_action(action), m_height(height)
+        {
+        }
+
+        Entry(deserialize_type, CAutoFile& file)
+        {
+            Unserialize(file);
+        }
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
+        {
+            uint8_t action = static_cast<uint8_t>(m_action);
+            READWRITE(action);
+            m_action = static_cast<Action>(action);
+
+            READWRITE(m_height);
+        }
+    };
+
+    FILE* m_file;                    //!< Handle of the registry file.
+    std::vector<uint64_t> m_heights; //!< Ordered heights of each snapshot.
+
+    //!
+    //! \brief
+    //!
+    static fs::path RegistryPath()
+    {
+        return SnapshotDirectory() / "registry.dat";
+    }
+
+    //!
+    //! \brief Truncate the registry file and reopen it for writing.
+    //!
+    //! \return \c false if an IO error occurred.
+    //!
+    bool ReopenForWrite()
+    {
+        if (m_file && fclose(m_file) != 0) {
+            return error("%s: failed to close registry", __func__);
+        }
+
+        m_file = fsbridge::fopen(RegistryPath(), "wb");
+
+        return m_file || error(
+            "%s: failed to open snapshot registry for writing: %s",
+            __func__,
+            RegistryPath().string());
+    }
+
+    //!
+    //! \brief Prunes the registry file of any non-current entries and opens it
+    //! for writing.
+    //!
+    //! \return \c false if an IO error occurred.
+    //!
+    bool Rewrite()
+    {
+        if (!ReopenForWrite()) {
+            return false;
+        }
+
+        try {
+            ::Serialize(*this, CURRENT_VERSION);
+        } catch (const std::exception& e) {
+            return error("%s: %s", __func__, e.what());
+        }
+
+        if (m_heights.empty()) {
+            return true;
+        }
+
+        if (!WriteEntry(Action::BASELINE, m_heights.front())) {
+            return false;
+        }
+
+        for (const auto& height : m_heights) {
+            if (!WriteEntry(Action::REGISTER, height)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    //!
+    //! \brief Write a registry entry to disk.
+    //!
+    //! \param action Type of registry entry to write.
+    //! \param height Height of the accrual snapshot associated with the entry.
+    //!
+    //! \return \c false if an IO error occurred.
+    //!
+    bool WriteEntry(const Action action, const uint64_t height)
+    {
+        try {
+            ::Serialize(*this, Entry(action, height));
+        } catch (const std::exception& e) {
+            return error("%s: %s", __func__, e.what());
+        }
+
+        return fflush(m_file) == 0;
+    }
+
+    //!
+    //! \brief Read the snapshot registry file from disk.
+    //!
+    //! \param file Wraps the registry file to deserialize.
+    //!
+    void Unserialize(CAutoFile& file)
+    {
+        m_heights.clear();
+
+        uint32_t version;
+        file >> version;
+
+        while (true) {
+            try {
+                const Entry entry(deserialize, file);
+
+                switch (entry.m_action) {
+                    case Action::BASELINE:
+                        LogPrint(LogFlags::ACCRUAL,
+                            "  Baseline: %" PRIu64, entry.m_height);
+
+                        m_heights.clear();
+                        break;
+                    case Action::REGISTER:
+                        LogPrint(LogFlags::ACCRUAL,
+                            "  Added: %" PRIu64, entry.m_height);
+
+                        m_heights.emplace_back(entry.m_height);
+                        break;
+                    case Action::DEREGISTER:
+                        LogPrint(LogFlags::ACCRUAL,
+                            "  Removed: %" PRIu64, entry.m_height);
+
+                        m_heights.pop_back();
+                }
+            } catch (const std::ios_base::failure& e) {
+                if (feof(file.Get())) {
+                    break;
+                }
+
+                throw;
+            }
+        }
+    }
+}; // AccrualSnapshotRegistry
+
+//!
+//! \brief Manages storage of accrual snapshots.
+//!
+//! TODO: Add snapshot pruning to reclaim disk space for very old snapshots.
+//! TODO: Add a way to rebuild the snapshots in case of file corruption, etc.
+//!
+class AccrualSnapshotRepository
+{
+public:
+    //!
+    //! \brief Initialize the accrual snapshot system.
+    //!
+    //! \return \c false if the snapshot system failed to initialize because of
+    //! an error.
+    //!
+    bool Initialize()
+    {
+        try {
+            fs::create_directory(SnapshotDirectory());
+        } catch (const std::exception& e) {
+            return error(
+                "%s: failed to create the accrual snapshot directory %s: %s",
+                __func__,
+                SnapshotDirectory().string(),
+                e.what());
+        }
+
+        return m_registry.Initialize();
+    }
+
+    //!
+    //! \brief Determine whether the node already stored a baseline accrual
+    //! snapshot.
+    //!
+    //! \return \c true if the node previously activated the accrual snapshot
+    //! system.
+    //!
+    bool HasBaseline() const
+    {
+        return m_registry.BaselineHeight() > 0;
+    }
+
+    //!
+    //! \brief Store a snapshot of accrual for each account as the baseline.
+    //!
+    //! \param height   Height of the block to associate with the snapshot.
+    //! \param accounts Research accounts to record accrual from.
+    //!
+    //! \return \c false when an error occurs while creating a snapshot.
+    //!
+    bool StoreBaseline(const uint64_t height, const ResearchAccountMap& accounts)
+    {
+        return m_registry.ResetBaseline(height) && Store(height, accounts);
+    }
+
+    //!
+    //! \brief Store a snapshot of accrual for each account to disk.
+    //!
+    //! \param height   Height of the block to associate with the snapshot.
+    //! \param accounts Research accounts to record accrual from.
+    //!
+    //! \return \c false when an error occurs while creating a snapshot.
+    //!
+    bool Store(const uint64_t height, const ResearchAccountMap& accounts)
+    {
+        LogPrint(LogFlags::TALLY,
+            "Tally: storing new accrual snapshot %" PRIu64 "...", height);
+
+        AccrualSnapshotWriter writer(SnapshotPath(height));
+
+        if (writer.IsNull()) {
+            return error("%s: failed to open %" PRIu64, __func__, height);
+        }
+
+        try {
+            writer.WriteHeader(height);
+
+            for (const auto& account_pair : accounts) {
+                if (account_pair.second.m_accrual > 0) {
+                    writer.WriteRecord(
+                        account_pair.first, // CPID
+                        account_pair.second.m_accrual);
+                }
+            }
+        } catch (const std::exception& e) {
+            return error("%s: %s", __func__, e.what());
+        }
+
+        return m_registry.Register(height);
+    }
+
+    //!
+    //! \brief Load the most recent accrual snapshot for each account.
+    //!
+    //! \param accounts Research accounts to apply snapshot accrual to.
+    //!
+    //! \return \c false when an error occurs while loading a snapshot.
+    //!
+    bool ApplyLatest(ResearchAccountMap& accounts) const
+    {
+        return Apply(m_registry.LatestHeight(), accounts);
+    }
+
+    //!
+    //! \brief Load the specified accrual snapshot for each account.
+    //!
+    //! \param height   Block height of the snapshot. Usually a superblock.
+    //! \param accounts Research accounts to apply snapshot accrual to.
+    //!
+    //! \return \c false when an error occurs while loading a snapshot.
+    //!
+    bool Apply(const uint64_t height, ResearchAccountMap& accounts) const
+    {
+        LogPrint(LogFlags::TALLY,
+            "Tally: applying accrual snapshot %" PRIu64 "...", height);
+
+        AccrualSnapshotReader reader(SnapshotPath(height));
+
+        if (reader.IsNull()) {
+            return error("%s: failed to open %" PRIu64, __func__, height);
+        }
+
+        try {
+            const AccrualSnapshot snapshot = reader.Read();
+
+            for (auto& account_pair : accounts) {
+                const Cpid& cpid = account_pair.first;
+                ResearchAccount& account = account_pair.second;
+
+                account.m_accrual = snapshot.GetAccrual(cpid);
+            }
+        } catch (const std::exception& e) {
+            return error("%s: %s", __func__, e.what());
+        }
+
+        return true;
+    }
+
+    //!
+    //! \brief Erase the specified accrual snapshot.
+    //!
+    //! \param height Block height of the snapshot. Usually a superblock.
+    //!
+    //! \return \c false when an error occurs while removing a snapshot.
+    //!
+    bool Drop(const uint64_t height)
+    {
+        LogPrint(LogFlags::TALLY,
+            "Tally: dropping accrual snapshot %" PRIu64 "...", height);
+
+        try {
+            fs::remove(SnapshotPath(height));
+        } catch (const std::exception& e) {
+            // Failing to remove the snapshot file is not a critical error as
+            // long as we can remove it from the registry.
+            //
+            LogPrintf("WARNING: %s: %s", __func__, e.what());
+        }
+
+        return m_registry.Deregister(height);
+    }
+
+private:
+    AccrualSnapshotRegistry m_registry; //!< Tracks snapshot files state.
+}; // AccrualSnapshotRepository
+
+//!
+//! \brief Establishes the baseline accrual for each CPID in the network for
+//! the transition to snapshot accrual calculations.
+//!
+class SnapshotBaselineBuilder
+{
+public:
+    //!
+    //! \brief Initialize a new baseline builder.
+    //!
+    //! \param researchers The current set of research accounts for known CPIDs.
+    //!
+    SnapshotBaselineBuilder(ResearchAccountMap& researchers)
+        : m_researchers(researchers)
+        , m_superblock(SuperblockPtr::Empty())
+    {
+    }
+
+    //!
+    //! \brief Scan the chain to establish the baseline delta snapshot accrual
+    //! for each CPID in the network and apply it to the research accounts.
+    //!
+    //! \param pindex             Block to establish the accrual baseline from.
+    //! \param current_superblock Baseline starts from before this superblock.
+    //!
+    //! \return \c false if an error occurs while processing historical accrual.
+    //!
+    bool Run(const CBlockIndex* pindex, const SuperblockPtr current_superblock)
+    {
+        LogPrint(LogFlags::TALLY, "Tally: Building baseline snapshot...");
+
+        // Although research accounts initialize with zero snapshot accrual,
+        // we'll zero-out these again in case something changed those values
+        // (like a testing RPC call):
+        //
+        for (auto& account_pair : m_researchers) {
+            account_pair.second.m_accrual = 0;
+        }
+
+        // The maximum depth to consider for rewards corresponds to the legacy
+        // rule that limits unclaimed accrual validity to roughly six months.
+        //
+        // We establish the baseline when connecting the block below the first
+        // version 11 block, so we add 1 to the maximum depth:
+        //
+        const int64_t max_depth = pindex->nHeight + 1 - BLOCKS_PER_DAY * 30 * 6;
+
+        LogPrint(LogFlags::TALLY, "  Snapshot max depth: %" PRId64, max_depth);
+
+        // Seek to the block before the current superblock.
+        //
+        // We don't include the current superblock in the delta accrual baseline
+        // because an accrual snapshot is active until the next superblock.
+        //
+        for (;
+            pindex && pindex->nHeight >= current_superblock.m_height;
+            pindex = pindex->pprev);
+
+        // Calculate the pending accrual for active CPIDs from each historical
+        // superblock.
+        //
+        // We begin tallying research reward accrual from the superblock prior
+        // to the current superblock and sum the reward for each CPID by using
+        // the magnitudes stored in each of the superblocks to compute accrual
+        // earned during the period that a superblock was active.
+        //
+        int64_t payment_time = current_superblock.m_timestamp;
+
+        for (; pindex && pindex->nHeight > max_depth; pindex = pindex->pprev) {
+            if (pindex->nIsSuperBlock != 1) {
+                continue;
+            }
+
+            if (!LoadSuperblock(pindex)) {
+                return false;
+            }
+
+            TallyAccrual(payment_time);
+
+            payment_time = pindex->nTime;
+        }
+
+        // If the maximum depth is a superblock, we're done.
+        //
+        if (pindex->nIsSuperBlock == 1) {
+            return true;
+        }
+
+        // Otherwise, we need to credit the remaining accrual between the last
+        // superblock and the maximum depth for any CPIDs left.
+        //
+        // To accomplish this, we slide back one more superblock to engage the
+        // magnitudes for this window that we then apply to the period between
+        // the maximum depth and the superblock above it.
+        //
+        const CBlockIndex* const pindex_max = pindex;
+
+        for (; pindex; pindex = pindex->pprev) {
+            if (pindex->nIsSuperBlock != 1) {
+                continue;
+            }
+
+            // We intentionally bind the superblock to the wrong block index
+            // to force accrual calculation at the time of the maximum depth
+            // rather than at the time of the superblock's containing block:
+            //
+            if (!LoadSuperblock(pindex, pindex_max)) {
+                return false;
+            }
+
+            TallyAccrual(payment_time);
+
+            break;
+        }
+
+        return true;
+    }
+
+private:
+    ResearchAccountMap& m_researchers; //!< Current set of known CPIDs.
+    SuperblockPtr m_superblock;        //!< Current historical superblock.
+
+    //!
+    //! \brief Read the superblock at the specified block index from disk.
+    //!
+    //! The optional \p pindex_bind parameter overrides the superblock's block
+    //! context by instructing this method to associate a superblock with that
+    //! block instead. This allows us to request a SuperblockPtr object with a
+    //! different block height and timestamp than the block which contains the
+    //! superblock to manipulate the calculated accrual at the baseline window
+    //! limit (the deepest block) when that block is not a superblock itself.
+    //!
+    //! \param pindex      Used to locate the containing block on disk.
+    //! \param pindex_bind Context of the block to bind to the superblock.
+    //!
+    //! \return \c false if an error occurred while reading the block from disk.
+    //!
+    bool LoadSuperblock(
+        const CBlockIndex* const pindex,
+        const CBlockIndex* const pindex_bind = nullptr)
+    {
+        assert(pindex->nIsSuperBlock == 1);
+
+        LogPrint(LogFlags::TALLY, "  Superblock: %" PRId64, pindex->nHeight);
+
+        CBlock block;
+
+        if (!block.ReadFromDisk(pindex)) {
+            return error(
+                "SnapshotBaselineBuilder: failed to load superblock %" PRIu64,
+                pindex->nHeight);
+        }
+
+        m_superblock = SuperblockPtr::BindShared(
+            block.PullSuperblock(),
+            pindex_bind != nullptr ? pindex_bind : pindex);
+
+        return true;
+    }
+
+    //!
+    //! \brief Apply the accrual earned for the current superblock to the total
+    //! accrual for each of the CPIDs that it contains.
+    //!
+    //! \param payment_time Timestamp of the end of the accrual period.
+    //!
+    void TallyAccrual(const int64_t payment_time)
+    {
+        const SnapshotCalculator calc(payment_time, m_superblock);
+
+        for (const auto& cpid_pair : m_superblock->m_cpids) {
+            ResearchAccount& account = m_researchers[cpid_pair.Cpid()];
+            account.m_accrual += calc.AccrualDelta(cpid_pair.Cpid(), account);
+        }
+    }
+}; // SnapshotBaselineBuilder
+} // anonymous namespace

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -133,7 +133,19 @@ public:
     //!
     void PushSuperblock(SuperblockPtr superblock)
     {
-        m_pending.emplace(superblock.m_height, std::move(superblock));
+        // Version 11+ blocks no longer rely on the tally trigger heights. We
+        // commit version 2+ superblocks immediately instead of holding these
+        // in a pending state:
+        //
+        if (superblock->m_version >= 2) {
+            if (m_cache.size() > CACHE_SIZE + 1) {
+                m_cache.pop_back();
+            }
+
+            m_cache.emplace_front(std::move(superblock));
+        } else {
+            m_pending.emplace(superblock.m_height, std::move(superblock));
+        }
     }
 
     //!

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -625,7 +625,7 @@ public:
                 Sequence copy(*this);
                 ++(*this);
 
-                return std::move(copy);
+                return copy;
             }
 
             //!

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -454,9 +454,13 @@ int64_t Tally::MaxEmission(const int64_t payment_time)
     return NetworkTally::MaxEmission(payment_time) * COIN;
 }
 
-double Tally::GetMagnitudeUnit(const int64_t payment_time)
+double Tally::GetMagnitudeUnit(const CBlockIndex* const pindex)
 {
-    return g_network_tally.GetMagnitudeUnit(payment_time);
+    if (pindex->nVersion >= 11) {
+        return SnapshotCalculator::MagnitudeUnit();
+    }
+
+    return g_network_tally.GetMagnitudeUnit(pindex->nTime);
 }
 
 ResearchAccountRange Tally::Accounts()
@@ -524,7 +528,7 @@ AccrualComputer Tally::GetLegacyComputer(
         return MakeUnique<NewbieAccrualComputer>(
             cpid,
             payment_time,
-            GetMagnitudeUnit(payment_time),
+            g_network_tally.GetMagnitudeUnit(payment_time),
             Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(cpid).Floating());
     }
 
@@ -533,7 +537,7 @@ AccrualComputer Tally::GetLegacyComputer(
         account,
         Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(cpid).Floating(),
         payment_time,
-        GetMagnitudeUnit(payment_time),
+        g_network_tally.GetMagnitudeUnit(payment_time),
         last_block_ptr->nHeight);
 }
 

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 using namespace NN;
+using LogFlags = BCLog::LogFlags;
 
 namespace {
 //!
@@ -36,12 +37,12 @@ void RepairZeroCpidIndex(CBlockIndex* const pindex)
 
     if (claim->m_mining_id != pindex->GetMiningId())
     {
-        if(fDebug)
-            LogPrintf("WARNING: BlockIndex CPID %s did not match %s in block {%s %d}",
-                pindex->GetMiningId().ToString(),
-                claim->m_mining_id.ToString(),
-                pindex->GetBlockHash().GetHex(),
-                pindex->nHeight);
+        LogPrint(LogFlags::TALLY,
+            "WARNING: BlockIndex CPID %s did not match %s in block {%s %d}",
+            pindex->GetMiningId().ToString(),
+            claim->m_mining_id.ToString(),
+            pindex->GetBlockHash().GetHex(),
+            pindex->nHeight);
 
         /* Repair the cpid field */
         pindex->SetMiningId(claim->m_mining_id);
@@ -126,7 +127,9 @@ public:
     //!
     void ApplySuperblock(const SuperblockPtr superblock)
     {
-        LogPrintf("NetworkTally::ApplySuperblock(%" PRId64 ")", superblock.m_height);
+        LogPrint(LogFlags::TALLY,
+            "NetworkTally::ApplySuperblock(%" PRId64 ")", superblock.m_height);
+
         m_total_magnitude = superblock->m_cpids.TotalMagnitude();
     }
 
@@ -405,7 +408,7 @@ void Tally::LegacyRecount(const CBlockIndex* pindex)
         return;
     }
 
-    LogPrintf("Tally::LegacyRecount(%" PRId64 ")", pindex->nHeight);
+    LogPrint(LogFlags::TALLY, "Tally::LegacyRecount(%" PRId64 ")", pindex->nHeight);
 
     const int64_t consensus_depth = pindex->nHeight - CONSENSUS_LOOKBACK;
     const int64_t lookback_depth = BLOCKS_PER_DAY * TALLY_DAYS;
@@ -414,7 +417,7 @@ void Tally::LegacyRecount(const CBlockIndex* pindex)
     int64_t min_depth = max_depth - lookback_depth;
 
     if (fTestNet && !IsV9Enabled_Tally(pindex->nHeight)) {
-        LogPrintf("Tally::LegacyRecount(): retired tally");
+        LogPrint(LogFlags::TALLY, "Tally::LegacyRecount(): retired tally");
         max_depth = consensus_depth - (consensus_depth % BLOCK_GRANULARITY);
         min_depth -= (max_depth - lookback_depth) % TALLY_GRANULARITY;
     }

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -400,6 +400,10 @@ bool Tally::Initialize(CBlockIndex* pindex)
     const int64_t start_time = GetTimeMillis();
 
     for (; pindex; pindex = pindex->pnext) {
+        if (pindex->nHeight + 1 == GetV11Threshold()) {
+            ActivateSnapshotAccrual(pindex);
+        }
+
         if (pindex->nResearchSubsidy <= 0) {
             continue;
         }

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -323,15 +323,20 @@ AccrualComputer Tally::GetComputer(
         return MakeUnique<NullAccrualComputer>();
     }
 
-    if (!GetAccount(cpid).IsActive(last_block_ptr->nHeight)) {
+    const ResearchAccount& account = GetAccount(cpid);
+
+    if (!account.IsActive(last_block_ptr->nHeight)) {
         return MakeUnique<NewbieAccrualComputer>(
             cpid,
             payment_time,
-            GetMagnitudeUnit(payment_time));
+            GetMagnitudeUnit(payment_time),
+            Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(cpid));
     }
 
     return MakeUnique<ResearchAgeComputer>(
         cpid,
+        account,
+        Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(cpid),
         payment_time,
         GetMagnitudeUnit(payment_time),
         last_block_ptr->nHeight);

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -79,11 +79,11 @@ public:
     //!
     //! \brief Get the current network magnitude unit.
     //!
-    //! \param payment_time Timestamp to calculate the magnitude unit for.
+    //! \param pindex Block context to calculate the magnitude unit for.
     //!
-    //! \return Current magnitude unit adjusted for the specified time.
+    //! \return Current magnitude unit adjusted for the specified block.
     //!
-    static double GetMagnitudeUnit(const int64_t payment_time);
+    static double GetMagnitudeUnit(const CBlockIndex* const pindex);
 
     //!
     //! \brief Get a traversable object for the research accounts stored in

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -24,6 +24,18 @@ class Tally
 {
 public:
     //!
+    //! \brief Initialize the research reward context for each CPID in the
+    //! network.
+    //!
+    //! This scans historical block metadata to create an in-memory database of
+    //! the pending accrual owed to each CPID in the network.
+    //!
+    //! \param pindex Index for the first research age block.
+    //!
+    //! \return \c true if the tally initialized without an error.
+    //!
+    static bool Initialize(CBlockIndex* pindex);
+
     //! \brief Check whether the height of the specified block matches the
     //! tally granularity.
     //!

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -56,7 +56,7 @@ public:
     //!
     //! \return \c true if the block height should trigger a recount.
     //!
-    static bool IsTrigger(const uint64_t height);
+    static bool IsLegacyTrigger(const uint64_t height);
 
     //!
     //! \brief Find the previous tally trigger below the specified block.
@@ -65,7 +65,7 @@ public:
     //!
     //! \return Index of the first tally trigger block.
     //!
-    static CBlockIndex* FindTrigger(CBlockIndex* pindex);
+    static CBlockIndex* FindLegacyTrigger(CBlockIndex* pindex);
 
     //!
     //! \brief Get the maximum network-wide research reward amount per day.

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -1,38 +1,14 @@
 #include "aboutdialog.h"
 #include "ui_aboutdialog.h"
 #include "clientmodel.h"
-#include "version.h"
-#ifdef WIN32
-#include <QAxObject>
-#endif
-#include <sys/types.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <iostream>
-#include "uint256.h"
-#include "base58.h"
-#include "../global_objects.hpp"
-#include "../global_objects_noui.hpp"
-
-
 
 AboutDialog::AboutDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AboutDialog)
 {
     ui->setupUi(this);
-
-    // Set current copyright year and boinc utilization
-    QString cr = "Copyright 2009-2020 The Bitcoin/Peercoin/Black-Coin/Gridcoin developers";
-    std::string sBoincUtilization="";
-    sBoincUtilization = strprintf("%d",nBoincUtilization);
-	QString qsUtilization = QString::fromUtf8(sBoincUtilization.c_str());
-	QString qsRegVersion  = QString::fromUtf8(sRegVer.c_str());
-    ui->copyrightLabel->setText("Boinc Magnitude: " + qsUtilization + "              " + ", Registered Version: " + qsRegVersion + "             " + cr);
-   // setTheme(this, THEME_ABOUTDIALOG);
-
+    ui->copyrightLabel->setText("Copyright 2009-2020 The Bitcoin/Peercoin/Black-Coin/Gridcoin developers");
 }
-
 
 void AboutDialog::setModel(ClientModel *model)
 {

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1476,7 +1476,7 @@ UniValue network(const UniValue& params, bool fHelp)
 
     res.pushKV("total_magnitude", (int)superblock->m_cpids.TotalMagnitude());
     res.pushKV("average_magnitude", superblock->m_cpids.AverageMagnitude());
-    res.pushKV("magnitude_unit", NN::Tally::GetMagnitudeUnit(now));
+    res.pushKV("magnitude_unit", NN::Tally::GetMagnitudeUnit(pindexBest));
     res.pushKV("research_paid_two_weeks", ValueFromAmount(two_week_research_subsidy));
     res.pushKV("research_paid_daily_average", ValueFromAmount(two_week_research_subsidy / 14));
     res.pushKV("research_paid_daily_limit", ValueFromAmount(NN::Tally::MaxEmission(now)));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1935,23 +1935,23 @@ UniValue MagnitudeReport(const NN::Cpid cpid)
     json.pushKV("Last Block Paid", account.LastRewardBlockHash().ToString());
     json.pushKV("Last Height Paid", (int)account.LastRewardHeight());
 
-    json.pushKV("Accrual Days", calc->AccrualDays(account));
-    json.pushKV("Owed", ValueFromAmount(calc->Accrual(account)));
+    json.pushKV("Accrual Days", calc->AccrualDays());
+    json.pushKV("Owed", ValueFromAmount(calc->Accrual()));
 
     if (fDebug) {
-        json.pushKV("Owed (raw)", ValueFromAmount(calc->RawAccrual(account)));
+        json.pushKV("Owed (raw)", ValueFromAmount(calc->RawAccrual()));
     }
 
-    json.pushKV("Expected Earnings (14 days)", ValueFromAmount(calc->ExpectedDaily(account) * 14));
-    json.pushKV("Expected Earnings (Daily)", ValueFromAmount(calc->ExpectedDaily(account)));
+    json.pushKV("Expected Earnings (14 days)", ValueFromAmount(calc->ExpectedDaily() * 14));
+    json.pushKV("Expected Earnings (Daily)", ValueFromAmount(calc->ExpectedDaily()));
 
     json.pushKV("Lifetime Research Paid", ValueFromAmount(account.m_total_research_subsidy));
     json.pushKV("Lifetime Magnitude Sum", (int)account.m_total_magnitude);
     json.pushKV("Lifetime Magnitude Average", account.AverageLifetimeMagnitude());
     json.pushKV("Lifetime Payments", (int)account.m_accuracy);
 
-    json.pushKV("Lifetime Payments Per Day", ValueFromAmount(calc->PaymentPerDay(account)));
-    json.pushKV("Lifetime Payments Per Day Limit", ValueFromAmount(calc->PaymentPerDayLimit(account)));
+    json.pushKV("Lifetime Payments Per Day", ValueFromAmount(calc->PaymentPerDay()));
+    json.pushKV("Lifetime Payments Per Day Limit", ValueFromAmount(calc->PaymentPerDayLimit()));
 
     return json;
 }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1940,6 +1940,7 @@ UniValue MagnitudeReport(const NN::Cpid cpid)
 
     if (fDebug) {
         json.pushKV("Owed (raw)", ValueFromAmount(calc->RawAccrual()));
+        json.pushKV("Owed (last superblock)", ValueFromAmount(account.m_accrual));
     }
 
     json.pushKV("Expected Earnings (14 days)", ValueFromAmount(calc->ExpectedDaily() * 14));

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -3,13 +3,14 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "main.h"
 #include "init.h"
+#include "main.h"
 #include "miner.h"
-#include "rpcserver.h"
 #include "neuralnet/quorum.h"
 #include "neuralnet/researcher.h"
 #include "neuralnet/tally.h"
+#include "rpcprotocol.h"
+#include "rpcserver.h"
 
 using namespace std;
 
@@ -145,4 +146,326 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.pushKV("MiningInfo 8", msMiningErrors8);
 
     return obj;
+}
+
+
+UniValue activatesnapshotaccrual(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "activatesnapshotaccrual\n"
+            "\n"
+            "TESTING ONLY: enable delta research reward accrual calculations.\n");
+
+    LOCK(cs_main);
+
+    return NN::Tally::ActivateSnapshotAccrual(pindexBest);
+}
+
+UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "auditsnapshotaccrual\n"
+            "\n"
+            "Report accrual snapshot deltas for the specified CPID.\n");
+
+    const NN::MiningId mining_id = params.size() > 0
+        ? NN::MiningId::Parse(params[0].get_str())
+        : NN::Researcher::Get()->Id();
+
+    if (!mining_id.Valid()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid CPID.");
+    }
+
+    const NN::CpidOption cpid = mining_id.TryCpid();
+
+    if (!cpid) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "No data for investor.");
+    }
+
+    if (!pindexBest) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Invalid chain.");
+    }
+
+    UniValue result(UniValue::VOBJ);
+    UniValue audit(UniValue::VARR);
+
+    LOCK(cs_main);
+
+    if (!NN::Tally::ActivateSnapshotAccrual(pindexBest)) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Snapshot accrual activation failed.");
+    }
+
+    const int64_t now = GetAdjustedTime();
+    const CBlockIndex* pindex = pindexBest;
+    const CBlockIndex* pindex_end = pindex;
+    const int64_t max_depth = IsV11Enabled(pindex->nHeight)
+        ? GetV11Threshold() - BLOCKS_PER_DAY * 30 * 6
+        : pindex->nHeight + 1 - BLOCKS_PER_DAY * 30 * 6;
+
+    NN::ResearchAccount account = NN::Tally::GetAccount(*cpid); // copy
+    NN::SuperblockPtr superblock = NN::Quorum::CurrentSuperblock();
+
+    NN::AccrualComputer calc = NN::Tally::GetSnapshotComputer(
+        *cpid,
+        account,
+        now, // payment time
+        pindex,
+        superblock);
+
+    const int64_t computed_accrual = calc->RawAccrual();
+
+    int64_t total_accrual = 0;
+    account.m_accrual = 0;
+
+    // Record the latest stake after the current superblock if one exists:
+    for (;
+        pindex && pindex->nHeight > superblock.m_height;
+        pindex = pindex->pprev)
+    {
+        if (pindex == account.m_last_block_ptr) {
+            calc = NN::Tally::GetSnapshotComputer(*cpid, account, now, pindex, superblock);
+
+            int64_t accrual_now = calc->RawAccrual();
+            total_accrual += accrual_now;
+
+            UniValue from(UniValue::VOBJ);
+            from.pushKV("boundary", "stake");
+            from.pushKV("height", (uint64_t)account.LastRewardHeight());
+
+            UniValue to(UniValue::VOBJ);
+            to.pushKV("boundary", "tip");
+            to.pushKV("height", NullUniValue);
+
+            UniValue delta(UniValue::VOBJ);
+            delta.pushKV("from", from);
+            delta.pushKV("to", to);
+
+            delta.pushKV("magnitude", superblock->m_cpids.MagnitudeOf(*cpid).Floating());
+            delta.pushKV("accrual", ValueFromAmount(accrual_now));
+
+            audit.push_back(delta);
+
+            pindex = pindexGenesisBlock; // Skip the rest
+        }
+    }
+
+    // Record accrual from the current superblock to the chain tip:
+    if (pindex) {
+        calc = NN::Tally::GetSnapshotComputer(*cpid, account, now, pindex, superblock);
+
+        int64_t accrual_now = calc->RawAccrual();
+        total_accrual += accrual_now;
+
+        UniValue from(UniValue::VOBJ);
+        from.pushKV("boundary", "superblock");
+        from.pushKV("height", pindex->nHeight);
+
+        UniValue to(UniValue::VOBJ);
+        to.pushKV("boundary", "tip");
+        to.pushKV("height", NullUniValue);
+
+        UniValue delta(UniValue::VOBJ);
+        delta.pushKV("from", from);
+        delta.pushKV("to", to);
+
+        delta.pushKV("magnitude", superblock->m_cpids.MagnitudeOf(*cpid).Floating());
+        delta.pushKV("accrual", ValueFromAmount(accrual_now));
+
+        audit.push_back(delta);
+    }
+
+    // Record accrual for historical superblocks:
+    for (pindex_end = pindex, pindex = pindex ? pindex->pprev : nullptr;
+        pindex && pindex->nHeight > max_depth;
+        pindex = pindex->pprev)
+    {
+        if (pindex->nIsSuperBlock != 1) {
+            continue;
+        }
+
+        CBlock block;
+
+        if (!block.ReadFromDisk(pindex)) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Failed to read superblock.");
+        }
+
+        superblock = NN::SuperblockPtr::BindShared(block.PullSuperblock(), pindex);
+
+        calc = NN::Tally::GetSnapshotComputer(
+            *cpid,
+            account,
+            pindex_end->nTime, // payment time
+            pindex,
+            superblock);
+
+        int64_t accrual_now = calc->RawAccrual();
+        total_accrual += accrual_now;
+
+        UniValue from(UniValue::VOBJ);
+        UniValue to(UniValue::VOBJ);
+
+        if (account.LastRewardHeight() >= (uint64_t)pindex->nHeight) {
+            from.pushKV("boundary", "stake");
+            from.pushKV("height", (uint64_t)account.LastRewardHeight());
+
+            to.pushKV("boundary", "superblock");
+            to.pushKV("height", pindex_end->nHeight);
+
+            pindex = pindexGenesisBlock; // Skip the rest
+        } else {
+            from.pushKV("boundary", "superblock");
+            from.pushKV("height", pindex->nHeight);
+
+            to.pushKV("boundary", "superblock");
+            to.pushKV("height", pindex_end->nHeight);
+        }
+
+        UniValue delta(UniValue::VOBJ);
+        delta.pushKV("from", from);
+        delta.pushKV("to", to);
+
+        delta.pushKV("magnitude", superblock->m_cpids.MagnitudeOf(*cpid).Floating());
+        delta.pushKV("accrual", ValueFromAmount(accrual_now));
+
+        audit.push_back(delta);
+
+        pindex_end = pindex;
+    }
+
+    // If the maximum depth is a superblock, we're done:
+    //
+    if (pindex && pindex->nIsSuperBlock == 1) {
+        pindex = pindexGenesisBlock; // Skip the rest
+    }
+
+    const CBlockIndex* const pindex_max = pindex;
+
+    // Record accrual for the period between the max depth and the superblock
+    // after that:
+    for (; pindex; pindex = pindex->pprev) {
+        if (pindex->nIsSuperBlock != 1) {
+            continue;
+        }
+
+        CBlock block;
+
+        if (!block.ReadFromDisk(pindex)) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Failed to read superblock.");
+        }
+
+        superblock = NN::SuperblockPtr::BindShared(block.PullSuperblock(), pindex_max);
+
+        calc = NN::Tally::GetSnapshotComputer(
+            *cpid,
+            account,
+            pindex_end->nTime, // payment time
+            pindex_max,
+            superblock);
+
+        int64_t accrual_now = calc->RawAccrual();
+        total_accrual += accrual_now;
+
+        UniValue from(UniValue::VOBJ);
+        UniValue to(UniValue::VOBJ);
+
+        if (account.LastRewardHeight() >= (uint64_t)pindex_max->nHeight) {
+            from.pushKV("boundary", "stake");
+            from.pushKV("height", (uint64_t)account.LastRewardHeight());
+
+            to.pushKV("boundary", "superblock");
+            to.pushKV("height", pindex_end->nHeight);
+        } else {
+            from.pushKV("boundary", "limit");
+            from.pushKV("height", pindex_max->nHeight);
+
+            to.pushKV("boundary", "superblock");
+            to.pushKV("height", pindex_end->nHeight);
+        }
+
+        UniValue delta(UniValue::VOBJ);
+        delta.pushKV("from", from);
+        delta.pushKV("to", to);
+
+        delta.pushKV("magnitude", superblock->m_cpids.MagnitudeOf(*cpid).Floating());
+        delta.pushKV("accrual", ValueFromAmount(accrual_now));
+
+        audit.push_back(delta);
+
+        break;
+    }
+
+    result.pushKV("audit", audit);
+    result.pushKV("audited_accrual", ValueFromAmount(total_accrual));
+    result.pushKV("computed_accrual", ValueFromAmount(computed_accrual));
+
+    return result;
+}
+
+UniValue comparesnapshotaccrual(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "comparesnapshotaccrual\n"
+            "\n"
+            "Compare snapshot and legacy accrual for active CPIDs.\n");
+
+    const int64_t now = GetAdjustedTime();
+
+    size_t active_account_count = 0;
+    int64_t legacy_total = 0;
+    int64_t snapshot_total = 0;
+
+    UniValue result(UniValue::VOBJ);
+
+    LOCK(cs_main);
+
+    if (!NN::Tally::ActivateSnapshotAccrual(pindexBest)) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Snapshot accrual activation failed.");
+    }
+
+    for (const auto& account_pair : NN::Tally::Accounts()) {
+        const NN::Cpid& cpid = account_pair.first;
+        const NN::ResearchAccount& account = account_pair.second;
+
+        const NN::AccrualComputer legacy = NN::Tally::GetLegacyComputer(cpid, now, pindexBest);
+        const NN::AccrualComputer snapshot = NN::Tally::GetSnapshotComputer(cpid, now, pindexBest);
+
+        const int64_t legacy_accrual = legacy->RawAccrual();
+        const int64_t snapshot_accrual = snapshot->RawAccrual();
+
+        if (legacy_accrual == 0 && snapshot_accrual == 0) {
+            if (!account.IsNew() && !account.IsActive(pindexBest->nHeight)) {
+                continue;
+            }
+        }
+
+        UniValue accrual(UniValue::VOBJ);
+
+        accrual.pushKV("legacy", ValueFromAmount(legacy_accrual));
+        accrual.pushKV("snapshot", ValueFromAmount(snapshot_accrual));
+
+        //UniValue params(UniValue::VARR);
+        //params.push_back(cpid.ToString());
+        //accrual.pushKV("audit", auditdeltaaccrual(params, false));
+
+        result.pushKV(cpid.ToString(), accrual);
+
+        legacy_total += legacy_accrual;
+        snapshot_total += snapshot_accrual;
+        ++active_account_count;
+    }
+
+    UniValue summary(UniValue::VOBJ);
+
+    summary.pushKV("active_accounts", (uint64_t)active_account_count);
+    summary.pushKV("legacy_total", ValueFromAmount(legacy_total));
+    summary.pushKV("legacy_average", ValueFromAmount(legacy_total / active_account_count));
+    summary.pushKV("snapshot_total", ValueFromAmount(snapshot_total));
+    summary.pushKV("snapshot_average", ValueFromAmount(snapshot_total / active_account_count));
+
+    result.pushKV("summary", summary);
+
+    return result;
 }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -122,11 +122,10 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
 
     if (const NN::CpidOption cpid = mining_id.TryCpid())
     {
-        const NN::ResearchAccount& account = NN::Tally::GetAccount(*cpid);
         const NN::AccrualComputer calc = NN::Tally::GetComputer(*cpid, nTime, pindexBest);
 
         obj.pushKV("Magnitude Unit", calc->MagnitudeUnit());
-        obj.pushKV("BoincRewardPending", ValueFromAmount(calc->Accrual(account)));
+        obj.pushKV("BoincRewardPending", ValueFromAmount(calc->Accrual()));
     }
 
     std::string current_poll = "Poll: ";

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -356,7 +356,10 @@ static const CRPCCommand vRPCCommands[] =
     { "upgradedbeaconreport",    &upgradedbeaconreport,    cat_mining        },
 
   // Developer commands
+    { "activatesnapshotaccrual", &activatesnapshotaccrual, cat_developer     },
+    { "auditsnapshotaccrual",    &auditsnapshotaccrual,    cat_developer     },
     { "addkey",                  &addkey,                  cat_developer     },
+    { "comparesnapshotaccrual",  &comparesnapshotaccrual,  cat_developer     },
     { "currentcontractaverage",  &currentcontractaverage,  cat_developer     },
     { "debug",                   &debug,                   cat_developer     },
     { "debug10",                 &debug10,                 cat_developer     },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -174,7 +174,10 @@ extern UniValue superblocks(const UniValue& params, bool fHelp);
 extern UniValue upgradedbeaconreport(const UniValue& params, bool fHelp);
 
 // Developers
+extern UniValue activatesnapshotaccrual(const UniValue& params, bool fHelp);
+extern UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp);
 extern UniValue addkey(const UniValue& params, bool fHelp);
+extern UniValue comparesnapshotaccrual(const UniValue& params, bool fHelp);
 extern UniValue currentcontractaverage(const UniValue& params, bool fHelp);
 extern UniValue debug(const UniValue& params, bool fHelp);
 extern UniValue debug10(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Current research reward accrual calculations use a two- or three-point magnitude average to determine the research reward owed to a CPID. This rudimentary approach is simple and inexpensive to compute, but it's not very accurate. Unclaimed research rewards can fluctuate as a participant's magnitude or the network magnitude unit changes. 

These updates replace the old implementation with a strategy that calculates accrual precisely from the magnitude values in each superblock. The system takes a snapshot of the pending research reward accrued for each CPID whenever the network produces a new superblock. When a CPID stakes a block, any accrual earned since the current superblock is added to the accrual snapshot and submitted as the research reward claimed for the block. By using snapshots, we avoid the performance penalty incurred by scanning the chain for each new block to determine accrual dynamically (which could require reading hundreds of MB of blocks from disk as the network grows). Instead, accrual calculations are essentially instantaneous. It's a rendition of the "superblock windows" concept described in #768. 

The wallet caches accrual snapshots on disk as flat files in the data directory and reloads the latest snapshot on startup or when reorganizing a section of the chain that contains a superblock. ~~For now, we'll need to include the "accrual" directory in the official blockchain snapshot, but we can add a way to regenerate this data in the future.~~ [Note: this was implemented, along with snapshot integrity checking in #1727.]

These changes include a new `IAccrualComputer` (#1583) implementation used for snapshot accrual in version 11 blocks that follows different rules than the old "research age" computer. In particular, it:

 - pins the network magnitude unit to a static value of 0.25 (#1578)
 - raises the max research reward allowed per block to 16384 GRC (2 day's accrual at max mag) (#913)
 - removes the 500 GRC research reward limit for a newbie's first block
 - removes the 6-month expiration for unclaimed rewards (assuming valid beacon) (#1579)
 - removes the 10-block spacing requirement between research reward claims for the same CPID
 - removes the 5-day payment-per-day limit based on lifetime average magnitude
 - removes legacy tolerances for floating-point error and time drift in old tally code (#370)

The new system bootstraps itself when the first version 11 block arrives at the mandatory threshold and creates the first snapshot from about 6 months of the preceding superblocks. For a more seamless transition, the initial look-back depth matches the depth allowed for the current system, but research rewards will accrue indefinitely after the switch. Participants still need to renew beacons every 6 months.