### PR TITLE
Finish the conversion to the BCLog class based logger

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -302,7 +302,7 @@ void CAddrMan::Good_(const CService &addr, int64_t nTime)
     // TODO: maybe re-add the node, but for now, just bail out
     if (nUBucket == -1) return;
 
-    LogPrint("addrman", "Moving %s to tried", addr.ToString());
+    LogPrint(BCLog::LogFlags::ADDRMAN, "Moving %s to tried", addr.ToString());
 
     // move nId to the tried tables
     MakeTried(info, nId, nUBucket);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -403,7 +403,7 @@ public:
             LOCK(cs);
             int err;
             if ((err=Check_()))
-                LogPrint("addrman", "ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i", err);
+                LogPrint(BCLog::LogFlags::ADDRMAN, "ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i", err);
         }
 #endif
     }
@@ -419,7 +419,7 @@ public:
             Check();
         }
         if (fRet)
-            LogPrint("addrman","Added %s from %s: %i tried, %i new", addr.ToStringIPPort(), source.ToString(), nTried, nNew);
+            LogPrint(BCLog::LogFlags::ADDRMAN,"Added %s from %s: %i tried, %i new", addr.ToStringIPPort(), source.ToString(), nTried, nNew);
         return fRet;
     }
 
@@ -435,7 +435,7 @@ public:
             Check();
         }
         if (nAdd)
-            LogPrint("addrman","Added %i addresses from %s: %i tried, %i new", nAdd, source.ToString(), nTried, nNew);
+            LogPrint(BCLog::LogFlags::ADDRMAN,"Added %i addresses from %s: %i tried, %i new", nAdd, source.ToString(), nTried, nNew);
         return nAdd > 0;
     }
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -213,13 +213,13 @@ bool CAlert::ProcessAlert(bool fThread)
             const CAlert& alert = (*mi).second;
             if (Cancels(alert))
             {
-                LogPrint("alert", "cancelling alert %d", alert.nID);
+                LogPrint(BCLog::LogFlags::ALERT, "cancelling alert %d", alert.nID);
                 uiInterface.NotifyAlertChanged((*mi).first, CT_DELETED);
                 mapAlerts.erase(mi++);
             }
             else if (!alert.IsInEffect())
             {
-                LogPrint("alert", "expiring alert %d", alert.nID);
+                LogPrint(BCLog::LogFlags::ALERT, "expiring alert %d", alert.nID);
                 uiInterface.NotifyAlertChanged((*mi).first, CT_DELETED);
                 mapAlerts.erase(mi++);
             }
@@ -233,7 +233,7 @@ bool CAlert::ProcessAlert(bool fThread)
             const CAlert& alert = item.second;
             if (alert.Cancels(*this))
             {
-                LogPrint("alert", "alert already cancelled by %d", alert.nID);
+                LogPrint(BCLog::LogFlags::ALERT, "alert already cancelled by %d", alert.nID);
                 return false;
             }
         }
@@ -271,6 +271,6 @@ bool CAlert::ProcessAlert(bool fThread)
         }
     }
 
-    LogPrint("alert", "accepted alert %d, AppliesToMe()=%d", nID, AppliesToMe());
+    LogPrint(BCLog::LogFlags::ALERT, "accepted alert %d, AppliesToMe()=%d", nID, AppliesToMe());
     return true;
 }

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -23,7 +23,7 @@ BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t 
         SetBannedSetDirty(false); // no need to write down, just read data
         SweepBanned();            // sweep out unused entries
 
-        LogPrint("network", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
+        LogPrint(BCLog::LogFlags::NET, "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
             banmap.size(), GetTimeMillis() - n_start);
     } else {
         LogPrintf("Invalid or missing banlist.dat; recreating\n");
@@ -51,7 +51,7 @@ void BanMan::DumpBanlist()
         SetBannedSetDirty(false);
     }
 
-    LogPrint("network", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
+    LogPrint(BCLog::LogFlags::NET, "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
         banmap.size(), GetTimeMillis() - n_start);
 }
 
@@ -208,7 +208,7 @@ void BanMan::SweepBanned()
 
                 m_is_dirty = true;
                 notify_ui = true;
-                LogPrint("net", "%s: Removed banned node ip/subnet from banlist.dat: %s\n", __func__, sub_net.ToString());
+                LogPrint(BCLog::LogFlags::NET, "%s: Removed banned node ip/subnet from banlist.dat: %s\n", __func__, sub_net.ToString());
             } else
                 ++it;
         }

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -467,7 +467,7 @@ double ReturnVerifiedVotingBalance(std::string sXML, bool bCreatedAfterSecurityU
     double dTotalVotedBalance = RoundFromString(ExtractXML(sPayload,"<TOTALVOTEDBALANCE>","</TOTALVOTEDBALANCE>"),2);
     double dLegacyBalance = RoundFromString(ExtractXML(sXML,"<BALANCE>","</BALANCE>"),0);
 
-    if (fDebug10) LogPrintf("Total Voted Balance %f, Legacy Balance %f", dTotalVotedBalance, dLegacyBalance);
+    LogPrint(BCLog::LogFlags::NOISY, "Total Voted Balance %f, Legacy Balance %f", dTotalVotedBalance, dLegacyBalance);
     if (!bCreatedAfterSecurityUpgrade) return dLegacyBalance;
 
     double dCounted = 0;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -118,7 +118,7 @@ void CDBEnv::MakeMock()
     if (fShutdown)
         throw runtime_error("CDBEnv::MakeMock(): during shutdown");
 
-    LogPrint("db", "CDBEnv::MakeMock()");
+    LogPrint(BCLog::LogFlags::WALLETDB, "CDBEnv::MakeMock()");
 
     dbenv.set_cachesize(1, 0, 1);
     dbenv.set_lg_bsize(10485760*4);
@@ -452,7 +452,7 @@ void CDBEnv::Flush(bool fShutdown)
     int64_t nStart = GetTimeMillis();
     // Flush log data to the actual data file
     //  on all files that are not in use
-    LogPrint("db", "Flush(%s)%s", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
+    LogPrint(BCLog::LogFlags::WALLETDB, "Flush(%s)%s", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
     if (!fDbEnvInit)
         return;
     {
@@ -462,23 +462,23 @@ void CDBEnv::Flush(bool fShutdown)
         {
             string strFile = (*mi).first;
             int nRefCount = (*mi).second;
-            LogPrint("db", "%s refcount=%d", strFile, nRefCount);
+            LogPrint(BCLog::LogFlags::WALLETDB, "%s refcount=%d", strFile, nRefCount);
             if (nRefCount == 0)
             {
                 // Move log data to the dat file
                 CloseDb(strFile);
-                LogPrint("db", "%s checkpoint", strFile);
+                LogPrint(BCLog::LogFlags::WALLETDB, "%s checkpoint", strFile);
                 dbenv.txn_checkpoint(0, 0, 0);
-                LogPrint("db", "%s detach", strFile);
+                LogPrint(BCLog::LogFlags::WALLETDB, "%s detach", strFile);
                 if (!fMockDb)
                     dbenv.lsn_reset(strFile.c_str(), 0);
-                LogPrint("db", "%s closed", strFile);
+                LogPrint(BCLog::LogFlags::WALLETDB, "%s closed", strFile);
                 mapFileUseCount.erase(mi++);
             }
             else
                 mi++;
         }
-        LogPrint("db", "DBFlush(%s)%s ended %15" PRId64 "ms", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started", GetTimeMillis() - nStart);
+        LogPrint(BCLog::LogFlags::WALLETDB, "DBFlush(%s)%s ended %15" PRId64 "ms", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started", GetTimeMillis() - nStart);
         if (fShutdown)
         {
             char** listp;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -600,11 +600,8 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     // ********************************************************* Step 3: parameter-to-internal-flags
 
-    fDebug = false;
-
     if (GetArg("-debug", "false") == "true")
     {
-            fDebug = true;
             LogPrintf("Enabling debug category VERBOSE from legacy debug.");
             LogInstance().EnableCategory(BCLog::LogFlags::VERBOSE);
     }
@@ -732,7 +729,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         fDevbuildCripple = true;
         LogPrintf("WARNING: Running development version outside of testnet!\n"
                   "Staking and sending transactions will be disabled.");
-        if( (GetArg("-devbuild", "") == "override") && fDebug )
+        if( (GetArg("-devbuild", "") == "override") && LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
             fDevbuildCripple = false;
     }
 
@@ -1126,7 +1123,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     RandAddSeedPerfmon();
 
     //// debug print
-    if (fDebug)
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
     {
         LogPrintf("mapBlockIndex.size() = %" PRIszu,   mapBlockIndex.size());
         LogPrintf("nBestHeight = %d",            nBestHeight);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -608,14 +608,6 @@ bool AppInit2(ThreadHandlerPtr threads)
             LogPrintf("Entering debug mode.");
     }
 
-    fDebug2 = false;
-
-    if (GetArg("-debug2", "false") == "true")
-    {
-            fDebug2 = true;
-            LogPrintf("Entering GRC debug mode 2.");
-    }
-
     fDebug10 = false;
 
     if (GetArg("-debug10", "false") == "true")

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -605,15 +605,14 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (GetArg("-debug", "false") == "true")
     {
             fDebug = true;
-            LogPrintf("Entering debug mode.");
+            LogPrintf("Enabling debug category VERBOSE from legacy debug.");
+            LogInstance().EnableCategory(BCLog::LogFlags::VERBOSE);
     }
-
-    fDebug10 = false;
 
     if (GetArg("-debug10", "false") == "true")
     {
-            fDebug10 = true;
-            LogPrintf("Entering GRC debug mode 10.");
+            LogPrintf("Entering debug category NOISY from legacy debug mode 10.");
+            LogInstance().EnableCategory(BCLog::LogFlags::NOISY);
     }
 
 
@@ -1098,7 +1097,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     g_banman = MakeUnique<BanMan>(GetDataDir() / "banlist.dat", &uiInterface, GetArg("-bantime", DEFAULT_MISBEHAVING_BANTIME));
 
     uiInterface.InitMessage(_("Loading addresses..."));
-    if (fDebug10) LogPrintf("Loading addresses...");
+    LogPrint(BCLog::LogFlags::NOISY, "Loading addresses...");
     nStart = GetTimeMillis();
 
     {

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -280,10 +280,9 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     int64_t nModifierTime = 0;
     if (!GetLastStakeModifier(pindexPrev, nStakeModifier, nModifierTime))
         return error("ComputeNextStakeModifier: unable to get last modifier");
-    if (fDebug10)
-    {
-        LogPrintf("ComputeNextStakeModifier: prev modifier=0x%016" PRIx64 " time=%s", nStakeModifier, DateTimeStrFormat(nModifierTime));
-    }
+
+    LogPrint(BCLog::LogFlags::VERBOSE, "ComputeNextStakeModifier: prev modifier=0x%016" PRIx64 " time=%s", nStakeModifier, DateTimeStrFormat(nModifierTime));
+
     if (nModifierTime / nModifierInterval >= pindexPrev->GetBlockTime() / nModifierInterval)
         return true;
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -247,7 +247,7 @@ static bool SelectBlockFromCandidates(
         }
     }
 
-    if (fDebug && GetBoolArg("-printstakemodifier"))
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) && GetBoolArg("-printstakemodifier"))
         LogPrintf("SelectBlockFromCandidates: selection hash=%s", hashBest.ToString());
 
     return fSelected;
@@ -333,12 +333,12 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
         nStakeModifierNew |= (((uint64_t)pindex->GetStakeEntropyBit()) << nRound);
         // add the selected block from candidates to selected list
         mapSelectedBlocks.insert(make_pair(pindex->GetBlockHash(), pindex));
-        if (fDebug && GetBoolArg("-printstakemodifier"))
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) && GetBoolArg("-printstakemodifier"))
             LogPrintf("ComputeNextStakeModifier: selected round %d stop=%s height=%d bit=%d", nRound, DateTimeStrFormat(nSelectionIntervalStop), pindex->nHeight, pindex->GetStakeEntropyBit());
     }
 
     // Print selection map for visualization of the selected blocks
-    if (fDebug && GetBoolArg("-printstakemodifier"))
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) && GetBoolArg("-printstakemodifier"))
     {
         string strSelectionMap = "";
         // '-' indicates proof-of-work blocks not selected
@@ -360,7 +360,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
         LogPrintf("ComputeNextStakeModifier: selection height [%d, %d] map %s", nHeightFirstCandidate,
             pindexPrev->nHeight, strSelectionMap);
     }
