### PR TITLE
Add support for self-service beacon deletion

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1203,6 +1203,10 @@ bool CTransaction::CheckContracts(const MapPrevTx& inputs) const
     }
 
     for (const auto& contract : GetContracts()) {
+        if (contract.m_version <= 1) {
+            return DoS(100, error("%s: legacy contract", __func__));
+        }
+
         if (!contract.Validate()) {
             return DoS(100, error("%s: malformed contract", __func__));
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2642,6 +2642,10 @@ bool TryLoadSuperblock(
         if (!NN::Tally::ApplySuperblock(superblock)) {
             return false;
         }
+
+        NN::GetBeaconRegistry().ActivatePending(
+            superblock->m_verified_beacons,
+            superblock.m_timestamp);
     }
 
     NN::Quorum::PushSuperblock(std::move(superblock));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2644,7 +2644,7 @@ bool TryLoadSuperblock(
         }
 
         NN::GetBeaconRegistry().ActivatePending(
-            superblock->m_verified_beacons,
+            superblock->m_verified_beacons.m_verified,
             superblock.m_timestamp);
     }
 

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -526,7 +526,11 @@ Contract Contract::Parse(const std::string& message, const int64_t timestamp)
 bool Contract::RequiresMasterKey() const
 {
     switch (m_type.Value()) {
-        case ContractType::BEACON:   return m_action == ContractAction::REMOVE;
+        case ContractType::BEACON:
+            // Contracts version 2+ allow participants to revoke their own
+            // beacons by signing them with the original private key:
+            return m_version == 1 && m_action == ContractAction::REMOVE;
+
         case ContractType::POLL:     return m_action == ContractAction::REMOVE;
         case ContractType::PROJECT:  return true;
         case ContractType::PROTOCOL: return true;

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -332,7 +332,7 @@ void NN::ReplayContracts(const CBlockIndex* pindex)
             }
 
             GetBeaconRegistry().ActivatePending(
-                block.GetSuperblock().m_verified_beacons,
+                block.GetSuperblock().m_verified_beacons.m_verified,
                 block.GetBlockTime());
         }
     }

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -14,8 +14,8 @@
 using namespace NN;
 
 // TODO: use a header
