### PR TITLE
Fix out-of-bounds exception for peers tab version slashes

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -163,8 +163,12 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
             // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
             return QString(rec->nodeStats.fInbound ? "↓ " : "↑ ") + QString::fromStdString(rec->nodeStats.addrName);
         case Subversion:
-            // remove leading and trailing slash
-            return QString::fromStdString(rec->nodeStats.strSubVer.substr(1, rec->nodeStats.strSubVer.length() - 2));
+            if (!rec->nodeStats.strSubVer.empty()) {
+                // remove leading and trailing slash
+                return QString::fromStdString(rec->nodeStats.strSubVer.substr(1, rec->nodeStats.strSubVer.length() - 2));
+            } else {
+                return QString();
+            }
         case Ping:
             return GUIUtil::formatPingTime(rec->nodeStats.dPingTime);
         case Sent:

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -725,8 +725,12 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.dMinPing));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString("%1").arg(QString::number(stats->nodeStats.nVersion)));
-    // remove leading and trailing slash
-    ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.strSubVer.substr(1, stats->nodeStats.strSubVer.length() - 2)));
+    if (!stats->nodeStats.strSubVer.empty()) {
+        // remove leading and trailing slash
+        ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.strSubVer.substr(1, stats->nodeStats.strSubVer.length() - 2)));
+    } else {
+        ui->peerSubversion->clear();
+    }
     ui->peerDirection->setText(stats->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
     ui->peerHeight->setText(QString("%1").arg(QString::number(stats->nodeStats.nStartingHeight)));
     // ui->peerWhitelisted->setText(stats->nodeStats.fWhitelisted ? tr("Yes") : tr("No"));


### PR DESCRIPTION
The removal of the slashes from the version field on the debug console peers tab did not check the bounds of the string. This causes `substr()` to throw an out-of-bounds exception before a new peer replies with the version string if a node connects at the moment that the widget redraws.