### PR TITLE
Add preliminary testing option for block v11 height on testnet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -674,6 +674,8 @@ bool AppInit2(ThreadHandlerPtr threads)
     std::string sha256_algo = SHA256AutoDetect();
     LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);
 
+    LogPrintf("Block version 11 hard fork configured for block %d", GetV11Threshold());
+
     fs::path datadir = GetDataDir();
     fs::path walletFileName = GetArg("-wallet", "wallet.dat");
 

--- a/src/main.h
+++ b/src/main.h
@@ -123,9 +123,16 @@ inline bool IsV10Enabled(int nHeight)
 inline int32_t GetV11Threshold()
 {
     // Returns "never" before planned intro of bv11.
-    return fTestNet
-            ? std::numeric_limits<int32_t>::max()
-            : std::numeric_limits<int32_t>::max();
+    try {
+        return fTestNet
+                // Temporary: configure testnet v11 height via parameter before
+                // releasing v11 to regular testnet:
+                //
+                ? std::stoi(GetArg("-v11height", ""))
+                : std::numeric_limits<int32_t>::max();
+    } catch (...) {
+        return std::numeric_limits<int32_t>::max();
+    }
 }
 
 inline bool IsV11Enabled(int nHeight)


### PR DESCRIPTION
This allows for configuration of the testnet block version 11 transition height for early testing of hard fork changes. Specify `-v11height=X` from the command line or add the directive to the configuration file to start a node that will switch to the block version 11 protocol after the chain grows to `X` number of blocks.