### PR TITLE
Fix Windows cross-compilation in newer environments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ AC_ARG_ENABLE([lcov],
   [enable lcov testing (default is no)])],
   [use_lcov=yes],
   [use_lcov=no])
-  
+
 AC_ARG_ENABLE([lcov-branch-coverage],
   [AS_HELP_STRING([--enable-lcov-branch-coverage],
   [enable lcov testing branch coverage (default is no)])],
@@ -741,6 +741,22 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ]
 )
 
+dnl check for gmtime_r(), fallback to gmtime_s() if that is unavailable
+dnl fail if neither are available.
+AC_MSG_CHECKING(for gmtime_r)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+  [[ gmtime_r((const time_t *) nullptr, (struct tm *) nullptr); ]])],
+  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GMTIME_R, 1, [Define this symbol if gmtime_r is available]) ],
+  [ AC_MSG_RESULT(no);
+    AC_MSG_CHECKING(for gmtime_s);
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+       [[ gmtime_s((struct tm *) nullptr, (const time_t *) nullptr); ]])],
+       [ AC_MSG_RESULT(yes)],
+       [ AC_MSG_RESULT(no); AC_MSG_ERROR(Both gmtime_r and gmtime_s are unavailable) ]
+    )
+  ]
+)
+
 # Check for different ways of gathering OS randomness
 AC_MSG_CHECKING(for Linux getrandom syscall)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
@@ -1228,7 +1244,7 @@ AC_SUBST(MINIUPNPC_CPPFLAGS)
 AC_SUBST(MINIUPNPC_LIBS)
 AC_SUBST(CRYPTO_LIBS)
 AC_SUBST(SSL_LIBS)
-AC_SUBST(CURL_LIBS)	
+AC_SUBST(CURL_LIBS)
 AC_SUBST(LIBZIP_LIBS)
 AC_SUBST(EVENT_LIBS)
 AC_SUBST(EVENT_PTHREADS_LIBS)
@@ -1286,7 +1302,7 @@ case ${OS} in
    ;;
 esac
 
-echo 
+echo
 echo "Options used to compile and link:"
 echo "  with wallet   = $enable_wallet"
 echo "  with gui / qt = $bitcoin_enable_qt"
@@ -1300,7 +1316,7 @@ echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"
 echo "  debug enabled = $enable_debug"
 echo "  werror        = $enable_werror"
-echo 
+echo
 echo "  target os     = $TARGET_OS"
 echo "  build os      = $BUILD_OS"
 echo
@@ -1312,4 +1328,4 @@ echo "  CXXFLAGS      = $CXXFLAGS"
 echo "  LDFLAGS       = $LDFLAGS"
 echo "  AS            = $CCAS"
 echo "  ASFLAGS       = $CCASFLAGS"
-echo 
+echo

--- a/depends/packages/bzip2.mk
+++ b/depends/packages/bzip2.mk
@@ -26,10 +26,12 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $($(package)_build_opts) $(MAKE) install  PREFIX=local_build
+  $($(package)_build_opts) $(MAKE) libbz2.a
 endef
 
 define $(package)_stage_cmds
-  cp -a local_build/. $($(package)_staging_dir)/$(host_prefix)
+  mkdir $($(package)_staging_prefix_dir)/include && \
+  cp -f bzlib.h $($(package)_staging_prefix_dir)/include && \
+  mkdir $($(package)_staging_prefix_dir)/lib && \
+  cp -f libbz2.a $($(package)_staging_prefix_dir)/lib
 endef
-

--- a/depends/patches/bzip2/Makefile.patch
+++ b/depends/patches/bzip2/Makefile.patch
@@ -2,7 +2,7 @@
 +++ Makefile	2019-10-28 13:31:36.918640240 -0400
 @@ -15,10 +15,10 @@
  SHELL=/bin/sh
- 
+
  # To assist in cross-compiling
 -CC=gcc
 -AR=ar
@@ -12,15 +12,6 @@
 +# AR=ar
 +# RANLIB=ranlib
 +# LDFLAGS=
- 
+
  BIGFILES=-D_FILE_OFFSET_BITS=64
  CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
-@@ -35,7 +35,7 @@
-       decompress.o \
-       bzlib.o
- 
--all: libbz2.a bzip2 bzip2recover test
-+all: libbz2.a bzip2 bzip2recover
- 
- bzip2: libbz2.a bzip2.o
- 	$(CC) $(CFLAGS) $(LDFLAGS) -o bzip2 bzip2.o -L. -lbz2

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -101,22 +101,26 @@ void MilliSleep(int64_t n)
 std::string FormatISO8601DateTime(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
-    gmtime_s(&ts, &time_val);
+#ifdef HAVE_GMTIME_R
+    if (gmtime_r(&time_val, &ts) == nullptr) {
 #else
-    gmtime_r(&time_val, &ts);
+    if (gmtime_s(&ts, &time_val) != 0) {
 #endif
+        return {};
+    }
     return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
 
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
-    gmtime_s(&ts, &time_val);
+#ifdef HAVE_GMTIME_R
+    if (gmtime_r(&time_val, &ts) == nullptr) {
 #else
-    gmtime_r(&time_val, &ts);
+    if (gmtime_s(&ts, &time_val) != 0) {
 #endif
+        return {};
+    }
     return strprintf("%04i-%02i-%02i", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday);
 }
 


### PR DESCRIPTION
This fixes a couple of issues found when compiling the depends path under Ubuntu 20.04. It updates the detection for `gmtime_r()` and `gmtime_s()` functions that appeared to change with newer MinGW headers and removes the unneeded executables from the bzip2 depends recipe that failed on the Windows _.exe_ file extensions.