### PR TITLE
Fix out-of-bounds access in IsMineInner()

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1577,7 +1577,7 @@ isminetype IsMine(const CKeyStore &keystore, const CTxDestination &dest)
 IsMineResult IsMineInner(const CKeyStore &keystore, const CScript& scriptPubKey)
 {
     IsMineResult ret = IsMineResult::NO;
-    
+
     vector<valtype> vSolutions;
     txnouttype whichType;
     if (!Solver(scriptPubKey, whichType, vSolutions))
@@ -1588,6 +1588,7 @@ IsMineResult IsMineInner(const CKeyStore &keystore, const CScript& scriptPubKey)
     {
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
+        break;
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
         if (keystore.HaveKey(keyID)) {


### PR DESCRIPTION
This fixes a memory access violation for `OP_RETURN` transaction outputs in the `IsMineInner()` function. These outputs have no solutions, so we exit early to avoid indexing into the `vSolutions` vector. 