-    if (fDebug)
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
     {
         LogPrintf("ComputeNextStakeModifier: new modifier=0x%016" PRIx64 " time=%s", nStakeModifierNew, DateTimeStrFormat(pindexPrev->GetBlockTime()));
     }
@@ -599,14 +599,14 @@ bool CheckProofOfStakeV8(
     bnTarget *= Weight;
 
 
-    if(fDebug) LogPrintf(
-"CheckProofOfStakeV8:%s Time1 %.f, Time2 %.f, Time3 %.f, Bits %u, Weight %.f\n"
-" Stk %72s\n"
-" Trg %72s", generated_by_me?" Local,":"",
-        (double)header.nTime, (double)txPrev.nTime, (double)tx.nTime,
-        Block.nBits, (double)Weight,
-        CBigNum(hashProofOfStake).GetHex(), bnTarget.GetHex()
-    );
+    LogPrint(BCLog::LogFlags::VERBOSE,
+             "CheckProofOfStakeV8:%s Time1 %.f, Time2 %.f, Time3 %.f, Bits %u, Weight %.f\n"
+             " Stk %72s\n"
+             " Trg %72s", generated_by_me?" Local,":"",
+             (double)header.nTime, (double)txPrev.nTime, (double)tx.nTime,
+             Block.nBits, (double)Weight,
+             CBigNum(hashProofOfStake).GetHex(), bnTarget.GetHex()
+             );
 
     // Now check if proof-of-stake hash meets target protocol
     return bnHashProof <= bnTarget;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -182,6 +182,9 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::TALLY, "tally"},
     {BCLog::ACCRUAL, "accrual"},
     {BCLog::CONTRACT, "contract"},
+    {BCLog::MINER, "miner"},
+    {BCLog::VERBOSE, "verbose"},
+    {BCLog::NOISY, "noisy"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -84,6 +84,8 @@ namespace BCLog {
         ACCRUAL     = (1 << 26),
         CONTRACT    = (1 << 27),
         MINER       = (1 << 28),
+        VERBOSE     = (1 << 29), // This corresponds to the old horizontal category "debug".
+        NOISY        = (1 << 30), // This corresponds to the old horizontal category "debug10".
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -83,6 +83,7 @@ namespace BCLog {
         TALLY       = (1 << 25),
         ACCRUAL     = (1 << 26),
         CONTRACT    = (1 << 27),
+        MINER       = (1 << 28),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -85,7 +85,7 @@ namespace BCLog {
         CONTRACT    = (1 << 27),
         MINER       = (1 << 28),
         VERBOSE     = (1 << 29), // This corresponds to the old horizontal category "debug".
-        NOISY        = (1 << 30), // This corresponds to the old horizontal category "debug10".
+        NOISY       = (1 << 30), // This corresponds to the old horizontal category "debug10".
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1435,10 +1435,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
                 // At default rate it would take over a month to fill 1GB
                 if (dFreeCount > GetArg("-limitfreerelay", 15)*10*1000 && !IsFromMe(tx))
                     return error("AcceptToMemoryPool : free transaction rejected by rate limiter");
-                if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY))
-                {
-                    LogPrint(BCLog::LogFlags::MEMPOOL, "Rate limit dFreeCount: %g => %g", dFreeCount, dFreeCount+nSize);
-                }
+
+                LogPrint(BCLog::LogFlags::MEMPOOL, "Rate limit dFreeCount: %g => %g", dFreeCount, dFreeCount+nSize);
                 dFreeCount += nSize;
             }
         }
@@ -1478,10 +1476,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
     // If updated, erase old tx from wallet
     if (ptxOld)
         EraseFromWallets(ptxOld->GetHash());
-    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
-    {
-            LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")", hash.ToString(), pool.mapTx.size());
-    }
+
+    LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")", hash.ToString(), pool.mapTx.size());
+
     return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -776,7 +776,7 @@ bool AddOrphanTx(const CTransaction& tx)
 
     if (nSize > 5000)
     {
-        LogPrint("mempool", "ignoring large orphan tx (size: %" PRIszu ", hash: %s)", nSize, hash.ToString().substr(0,10));
+        LogPrint(BCLog::LogFlags::MEMPOOL, "ignoring large orphan tx (size: %" PRIszu ", hash: %s)", nSize, hash.ToString().substr(0,10));
         return false;
     }
 
@@ -784,7 +784,7 @@ bool AddOrphanTx(const CTransaction& tx)
     for (auto const& txin : tx.vin)
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
-    LogPrint("mempool", "stored orphan tx %s (mapsz %" PRIszu ")", hash.ToString().substr(0,10), mapOrphanTransactions.size());
+    LogPrint(BCLog::LogFlags::MEMPOOL, "stored orphan tx %s (mapsz %" PRIszu ")", hash.ToString().substr(0,10), mapOrphanTransactions.size());
     return true;
 }
 
@@ -1468,7 +1468,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         LOCK(pool.cs);
         if (ptxOld)
         {
-            LogPrint("mempool", "AcceptToMemoryPool : replacing tx %s with new version", ptxOld->GetHash().ToString());
+            LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : replacing tx %s with new version", ptxOld->GetHash().ToString());
             pool.remove(*ptxOld);
         }
         pool.addUnchecked(hash, tx);
@@ -1480,7 +1480,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         EraseFromWallets(ptxOld->GetHash());
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
     {
-            LogPrint("mempool", "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")", hash.ToString(), pool.mapTx.size());
+            LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")", hash.ToString(), pool.mapTx.size());
     }
     return true;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -1300,7 +1300,7 @@ public:
     {
         // Take last bit of block hash as entropy bit
         unsigned int nEntropyBit = ((GetHash(true).GetUint64()) & 1llu);
-        if (fDebug && GetBoolArg("-printstakemodifier"))
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) && GetBoolArg("-printstakemodifier"))
             LogPrintf("GetStakeEntropyBit: hashBlock=%s nEntropyBit=%u", GetHash(true).ToString(), nEntropyBit);
         return nEntropyBit;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -72,9 +72,7 @@ bool ReturnMinerError(CMinerStatus& status, CMinerStatus::ReasonNotStakingCatego
 
     status.SetReasonNotStaking(not_staking_error);
 
-    if (fDebug) {
-        LogPrintf("CreateCoinStake: %s", MinerStatus.ReasonNotStaking);
-    }
+    LogPrint(BCLog::LogFlags::VERBOSE, "CreateCoinStake: %s", MinerStatus.ReasonNotStaking);
 
     return false;
 }
@@ -294,7 +292,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
                     if (!mempool.mapTx.count(txin.prevout.hash))
                     {
                         LogPrintf("ERROR: mempool transaction missing input");
-                        if (fDebug) assert("mempool transaction missing input" == 0);
+                        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) assert("mempool transaction missing input" == 0);
                         fMissingInputs = true;
                         if (porphan)
                             vOrphan.pop_back();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -284,7 +284,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
                 CTransaction txPrev;
                 CTxIndex txindex;
 
-                if (fDebug10) LogPrintf("Enumerating tx %s ",tx.GetHash().GetHex());
+                LogPrint(BCLog::LogFlags::NOISY, "Enumerating tx %s ",tx.GetHash().GetHex());
 
                 if (!txPrev.ReadFromDisk(txdb, txin.prevout, txindex))
                 {
@@ -307,7 +307,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
                         // Use list for automatic deletion
                         vOrphan.push_back(COrphan(&tx));
                         porphan = &vOrphan.back();
-                        if (fDebug10) LogPrintf("Orphan tx %s ",tx.GetHash().GetHex());
+                        LogPrint(BCLog::LogFlags::NOISY, "Orphan tx %s ",tx.GetHash().GetHex());
                         msMiningErrorsExcluded += tx.GetHash().GetHex() + ":ORPHAN;";
                     }
                     mapDependers[txin.prevout.hash].push_back(porphan);
@@ -416,7 +416,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             bool fInvalid;
             if (!tx.FetchInputs(txdb, mapTestPoolTmp, false, true, mapInputs, fInvalid))
             {
-                if (fDebug10) LogPrintf("Unable to fetch inputs for tx %s ", tx.GetHash().GetHex());
+                LogPrint(BCLog::LogFlags::NOISY, "Unable to fetch inputs for tx %s ", tx.GetHash().GetHex());
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":UnableToFetchInputs;";
                 continue;
             }
