### PR TITLE
Touch up some details for block version 11

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2717,7 +2717,7 @@ bool GridcoinConnectBlock(
 bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 {
     // Check it again in case a previous version let a bad block in, but skip BlockSig checking
-    if (!CheckBlock("ConnectBlock",pindex->pprev->nHeight, 395*COIN, !fJustCheck, !fJustCheck, false,false))
+    if (!CheckBlock("ConnectBlock",pindex->nHeight, 395*COIN, !fJustCheck, !fJustCheck, false,false))
     {
         LogPrintf("ConnectBlock::Failed - ");
         return false;
@@ -3856,7 +3856,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
     }
 
     // Preliminary checks
-    if (!pblock->CheckBlock("ProcessBlock", pindexBest->nHeight, 100*COIN))
+    if (!pblock->CheckBlock("ProcessBlock", pindexBest->nHeight + 1, 100*COIN))
         return error("ProcessBlock() : CheckBlock FAILED");
 
     // If don't already have its previous block, shunt it off to holding area until we get it

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2722,14 +2722,17 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
         LogPrintf("ConnectBlock::Failed - ");
         return false;
     }
-    //// issue here: it doesn't know the version
+
     unsigned int nTxPos;
-    if (fJustCheck)
+    if (fJustCheck) {
         // FetchInputs treats CDiskTxPos(1,1,1) as a special "refer to memorypool" indicator
         // Since we're just checking the block and not actually connecting it, it might not (and probably shouldn't) be on the disk to get the transaction from
         nTxPos = 1;
-    else
-        nTxPos = pindex->nBlockPos + ::GetSerializeSize(CBlock(), SER_DISK, CLIENT_VERSION) - (2 * GetSizeOfCompactSize(0)) + GetSizeOfCompactSize(vtx.size());
+    } else {
+        nTxPos = pindex->nBlockPos
+            + ::GetSerializeSize<CBlockHeader>(*this, SER_DISK, CLIENT_VERSION)
+            + GetSizeOfCompactSize(vtx.size());
+    }
 
     map<uint256, CTxIndex> mapQueuedChanges;
     int64_t nFees = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -1063,7 +1063,7 @@ public:
 class CBlockHeader
 {
 public:
-    static const int32_t CURRENT_VERSION = 10;
+    static const int32_t CURRENT_VERSION = 11;
 
     // header
     int32_t nVersion;

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -1609,6 +1609,10 @@ void Quorum::LoadSuperblockIndex(const CBlockIndex* pindexLast)
     }
 
     g_superblock_index.Reload(pindexLast);
+
+    if (pindexLast->nVersion >= 11) {
+        g_superblock_index.Commit(pindexLast->nHeight);
+    }
 }
 
 Superblock Quorum::CreateSuperblock()

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -123,7 +123,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
     result.pushKV("version", block.nVersion);
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
     result.pushKV("mint", ValueFromAmount(blockindex->nMint));
-    result.pushKV("MoneySupply", blockindex->nMoneySupply);
+    result.pushKV("MoneySupply", ValueFromAmount(blockindex->nMoneySupply));
     result.pushKV("time", block.GetBlockTime());
     result.pushKV("nonce", (uint64_t)block.nNonce);
     result.pushKV("bits", strprintf("%08x", block.nBits));


### PR DESCRIPTION
This fixes issues caused by some overlooked details for the updated fields in block version 11 that prevent a node from transitioning to the new format.