-ScraperStats GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
-ScraperStats GetScraperStatsFromSingleManifest(CScraperManifest &manifest);
+ScraperStatsAndVerifiedBeacons  GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
+ScraperStatsAndVerifiedBeacons  GetScraperStatsFromSingleManifest(CScraperManifest &manifest);
 unsigned int NumScrapersForSupermajority(unsigned int nScraperCount);
 mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests();
 Superblock ScraperGetSuperblockContract(
@@ -782,9 +782,9 @@ private: // SuperblockValidator classes
         //!
         QuorumHash ComputeQuorumHash() const
         {
-            const ScraperStats stats = GetScraperStatsByConvergedManifest(m_convergence);
+            const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetScraperStatsByConvergedManifest(m_convergence);
 
-            return QuorumHash::Hash(stats);
+            return QuorumHash::Hash(stats_and_verified_beacons);
         }
 
     private:
@@ -1314,9 +1314,9 @@ private: // SuperblockValidator methods
     //!
     bool TryManifest(CScraperManifest& manifest) const
     {
-        const ScraperStats stats = GetScraperStatsFromSingleManifest(manifest);
+        const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetScraperStatsFromSingleManifest(manifest);
 
-        return QuorumHash::Hash(stats) == m_quorum_hash;
+        return QuorumHash::Hash(stats_and_verified_beacons) == m_quorum_hash;
     }
 
     //!

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -405,6 +405,7 @@ public:
     //!  - No beacon exists for the CPID or it expired, or...
     //!  - A beacon for the CPID exists and elapsed the renewal threshold
     //!  - The wallet generated a new beacon key successfully if needed
+    //!  - The wallet signed the new beacon payload with its private key
     //!  - The wallet is fully unlocked
     //!  - The wallet contains a balance sufficient to send a transaction
     //!
@@ -412,6 +413,19 @@ public:
     //! description of the error that occurred.
     //!
     AdvertiseBeaconResult AdvertiseBeacon();
+
+    //!
+    //! \brief Submit a contract to the network to revoke an existing beacon.
+    //!
+    //! This process only works for the beacons that a node owns the private
+    //! keys for.
+    //!
+    //! \param cpid CPID associated with the beacon to delete.
+    //!
+    //! \return A variant that contains the public key of the deleted beacon if
+    //! successful or a description of the error that occurred.
+    //!
+    AdvertiseBeaconResult RevokeBeacon(const Cpid cpid);
 
     //!
     //! \brief Load legacy beacon private keys from the configuration file into

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -268,6 +268,8 @@ private:
             {
                 uint160 key_id;
 
+                m_hasher << COMPACTSIZE(stats_and_verified_beacons.mVerifiedMap.size());
+
                 for (const auto& entry_pair : stats_and_verified_beacons.mVerifiedMap) {
                     key_id.SetHex(entry_pair.first);
                     m_hasher << key_id;

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -10,6 +10,8 @@
 
 using namespace NN;
 
+extern std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
+
 std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 namespace {
@@ -532,6 +534,8 @@ Superblock Superblock::FromConvergence(
 
         projects.SetHint(project_name, part_data);
     }
+
+    superblock.m_verified_beacons = GetVerifiedBeaconIDs(stats.Convergence);
 
     return superblock;
 }

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -266,7 +266,12 @@ private:
             //!
             void Add(const ScraperStatsAndVerifiedBeacons& stats_and_verified_beacons)
             {
-                m_hasher << stats_and_verified_beacons.mVerifiedMap;
+                uint160 key_id;
+
+                for (const auto& entry_pair : stats_and_verified_beacons.mVerifiedMap) {
+                    key_id.SetHex(entry_pair.first);
+                    m_hasher << key_id;
+                }
             }
 
             //!

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1208,7 +1208,7 @@ public:
 
         READWRITE(m_cpids);
         READWRITE(m_projects);
-        //READWRITE(m_verified_beacons);
+        READWRITE(m_verified_beacons);
     }
 
     //!

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1173,7 +1173,7 @@ public:
 
         VerifiedBeacons() {};
 
-        void Add(const ScraperStatsAndVerifiedBeacons& stats_and_verified_beacons);
+        void Reset(const ScraperPendingBeaconMap& verified_beacon_id_map);
 
         ADD_SERIALIZE_METHODS;
 

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1175,34 +1175,12 @@ public:
 
         void Add(const ScraperStatsAndVerifiedBeacons& stats_and_verified_beacons);
 
-        template<typename Stream>
-        void Serialize(Stream& stream) const
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
         {
-            if (!(stream.GetType() & SER_GETHASH)) {
-                WriteCompactSize(stream, m_verified.size());
-            }
-
-            for (const auto& iter : m_verified)
-            {
-                stream << iter;
-            }
-        }
-
-        template<typename Stream>
-        void Unserialize(Stream& stream)
-        {
-            m_verified.clear();
-
-            const uint64_t verified_beacon_count = ReadCompactSize(stream);
-            m_verified.reserve(verified_beacon_count);
-
-            for (uint64_t i = 0; i < verified_beacon_count; i++)
-            {
-                uint160 beacon_key_id;
-                stream >> beacon_key_id;
-
-                m_verified.emplace_back(std::move(beacon_key_id));
-            }
+            READWRITE(m_verified);
         }
     };
 

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1185,7 +1185,15 @@ public:
 
     CpidIndex m_cpids;       //!< Maps superblock CPIDs to magntudes.
     ProjectIndex m_projects; //!< Whitelisted projects statistics.
-    //std::vector<BeaconAcknowledgement> m_verified_beacons;
+
+    //!
+    //! \brief Contains the beacon IDs verified by scraper convergence.
+    //!
+    //! This contains a collection of the RIPEMD-160 hashes of the beacon public
+    //! keys verified by the scrapers. Nodes shall activate these beacons during
+    //! superblock processing.
+    //!
+    std::vector<uint160> m_verified_beacons;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -349,6 +349,7 @@ static const CRPCCommand vRPCCommands[] =
     { "myneuralhash",            &myneuralhash,            cat_mining        },
     { "neuralhash",              &neuralhash,              cat_mining        },
     { "resetcpids",              &resetcpids,              cat_mining        },
+    { "revokebeacon",            &revokebeacon,            cat_mining        },
     { "staketime",               &staketime,               cat_mining        },
     { "superblockage",           &superblockage,           cat_mining        },
     { "superblocks",             &superblocks,             cat_mining        },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -167,6 +167,7 @@ extern UniValue magnitude(const UniValue& params, bool fHelp);
 extern UniValue myneuralhash(const UniValue& params, bool fHelp);
 extern UniValue neuralhash(const UniValue& params, bool fHelp);
 extern UniValue resetcpids(const UniValue& params, bool fHelp);
+extern UniValue revokebeacon(const UniValue& params, bool fHelp);
 extern UniValue staketime(const UniValue& params, bool fHelp);
 extern UniValue superblockage(const UniValue& params, bool fHelp);
 extern UniValue superblocks(const UniValue& params, bool fHelp);

--- a/src/scraper/fwd.h
+++ b/src/scraper/fwd.h
@@ -130,6 +130,57 @@ struct ScraperObjectStatsKeyComp
 
 typedef std::map<ScraperObjectStatsKey, ScraperObjectStats, ScraperObjectStatsKeyComp> ScraperStats;
 
+// This is modeled after AppCacheEntry/Section but named separately.
+struct ScraperBeaconEntry
+{
+    std::string value; //!< Value of entry.
+    int64_t timestamp; //!< Timestamp of entry.
+};
+
+typedef std::map<std::string, ScraperBeaconEntry> ScraperBeaconMap;
+
+struct ScraperPendingBeaconEntry
+{
+    std::string cpid;
+    int64_t timestamp;
+
+    template<typename Stream>
+    void Serialize(Stream& stream) const
+    {
+        stream << cpid;
+        stream << timestamp;
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& stream)
+    {
+        stream >> cpid;
+        stream >> timestamp;
+    }
+};
+
+typedef std::map<std::string, ScraperPendingBeaconEntry> ScraperPendingBeaconMap;
+
+struct BeaconConsensus
+{
+    uint256 nBlockHash;
+    ScraperBeaconMap mBeaconMap;
+    ScraperPendingBeaconMap mPendingMap;
+};
+
+struct ScraperVerifiedBeacons
+{
+    // Initialize the timestamp to the current adjusted time.
+    int64_t timestamp = GetAdjustedTime();
+    ScraperPendingBeaconMap mVerifiedMap;
+};
+
+struct ScraperStatsAndVerifiedBeacons
+{
+    ScraperStats mScraperStats;
+    ScraperPendingBeaconMap mVerifiedMap;
+};
+
 // Extended AppCache structures similar to those in AppCache.h, except a deleted flag is provided
 struct AppCacheEntryExt
 {

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -3957,7 +3957,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
         manifest->BeaconList = iPartNum;
         manifest->BeaconList_c = 0;
 
-        CDataStream part(vchData, SER_NETWORK, 1);
+        CDataStream part(std::move(vchData), SER_NETWORK, 1);
 
         manifest->addPartData(std::move(part));
 
@@ -3990,8 +3990,6 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
             manifest->projects.push_back(ProjectEntry);
 
             CDataStream part(SER_NETWORK, 1);
-
-            WriteCompactSize(part, ScraperVerifiedBeacons.mVerifiedMap.size());
 
             part << ScraperVerifiedBeacons.mVerifiedMap;
 
@@ -4866,9 +4864,9 @@ std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConverg
 
         for (const auto& entry : VerifiedBeaconMap)
         {
-            CPubKey PubKey;
+            CKeyID KeyID;
 
-            CKeyID KeyID = PubKey.Parse(entry.first).GetID();
+            KeyID.SetHex(entry.first);
 
             result.push_back(KeyID);
         }

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -275,6 +275,7 @@ void UpdateVerifiedBeaconsFromConsensus(BeaconConsensus& Consensus)
     unsigned int now_active = 0;
 
     LOCK(cs_VerifiedBeacons);
+    _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
     ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -299,6 +300,8 @@ void UpdateVerifiedBeaconsFromConsensus(BeaconConsensus& Consensus)
         _log(logattribute::INFO, "UpdateVerifiedBeaconsFromConsensus", std::to_string(now_active)
              + " verified beacons now active and removed from verified beacon map.");
     }
+
+    _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
 }
 } // anonymous namespace
 