@@ -424,7 +424,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             int64_t nTxFees = tx.GetValueIn(mapInputs)-tx.GetValueOut();
             if (nTxFees < nMinFee)
             {
-                if (fDebug10) LogPrintf("Not including tx %s  due to TxFees of %" PRId64 ", bare min fee is %" PRId64, tx.GetHash().GetHex(), nTxFees, nMinFee);
+                LogPrint(BCLog::LogFlags::NOISY, "Not including tx %s  due to TxFees of %" PRId64 ", bare min fee is %" PRId64, tx.GetHash().GetHex(), nTxFees, nMinFee);
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":FeeTooSmall("
                     + RoundToString(CoinToDouble(nFees),8) + "," +RoundToString(CoinToDouble(nMinFee),8) + ");";
                 continue;
@@ -433,7 +433,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             nTxSigOps += tx.GetP2SHSigOpCount(mapInputs);
             if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
             {
-                if (fDebug10) LogPrintf("Not including tx %s due to exceeding max sigops of %d, sigops is %d",
+                LogPrint(BCLog::LogFlags::NOISY, "Not including tx %s due to exceeding max sigops of %d, sigops is %d",
                     tx.GetHash().GetHex(), (nBlockSigOps+nTxSigOps), MAX_BLOCK_SIGOPS);
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":ExceededSigOps("
                     + ToString(nBlockSigOps) + "," + ToString(nTxSigOps) + ")("
@@ -444,7 +444,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
 
             if (!tx.ConnectInputs(txdb, mapInputs, mapTestPoolTmp, CDiskTxPos(1,1,1), pindexPrev, false, true))
             {
-                if (fDebug10) LogPrintf("Unable to connect inputs for tx %s ",tx.GetHash().GetHex());
+                LogPrint(BCLog::LogFlags::NOISY, "Unable to connect inputs for tx %s ",tx.GetHash().GetHex());
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":UnableToConnectInputs();";
                 continue;
             }
@@ -459,7 +459,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             nBlockSigOps += nTxSigOps;
             nFees += nTxFees;
 
-            if (fDebug10 || GetBoolArg("-printpriority"))
+            if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY) || GetBoolArg("-printpriority"))
             {
                 LogPrintf("priority %.1f feeperkb %.1f txid %s",
                        dPriority, dFeePerKb, tx.GetHash().ToString());
@@ -484,7 +484,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             }
         }
 
-        if (fDebug10 || GetBoolArg("-printpriority"))
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY) || GetBoolArg("-printpriority"))
             LogPrintf("CreateNewBlock(): total size %" PRIu64, nBlockSize);
     }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,13 +129,11 @@ bool SignClaim(
         return error("%s: Signature failed. Check beacon key", __func__);
     }
 
-    if (fDebug2) {
-        LogPrintf(
-            "%s: Signed for CPID %s and block hash %s with signature %s",
-            cpid->ToString(),
-            last_block_hash.ToString(),
-            HexStr(claim.m_signature));
-    }
+    LogPrint(BCLog::LogFlags::MINER,
+             "%s: Signed for CPID %s and block hash %s with signature %s",
+             cpid->ToString(),
+             last_block_hash.ToString(),
+             HexStr(claim.m_signature));
 
     return true;
 }
@@ -536,7 +534,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
         return false;
     }
 
-    if(fDebug2) LogPrintf("CreateCoinStake: Staking nTime/16= %d Bits= %u",
+    LogPrint(BCLog::LogFlags::MINER, "CreateCoinStake: Staking nTime/16= %d Bits= %u",
     txnew.nTime/16,blocknew.nBits);
 
     for(const auto& pcoin : CoinsToStake)
@@ -576,19 +574,17 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
         StakeDiffSum += StakeKernelDiff;
         StakeDiffMax = std::max(StakeDiffMax,StakeKernelDiff);
 
-        if (fDebug2) {
-            LogPrintf(
-"CreateCoinStake: V%d Time %.f, Por_Nonce %.f, Bits %jd, Weight %jd\n"
-" Stk %72s\n"
-" Trg %72s\n"
-" Diff %0.7f of %0.7f",
-            blocknew.nVersion,
-            (double)txnew.nTime, mdPORNonce,
-            (intmax_t)blocknew.nBits,(intmax_t)CoinWeight,
-            StakeKernelHash.GetHex().c_str(), StakeTarget.GetHex().c_str(),
-            StakeKernelDiff, GetBlockDifficulty(blocknew.nBits)
-            );
-        }
+        LogPrint(BCLog::LogFlags::MINER,
+                 "CreateCoinStake: V%d Time %.f, Por_Nonce %.f, Bits %jd, Weight %jd\n"
+                 " Stk %72s\n"
+                 " Trg %72s\n"
+                 " Diff %0.7f of %0.7f",
+                 blocknew.nVersion,
+                 (double)txnew.nTime, mdPORNonce,
+                 (intmax_t)blocknew.nBits,(intmax_t)CoinWeight,
+                 StakeKernelHash.GetHex().c_str(), StakeTarget.GetHex().c_str(),
+                 StakeKernelDiff, GetBlockDifficulty(blocknew.nBits)
+                 );
 
         if( StakeKernelHash <= StakeTarget )
         {
@@ -821,14 +817,14 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
     if (fEnableStakeSplit)
     {
         unsigned int nSplitStakeOutputs = min((nMaxOutputs - nOutputsUsed), GetNumberOfStakeOutputs(nRemainingStakeOutputValue, nMinStakeSplitValue, dEfficiency));
-        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nStakeOutputs = %u", nSplitStakeOutputs);
+        LogPrint(BCLog::LogFlags::MINER, "SplitCoinStakeOutput: nStakeOutputs = %u", nSplitStakeOutputs);
 
         // Set Actual Stake output value for split stakes to remaining output value divided by the number of split
         // stake outputs.
         int64_t nActualStakeOutputValue = nRemainingStakeOutputValue / nSplitStakeOutputs;
 
-        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nSplitStakeOutputs = %f", nSplitStakeOutputs);
-        if (fDebug2) LogPrintf("SplitCoinStakeOutput: nActualStakeOutputValue = %f", CoinToDouble(nActualStakeOutputValue));
+        LogPrint(BCLog::LogFlags::MINER, "SplitCoinStakeOutput: nSplitStakeOutputs = %f", nSplitStakeOutputs);
+        LogPrint(BCLog::LogFlags::MINER, "SplitCoinStakeOutput: nActualStakeOutputValue = %f", CoinToDouble(nActualStakeOutputValue));
 
         int64_t nSumStakeOutputValue = 0;
         for (unsigned int i = 1; i < nSplitStakeOutputs; i++)
@@ -884,12 +880,12 @@ unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitVal
         nDesiredStakeOutputValue = G * GetAverageDifficulty(160) * (3.0 / 2.0) * (1 / dEfficiency  - 1) * COIN;
         nDesiredStakeOutputValue = max(nMinStakeSplitValue, nDesiredStakeOutputValue);
 
-        if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nDesiredStakeOutputValue = %f", CoinToDouble(nDesiredStakeOutputValue));
+        LogPrint(BCLog::LogFlags::MINER, "GetNumberOfStakeOutputs: nDesiredStakeOutputValue = %f", CoinToDouble(nDesiredStakeOutputValue));
 
         // Divide nValue by nDesiredStakeUTXOValue. We purposely want this to be integer division to round down.
         nStakeOutputs = max((int64_t) 1, nValue / nDesiredStakeOutputValue);
 
-        if (fDebug2) LogPrintf("GetNumberOfStakeOutputs: nStakeOutputs = %u", nStakeOutputs);
+        LogPrint(BCLog::LogFlags::MINER, "GetNumberOfStakeOutputs: nStakeOutputs = %u", nStakeOutputs);
     }
 
     return(nStakeOutputs);
@@ -1135,7 +1131,7 @@ bool GetSideStakingStatusAndAlloc(SideStakeAlloc& vSideStakeAlloc)
     double dSumAllocation = 0.0;
 
     bool fEnableSideStaking = GetBoolArg("-enablesidestaking");
-    if (fDebug2) LogPrintf("StakeMiner: fEnableSideStaking = %u", fEnableSideStaking);
+    LogPrint(BCLog::LogFlags::MINER, "StakeMiner: fEnableSideStaking = %u", fEnableSideStaking);
 
     // If side staking is enabled, parse destinations and allocations. We don't need to worry about any that are rejected
     // other than a warning message, because any unallocated rewards will go back into the coinstake output(s).
@@ -1194,7 +1190,7 @@ bool GetSideStakingStatusAndAlloc(SideStakeAlloc& vSideStakeAlloc)
                 }
 
                 vSideStakeAlloc.push_back(std::pair<std::string, double>(sAddress, dAllocation));
-                if (fDebug2) LogPrintf("StakeMiner: SideStakeAlloc Address %s, Allocation %f", sAddress.c_str(), dAllocation);
+                LogPrint(BCLog::LogFlags::MINER, "StakeMiner: SideStakeAlloc Address %s, Allocation %f", sAddress.c_str(), dAllocation);
 
                 vSubParam.clear();
             }
@@ -1214,7 +1210,7 @@ bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficie
 {
     // Parse StakeSplit and SideStaking flags.
     bool fEnableStakeSplit = GetBoolArg("-enablestakesplit");
-    if (fDebug2) LogPrintf("StakeMiner: fEnableStakeSplit = %u", fEnableStakeSplit);
+    LogPrint(BCLog::LogFlags::MINER, "StakeMiner: fEnableStakeSplit = %u", fEnableStakeSplit);
 
     // If stake output splitting is enabled, determine efficiency and minimum stake split value.
     if (fEnableStakeSplit)
@@ -1226,13 +1222,13 @@ bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficie
         else if (dEfficiency < 0.75)
             dEfficiency = 0.75;
 
-        if (fDebug2) LogPrintf("StakeMiner: dEfficiency = %f", dEfficiency);
+        LogPrint(BCLog::LogFlags::MINER, "StakeMiner: dEfficiency = %f", dEfficiency);
 
         // Pull Minimum Post Stake UTXO Split Value from config or command line parameter.
         // Default to 800 and do not allow it to be specified below 800 GRC.
         nMinStakeSplitValue = max(GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC), MIN_STAKE_SPLIT_VALUE_GRC) * COIN;
 
