### PR TITLE
Suppress deprecated copy warnings for Qt with GCC 9+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -268,6 +268,8 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[CXXFLAGS="$CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[CXXFLAGS="$CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
+  dnl For Qt versions < 5.14 with GCC 9+:
+  AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 
 enable_hwcrc32=no


### PR DESCRIPTION
I updated my build environment to Ubuntu 20.04 LTS which comes with GCC 9.3 and Qt 5.12. Compiling GUI code now spams a bunch of `-Wdeprecated-copy` warnings for Qt internals. This change suppresses those warnings so that they don't distract from more important messages. We can probably remove this provision when upgrading the depends version of Qt to 5.14 (or maybe 5.13 if Qt backports the fix).