### PR TITLE
Fix suffix when copying txids

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -342,7 +342,7 @@ bool TransactionRecord::statusUpdateNeeded()
 
 std::string TransactionRecord::getTxID()
 {
-    return hash.ToString() + strprintf("-%03d", idx);
+    return hash.ToString();
 }
 
 


### PR DESCRIPTION
This PR removes the "-000" suffix appended to transaction IDs.

Closes #1675 