-        if (fDebug2) LogPrintf("StakeMiner: nMinStakeSplitValue = %f", CoinToDouble(nMinStakeSplitValue));
+        LogPrint(BCLog::LogFlags::MINER, "StakeMiner: nMinStakeSplitValue = %f", CoinToDouble(nMinStakeSplitValue));
 
         // For the definition of the constant G, please see
         // https://docs.google.com/document/d/1OyuTwdJx1Ax2YZ42WYkGn_UieN0uY13BTlA5G5IAN00/edit?usp=sharing

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -756,13 +756,13 @@ bool CNode::Misbehaving(int howmuch)
 
         if (nMisbehavior >= GetArg("-banscore", 100))
         {
-            if (fDebug) LogPrintf("Misbehaving: %s (%d -> %d) DISCONNECTING", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
+            LogPrint(BCLog::LogFlags::VERBOSE, "Misbehaving: %s (%d -> %d) DISCONNECTING", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
 
             g_banman->Ban(addr, BanReasonNodeMisbehaving);
             CloseSocketDisconnect();
             return true;
         } else
-            if (fDebug) LogPrintf("Misbehaving: %s (%d -> %d)", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
+            LogPrint(BCLog::LogFlags::VERBOSE, "Misbehaving: %s (%d -> %d)", addr.ToString(), nMisbehavior-howmuch, nMisbehavior);
         return false;
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -290,14 +290,14 @@ bool RecvLine(SOCKET hSocket, string& strLine)
             if (nBytes == 0)
             {
                 // socket closed
-                if (fDebug10) LogPrintf("socket closed");
+                LogPrint(BCLog::LogFlags::NOISY, "socket closed");
                 return false;
             }
             else
             {
                 // socket error
                 int nErr = WSAGetLastError();
-                if (fDebug10) LogPrintf("recv err: %d", nErr);
+                LogPrint(BCLog::LogFlags::NOISY, "recv err: %d", nErr);
                 return false;
             }
         }
@@ -345,7 +345,7 @@ bool AddLocal(const CService& addr, int nScore)
 
     try
     {
-    if (fDebug10) LogPrintf("AddLocal(%s,%i)", addr.ToString(), nScore);
+    LogPrint(BCLog::LogFlags::NOISY, "AddLocal(%s,%i)", addr.ToString(), nScore);
 
     {
         LOCK(cs_mapLocalHost);
@@ -428,7 +428,7 @@ bool GetMyExternalIP2(const CService& addrConnect, const char* pszGet, const cha
     SOCKET hSocket;
     if (!ConnectSocket(addrConnect, hSocket))
     {
-        if (fDebug10) LogPrintf("GetMyExternalIP() : unable to connect to %s ", addrConnect.ToString());
+        LogPrint(BCLog::LogFlags::NOISY, "GetMyExternalIP() : unable to connect to %s ", addrConnect.ToString());
         return false;
     }
 
@@ -461,7 +461,7 @@ bool GetMyExternalIP2(const CService& addrConnect, const char* pszGet, const cha
             while (strLine.size() > 0 && isspace(strLine[strLine.size()-1]))
                 strLine.resize(strLine.size()-1);
             CService addr(strLine,0,true);
-            if (fDebug10) LogPrintf("GetMyExternalIP() received [%s] %s", strLine, addr.ToString());
+            LogPrint(BCLog::LogFlags::NOISY, "GetMyExternalIP() received [%s] %s", strLine, addr.ToString());
             if (!addr.IsValid() || !addr.IsRoutable())
                 return false;
             ipRet.SetIP(addr);
@@ -622,7 +622,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
     {
         addrman.Attempt(addrConnect);
         /// debug print
-        if (fDebug10) LogPrintf("connected %s", pszDest ? pszDest : addrConnect.ToString());
+        LogPrint(BCLog::LogFlags::NOISY, "connected %s", pszDest ? pszDest : addrConnect.ToString());
         // Set to non-blocking
 #ifdef WIN32
         u_long nOne = 1;
@@ -661,7 +661,7 @@ void CNode::CloseSocketDisconnect()
     fDisconnect = true;
     if (hSocket != INVALID_SOCKET)
     {
-        if (fDebug10) LogPrintf("disconnecting node %s", addrName);
+        LogPrint(BCLog::LogFlags::NOISY, "disconnecting node %s", addrName);
         closesocket(hSocket);
         hSocket = INVALID_SOCKET;
 
@@ -719,7 +719,7 @@ void CNode::PushVersion()
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0",0)));
     CAddress addrMe = GetLocalAddress(&addr);
     RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
-    if (fDebug10) LogPrintf("send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s",
+    LogPrint(BCLog::LogFlags::NOISY, "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s",
         PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), addr.ToString());
 
     std::string sboinchashargs;
@@ -966,7 +966,7 @@ void SocketSendData(CNode *pnode)
                 int nErr = WSAGetLastError();
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
-                    if (fDebug10) LogPrintf("socket send error %d", nErr);
+                    LogPrint(BCLog::LogFlags::NOISY, "socket send error %d", nErr);
                     pnode->CloseSocketDisconnect();
                 }
             }
@@ -1009,7 +1009,7 @@ void ThreadSocketHandler(void* parg)
 
 void ThreadSocketHandler2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadSocketHandler started");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadSocketHandler started");
     list<CNode*> vNodesDisconnected;
     unsigned int nPrevNodeCount = 0;
 
@@ -1142,7 +1142,7 @@ void ThreadSocketHandler2(void* parg)
             if (have_fds)
             {
                 int nErr = WSAGetLastError();
-                if (fDebug10) LogPrintf("socket select error %d", nErr);
+                LogPrint(BCLog::LogFlags::NOISY, "socket select error %d", nErr);
                 for (unsigned int i = 0; i <= hSocketMax; i++)
                     FD_SET(i, &fdsetRecv);
             }
@@ -1183,18 +1183,21 @@ void ThreadSocketHandler2(void* parg)
             }
             else if (nInbound >= GetArg("-maxconnections", 250) - MAX_OUTBOUND_CONNECTIONS)
             {
-                if (fDebug10)
-                    LogPrintf("Surpassed max inbound connections maxconnections:%" PRId64 " minus max_outbound:%i", GetArg("-maxconnections",250), MAX_OUTBOUND_CONNECTIONS);
+                LogPrint(BCLog::LogFlags::NOISY,
+                         "Surpassed max inbound connections maxconnections:%" PRId64 " minus max_outbound:%i",
+                         GetArg("-maxconnections",250),
+                         MAX_OUTBOUND_CONNECTIONS);
+
                 closesocket(hSocket);
             }
             else if (g_banman->IsBanned(addr))
             {
-                if (fDebug10) LogPrintf("connection from %s dropped (banned)", addr.ToString());
+                LogPrint(BCLog::LogFlags::NOISY, "connection from %s dropped (banned)", addr.ToString());
                 closesocket(hSocket);
             }
             else
             {
-                if (fDebug10) LogPrintf("accepted connection %s", addr.ToString());
+                LogPrint(BCLog::LogFlags::NOISY, "accepted connection %s", addr.ToString());
                 CNode* pnode = new CNode(hSocket, addr, "", true);
                 pnode->AddRef();
                 {
@@ -1251,7 +1254,7 @@ void ThreadSocketHandler2(void* parg)
                             // socket closed gracefully
                             if (!pnode->fDisconnect)
                             {
-                              if (fDebug10)   LogPrintf("socket closed");
+                              LogPrint(BCLog::LogFlags::NOISY, "socket closed");
                             }
                             pnode->CloseSocketDisconnect();
                         }
@@ -1263,7 +1266,7 @@ void ThreadSocketHandler2(void* parg)
                             {
                                 if (!pnode->fDisconnect)
                                 {
-                                   if (fDebug10)  LogPrintf("socket recv error %d", nErr);
+                                   LogPrint(BCLog::LogFlags::NOISY, "socket recv error %d", nErr);
                                 }
                                 pnode->CloseSocketDisconnect();
                             }
@@ -1290,8 +1293,8 @@ void ThreadSocketHandler2(void* parg)
             // Consider this for future removal as this really is not beneficial nor harmful.
             if ((GetAdjustedTime() - pnode->nTimeConnected) > (60*60*2) && (vNodes.size() > (MAX_OUTBOUND_CONNECTIONS*.75)))
             {
-                    if (fDebug10)
-                        LogPrintf("Node %s connected longer than 2 hours with connection count of %zd, disconnecting. ", NodeAddress(pnode), vNodes.size());
+                    LogPrint(BCLog::LogFlags::NOISY, "Node %s connected longer than 2 hours with connection count of %zd, disconnecting. ",
+                             NodeAddress(pnode), vNodes.size());
 
                     pnode->fDisconnect = true;
 
@@ -1304,8 +1307,8 @@ void ThreadSocketHandler2(void* parg)
             {
                 if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
                 {
-                    if (fDebug10)
-                        LogPrintf("socket no message in first %d seconds, %d %d", PEER_TIMEOUT, pnode->nLastRecv != 0, pnode->nLastSend != 0);
+                    LogPrint(BCLog::LogFlags::NOISY, "socket no message in first %d seconds, %d %d",
+                             PEER_TIMEOUT, pnode->nLastRecv != 0, pnode->nLastSend != 0);
 
                     pnode->fDisconnect = true;
 
@@ -1377,7 +1380,7 @@ void ThreadMapPort(void* parg)
 
 void ThreadMapPort2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadMapPort started");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadMapPort started");
 
     std::string port = strprintf("%u", GetListenPort());
     const char * multicastif = 0;
@@ -1471,7 +1474,7 @@ void ThreadMapPort2(void* parg)
             i++;
         }
     } else {
-        if (fDebug10) LogPrintf("No valid UPnP IGDs found");
+        LogPrint(BCLog::LogFlags::NOISY, "No valid UPnP IGDs found");
         freeUPNPDevlist(devlist); devlist = 0;
         if (r != 0)
             FreeUPNPUrls(&urls);
@@ -1528,24 +1531,24 @@ void ThreadDNSAddressSeed(void* parg)
     }
     catch(boost::thread_interrupted&)
     {
-        if (fDebug10) LogPrintf("ThreadDNSAddressSeed exited (interrupt)");
+        LogPrint(BCLog::LogFlags::NOISY, "ThreadDNSAddressSeed exited (interrupt)");
         return;
     }
     catch (...)
     {
         throw; // support pthread_cancel()
     }
-    if (fDebug10) LogPrintf("ThreadDNSAddressSeed exited");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadDNSAddressSeed exited");
 }
 
 void ThreadDNSAddressSeed2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadDNSAddressSeed started");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadDNSAddressSeed started");
     int found = 0;
 
     if (!fTestNet)
     {
-        if (fDebug10) LogPrintf("Loading addresses from DNS seeds (could take a while)");
+        LogPrint(BCLog::LogFlags::NOISY, "Loading addresses from DNS seeds (could take a while)");
 
         for (unsigned int seed_idx = 0; seed_idx < ARRAYLEN(strDNSSeed); seed_idx++) {
             if (HaveNameProxy()) {
@@ -1569,7 +1572,7 @@ void ThreadDNSAddressSeed2(void* parg)
         }
     }
 
-    if (fDebug10) LogPrintf("%d addresses found from DNS seeds", found);
+    LogPrint(BCLog::LogFlags::NOISY, "%d addresses found from DNS seeds", found);
 }
 
 
@@ -1597,7 +1600,7 @@ void DumpAddresses()
     CAddrDB adb;
     adb.Write(addrman);
 
-    if (fDebug10) LogPrintf("Flushed %d addresses to peers.dat  %" PRId64 "ms",           addrman.size(), GetTimeMillis() - nStart);
+    LogPrint(BCLog::LogFlags::NOISY, "Flushed %d addresses to peers.dat  %" PRId64 "ms",           addrman.size(), GetTimeMillis() - nStart);
 
 }
 
@@ -1681,7 +1684,7 @@ void static ProcessOneShot()
 void static ThreadStakeMiner(void* parg)
 {
 
-    if (fDebug10) LogPrintf("ThreadStakeMiner started");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadStakeMiner started");
     CWallet* pwallet = (CWallet*)parg;
     try
     {
@@ -1705,7 +1708,7 @@ void static ThreadStakeMiner(void* parg)
 
 void static ThreadScraper(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadSraper starting");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadSraper starting");
     try
     {
         fScraperActive = true;
@@ -1733,7 +1736,7 @@ void static ThreadScraper(void* parg)
 
 void static ThreadNeuralNetwork(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadNeuralNetwork starting");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadNeuralNetwork starting");
     try
     {
         NeuralNetwork();
@@ -1776,7 +1779,7 @@ uint64_t CNode::GetTotalBytesSent()
 
 void ThreadOpenConnections2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadOpenConnections started");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadOpenConnections started");
 
     // Connect to specific addresses
     if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0)
@@ -1918,7 +1921,7 @@ void ThreadOpenAddedConnections(void* parg)
 
 void ThreadOpenAddedConnections2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadOpenAddedConnections started");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadOpenAddedConnections started");
 
     if (mapArgs.count("-addnode") == 0)
         return;
@@ -2040,7 +2043,7 @@ void ThreadMessageHandler(void* parg)
 
 void ThreadMessageHandler2(void* parg)
 {
-    if (fDebug10) LogPrintf("ThreadMessageHandler started");
+    LogPrint(BCLog::LogFlags::NOISY, "ThreadMessageHandler started");
     while (!fShutdown)
     {
         vector<CNode*> vNodesCopy;
@@ -2160,12 +2163,12 @@ bool BindListenPort(const CService &addrBind, string& strError)
     // Allow binding if the port is still in TIME_WAIT state after
     // the program was closed and restarted.  Not an issue on windows.
     if (setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (void*)&nOne, sizeof(int)) < 0)
-        if (fDebug10) LogPrintf("setsockopt(SO_REUSEADDR) failed");
+        LogPrint(BCLog::LogFlags::NOISY, "setsockopt(SO_REUSEADDR) failed");
 #ifdef SO_REUSEPORT
     // Not all systems have SO_REUSEPORT. Required by OSX, available in some
     // Linux flavors.
     if (setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEPORT, (void*)&nOne, sizeof(int)) < 0)
-        if (fDebug10) LogPrintf("setsockopt(SO_SO_REUSEPORT) failed");
+        LogPrint(BCLog::LogFlags::NOISY, "setsockopt(SO_SO_REUSEPORT) failed");
 #endif
 #endif
 
@@ -2210,7 +2213,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
         LogPrintf("%s", strError);
         return false;
     }
-    if (fDebug10) LogPrintf("Bound to %s", addrBind.ToString());
+    LogPrint(BCLog::LogFlags::NOISY, "Bound to %s", addrBind.ToString());
 
     // Listen for incoming connections
     if (listen(hListenSocket, SOMAXCONN) == SOCKET_ERROR)

--- a/src/net.h
+++ b/src/net.h
@@ -463,8 +463,7 @@ public:
 
         LEAVE_CRITICAL_SECTION(cs_vSend);
 
-        if (fDebug10)
-            LogPrintf("(aborted)");
+        LogPrint(BCLog::LogFlags::NOISY, "(aborted)");
     }
 
     void EndMessage()
@@ -490,10 +489,7 @@ public:
         assert(ssSend.size () >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));
         memcpy((char*)&ssSend[CMessageHeader::CHECKSUM_OFFSET], &nChecksum, sizeof(nChecksum));
 
