### PR TITLE
Optimize bdb to avoid synchronous flush of database

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -99,10 +99,12 @@ protected:
     std::string strFile;
     DbTxn *activeTxn;
     bool fReadOnly;
+    bool fFlushOnClose;
 
-    explicit CDB(const char* pszFile, const char* pszMode="r+");
+    explicit CDB(const std::string &strFilename, const char* pszMode="r+", bool fFlushOnCloseIn = true);
     ~CDB() { Close(); }
 public:
+    void Flush();
     void Close();
 private:
     CDB(const CDB&);

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     walletdb.WriteAccountingEntry(ae);
 
     wtx.mapValue["comment"] = "z";
-    pwalletMain->AddToWallet(wtx);
+    pwalletMain->AddToWallet(wtx, &walletdb);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[0]->nTimeReceived = (unsigned int)1333333335;
     vpwtx[0]->nOrderPos = -1;
@@ -78,13 +78,13 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
 
     wtx.mapValue["comment"] = "y";
     --wtx.nLockTime;  // Just to change the hash :)
-    pwalletMain->AddToWallet(wtx);
+    pwalletMain->AddToWallet(wtx, &walletdb);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[1]->nTimeReceived = (unsigned int)1333333336;
 
     wtx.mapValue["comment"] = "x";
     --wtx.nLockTime;  // Just to change the hash :)
-    pwalletMain->AddToWallet(wtx);
+    pwalletMain->AddToWallet(wtx, &walletdb);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[2]->nTimeReceived = (unsigned int)1333333329;
     vpwtx[2]->nOrderPos = -1;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -247,10 +247,10 @@ public:
     TxItems OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount = "");
 
     void MarkDirty();
-    bool AddToWallet(const CWalletTx& wtxIn);
+    bool AddToWallet(const CWalletTx& wtxIn, CWalletDB *pwalletdb);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate = false, bool fFindBlock = false);
     bool EraseFromWallet(uint256 hash);
-    void WalletUpdateSpent(const CTransaction& prevout, bool fBlock = false);
+    void WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* pwalletdb);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(bool fForce = false);
@@ -823,7 +823,7 @@ public:
         return true;
     }
 
-    bool WriteToDisk();
+    bool WriteToDisk(CWalletDB *pwalletdb);
 
     int64_t GetTxTime() const;
     int GetRequestCount() const;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -654,7 +654,7 @@ void ThreadFlushWalletDB(void* parg)
                     map<string, int>::iterator mi = bitdb.mapFileUseCount.find(strFile);
                     if (mi != bitdb.mapFileUseCount.end())
                     {
-                        if (fDebug10) LogPrintf("Flushing wallet.dat");
+                        LogPrint(BCLog::LogFlags::WALLETDB, "Flushing wallet.dat");
                         nLastFlushed = nWalletDBUpdated;
                         int64_t nStart = GetTimeMillis();
 
@@ -666,7 +666,7 @@ void ThreadFlushWalletDB(void* parg)
                         // This is handled in CDB::Flush, which has a while loop that also does in the right place what
                         // the intention of the below line was.
                         // bitdb.mapFileUseCount.erase(mi++);
-                        if (fDebug10) LogPrintf("Flushed wallet.dat %" PRId64 "ms", GetTimeMillis() - nStart);
+                        LogPrint(BCLog::LogFlags::WALLETDB, "Flushed wallet.dat %" PRId64 "ms", GetTimeMillis() - nStart);
                     }
                 }
             }

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -61,7 +61,7 @@ public:
 class CWalletDB : public CDB
 {
 public:
-    CWalletDB(std::string strFilename, const char* pszMode="r+") : CDB(strFilename.c_str(), pszMode)
+    CWalletDB(const std::string& strFilename, const char* pszMode = "r+", bool fFlushOnClose = true) : CDB(strFilename, pszMode, fFlushOnClose)
     {
     }
 private:


### PR DESCRIPTION
during AddToWalletIfInvolvingMe() calls.

This is a backport of https://github.com/bitcoin/bitcoin/pull/4805 specific to Gridcoin.