### PR TITLE
qt: Include QPainterPath in trafficgraphwidget.cpp

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -2,6 +2,7 @@
 #include "clientmodel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
This PR includes QPainterPath in `src/qt/trafficgraphwidget.cpp`.
Tested on QT 5.15, ~~would appreciate it if someone can test it on older versions~~. (Travis compiles fine)