@@ -988,9 +991,9 @@ void Scraper(bool bSingleShot)
                 fs::path plogfile_out;
 
                 if (log.archive(false, plogfile_out))
+                {
                     _log(logattribute::INFO, "Scraper", "Archived scraper.log to " + plogfile_out.filename().string());
-
-                //log.closelogfile();
+                }
 
                 sbage = SuperblockAge();
                 _log(logattribute::INFO, "Scraper", "Superblock not needed. age=" + std::to_string(sbage));
@@ -2062,6 +2065,7 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
     }
 
     LOCK(cs_VerifiedBeacons);
+    _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
     ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -2144,6 +2148,8 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
         }
         else
             builder.append(line);
+
+        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
     }
 
     if (bfileerror)
@@ -3181,11 +3187,10 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByConsensusBeaconList()
 
     // Since this function uses the current project files for statistics, it also makes sense to use the current verified beacons map.
 
-    ScraperVerifiedBeacons verified_beacons;
-
     LOCK(cs_VerifiedBeacons);
+    _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
-    verified_beacons = GetVerifiedBeacons();
+    ScraperVerifiedBeacons& verified_beacons = GetVerifiedBeacons();
 
     ScraperStatsAndVerifiedBeacons stats_and_verified_beacons;
 
@@ -3193,6 +3198,8 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByConsensusBeaconList()
     stats_and_verified_beacons.mVerifiedMap = verified_beacons.mVerifiedMap;
 
     _log(logattribute::INFO, "GetScraperStatsByConsensusBeaconList", "Completed stats processing");
