### PR TITLE
Avoid mutating transactions in ConnectBlock()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2302,24 +2302,17 @@ NN::Claim CBlock::PullClaim()
     return NN::Claim::Parse(vtx[0].hashBoinc, nVersion);
 }
 
-const NN::Superblock& CBlock::GetSuperblock() const
+NN::SuperblockPtr CBlock::GetSuperblock() const
 {
     return GetClaim().m_superblock;
 }
 
-NN::Superblock CBlock::PullSuperblock()
+NN::SuperblockPtr CBlock::GetSuperblock(const CBlockIndex* const pindex) const
 {
-    if (nVersion >= 11 || !vtx[0].vContracts.empty()) {
-        auto payload = vtx[0].vContracts[0].SharePayload();
-        return std::move(payload.As<NN::Claim>().m_superblock);
-    }
+    NN::SuperblockPtr superblock = GetSuperblock();
+    superblock.Rebind(pindex);
 
-    // Before block version 11, the Gridcoin reward claim context is stored
-    // in the hashBoinc field of the first transaction.
-    //
-    NN::Claim claim = NN::Claim::Parse(vtx[0].hashBoinc, nVersion);
-
-    return std::move(claim.m_superblock);
+    return superblock;
 }
 
 //
@@ -2675,11 +2668,7 @@ bool TryLoadSuperblock(
     const CBlockIndex* const pindex,
     const NN::Claim& claim)
 {
-    // Note: PullSuperblock() invalidates the coinbase tx claim contract
-    // by moving it. This must be the last instance where we reference a
-    // superblock in a block's claim contract:
-    //
-    NN::SuperblockPtr superblock = NN::SuperblockPtr::BindShared(block.PullSuperblock(), pindex);
+    NN::SuperblockPtr superblock = block.GetSuperblock(pindex);
 
     // TODO: find the invalid historical superblocks so we can remove
     // the fColdBoot condition that skips this check when syncing the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2732,16 +2732,13 @@ bool GridcoinConnectBlock(
         }
     }
 
-    for (auto iter = ++++block.vtx.begin(), end = block.vtx.end(); iter != end; ++iter) {
-        if (!iter->GetContracts().empty()) {
-            pindex->nIsContract = 1;
-            NN::ApplyContracts(iter->PullContracts());
-        }
-    }
+    bool found_contract;
+    NN::ApplyContracts(block, found_contract);
 
     pindex->SetMiningId(claim.m_mining_id);
     pindex->nResearchSubsidy = claim.m_research_subsidy;
     pindex->nInterestSubsidy = claim.m_block_subsidy;
+    pindex->nIsContract = found_contract;
 
     if (block.nVersion >= 11) {
         pindex->nMagnitude = NN::Quorum::GetMagnitude(claim.m_mining_id).Floating();

--- a/src/main.h
+++ b/src/main.h
@@ -31,7 +31,7 @@ class CTxMemPool;
 
 namespace NN {
 class Claim;
-class Superblock;
+class SuperblockPtr;
 
 //!
 //! \brief An optional type that either contains some claim object or does not.
@@ -1243,8 +1243,8 @@ public:
 
     const NN::Claim& GetClaim() const;
     NN::Claim PullClaim();
-    const NN::Superblock& GetSuperblock() const;
-    NN::Superblock PullSuperblock();
+    NN::SuperblockPtr GetSuperblock() const;
+    NN::SuperblockPtr GetSuperblock(const CBlockIndex* const pindex) const;
 
     // entropy bit for stake modifier if chosen by modifier
     unsigned int GetStakeEntropyBit() const

--- a/src/main.h
+++ b/src/main.h
@@ -912,19 +912,6 @@ public:
         return vContracts;
     }
 
-    //!
-    //! \brief Move the contracts contained in the transaction.
-    //!
-    //! \return The set of contracts contained in the transaction. Version 1
-    //! transactions can only store one contract.
-    //!
-    std::vector<NN::Contract> PullContracts()
-    {
-        GetContracts(); // Populate vContracts for legacy transactions
-
-        return std::move(vContracts);
-    }
-
     bool GetCoinAge(CTxDB& txdb, uint64_t& nCoinAge) const;  // ppcoin: get transaction coin age
 
 protected:

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -944,7 +944,7 @@ void AddNeuralContractOrVote(CBlock& blocknew)
         NN::Claim& claim = const_cast<NN::Claim&>(blocknew.GetClaim());
 
         claim.m_quorum_hash = superblock.GetHash();
-        claim.m_superblock = std::move(superblock);
+        claim.m_superblock.Replace(std::move(superblock));
 
         LogPrintf(
             "AddNeuralContractOrVote: Added our Superblock (size %" PRIszu ").",
@@ -992,7 +992,7 @@ void AddNeuralContractOrVote(CBlock& blocknew)
     }
 
     // We have consensus, add our superblock contract:
-    claim.m_superblock = NN::Quorum::CreateSuperblock();
+    claim.m_superblock.Replace(NN::Quorum::CreateSuperblock());
 
     LogPrintf(
         "AddNeuralContractOrVote: Added our Superblock (size %" PRIszu ").",

--- a/src/neuralnet/accrual/snapshot.h
+++ b/src/neuralnet/accrual/snapshot.h
@@ -1178,9 +1178,7 @@ private:
                 pindex->nHeight);
         }
 
