### PR TITLE
util: Fix braindamage in GetDefaultDataDir()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -427,7 +427,10 @@ void InitLogging()
     }
 
     if (!LogInstance().m_log_timestamps)
+    {
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
+    }
+
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());
 
@@ -741,10 +744,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 #endif
 
     LogPrintf("Using OpenSSL version %s", SSLeay_version(SSLEAY_VERSION));
-    if (!fLogTimestamps)
-        LogPrintf("Startup time: %s", DateTimeStrFormat("%x %H:%M:%S",  GetAdjustedTime()));
-    LogPrintf("Default data directory %s", GetDefaultDataDir().string());
-    LogPrintf("Used data directory %s", datadir.string());
+
     std::ostringstream strErrors;
 
     fDevbuildCripple = false;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -16,7 +16,7 @@
 #include <mutex>
 #include <set>
 
-// Unavoidable because these are in util.h.
+// externs unavoidable because these are in util.h.
 extern fs::path &GetDataDir(bool fNetSpecific = true);
 extern bool GetBoolArg(const std::string& strArg, bool fDefault);
 extern int64_t GetArg(const std::string& strArg, int64_t nDefault);
@@ -512,4 +512,3 @@ bool BCLog::Logger::archive(bool fImmediate, fs::path pfile_out)
         return false; // archive condition was not satisfied. Do nothing and return false.
     }
 }
-

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -17,7 +17,7 @@
 #include <set>
 
 // Unavoidable because these are in util.h.
-extern fs::path &GetDataDir(bool fNetSpecific);
+extern fs::path &GetDataDir(bool fNetSpecific = true);
 extern bool GetBoolArg(const std::string& strArg, bool fDefault);
 extern int64_t GetArg(const std::string& strArg, int64_t nDefault);
 
@@ -374,7 +374,7 @@ bool BCLog::Logger::archive(bool fImmediate, fs::path pfile_out)
     boost::gregorian::date ArchiveCheckDate = boost::posix_time::from_time_t(nTime).date();
     fs::path plogfile;
     fs::path pfile_temp;
-    fs::path pathDataDir = GetDataDir(false);
+    fs::path pathDataDir = GetDataDir();
 
     std::stringstream ssArchiveCheckDate, ssPrevArchiveCheckDate;
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -398,19 +398,9 @@ AutoStartupArguments GetAutoStartupArguments()
 
     AutoStartupArguments result;
 
-    // We can't use GetDataDir() here because it appends /testnet for
-    // testnet, which is correct for internal use, but not what we
-    // need for the command line argument. I think the fNetSpecific flag
-    // for GetDataDir is not coded right.
-    // TODO: Review GetDataDir() fix and replace this.
-    if (mapArgs.count("-datadir"))
-    {
-            result.data_dir = fs::system_complete(mapArgs["-datadir"]);
-            if (!fs::is_directory(result.data_dir))
-            {
-                result.data_dir = "";
-            }
-    }
+    // We do NOT want testnet appended here for the path in the autostart
+    // shortcut, so use false in GetDataDir().
+    result.data_dir = GetDataDir(false);
 
     result.arguments = "-min";
 

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -962,8 +962,7 @@ void Scraper(bool bSingleShot)
         pathScraper = pathDataDir  / "Scraper";
     }
 
-    // Initialize log singleton. Must be after the imbue.
-    ScraperLogInstance();
+    _log(logattribute::INFO, "Scraper", "Using data directory " + pathScraper.string());
 
     if (!bSingleShot)
         _log(logattribute::INFO, "Scraper", "Starting Scraper thread.");
@@ -1217,11 +1216,9 @@ void NeuralNetwork()
     {
         pathDataDir = GetDataDir();
         pathScraper = pathDataDir  / "Scraper";
-
-        // Initialize log singleton. Must be after the imbue.
-        ScraperLogInstance();
     }
 
