### PR TITLE
gui: Show peers tab on connections icon click

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -500,7 +500,8 @@ void BitcoinGUI::createToolBars()
     frameBlocksLayout->setSpacing(-1);
     labelEncryptionIcon = new QLabel();
     labelStakingIcon = new QLabel();
-    labelConnectionsIcon = new QLabel();
+    labelConnectionsIcon = new ClickLabel();
+    connect(labelConnectionsIcon, SIGNAL(clicked()), this, SLOT(peersClicked()));
     labelBlocksIcon = new QLabel();
     labelScraperIcon = new QLabel();
     labelBeaconIcon = new QLabel();
@@ -1123,6 +1124,12 @@ void BitcoinGUI::websiteClicked()
 void BitcoinGUI::exchangeClicked()
 {
     QDesktopServices::openUrl(QUrl("https://gridcoin.us/exchange.htm#GridcoinWallet"));
+}
+
+void BitcoinGUI::peersClicked()
+{
+    if (rpcConsole != nullptr)
+        rpcConsole->showPeersTab();
 }
 
 void BitcoinGUI::gotoOverviewPage()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -201,6 +201,7 @@ private slots:
     void boincStatsClicked();
 	void chatClicked();
     void diagnosticsClicked();
+    void peersClicked();
 
     void newUserWizardClicked();
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -759,6 +759,12 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->peerDetailWidget->show();
 }
 
+void RPCConsole::showPeersTab()
+{
+    show();
+    ui->tabWidget->setCurrentWidget(ui->tab_peers);
+}
+
 
 void RPCConsole::resizeEvent(QResizeEvent *event)
 {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -92,6 +92,8 @@ public slots:
     void banSelectedNode(int bantime);
     /** Unban a selected node on the Bans tab */
     void unbanSelectedNode();
+    /** Show peer tab */
+    void showPeersTab();
 
 
 signals:


### PR DESCRIPTION
Changes the labelConnectionsIcon to a ClickLabel and makes it open the peers tab on click.
Closes #1729 (if single-click is acceptable)
Compiles fine, works with no apparent issues.