### PR TITLE
build: Updates boost to 1.73.0 for depends

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -886,9 +886,6 @@ fi
 if test x$use_boost = xyes; then
 
 BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_ZLIB_LIB $BOOST_IOSTREAMS_LIB $BOOST_PROGRAM_OPTIONS_LIB $BOOST_THREAD_LIB $BOOST_CHRONO_LIB $BOOST_ZLIB_LIB"
-if test x$TARGET_OS = xdarwin; then
-  BOOST_LIBS="$BOOST_LIBS -lboost_system-mt"
-fi
 
 dnl If boost (prior to 1.57) was built without c++11, it emulated scoped enums
 dnl using c++98 constructs. Unfortunately, this implementation detail leaked into

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,9 +1,9 @@
 package=boost
 GCCFLAGS?=
-$(package)_version=1_65_1
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.65.1/source/
+$(package)_version=1_73_0
+$(package)_download_path=https://dl.bintray.com/boostorg/release/1.73.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81
+$(package)_sha256_hash=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402
 $(package)_dependencies=zlib
 
 define $(package)_set_vars


### PR DESCRIPTION
Followup to #1672.

I compiled this against boost 1.65.1 (the same as the old depends) and 1.73 (the new depends boost version). I did not try really ancient versions of boost.