### PR TITLE
Add options checkbox to disable transaction notifications

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1014,10 +1014,12 @@ void BitcoinGUI::incomingTransaction(const QModelIndex & parent, int start, int 
     TransactionTableModel *ttm = walletModel->getTransactionTableModel();
     qint64 amount = ttm->index(start, TransactionTableModel::Amount, parent)
                     .data(Qt::EditRole).toULongLong();
-    if(!clientModel->inInitialBlockDownload())
+
+    // On new transaction, make an info balloon
+    // Unless the initial block download is in progress OR transaction notification
+    // is disabled, to prevent balloon-spam.
+    if(!(clientModel->inInitialBlockDownload() || walletModel->getOptionsModel()->getDisableTrxNotifications()))
     {
-        // On new transaction, make an info balloon
-        // Unless the initial block download is in progress, to prevent balloon-spam
         QString date = ttm->index(start, TransactionTableModel::Date, parent)
                         .data().toString();
         QString type = ttm->index(start, TransactionTableModel::Type, parent)

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -325,6 +325,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="disableTransactionNotifications">
+         <property name="text">
+          <string>Disable Transaction Notifications</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Window">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -141,6 +141,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->socksVersion, OptionsModel::ProxySocksVersion);
 
     /* Window */
+    mapper->addMapping(ui->disableTransactionNotifications, OptionsModel::DisableTrxNotifications);
 #ifndef Q_OS_MAC
     mapper->addMapping(ui->minimizeToTray, OptionsModel::MinimizeToTray);
     mapper->addMapping(ui->minimizeOnClose, OptionsModel::MinimizeOnClose);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -41,7 +41,8 @@ void OptionsModel::Init()
     // These are Qt-only settings:
     nDisplayUnit = settings.value("nDisplayUnit", BitcoinUnits::BTC).toInt();
     fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
-	bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
+    fDisableTrxNotifications = settings.value("fDisableTrxNotifications", false).toBool();
+    bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
     nTransactionFee = settings.value("nTransactionFee").toLongLong();
@@ -79,6 +80,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(GUIUtil::GetStartOnSystemStartup());
         case MinimizeToTray:
             return QVariant(fMinimizeToTray);
+        case DisableTrxNotifications:
+            return QVariant(fDisableTrxNotifications);
         case MapPortUPnP:
             return settings.value("fUseUPnP", GetBoolArg("-upnp", true));
         case MinimizeOnClose:
@@ -138,6 +141,10 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case MinimizeToTray:
             fMinimizeToTray = value.toBool();
             settings.setValue("fMinimizeToTray", fMinimizeToTray);
+            break;
+        case DisableTrxNotifications:
+            fDisableTrxNotifications = value.toBool();
+            settings.setValue("fDisableTrxNotifications", fDisableTrxNotifications);
             break;
         case MapPortUPnP:
             fUseUPnP = value.toBool();
@@ -247,6 +254,11 @@ bool OptionsModel::getCoinControlFeatures()
 bool OptionsModel::getMinimizeToTray()
 {
     return fMinimizeToTray;
+}
+
+bool OptionsModel::getDisableTrxNotifications()
+{
+    return fDisableTrxNotifications;
 }
 
 bool OptionsModel::getMinimizeOnClose()

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -19,6 +19,7 @@ public:
     enum OptionID {
         StartAtStartup,    // bool
         MinimizeToTray,    // bool
+        DisableTrxNotifications, // bool
         MapPortUPnP,       // bool
         MinimizeOnClose,   // bool
         ProxyUse,          // bool
@@ -46,6 +47,7 @@ public:
     qint64 getTransactionFee();
     qint64 getReserveBalance();
     bool getMinimizeToTray();
+    bool getDisableTrxNotifications();
     bool getMinimizeOnClose();
     int getDisplayUnit();
 	bool getDisplayAddresses();
@@ -56,6 +58,7 @@ public:
 private:
     int nDisplayUnit;
     bool fMinimizeToTray;
+    bool fDisableTrxNotifications;
 	bool bDisplayAddresses;
     bool fMinimizeOnClose;
     bool fCoinControlFeatures;


### PR DESCRIPTION
This small PR adds a checkbox in the options->Window tab to disable the popup notifications for transactions. This is useful if running several instances of a wallet, where notifications can be confusing, and also where staking is occurring very often. The operating system notifications seem to be less reliable at squelching these than the internal approach.

Note that the optionsModel has been updated to maintain state of the checkbox between reboots.