### PR TITLE
Remove slashes from User Agent in peers tab

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -164,8 +164,7 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
             return QString(rec->nodeStats.fInbound ? "↓ " : "↑ ") + QString::fromStdString(rec->nodeStats.addrName);
         case Subversion:
             // remove leading and trailing slash
-            std::string strSubVer = rec->nodeStats.strSubVer;
-            return QString::fromStdString(strSubVer.substr(1, strSubVer.length() - 2));
+            return QString::fromStdString(rec->nodeStats.strSubVer.substr(1, rec->nodeStats.strSubVer.length() - 2));
         case Ping:
             return GUIUtil::formatPingTime(rec->nodeStats.dPingTime);
         case Sent:

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -163,7 +163,9 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
             // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
             return QString(rec->nodeStats.fInbound ? "↓ " : "↑ ") + QString::fromStdString(rec->nodeStats.addrName);
         case Subversion:
-            return QString::fromStdString(rec->nodeStats.strSubVer);
+            // remove leading and trailing slash
+            std::string strSubVer = rec->nodeStats.strSubVer;
+            return QString::fromStdString(strSubVer.substr(1, strSubVer.length() - 2));
         case Ping:
             return GUIUtil::formatPingTime(rec->nodeStats.dPingTime);
         case Sent:

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -725,6 +725,7 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.dMinPing));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString("%1").arg(QString::number(stats->nodeStats.nVersion)));
+    // remove leading and trailing slash
     std::string strSubVer = stats->nodeStats.strSubVer;
     ui->peerSubversion->setText(QString::fromStdString(strSubVer.substr(1, strSubVer.length() - 2)));
     ui->peerDirection->setText(stats->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -725,7 +725,8 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.dMinPing));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString("%1").arg(QString::number(stats->nodeStats.nVersion)));
-    ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.strSubVer));
+    std::string strSubVer = stats->nodeStats.strSubVer;
+    ui->peerSubversion->setText(QString::fromStdString(strSubVer.substr(1, strSubVer.length() - 2)));
     ui->peerDirection->setText(stats->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
     ui->peerHeight->setText(QString("%1").arg(QString::number(stats->nodeStats.nStartingHeight)));
     // ui->peerWhitelisted->setText(stats->nodeStats.fWhitelisted ? tr("Yes") : tr("No"));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -726,8 +726,7 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString("%1").arg(QString::number(stats->nodeStats.nVersion)));
     // remove leading and trailing slash
-    std::string strSubVer = stats->nodeStats.strSubVer;
-    ui->peerSubversion->setText(QString::fromStdString(strSubVer.substr(1, strSubVer.length() - 2)));
+    ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.strSubVer.substr(1, stats->nodeStats.strSubVer.length() - 2)));
     ui->peerDirection->setText(stats->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
     ui->peerHeight->setText(QString("%1").arg(QString::number(stats->nodeStats.nStartingHeight)));
     // ui->peerWhitelisted->setText(stats->nodeStats.fWhitelisted ? tr("Yes") : tr("No"));


### PR DESCRIPTION
This PR removes trailing and leading slashes from the peers tab

Closes #1555 