### PR TITLE
Fix legacy accrual for newbie with non-zero past reward

### DIFF
--- a/src/gridcoin.cpp
+++ b/src/gridcoin.cpp
@@ -36,6 +36,7 @@ namespace
         uint256S("639756cf39bf12a4a0ab4ea5ec10938fd0f463cc7bc1bd2916529a445ceba2ab"), //T680406
         uint256S("ba1aae8ea37a9c330b298bd2b569448f0249a685bb0a8e85698fe44d1edca774"), //T1145954 (6-month cutoff)
         uint256S("b05e6c04c7b414a29746b2d642fd19f64e9fdb13dcc4873144233a23138bd419"), //T1154377 (zero-mag newbie)
+        uint256S("99a47d7e8ba54a4444ca9cd762abb6dbac50065968ac1f2012f6f90ca3feb50b"), //T1219105 (returning newbie)
     };
 
 

--- a/src/neuralnet/accrual/newbie.h
+++ b/src/neuralnet/accrual/newbie.h
@@ -20,16 +20,19 @@ public:
     //! a research reward before.
     //!
     //! \param cpid           CPID to calculate research accrual for.
+    //! \param account        CPID's historical accrual context.
     //! \param payment_time   Time of payment to calculate rewards at.
     //! \param magnitude_unit Current network magnitude unit to factor in.
     //! \param magnitude      CPID's magnitude in the last superblock.
     //!
     NewbieAccrualComputer(
         const Cpid cpid,
+        const ResearchAccount& account,
         const int64_t payment_time,
         const double magnitude_unit,
         const double magnitude)
         : m_cpid(cpid)
+        , m_account(account)
         , m_payment_time(payment_time)
         , m_magnitude_unit(magnitude_unit)
         , m_magnitude(magnitude)
@@ -100,7 +103,7 @@ public:
 
         constexpr int64_t six_months = 86400 * 30 * 6; // seconds
 
-        if (AccrualAge() >= six_months) {
+        if (AccrualAge() >= six_months || m_account.m_total_research_subsidy > 0) {
             LogPrint(BCLog::LogFlags::ACCRUAL,
                 "Accrual: %s Invalid Beacon, Using 0.01 age bootstrap",
                 m_cpid.ToString());
@@ -123,6 +126,7 @@ public:
 
 private:
     const Cpid m_cpid;             //!< CPID to calculate research accrual for.
+    const ResearchAccount& m_account; //!< CPID's historical accrual context.
     const int64_t m_payment_time;  //!< Time of payment to calculate rewards at.
     const double m_magnitude_unit; //!< Network magnitude unit to factor in.
     const double m_magnitude;      //!< CPID's magnitude in the last superblock.

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -533,6 +533,7 @@ AccrualComputer Tally::GetLegacyComputer(
     if (!account.IsActive(last_block_ptr->nHeight)) {
         return MakeUnique<NewbieAccrualComputer>(
             cpid,
+            account,
             payment_time,
             g_network_tally.GetMagnitudeUnit(payment_time),
             Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(cpid).Floating());


### PR DESCRIPTION
The newbie accrual computer for block version 10 and below is missing a legacy rule for researchers with historical research rewards when those researchers begin participating again after a span of about six months pass.