### PR TITLE
doc: Update threads in coding.txt

### DIFF
--- a/doc/coding.txt
+++ b/doc/coding.txt
@@ -60,40 +60,56 @@ and its cs_KeyStore lock for example).
 -------
 Threads
 
-StartNode : Starts other threads.
+Shutdown      : Does an orderly shutdown of everything.     (grc-shutoff)
 
-ThreadGetMyExternalIP : Determines outside-the-firewall IP address,
-sends addr message to connected peers when it determines it. 
+ThreadAppInit2: Initializes Gridcoin.                       (grc-appinit2)
 
-ThreadIRCSeed : Joins IRC bootstrapping channel, watching for new
-peers and advertising this node's IP address. 
+    ThreadFlushWalletDB: Close the wallet.dat file if it hasn't been used (grc-wallet)
+                         in 500ms.
 
-ThreadSocketHandler : Sends/Receives data from peers on port 8333.
+    StartNode          : Starts other network threads.                    (grc-start)
 
-ThreadMessageHandler : Higher-level message handling (sending and
-receiving).
+        ThreadGetMyExternalIP     : Determines outside-the-firewall IP address,            (grc-ext-ip)
+                                    sends addr message to connected peers when
+                                    it determines it.
 
-ThreadOpenConnections : Initiates new connections to peers.
+        ThreadDNSAddressSeed      : Loads addresses of peers from the DNS.                 (grc-dnsseed)
 
-ThreadTopUpKeyPool : replenishes the keystore's keypool.
+        ThreadMapPort             : Universal plug-and-play startup/shutdown.              (grc-UPnP)
 
-ThreadCleanWalletPassphrase : re-locks an encrypted wallet after user
-has unlocked it for a period of time. 
+        ThreadSocketHandler       : Sends/Receives data from peers on port 8333.           (grc-net)
 
-SendingDialogStartTransfer : used by pay-via-ip-address code (obsolete)
+        ThreadOpenAddedConnections: Opens network connections to added nodes.              (grc-opencon)
 
-ThreadDelayedRepaint : repaint the gui 
+        ThreadOpenConnections     : Initiates new connections to peers.                    (grc-opencon)
+        
+        ThreadMessageHandler      : Higher-level message handling (sending and receiving). (grc-msghand)
 
-ThreadFlushWalletDB : Close the wallet.dat file if it hasn't been used
-in 500ms.
+        ThreadDumpAddress         : Saves peers to peers.dat                               (grc-adrdump)
 
-ThreadRPCServer : Remote procedure call handler, listens on port 8332
-for connections and services them.
+        ThreadStakeMiner          : Generates Gridcoins.                                   (grc-stake-miner)
+        
+        ThreadScraper             : Pulls statistics from project servers.
+                                    Mutually exclusive with NeuralNetwork
 
-ThreadBitcoinMiner : Generates bitcoins
+        NeuralNetwork             : Generates superblocks.
+                                    Mutually exclusive with ThreadScraper
 
-ThreadMapPort : Universal plug-and-play startup/shutdown
+    ThreadRPCServer    : Remote procedure call handler, listens on port 8332
+                          for connections and services them.
+        
+        ThreadTopUpKeyPool          : replenishes the keystore's keypool.     (grc-key-top)
+        
+        ThreadCleanWalletPassphrase : re-locks an encrypted wallet after user (grc-lock-wa)
+                                      has unlocked it for a period of time.
 
-Shutdown : Does an orderly shutdown of everything
+    CScheduler         : Schedules tasks.
 
-ExitTimeout : Windows-only, sleeps 5 seconds then exits application
+ipcThread     : Scan to check if a URI (gridcoin:) is used. (grc-gui-ipc)
+
+----------------
+Snapshot Threads
+
+SnapshotDownloadThread: Downloads the snapshot from gridcoin.us. (grc-snapshotdl)
+
+SnapshotExtractThread : Extracts the downloaded snapshot.        (grc-snapshotex)

--- a/doc/coding.txt
+++ b/doc/coding.txt
@@ -60,8 +60,6 @@ and its cs_KeyStore lock for example).
 -------
 Threads
 
-Shutdown      : Does an orderly shutdown of everything.     (grc-shutoff)
-
 ThreadAppInit2: Initializes Gridcoin.                       (grc-appinit2)
 
     ThreadFlushWalletDB: Close the wallet.dat file if it hasn't been used (grc-wallet)
@@ -98,14 +96,16 @@ ThreadAppInit2: Initializes Gridcoin.                       (grc-appinit2)
     ThreadRPCServer    : Remote procedure call handler, listens on port 8332
                           for connections and services them.
         
-        ThreadTopUpKeyPool          : replenishes the keystore's keypool.     (grc-key-top)
+        ThreadTopUpKeyPool          : Replenishes the keystore's keypool.     (grc-key-top)
         
-        ThreadCleanWalletPassphrase : re-locks an encrypted wallet after user (grc-lock-wa)
+        ThreadCleanWalletPassphrase : Re-locks an encrypted wallet after user (grc-lock-wa)
                                       has unlocked it for a period of time.
 
     CScheduler         : Schedules tasks.
 
-ipcThread     : Scan to check if a URI (gridcoin:) is used. (grc-gui-ipc)
+ipcThread     : Scans to check if a URI (gridcoin:) is used. (grc-gui-ipc)
+
+Shutdown      : Does an orderly shutdown of everything.     (grc-shutoff)
 
 ----------------
 Snapshot Threads


### PR DESCRIPTION
This PR updates docs/coding.txt with the current threads, sorts them in call order and a tree depending on which thread are they called from.

Is there any that's missing?

For preview: https://github.com/div72/Gridcoin-Research/blob/docs-coding/doc/coding.txt