### PR TITLE
Skip beacon advertisement when already pending

### DIFF
--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -276,6 +276,19 @@ bool BeaconRegistry::ContainsActive(const Cpid& cpid) const
     return ContainsActive(cpid, GetAdjustedTime());
 }
 
+std::vector<CKeyID> BeaconRegistry::FindPendingKeys(const Cpid& cpid) const
+{
+    std::vector<CKeyID> found;
+
+    for (const auto& beacon_pair : m_pending) {
+        if (beacon_pair.second.m_cpid == cpid) {
+            found.emplace_back(beacon_pair.first);
+        }
+    }
+
+    return found;
+}
+
 void BeaconRegistry::Add(Contract contract)
 {
     BeaconPayload payload = contract.CopyPayloadAs<BeaconPayload>();

--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -36,7 +36,7 @@ uint256 HashBeaconPayload(const BeaconPayload& payload)
 //! \return \c true if the supplied beacon contract matches an active beacon.
 //! This updates the matched beacon with a new timestamp.
 //!
-bool TryRenewal(BeaconRegistry::BeaconMap beacons, const BeaconPayload& payload)
+bool TryRenewal(BeaconRegistry::BeaconMap& beacons, const BeaconPayload& payload)
 {
     auto beacon_pair_iter = beacons.find(payload.m_cpid);
 

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -434,6 +434,20 @@ public:
     bool ContainsActive(const Cpid& cpid) const;
 
     //!
+    //! \brief Look up the key IDs of pending beacons for the specified CPID.
+    //!
+    //! The wallet matches key IDs returned by this method to determine whether
+    //! it contains private keys for pending beacons so that it can skip beacon
+    //! advertisement if it submitted one recently.
+    //!
+    //! \param cpid CPID of the beacons to find results for.
+    //!
+    //! \return The set of RIPEMD-160 hashes of the keys for the beacons that
+    //! match the supplied CPID.
+    //!
+    std::vector<CKeyID> FindPendingKeys(const Cpid& cpid) const;
+
+    //!
     //! \brief Determine whether a beacon contract is valid.
     //!
     //! \param contract Contains the beacon data to validate.

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -199,7 +199,7 @@ enum class BeaconError
     MISSING_KEY,        //!< Beacon private key missing or invalid.
     NO_CPID,            //!< No valid CPID detected (investor mode).
     NOT_NEEDED,         //!< Beacon exists for the CPID. No renewal needed.
-    TOO_SOON,           //!< Not enough time elapsed for pending advertisement.
+    PENDING,            //!< Not enough time elapsed for pending advertisement.
     TX_FAILED,          //!< Beacon contract transacton failed to send.
     WALLET_LOCKED,      //!< Wallet not fully unlocked.
 };

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -660,7 +660,7 @@ UniValue advertisebeacon(const UniValue& params, bool fHelp)
             throw JSONRPCError(
                 RPC_INVALID_REQUEST,
                 "An active beacon already exists for this CPID");
-        case NN::BeaconError::TOO_SOON:
+        case NN::BeaconError::PENDING:
             throw JSONRPCError(
                 RPC_INVALID_REQUEST,
                 "A beacon advertisement is already pending for this CPID");
@@ -729,7 +729,7 @@ UniValue revokebeacon(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_REQUEST, "No active beacon for CPID");
         case NN::BeaconError::NOT_NEEDED:
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Unexpected error occurred");
-        case NN::BeaconError::TOO_SOON:
+        case NN::BeaconError::PENDING:
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Unexpected error occurred");
         case NN::BeaconError::TX_FAILED:
             throw JSONRPCError(


### PR DESCRIPTION
This fixes an issue that caused nodes to automatically advertise a new beacon before the previous beacon confirmed. It also fixes a typo for the `beacons` parameter in `TryRenewal()`&mdash;the pass-by-value should be pass-by-reference.