+    _log(logattribute::INFO, "Scraper", "Using data directory " + pathScraper.string());
 
     _log(logattribute::INFO, "NeuralNetwork", "Starting Neural Network housekeeping thread (new C++ implementation). \n"
                                               "Note that this does NOT mean the NN is active. This simply does housekeeping "

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -589,7 +589,7 @@ const fs::path &GetDataDir(bool fNetSpecific)
 
     // This can be called during exceptions by LogPrintf, so we cache the
     // value so we don't have to do memory allocations after that.
-    if (cachedPath[fNetSpecific]  && (fs::is_directory(path))  )
+    if (cachedPath[fNetSpecific] && fs::is_directory(path))
     {
         return path;
     }
@@ -601,11 +601,8 @@ const fs::path &GetDataDir(bool fNetSpecific)
             path = fs::system_complete(mapArgs["-datadir"]);
             if (!fs::is_directory(path))
             {
-                // If the specified path is not a directory, then
-                // use the default path as that is the safest thing
-                // to do.
-                path = GetDefaultDataDir();
-                return path;
+                throw std::runtime_error("Supplied datadir is invalid! "
+                                         "Please check your datadir argument. Aborting.");
             }
     }
     else
@@ -620,7 +617,8 @@ const fs::path &GetDataDir(bool fNetSpecific)
 
     if (!fs::exists(path)) fs::create_directory(path);
 
-    cachedPath[fNetSpecific]=true;
+    cachedPath[fNetSpecific] = true;
+
     return path;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -582,7 +582,7 @@ fs::path GetDefaultDataDir()
 const fs::path &GetDataDir(bool fNetSpecific)
 {
     static fs::path pathCached[2];
-    static CCriticalSection csPathCached;
+    static CCriticalSection cs_PathCached;
     static bool cachedPath[2] = {false, false};
 
     fs::path &path = pathCached[fNetSpecific];
@@ -594,7 +594,7 @@ const fs::path &GetDataDir(bool fNetSpecific)
         return path;
     }
 
-    LOCK(csPathCached);
+    LOCK(cs_PathCached);
 
     if (mapArgs.count("-datadir"))
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -562,7 +562,7 @@ fs::path GetDefaultDataDir()
     char* pszHome = getenv("HOME");
 
     // There is no home path, so default to the root directory.
-    if (pszHome == NULL || strlen(pszHome) == 0) {
+    if (pszHome == nullptr || strlen(pszHome) == 0) {
         pathRet = fs::path("/");
     } else {
         pathRet = fs::path(pszHome);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -668,7 +668,7 @@ fs::path GetProgramDir()
 fs::path GetConfigFile()
 {
     fs::path pathConfigFile(GetArg("-conf", "gridcoinresearch.conf"));
-    if (!pathConfigFile.is_absolute()) pathConfigFile = GetDataDir(false) / pathConfigFile;
+    if (!pathConfigFile.is_absolute()) pathConfigFile = GetDataDir() / pathConfigFile;
     return pathConfigFile;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -601,7 +601,10 @@ const fs::path &GetDataDir(bool fNetSpecific)
             path = fs::system_complete(mapArgs["-datadir"]);
             if (!fs::is_directory(path))
             {
-                path = "";
+                // If the specified path is not a directory, then
+                // use the default path as that is the safest thing
+                // to do.
+                path = GetDefaultDataDir();
                 return path;
             }
     }


### PR DESCRIPTION
Also fixes consistencies in a couple other areas.

There seemed to be some general confusion in the code in GetDefaultDataDir. GetDefaultDataDir is ONLY called by GetDataDir. GetDataDir already has the conditional to use the -datadir override. All of those conditions on -datadir are irrelevant and confusing in GetDefaultDataDir. I also think I straightened out the Mac stuff. Someone please double check.

I also repaired the mistake in logging where GetDataDir(false) was called, and since it SHOULD be net specific, it should have been GetDataDir().