### PR TITLE
Fix transition for v1 superblocks when reorganizing

### DIFF
--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -181,7 +181,7 @@ public:
             CBlock block;
             block.ReadFromDisk(pindex);
 
-            PushSuperblock(SuperblockPtr::BindShared(
+            m_cache.emplace_front(SuperblockPtr::BindShared(
                 block.PullSuperblock(),
                 pindex));
 


### PR DESCRIPTION
This fixes an issue that prevents the last version 1 superblock from reloading if the chain reorganizes after the switch to block version 11.