-        if (fDebug10)
-		{
-            LogPrintf("(%d bytes)", nSize);
-        }
+        LogPrint(BCLog::LogFlags::NOISY, "(%d bytes)", nSize);
 
         std::deque<CSerializeData>::iterator it = vSendMsg.insert(vSendMsg.end(), CSerializeData());
         ssSend.GetAndClear(*it);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -393,7 +393,9 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             }
             if (nRet != 0)
             {
-                if (fDebug10) LogPrintf("socket connect() failed after select(): %s, Destination Addr %s ",strerror(nRet),addrConnect.ToString());
+                LogPrint(BCLog::LogFlags::NOISY, "socket connect() failed after select(): %s, Destination Addr %s ",
+                         strerror(nRet), addrConnect.ToString());
+
                 closesocket(hSocket);
                 return false;
             }

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -94,7 +94,7 @@ public:
         };
 
         if (m_pending.empty()) {
-            if (fDebug) {
+            if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) {
                 log(height, "none pending.");
             }
 
@@ -104,7 +104,7 @@ public:
         auto pending_iter = m_pending.upper_bound(height);
 
         if (pending_iter == m_pending.begin()) {
-            if (fDebug) {
+            if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) {
                 log(height, "not pending.");
             }
 
@@ -358,21 +358,18 @@ public:
         CBitcoinAddress address(grc_address);
 
         if (!address.IsValid()) {
-            if (fDebug) {
-                LogPrintf("Quorum::RecordVote: invalid address: %s HASH: %s",
-                    grc_address,
-                    quorum_hash.ToString());
-            }
+            LogPrint(BCLog::LogFlags::VERBOSE,
+                     "Quorum::RecordVote: invalid address: %s HASH: %s",
+                     grc_address,
+                     quorum_hash.ToString());
 
             return;
         }
 
         if (!Participating(grc_address, pindex->nTime)) {
-            if (fDebug) {
-                LogPrintf("Quorum::RecordVote: not participating: %s HASH: %s",
-                    grc_address,
-                    quorum_hash.ToString());
-            }
+            LogPrint(BCLog::LogFlags::VERBOSE, "Quorum::RecordVote: not participating: %s HASH: %s",
+                     grc_address,
+                     quorum_hash.ToString());
 
             return;
         }
@@ -910,15 +907,13 @@ private: // SuperblockValidator classes
                 const ResolvedProject& project = project_pair.second;
                 const size_t part_index = remainder / project.m_combiner_mask;
 
-                if (fDebug) {
-                    LogPrintf(
+                    LogPrint(BCLog::LogFlags::VERBOSE,
                         "ValidateSuperblock(): uncached by project: "
                         "%" PRIszu "/%" PRIszu " = part_index = %" PRIszu " index max = %" PRIszu,
                         remainder,
                         project.m_combiner_mask,
                         part_index,
                         project.m_resolved_parts.size() - 1);
-                }
 
                 const auto& resolved_part = project.m_resolved_parts[part_index];
 
@@ -1249,21 +1244,17 @@ private: // SuperblockValidator methods
                         content_hash_tally[content_hash]++;
                     }
 
-                    if (fDebug) {
-                        LogPrintf(
-                            "ValidateSuperblock(): manifest content hash %s "
-                            "matched convergence hint. Matches %" PRIszu,
-                            content_hash.ToString(),
-                            content_hash_tally[content_hash]);
-                    }
+                    LogPrint(BCLog::LogFlags::VERBOSE,
+                             "ValidateSuperblock(): manifest content hash %s "
+                             "matched convergence hint. Matches %" PRIszu,
+                             content_hash.ToString(),
+                             content_hash_tally[content_hash]);
 
                     if (content_hash_tally[content_hash] >= supermajority) {
-                        if (fDebug) {
-                            LogPrintf(
+                            LogPrint(BCLog::LogFlags::VERBOSE,
                                 "ValidateSuperblock(): supermajority found for "
                                 "manifest content hash: %s. Trying validation.",
                                 content_hash.ToString());
-                        }
 
                         if (TryManifest(manifest_hash)) {
                             return true;
@@ -1353,11 +1344,9 @@ private: // SuperblockValidator methods
         ProjectResolver resolver(std::move(candidates), ScraperCullAndBinCScraperManifests());
         ProjectCombiner combiner = resolver.ResolveProjectParts();
 
-        if (fDebug) {
-            LogPrintf(
-                "ValidateSuperblock(): by-project possible combinations: %" PRIszu,
-                combiner.TotalCombinations());
-        }
+        LogPrint(BCLog::LogFlags::VERBOSE,
+                 "ValidateSuperblock(): by-project possible combinations: %" PRIszu,
+                 combiner.TotalCombinations());
 
         while (const auto combination_option = combiner.GetNextConvergence()) {
             if (combination_option->ComputeQuorumHash() == m_quorum_hash) {

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -91,7 +91,7 @@ static void ipcThread(void* pArg)
 
 static void ipcThread2(void* pArg)
 {
-    if (fDebug) LogPrintf("ipcThread started");
+    LogPrint(BCLog::LogFlags::VERBOSE, "ipcThread started");
 
     message_queue* mq = (message_queue*)pArg;
     char buffer[MAX_URI_LENGTH + 1] = "";

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -333,7 +333,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
         }
     }
 
-    if (fDebug || true)
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) || true)
     {
         strHTML += "<hr><br><b>" + tr("Transaction Debits/Credits") + "</b><br><br>";
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -66,7 +66,7 @@ public:
      */
     void refreshWallet()
     {
-        if (fDebug) LogPrintf("refreshWallet");
+        LogPrint(BCLog::LogFlags::VERBOSE, "refreshWallet");
         cachedWallet.clear();
         {
             LOCK2(cs_main, wallet->cs_wallet);
@@ -85,7 +85,7 @@ public:
      */
     void updateWallet(const uint256 &hash, int status)
     {
-        if (fDebug) LogPrintf("updateWallet %s %i", hash.ToString(), status);
+        LogPrint(BCLog::LogFlags::VERBOSE, "updateWallet %s %i", hash.ToString(), status);
         {
             LOCK2(cs_main, wallet->cs_wallet);
 
@@ -115,7 +115,7 @@ public:
                     status = CT_DELETED; /* In model, but want to hide, treat as deleted */
             }
 
-            if (fDebug) LogPrintf("   inWallet=%i inModel=%i Index=%i-%i showTransaction=%i derivedStatus=%i",                     inWallet, inModel, lowerIndex, upperIndex, showTransaction, status);
+            LogPrint(BCLog::LogFlags::VERBOSE, "   inWallet=%i inModel=%i Index=%i-%i showTransaction=%i derivedStatus=%i",                     inWallet, inModel, lowerIndex, upperIndex, showTransaction, status);
 
 
             switch(status)
@@ -123,12 +123,12 @@ public:
             case CT_NEW:
                 if(inModel)
                 {
-                    if (fDebug) LogPrintf("Warning: updateWallet: Got CT_NEW, but transaction is already in model");
+                    LogPrint(BCLog::LogFlags::VERBOSE, "Warning: updateWallet: Got CT_NEW, but transaction is already in model");
                     break;
                 }
                 if(!inWallet)
                 {
-                    if (fDebug) LogPrintf("Warning: updateWallet: Got CT_NEW, but transaction is not in wallet");
+                    LogPrint(BCLog::LogFlags::VERBOSE, "Warning: updateWallet: Got CT_NEW, but transaction is not in wallet");
                     break;
                 }
                 if(showTransaction)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -360,7 +360,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet, 
 
 static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)
 {
-    if (fDebug) LogPrintf("NotifyTransactionChanged %s status=%i", hash.GetHex(), status);
+    LogPrint(BCLog::LogFlags::VERBOSE, "NotifyTransactionChanged %s status=%i", hash.GetHex(), status);
     QMetaObject::invokeMethod(walletmodel, "updateTransaction", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(hash.GetHex())),
                               Q_ARG(int, status));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1233,7 +1233,7 @@ UniValue debug(const UniValue& params, bool fHelp)
         LogInstance().DisableCategory(BCLog::LogFlags::VERBOSE);
     }
 
-    res.pushKV("Logging category NOISY (aka old debug10) ", LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) ? "Enabled." : "Disabled.");
+    res.pushKV("Logging category VERBOSE (aka old debug) ", LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) ? "Enabled." : "Disabled.");
 
     return res;
 }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1248,25 +1248,6 @@ UniValue debug10(const UniValue& params, bool fHelp)
     return res;
 }
 
-UniValue debug2(const UniValue& params, bool fHelp)
-{
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "debug2 <bool>\n"
-                "\n"
-                "<bool> -> Specify true or false\n"
-                "\n"
-                "Enable or disable debug mode on the fly\n");
-
-    UniValue res(UniValue::VOBJ);
-
-    fDebug2 = params[0].get_bool();
-
-    res.pushKV("Debug2", fDebug2 ? "Entering debug mode." : "Exiting debug mode.");
-
-    return res;
-}
-
 UniValue getlistof(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -317,8 +317,8 @@ UniValue getblockhash(const UniValue& params, bool fHelp)
     int nHeight = params[0].get_int();
     if (nHeight < 0 || nHeight > nBestHeight)
         throw runtime_error("Block number out of range.");
-    if (fDebug10)
-        LogPrintf("Getblockhash %d", nHeight);
+
+    LogPrint(BCLog::LogFlags::NOISY, "Getblockhash %d", nHeight);
 
     LOCK(cs_main);
 
@@ -1237,13 +1237,21 @@ UniValue debug10(const UniValue& params, bool fHelp)
                 "debug10 <bool>\n"
                 "\n"
                 "<bool> -> Specify true or false\n"
-                "Enable or disable debug mode on the fly\n");
+                "Enable or disable NOISY logging category (aka old debug10) on the fly\n"
+                "This is deprecated by the \"logging noisy\" command.\n");
 
     UniValue res(UniValue::VOBJ);
 