+
+    _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
 
     return stats_and_verified_beacons;
 }
@@ -3975,6 +3982,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
     // because it will never match any whitelisted project. Only include it if it is not empty.
     {
         LOCK(cs_VerifiedBeacons);
+        _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
         ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -4003,6 +4011,8 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
 
             iPartNum++;
         }
+
+        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
     }
 
 

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -5002,7 +5002,7 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bCon
                     ConvergedScraperStatsCache.nTime = GetAdjustedTime();
                     ConvergedScraperStatsCache.Convergence = StructConvergedManifest;
 
-                    if (IsV11Enabled(nBestHeight)) {
+                    if (IsV11Enabled(nBestHeight + 1)) {
                         superblock = NN::Superblock::FromConvergence(ConvergedScraperStatsCache);
                     } else {
                         superblock = NN::Superblock::FromConvergence(ConvergedScraperStatsCache, 1);

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -4567,7 +4567,7 @@ bool ScraperConstructConvergedManifestByProject(const NN::WhitelistSnapshot& pro
             // must be greater than zero, or else the VerifiedBeacons was not included in the
             // manifest. Note it does NOT have to be present, but needs to be put in the
             // converged manifest if it is.
-            if (nPart)
+            if (nPart > 0)
             {
                 StructConvergedManifest.ConvergedManifestPartsMap.insert(std::make_pair("VerifiedBeacons", manifest.vParts[nPart]->data));
             }

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -122,6 +122,7 @@ bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& Pub
 NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
 bool ScraperSynchronizeDPOR();
 scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperblock, bool bUseCache = true, unsigned int nReducedCacheBits = 32);
+std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
 
 static std::vector<std::string> vstatsobjecttypestrings = { "NetWorkWide", "byCPID", "byProject", "byCPIDbyProject" };
 

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -114,7 +114,7 @@ CCriticalSection cs_mScrapersExt;
 *********************/
 
 uint256 GetFileHash(const fs::path& inputfile);
-ScraperStats GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
+ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
 std::string ExplainMagnitude(std::string sCPID);
 bool IsScraperAuthorized();
 bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& KeyOut);
@@ -123,6 +123,8 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, b
 bool ScraperSynchronizeDPOR();
 scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperblock, bool bUseCache = true, unsigned int nReducedCacheBits = 32);
 std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
+std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& VerifiedBeaconMap);
+ScraperStatsAndVerifiedBeacons GetScraperStatsAndVerifiedBeacons(const ConvergedScraperStats &stats);
 
 static std::vector<std::string> vstatsobjecttypestrings = { "NetWorkWide", "byCPID", "byProject", "byCPIDbyProject" };
 