-        m_superblock = SuperblockPtr::BindShared(
-            block.PullSuperblock(),
-            pindex_bind != nullptr ? pindex_bind : pindex);
+        m_superblock = block.GetSuperblock(pindex_bind ? pindex_bind : pindex);
 
         return true;
     }

--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -278,7 +278,7 @@ bool BeaconRegistry::ContainsActive(const Cpid& cpid) const
 
 void BeaconRegistry::Add(Contract contract)
 {
-    BeaconPayload payload = contract.PullPayloadAs<BeaconPayload>();
+    BeaconPayload payload = contract.CopyPayloadAs<BeaconPayload>();
 
     payload.m_beacon.m_timestamp = contract.m_tx_timestamp;
 

--- a/src/neuralnet/claim.cpp
+++ b/src/neuralnet/claim.cpp
@@ -93,7 +93,7 @@ Claim Claim::Parse(const std::string& claim, int block_version)
         case 25: c.m_magnitude_unit = RoundFromString(s[25], MAG_UNIT_PLACES);
         case 24: //c.m_research_age = RoundFromString(s[24], 6);
         case 23: //c.ResearchSubsidy2 = RoundFromString(s[23], subsidy_places);
-        case 22: c.m_superblock = Superblock::UnpackLegacy(s[22]);
+        case 22: c.m_superblock.Replace(Superblock::UnpackLegacy(s[22]));
         case 21: if (!c.m_quorum_hash.Valid())
                     c.m_quorum_hash = QuorumHash::Parse(s[21]);
         case 20: //c.OrganizationKey = s[20];
@@ -154,7 +154,7 @@ bool Claim::WellFormed() const
         }
     }
 
-    if (m_quorum_hash.Valid() && !m_superblock.WellFormed()) {
+    if (m_quorum_hash.Valid() && !m_superblock->WellFormed()) {
         return false;
     }
 
@@ -168,7 +168,7 @@ bool Claim::HasResearchReward() const
 
 bool Claim::ContainsSuperblock() const
 {
-    return m_superblock.WellFormed();
+    return m_superblock->WellFormed();
 }
 
 int64_t Claim::TotalSubsidy() const
@@ -245,7 +245,7 @@ std::string Claim::ToString(const int block_version) const
         + delim + m_organization
         + delim // + mcpid.OrganizationKey
         + delim + m_quorum_hash.ToString()
-        + delim + (m_superblock.WellFormed() ? m_superblock.PackLegacy() : "")
+        + delim + (m_superblock->WellFormed() ? m_superblock->PackLegacy() : "")
         + delim // + RoundToString(mcpid.ResearchSubsidy2,2)
         + delim // + RoundToString(m_research_age, 6)
         + delim + RoundToString(m_magnitude_unit, MAG_UNIT_PLACES)

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -191,7 +191,7 @@ public:
     //! Must be accompanied by a valid superblock hash in the \c m_quorum_hash
     //! field.
     //!
-    Superblock m_superblock; // MiningCPID::superblock
+    SuperblockPtr m_superblock; // MiningCPID::superblock
 
     //!
     //! \brief Initialize an empty, invalid reward claim object.

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -344,7 +344,7 @@ void NN::ReplayContracts(const CBlockIndex* pindex)
             }
 
             GetBeaconRegistry().ActivatePending(
-                block.GetSuperblock().m_verified_beacons.m_verified,
+                block.GetSuperblock()->m_verified_beacons.m_verified,
                 block.GetBlockTime());
         }
     }

