### PR TITLE
Remove informational magnitude field from binary claims

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2652,9 +2652,14 @@ bool GridcoinConnectBlock(
     }
 
     pindex->SetMiningId(claim.m_mining_id);
-    pindex->nMagnitude = claim.m_magnitude;
     pindex->nResearchSubsidy = claim.m_research_subsidy;
     pindex->nInterestSubsidy = claim.m_block_subsidy;
+
+    if (block.nVersion >= 11) {
+        pindex->nMagnitude = NN::Quorum::GetMagnitude(claim.m_mining_id).Floating();
+    } else {
+        pindex->nMagnitude = claim.m_magnitude;
+    }
 
     NN::Tally::RecordRewardBlock(pindex);
 

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -322,8 +322,6 @@ struct Claim
         //
         if (m_mining_id.Which() == MiningId::Kind::CPID) {
             READWRITE(m_research_subsidy);
-            READWRITE(m_magnitude);
-
             READWRITE(m_signature);
         }
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -62,10 +62,10 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
     res.push_back(std::make_pair(_("CPID"), claim.m_mining_id.ToString()));
     res.push_back(std::make_pair(_("Interest"), FormatMoney(claim.m_block_subsidy)));
 
-    if (claim.m_magnitude > 0)
+    if (pindex->nMagnitude > 0)
     {
         res.push_back(std::make_pair(_("Boinc Reward"), FormatMoney(claim.m_research_subsidy)));
-        res.push_back(std::make_pair(_("Magnitude"), RoundToString(claim.m_magnitude, 8)));
+        res.push_back(std::make_pair(_("Magnitude"), RoundToString(pindex->nMagnitude, 8)));
     }
 
     res.push_back(std::make_pair(_("Fees Collected"), FormatMoney(GetFeesCollected(block))));
@@ -466,7 +466,7 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
     {
         fVerbose = params[1].isNum() ? (params[1].get_int() != 0) : params[1].get_bool();
     }
-    
+
     LOCK(cs_main);
 
     CTransaction tx;
@@ -697,7 +697,7 @@ UniValue consolidateunspent(const UniValue& params, bool fHelp)
 
         return result;
     }
-    
+
     CReserveKey reservekey(pwalletMain);
 
 

--- a/src/test/neuralnet/claim_tests.cpp
+++ b/src/test/neuralnet/claim_tests.cpp
@@ -352,7 +352,6 @@ BOOST_AUTO_TEST_CASE(it_generates_a_hash_for_a_research_reward_claim)
         << claim.m_organization
         << claim.m_block_subsidy
         << claim.m_research_subsidy
-        << claim.m_magnitude
         << claim.m_signature
         << claim.m_quorum_hash;
 
@@ -561,7 +560,6 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_researcher)
         << claim.m_organization
         << claim.m_block_subsidy
         << claim.m_research_subsidy
-        << claim.m_magnitude
         << claim.m_signature
         << claim.m_quorum_hash;
 
@@ -590,7 +588,6 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_researcher_with_superblock)
         << claim.m_organization
         << claim.m_block_subsidy
         << claim.m_research_subsidy
-        << claim.m_magnitude
         << claim.m_signature
         << claim.m_quorum_hash
         << claim.m_superblock;
@@ -617,7 +614,6 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher)
         << expected.m_organization
         << expected.m_block_subsidy
         << expected.m_research_subsidy
-        << expected.m_magnitude
         << expected.m_signature
         << expected.m_quorum_hash;
 
@@ -632,7 +628,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher)
     BOOST_CHECK(claim.m_block_subsidy == expected.m_block_subsidy);
 
     BOOST_CHECK(claim.m_research_subsidy == expected.m_research_subsidy);
-    BOOST_CHECK(claim.m_magnitude == expected.m_magnitude);
+    BOOST_CHECK(claim.m_magnitude == 0.0);
     BOOST_CHECK(claim.m_magnitude_unit == 0.0);
     BOOST_CHECK(claim.m_signature == expected.m_signature);
 
@@ -656,7 +652,6 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher_with_superbloc
         << expected.m_organization
         << expected.m_block_subsidy
         << expected.m_research_subsidy
-        << expected.m_magnitude
         << expected.m_signature
         << expected.m_quorum_hash
         << expected.m_superblock;
@@ -672,7 +667,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher_with_superbloc
     BOOST_CHECK(claim.m_block_subsidy == expected.m_block_subsidy);
 
     BOOST_CHECK(claim.m_research_subsidy == expected.m_research_subsidy);
-    BOOST_CHECK(claim.m_magnitude == expected.m_magnitude);
+    BOOST_CHECK(claim.m_magnitude == 0.0);
     BOOST_CHECK(claim.m_magnitude_unit == 0.0);
     BOOST_CHECK(claim.m_signature == expected.m_signature);
 


### PR DESCRIPTION
This removes the magnitude field from the block claim context in version 11+ blocks to conserve space. A node can reproduce the value when needed from the current superblock.