### PR TITLE
Optimize proof-of-stake validation

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -287,11 +287,13 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     if (nModifierTime / nModifierInterval >= pindexPrev->GetBlockTime() / nModifierInterval)
         return true;
 
-    const uint256 ModifGlitch_hash = uint256S("439b96fd59c3d585a6b93ee63b6e1d78361d7eb9b299657dee6a2c5400ccba29");
-    const uint64_t ModifGlitch_correct=0xdf209a3032807577;
-    if(pindexPrev->GetBlockHash()==ModifGlitch_hash)
+    // A bug caused by the grandfather rule in legacy clients botched the stake
+    // modifier on mainnet. This resets the correct modifier at this height:
+    //
+    if (pindexPrev->nHeight == 1009994
+        && pindexPrev->GetBlockHash() == uint256S("439b96fd59c3d585a6b93ee63b6e1d78361d7eb9b299657dee6a2c5400ccba29"))
     {
-        nStakeModifier = ModifGlitch_correct;
+        nStakeModifier = 0xdf209a3032807577;
         fGeneratedStakeModifier = true;
         return true;
     }

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -94,7 +94,7 @@ bool CheckProofOfStakeV8(
 bool FindStakeModifierRev(uint64_t& StakeModifier,CBlockIndex* pindexPrev);
 
 // Kernel for V8
-CBigNum CalculateStakeHashV8(
+uint256 CalculateStakeHashV8(
     const CBlockHeader& CoinBlock,
     const CTransaction& CoinTx,
     unsigned CoinTxN,

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -30,6 +30,27 @@ bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierCheck
 int64_t GetWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd);
 
 //!
+//! \brief Load the previous transaction and its containing block header from
+//! disk for the specified output.
+//!
+//! This function provides an optimized routine to load the staked transaction
+//! and block header for a coinstake output by reading both from disk at once.
+//!
+//! \param txdb         Finds the previous transaction location on disk.
+//! \param prevout_hash Hash of the input transaction to load from disk.
+//! \param out_header   Header of the previous transaction's block.
+//! \param out_txprev   The previous transaction data loaded from disk.
+//!
+//! \return \c true if the previous transaction and block header were loaded
+//! from disk successfully.
+//!
+bool ReadStakedInput(
+    CTxDB& txdb,
+    const uint256 prevout_hash,
+    CBlockHeader& out_header,
+    CTransaction& out_txprev);
+
+//!
 //! \brief Calculate the provided block's proof hash with the version 3 staking
 //! kernel algorithm for version 7 blocks to carry the stake modifier.
 //!
@@ -57,22 +78,25 @@ int64_t GetWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd);
 //! disk fails.
 //!
 bool CalculateLegacyV3HashProof(
+    CTxDB& txdb,
     const CBlock& block,
     const double por_nonce,
     uint256& out_hash_proof);
 
 //Block version 8+ Staking
 bool CheckProofOfStakeV8(
+    CTxDB& txdb,
     CBlockIndex* pindexPrev, //previous block in chain index
-    CBlock &Block, //block to check
+    CBlock& Block, //block to check
     bool generated_by_me,
     uint256& hashProofOfStake); //proof hash out-parameter
+
 bool FindStakeModifierRev(uint64_t& StakeModifier,CBlockIndex* pindexPrev);
 
 // Kernel for V8
 CBigNum CalculateStakeHashV8(
-    const CBlock &CoinBlock,
-    const CTransaction &CoinTx,
+    const CBlockHeader& CoinBlock,
+    const CTransaction& CoinTx,
     unsigned CoinTxN,
     unsigned nTimeTx,
     uint64_t StakeModifier);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2732,7 +2732,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 
     bool bIsDPOR = false;
 
-    if(nVersion>=8)
+    if (nVersion >= 8 && pindex->nStakeModifier == 0 && pindex->nStakeModifierChecksum == 0)
     {
         uint256 tmp_hashProof;
         if(!CheckProofOfStakeV8(pindex->pprev, *this, /*generated_by_me*/ false, tmp_hashProof))

--- a/src/main.h
+++ b/src/main.h
@@ -1401,7 +1401,7 @@ public:
 
         // Flush stdio buffers and commit to disk before returning
         fflush(fileout.Get());
-        if (!IsInitialBlockDownload() || (nBestHeight+1) % 500 == 0)
+        if (!IsInitialBlockDownload() || (nBestHeight+1) % 5000 == 0)
             FileCommit(fileout.Get());
 
         return true;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -564,7 +564,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
         if(!FindStakeModifierRev(StakeModifier,pindexPrev))
             continue;
         CoinWeight = CalculateStakeWeightV8(CoinTx,CoinTxN);
-        StakeKernelHash= CalculateStakeHashV8(CoinBlock,CoinTx,CoinTxN,txnew.nTime,StakeModifier);
+        StakeKernelHash.setuint256(CalculateStakeHashV8(CoinBlock,CoinTx,CoinTxN,txnew.nTime,StakeModifier));
 
         CBigNum StakeTarget;
         StakeTarget.SetCompact(blocknew.nBits);


### PR DESCRIPTION
This set of changes improves the performance of the proof-of-stake subsystem. Most significantly, this adds memoization for the stake modifier candidate hashes generated when selecting the next stake modifier value. Before, this process could potentially trigger hundreds of hashing operations in the worst case for each stake modifier selection interval. We avoid a vast amount of redundant overhead by caching these hashes. 

These changes also reduce the proof/signature verification cost and disk access overhead for PoS validation. Please read the commit descriptions for details. Collectively, this PR seems to reduce the initial sync time by about another 30-60 minutes, depending on the hardware. At this point, we won't get much more speed until we port Bitcoin's parallel block downloading abilities. 

To prepare for the mandatory release, I also removed a stray condition in the kernel code that supposed that block version 11 will merge the coinbase and coinstake transactions into one. I don't think we will manage that before the next version.