--- a/src/neuralnet/contract/contract.h
+++ b/src/neuralnet/contract/contract.h
@@ -805,12 +805,21 @@ Contract MakeLegacyContract(
 void ReplayContracts(const CBlockIndex* pindex);
 
 //!
+//! \brief Apply contracts from transactions in a block by passing them to the
+//! appropriate contract handlers.
+//!
+//! \param block     Block to extract contracts from.
+//! \param out_found Will update to \c true when a block contains a contract.
+//!
+void ApplyContracts(const CBlock& block, bool& out_found);
+
+//!
 //! \brief Apply contracts from transactions by passing them to the appropriate
 //! contract handlers.
 //!
 //! \param contracts Received in a transaction.
 //!
-void ApplyContracts(std::vector<Contract> contracts);
+void ApplyContracts(const std::vector<Contract>& contracts);
 
 //!
 //! \brief Revert previously-applied contracts from a transaction by passing

--- a/src/neuralnet/project.cpp
+++ b/src/neuralnet/project.cpp
@@ -155,7 +155,7 @@ WhitelistSnapshot Whitelist::Snapshot() const
 
 void Whitelist::Add(Contract contract)
 {
-    Project project = contract.PullPayloadAs<Project>();
+    Project project = contract.CopyPayloadAs<Project>();
     project.m_timestamp = contract.m_tx_timestamp;
 
     ProjectListPtr copy = CopyFilteredWhitelist(project.m_name);

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -181,9 +181,7 @@ public:
             CBlock block;
             block.ReadFromDisk(pindex);
 
-            m_cache.emplace_front(SuperblockPtr::BindShared(
-                block.PullSuperblock(),
-                pindex));
+            m_cache.emplace_front(block.GetSuperblock(pindex));
 
             return;
         }
@@ -226,8 +224,7 @@ public:
             CBlock block;
             block.ReadFromDisk(pindexLast);
 
-            PushSuperblock(
-                SuperblockPtr::BindShared(block.PullSuperblock(), pindexLast));
+            PushSuperblock(block.GetSuperblock(pindexLast));
 
             pindexLast = pindexLast->pprev;
         }

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -992,6 +992,12 @@ SuperblockPtr::SuperblockPtr(
 {
 }
 
+void SuperblockPtr::Rebind(const CBlockIndex* const pindex)
+{
+    m_height = pindex->nHeight;
+    m_timestamp = pindex->nTime;
+}
+
 // -----------------------------------------------------------------------------
 // Class: QuorumHash
 // -----------------------------------------------------------------------------

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -112,6 +112,11 @@ UniValue SuperblockToJson(const NN::Superblock& superblock)
 
     return json;
 }
+
+UniValue SuperblockToJson(const NN::SuperblockPtr& superblock)
+{
+    return SuperblockToJson(*superblock);
+}
 } // anonymous namespace
 
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPrintTransactionDetail)
@@ -1865,7 +1870,7 @@ UniValue SuperblockReport(int lookback, bool displaycontract, std::string cpid)
 
             if (claim && claim->ContainsSuperblock())
             {
-                const NN::Superblock& superblock = claim->m_superblock;
+                const NN::Superblock& superblock = *claim->m_superblock;
 
                 UniValue c(UniValue::VOBJ);
                 c.pushKV("height", ToString(pblockindex->nHeight));

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -325,7 +325,7 @@ UniValue rpc_getsupervotes(const UniValue& params, bool fHelp)
             throw runtime_error("failed to read block");
         //assert(block.vtx.size() > 0);
         const NN::Claim claim = block.GetClaim();
-        const NN::Superblock& sb = claim.m_superblock;
+        const NN::Superblock& sb = *claim.m_superblock;
 
         info.pushKV("block_hash",pStart->GetBlockHash().GetHex());
         info.pushKV("height",pStart->nHeight);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -288,7 +288,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_MISC_ERROR, "Failed to read superblock.");
         }
 