--- a/src/test/neuralnet/researcher_tests.cpp
+++ b/src/test/neuralnet/researcher_tests.cpp
@@ -73,15 +73,21 @@ boost::test_tools::assertion_result ClientStateStubExists(boost::unit_test::test
 void AddTestBeacon(const NN::Cpid cpid)
 {
     // TODO: mock the beacon registry
+    CPubKey public_key = CPubKey(ParseHex(
+        "111111111111111111111111111111111111111111111111111111111111111111"));
+
+    const CKeyID key_id = public_key.GetID();
+    const int64_t now = GetAdjustedTime();
+
     NN::Contract contract = NN::MakeContract<NN::BeaconPayload>(
         NN::ContractAction::ADD,
         cpid,
-        CPubKey(ParseHex(
-            "111111111111111111111111111111111111111111111111111111111111111111")));
+        std::move(public_key));
 
-    contract.m_tx_timestamp = GetAdjustedTime();
+    contract.m_tx_timestamp = now;
 
     NN::GetBeaconRegistry().Add(std::move(contract));
+    NN::GetBeaconRegistry().ActivatePending({ key_id }, now);
 }
 
 //!
@@ -92,13 +98,18 @@ void AddTestBeacon(const NN::Cpid cpid)
 void AddExpiredTestBeacon(const NN::Cpid cpid)
 {
     // TODO: mock the beacon registry
+    CPubKey public_key = CPubKey(ParseHex(
+        "111111111111111111111111111111111111111111111111111111111111111111"));
+
+    const CKeyID key_id = public_key.GetID();
+
     NN::Contract contract = NN::MakeContract<NN::BeaconPayload>(
         NN::ContractAction::ADD,
         cpid,
-        CPubKey(ParseHex(
-            "111111111111111111111111111111111111111111111111111111111111111111")));
+        std::move(public_key));
 
     NN::GetBeaconRegistry().Add(std::move(contract));
+    NN::GetBeaconRegistry().ActivatePending({ key_id }, 0);
 }
 
 //!
@@ -109,13 +120,17 @@ void AddExpiredTestBeacon(const NN::Cpid cpid)
 void RemoveTestBeacon(const NN::Cpid cpid)
 {
     // TODO: mock the beacon registry
+    CPubKey public_key = CPubKey(ParseHex(
+        "111111111111111111111111111111111111111111111111111111111111111111"));
+
+    //const CKeyID key_id = public_key.GetID();
+
     NN::Contract contract = NN::MakeContract<NN::BeaconPayload>(
         NN::ContractAction::ADD,
         cpid,
-        CPubKey());
+        std::move(public_key));
 
-    contract.m_tx_timestamp = GetAdjustedTime();
-
+    NN::GetBeaconRegistry().Deactivate(0);
     NN::GetBeaconRegistry().Delete(contract);
 }
 } // anonymous namespace

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -883,7 +883,8 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
         << meta.project2
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
-        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock = NN::Superblock::FromConvergence(GetTestConvergence(meta));
 
@@ -927,7 +928,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
         << meta.project2
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
-        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock;
     stream >> superblock;
@@ -1004,7 +1006,8 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_fallback_convergences)
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
         << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
-        << uint32_t{0xd3591376};                        // Convergence hint
+        << uint32_t{0xd3591376}                         // Convergence hint
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock = NN::Superblock::FromConvergence(
         GetTestConvergence(meta, true)); // Set fallback by project flag
@@ -1054,7 +1057,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_fallback_convergence)
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
         << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
-        << uint32_t{0xd3591376};                        // Convergence hint
+        << uint32_t{0xd3591376}                         // Convergence hint
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock;
     stream >> superblock;

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -281,9 +281,9 @@ struct ScraperStatsMeta
 //!
 //! \param meta Contains the values to initialize the scraper stats object with.
 //!
-ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
+const ScraperStatsAndVerifiedBeacons GetTestScraperStats(const ScraperStatsMeta& meta)
 {
-    ScraperStats stats;
+    ScraperStatsAndVerifiedBeacons stats_and_verified_beacons;
 
     ScraperObjectStats p1c1;
     p1c1.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -292,7 +292,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1c1.statsvalue.dRAC = meta.p1c1_rac;
     p1c1.statsvalue.dAvgRAC = meta.p1c1_avg_rac;
     p1c1.statsvalue.dMag = meta.p1c1_mag;
-    stats.emplace(p1c1.statskey, p1c1);
+    stats_and_verified_beacons.mScraperStats.emplace(p1c1.statskey, p1c1);
 
     ScraperObjectStats p1c2;
     p1c2.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -301,7 +301,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1c2.statsvalue.dRAC = meta.p1c2_rac;
     p1c2.statsvalue.dAvgRAC = meta.p1c2_avg_rac;
     p1c2.statsvalue.dMag = meta.p1c2_mag;
-    stats.emplace(p1c2.statskey, p1c2);
+    stats_and_verified_beacons.mScraperStats.emplace(p1c2.statskey, p1c2);
 
     ScraperObjectStats p2c1;
     p2c1.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -310,7 +310,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2c1.statsvalue.dRAC = meta.p2c1_rac;
     p2c1.statsvalue.dAvgRAC = meta.p2c1_avg_rac;
     p2c1.statsvalue.dMag = meta.p2c1_mag;
-    stats.emplace(p2c1.statskey, p2c1);
+    stats_and_verified_beacons.mScraperStats.emplace(p2c1.statskey, p2c1);
 
     ScraperObjectStats p2c2;
     p2c2.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -319,7 +319,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2c2.statsvalue.dRAC = meta.p2c2_rac;
     p2c2.statsvalue.dAvgRAC = meta.p2c2_avg_rac;
     p2c2.statsvalue.dMag = meta.p2c2_mag;
-    stats.emplace(p2c2.statskey, p2c2);
+    stats_and_verified_beacons.mScraperStats.emplace(p2c2.statskey, p2c2);
 
     ScraperObjectStats p1c3;
     p1c3.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -328,7 +328,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1c3.statsvalue.dRAC = meta.p1c3_rac;
     p1c3.statsvalue.dAvgRAC = meta.p1c3_avg_rac;
     p1c3.statsvalue.dMag = meta.p1c3_mag;
-    stats.emplace(p1c2.statskey, p1c3);
+    stats_and_verified_beacons.mScraperStats.emplace(p1c2.statskey, p1c3);
 
     ScraperObjectStats p2c3;
     p2c3.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -337,7 +337,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2c3.statsvalue.dRAC = meta.p2c3_rac;
     p2c3.statsvalue.dAvgRAC = meta.p2c3_avg_rac;
     p2c3.statsvalue.dMag = meta.p2c3_mag;
-    stats.emplace(p2c2.statskey, p2c3);
+    stats_and_verified_beacons.mScraperStats.emplace(p2c2.statskey, p2c3);
 
     ScraperObjectStats c1;
     c1.statskey.objecttype = statsobjecttype::byCPID;
@@ -346,7 +346,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     c1.statsvalue.dRAC = meta.c1_rac;
     c1.statsvalue.dAvgRAC = meta.c1_rac;
     c1.statsvalue.dMag = meta.c1_mag;
-    stats.emplace(c1.statskey, c1);
+    stats_and_verified_beacons.mScraperStats.emplace(c1.statskey, c1);
 
     ScraperObjectStats c2;
     c2.statskey.objecttype = statsobjecttype::byCPID;
@@ -355,7 +355,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     c2.statsvalue.dRAC = meta.c2_rac;
     c2.statsvalue.dAvgRAC = meta.c2_rac;
     c2.statsvalue.dMag = meta.c2_mag;
-    stats.emplace(c2.statskey, c2);
+    stats_and_verified_beacons.mScraperStats.emplace(c2.statskey, c2);
 
     ScraperObjectStats c3;
     c3.statskey.objecttype = statsobjecttype::byCPID;
@@ -364,7 +364,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     c3.statsvalue.dRAC = meta.c3_rac;
     c3.statsvalue.dAvgRAC = meta.c3_rac;
     c3.statsvalue.dMag = meta.c3_mag;
-    stats.emplace(c3.statskey, c3);
+    stats_and_verified_beacons.mScraperStats.emplace(c3.statskey, c3);
 
     ScraperObjectStats p1;
     p1.statskey.objecttype = statsobjecttype::byProject;
@@ -373,7 +373,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1.statsvalue.dRAC = meta.p1_rac;
     p1.statsvalue.dAvgRAC = meta.p1_avg_rac;
     p1.statsvalue.dMag = meta.p1_mag;
-    stats.emplace(p1.statskey, p1);
+    stats_and_verified_beacons.mScraperStats.emplace(p1.statskey, p1);
 
     ScraperObjectStats p2;
     p2.statskey.objecttype = statsobjecttype::byProject;
@@ -382,9 +382,11 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2.statsvalue.dRAC = meta.p2_rac;
     p2.statsvalue.dAvgRAC = meta.p2_avg_rac;
     p2.statsvalue.dMag = meta.p2_mag;
-    stats.emplace(p2.statskey, p2);
+    stats_and_verified_beacons.mScraperStats.emplace(p2.statskey, p2);
 
-    return stats;
+    //TODO: Put in verified beacon map.
+
+    return stats_and_verified_beacons;
 }
 
 //!
