### PR TITLE
Add support for type-specific contract fee amounts

### DIFF
--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -280,6 +280,16 @@ public:
     }
 
     //!
+    //! \brief Get the burn fee amount required to send a particular contract.
+    //!
+    //! \return Burn fee in units of 1/100000000 GRC.
+    //!
+    int64_t RequiredBurnAmount() const override
+    {
+        return 0.5 * COIN;
+    }
+
+    //!
     //! \brief Sign the beacon with its private key.
     //!
     //! \param private_key Corresponds to the beacon's public key.

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -45,6 +45,11 @@ public:
         return "";
     }
 
+    int64_t RequiredBurnAmount() const override
+    {
+        return MAX_MONEY;
+    }
+
     ADD_CONTRACT_PAYLOAD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
@@ -108,6 +113,11 @@ public:
     std::string LegacyValueString() const override
     {
         return m_value;
+    }
+
+    int64_t RequiredBurnAmount() const override
+    {
+        return Contract::STANDARD_BURN_AMOUNT;
     }
 
     ADD_CONTRACT_PAYLOAD_SERIALIZE_METHODS;
@@ -383,7 +393,7 @@ void NN::RevertContracts(const std::vector<Contract>& contracts)
 // Class: Contract
 // -----------------------------------------------------------------------------
 
-constexpr int64_t Contract::BURN_AMOUNT; // for clang
+constexpr int64_t Contract::STANDARD_BURN_AMOUNT; // for clang
 
 Contract::Contract()
     : m_version(Contract::CURRENT_VERSION)
@@ -566,6 +576,11 @@ const CPubKey& Contract::ResolvePublicKey() const
     }
 
     return m_public_key.Key();
+}
+
+int64_t Contract::RequiredBurnAmount() const
+{
+    return m_body.m_payload->RequiredBurnAmount();
 }
 
 bool Contract::WellFormed() const

--- a/src/neuralnet/contract/contract.h
+++ b/src/neuralnet/contract/contract.h
@@ -150,7 +150,7 @@ public:
     //! \brief The amount of coin set for a burn output in a transaction that
     //! broadcasts a contract in units of 1/100000000 GRC.
     //!
-    static constexpr int64_t BURN_AMOUNT = 0.5 * COIN;
+    static constexpr int64_t STANDARD_BURN_AMOUNT = 0.5 * COIN;
 
     //!
     //! \brief A contract type from a transaction message.
@@ -562,6 +562,13 @@ public:
     //! \return The appropriate public key for the contract type.
     //!
     const CPubKey& ResolvePublicKey() const;
+
+    //!
+    //! \brief Get the burn fee amount required to send a particular contract.
+    //!
+    //! \return Burn fee in units of 1/100000000 GRC.
+    //!
+    int64_t RequiredBurnAmount() const;
 
     //!
     //! \brief Determine whether the instance represents a complete contract.

--- a/src/neuralnet/contract/message.cpp
+++ b/src/neuralnet/contract/message.cpp
@@ -52,14 +52,19 @@ bool SelectMasterInputOutput(CCoinControl& coin_control)
 //!
 //! \param wtx_new     A new transaction with a contract.
 //! \param reserve_key Key reserved for any change.
-//! \param admin       \c true for an administrative contract.
+//! \param burn_fee    Total burn fee required for contracts in the transaction.
 //!
 //! \return \c true if coin selection succeeded.
 //!