-        superblock = NN::SuperblockPtr::BindShared(block.PullSuperblock(), pindex);
+        superblock = block.GetSuperblock(pindex);
 
         calc = NN::Tally::GetSnapshotComputer(
             *cpid,
@@ -352,7 +352,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_MISC_ERROR, "Failed to read superblock.");
         }
 
-        superblock = NN::SuperblockPtr::BindShared(block.PullSuperblock(), pindex_max);
+        superblock = block.GetSuperblock(pindex_max);
 
         calc = NN::Tally::GetSnapshotComputer(
             *cpid,

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -259,10 +259,10 @@ std::vector<std::pair<std::string, std::string>> GetTxNormalBoincHashInfo(const 
                     if (pblockindex && pblockindex->nIsSuperBlock)
                     {
                         block.ReadFromDisk(pblockindex);
-                        const NN::Superblock& superblock = block.GetSuperblock();
+                        const NN::SuperblockPtr superblock = block.GetSuperblock();
 
-                        double dOutAverage = superblock.m_cpids.AverageMagnitude();
-                        double dTotalNetworkMagnitude = (double)superblock.m_cpids.size() * dOutAverage;
+                        double dOutAverage = superblock->m_cpids.AverageMagnitude();
+                        double dTotalNetworkMagnitude = (double)superblock->m_cpids.size() * dOutAverage;
                         double dMoneySupply = (double)pblockindex->nMoneySupply / COIN;
                         double dMoneySupplyFactor = (dMoneySupply/dTotalNetworkMagnitude + .01);
 

--- a/src/test/neuralnet/claim_tests.cpp
+++ b/src/test/neuralnet/claim_tests.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_claim)
 
     BOOST_CHECK(claim.m_quorum_hash.Valid() == false);
     BOOST_CHECK(claim.m_quorum_address.empty() == true);
-    BOOST_CHECK(claim.m_superblock.m_cpids.empty() == true);
+    BOOST_CHECK(claim.m_superblock->m_cpids.empty() == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_to_the_specified_version)
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_the_specified_version)
 
     BOOST_CHECK(claim.m_quorum_hash.Valid() == false);
     BOOST_CHECK(claim.m_quorum_address.empty() == true);
-    BOOST_CHECK(claim.m_superblock.m_cpids.empty() == true);
+    BOOST_CHECK(claim.m_superblock->m_cpids.empty() == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_parses_a_legacy_boincblock_string_for_researcher)
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_legacy_boincblock_string_for_researcher)
 
     BOOST_CHECK(claim.m_quorum_hash == quorum_hash);
     BOOST_CHECK(claim.m_quorum_address == quorum_address);
-    BOOST_CHECK(claim.m_superblock.GetHash() == superblock.GetHash());
+    BOOST_CHECK(claim.m_superblock->GetHash() == superblock.GetHash());
 }
 
 BOOST_AUTO_TEST_CASE(it_behaves_like_a_contract_payload)
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_it_contains_a_superblock)
 
     BOOST_CHECK(claim.ContainsSuperblock() == false);
 
-    claim.m_superblock = GetTestSuperblock();
+    claim.m_superblock.Replace(GetTestSuperblock());
 
     BOOST_CHECK(claim.ContainsSuperblock() == true);
 }
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(it_represents_itself_as_a_legacy_boincblock_string)
     claim.m_signature = signature;
     claim.m_quorum_hash = quorum_hash;
     claim.m_quorum_address = quorum_address;
-    claim.m_superblock = superblock;
+    claim.m_superblock.Replace(superblock);
 
     BOOST_CHECK(claim.ToString(8) ==
         cpid.ToString() +                // Mining ID
@@ -467,8 +467,8 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_investor_with_superblock)
 {
     NN::Claim claim = GetInvestorClaim();
 
-    claim.m_superblock = GetTestSuperblock();
-    claim.m_quorum_hash = claim.m_superblock.GetHash();
+    claim.m_superblock.Replace(GetTestSuperblock());
+    claim.m_quorum_hash = claim.m_superblock->GetHash();
 
     CDataStream expected(SER_NETWORK, PROTOCOL_VERSION);
 
@@ -518,15 +518,15 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_investor)
     BOOST_CHECK(claim.m_magnitude_unit == 0.0);
     BOOST_CHECK(claim.m_signature.empty() == true);
     BOOST_CHECK(claim.m_quorum_address.empty() == true);