-    fDebug10 = params[0].get_bool();
+    if(params[0].get_bool())
+    {
+        LogInstance().EnableCategory(BCLog::LogFlags::NOISY);
+    }
+    else
+    {
+        LogInstance().DisableCategory(BCLog::LogFlags::NOISY);
+    }
 
-    res.pushKV("Debug10", fDebug10 ? "Entering debug mode." : "Exiting debug mode.");
+    res.pushKV("Logging category NOISY (aka old debug10) ", LogInstance().WillLogCategory(BCLog::LogFlags::NOISY) ? "Enabled." : "Disabled.");
 
     return res;
 }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -438,7 +438,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
 
     std::string sProject = params[0].get_str();
 
-    if (fDebug) LogPrintf("rainbymagnitude: sProject = %s", sProject.c_str());
+    LogPrint(BCLog::LogFlags::VERBOSE, "rainbymagnitude: sProject = %s", sProject.c_str());
 
     double dAmount = params[1].get_real();
 
@@ -466,7 +466,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
         mScraperConvergedStats = ConvergedScraperStatsCache.mScraperConvergedStats;
     }
 
-    if (fDebug) LogPrintf("rainbymagnitude: mScraperConvergedStats size = %u", mScraperConvergedStats.size());
+    LogPrint(BCLog::LogFlags::VERBOSE, "rainbymagnitude: mScraperConvergedStats size = %u", mScraperConvergedStats.size());
 
     double dTotalAmount = 0;
     int64_t nTotalAmount = 0;
@@ -517,7 +517,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
                 continue;
             }
 
-            if (fDebug) LogPrintf("INFO: rainbymagnitude: address = %s.", address.ToString());
+            LogPrint(BCLog::LogFlags::VERBOSE, "INFO: rainbymagnitude: address = %s.", address.ToString());
 
             mCPIDRain[CPIDKey] = std::make_pair(address, dCPIDMag);
 
@@ -525,7 +525,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
             // into the RAIN map, and will be used to normalize the payments.
             dTotalMagnitude += dCPIDMag;
 
-            if (fDebug) LogPrintf("rainmagnitude: CPID = %s, address = %s, dCPIDMag = %f",
+            LogPrint(BCLog::LogFlags::VERBOSE, "rainmagnitude: CPID = %s, address = %s, dCPIDMag = %f",
                                   CPIDKey.ToString(), address.ToString(), dCPIDMag);
         }
     }
@@ -554,7 +554,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
 
             vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
 
-            if (fDebug) LogPrintf("rainmagnitude: address = %s, amount = %f", iter.second.first.ToString(), CoinToDouble(nAmount));
+            LogPrint(BCLog::LogFlags::VERBOSE, "rainmagnitude: address = %s, amount = %f", iter.second.first.ToString(), CoinToDouble(nAmount));
     }
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
@@ -1025,19 +1025,19 @@ UniValue superblocks(const UniValue& params, bool fHelp)
     if (params.size() > 0)
     {
         lookback = params[0].get_int();
-        if (fDebug) LogPrintf("INFO: superblocks: lookback %i", lookback);
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: superblocks: lookback %i", lookback);
     }
 
     if (params.size() > 1)
     {
         displaycontract = params[1].get_bool();
-        if (fDebug) LogPrintf("INFO: superblocks: display contract %i", displaycontract);
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: superblocks: display contract %i", displaycontract);
     }
 
     if (params.size() > 2)
     {
         cpid = params[2].get_str();
-        if (fDebug) LogPrintf("INFO: superblocks: CPID %s", cpid);
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: superblocks: CPID %s", cpid);
     }
 
     LOCK(cs_main);
@@ -1219,13 +1219,21 @@ UniValue debug(const UniValue& params, bool fHelp)
                 "\n"
                 "<bool> -> Specify true or false\n"
                 "\n"
-                "Enable or disable debug mode on the fly\n");
+                "Enable or disable VERBOSE logging category (aka old debug) on the fly\n"
+                "This is deprecated by the \"logging verbose\" command.\n");
 
     UniValue res(UniValue::VOBJ);
 
-    fDebug = params[0].get_bool();
+    if(params[0].get_bool())
+    {
+        LogInstance().EnableCategory(BCLog::LogFlags::VERBOSE);
+    }
+    else
+    {
+        LogInstance().DisableCategory(BCLog::LogFlags::VERBOSE);
+    }
 
-    res.pushKV("Debug", fDebug ? "Entering debug mode." : "Exiting debug mode.");
+    res.pushKV("Logging category NOISY (aka old debug10) ", LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) ? "Enabled." : "Disabled.");
 
     return res;
 }
@@ -1794,7 +1802,7 @@ UniValue MagnitudeReport(const NN::Cpid cpid)
     json.pushKV("Accrual Days", calc->AccrualDays());
     json.pushKV("Owed", ValueFromAmount(calc->Accrual()));
 
-    if (fDebug) {
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) {
         json.pushKV("Owed (raw)", ValueFromAmount(calc->RawAccrual()));
         json.pushKV("Owed (last superblock)", ValueFromAmount(account.m_accrual));
     }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -74,7 +74,7 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
     res.push_back(std::make_pair(_("Fees Collected"), FormatMoney(GetFeesCollected(block))));
     res.push_back(std::make_pair(_("Is Superblock"), (claim.ContainsSuperblock() ? "Yes" : "No")));
 