-bool CreateContractTx(CWalletTx& wtx_out, CReserveKey reserve_key, bool admin)
+bool CreateContractTx(CWalletTx& wtx_out, CReserveKey reserve_key, int64_t burn_fee)
 {
     CCoinControl coin_control_out;
     int64_t applied_fee_out; // Unused
+    bool admin = false;
+
+    for (const auto& contract : wtx_out.vContracts) {
+        admin |= contract.RequiresMasterKey();
+    }
 
     // Configure inputs/outputs for the address associated with the master key.
     // Nodes validate administrative contracts by checking that the containing
@@ -79,7 +84,7 @@ bool CreateContractTx(CWalletTx& wtx_out, CReserveKey reserve_key, bool admin)
     scriptPubKey << OP_RETURN;
 
     return pwalletMain->CreateTransaction(
-        { std::make_pair(std::move(scriptPubKey), Contract::BURN_AMOUNT) },
+        { std::make_pair(std::move(scriptPubKey), burn_fee) },
         wtx_out,
         reserve_key,
         applied_fee_out,
@@ -90,12 +95,11 @@ bool CreateContractTx(CWalletTx& wtx_out, CReserveKey reserve_key, bool admin)
 //! \brief Send a transaction that contains a contract.
 //!
 //! \param wtx_new A new transaction with a contract.
-//! \param admin   \c true for an administrative contract.
 //!
 //! \return An empty string when successful or a description of the error that
 //! occurred. TODO: Refactor to remove string-based signaling.
 //!
-std::string SendContractTx(CWalletTx& wtx_new, const bool admin)
+std::string SendContractTx(CWalletTx& wtx_new)
 {
     CReserveKey reserve_key(pwalletMain);
 
@@ -112,14 +116,19 @@ std::string SendContractTx(CWalletTx& wtx_new, const bool admin)
     }
 
     int64_t balance = pwalletMain->GetBalance();
+    int64_t burn_fee = 0;
 
-    if (balance < COIN || balance < Contract::BURN_AMOUNT + nTransactionFee) {
+    for (const auto& contract : wtx_new.vContracts) {
+        burn_fee += contract.RequiredBurnAmount();
+    }
+
+    if (balance < COIN || balance < burn_fee + nTransactionFee) {
         std::string strError = _("Balance too low to create a contract.");
         LogPrintf("%s: %s", __func__, strError);
         return strError;
     }
 
-    if (!CreateContractTx(wtx_new, reserve_key, admin)) {
+    if (!CreateContractTx(wtx_new, reserve_key, burn_fee)) {
         std::string strError = _("Error: Transaction creation failed.");
         LogPrintf("%s: %s", __func__, strError);
         return strError;
@@ -175,7 +184,7 @@ std::pair<CWalletTx, std::string> NN::SendContract(Contract contract)
 
     wtx.vContracts.emplace_back(std::move(contract));
 
-    std::string error = SendContractTx(wtx, contract.RequiresMasterKey());
+    std::string error = SendContractTx(wtx);
 
     return std::make_pair(std::move(wtx), std::move(error));
 }

--- a/src/neuralnet/contract/payload.h
+++ b/src/neuralnet/contract/payload.h
@@ -115,6 +115,13 @@ public:
     virtual std::string LegacyValueString() const = 0;
 
     //!
+    //! \brief Get the burn fee amount required to send a particular contract.
+    //!
+    //! \return Burn fee in units of 1/100000000 GRC.
+    //!
+    virtual int64_t RequiredBurnAmount() const = 0;
+
+    //!
     //! \brief Serialize the contract to the provided file.
     //!
     virtual void Serialize(CAutoFile& s, const ContractAction action) const = 0;

--- a/src/neuralnet/project.h
+++ b/src/neuralnet/project.h
@@ -112,6 +112,16 @@ public:
     }
 
     //!
+    //! \brief Get the burn fee amount required to send a particular contract.
+    //!
+    //! \return Burn fee in units of 1/100000000 GRC.
+    //!
+    int64_t RequiredBurnAmount() const override
+    {
+        return 0.5 * COIN; // TODO: reduce fee for admin contracts?
+    }
+
+    //!
     //! \brief Get a user-friendly display name created from the project key.
     //!
     std::string DisplayName() const;

--- a/src/test/neuralnet/beacon_tests.cpp
+++ b/src/test/neuralnet/beacon_tests.cpp
@@ -271,6 +271,7 @@ BOOST_AUTO_TEST_CASE(it_behaves_like_a_contract_payload)
     BOOST_CHECK(payload.WellFormed(NN::ContractAction::ADD) == true);
     BOOST_CHECK(payload.LegacyKeyString() == cpid.ToString());
     BOOST_CHECK(payload.LegacyValueString() == payload.m_beacon.ToString());
+    BOOST_CHECK(payload.RequiredBurnAmount() > 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_whether_the_payload_is_well_formed_for_add)

--- a/src/test/neuralnet/contract_tests.cpp
+++ b/src/test/neuralnet/contract_tests.cpp
@@ -39,6 +39,11 @@ public:
         return m_data;
     }
 
+    int64_t RequiredBurnAmount() const override
+    {
+        return NN::Contract::STANDARD_BURN_AMOUNT;
+    }
+
     ADD_CONTRACT_PAYLOAD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
@@ -940,6 +945,13 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_legacy_v1_contract_is_valid)
 
     contract = NN::Contract::Parse("<MESSAGE></MESSAGE>", 123);
     BOOST_CHECK(contract.Validate() == false);
+}
+
+BOOST_AUTO_TEST_CASE(it_determines_the_requred_burn_fee)
+{
+    const NN::Contract contract = TestMessage::Current();
+
+    BOOST_CHECK(contract.RequiredBurnAmount() > 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_provides_access_to_the_contract_payload)

--- a/src/test/neuralnet/project_tests.cpp
+++ b/src/test/neuralnet/project_tests.cpp
@@ -104,6 +104,7 @@ BOOST_AUTO_TEST_CASE(it_behaves_like_a_contract_payload)
     BOOST_CHECK(project.WellFormed(NN::ContractAction::ADD) == true);
     BOOST_CHECK(project.LegacyKeyString() == "Enigma");
     BOOST_CHECK(project.LegacyValueString() == "http://enigma.test/@");
+    BOOST_CHECK(project.RequiredBurnAmount() > 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_whether_the_payload_is_well_formed_for_add)


### PR DESCRIPTION
This adds the ability to define contract burn amounts for each contract type rather than forcing a universal fee. I left the fees as those were before. We can update these as needed.