-    BOOST_CHECK(claim.m_superblock.WellFormed() == false);
+    BOOST_CHECK(claim.m_superblock->WellFormed() == false);
 }
 
 BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_investor_with_superblock)
 {
     NN::Claim expected = GetInvestorClaim();
 
-    expected.m_superblock = GetTestSuperblock();
-    expected.m_quorum_hash = expected.m_superblock.GetHash();
+    expected.m_superblock.Replace(GetTestSuperblock());
+    expected.m_quorum_hash = expected.m_superblock->GetHash();
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
 
@@ -550,8 +550,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_investor_with_superblock)
 
     BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
     BOOST_CHECK(claim.m_quorum_address.empty() == true);
-    BOOST_CHECK(claim.m_superblock.WellFormed() == true);
-    BOOST_CHECK(claim.m_superblock.GetHash() == expected.m_superblock.GetHash());
+    BOOST_CHECK(claim.m_superblock->WellFormed() == true);
+    BOOST_CHECK(claim.m_superblock->GetHash() == expected.m_superblock->GetHash());
 
     BOOST_CHECK(claim.m_research_subsidy == 0);
     BOOST_CHECK(claim.m_magnitude == 0.0);
@@ -588,8 +588,8 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_researcher_with_superblock)
 {
     NN::Claim claim = GetResearcherClaim();
 
-    claim.m_superblock = GetTestSuperblock();
-    claim.m_quorum_hash = claim.m_superblock.GetHash();
+    claim.m_superblock.Replace(GetTestSuperblock());
+    claim.m_quorum_hash = claim.m_superblock->GetHash();
 
     CDataStream expected(SER_NETWORK, claim.m_version);
 
@@ -645,15 +645,15 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher)
 
     BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
     BOOST_CHECK(claim.m_quorum_address.empty() == true);
-    BOOST_CHECK(claim.m_superblock.WellFormed() == false);
+    BOOST_CHECK(claim.m_superblock->WellFormed() == false);
 }
 
 BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher_with_superblock)
 {
     NN::Claim expected = GetResearcherClaim();
 
-    expected.m_superblock = GetTestSuperblock();
-    expected.m_quorum_hash = expected.m_superblock.GetHash();
+    expected.m_superblock.Replace(GetTestSuperblock());
+    expected.m_quorum_hash = expected.m_superblock->GetHash();
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
 
@@ -684,8 +684,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_researcher_with_superbloc
 
     BOOST_CHECK(claim.m_quorum_hash == expected.m_quorum_hash);
     BOOST_CHECK(claim.m_quorum_address.empty() == true);
-    BOOST_CHECK(claim.m_superblock.WellFormed() == true);
-    BOOST_CHECK(claim.m_superblock.GetHash() == expected.m_superblock.GetHash());
+    BOOST_CHECK(claim.m_superblock->WellFormed() == true);
+    BOOST_CHECK(claim.m_superblock->GetHash() == expected.m_superblock->GetHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -812,8 +812,7 @@ void CWalletTx::GetAmounts2(list<COutputEntry>& listReceived,
         }
         else
         {
-            if (   ( !ExtractDestination(txout.scriptPubKey, address) )
-                || ( !ExtractDestination(txout.scriptPubKey, address) && txout.scriptPubKey[0] != OP_RETURN) )
+            if (!ExtractDestination(txout.scriptPubKey, address) && txout.scriptPubKey[0] != OP_RETURN)
             {
                 LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                      this->GetHash().ToString().c_str());
@@ -892,7 +891,7 @@ void CWalletTx::GetAmounts(list<pair<CTxDestination, int64_t> >& listReceived,
 
         // In either case, we need to get the destination address
         CTxDestination address;
-        if (!ExtractDestination(txout.scriptPubKey, address))
+        if (!ExtractDestination(txout.scriptPubKey, address) && txout.scriptPubKey[0] != OP_RETURN)
         {
             LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                      this->GetHash().ToString().c_str());


### PR DESCRIPTION
This refactors the intake of contracts and superblocks in `ConnectBlock()` to avoid mutating the containing transaction. These could potentially move the contract or superblock data which breaks the hash-based lookup for removal from the memory pool. We now copy the data instead until we can rework the flow for the more efficient move operations.