-    if(fDebug)
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
     {
         if (claim.ContainsSuperblock())
             res.push_back(std::make_pair(_("Neural Contract Binary Size"), ToString(GetSerializeSize(claim.m_superblock, 1, 1))));
@@ -99,7 +99,7 @@ std::vector<std::pair<std::string, std::string>> GetTxNormalBoincHashInfo(const 
 
         res.push_back(std::make_pair(_("Network Date"), TimestampToHRDate((double)mtx.nTime)));
 
-        if (fDebug)
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
             res.push_back(std::make_pair(_("Message Length"), ToString(msg.length())));
 
         std::string sMessageType = ExtractXML(msg, "<MT>", "</MT>");
@@ -128,7 +128,7 @@ std::vector<std::pair<std::string, std::string>> GetTxNormalBoincHashInfo(const 
                         // of delete in addkey to remove a beacon the 1 in <MV>1</MV>
                         res.push_back(std::make_pair(_("ERROR"), _("Invalid beacon contract. Size: ") + ToString(sBeaconEncodedContract.length())));
 
-                        if (fDebug)
+                        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
                             res.push_back(std::make_pair(_("Message Data"), sBeaconEncodedContract));
 
                         return res;
@@ -196,7 +196,7 @@ std::vector<std::pair<std::string, std::string>> GetTxNormalBoincHashInfo(const 
                     res.push_back(std::make_pair(_("Share Type"), _("Unable to extract Share Type. Vote likely > 6 months old")));
                     res.push_back(std::make_pair(_("Answer"), sVoteAnswer));
 
-                    if (fDebug)
+                    if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
                         res.push_back(std::make_pair(_("Share Type Debug"), sVoteShareType));
 
                     return res;
@@ -316,7 +316,7 @@ std::vector<std::pair<std::string, std::string>> GetTxNormalBoincHashInfo(const 
             {
                 res.push_back(std::make_pair(_("Message Type"), _("Unknown")));
 
-                if (fDebug)
+                if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
                     res.push_back(std::make_pair(_("Data"), msg));
 
                 return res;
@@ -757,7 +757,7 @@ UniValue consolidateunspent(const UniValue& params, bool fHelp)
 
         nValue += nUTXOValue;
 
-        if (fDebug) LogPrintf("INFO: consolidateunspent: input value = %f, confirmations = %" PRId64, ((double) out.first) / (double) COIN, out.second.nDepth);
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: consolidateunspent: input value = %f, confirmations = %" PRId64, ((double) out.first) / (double) COIN, out.second.nDepth);
 
         setCoins.insert(make_pair(out.second.tx, out.second.i));
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -722,7 +722,7 @@ void JSONRequest::parse(const UniValue& valRequest)
         throw JSONRPCError(RPC_INVALID_REQUEST, "Method must be a string");
     strMethod = valMethod.get_str();
     if (strMethod != "getwork" && strMethod != "getblocktemplate")
-        if (fDebug10) LogPrintf("ThreadRPCServer method=%s", strMethod);
+        LogPrint(BCLog::LogFlags::NOISY, "ThreadRPCServer method=%s", strMethod);
 
     // Parse params
     UniValue valParams = find_value(request, "params");

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -362,7 +362,6 @@ static const CRPCCommand vRPCCommands[] =
     { "currentcontractaverage",  &currentcontractaverage,  cat_developer     },
     { "debug",                   &debug,                   cat_developer     },
     { "debug10",                 &debug10,                 cat_developer     },
-    { "debug2",                  &debug2,                  cat_developer     },
     { "exportstats1",            &rpc_exportstats,         cat_developer     },
     { "getblockstats",           &rpc_getblockstats,       cat_developer     },
     { "getlistof",               &getlistof,               cat_developer     },

--- a/src/scraper/http.cpp
+++ b/src/scraper/http.cpp
@@ -392,8 +392,7 @@ std::string Http::GetSnapshotSHA256()
 
     else
     {
-        if (fDebug)
-            LogPrintf("Snapshot Downloader: Receives SHA256SUM of %s", buffer.substr(0, loc));
+        LogPrint(BCLog::LogFlags::VERBOSE, "Snapshot Downloader: Receives SHA256SUM of %s", buffer.substr(0, loc));
 
         return buffer.substr(0, loc);
     }

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -1330,7 +1330,10 @@ bool ScraperDirectoryAndConfigSanity()
                     {
                         entry = StructScraperFileManifest.mScraperFileManifest.find(dir.path().filename().string());
                         
-                        if (fDebug10) _log(logattribute::INFO, "ScraperDirectoryAndConfigSanity", "Iterating through directory - checking file " + filename);
+                        if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY))
+                        {
+                            _log(logattribute::INFO, "ScraperDirectoryAndConfigSanity", "Iterating through directory - checking file " + filename);
+                        }
                         
                         if (entry == StructScraperFileManifest.mScraperFileManifest.end())
                         {
@@ -1360,7 +1363,10 @@ bool ScraperDirectoryAndConfigSanity()
 
                     int64_t nFileRetentionTime = fExplorer ? EXPLORER_EXTENDED_FILE_RETENTION_TIME : SCRAPER_FILE_RETENTION_TIME;
                     
-                    if (fDebug10) _log(logattribute::INFO, "ScraperDirectoryAndConfigSanity", "Iterating through map - checking map entry " + entry_copy->first);
+                    if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY))
+                    {
+                        _log(logattribute::INFO, "ScraperDirectoryAndConfigSanity", "Iterating through map - checking map entry " + entry_copy->first);
+                    }
 
                     if (!fs::exists(pathScraper / entry_copy->first)
                             || ((GetAdjustedTime() - entry_copy->second.timestamp) > nFileRetentionTime)
@@ -1390,7 +1396,7 @@ bool ScraperDirectoryAndConfigSanity()
                     else
                     {
                         _log(logattribute::INFO, "ScraperDirectoryAndConfigSanity", "Loaded team IDs file into map.");
-                        if (fDebug10)
+                        if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY))
                         {
                             _log(logattribute::INFO, "ScraperDirectoryAndConfigSanity", "TeamIDMap contents:");
                             for (const auto& iter : TeamIDMap)
@@ -5243,13 +5249,19 @@ scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperb
         // content hash - manifest hash
         std::map<uint256, uint256> mMatchingManifestContentHashes;
 
-        if (fDebug10) _log(logattribute::INFO, "ValidateSuperblock", "nUnderlyingManifestReducedContentHash = " + std::to_string(nUnderlyingManifestReducedContentHash));
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY))
+        {
+            _log(logattribute::INFO, "ValidateSuperblock", "nUnderlyingManifestReducedContentHash = " + std::to_string(nUnderlyingManifestReducedContentHash));
+        }
 
         for (const auto& iter : mManifestsBinnedbyContent)
         {
             uint32_t nReducedManifestContentHash = iter.first.GetUint64() >> (32 + nAdditionalBitShift);
 
-            if (fDebug10) _log(logattribute::INFO, "ValidateSuperblock", "nReducedManifestContentHash = " + std::to_string(nReducedManifestContentHash));
+            if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY))
+            {
+                _log(logattribute::INFO, "ValidateSuperblock", "nReducedManifestContentHash = " + std::to_string(nReducedManifestContentHash));
+            }
 
             // This has the effect of only storing the first one of the series of matching manifests that match the hint,
             // because of the insert. Below we will count the others matching to check for a supermajority.
@@ -5426,15 +5438,18 @@ scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperb
                 // Only process if there is a valid entry in the superblock.
                 if (const auto SBProjectIter = NewFormatSuperblock.m_projects.Try(iWhitelistProject.m_name))
                 {
-                    if (fDebug10) _log(logattribute::INFO,
-                                      "ValidateSuperblock",
-                                      "by project uncached:\n"
-                                      "nReducedProjectObjectContentHash_prebitshift = " + std::to_string(nReducedProjectObjectContentHash_prebitshift) + "\n"
-                                      + "           SBProjectIter->m_convergence_hint = " + std::to_string(SBProjectIter->m_convergence_hint) + "\n"
-                                      + "            nReducedProjectObjectContentHash = " + std::to_string(nReducedProjectObjectContentHash) + "\n"
-                                      + "     SBProjectIter->m_convergence_hint >> " + std::to_string(nAdditionalBitShift)
-                                      + " = " + std::to_string(SBProjectIter->m_convergence_hint >> nAdditionalBitShift) + "\n"
-                                      );
+                    if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY))
+                    {
+                        _log(logattribute::INFO,
+                             "ValidateSuperblock",
+                             "by project uncached:\n"
+                             "nReducedProjectObjectContentHash_prebitshift = " + std::to_string(nReducedProjectObjectContentHash_prebitshift) + "\n"
+                             + "           SBProjectIter->m_convergence_hint = " + std::to_string(SBProjectIter->m_convergence_hint) + "\n"
+                             + "            nReducedProjectObjectContentHash = " + std::to_string(nReducedProjectObjectContentHash) + "\n"
+                             + "     SBProjectIter->m_convergence_hint >> " + std::to_string(nAdditionalBitShift)
+                             + " = " + std::to_string(SBProjectIter->m_convergence_hint >> nAdditionalBitShift) + "\n"
+                             );
+                    }
 
                     // Only process if the (reduced content hash) for the project object matches the hint.
                     if (nReducedProjectObjectContentHash == SBProjectIter->m_convergence_hint >> nAdditionalBitShift)

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -33,7 +33,6 @@ fs::path pathDataDir = {};
 fs::path pathScraper = {};
 
 extern bool fShutdown;
-extern bool fDebug;
 extern CWallet* pwalletMain;
 bool fScraperActive = false;
 std::vector<std::pair<std::string, std::string>> vuserpass;
@@ -381,7 +380,7 @@ public:
         ssPrevArchiveCheckDate << PrevArchiveCheckDate;
 
         // Goes in main log only and not subject to category.
-        if (fDebug) LogPrintf("INFO: ScraperLogger: ArchiveCheckDate %s, PrevArchiveCheckDate %s", ssArchiveCheckDate.str(), ssPrevArchiveCheckDate.str());
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: ScraperLogger: ArchiveCheckDate %s, PrevArchiveCheckDate %s", ssArchiveCheckDate.str(), ssPrevArchiveCheckDate.str());
 
         fs::path LogArchiveDir = pathDataDir / "logarchive";
 

--- a/src/scraper_net.cpp
+++ b/src/scraper_net.cpp
@@ -57,7 +57,7 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
 
         if (!part.present())
         {
-            LogPrint("manifest", "received part %s %u refs", hash.GetHex(), (unsigned) part.refs.size());
+            LogPrint(BCLog::LogFlags::MANIFEST, "received part %s %u refs", hash.GetHex(), (unsigned) part.refs.size());
 
             part.data = CSerializeData(vRecv.begin(),vRecv.end()); //TODO: replace with move constructor
             for (const auto& ref : part.refs)
@@ -74,7 +74,7 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
         }
         else
         {
-            LogPrint("manifest", "received duplicate part %s", hash.GetHex());
+            LogPrint(BCLog::LogFlags::MANIFEST, "received duplicate part %s", hash.GetHex());
             return false;
         }
     }
@@ -213,7 +213,7 @@ bool CScraperManifest::AlreadyHave(CNode* pfrom, const CInv& inv)
     }
     else
     {
-        if (pfrom) LogPrint("manifest", "new manifest %s from %s", inv.hash.GetHex(), pfrom->addrName);
+        if (pfrom) LogPrint(BCLog::LogFlags::MANIFEST, "new manifest %s from %s", inv.hash.GetHex(), pfrom->addrName);
         return false;
     }
 }
@@ -514,7 +514,7 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     uint256 hash = Hash(pbegin, ss.begin());
 
     ss >> signature;
-    LogPrint("manifest", "CScraperManifest::UnserializeCheck: hash of signature = %s", Hash(signature.begin(), signature.end()).GetHex());
+    LogPrint(BCLog::LogFlags::MANIFEST, "CScraperManifest::UnserializeCheck: hash of signature = %s", Hash(signature.begin(), signature.end()).GetHex());
 
     CKey mkey;
     if (!mkey.SetPubKey(pubkey)) throw error("CScraperManifest: Invalid manifest key");
