### PR TITLE
Replace boost::optional<T&> with non-owning pointers

### DIFF
--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -148,10 +148,10 @@ BeaconOption BeaconRegistry::Try(const Cpid& cpid) const
     const auto iter = m_beacons.find(cpid);
 
     if (iter == m_beacons.end()) {
-        return boost::none;
+        return nullptr;
     }
 
-    return iter->second;
+    return &iter->second;
 }
 
 BeaconOption BeaconRegistry::TryActive(const Cpid& cpid, const int64_t now) const
@@ -162,7 +162,7 @@ BeaconOption BeaconRegistry::TryActive(const Cpid& cpid, const int64_t now) cons
         }
     }
 
-    return boost::none;
+    return nullptr;
 }
 
 bool BeaconRegistry::ContainsActive(const Cpid& cpid, const int64_t now) const

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -6,7 +6,6 @@
 #include "neuralnet/cpid.h"
 #include "serialize.h"
 
-#include <boost/optional.hpp>
 #include <string>
 #include <vector>
 
@@ -161,9 +160,9 @@ public:
 };
 
 //!
-//! \brief A type that either contains a reference to some beacon or does not.
+//! \brief A type that either points to to some beacon or does not.
 //!
-typedef boost::optional<const Beacon&> BeaconOption;
+typedef const Beacon* BeaconOption;
 
 //!
 //! \brief The body of a beacon contract advertised in a transaction.

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -1126,19 +1126,19 @@ private: // SuperblockValidator classes
         //! \brief Record the supplied scraper ID for the specified project to
         //! track supermajority status.
         //!
-        //! \return A reference to the project resolution state if the project
+        //! \return A pointer to the project resolution state if the project
         //! exists in the superblock.
         //!
-        boost::optional<ResolvedProject&>
+        ResolvedProject*
         TallyProject(const std::string& project, const ScraperID& scraper_id)
         {
             if (m_resolved_projects.count(project)) {
-                return m_resolved_projects.at(project);
+                return &m_resolved_projects.at(project);
             }
 
             m_other_projects[project].emplace(scraper_id);
 
-            return boost::none;
+            return nullptr;
         }
 
         //!

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -12,6 +12,7 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/optional.hpp>
 #include <openssl/md5.h>
 #include <set>
 
@@ -613,10 +614,10 @@ ProjectOption MiningProjectMap::Try(const std::string& name) const
     const auto iter = m_projects.find(name);
 
     if (iter == m_projects.end()) {
-        return boost::none;
+        return nullptr;
     }
 
-    return iter->second;
+    return &iter->second;
 }
 
 void MiningProjectMap::Set(MiningProject project)
@@ -660,22 +661,22 @@ AdvertiseBeaconResult::AdvertiseBeaconResult(const BeaconError error)
 {
 }
 
-boost::optional<CPubKey&> AdvertiseBeaconResult::TryPublicKey()
+CPubKey* AdvertiseBeaconResult::TryPublicKey()
 {
     if (m_result.which() == 0) {
-        return boost::get<CPubKey>(m_result);
+        return &boost::get<CPubKey>(m_result);
     }
 
-    return boost::none;
+    return nullptr;
 }
 
-boost::optional<const CPubKey&> AdvertiseBeaconResult::TryPublicKey() const
+const CPubKey* AdvertiseBeaconResult::TryPublicKey() const
 {
     if (m_result.which() == 0) {
-        return boost::get<CPubKey>(m_result);
+        return &boost::get<CPubKey>(m_result);
     }
 
-    return boost::none;
+    return nullptr;
 }
 
 BeaconError AdvertiseBeaconResult::Error() const

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -3,7 +3,6 @@
 #include "key.h"
 #include "neuralnet/cpid.h"
 
-#include <boost/optional.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
 #include <map>
@@ -90,10 +89,10 @@ struct MiningProject
 };
 
 //!
-//! \brief An optional type that either contains a reference to some local BOINC
-//! project or does not.
+//! \brief An optional type that either points to some local BOINC project or
+//! does not.
 //!
-typedef boost::optional<const MiningProject&> ProjectOption;
+typedef const MiningProject* ProjectOption;
 
 //!
 //! \brief Contains a local set of BOINC projects loaded from client_state.xml.
@@ -228,18 +227,18 @@ public:
     //!
     //! \brief Get the beacon public key if advertisement succeeded.
     //!
-    //! \return An object that contains a reference to the beacon public key
-    //! if advertisement succeeded or does not.
+    //! \return An object that points to the beacon public key if advertisement
+    //! succeeded or does not.
     //!
-    boost::optional<CPubKey&> TryPublicKey();
+    CPubKey* TryPublicKey();
 
     //!
     //! \brief Get the beacon public key if advertisement succeeded.
     //!
-    //! \return An object that contains a reference to the beacon public key
-    //! if advertisement succeeded or does not.
+    //! \return An object that points to the beacon public key if advertisement
+    //! succeeded or does not.
     //!
-    boost::optional<const CPubKey&> TryPublicKey() const;
+    const CPubKey* TryPublicKey() const;
 
     //!
     //! \brief Get a description of the error that occurred, if any.

--- a/src/test/neuralnet/researcher_tests.cpp
+++ b/src/test/neuralnet/researcher_tests.cpp
@@ -380,8 +380,8 @@ BOOST_AUTO_TEST_CASE(it_fetches_a_project_by_name)
 
     projects.Set(NN::MiningProject("project name", NN::Cpid(), "team name"));
 
-    BOOST_CHECK(projects.Try("project name").value().m_name == "project name");
-    BOOST_CHECK(projects.Try("nonexistent") == boost::none);
+    BOOST_CHECK(projects.Try("project name")->m_name == "project name");
+    BOOST_CHECK(projects.Try("nonexistent") == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(it_does_not_overwrite_projects_with_the_same_name)
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(it_does_not_overwrite_projects_with_the_same_name)
     projects.Set(NN::MiningProject("project name", NN::Cpid(), "team name 1"));
     projects.Set(NN::MiningProject("project name", NN::Cpid(), "team name 2"));
 
-    BOOST_CHECK(projects.Try("project name").value().m_team == "team name 1");
+    BOOST_CHECK(projects.Try("project name")->m_team == "team name 1");
 }
 
 BOOST_AUTO_TEST_CASE(it_applies_a_provided_team_whitelist)


### PR DESCRIPTION
I used `boost::optional` in a few places to return an optional type that wraps a reference type. Although Boost supports this, I read that this is not a good practice, and that the `std::optional` type in C++17 won't allow a reference type for the template argument. This change replaces the optional references with non-owning pointers in a way that avoids changing the public APIs.