@@ -399,7 +401,7 @@ ConvergedScraperStats GetTestConvergence(
 {
     ConvergedScraperStats convergence;
 
-    convergence.mScraperConvergedStats = GetTestScraperStats(meta);
+    convergence.mScraperConvergedStats = GetTestScraperStats(meta).mScraperStats;
 
     convergence.Convergence.bByParts = by_parts;
     convergence.Convergence.nContentHash
@@ -412,6 +414,8 @@ ConvergedScraperStats GetTestConvergence(
     //
     convergence.Convergence.ConvergedManifestPartsMap.emplace("project_1", CSerializeData());
     convergence.Convergence.ConvergedManifestPartsMap.emplace("project_2", CSerializeData());
+
+    //TODO: should we add a VerifiedBeacons project here?
 
     return convergence;
 }
@@ -1942,10 +1946,10 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
 BOOST_AUTO_TEST_CASE(it_hashes_a_set_of_scraper_statistics_like_a_superblock)
 {
     const ScraperStatsMeta meta;
-    const ScraperStats stats = GetTestScraperStats(meta);
+    const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetTestScraperStats(meta);
 
-    NN::Superblock superblock = NN::Superblock::FromStats(stats);
-    NN::QuorumHash quorum_hash = NN::QuorumHash::Hash(stats);
+    NN::Superblock superblock = NN::Superblock::FromStats(stats_and_verified_beacons);
+    NN::QuorumHash quorum_hash = NN::QuorumHash::Hash(stats_and_verified_beacons);
 
     BOOST_CHECK(quorum_hash == superblock.GetHash());
 }

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -1934,7 +1934,8 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
         << meta.project2
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
-        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << std::vector<uint160> {};                     // Verified beacons
 
     const uint256 expected = expected_hasher.GetHash();
 
@@ -2093,7 +2094,8 @@ BOOST_AUTO_TEST_CASE(it_compares_a_sha256_hash_for_equality)
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash())
             .GetHash()
-        << VARINT(uint32_t{0}); // Zero-magnitude count
+        << VARINT(uint32_t{0})      // Zero-magnitude count
+        << std::vector<uint160> {}; // Verified beacons
 
     // Hashed byte content of an empty superblock. Note that container sizes
     // are not considered in the hash:
@@ -2119,7 +2121,8 @@ BOOST_AUTO_TEST_CASE(it_compares_a_string_for_equality)
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash())
             .GetHash()
-        << VARINT(uint32_t{0}); // Zero-magnitude count
+        << VARINT(uint32_t{0})      // Zero-magnitude count
+        << std::vector<uint160> {}; // Verified beacons
 
     // Hashed byte content of an empty superblock. Note that container sizes
     // are not considered in the hash:


### PR DESCRIPTION
This adds the ability for a participant to delete their own beacons when they own the private keys. It replaces the current process which requires digging through coin control to find the beacon address to send a transaction from.

I added a `revokebeacon` RPC function which requires an explicit CPID parameter to help prevent mistakes when a wallet contains keys for more than one beacon. A user may choose which (active) beacon to delete by passing the CPID associated with that beacon to this RPC.