@@ -640,7 +640,7 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
     } catch (bool& e)
     {
         mapManifest.erase(hash);
-        LogPrint("manifest", "invalid manifest %s received", hash.GetHex());
+        LogPrint(BCLog::LogFlags::MANIFEST, "invalid manifest %s received", hash.GetHex());
 
         if (pfrom)
         {
@@ -652,7 +652,7 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
     } catch(std::ios_base::failure& e)
     {
         mapManifest.erase(hash);
-        LogPrint("manifest", "invalid manifest %s received", hash.GetHex());
+        LogPrint(BCLog::LogFlags::MANIFEST, "invalid manifest %s received", hash.GetHex());
 
         if (pfrom)
         {
@@ -673,7 +673,7 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
 
     LOCK(cs_mapParts);
 
-    LogPrint("manifest", "received manifest %s with %u / %u parts", hash.GetHex(),(unsigned)manifest.cntPartsRcvd,(unsigned)manifest.vParts.size());
+    LogPrint(BCLog::LogFlags::MANIFEST, "received manifest %s with %u / %u parts", hash.GetHex(),(unsigned)manifest.cntPartsRcvd,(unsigned)manifest.vParts.size());
     if (manifest.isComplete())
     {
         /* If we already got all the parts in memory, signal completion */
@@ -711,7 +711,7 @@ bool CScraperManifest::addManifest(std::unique_ptr<CScraperManifest>&& m, CKey& 
 
     LogPrint(BCLog::LogFlags::SCRAPER, "INFO: CScraperManifest::addManifest: hash of signature = %s", Hash(m->signature.begin(), m->signature.end()).GetHex());
 
-    LogPrint("manifest", "adding new local manifest");
+    LogPrint(BCLog::LogFlags::MANIFEST, "adding new local manifest");
 
     /* try inserting into map */
     const auto it = mapManifest.emplace(hash, std::move(m));
@@ -748,7 +748,7 @@ bool CScraperManifest::addManifest(std::unique_ptr<CScraperManifest>&& m, CKey& 
 void CScraperManifest::Complete()
 {
     /* Notify peers that we have a new manifest */
-    LogPrint("manifest", "manifest %s complete with %u parts", phash->GetHex(),(unsigned)vParts.size());
+    LogPrint(BCLog::LogFlags::MANIFEST, "manifest %s complete with %u parts", phash->GetHex(),(unsigned)vParts.size());
     {
         LOCK(cs_vNodes);
         for (auto const& pnode : vNodes)

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(DoS_checkSig)
     boost::posix_time::ptime mst2 = boost::posix_time::microsec_clock::local_time();
     boost::posix_time::time_duration msdiff = mst2 - mst1;
     long nOneValidate = msdiff.total_milliseconds();
-    if (fDebug) LogPrintf("DoS_Checksig sign: %ld", nOneValidate);
+    LogPrint(BCLog::LogFlags::VERBOSE, "DoS_Checksig sign: %ld", nOneValidate);
 
     // ... now validating repeatedly should be quick:
     // 2.8GHz machine, -g build: Sign takes ~760ms,
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(DoS_checkSig)
     mst2 = boost::posix_time::microsec_clock::local_time();
     msdiff = mst2 - mst1;
     long nManyValidate = msdiff.total_milliseconds();
-    if (fDebug) LogPrintf("DoS_Checksig five: %ld", nManyValidate);
+    LogPrint(BCLog::LogFlags::VERBOSE, "DoS_Checksig five: %ld", nManyValidate);
 
     BOOST_CHECK_MESSAGE(nManyValidate < nOneValidate, "Signature cache timing failed");
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -67,7 +67,6 @@ ArgsMap mapArgs;
 ArgsMultiMap mapMultiArgs;
 
 bool fDebug = false;
-bool fDebug2 = false;
 bool fDebug10 = false;
 
 bool fPrintToConsole = false;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -67,7 +67,6 @@ ArgsMap mapArgs;
 ArgsMultiMap mapMultiArgs;
 
 bool fDebug = false;
-bool fDebug10 = false;
 
 bool fPrintToConsole = false;
 bool fPrintToDebugger = false;
@@ -199,7 +198,7 @@ void RandAddSeedPerfmon()
     {
         RAND_add(pdata, nSize, nSize/100.0);
         memset(pdata, 0, nSize);
-        if (fDebug10) LogPrint("rand", "RandAddSeed() %lu bytes", nSize);
+        LogPrint(BCLog::LogFlags::NOISY, "rand", "RandAddSeed() %lu bytes", nSize);
     }
 #endif
 }
@@ -848,7 +847,7 @@ std::string GetFileContents(const fs::path filepath)
         return "-1";
     }
 
-    if (fDebug10) LogPrintf("loading file to string %s", filepath);
+    LogPrint(BCLog::LogFlags::NOISY, "loading file to string %s", filepath);
 
     std::ostringstream out;
 
@@ -885,7 +884,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
 
     // Add data
     vTimeOffsets.input(nOffsetSample);
-    if (fDebug10) LogPrintf("Added time data, samples %d, offset %+" PRId64 " (%+" PRId64 " minutes)", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
+    LogPrint(BCLog::LogFlags::NOISY, "Added time data, samples %d, offset %+" PRId64 " (%+" PRId64 " minutes)", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
     if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
     {
         // We believe the median of the other nodes 95% and our own node's time ("0" initial offset) 5%. This will also act to gently converge the network to consensus UTC, in case
@@ -916,12 +915,12 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 }
             }
         }
-        if (fDebug10) {
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY)) {
             for (auto const& n : vSorted)
                 LogPrintf("%+" PRId64 "  ", n);
             LogPrintf("|  ");
         }
-        if (fDebug10) LogPrintf("nTimeOffset = %+" PRId64 "  (%+" PRId64 " minutes)", nTimeOffset, nTimeOffset/60);
+        LogPrint(BCLog::LogFlags::NOISY, "nTimeOffset = %+" PRId64 "  (%+" PRId64 " minutes)", nTimeOffset, nTimeOffset/60);
     }
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -66,8 +66,6 @@ using namespace std;
 ArgsMap mapArgs;
 ArgsMultiMap mapMultiArgs;
 
-bool fDebug = false;
-
 bool fPrintToConsole = false;
 bool fPrintToDebugger = false;
 bool fRequestShutdown = false;

--- a/src/util.h
+++ b/src/util.h
@@ -119,7 +119,6 @@ extern ArgsMap mapArgs;
 extern ArgsMultiMap mapMultiArgs;
 
 extern bool fDebug;
-extern bool fDebug2;
 extern bool fDebug10;
 
 extern bool fPrintToConsole;

--- a/src/util.h
+++ b/src/util.h
@@ -119,7 +119,6 @@ extern ArgsMap mapArgs;
 extern ArgsMultiMap mapMultiArgs;
 
 extern bool fDebug;
-extern bool fDebug10;
 
 extern bool fPrintToConsole;
 extern bool fPrintToDebugger;

--- a/src/util.h
+++ b/src/util.h
@@ -118,8 +118,6 @@ typedef std::map<std::string, std::vector<std::string>, mapArgscomp> ArgsMultiMa
 extern ArgsMap mapArgs;
 extern ArgsMultiMap mapMultiArgs;
 
-extern bool fDebug;
-
 extern bool fPrintToConsole;
 extern bool fPrintToDebugger;
 extern bool fRequestShutdown;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1122,7 +1122,7 @@ void CWalletTx::RelayWalletTransaction(CTxDB& txdb)
         uint256 hash = GetHash();
         if (!txdb.ContainsTx(hash))
         {
-            if (fDebug10) LogPrintf("Relaying wtx %s", hash.ToString().substr(0,10));
+            LogPrint(BCLog::LogFlags::NOISY, "Relaying wtx %s", hash.ToString().substr(0,10));
             RelayTransaction((CTransaction)*this, hash);
         }
     }
@@ -2187,7 +2187,7 @@ bool CWallet::TopUpKeyPool(unsigned int nSize)
             if (!walletdb.WritePool(nEnd, CKeyPool(GenerateNewKey())))
                 throw runtime_error("TopUpKeyPool() : writing generated key failed");
             setKeyPool.insert(nEnd);
-            if (fDebug10) LogPrintf("keypool added key %" PRId64 ", size=%" PRIszu, nEnd, setKeyPool.size());
+            LogPrint(BCLog::LogFlags::NOISY, "keypool added key %" PRId64 ", size=%" PRIszu, nEnd, setKeyPool.size());
         }
     }
     return true;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1564,7 +1564,7 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
         return false;
     }
 
-    if (fDebug2 && fMiner)
+    if (LogInstance().WillLogCategory(BCLog::LogFlags::MINER) && fMiner)
         LogPrintf("SelectCoinsForStaking: Balance considered for staking %.8f", BalanceToConsider / (double)COIN);
 
     vector<COutput> vCoins;
@@ -1590,7 +1590,7 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
         // If the Spendable balance is more then utxo value it is classified as able to stake
         if (BalanceToConsider >= n)
         {
-            if (fDebug2 && fMiner)
+            if (LogInstance().WillLogCategory(BCLog::LogFlags::MINER) && fMiner)
                 LogPrintf("SelectCoinsForStaking: UTXO=%s (BalanceToConsider=%.8f >= Value=%.8f)", pcoin->vout[i].GetHash().ToString(), BalanceToConsider / (double)COIN, n / (double)COIN);
 
             vCoinsRet.push_back(make_pair(pcoin, i));

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -435,7 +435,7 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* 
                     LogPrintf("WalletUpdateSpent: bad wtx %s", wtx.GetHash().ToString());
                 else if (!wtx.IsSpent(txin.prevout.n) && IsMine(wtx.vout[txin.prevout.n]))
                 {
-                    if (fDebug) LogPrintf("WalletUpdateSpent found spent coin %s gC %s", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
+                    LogPrint(BCLog::LogFlags::VERBOSE, "WalletUpdateSpent found spent coin %s gC %s", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
                     wtx.MarkSpent(txin.prevout.n);
                     wtx.WriteToDisk(pwalletdb);
                     NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
@@ -530,7 +530,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb)
                 }
                 else
                 {
-                    if (fDebug) LogPrintf("AddToWallet() : found %s in block %s not in index",
+                    LogPrint(BCLog::LogFlags::VERBOSE, "AddToWallet() : found %s in block %s not in index",
                            wtxIn.GetHash().ToString().substr(0,10),
                            wtxIn.hashBlock.ToString());
                 }
@@ -1495,7 +1495,7 @@ bool CWallet::SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, 
                 nValueRet += vValue[i].first;
             }
 
-        if (fDebug && GetBoolArg("-printpriority"))
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) && GetBoolArg("-printpriority"))
         {
             //// debug print
             LogPrintf("SelectCoins() best subset: ");
@@ -1877,7 +1877,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
     }
     {
         LOCK2(cs_main, cs_wallet);
-        if (fDebug) LogPrintf("CommitTransaction:\n%s", wtxNew.ToString());
+        LogPrint(BCLog::LogFlags::VERBOSE, "CommitTransaction:\n%s", wtxNew.ToString());
         {
             // This is only to keep the database open to defeat the auto-flush for the
             // duration of this scope.  This is the only place where this optimization
@@ -2216,7 +2216,7 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
         if (!HaveKey(keypool.vchPubKey.GetID()))
             throw runtime_error("ReserveKeyFromKeyPool() : unknown key in key pool");
         assert(keypool.vchPubKey.IsValid());
-        if (fDebug && GetBoolArg("-printkeypool"))
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE) && GetBoolArg("-printkeypool"))
             LogPrintf("keypool reserve %" PRId64, nIndex);
     }
 }
@@ -2244,8 +2244,7 @@ void CWallet::KeepKey(int64_t nIndex)
         CWalletDB walletdb(strWalletFile);
         walletdb.ErasePool(nIndex);
     }
-    if(fDebug)
-        LogPrintf("keypool keep %" PRId64, nIndex);
+    LogPrint(BCLog::LogFlags::VERBOSE, "keypool keep %" PRId64, nIndex);
 }
 
 void CWallet::ReturnKey(int64_t nIndex)
@@ -2255,8 +2254,7 @@ void CWallet::ReturnKey(int64_t nIndex)
         LOCK(cs_wallet);
         setKeyPool.insert(nIndex);
     }
-    if(fDebug)
-        LogPrintf("keypool return %" PRId64, nIndex);
+    LogPrint(BCLog::LogFlags::VERBOSE, "keypool return %" PRId64, nIndex);
 }
 
 bool CWallet::GetKeyFromPool(CPubKey& result, bool fAllowReuse)


### PR DESCRIPTION
This PR removes debug, debug2, and debug10 and replaces them with logging categories VERBOSE, MINER, and NOISY, respectively. I have left the debug and debug2 rpc functions and GetArgs in init to allow activating the VERBOSE and NOISY categories via legacy parameters/rpc functions for the time being.

The other categories had already been removed in #1600.