### PR TITLE
gui: Build onboarding/beacon wizard

### DIFF
--- a/gridcoinresearch.pro
+++ b/gridcoinresearch.pro
@@ -172,6 +172,14 @@ QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wextra -Wno-ignored-qu
 
 DEPENDPATH += src src/json src/qt
 HEADERS += src/qt/bitcoingui.h \
+    src/qt/researcher/projecttablemodel.h \
+    src/qt/researcher/researchermodel.h \
+    src/qt/researcher/researcherwizard.h \
+    src/qt/researcher/researcherwizardauthpage.h \
+    src/qt/researcher/researcherwizardbeaconpage.h \
+    src/qt/researcher/researcherwizardemailpage.h \
+    src/qt/researcher/researcherwizardprojectspage.h \
+    src/qt/researcher/researcherwizardsummarypage.h \
     src/qt/transactiontablemodel.h \
     src/qt/addresstablemodel.h \
     src/qt/optionsdialog.h \
@@ -265,6 +273,14 @@ HEADERS += src/qt/bitcoingui.h \
 
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
+    src/qt/researcher/projecttablemodel.cpp \
+    src/qt/researcher/researchermodel.cpp \
+    src/qt/researcher/researcherwizard.cpp \
+    src/qt/researcher/researcherwizardauthpage.cpp \
+    src/qt/researcher/researcherwizardbeaconpage.cpp \
+    src/qt/researcher/researcherwizardemailpage.cpp \
+    src/qt/researcher/researcherwizardprojectspage.cpp \
+    src/qt/researcher/researcherwizardsummarypage.cpp \
     src/qt/transactiontablemodel.cpp \
     src/qt/addresstablemodel.cpp \
     src/qt/optionsdialog.cpp \
@@ -354,6 +370,12 @@ RESOURCES += \
 
 FORMS += \
     src/qt/forms/coincontroldialog.ui \
+    src/qt/forms/researcherwizard.ui \
+    src/qt/forms/researcherwizardauthpage.ui \
+    src/qt/forms/researcherwizardbeaconpage.ui \
+    src/qt/forms/researcherwizardemailpage.ui \
+    src/qt/forms/researcherwizardprojectspage.ui \
+    src/qt/forms/researcherwizardsummarypage.ui \
     src/qt/forms/sendcoinsdialog.ui \
     src/qt/forms/addressbookpage.ui \
     src/qt/forms/signverifymessagedialog.ui \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -85,7 +85,7 @@ QT_FORMS_UI = \
   qt/forms/transactiondescdialog.ui \
   qt/forms/askpassphrasedialog.ui \
   qt/forms/sendcoinsentry.ui
-  
+
 QT_MOC_CPP = \
   qt/moc_aboutdialog.cpp \
   qt/moc_addressbookpage.cpp \
@@ -113,6 +113,7 @@ QT_MOC_CPP = \
   qt/moc_peertablemodel.cpp \
   qt/moc_qvalidatedlineedit.cpp \
   qt/moc_qvaluecombobox.cpp \
+  qt/researcher/moc_researchermodel.cpp \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sendcoinsentry.cpp \
@@ -169,6 +170,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/qtipcserver.h \
   qt/qvalidatedlineedit.h \
   qt/qvaluecombobox.h \
+  qt/researcher/researchermodel.h \
   qt/rpcconsole.h \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
@@ -212,6 +214,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/qtipcserver.cpp \
   qt/qvalidatedlineedit.cpp \
   qt/qvaluecombobox.cpp \
+  qt/researcher/researchermodel.cpp \
   qt/rpcconsole.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
@@ -409,7 +412,7 @@ CLEANFILES += $(CLEAN_QT)
 gridcoinresearch_clean: FORCE
 	rm -f $(CLEAN_QT) $(qt_gridcoinresearch_OBJECTS) qt/gridcoinresearch$(EXEEXT)
 
-gridcoinresearch: 
+gridcoinresearch:
 	@echo "$(ZIP_LIBS)"
 	qt/gridcoinresearch$(EXEEXT)
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -81,6 +81,12 @@ QT_FORMS_UI = \
   qt/forms/addressbookpage.ui \
   qt/forms/editaddressdialog.ui \
   qt/forms/overviewpage.ui \
+  qt/forms/researcherwizard.ui \
+  qt/forms/researcherwizardauthpage.ui \
+  qt/forms/researcherwizardbeaconpage.ui \
+  qt/forms/researcherwizardemailpage.ui \
+  qt/forms/researcherwizardprojectspage.ui \
+  qt/forms/researcherwizardsummarypage.ui \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/transactiondescdialog.ui \
   qt/forms/askpassphrasedialog.ui \
@@ -113,7 +119,6 @@ QT_MOC_CPP = \
   qt/moc_peertablemodel.cpp \
   qt/moc_qvalidatedlineedit.cpp \
   qt/moc_qvaluecombobox.cpp \
-  qt/researcher/moc_researchermodel.cpp \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sendcoinsentry.cpp \
@@ -125,7 +130,15 @@ QT_MOC_CPP = \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_votingdialog.cpp \
-  qt/moc_walletmodel.cpp
+  qt/moc_walletmodel.cpp \
+  qt/researcher/moc_projecttablemodel.cpp \
+  qt/researcher/moc_researchermodel.cpp \
+  qt/researcher/moc_researcherwizard.cpp \
+  qt/researcher/moc_researcherwizardauthpage.cpp \
+  qt/researcher/moc_researcherwizardbeaconpage.cpp \
+  qt/researcher/moc_researcherwizardemailpage.cpp \
+  qt/researcher/moc_researcherwizardprojectspage.cpp \
+  qt/researcher/moc_researcherwizardsummarypage.cpp
 
 GRIDCOIN_MM = \
   qt/macdockiconhandler.mm \
@@ -170,7 +183,14 @@ GRIDCOINRESEARCH_QT_H = \
   qt/qtipcserver.h \
   qt/qvalidatedlineedit.h \
   qt/qvaluecombobox.h \
+  qt/researcher/projecttablemodel.h \
   qt/researcher/researchermodel.h \
+  qt/researcher/researcherwizard.h \
+  qt/researcher/researcherwizardauthpage.h \
+  qt/researcher/researcherwizardbeaconpage.h \
+  qt/researcher/researcherwizardemailpage.h \
+  qt/researcher/researcherwizardprojectspage.h \
+  qt/researcher/researcherwizardsummarypage.h \
   qt/rpcconsole.h \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
@@ -214,7 +234,14 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/qtipcserver.cpp \
   qt/qvalidatedlineedit.cpp \
   qt/qvaluecombobox.cpp \
+  qt/researcher/projecttablemodel.cpp \
   qt/researcher/researchermodel.cpp \
+  qt/researcher/researcherwizard.cpp \
+  qt/researcher/researcherwizardauthpage.cpp \
+  qt/researcher/researcherwizardbeaconpage.cpp \
+  qt/researcher/researcherwizardemailpage.cpp \
+  qt/researcher/researcherwizardprojectspage.cpp \
+  qt/researcher/researcherwizardsummarypage.cpp \
   qt/rpcconsole.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
@@ -280,6 +307,7 @@ RES_ICONS = \
   qt/res/icons/tx_output.svg \
   qt/res/icons/tx_por_ss.svg \
   qt/res/icons/tx_por.svg \
+  qt/res/icons/warning.svg \
   qt/res/icons/white_and_red_x.svg \
   qt/res/icons/www.png \
   qt/res/icons/icons_native/overview.svg \

--- a/src/contract/polls.cpp
+++ b/src/contract/polls.cpp
@@ -12,6 +12,7 @@
 #include "neuralnet/contract/contract.h"
 #include "neuralnet/contract/message.h"
 #include "neuralnet/quorum.h"
+#include "neuralnet/researcher.h"
 #include "neuralnet/superblock.h"
 #include "neuralnet/tally.h"
 
@@ -174,7 +175,7 @@ std::pair<std::string, std::string> CreateVoteContract(std::string sTitle, std::
     const std::string primary_cpid = NN::GetPrimaryCpid();
 
     std::string GRCAddress = DefaultWalletAddress();
-    double dmag = NN::Quorum::MyMagnitude().Floating();
+    double dmag = NN::Researcher::Get()->Magnitude().Floating();
     double poll_duration = PollDuration(sTitle) * 86400;
 
     // Prevent Double Voting

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -194,6 +194,19 @@ bool static Bind(const CService &addr, bool fError = true) {
     return true;
 }
 
+static void CreateNewConfigFile()
+{
+    fsbridge::ofstream myConfig;
+    myConfig.open(GetConfigFile());
+
+    myConfig
+        << "addnode=addnode-us-central.cycy.me\n"
+        << "addnode=ec2-3-81-39-58.compute-1.amazonaws.com\n"
+        << "addnode=gridcoin.ddns.net\n"
+        << "addnode=seeds.gridcoin.ifoggz-network.xyz\n"
+        << "addnode=www.grcpool.com\n";
+}
+
 // Core-specific options shared between UI and daemon
 std::string HelpMessage()
 {
@@ -493,11 +506,17 @@ bool AppInit2(ThreadHandlerPtr threads)
     // ********************************************************* Step 2: parameter interactions
 
 
-    // Gridcoin - Check to see if config is empty?
     if (IsConfigFileEmpty())
     {
-           uiInterface.ThreadSafeMessageBox(
-                 "Configuration file empty.  \n" + _("Please wait for new user wizard to start..."), "", 0);
+        try
+        {
+            CreateNewConfigFile();
+            ReadConfigFile(mapArgs, mapMultiArgs);
+        }
+        catch (const std::exception& e)
+        {
+            LogPrintf("WARNING: failed to create configuration file: %s", e.what());
+        }
     }
 
     //6-10-2014: R Halford: Updating Boost version to 1.5.5 to prevent sync issues; print the boost version to verify:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1135,8 +1135,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     NN::ReplayContracts(pindexBest);
 
-    uiInterface.InitMessage(_("Finding first applicable Research Project..."));
-    NN::Researcher::Reload();
+    NN::Researcher::Initialize();
 
     if (!pwalletMain->IsLocked())
         NN::Researcher::Get()->ImportBeaconKeysFromConfig(pwalletMain);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -202,7 +202,10 @@ static void CreateNewConfigFile()
     myConfig
         << "addnode=addnode-us-central.cycy.me\n"
         << "addnode=ec2-3-81-39-58.compute-1.amazonaws.com\n"
+        << "addnode=gridcoin.crypto.fans\n"
         << "addnode=gridcoin.ddns.net\n"
+        << "addnode=london.grcnode.co.uk\n"
+        << "addnode=nuad.de\n"
         << "addnode=seeds.gridcoin.ifoggz-network.xyz\n"
         << "addnode=www.grcpool.com\n";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2618,7 +2618,7 @@ private:
         int64_t research_owed = 0;
 
         if (const NN::CpidOption cpid = m_claim.m_mining_id.TryCpid()) {
-            research_owed = NN::Tally::GetComputer(*cpid, m_block.nTime, m_pindex)->Accrual();
+            research_owed = NN::Tally::GetAccrual(*cpid, m_block.nTime, m_pindex);
         }
 
         int64_t out_stake_owed;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,8 +544,6 @@ void GetGlobalStatus()
             LogPrintf("Error obtaining last poll: %s", e.what());
         }
 
-        const NN::ResearcherPtr researcher = NN::Researcher::Get();
-
         LOCK(GlobalStatusStruct.lock);
 
         GlobalStatusStruct.blocks = ToString(nBestHeight);
@@ -553,11 +551,7 @@ void GetGlobalStatus()
         GlobalStatusStruct.netWeight = RoundToString(GetEstimatedNetworkWeight() / 80.0,2);
         //todo: use the real weight from miner status (requires scaling)
         GlobalStatusStruct.coinWeight = sWeight;
-        GlobalStatusStruct.magnitude = researcher->Magnitude().ToString();
-        GlobalStatusStruct.cpid = researcher->Id().ToString();
         GlobalStatusStruct.poll = std::move(current_poll);
-
-        GlobalStatusStruct.status = msMiningErrors;
 
         unsigned long stk_dropped;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2743,6 +2743,7 @@ bool GridcoinConnectBlock(
     }
 
     NN::Tally::RecordRewardBlock(pindex);
+    NN::Researcher::Refresh();
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,6 +544,8 @@ void GetGlobalStatus()
             LogPrintf("Error obtaining last poll: %s", e.what());
         }
 
+        const NN::ResearcherPtr researcher = NN::Researcher::Get();
+
         LOCK(GlobalStatusStruct.lock);
 
         GlobalStatusStruct.blocks = ToString(nBestHeight);
@@ -551,8 +553,8 @@ void GetGlobalStatus()
         GlobalStatusStruct.netWeight = RoundToString(GetEstimatedNetworkWeight() / 80.0,2);
         //todo: use the real weight from miner status (requires scaling)
         GlobalStatusStruct.coinWeight = sWeight;
-        GlobalStatusStruct.magnitude = NN::Quorum::MyMagnitude().ToString();
-        GlobalStatusStruct.cpid = NN::GetPrimaryCpid();
+        GlobalStatusStruct.magnitude = researcher->Magnitude().ToString();
+        GlobalStatusStruct.cpid = researcher->Id().ToString();
         GlobalStatusStruct.poll = std::move(current_poll);
 
         GlobalStatusStruct.status = msMiningErrors;

--- a/src/main.h
+++ b/src/main.h
@@ -219,9 +219,6 @@ struct globalStatusType
     std::string difficulty;
     std::string netWeight;
     std::string coinWeight;
-    std::string magnitude;
-    std::string cpid;
-    std::string status;
     std::string poll;
     std::string errors;
 };

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1050,8 +1050,7 @@ bool CreateGridcoinReward(
         index.nVersion = blocknew.nVersion;
         index.nHeight = pindexPrev->nHeight + 1;
 
-        const NN::AccrualComputer calc = NN::Tally::GetComputer(*cpid, blocknew.nTime, &index);
-        claim.m_research_subsidy = calc->Accrual();
+        claim.m_research_subsidy = NN::Tally::GetAccrual(*cpid, blocknew.nTime, &index);
 
         // If no pending research subsidy value exists, build an investor claim.
         // This avoids polluting the block index with non-research reward blocks

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1507,11 +1507,9 @@ void MapPort()
 // The first name is used as information source for addrman.
 // The second name should resolve to a list of seed addresses.
 static const char *strDNSSeed[][2] = {
-    {"node.gridcoin.us", "node.gridcoin.us"},
-    {"london.grcnode.co.uk", "london.grcnode.co.uk"},
-    {"gridcoin.crypto.fans", "gridcoin.crypto.fans"},
+    {"addnode-us-central.cycy.me", "addnode-us-central.cycy.me"},
+    {"ec2-3-81-39-58.compute-1.amazonaws.com", "ec2-3-81-39-58.compute-1.amazonaws.com"},
     {"node.grcpool.com", "node.grcpool.com"},
-    {"nuad.de", "nuad.de"},
     {"seeds.gridcoin.ifoggz-network.xyz", "seeds.gridcoin.ifoggz-network.xyz"},
     {"", ""},
 };

--- a/src/neuralnet/accrual/snapshot.h
+++ b/src/neuralnet/accrual/snapshot.h
@@ -234,13 +234,15 @@ public:
         // a superblock after contract improvements for more accurate age.
         //
         if (m_account.IsNew()) {
-            const int64_t beacon_time = GetBeaconRegistry().Try(m_cpid)->m_timestamp;
+            if (const BeaconOption beacon = GetBeaconRegistry().Try(m_cpid)) {
+                const int64_t beacon_time = beacon->m_timestamp;
 
-            if (beacon_time <= 0) {
-                return 0;
+                if (beacon_time > 0) {
+                    return m_payment_time - beacon_time;
+                }
             }
 
-            return m_payment_time - beacon_time;
+            return 0;
         }
 
         return SnapshotCalculator::AccrualAge(m_account);

--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -262,6 +262,26 @@ BeaconOption BeaconRegistry::TryActive(const Cpid& cpid, const int64_t now) cons
     return nullptr;
 }
 
+std::vector<const PendingBeacon*> BeaconRegistry::FindPending(const Cpid cpid) const
+{
+    // TODO: consider adding a lookup table for pending beacons keyed by CPID.
+    // Since the protocol just needs to look up pending beacons by public key,
+    // we just do a search here. Informational RPCs or local beacon management
+    // only need to call this occasionally.
+
+    std::vector<const PendingBeacon*> found;
+
+    for (const auto& pending_beacon_pair : m_pending) {
+        const PendingBeacon& beacon = pending_beacon_pair.second;
+
+        if (beacon.m_cpid == cpid) {
+            found.emplace_back(&beacon);
+        }
+    }
+
+    return found;
+}
+
 bool BeaconRegistry::ContainsActive(const Cpid& cpid, const int64_t now) const
 {
     if (const BeaconOption beacon = Try(cpid)) {
@@ -274,19 +294,6 @@ bool BeaconRegistry::ContainsActive(const Cpid& cpid, const int64_t now) const
 bool BeaconRegistry::ContainsActive(const Cpid& cpid) const
 {
     return ContainsActive(cpid, GetAdjustedTime());
-}
-
-std::vector<CKeyID> BeaconRegistry::FindPendingKeys(const Cpid& cpid) const
-{
-    std::vector<CKeyID> found;
-
-    for (const auto& beacon_pair : m_pending) {
-        if (beacon_pair.second.m_cpid == cpid) {
-            found.emplace_back(beacon_pair.first);
-        }
-    }
-
-    return found;
 }
 
 void BeaconRegistry::Add(Contract contract)

--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -167,9 +167,15 @@ BeaconPayload::BeaconPayload()
 {
 }
 
-BeaconPayload::BeaconPayload(const Cpid cpid, Beacon beacon)
-    : m_cpid(cpid)
+BeaconPayload::BeaconPayload(const uint32_t version, const Cpid cpid, Beacon beacon)
+    : m_version(version)
+    , m_cpid(cpid)
     , m_beacon(std::move(beacon))
+{
+}
+
+BeaconPayload::BeaconPayload(const Cpid cpid, Beacon beacon)
+    : BeaconPayload(CURRENT_VERSION, cpid, std::move(beacon))
 {
 }
 
@@ -181,13 +187,8 @@ BeaconPayload BeaconPayload::Parse(const std::string& key, const std::string& va
         return BeaconPayload();
     }
 
-    Beacon beacon = Beacon::Parse(value);
-
-    if (!beacon.WellFormed()) {
-        return BeaconPayload();
-    }
-
-    return BeaconPayload(*cpid, std::move(beacon));
+    // Legacy beacon payloads always parse to version 1:
+    return BeaconPayload(1, *cpid, Beacon::Parse(value));
 }
 
 bool BeaconPayload::Sign(CKey& private_key)

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -412,6 +412,15 @@ public:
     BeaconOption TryActive(const Cpid& cpid, const int64_t now) const;
 
     //!
+    //! \brief Get the set of pending beacons for the specified CPID.
+    //!
+    //! \param cpid CPID to find pending beacons for.
+    //!
+    //! \return A set of pending beacons advertised for the supplied CPID.
+    //!
+    std::vector<const PendingBeacon*> FindPending(const Cpid cpid) const;
+
+    //!
     //! \brief Determine whether a beacon is active for the specified CPID.
     //!
     //! \param cpid The CPID to check for an active beacon.
@@ -432,20 +441,6 @@ public:
     //! specified CPID.
     //!
     bool ContainsActive(const Cpid& cpid) const;
-
-    //!
-    //! \brief Look up the key IDs of pending beacons for the specified CPID.
-    //!
-    //! The wallet matches key IDs returned by this method to determine whether
-    //! it contains private keys for pending beacons so that it can skip beacon
-    //! advertisement if it submitted one recently.
-    //!
-    //! \param cpid CPID of the beacons to find results for.
-    //!
-    //! \return The set of RIPEMD-160 hashes of the keys for the beacons that
-    //! match the supplied CPID.
-    //!
-    std::vector<CKeyID> FindPendingKeys(const Cpid& cpid) const;
 
     //!
     //! \brief Determine whether a beacon contract is valid.

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -350,6 +350,8 @@ void NN::ReplayContracts(const CBlockIndex* pindex)
                 block.GetBlockTime());
         }
     }
+
+    NN::Researcher::Refresh();
 }
 
 void NN::ApplyContracts(const CBlock& block, bool& found_contract)
@@ -388,7 +390,7 @@ void NN::ApplyContracts(const std::vector<Contract>& contracts)
             {
                 // Rescan in-memory project CPIDs to resolve a primary CPID
                 // that fits the now active team requirement settings:
-                NN::Researcher::Refresh();
+                NN::Researcher::MarkDirty();
             }
         }
 

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -3,7 +3,6 @@
 #include "neuralnet/claim.h"
 #include "neuralnet/magnitude.h"
 #include "neuralnet/quorum.h"
-#include "neuralnet/researcher.h"
 #include "neuralnet/superblock.h"
 #include "scraper_net.h"
 #include "util/reverse_iterator.h"
@@ -1587,15 +1586,6 @@ bool Quorum::ValidateSuperblock(
     LogPrintf("ValidateSuperblock(): %s.", message);
 
     return result != Result::INVALID;
-}
-
-Magnitude Quorum::MyMagnitude()
-{
-    if (const auto cpid_option = NN::Researcher::Get()->Id().TryCpid()) {
-        return Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(*cpid_option);
-    }
-
-    return Magnitude::Zero();
 }
 
 Magnitude Quorum::GetMagnitude(const Cpid cpid)

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -1602,6 +1602,50 @@ Magnitude Quorum::GetMagnitude(const MiningId mining_id)
     return Magnitude::Zero();
 }
 
+std::vector<ExplainMagnitudeProject> Quorum::ExplainMagnitude(const Cpid cpid)
+{
+    // Force a scraper convergence update if needed:
+    // TODO: unwrap this from ScraperGetSuperblockContract()
+    CreateSuperblock();
+
+    const std::string cpid_str = cpid.ToString();
+    const Span<const char> cpid_span = MakeSpan(cpid_str);
+
+    // Compare the stats entry CPID and return the project name if it matches:
+    const auto try_item = [&](const std::string& object_id) {
+        const Span<const char> id_span = MakeSpan(object_id);
+        const Span<const char> cpid_subspan = id_span.last(32);
+
+        if (cpid_subspan != cpid_span) {
+            return Span<const char>();
+        }
+
+        return id_span.first(id_span.size() - 33);
+    };
+
+    std::vector<ExplainMagnitudeProject> projects;
+
+    LOCK(cs_ConvergedScraperStatsCache);
+
+    // Although the map is ordered, the keys begin with project names, so we
+    // cannot binary search for a block of CPID entries yet:
+    //
+    for (const auto& entry : ConvergedScraperStatsCache.mScraperConvergedStats) {
+        if (entry.first.objecttype == statsobjecttype::byCPIDbyProject) {
+            const Span<const char> project_name = try_item(entry.first.objectID);
+
+            if (project_name.size() > 0) {
+                projects.emplace_back(
+                    std::string(project_name.begin(), project_name.end()),
+                    entry.second.statsvalue.dRAC,
+                    entry.second.statsvalue.dMag);
+            }
+        }
+    }
+
+    return projects;
+}
+
 SuperblockPtr Quorum::CurrentSuperblock()
 {
     return g_superblock_index.Current();

--- a/src/neuralnet/quorum.h
+++ b/src/neuralnet/quorum.h
@@ -109,14 +109,6 @@ public:
         const size_t hint_bits = 32);
 
     //!
-    //! \brief Get the current magnitude of the CPID loaded by the wallet.
-    //!
-    //! \return The wallet user's magnitude or zero if the wallet started in
-    //! investor mode.
-    //!
-    static Magnitude MyMagnitude();
-
-    //!
     //! \brief Get the current magnitude for the specified CPID.
     //!
     //! \param cpid The CPID to fetch the magnitude for.

--- a/src/neuralnet/quorum.h
+++ b/src/neuralnet/quorum.h
@@ -13,6 +13,31 @@ class Superblock;
 class SuperblockPtr;
 
 //!
+//! \brief A CPID's project magnitude record produced from scraper statistics.
+//!
+class ExplainMagnitudeProject
+{
+public:
+    std::string m_name; //!< Project name.
+    double m_rac;       //!< CPID's recent average credit for the project.
+    double m_magnitude; //!< CPID's magnitude for the project.
+
+    //!
+    //! \brief Initialize a new project magnitude record.
+    //!
+    //! \param name      Project name.
+    //! \param rac       CPID's recent average credit for the project.
+    //! \param magnitude CPID's magnitude for the project.
+    //!
+    ExplainMagnitudeProject(std::string name, double rac, double magnitude)
+        : m_name(std::move(name))
+        , m_rac(rac)
+        , m_magnitude(magnitude)
+    {
+    }
+}; // ExplainMagnitudeProject
+
+//!
 //! \brief Produces, stores, and validates superblocks.
 //!
 //! The quorum system enables the Gridcoin network to arrive at a consensus on
@@ -126,6 +151,16 @@ public:
     //! mining ID represents an investor.
     //!
     static Magnitude GetMagnitude(const MiningId mining_id);
+
+    //!
+    //! \brief Generate a report from scraper statistics that contains the
+    //! project-level magnitude and recent average credit for a CPID.
+    //!
+    //! \param cpid CPID to generate the report for.
+    //!
+    //! \return A set of records with statistics for each project.
+    //!
+    static std::vector<ExplainMagnitudeProject> ExplainMagnitude(const Cpid cpid);
 
     //!
     //! \brief Get a reference to the current active superblock.

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -5,6 +5,8 @@
 #include "global_objects_noui.hpp"
 #include "init.h"
 #include "neuralnet/beacon.h"
+#include "neuralnet/magnitude.h"
+#include "neuralnet/quorum.h"
 #include "neuralnet/researcher.h"
 #include "ui_interface.h"
 #include "util.h"
@@ -863,6 +865,16 @@ bool Researcher::Eligible() const
 bool Researcher::IsInvestor() const
 {
     return m_mining_id.Which() == MiningId::Kind::INVESTOR;
+}
+
+NN::Magnitude Researcher::Magnitude() const
+{
+    if (const auto cpid_option = m_mining_id.TryCpid()) {
+        LOCK(cs_main);
+        return Quorum::GetMagnitude(*cpid_option);
+    }
+
+    return NN::Magnitude::Zero();
 }
 
 ResearcherStatus Researcher::Status() const

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -15,6 +15,7 @@ class uint256;
 
 namespace NN {
 
+class Beacon;
 class Magnitude;
 class Project;
 class WhitelistSnapshot;
@@ -316,6 +317,11 @@ public:
         const BeaconError beacon_error = BeaconError::NONE);
 
     //!
+    //! \brief Set up the local researcher context.
+    //!
+    static void Initialize();
+
+    //!
     //! \brief Get the configured BOINC account email address.
     //!
     //! \return Lowercase BOINC email address as set in the configuration file.
@@ -455,6 +461,20 @@ public:
     //! eligible CPIDs from BOINC.
     //!
     ResearcherStatus Status() const;
+
+    //!
+    //! \brief Get the beacon for the current CPID if it exists.
+    //!
+    //! \return Contains the beacon for the CPID or does not.
+    //!
+    boost::optional<Beacon> TryBeacon() const;
+
+    //!
+    //! \brief Get the pending beacon for the current CPID if it exists.
+    //!
+    //! \return Contains the pending beacon for the CPID or does not.
+    //!
+    boost::optional<Beacon> TryPendingBeacon() const;
 
     //!
     //! \brief Get the error from the last beacon advertisement, if any.

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -427,6 +427,20 @@ public:
     NN::BeaconError BeaconError() const;
 
     //!
+    //! \brief Update the node's BOINC account email address used to detect
+    //! whitelisted projects from a BOINC installation.
+    //!
+    //! This method rewrites the configuration file for the new email address,
+    //! re-reads local BOINC projects, and reloads the researcher context.
+    //!
+    //! \param email The email address to update the directive to.
+    //!
+    //! \return \c false if a filesystem error occurs while rewriting the
+    //! configuration file.
+    //!
+    bool UpdateEmail(std::string email);
+
+    //!
     //! \brief Submit a beacon contract to the network for the current CPID.
     //!
     //! This method sends a transaction to advertise a new beacon key when all

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -285,8 +285,12 @@ public:
     //!
     //! \param mining_id Represents a CPID or an investor.
     //! \param projects  A set of local projects loaded from BOINC.
+    //! \param beacon_error Last beacon advertisement error, if any.
     //!
-    Researcher(MiningId mining_id, MiningProjectMap projects);
+    Researcher(
+        MiningId mining_id,
+        MiningProjectMap projects,
+        const BeaconError beacon_error = BeaconError::NONE);
 
     //!
     //! \brief Get the configured BOINC account email address.
@@ -329,8 +333,11 @@ public:
     //!
     //! \param projects Data for one or more projects as loaded from BOINC's
     //! client_state.xml file.
+    //! \param beacon_error Set or transfer the last beacon advertisement error.
     //!
-    static void Reload(MiningProjectMap projects);
+    static void Reload(
+        MiningProjectMap projects,
+        BeaconError beacon_error = BeaconError::NONE);
 
     //!
     //! \brief Rescan the set of in-memory projects for eligible CPIDs without
@@ -396,13 +403,28 @@ public:
     NN::Magnitude Magnitude() const;
 
     //!
+    //! \brief Get the current research reward accrued for the CPID loaded by
+    //! the wallet.
+    //!
+    //! \return Research reward accrual in units of 1/100000000 GRC.
+    //!
+    int64_t Accrual() const;
+
+    //!
     //! \brief Get a value that indicates how the wallet participates in the
-    //! Proof-of-Research protocol.
+    //! research reward protocol.
     //!
     //! \return The status depends on whether the wallet successfully loaded
     //! eligible CPIDs from BOINC.
     //!
     ResearcherStatus Status() const;
+
+    //!
+    //! \brief Get the error from the last beacon advertisement, if any.
+    //!
+    //! \return Describes an error that occurred during beacon advertisement.
+    //!
+    NN::BeaconError BeaconError() const;
 
     //!
     //! \brief Submit a beacon contract to the network for the current CPID.
@@ -452,9 +474,9 @@ public:
     bool ImportBeaconKeysFromConfig(CWallet* const pwallet) const;
 
 private:
-    MiningId m_mining_id;        //!< CPID or INVESTOR variant.
-    MiningProjectMap m_projects; //!< Local projects loaded from BOINC.
-    BeaconError m_beacon_error;  //!< Last beacon error that occurred, if any.
+    MiningId m_mining_id;           //!< CPID or INVESTOR variant.
+    MiningProjectMap m_projects;    //!< Local projects loaded from BOINC.
+    NN::BeaconError m_beacon_error; //!< Last beacon error that occurred, if any.
 }; // Researcher
 
 //!

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -316,6 +316,20 @@ public:
     static ResearcherPtr Get();
 
     //!
+    //! \brief Declare that the researcher context needs to be refreshed.
+    //!
+    //! When executing batches of operations that may change the validity of
+    //! the researcher context, it's expensive to call refresh each time one
+    //! of those operations induces a need update the researcher state. Call
+    //! this method instead to flag the researcher context for update. Then,
+    //! refresh the context after a batch finishes.
+    //!
+    //! For example, we may do this while processing all of the contracts in
+    //! transaction or when reading a series of blocks from disk.
+    //!
+    static void MarkDirty();
+
+    //!
     //! \brief Reload the wallet's researcher mining context from BOINC.
     //!
     //! This method attempts to read BOINC's client_state.xml file to gather

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -15,6 +15,8 @@ class uint256;
 
 namespace NN {
 
+class Magnitude;
+
 //!
 //! \brief Describes the eligibility status for earning rewards as part of the
 //! research reward protocol.
@@ -384,6 +386,14 @@ public:
     //! is configured to start in investor mode.
     //!
     bool IsInvestor() const;
+
+    //!
+    //! \brief Get the current magnitude of the CPID loaded by the wallet.
+    //!
+    //! \return The wallet user's magnitude or zero if the wallet started in
+    //! investor mode.
+    //!
+    NN::Magnitude Magnitude() const;
 
     //!
     //! \brief Get a value that indicates how the wallet participates in the

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -16,6 +16,8 @@ class uint256;
 namespace NN {
 
 class Magnitude;
+class Project;
+class WhitelistSnapshot;
 
 //!
 //! \brief Describes the eligibility status for earning rewards as part of the
@@ -56,8 +58,9 @@ struct MiningProject
     //! \param name Project name from the \c <project_name> element.
     //! \param cpid External CPID parsed from the \c <external_cpid> element.
     //! \param team Associated team parsed from the \c <team_name> element.
+    //! \param url  Project website URL parsed from the \c <master_url> element.
     //!
-    MiningProject(std::string name, Cpid cpid, std::string team);
+    MiningProject(std::string name, Cpid cpid, std::string team, std::string url);
 
     //!
     //! \brief Initialize a MiningProject instance by parsing the project XML
@@ -71,6 +74,7 @@ struct MiningProject
     std::string m_name; //!< Normalized project name.
     Cpid m_cpid;        //!< CPID of the BOINC account for the project.
     std::string m_team; //!< Name of the team joined for the project.
+    std::string m_url;  //!< URL of the project website.
     Error m_error;      //!< May describe why a project is ineligible.
 
     //!
@@ -80,6 +84,25 @@ struct MiningProject
     //! CPID joined to a whitelisted team.
     //!
     bool Eligible() const;
+
+    //!
+    //! \brief Attempt to resolve a matching project from the current Gridcoin
+    //! whitelist.
+    //!
+    //! \param whitelist A snapshot of the current whitelisted projects.
+    //!
+    //! \return A pointer to the whitelist project if it matches.
+    //!
+    const Project* TryWhitelist(const WhitelistSnapshot& whitelist) const;
+
+    //!
+    //! \brief Determine whether the project is whitelisted.
+    //!
+    //! \param whitelist A snapshot of the current whitelisted projects.
+    //!
+    //! \return \c true if the project matches a project on the whitelist.
+    //!
+    bool Whitelisted(const WhitelistSnapshot& whitelist) const;
 
     //!
     //! \brief Get a friendly, human-readable message that describes why the

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -622,6 +622,14 @@ const ResearchAccount& Tally::GetAccount(const Cpid cpid)
     return g_researcher_tally.GetAccount(cpid);
 }
 
+int64_t Tally::GetAccrual(
+    const Cpid cpid,
+    const int64_t payment_time,
+    const CBlockIndex* const last_block_ptr)
+{
+    return GetComputer(cpid, payment_time, last_block_ptr)->Accrual();
+}
+
 AccrualComputer Tally::GetComputer(
     const Cpid cpid,
     const int64_t payment_time,

--- a/src/neuralnet/tally.h
+++ b/src/neuralnet/tally.h
@@ -104,6 +104,20 @@ public:
     static const ResearchAccount& GetAccount(const Cpid cpid);
 
     //!
+    //! \brief Calculate the research reward accrual for the specified CPID.
+    //!
+    //! \param cpid           CPID to calculate research accrual for.
+    //! \param payment_time   Time of payment to calculate rewards at.
+    //! \param last_block_ptr Refers to the block for the reward.
+    //!
+    //! \return Research reward accrual in units of 1/100000000 GRC.
+    //!
+    static int64_t GetAccrual(
+        const Cpid cpid,
+        const int64_t payment_time,
+        const CBlockIndex* const last_block_ptr);
+
+    //!
     //! \brief Get an initialized research reward accrual calculator.
     //!
     //! \param cpid           CPID to calculate research accrual for.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -9,6 +9,7 @@
 #include "bitcoingui.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
+#include "researcher/researchermodel.h"
 #include "optionsmodel.h"
 #include "global_objects_noui.hpp"
 #include "guiutil.h"
@@ -477,9 +478,11 @@ int StartGridcoinQt(int argc, char *argv[])
 
                 ClientModel clientModel(&optionsModel);
                 WalletModel walletModel(pwalletMain, &optionsModel);
+                ResearcherModel researcherModel;
 
                 window.setClientModel(&clientModel);
                 window.setWalletModel(&walletModel);
+                window.setResearcherModel(&researcherModel);
 
                 // If -min option passed, start window minimized.
                 if(GetBoolArg("-min"))
@@ -506,6 +509,7 @@ int StartGridcoinQt(int argc, char *argv[])
                 window.hide();
                 window.setClientModel(0);
                 window.setWalletModel(0);
+                window.setResearcherModel(0);
                 guiref = 0;
             }
             // Shutdown the core and its threads, but don't exit Bitcoin-Qt here

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -73,6 +73,7 @@
         <file alias="white_and_red_x">res/icons/white_and_red_x.svg</file>
         <file alias="staking_unable">res/icons/staking_unable.svg</file>
         <file alias="superblock">res/icons/superblock.svg</file>
+        <file alias="warning">res/icons/warning.svg</file>
     </qresource>
     <qresource prefix="/images">
         <file alias="splash">res/images/splash3.png</file>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -499,7 +499,8 @@ void BitcoinGUI::createToolBars()
     connect(labelConnectionsIcon, SIGNAL(clicked()), this, SLOT(peersClicked()));
     labelBlocksIcon = new QLabel();
     labelScraperIcon = new QLabel();
-    labelBeaconIcon = new QLabel();
+    labelBeaconIcon = new ClickLabel();
+    connect(labelBeaconIcon, SIGNAL(clicked()), this, SLOT(researcherClicked()));
 
     frameBlocksLayout->addWidget(labelEncryptionIcon);
     frameBlocksLayout->addWidget(labelStakingIcon);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -319,6 +319,9 @@ void BitcoinGUI::createActions()
     optionsAction = new QAction(tr("&Options..."), this);
     optionsAction->setToolTip(tr("Modify configuration options for Gridcoin"));
     optionsAction->setMenuRole(QAction::PreferencesRole);
+    researcherAction = new QAction(tr("&Researcher Wizard..."), this);
+    researcherAction->setToolTip(tr("Open BOINC and beacon settings for Gridcoin"));
+    researcherAction->setMenuRole(QAction::PreferencesRole);
     toggleHideAction = new QAction(tr("&Show / Hide"), this);
     encryptWalletAction = new QAction(tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setToolTip(tr("Encrypt or decrypt wallet"));
@@ -344,6 +347,7 @@ void BitcoinGUI::createActions()
     connect(quitAction, SIGNAL(triggered()), qApp, SLOT(quit()));
     connect(aboutAction, SIGNAL(triggered()), this, SLOT(aboutClicked()));
     connect(optionsAction, SIGNAL(triggered()), this, SLOT(optionsClicked()));
+    connect(researcherAction, SIGNAL(triggered()), this, SLOT(researcherClicked()));
     connect(toggleHideAction, SIGNAL(triggered()), this, SLOT(toggleHidden()));
     connect(encryptWalletAction, SIGNAL(triggered(bool)), this, SLOT(encryptWallet(bool)));
     connect(backupWalletAction, SIGNAL(triggered()), this, SLOT(backupWallet()));
@@ -378,6 +382,7 @@ void BitcoinGUI::setIcons()
     aboutAction->setIcon(QPixmap(":/images/gridcoin"));
     diagnosticsAction->setIcon(QPixmap(":/images/gridcoin"));
     optionsAction->setIcon(QPixmap(":/icons/options"));
+    researcherAction->setIcon(QPixmap(":/images/gridcoin"));
     toggleHideAction->setIcon(QPixmap(":/images/gridcoin"));
     backupWalletAction->setIcon(QPixmap(":/icons/filesave"));
     changePassphraseAction->setIcon(QPixmap(":/icons/key"));
@@ -420,6 +425,8 @@ void BitcoinGUI::createMenuBar()
 
     settings->addAction(unlockWalletAction);
     settings->addAction(lockWalletAction);
+    settings->addSeparator();
+    settings->addAction(researcherAction);
     settings->addSeparator();
     settings->addAction(optionsAction);
 
@@ -695,6 +702,8 @@ void BitcoinGUI::createTrayIconMenu()
     trayIconMenu->addAction(signMessageAction);
     trayIconMenu->addAction(verifyMessageAction);
     trayIconMenu->addSeparator();
+    trayIconMenu->addAction(researcherAction);
+    trayIconMenu->addSeparator();
     trayIconMenu->addAction(optionsAction);
     trayIconMenu->addAction(openRPCConsoleAction);
 #ifndef Q_OS_MAC // This is built-in on Mac
@@ -721,6 +730,15 @@ void BitcoinGUI::optionsClicked()
     OptionsDialog dlg;
     dlg.setModel(clientModel->getOptionsModel());
     dlg.exec();
+}
+
+void BitcoinGUI::researcherClicked()
+{
+    if (!researcherModel || !walletModel) {
+        return;
+    }
+
+    researcherModel->showWizard(walletModel);
 }
 
 void BitcoinGUI::aboutClicked()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -10,6 +10,7 @@
 class TransactionTableModel;
 class ClientModel;
 class WalletModel;
+class ResearcherModel;
 class TransactionView;
 class OverviewPage;
 class AddressBookPage;
@@ -52,6 +53,11 @@ public:
     */
     void setWalletModel(WalletModel *walletModel);
 
+    /** Set the researcher model.
+        The researcher model provides the BOINC context for the research reward system.
+    */
+    void setResearcherModel(ResearcherModel *researcherModel);
+
 protected:
     void changeEvent(QEvent *e);
     void closeEvent(QCloseEvent *event);
@@ -61,6 +67,7 @@ protected:
 private:
     ClientModel *clientModel;
     WalletModel *walletModel;
+    ResearcherModel *researcherModel;
 
     QStackedWidget *centralWidget;
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -93,7 +93,6 @@ private:
 	QAction *exchangeAction;
     QAction *votingAction;
 	QAction *diagnosticsAction;
-    QAction *newUserWizardAction;
     QAction *verifyMessageAction;
     QAction *aboutAction;
     QAction *receiveCoinsAction;
@@ -166,7 +165,6 @@ public slots:
 
 	void askQuestion(std::string caption, std::string body, bool *result);
 
-	void NewUserWizard();
     void handleURI(QString strURI);
     void setOptionsStyleSheet(QString qssFileName);
 
@@ -202,9 +200,6 @@ private slots:
 	void chatClicked();
     void diagnosticsClicked();
     void peersClicked();
-
-    void newUserWizardClicked();
-
     void snapshotClicked();
 
 #ifndef Q_OS_MAC

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -103,6 +103,7 @@ private:
     QAction *verifyMessageAction;
     QAction *aboutAction;
     QAction *receiveCoinsAction;
+    QAction *researcherAction;
     QAction *optionsAction;
     QAction *toggleHideAction;
     QAction *exportAction;
@@ -196,6 +197,8 @@ private slots:
 
     /** Show configuration dialog */
     void optionsClicked();
+    /** Show researcher/beacon configuration dialog */
+    void researcherClicked();
     /** Show about dialog */
     void aboutClicked();
 

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -228,7 +228,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Output extra debugging information. Implies a
 QT_TRANSLATE_NOOP("bitcoin-core", "Output extra network debugging information"),
 QT_TRANSLATE_NOOP("bitcoin-core", "POR Blocks Verified"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Password for JSON-RPC connections"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Please wait for new user wizard to start..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Prepend debug output with timestamp"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Print version and exit"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Project email mismatch"),

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -203,33 +203,14 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0" colspan="2">
-             <widget class="Line" name="balanceDividerLine">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
+            <item row="4" column="0">
              <widget class="QLabel" name="totalBalanceLabel">
               <property name="text">
                <string>Total:</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="4" column="1">
              <widget class="QLabel" name="totalLabel">
               <property name="toolTip">
                <string>Your current total balance</string>
@@ -255,17 +236,40 @@
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
-              <height>40</height>
+              <height>20</height>
              </size>
             </property>
            </spacer>
           </item>
           <item>
-           <widget class="Line" name="dividerLine">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+           <layout class="QHBoxLayout" name="stakingHeaderLayout">
+            <property name="spacing">
+             <number>7</number>
             </property>
-           </widget>
+            <item>
+             <widget class="QLabel" name="stakingHeaderLabel">
+              <property name="text">
+               <string>Staking</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::PlainText</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="stakingHorizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
           <item>
            <layout class="QFormLayout" name="formLayout">
@@ -336,27 +340,6 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="magnitudeTextLabel">
-              <property name="text">
-               <string>Magnitude:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="cpidTextLabel">
-              <property name="text">
-               <string>CPID:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0">
-             <widget class="QLabel" name="statusTextLabel">
-              <property name="text">
-               <string>Status:</string>
-              </property>
-             </widget>
-            </item>
             <item row="3" column="1">
              <widget class="QLabel" name="coinWeightLabel">
               <property name="text">
@@ -367,8 +350,84 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
-             <widget class="QLabel" name="magnitudeLabel">
+           </layout>
+          </item>
+          <item>
+           <spacer name="researcherSectionVerticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="researcherHeaderLayout">
+            <property name="spacing">
+             <number>7</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="researcherHeaderLabel">
+              <property name="text">
+               <string>Researcher</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::PlainText</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="researcherWarningLabel">
+              <property name="text">
+               <string notr="true">(action needed)</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="researcherHorizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QFormLayout" name="researcherFormLayout">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+            </property>
+            <property name="horizontalSpacing">
+             <number>12</number>
+            </property>
+            <property name="verticalSpacing">
+             <number>12</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="statusTextLabel">
+              <property name="text">
+               <string>Status:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="statusLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -377,7 +436,14 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="1" column="0">
+             <widget class="QLabel" name="cpidTextLabel">
+              <property name="text">
+               <string>CPID:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
              <widget class="QLabel" name="cpidLabel">
               <property name="text">
                <string notr="true"/>
@@ -387,8 +453,15 @@
               </property>
              </widget>
             </item>
-            <item row="6" column="1">
-             <widget class="QLabel" name="statusLabel">
+            <item row="2" column="0">
+             <widget class="QLabel" name="magnitudeTextLabel">
+              <property name="text">
+               <string>Magnitude:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="magnitudeLabel">
               <property name="text">
                <string notr="true"/>
               </property>
@@ -413,7 +486,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>20</height>
           </size>
          </property>
         </spacer>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -470,6 +470,23 @@
               </property>
              </widget>
             </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="accrualTextLabel">
+              <property name="text">
+               <string>Pending Accrual:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="accrualLabel">
+              <property name="text">
+               <string notr="true"/>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
          </layout>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>948</width>
-    <height>559</height>
+    <height>635</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -384,16 +384,6 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="researcherWarningLabel">
-              <property name="text">
-               <string notr="true">(action needed)</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
              <spacer name="researcherHorizontalSpacer">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
@@ -473,7 +463,7 @@
             <item row="3" column="0">
              <widget class="QLabel" name="accrualTextLabel">
               <property name="text">
-               <string>Pending Accrual:</string>
+               <string>Pending Reward:</string>
               </property>
              </widget>
             </item>
@@ -485,6 +475,103 @@
               <property name="textInteractionFlags">
                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QPushButton" name="beaconButton">
+              <property name="toolTip">
+               <string>Open the researcher/beacon configuration wizard.</string>
+              </property>
+              <property name="text">
+               <string>&amp;Beacon...</string>
+              </property>
+              <property name="default">
+               <bool>false</bool>
+              </property>
+              <property name="flat">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QWidget" name="researcherAlertWrapper" native="true">
+              <layout class="QHBoxLayout" name="researcherAlertLayout">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+                <widget class="QLabel" name="researcherAlertIconLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>16</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="pixmap">
+                  <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
+                 </property>
+                 <property name="scaledContents">
+                  <bool>true</bool>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::NoTextInteraction</set>
+                 </property>
+                </widget>
+               </item>
+               <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+                <widget class="QLabel" name="researcherAlertLabel">
+                 <property name="text">
+                  <string notr="true">Action needed</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="researcherAlertSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
              </widget>
             </item>
            </layout>
@@ -688,6 +775,8 @@
    <header>clicklabel.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -551,7 +551,7 @@
                <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
                 <widget class="QLabel" name="researcherAlertLabel">
                  <property name="text">
-                  <string notr="true">Action needed</string>
+                  <string>Action Needed</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/qt/forms/researcherwizard.ui
+++ b/src/qt/forms/researcherwizard.ui
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResearcherWizard</class>
+ <widget class="QWizard" name="ResearcherWizard">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>660</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Researcher Configuration</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <property name="wizardStyle">
+   <enum>QWizard::ClassicStyle</enum>
+  </property>
+  <property name="options">
+   <set>QWizard::HaveCustomButton1|QWizard::NoBackButtonOnLastPage|QWizard::NoBackButtonOnStartPage|QWizard::NoCancelButtonOnLastPage</set>
+  </property>
+  <widget class="ResearcherWizardEmailPage" name="emailPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+  </widget>
+  <widget class="ResearcherWizardProjectsPage" name="projectsPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+  </widget>
+  <widget class="ResearcherWizardBeaconPage" name="beaconPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+  </widget>
+  <widget class="ResearcherWizardAuthPage" name="authPage"/>
+  <widget class="ResearcherWizardSummaryPage" name="summaryPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ResearcherWizardSummaryPage</class>
+   <extends>QWizardPage</extends>
+   <header>researcher/researcherwizardsummarypage.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ResearcherWizardEmailPage</class>
+   <extends>QWizardPage</extends>
+   <header>researcher/researcherwizardemailpage.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ResearcherWizardProjectsPage</class>
+   <extends>QWizardPage</extends>
+   <header>researcher/researcherwizardprojectspage.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ResearcherWizardBeaconPage</class>
+   <extends>QWizardPage</extends>
+   <header>researcher/researcherwizardbeaconpage.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ResearcherWizardAuthPage</class>
+   <extends>QWizardPage</extends>
+   <header>researcher/researcherwizardauthpage.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/researcherwizardauthpage.ui
+++ b/src/qt/forms/researcherwizardauthpage.ui
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResearcherWizardAuthPage</class>
+ <widget class="QWizardPage" name="ResearcherWizardAuthPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Beacon Verification</string>
+  </property>
+  <property name="title">
+   <string>Beacon Verification</string>
+  </property>
+  <property name="subTitle">
+   <string>Gridcoin needs to verify your BOINC account CPID. Please follow the instructions below to change your BOINC account username. The network needs 24 to 48 hours to verify a new CPID.</string>
+  </property>
+  <layout class="QVBoxLayout" name="authPageLayout">
+   <item>
+    <spacer name="headerSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="step1Label">
+     <property name="text">
+      <string>1. Sign in to your account at the website for a whitelisted BOINC project.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="step2Label">
+     <property name="text">
+      <string>2. Visit the settings page to change your username. Many projects label it as &quot;other account info&quot;.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="step3Label">
+     <property name="text">
+      <string>3. Change your username to the following verification code:</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="verificationCodeLayout">
+     <property name="leftMargin">
+      <number>16</number>
+     </property>
+     <property name="topMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <property name="bottomMargin">
+      <number>9</number>
+     </property>
+     <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+      <widget class="QLabel" name="verificationCodeLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <family>Monospace</family>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+      <widget class="QPushButton" name="copyToClipboardButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Copy the verification code to the system clipboard</string>
+       </property>
+       <property name="text">
+        <string>&amp;Copy</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verificationCodeSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="step4Label">
+     <property name="text">
+      <string>4. Wait 24 to 48 hours for the verification process to finish (beacon status will change to &quot;active&quot;).</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="step5Label">
+     <property name="text">
+      <string>5. After that, you may change the username back to your preference.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="rememberSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="rememberLabel">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;
+&lt;head/&gt;
+&lt;body&gt;
+&lt;h4 style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;
+&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;Remember:&lt;/span&gt;
+&lt;/h4&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0;&quot;&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:0px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The network only needs to verify the code above at a single whitelisted BOINC project even when you participate in multiple projects. &lt;/li&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:0px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The verification code expires after three days pass. &lt;/li&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:0px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A beacon expires after six months pass. &lt;/li&gt;&lt;li style=&quot; margin-top:6px; margin-bottom:0px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A beacon becomes eligible for renewal after five months pass. The wallet will remind you to renew the beacon. &lt;/li&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:12px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You will not need to change your username again to renew a beacon unless it expires. &lt;/li&gt;
+&lt;/ul&gt;
+&lt;/body&gt;
+&lt;/html&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="footerSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/forms/researcherwizardbeaconpage.ui
+++ b/src/qt/forms/researcherwizardbeaconpage.ui
@@ -23,7 +23,7 @@
    <string>Beacon Advertisement</string>
   </property>
   <property name="subTitle">
-   <string>A beacon is a special type of Gridcoin transaction that links a BOINC CPID to your wallet. After sending a beacon, the network tracks your BOINC statistics to calculate research rewards.</string>
+   <string>A beacon links your BOINC accounts to your wallet. After sending a beacon, the network tracks your BOINC statistics to calculate research rewards.</string>
   </property>
   <layout class="QVBoxLayout" name="beaconPageLayout">
    <item>

--- a/src/qt/forms/researcherwizardbeaconpage.ui
+++ b/src/qt/forms/researcherwizardbeaconpage.ui
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResearcherWizardBeaconPage</class>
+ <widget class="QWizardPage" name="ResearcherWizardBeaconPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Beacon Advertisement</string>
+  </property>
+  <property name="title">
+   <string>Beacon Advertisement</string>
+  </property>
+  <property name="subTitle">
+   <string>A beacon is a special type of Gridcoin transaction that links a BOINC CPID to your wallet. After sending a beacon, the network tracks your BOINC statistics to calculate research rewards.</string>
+  </property>
+  <layout class="QVBoxLayout" name="beaconPageLayout">
+   <item>
+    <spacer name="headerSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QLabel" name="beaconIconLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../bitcoin.qrc">:/icons/beacon_grey</pixmap>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::NoTextInteraction</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="beaconStatusLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QPushButton" name="sendBeaconButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;Advertise Beacon</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="cpidLayout">
+     <item>
+      <spacer name="cpidLeftSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="cpidLabelLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true">CPID:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="cpidLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="cpidRightSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QWidget" name="continuePromptWrapper" native="true">
+     <layout class="QHBoxLayout" name="continuePromptLayout">
+      <item>
+       <spacer name="continuePromptLeftSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="continuePromptIconLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true"/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../bitcoin.qrc">:/icons/synced</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>true</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::NoTextInteraction</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="continuePromptLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Press &quot;Next&quot; to continue.</string>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::NoTextInteraction</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="continuePromptRightSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="footerSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/forms/researcherwizardemailpage.ui
+++ b/src/qt/forms/researcherwizardemailpage.ui
@@ -23,7 +23,7 @@
    <string>BOINC Email Address</string>
   </property>
   <property name="subTitle">
-   <string>Confirm the email address that you provided to register the accounts for BOINC projects that you participate in. Gridcoin uses the email address to detect BOINC projects on your computer.</string>
+   <string>Enter the email address that you use for your BOINC project accounts. Gridcoin uses this email address to find BOINC projects on your computer.</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/qt/forms/researcherwizardemailpage.ui
+++ b/src/qt/forms/researcherwizardemailpage.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResearcherWizardEmailPage</class>
+ <widget class="QWizardPage" name="ResearcherWizardEmailPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>BOINC Email Address</string>
+  </property>
+  <property name="title">
+   <string>BOINC Email Address</string>
+  </property>
+  <property name="subTitle">
+   <string>Confirm the email address that you provided to register the accounts for BOINC projects that you participate in. Gridcoin uses the email address to detect BOINC projects on your computer.</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <spacer name="headerSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="emailAddressLabel">
+       <property name="text">
+        <string>Email Address:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="emailAddressLineEdit">
+       <property name="placeholderText">
+        <string notr="true">gridcoin@example.com</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="emailNoteLabelLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="emailNoteLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>The wallet will never transmit your email address.</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/researcherwizardprojectspage.ui
+++ b/src/qt/forms/researcherwizardprojectspage.ui
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResearcherWizardProjectsPage</class>
+ <widget class="QWizardPage" name="ResearcherWizardProjectsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>BOINC CPID Detection</string>
+  </property>
+  <property name="title">
+   <string>BOINC CPID Detection</string>
+  </property>
+  <property name="subTitle">
+   <string>Gridcoin scans the BOINC projects on your computer to find an eligible cross-project identifier (CPID). The network tracks CPIDs to allocate research rewards.</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMaximumSize</enum>
+     </property>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <layout class="QFormLayout" name="infoFormLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="emailLabelLabel">
+           <property name="text">
+            <string>Email Address:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="emailLabel">
+           <property name="cursor">
+            <cursorShape>IBeamCursor</cursorShape>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="boincPathLabelLabel">
+           <property name="text">
+            <string>BOINC Folder:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="boincPathLabel">
+           <property name="cursor">
+            <cursorShape>IBeamCursor</cursorShape>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="selectedCpidLabelLabel">
+           <property name="text">
+            <string>Selected CPID:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="selectedCpidhorizontalLayout">
+           <item>
+            <widget class="QLabel" name="selectedCpidLabel">
+             <property name="cursor">
+              <cursorShape>IBeamCursor</cursorShape>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+             </property>
+            </widget>
+           </item>
+           <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+            <widget class="QLabel" name="selectedCpidIconLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="pixmap">
+              <pixmap resource="../bitcoin.qrc">:/icons/white_and_red_x</pixmap>
+             </property>
+             <property name="scaledContents">
+              <bool>true</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::NoTextInteraction</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="refreshButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Re-scan the BOINC projects on your computer.</string>
+         </property>
+         <property name="text">
+          <string>&amp;Refresh</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QTableView" name="projectTableView">
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAsNeeded</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAsNeeded</enum>
+       </property>
+       <property name="showDropIndicator" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="dragEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="dragDropMode">
+        <enum>QAbstractItemView::NoDragDrop</enum>
+       </property>
+       <property name="defaultDropAction">
+        <enum>Qt::IgnoreAction</enum>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
+       </property>
+       <property name="showGrid">
+        <bool>true</bool>
+       </property>
+       <property name="gridStyle">
+        <enum>Qt::SolidLine</enum>
+       </property>
+       <property name="sortingEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="cornerButtonEnabled">
+        <bool>false</bool>
+       </property>
+       <attribute name="horizontalHeaderHighlightSections">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+        <bool>true</bool>
+       </attribute>
+       <attribute name="horizontalHeaderStretchLastSection">
+        <bool>true</bool>
+       </attribute>
+       <attribute name="verticalHeaderVisible">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="verticalHeaderShowSortIndicator" stdset="0">
+        <bool>true</bool>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/forms/researcherwizardsummarypage.ui
+++ b/src/qt/forms/researcherwizardsummarypage.ui
@@ -1,0 +1,874 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResearcherWizardSummaryPage</class>
+ <widget class="QWizardPage" name="ResearcherWizardSummaryPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Researcher Summary</string>
+  </property>
+  <property name="title">
+   <string/>
+  </property>
+  <property name="subTitle">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="summaryPageVerticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="summaryTab">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="title">
+       <string>Summary</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="summaryTabVerticalLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <spacer name="headerTopSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="cpidLabelLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string notr="true">CPID</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="cpidLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+          </font>
+         </property>
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter|Qt::AlignTop</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="overallStatusLayout">
+         <item>
+          <spacer name="overallStatusLeftSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+          <widget class="QLabel" name="overallStatusIconLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>16</width>
+             <height>16</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16</width>
+             <height>16</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="pixmap">
+            <pixmap resource="../bitcoin.qrc">:/icons/synced</pixmap>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::NoTextInteraction</set>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+          <widget class="QLabel" name="overallStatusLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Everything looks good.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="overallStatusRightSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="headerBottomSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>30</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="summaryTabDetailsLayout">
+         <item>
+          <widget class="QWidget" name="summaryDetailsWrapper" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>300</width>
+             <height>0</height>
+            </size>
+           </property>
+           <layout class="QVBoxLayout" name="summaryDetailsWrapperLayout">
+            <property name="spacing">
+             <number>10</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+             <widget class="QLabel" name="summaryDetailsIconLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>48</width>
+                <height>48</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="pixmap">
+               <pixmap resource="../bitcoin.qrc">:/images/gridcoin</pixmap>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::NoTextInteraction</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="summaryDetailsLine">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="summaryDetailsLayout">
+              <property name="leftMargin">
+               <number>6</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="statusLabelLabel">
+                <property name="text">
+                 <string>Status:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="statusLabel">
+                <property name="cursor">
+                 <cursorShape>IBeamCursor</cursorShape>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="magnitudeLabelLabel">
+                <property name="text">
+                 <string>Magnitude:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="magnitudeLabel">
+                <property name="cursor">
+                 <cursorShape>IBeamCursor</cursorShape>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="accrualLabelLabel">
+                <property name="text">
+                 <string>Pending Reward:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="accrualLabel">
+                <property name="cursor">
+                 <cursorShape>IBeamCursor</cursorShape>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <spacer name="summaryDetailsFooterSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="beaconDetailsWrapper" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>300</width>
+             <height>0</height>
+            </size>
+           </property>
+           <layout class="QVBoxLayout" name="beaconDetailsWrapperLayout">
+            <property name="spacing">
+             <number>10</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+             <widget class="QLabel" name="beaconDetailsIconLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>48</width>
+                <height>48</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>48</width>
+                <height>48</height>
+               </size>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="pixmap">
+               <pixmap resource="../bitcoin.qrc">:/icons/beacon_grey</pixmap>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::NoTextInteraction</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="beaconDetailsLine">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="beaconDetailsLayout">
+              <property name="leftMargin">
+               <number>6</number>
+              </property>
+              <property name="rightMargin">
+               <number>6</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="beaconStatusLabelLabel">
+                <property name="text">
+                 <string>Beacon:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="beaconStatusLabel">
+                <property name="cursor">
+                 <cursorShape>IBeamCursor</cursorShape>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="beaconAgeLabelLabel">
+                <property name="text">
+                 <string>Age:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="beaconAgeLabel">
+                <property name="cursor">
+                 <cursorShape>IBeamCursor</cursorShape>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="beaconExpiresLabelLabel">
+                <property name="text">
+                 <string>Expires:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="beaconExpiresLabel">
+                <property name="cursor">
+                 <cursorShape>IBeamCursor</cursorShape>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="rainAddressLabelLabel">
+                <property name="text">
+                 <string>Address:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QLabel" name="rainAddressLabel">
+                <property name="font">
+                 <font>
+                  <family>Monospace</family>
+                  <pointsize>8</pointsize>
+                 </font>
+                </property>
+                <property name="cursor">
+                 <cursorShape>IBeamCursor</cursorShape>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="Line" name="beaconButtonsLine">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="renewBeaconButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&amp;Renew</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="beaconDetailsFooterSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="footerSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="projectsTab">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="title">
+       <string>Projects</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="projectsTabVerticalLayout">
+       <item>
+        <layout class="QHBoxLayout" name="headerHorizontalLayout">
+         <item>
+          <layout class="QFormLayout" name="infoFormLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="emailLabelLabel">
+             <property name="text">
+              <string>Email Address:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="emailLabel">
+             <property name="cursor">
+              <cursorShape>IBeamCursor</cursorShape>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="boincPathLabelLabel">
+             <property name="text">
+              <string>BOINC Folder:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="boincPathLabel">
+             <property name="cursor">
+              <cursorShape>IBeamCursor</cursorShape>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="selectedCpidLabelLabel">
+             <property name="text">
+              <string>Selected CPID:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <layout class="QHBoxLayout" name="selectedCpidhorizontalLayout">
+             <item>
+              <widget class="QLabel" name="selectedCpidLabel">
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="toolTip">
+                <string/>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
+              </widget>
+             </item>
+             <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+              <widget class="QLabel" name="selectedCpidIconLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>16</width>
+                 <height>16</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16</width>
+                 <height>16</height>
+                </size>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="pixmap">
+                <pixmap resource="../bitcoin.qrc">:/icons/white_and_red_x</pixmap>
+               </property>
+               <property name="scaledContents">
+                <bool>true</bool>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::NoTextInteraction</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="headerHorizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="refreshButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Re-scan the BOINC projects on your computer.</string>
+           </property>
+           <property name="text">
+            <string>&amp;Refresh</string>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTableView" name="projectTableView">
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAsNeeded</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAsNeeded</enum>
+         </property>
+         <property name="showDropIndicator" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="dragEnabled">
+          <bool>false</bool>
+         </property>
+         <property name="dragDropMode">
+          <enum>QAbstractItemView::NoDragDrop</enum>
+         </property>
+         <property name="defaultDropAction">
+          <enum>Qt::IgnoreAction</enum>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="showGrid">
+          <bool>true</bool>
+         </property>
+         <property name="gridStyle">
+          <enum>Qt::SolidLine</enum>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <property name="cornerButtonEnabled">
+          <bool>false</bool>
+         </property>
+         <attribute name="horizontalHeaderHighlightSections">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+          <bool>true</bool>
+         </attribute>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="verticalHeaderShowSortIndicator" stdset="0">
+          <bool>true</bool>
+         </attribute>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -223,6 +223,7 @@ void OverviewPage::setResearcherModel(ResearcherModel *researcherModel)
 
     updateResearcherStatus();
     connect(researcherModel, SIGNAL(researcherChanged()), this, SLOT(updateResearcherStatus()));
+    connect(researcherModel, SIGNAL(accrualChanged()), this, SLOT(updatePendingAccrual()));
 }
 
 void OverviewPage::setWalletModel(WalletModel *model)
@@ -264,6 +265,7 @@ void OverviewPage::updateDisplayUnit()
         txdelegate->unit = walletModel->getOptionsModel()->getDisplayUnit();
 
         ui->listTransactions->update();
+        updatePendingAccrual();
     }
 }
 
@@ -276,6 +278,19 @@ void OverviewPage::updateResearcherStatus()
     ui->statusLabel->setText(researcherModel->formatStatus());
     ui->cpidLabel->setText(researcherModel->formatCpid());
     ui->magnitudeLabel->setText(researcherModel->formatMagnitude());
+
+    updatePendingAccrual();
+}
+
+void OverviewPage::updatePendingAccrual()
+{
+    if (!researcherModel) {
+        return;
+    }
+
+    const int unit = walletModel->getOptionsModel()->getDisplayUnit();
+
+    ui->accrualLabel->setText(researcherModel->formatAccrual(unit));
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)
@@ -287,7 +302,5 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 
 void OverviewPage::updateglobalstatus()
 {
-
 	OverviewPage::UpdateBoincUtilization();
 }
-

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -273,9 +273,9 @@ void OverviewPage::updateResearcherStatus()
         return;
     }
 
-    ui->magnitudeLabel->setText(researcherModel->formatMagnitude());
-    ui->cpidLabel->setText(researcherModel->formatCpid());
     ui->statusLabel->setText(researcherModel->formatStatus());
+    ui->cpidLabel->setText(researcherModel->formatCpid());
+    ui->magnitudeLabel->setText(researcherModel->formatMagnitude());
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -224,6 +224,8 @@ void OverviewPage::setResearcherModel(ResearcherModel *researcherModel)
     updateResearcherStatus();
     connect(researcherModel, SIGNAL(researcherChanged()), this, SLOT(updateResearcherStatus()));
     connect(researcherModel, SIGNAL(accrualChanged()), this, SLOT(updatePendingAccrual()));
+    connect(researcherModel, SIGNAL(beaconChanged()), this, SLOT(updateResearcherAlert()));
+    connect(ui->beaconButton, SIGNAL(clicked()), this, SLOT(onBeaconButtonClicked()));
 }
 
 void OverviewPage::setWalletModel(WalletModel *model)
@@ -280,6 +282,7 @@ void OverviewPage::updateResearcherStatus()
     ui->magnitudeLabel->setText(researcherModel->formatMagnitude());
 
     updatePendingAccrual();
+    updateResearcherAlert();
 }
 
 void OverviewPage::updatePendingAccrual()
@@ -288,9 +291,31 @@ void OverviewPage::updatePendingAccrual()
         return;
     }
 
-    const int unit = walletModel->getOptionsModel()->getDisplayUnit();
+    int unit = BitcoinUnits::BTC;
+
+    if (walletModel) {
+        unit = walletModel->getOptionsModel()->getDisplayUnit();
+    }
 
     ui->accrualLabel->setText(researcherModel->formatAccrual(unit));
+}
+
+void OverviewPage::updateResearcherAlert()
+{
+    if (!researcherModel) {
+        return;
+    }
+
+    ui->researcherAlertWrapper->setVisible(researcherModel->actionNeeded());
+}
+
+void OverviewPage::onBeaconButtonClicked()
+{
+    if (!researcherModel || !walletModel) {
+        return;
+    }
+
+    researcherModel->showWizard(walletModel);
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -64,6 +64,8 @@ private slots:
     void updateDisplayUnit();
     void updateResearcherStatus();
     void updatePendingAccrual();
+    void updateResearcherAlert();
+    void onBeaconButtonClicked();
     void handleTransactionClicked(const QModelIndex &index);
     void handlePollLabelClicked();
 };

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -15,6 +15,7 @@ QT_END_NAMESPACE
 namespace Ui {
     class OverviewPage;
 }
+class ResearcherModel;
 class WalletModel;
 class TxViewDelegate;
 class TransactionFilterProxy;
@@ -28,7 +29,8 @@ public:
     explicit OverviewPage(QWidget *parent = 0);
     ~OverviewPage();
 
-    void setModel(WalletModel *model);
+    void setResearcherModel(ResearcherModel *model);
+    void setWalletModel(WalletModel *model);
     void showOutOfSyncWarning(bool fShow);
 	void updateglobalstatus();
 	void UpdateBoincUtilization();
@@ -48,7 +50,8 @@ private:
     void updateTransactions();
 
     Ui::OverviewPage *ui;
-    WalletModel *model;
+    ResearcherModel *researcherModel;
+    WalletModel *walletModel;
     qint64 currentBalance;
     qint64 currentStake;
     qint64 currentUnconfirmedBalance;
@@ -59,6 +62,7 @@ private:
 
 private slots:
     void updateDisplayUnit();
+    void updateResearcherStatus();
     void handleTransactionClicked(const QModelIndex &index);
     void handlePollLabelClicked();
 };

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -63,6 +63,7 @@ private:
 private slots:
     void updateDisplayUnit();
     void updateResearcherStatus();
+    void updatePendingAccrual();
     void handleTransactionClicked(const QModelIndex &index);
     void handlePollLabelClicked();
 };

--- a/src/qt/res/icons/warning.svg
+++ b/src/qt/res/icons/warning.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2390"
+   sodipodi:docname="warning.svg"
+   viewBox="0 0 64.745819 59.27774"
+   sodipodi:version="0.32"
+   version="1.0"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   width="64.745819"
+   height="59.27774">
+  <defs
+     id="defs11" />
+  <sodipodi:namedview
+     id="base"
+     bordercolor="#666666"
+     inkscape:pageshadow="2"
+     guidetolerance="10"
+     pagecolor="#ffffff"
+     gridtolerance="10000"
+     inkscape:window-height="715"
+     inkscape:zoom="1.979899"
+     objecttolerance="10"
+     showgrid="false"
+     borderopacity="1.0"
+     inkscape:current-layer="layer1"
+     inkscape:cx="102.24053"
+     inkscape:cy="-28.794762"
+     inkscape:window-y="729"
+     inkscape:window-x="518"
+     inkscape:window-width="1170"
+     inkscape:pageopacity="0.0"
+     inkscape:document-units="px"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(-29.489064,-27.13431)">
+    <g
+       id="g2387"
+       style="fill:#ffd42a"
+       inkscape:export-ydpi="90"
+       inkscape:export-filename="/home/mgsmith/Desktop/warning.png"
+       transform="matrix(0.45541,0,0,0.45541,26.271,23.868)"
+       inkscape:export-xdpi="90">
+      <path
+         id="path2389"
+         d="m 12.473,121.08 c -0.914,1.76 -1.991,3.41 -1.991,5.34 l 0.009,0.81 c 0,4.17 3.266,6.69 7.02,6.69 h 121.32 c 3.76,0 6.99,-3.12 6.99,-7.29 l -0.04,-0.81 c 0,-1.94 -0.95,-3.62 -1.99,-5.35 L 83.707,12.69 C 81.052,9.7442 76.748,9.7442 74.093,12.694 l -61.619,108.39 z"
+         style="fill:none;fill-opacity:1;stroke:#f00000;stroke-width:6.83139992;stroke-opacity:1"
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <circle
+       id="path2393"
+       style="fill:#f00000;fill-opacity:1"
+       inkscape:export-ydpi="90"
+       inkscape:export-filename="/home/mgsmith/Desktop/warning.png"
+       transform="matrix(0.54212,0,0,0.54212,49.546,33.731)"
+       inkscape:export-xdpi="90"
+       cx="23.921297"
+       cy="74.47538"
+       r="8.0416269" />
+    <path
+       id="path2395"
+       style="fill:#f00000;fill-opacity:1;stroke:none;stroke-opacity:1"
+       d="m 62.486,43.817 c 1.713,0 4.371,1.365 4.371,3.06 l -1.279,17.615 c 0,1.695 -1.379,3.06 -3.092,3.06 -1.713,0 -3.091,-1.365 -3.091,-3.06 L 57.902,46.877 c 0,-1.695 2.871,-3.06 4.584,-3.06 z"
+       inkscape:export-ydpi="90"
+       sodipodi:nodetypes="cccsccc"
+       inkscape:export-filename="/home/mgsmith/Desktop/warning.png"
+       inkscape:export-xdpi="90"
+       inkscape:connector-curvature="0" />
+  </g>
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:publisher>
+          <cc:Agent
+             rdf:about="http://openclipart.org/">
+            <dc:title>Openclipart</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:title>warning icon</dc:title>
+        <dc:date>2010-03-03T13:31:08</dc:date>
+        <dc:description>A very simple warning icon that can be scaled down fairly small and still be recognizable.</dc:description>
+        <dc:source>https://openclipart.org/detail/29833/warning-icon-by-matthewgarysmith</dc:source>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>matthewgarysmith</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>icon</rdf:li>
+            <rdf:li>sign</rdf:li>
+            <rdf:li>warning</rdf:li>
+            <rdf:li>yellow</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -250,10 +250,6 @@ QWidget{
     color: white;
 }
 
-QWidget:focus{
-    border: 0.065em solid rgb(65,0,127);
-}
-
 QPushButton{
     background-color: rgb(64,68,82);
 }
@@ -266,12 +262,6 @@ QPushButton:selected{
 QPushButton:hover{
     background-color: rgb(65,0,127);
     color: white;
-}
-
-QPushButton:focus{
-    background-color: rgb(49,54,59);
-    color: white;
-    border: 0.065em solid rgb(65,0,127);
 }
 
 QTreeWidget{

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -446,7 +446,7 @@ QToolBar#toolbar3 QLabel{
 
 #walletStatusLabel,
 #transactionsStatusLabel,
-#researcherWarningLabel {
+#researcherAlertLabel {
     color: red;
 }
 

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -136,7 +136,7 @@ QScrollBar::sub-line:vertical {
       border: none;
       background-color: rgb(49,54,59);
       width: 0;
-      height: 0;      
+      height: 0;
 }
 
 QToolTip {
@@ -146,10 +146,10 @@ QToolTip {
 }
 
 QTableView{
-    background-color: rgb(49,54,59); 
+    background-color: rgb(49,54,59);
     color:white;
     alternate-background-color:rgb(35,38,41);
-} 
+}
 
 QTableView::item{
     background-color: transparent;
@@ -170,23 +170,23 @@ QHeaderView{
     background-color: rgb(64,68,82);
 }
 
-QHeaderView::section { 
+QHeaderView::section {
     background-color:rgb(64,68,82);
     color:white;
-} 
+}
 
 QHeaderView::section:hover {
     background-color:rgb(65,0,127);
     color:white;
 }
 
-QComboBox { 
+QComboBox {
     background-color:rgb(35,38,41);
     color: white;
     selection-color: white;
     selection-background-color:rgb(65,0,127);
     padding: 0.065em 0em 0.065em 0.19em;
-} 
+}
 
 QComboBox:!editable:hover,
 QComboBox::drop-down:!editable:hover
@@ -215,17 +215,17 @@ QAbstractItemView::item:checked {
     color: white;
 }
 
-QLineEdit { 
+QLineEdit {
     background-color:rgb(35,38,41);
     color: white;
     selection-color: white;
     selection-background-color:rgb(65,0,127);
-} 
+}
 
-QDateTimeEdit { 
+QDateTimeEdit {
     background-color:rgb(35,38,41);
     color: white;
-} 
+}
 
 QDateTimeEdit QAbstractItemView {
     background-color:rgb(49,54,59);
@@ -275,12 +275,12 @@ QPushButton:focus{
 }
 
 QTreeWidget{
-    color: rgb(255,255,255); 
+    color: rgb(255,255,255);
     background-color: rgb(49,54,59);
     alternate-background-color: rgb(35,38,41);
 }
 
-QListView { 
+QListView {
     background: rgb(49,54,59);
     alternate-background-color: rgb(35,38,41);
 }
@@ -305,12 +305,12 @@ QDoubleSpinBox{
 }
 
 QTabWidget{
-    background-color: rgb(49,54,59);    
+    background-color: rgb(49,54,59);
 }
 
 QTabWidget::pane {  /* The tab widget frame */
     border: 0.065em solid rgb(100,100,100);
-} 
+}
 
 QTabBar::tab {
     background: rgb(64,68,82);
@@ -350,7 +350,7 @@ QGroupBox{
 QListWidget{
     color:white;
     background-color:rgb(49,54,59);
-} 
+}
 
 QRadioButton{
     color: white;
@@ -440,33 +440,23 @@ QToolBar#toolbar3 QLabel{
 
 /* overview page */
 
-#overviewWalletLabel{
-    font-size:16pt;
+#overviewWalletLabel,
+#researcherHeaderLabel,
+#stakingHeaderLabel,
+#recentTransLabel {
+    font-size:15pt;
     font-weight:bold;
 }
 
-#availableLabel{
+#availableLabel,
+#immatureTextLabel,
+#totalBalanceLabel {
     font-weight:bold;
 }
 
-#immatureTextLabel{
-    font-weight:bold;
-}
-
-#totalBalanceLabel{
-    font-weight:bold;
-}
-
-#recentTransLabel{
-    font-size:16pt;
-    font-weight:bold;
-}
-
-#walletStatusLabel{
-    color: red;
-}
-
-#transactionsStatusLabel{
+#walletStatusLabel,
+#transactionsStatusLabel,
+#researcherWarningLabel {
     color: red;
 }
 

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -10,6 +10,16 @@ BitcoinAmountField{
     background-color: rgb(49,54,59);
 }
 
+/* HLine */
+QFrame[frameShape="4"] {
+    border-top: 0.065em solid rgb(67, 74, 80);
+}
+
+/* VLine */
+QFrame[frameShape="5"] {
+    border-left: 0.065em solid rgb(67, 74, 80);
+}
+
 QToolButton {
     color: white;
     background-color: qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(49,54,59), stop: 1 rgb(49,54,59));
@@ -294,35 +304,41 @@ QDoubleSpinBox{
     background-color: rgb(35,38,41);
 }
 
-QTabWidget{
-    background-color: rgb(49,54,59);
+QTabWidget::tab-bar {
+    left: 0.5em;
 }
 
 QTabWidget::pane {  /* The tab widget frame */
-    border: 0.065em solid rgb(100,100,100);
+    background-color: rgb(58, 64, 69);
+    border: 0.065em solid rgb(67, 74, 80);
 }
 
 QTabBar::tab {
-    background: rgb(64,68,82);
-    border: 0.065em solid rgb(100,100,100);
-    min-height:1.25em;
+    background-color: rgb(49, 54, 59);
+    border: 0.065em solid rgb(67, 74, 80);
+    border-bottom: none;
+    min-height: 1.25em;
     min-width: 0.5em;
-    padding: 0.125em;
+    padding: 0.125em 1em;
+}
+
+QTabBar::tab:!first {
+    margin-left: -0.065em;
 }
 
 QTabBar::tab:selected {
-    background: rgb(49,54,59);
-    border: 0.065em solid rgb(100,100,100);
-    border-bottom-color: rgb(49,54,59);
-}
-
-QTabBar::tab:hover {
-    background: rgb(65,0,127);
-    color: white;
+    background-color: rgb(58, 64, 69);
+    border-bottom-color: rgb(58, 64, 69);
+    border-top-color: rgb(120, 20, 255);
+    border-top-width: 0.13em;
 }
 
 QTabBar::tab:!selected {
-    margin-top: 0.18em;  /* make non-selected tabs look smaller */
+    margin-top: 0.13em;
+}
+
+QTabBar::tab:!selected:hover {
+    background-color: rgb(58, 64, 69);
 }
 
 QTextEdit{
@@ -526,5 +542,3 @@ QToolBar#toolbar3 QLabel{
 #capsLabel{
     font-weight:bold;
 }
-
-

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -136,7 +136,7 @@ QScrollBar::sub-line:vertical {
       border: none;
       background-color: rgb(240,240,240);
       width: 0;
-      height: 0;      
+      height: 0;
 }
 
 QToolTip {
@@ -147,10 +147,10 @@ QToolTip {
 
 
 QTableView{
-    background-color: rgb(240,240,240); 
-    color:black; 
+    background-color: rgb(240,240,240);
+    color:black;
     alternate-background-color:white;
-} 
+}
 
 QTableView::item{
     background-color: transparent;
@@ -171,23 +171,23 @@ QHeaderView{
     background-color: rgb(220,220,220);
 }
 
-QHeaderView::section { 
+QHeaderView::section {
     background-color:rgb(220,220,220);
-    color:black; 
-} 
+    color:black;
+}
 
 QHeaderView::section:hover {
     background-color:rgb(65,0,127);
     color:white;
 }
 
-QComboBox { 
+QComboBox {
     background-color:white;
-    color: black; 
+    color: black;
     selection-color: white;
     selection-background-color:rgb(65,0,127);
     padding: 0.065em 0em 0.065em 0.19em;
-} 
+}
 
 QComboBox:!editable:hover,
 QComboBox::drop-down:!editable:hover
@@ -203,7 +203,7 @@ QComboBox:selected {
 
 QComboBox QAbstractItemView {
     background-color:white;
-    color: black; 
+    color: black;
 }
 
 QAbstractItemView::item:selected {
@@ -216,17 +216,17 @@ QAbstractItemView::item:checked {
     color: white;
 }
 
-QLineEdit { 
+QLineEdit {
     background-color:white;
-    color: black; 
+    color: black;
     selection-color: white;
     selection-background-color:rgb(65,0,127);
-} 
+}
 
-QDateTimeEdit { 
+QDateTimeEdit {
     background-color:white;
-    color: black; 
-} 
+    color: black;
+}
 
 QDateTimeEdit QAbstractItemView {
     background-color:white;
@@ -276,12 +276,12 @@ QPushButton:focus{
 }
 
 QTreeWidget{
-    color: rgb(0,0,0); 
+    color: rgb(0,0,0);
     background-color: rgb(240,240,240);
     alternate-background-color: white;
 }
 
-QListView { 
+QListView {
     background: rgb(240,240,240);
     alternate-background-color: white;
 }
@@ -306,12 +306,12 @@ QDoubleSpinBox{
 }
 
 QTabWidget{
-    background-color: rgb(240,240,240);    
+    background-color: rgb(240,240,240);
 }
 
 QTabWidget::pane {  /* The tab widget frame */
     border: 0.065em solid rgb(100,100,100);
-} 
+}
 
 QTabBar::tab {
     background: rgb(200,200,200);
@@ -349,9 +349,9 @@ QGroupBox{
 }
 
 QListWidget{
-    color:black; 
+    color:black;
     background-color:rgb(240,240,240);
-} 
+}
 
 /* Main Window*/
 
@@ -431,33 +431,23 @@ QToolBar#toolbar3 QLabel{
 
 /* overview page */
 
-#overviewWalletLabel{
-    font-size:16pt;
+#overviewWalletLabel,
+#researcherHeaderLabel,
+#stakingHeaderLabel,
+#recentTransLabel {
+    font-size:15pt;
     font-weight:bold;
 }
 
-#availableLabel{
+#availableLabel,
+#immatureTextLabel,
+#totalBalanceLabel {
     font-weight:bold;
 }
 
-#immatureTextLabel{
-    font-weight:bold;
-}
-
-#totalBalanceLabel{
-    font-weight:bold;
-}
-
-#recentTransLabel{
-    font-size:16pt;
-    font-weight:bold;
-}
-
-#walletStatusLabel{
-    color: red;
-}
-
-#transactionsStatusLabel{
+#walletStatusLabel,
+#transactionsStatusLabel,
+#researcherWarningLabel {
     color: red;
 }
 

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -437,7 +437,7 @@ QToolBar#toolbar3 QLabel{
 
 #walletStatusLabel,
 #transactionsStatusLabel,
-#researcherWarningLabel {
+#researcherAlertLabel {
     color: red;
 }
 

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -251,10 +251,6 @@ QWidget{
     color: black;
 }
 
-QWidget:focus{
-    border: 0.065em solid rgb(65,0,127);
-}
-
 QPushButton{
     background-color: rgb(230,230,230);
 }
@@ -267,12 +263,6 @@ QPushButton:selected{
 QPushButton:hover{
     background-color: rgb(65,0,127);
     color: white;
-}
-
-QPushButton:focus{
-    background-color: rgb(240,240,240);
-    color: black;
-    border: 0.065em solid rgb(65,0,127);
 }
 
 QTreeWidget{

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -295,35 +295,41 @@ QDoubleSpinBox{
     background-color: white;
 }
 
-QTabWidget{
-    background-color: rgb(240,240,240);
+QTabWidget::tab-bar {
+    left: 0.5em;
 }
 
 QTabWidget::pane {  /* The tab widget frame */
-    border: 0.065em solid rgb(100,100,100);
+    background-color: rgb(255, 255, 255);
+    border: 0.065em solid rgb(200, 200, 200);
 }
 
 QTabBar::tab {
-    background: rgb(200,200,200);
-    border: 0.065em solid rgb(100,100,100);
-    min-height:1.25em;
+    background-color: rgb(240, 240, 240);
+    border: 0.065em solid rgb(200, 200, 200);
+    border-bottom: none;
+    min-height: 1.25em;
     min-width: 0.5em;
-    padding: 0.125em;
+    padding: 0.125em 1em;
+}
+
+QTabBar::tab:!first {
+    margin-left: -0.065em;
 }
 
 QTabBar::tab:selected {
-    background: rgb(240,240,240);
-    border: 0.065em solid rgb(100,100,100);
-    border-bottom-color: rgb(240,240,240);
-}
-
-QTabBar::tab:hover {
-    background: rgb(65,0,127);
-    color: white;
+    background-color: rgb(255, 255, 255);
+    border-bottom-color: rgb(255, 255, 255);
+    border-top-color: rgb(120, 20, 255);
+    border-top-width: 0.13em;
 }
 
 QTabBar::tab:!selected {
-    margin-top: 0.18em;  /* make non-selected tabs look smaller */
+    margin-top: 0.13em;
+}
+
+QTabBar::tab:!selected:hover {
+    background: rgb(255, 255, 255);
 }
 
 QTextEdit{
@@ -509,5 +515,3 @@ QToolBar#toolbar3 QLabel{
 #capsLabel{
     font-weight:bold;
 }
-
-

--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -50,7 +50,7 @@ QToolBar#toolbar3 QLabel{
     border:none;
 }
 
-#listTransactions{ 
+#listTransactions{
     background-color:transparent;
 }
 
@@ -80,33 +80,23 @@ QToolBar#toolbar3 QLabel{
 
 /* overview page */
 
-#overviewWalletLabel{
-    font-size:16pt;
+#overviewWalletLabel,
+#researcherHeaderLabel,
+#stakingHeaderLabel,
+#recentTransLabel {
+    font-size:15pt;
     font-weight:bold;
 }
 
-#availableLabel{
+#availableLabel,
+#immatureTextLabel,
+#totalBalanceLabel {
     font-weight:bold;
 }
 
-#immatureTextLabel{
-    font-weight:bold;
-}
-
-#totalBalanceLabel{
-    font-weight:bold;
-}
-
-#recentTransLabel{
-    font-size:16pt;
-    font-weight:bold;
-}
-
-#walletStatusLabel{
-    color: red;
-}
-
-#transactionsStatusLabel{
+#walletStatusLabel,
+#transactionsStatusLabel,
+#researcherWarningLabel {
     color: red;
 }
 

--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -96,7 +96,7 @@ QToolBar#toolbar3 QLabel{
 
 #walletStatusLabel,
 #transactionsStatusLabel,
-#researcherWarningLabel {
+#researcherAlertLabel {
     color: red;
 }
 

--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -168,5 +168,3 @@ QToolBar#toolbar3 QLabel{
 #capsLabel{
     font-weight:bold;
 }
-
-

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -1,0 +1,236 @@
+#include "neuralnet/researcher.h"
+
+#include "qt/researcher/projecttablemodel.h"
+#include "qt/researcher/researchermodel.h"
+
+#include <QIcon>
+
+namespace {
+//!
+//! \brief Compares rows in a project table for sorting order.
+//!
+class CompareRowLessThan
+{
+public:
+    CompareRowLessThan(int column, Qt::SortOrder order)
+        : m_column(column)
+        , m_order(order)
+    {
+    }
+
+    bool operator()(const ProjectRow& left, const ProjectRow& right) const
+    {
+        const ProjectRow* pLeft = &left;
+        const ProjectRow* pRight = &right;
+
+        if (m_order == Qt::DescendingOrder) {
+            std::swap(pLeft, pRight);
+        }
+
+        switch (m_column) {
+            case ProjectTableModel::Name:
+                return pLeft->m_name < pRight->m_name;
+            case ProjectTableModel::Eligible:
+                return pLeft->m_error < pRight->m_error;
+            case ProjectTableModel::Whitelisted:
+                return pLeft->m_whitelisted < pRight->m_whitelisted;
+            case ProjectTableModel::Magnitude:
+                return pLeft->m_magnitude < pRight->m_magnitude;
+            case ProjectTableModel::Cpid:
+                return pLeft->m_cpid < pRight->m_cpid;
+        }
+
+        return false;
+    }
+
+private:
+    int m_column;
+    Qt::SortOrder m_order;
+}; // CompareRowLessThan
+} // Anonymous namespace
+
+// -----------------------------------------------------------------------------
+// Class: ProjectTableData
+// -----------------------------------------------------------------------------
+
+class ProjectTableData
+{
+public:
+    ProjectTableData()
+        : m_sort_column(static_cast<int>(ProjectTableModel::ColumnIndex::Name))
+    {
+    }
+
+    size_t size() const
+    {
+        return m_rows.size();
+    }
+
+    ProjectRow* index(const int row)
+    {
+        if (row > static_cast<int>(m_rows.size())) {
+            return nullptr;
+        }
+
+        return &m_rows[row];
+    }
+
+    void sort(const int column, const Qt::SortOrder order)
+    {
+        m_sort_column = column;
+        m_sort_order = order;
+
+        DoSort();
+    }
+
+    void reload(std::vector<ProjectRow> rows)
+    {
+        m_rows = std::move(rows);
+
+        DoSort();
+    }
+
+private:
+    int m_sort_column;
+    Qt::SortOrder m_sort_order;
+    std::vector<ProjectRow> m_rows;
+
+    void DoSort()
+    {
+        std::stable_sort(
+            m_rows.begin(),
+            m_rows.end(),
+            CompareRowLessThan(m_sort_column, m_sort_order));
+    }
+}; // ProjectTableStats
+
+// -----------------------------------------------------------------------------
+// Class: ProjectTableModel
+// -----------------------------------------------------------------------------
+
+ProjectTableModel::ProjectTableModel(ResearcherModel *model, bool show_magnitude)
+    : m_model(model)
+    , m_data(new ProjectTableData())
+    , m_show_magnitude(show_magnitude)
+{
+    m_columns
+        << tr("Name")
+        << tr("Eligible")
+        << tr("Whitelist")
+        << tr("Magnitude")
+        << tr("CPID");
+}
+
+ProjectTableModel::~ProjectTableModel()
+{
+    // Nothing to do yet...
+}
+
+int ProjectTableModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return m_data->size();
+}
+
+int ProjectTableModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return m_columns.size();
+}
+
+QVariant ProjectTableModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
+    const ProjectRow* row = static_cast<const ProjectRow*>(index.internalPointer());
+
+    switch (role) {
+        case Qt::DisplayRole:
+            switch (index.column()) {
+                case Name:
+                    return row->m_name;
+                case Eligible:
+                    if (!row->m_error.isEmpty()) {
+                        return row->m_error;
+                    }
+                    break;
+                case Cpid:
+                    return row->m_cpid;
+                case Magnitude:
+                    return row->m_magnitude;
+            }
+            break;
+
+        case Qt::DecorationRole:
+            switch (index.column()) {
+                case Eligible:
+                    if (row->m_error.isEmpty()) {
+                        return QIcon(":/icons/synced");
+                    }
+                    break;
+                case Whitelisted:
+                    if (row->m_whitelisted) {
+                        return QIcon(":/icons/synced");
+                    }
+                    break;
+            }
+            break;
+
+        case Qt::TextAlignmentRole:
+            switch (index.column()) {
+                case Magnitude:
+                    return QVariant(Qt::AlignRight | Qt::AlignVCenter);
+            }
+            break;
+    }
+
+    return QVariant();
+}
+
+QVariant ProjectTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation == Qt::Horizontal) {
+        if (role == Qt::DisplayRole && section < m_columns.size()) {
+            return m_columns[section];
+        }
+    }
+
+    return QVariant();
+}
+
+QModelIndex ProjectTableModel::index(int row, int column, const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    ProjectRow* data = m_data->index(row);
+
+    if (data) {
+        return createIndex(row, column, data);
+    }
+
+    return QModelIndex();
+}
+
+Qt::ItemFlags ProjectTableModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid()) {
+        return Qt::NoItemFlags;
+    }
+
+    return (Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+}
+
+void ProjectTableModel::sort(int column, Qt::SortOrder order)
+{
+    emit layoutAboutToBeChanged();
+    m_data->sort(column, order);
+    emit layoutChanged();
+}
+
+void ProjectTableModel::refresh()
+{
+    emit layoutAboutToBeChanged();
+    m_data->reload(m_model->buildProjectTable(m_show_magnitude));
+    emit layoutChanged();
+}

--- a/src/qt/researcher/projecttablemodel.h
+++ b/src/qt/researcher/projecttablemodel.h
@@ -1,0 +1,50 @@
+#ifndef PROJECTTABLEMODEL_H
+#define PROJECTTABLEMODEL_H
+
+#include <memory>
+#include <QAbstractTableModel>
+#include <QStringList>
+
+class ProjectTableData;
+class ResearcherModel;
+
+class ProjectTableModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    enum ColumnIndex {
+        Name,
+        Eligible,
+        Whitelisted,
+        Magnitude,
+        Cpid,
+    };
+
+    explicit ProjectTableModel(
+        ResearcherModel *parent = nullptr,
+        bool show_magnitude = true);
+
+    ~ProjectTableModel();
+
+    void setModel(ResearcherModel *model);
+
+    int rowCount(const QModelIndex &parent) const override;
+    int columnCount(const QModelIndex &parent) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    void sort(int column, Qt::SortOrder order) override;
+
+public slots:
+    void refresh();
+
+private:
+    ResearcherModel *m_model;
+    QStringList m_columns;
+    std::unique_ptr<ProjectTableData> m_data;
+    bool m_show_magnitude;
+};
+
+#endif // PROJECTTABLEMODEL_H

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -56,7 +56,7 @@ BeaconStatus MapAdvertiseBeaconError(const BeaconError error)
         case BeaconError::MISSING_KEY:        return BeaconStatus::ERROR_MISSING_KEY;
         case BeaconError::NO_CPID:            return BeaconStatus::NO_CPID;
         case BeaconError::NOT_NEEDED:         return BeaconStatus::ACTIVE;
-        case BeaconError::TOO_SOON:           return BeaconStatus::PENDING;
+        case BeaconError::PENDING:            return BeaconStatus::PENDING;
         case BeaconError::TX_FAILED:          return BeaconStatus::ERROR_TX_FAILED;
         case BeaconError::WALLET_LOCKED:      return BeaconStatus::ERROR_WALLET_LOCKED;
     }

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -1,0 +1,291 @@
+#include "base58.h"
+#include "bitcoinunits.h"
+#include "guiutil.h"
+#include "neuralnet/beacon.h"
+#include "neuralnet/magnitude.h"
+#include "neuralnet/researcher.h"
+#include "researchermodel.h"
+#include "ui_interface.h"
+
+#include <QIcon>
+#include <QTimer>
+
+using namespace NN;
+
+extern CCriticalSection cs_main;
+extern std::string msMiningErrors;
+
+namespace {
+constexpr double SECONDS_IN_DAY = 24.0 * 60.0 * 60.0;
+constexpr int64_t BEACON_RENEWAL_WARNING_AGE = Beacon::MAX_AGE - (15 * SECONDS_IN_DAY);
+
+//!
+//! \brief Model callback bound to the \c ResearcherChanged core signal.
+//!
+void ResearcherChanged(ResearcherModel* model)
+{
+    LogPrintf("ResearcherChanged()");
+    QMetaObject::invokeMethod(
+        model,
+        "resetResearcher",
+        Qt::QueuedConnection,
+        Q_ARG(NN::ResearcherPtr, Researcher::Get()));
+}
+
+//!
+//! \brief Model callback bound to the \c BeaconChanged core signal.
+//!
+void BeaconChanged(ResearcherModel* model)
+{
+    LogPrintf("BeaconChanged()");
+    QMetaObject::invokeMethod(model, "updateBeacon", Qt::QueuedConnection);
+}
+
+//!
+//! \brief Convert a beacon advertisement error to a beacon status.
+//!
+//! \param error Beacon advertisement error provided the researcher API.
+//!
+//! \return Describes the advertisement error as a beacon status.
+//!
+BeaconStatus MapAdvertiseBeaconError(const BeaconError error)
+{
+    switch (error) {
+        case BeaconError::NONE:               return BeaconStatus::ACTIVE;
+        case BeaconError::INSUFFICIENT_FUNDS: return BeaconStatus::ERROR_INSUFFICIENT_FUNDS;
+        case BeaconError::MISSING_KEY:        return BeaconStatus::ERROR_MISSING_KEY;
+        case BeaconError::NO_CPID:            return BeaconStatus::NO_CPID;
+        case BeaconError::NOT_NEEDED:         return BeaconStatus::ACTIVE;
+        case BeaconError::TOO_SOON:           return BeaconStatus::PENDING;
+        case BeaconError::TX_FAILED:          return BeaconStatus::ERROR_TX_FAILED;
+        case BeaconError::WALLET_LOCKED:      return BeaconStatus::ERROR_WALLET_LOCKED;
+    }
+
+    return BeaconStatus::UNKNOWN;
+};
+} // anonymous namespace
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherModel
+// -----------------------------------------------------------------------------
+
+ResearcherModel::ResearcherModel()
+{
+    qRegisterMetaType<ResearcherPtr>("NN::ResearcherPtr");
+
+    resetResearcher(Researcher::Get());
+
+    if (NN::Researcher::ConfiguredForInvestorMode()) {
+        m_configured_for_investor_mode = true;
+        return;
+    }
+
+    m_configured_for_investor_mode = false;
+
+    subscribeToCoreSignals();
+
+    QTimer *refresh_timer = new QTimer(this);
+    connect(refresh_timer, SIGNAL(timeout()), this, SLOT(refresh()));
+    refresh_timer->start(30 * 1000);
+}
+
+ResearcherModel::~ResearcherModel()
+{
+    unsubscribeFromCoreSignals();
+}
+
+bool ResearcherModel::configuredForInvestorMode() const
+{
+    return m_configured_for_investor_mode;
+}
+
+QString ResearcherModel::formatCpid() const
+{
+    return QString::fromStdString(m_researcher->Id().ToString());
+}
+
+QString ResearcherModel::formatMagnitude() const
+{
+    return QString::fromStdString(m_researcher->Magnitude().ToString());
+}
+
+QString ResearcherModel::formatAccrual(const int display_unit) const
+{
+    return BitcoinUnits::formatWithUnit(display_unit, m_researcher->Accrual());
+}
+
+QString ResearcherModel::formatStatus() const
+{
+    if (configuredForInvestorMode()) {
+        return tr("Researcher mode disabled by configuration");
+    }
+
+    // TODO: The getmininginfo RPC shares this global. Refactor to remove it:
+    return QString::fromStdString(msMiningErrors);
+}
+
+BeaconStatus ResearcherModel::getBeaconStatus() const
+{
+    return m_beacon_status;
+}
+
+QString ResearcherModel::formatBeaconStatus() const
+{
+    switch (m_beacon_status) {
+        case BeaconStatus::ACTIVE:
+            return tr("Beacon is active.");
+        case BeaconStatus::ERROR_INSUFFICIENT_FUNDS:
+            return tr("Balance too low to send a beacon contract.");
+        case BeaconStatus::ERROR_MISSING_KEY:
+            return tr("Beacon private key missing or invalid.");
+        case BeaconStatus::ERROR_TX_FAILED:
+            return tr("Unable to send beacon transaction. See debug.log");
+        case BeaconStatus::ERROR_WALLET_LOCKED:
+            return tr("Unlock wallet fully to send a beacon transaction.");
+        case BeaconStatus::NO_BEACON:
+            return tr("No active beacon.");
+        case BeaconStatus::NO_CPID:
+            return tr("No CPID detected.");
+        case BeaconStatus::NO_MAGNITUDE:
+            return tr("Zero magnitude in the last superblock.");
+        case BeaconStatus::PENDING:
+            return tr("Pending beacon is awaiting network confirmation.");
+        case BeaconStatus::RENEWAL_NEEDED:
+            return tr("Beacon expires soon. Renew immediately.");
+        case BeaconStatus::RENEWAL_POSSIBLE:
+            return tr("Beacon eligible for renewal.");
+        case BeaconStatus::UNKNOWN:
+            return tr("Waiting for data.");
+    }
+
+    return tr("Waiting for data.");
+}
+
+QIcon ResearcherModel::getBeaconStatusIcon() const
+{
+    constexpr char success[] = ":/icons/beacon_green";
+    constexpr char warning[] = ":/icons/beacon_yellow";
+    constexpr char danger[] = ":/icons/beacon_red";
+    constexpr char inactive[] = ":/icons/beacon_grey";
+
+    switch (m_beacon_status) {
+        case BeaconStatus::ACTIVE:                   return QIcon(success);
+        case BeaconStatus::ERROR_INSUFFICIENT_FUNDS: return QIcon(danger);
+        case BeaconStatus::ERROR_MISSING_KEY:        return QIcon(danger);
+        case BeaconStatus::ERROR_TX_FAILED:          return QIcon(danger);
+        case BeaconStatus::ERROR_WALLET_LOCKED:      return QIcon(danger);
+        case BeaconStatus::NO_BEACON:                return QIcon(danger);
+        case BeaconStatus::NO_CPID:                  return QIcon(inactive);
+        case BeaconStatus::NO_MAGNITUDE:             return QIcon(warning);
+        case BeaconStatus::PENDING:                  return QIcon(warning);
+        case BeaconStatus::RENEWAL_NEEDED:           return QIcon(danger);
+        case BeaconStatus::RENEWAL_POSSIBLE:         return QIcon(warning);
+        case BeaconStatus::UNKNOWN:                  return QIcon(inactive);
+    }
+
+    return QIcon(inactive);
+}
+
+QString ResearcherModel::formatBeaconAge() const
+{
+    if (!m_beacon) {
+        return QString();
+    }
+
+    return GUIUtil::formatDurationStr(m_beacon->Age(GetAdjustedTime()));
+}
+
+QString ResearcherModel::formatTimeToBeaconExpiration() const
+{
+    if (!m_beacon) {
+        return QString();
+    }
+
+    return GUIUtil::formatDurationStr(Beacon::MAX_AGE - m_beacon->Age(GetAdjustedTime()));
+}
+
+QString ResearcherModel::formatBeaconAddress() const
+{
+    if (!m_beacon) {
+        return QString();
+    }
+
+    return QString::fromStdString(m_beacon->GetAddress().ToString());
+}
+
+void ResearcherModel::refresh()
+{
+    updateBeacon();
+
+    emit accrualChanged();
+}
+
+void ResearcherModel::resetResearcher(ResearcherPtr researcher)
+{
+    m_researcher = std::move(researcher);
+
+    emit researcherChanged();
+
+    updateBeacon();
+}
+
+void ResearcherModel::updateBeacon()
+{
+    const CpidOption cpid = m_researcher->Id().TryCpid();
+
+    if (!cpid) {
+        m_beacon.reset(nullptr);
+        m_beacon_status = BeaconStatus::NO_CPID;
+
+        emit beaconChanged();
+
+        return;
+    }
+
+    {
+        LOCK(cs_main);
+        const BeaconOption beacon = GetBeaconRegistry().Try(*cpid);
+
+        if (!beacon) {
+            m_beacon.reset(nullptr);
+            m_beacon_status = BeaconStatus::NO_BEACON;
+
+            emit beaconChanged();
+
+            return;
+        }
+
+        m_beacon.reset(new Beacon(*beacon));
+        m_beacon_status = MapAdvertiseBeaconError(m_researcher->BeaconError());
+    }
+
+    if (m_beacon_status == BeaconStatus::ACTIVE) {
+        const int64_t now = GetAdjustedTime();
+
+        if (m_beacon->Age(now) >= BEACON_RENEWAL_WARNING_AGE) {
+            m_beacon_status = BeaconStatus::RENEWAL_NEEDED;
+        } else if (m_beacon->Renewable(now)) {
+            m_beacon_status = BeaconStatus::RENEWAL_POSSIBLE;
+        } else if (m_researcher->Magnitude() == 0) {
+            m_beacon_status = BeaconStatus::NO_MAGNITUDE;
+        } else {
+            m_beacon_status = BeaconStatus::ACTIVE;
+        }
+    }
+
+    emit beaconChanged();
+}
+
+void ResearcherModel::subscribeToCoreSignals()
+{
+    // Connect signals to client
+    uiInterface.ResearcherChanged.connect(boost::bind(ResearcherChanged, this));
+    uiInterface.ResearcherChanged.connect(boost::bind(BeaconChanged, this));
+}
+
+void ResearcherModel::unsubscribeFromCoreSignals()
+{
+    // Disconnect signals from client
+    uiInterface.ResearcherChanged.disconnect(boost::bind(ResearcherChanged, this));
+    uiInterface.ResearcherChanged.disconnect(boost::bind(BeaconChanged, this));
+}

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -1,0 +1,82 @@
+#ifndef RESEARCHERMODEL_H
+#define RESEARCHERMODEL_H
+
+#include <memory>
+#include <QObject>
+
+class QIcon;
+
+namespace NN {
+class Beacon;
+class Researcher;
+
+//!
+//! \brief A smart pointer around the global BOINC researcher context.
+//!
+typedef std::shared_ptr<Researcher> ResearcherPtr;
+}
+
+//!
+//! \brief Describes the researcher's current beacon status.
+//!
+enum class BeaconStatus
+{
+    ACTIVE,
+    ERROR_INSUFFICIENT_FUNDS,
+    ERROR_MISSING_KEY,
+    ERROR_TX_FAILED,
+    ERROR_WALLET_LOCKED,
+    NO_BEACON,
+    NO_CPID,
+    NO_MAGNITUDE,
+    PENDING,
+    RENEWAL_NEEDED,
+    RENEWAL_POSSIBLE,
+    UNKNOWN,
+};
+
+//!
+//! \brief Presents researcher context state for UI components.
+//!
+class ResearcherModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    ResearcherModel();
+    ~ResearcherModel();
+
+    bool configuredForInvestorMode() const;
+    QString formatCpid() const;
+    QString formatMagnitude() const;
+    QString formatAccrual(const int display_unit) const;
+    QString formatStatus() const;
+
+    BeaconStatus getBeaconStatus() const;
+    QIcon getBeaconStatusIcon() const;
+    QString formatBeaconStatus() const;
+    QString formatBeaconAge() const;
+    QString formatTimeToBeaconExpiration() const;
+    QString formatBeaconAddress() const;
+
+private:
+    NN::ResearcherPtr m_researcher;
+    std::unique_ptr<NN::Beacon> m_beacon;
+    BeaconStatus m_beacon_status;
+    bool m_configured_for_investor_mode;
+
+    void subscribeToCoreSignals();
+    void unsubscribeFromCoreSignals();
+
+signals:
+    void researcherChanged();
+    void beaconChanged();
+    void accrualChanged();
+
+public slots:
+    void refresh();
+    void resetResearcher(NN::ResearcherPtr researcher);
+    void updateBeacon();
+};
+
+#endif // RESEARCHERMODEL_H

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -4,7 +4,12 @@
 #include <memory>
 #include <QObject>
 
+QT_BEGIN_NAMESPACE
 class QIcon;
+QT_END_NAMESPACE
+
+class ResearcherWizard;
+class WalletModel;
 
 namespace NN {
 class Beacon;
@@ -24,6 +29,7 @@ enum class BeaconStatus
     ACTIVE,
     ERROR_INSUFFICIENT_FUNDS,
     ERROR_MISSING_KEY,
+    ERROR_NOT_NEEDED,
     ERROR_TX_FAILED,
     ERROR_WALLET_LOCKED,
     NO_BEACON,
@@ -33,6 +39,26 @@ enum class BeaconStatus
     RENEWAL_NEEDED,
     RENEWAL_POSSIBLE,
     UNKNOWN,
+};
+
+//!
+//! \brief Combined information about a BOINC project to display in a table.
+//!
+//! These objects incorporate BOINC project context from:
+//!
+//!  - The Gridcoin whitelist
+//!  - Local BOINC projects detected in client_state.xml
+//!  - Scraper magnitude values for a CPID
+//!
+class ProjectRow
+{
+public:
+    bool m_eligible;
+    bool m_whitelisted;
+    QString m_name;
+    QString m_cpid;
+    double m_magnitude;
+    QString m_error;
 };
 
 //!
@@ -46,11 +72,26 @@ public:
     ResearcherModel();
     ~ResearcherModel();
 
+    static QString mapBeaconStatus(const BeaconStatus status);
+    static QIcon mapBeaconStatusIcon(const BeaconStatus status);
+
+    void showWizard(WalletModel* wallet_model);
+
     bool configuredForInvestorMode() const;
+    bool actionNeeded() const;
+    bool hasEligibleProjects() const;
+    bool hasActiveBeacon() const;
+    bool hasPendingBeacon() const;
+    bool hasRenewableBeacon() const;
+    bool hasMagnitude() const;
+    bool needsBeaconAuth() const;
+
+    QString email() const;
     QString formatCpid() const;
     QString formatMagnitude() const;
     QString formatAccrual(const int display_unit) const;
     QString formatStatus() const;
+    QString formatBoincPath() const;
 
     BeaconStatus getBeaconStatus() const;
     QIcon getBeaconStatusIcon() const;
@@ -58,12 +99,17 @@ public:
     QString formatBeaconAge() const;
     QString formatTimeToBeaconExpiration() const;
     QString formatBeaconAddress() const;
+    QString formatBeaconKeyId() const;
+
+    std::vector<ProjectRow> buildProjectTable(bool with_mag = true) const;
 
 private:
     NN::ResearcherPtr m_researcher;
     std::unique_ptr<NN::Beacon> m_beacon;
+    std::unique_ptr<NN::Beacon> m_pending_beacon;
     BeaconStatus m_beacon_status;
     bool m_configured_for_investor_mode;
+    bool m_wizard_open;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
@@ -74,9 +120,13 @@ signals:
     void accrualChanged();
 
 public slots:
+    void reload();
     void refresh();
     void resetResearcher(NN::ResearcherPtr researcher);
+    bool updateEmail(const QString& email);
     void updateBeacon();
+    BeaconStatus advertiseBeacon();
+    void onWizardClose();
 };
 
 #endif // RESEARCHERMODEL_H

--- a/src/qt/researcher/researcherwizard.cpp
+++ b/src/qt/researcher/researcherwizard.cpp
@@ -1,0 +1,76 @@
+#include "qt/forms/ui_researcherwizard.h"
+#include "qt/researcher/researchermodel.h"
+#include "qt/researcher/researcherwizard.h"
+
+#include "logging.h"
+
+namespace {
+//!
+//! \brief Alias for the "start over" custom wizard button.
+//!
+constexpr QWizard::WizardButton START_OVER_BUTTON = QWizard::CustomButton1;
+} // Anonymous namespace
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherWizard
+// -----------------------------------------------------------------------------
+
+ResearcherWizard::ResearcherWizard(
+    QWidget *parent,
+    ResearcherModel* researcher_model,
+    WalletModel* wallet_model)
+    : QWizard(parent)
+    , ui(new Ui::ResearcherWizard)
+    , m_researcher_model(researcher_model)
+{
+    ui->setupUi(this);
+    configureStartOverButton();
+
+    setAttribute(Qt::WA_DeleteOnClose, true);
+
+    ui->emailPage->setModel(researcher_model);
+    ui->projectsPage->setModel(researcher_model);
+    ui->beaconPage->setModel(researcher_model, wallet_model);
+    ui->authPage->setModel(researcher_model);
+    ui->summaryPage->setModel(researcher_model);
+
+    // This enables the beacon "renew" button on the summary page to switch the
+    // current page back to beacon page. Since the summary page cannot navigate
+    // back to a specific page directly, it emits a signal that we wire up here
+    // to change the page when requested:
+    //
+    connect(ui->summaryPage, SIGNAL(renewBeaconButtonClicked()),
+            this, SLOT(onRenewBeaconButtonClicked()));
+}
+
+ResearcherWizard::~ResearcherWizard()
+{
+    m_researcher_model->onWizardClose();
+
+    delete ui;
+}
+
+void ResearcherWizard::configureStartOverButton()
+{
+    setButtonText(START_OVER_BUTTON, tr("&Start Over"));
+    connect(this, SIGNAL(customButtonClicked(int)),
+            this, SLOT(onCustomButtonClicked(int)));
+}
+
+void ResearcherWizard::onCustomButtonClicked(int which)
+{
+    if (which == START_OVER_BUTTON) {
+        setStartId(PageEmail);
+        restart();
+    }
+}
+
+void ResearcherWizard::onRenewBeaconButtonClicked()
+{
+    // This handles the beacon "renew" button on the summary page. Qt doesn't
+    // give us a good way to switch directly to the beacon page, so we rewind
+    // and start from it instead:
+    //
+    setStartId(PageBeacon);
+    restart();
+}

--- a/src/qt/researcher/researcherwizard.h
+++ b/src/qt/researcher/researcherwizard.h
@@ -1,0 +1,45 @@
+#ifndef RESEARCHERWIZARD_H
+#define RESEARCHERWIZARD_H
+
+#include <QWizard>
+
+class ResearcherModel;
+class WalletModel;
+
+namespace Ui {
+class ResearcherWizard;
+}
+
+class ResearcherWizard : public QWizard
+{
+    Q_OBJECT
+
+public:
+    enum Pages
+    {
+        PageEmail,
+        PageProjects,
+        PageBeacon,
+        PageAuth,
+        PageSummary,
+    };
+
+    explicit ResearcherWizard(
+        QWidget *parent = nullptr,
+        ResearcherModel *researcher_model = nullptr,
+        WalletModel *wallet_model = nullptr);
+
+    ~ResearcherWizard();
+
+private:
+    Ui::ResearcherWizard *ui;
+    ResearcherModel *m_researcher_model;
+
+    void configureStartOverButton();
+
+private slots:
+    void onCustomButtonClicked(int which);
+    void onRenewBeaconButtonClicked();
+};
+
+#endif // RESEARCHERWIZARD_H

--- a/src/qt/researcher/researcherwizardauthpage.cpp
+++ b/src/qt/researcher/researcherwizardauthpage.cpp
@@ -1,0 +1,56 @@
+#include "qt/forms/ui_researcherwizardauthpage.h"
+#include "qt/researcher/researchermodel.h"
+#include "qt/researcher/researcherwizardauthpage.h"
+
+#include <QClipboard>
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherWizardAuthPage
+// -----------------------------------------------------------------------------
+
+ResearcherWizardAuthPage::ResearcherWizardAuthPage(QWidget *parent)
+    : QWizardPage(parent)
+    , ui(new Ui::ResearcherWizardAuthPage)
+    , m_researcher_model(nullptr)
+{
+    ui->setupUi(this);
+}
+
+ResearcherWizardAuthPage::~ResearcherWizardAuthPage()
+{
+    delete ui;
+}
+
+void ResearcherWizardAuthPage::setModel(ResearcherModel* researcher_model)
+{
+    this->m_researcher_model = researcher_model;
+
+    if (!m_researcher_model) {
+        return;
+    }
+
+    connect(m_researcher_model, SIGNAL(researcherChanged()), this, SLOT(refresh()));
+}
+
+void ResearcherWizardAuthPage::initializePage()
+{
+    if (!m_researcher_model) {
+        return;
+    }
+
+    refresh();
+}
+
+void ResearcherWizardAuthPage::refresh()
+{
+    if (!m_researcher_model) {
+        return;
+    }
+
+    ui->verificationCodeLabel->setText(m_researcher_model->formatBeaconKeyId());
+}
+
+void ResearcherWizardAuthPage::on_copyToClipboardButton_clicked()
+{
+    QApplication::clipboard()->setText(ui->verificationCodeLabel->text());
+}

--- a/src/qt/researcher/researcherwizardauthpage.h
+++ b/src/qt/researcher/researcherwizardauthpage.h
@@ -1,0 +1,33 @@
+#ifndef RESEARCHERWIZARDAUTHPAGE_H
+#define RESEARCHERWIZARDAUTHPAGE_H
+
+#include <QWizardPage>
+
+class ResearcherModel;
+
+namespace Ui {
+class ResearcherWizardAuthPage;
+}
+
+class ResearcherWizardAuthPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ResearcherWizardAuthPage(QWidget *parent = nullptr);
+    ~ResearcherWizardAuthPage();
+
+    void setModel(ResearcherModel *researcher_model);
+
+    void initializePage() override;
+
+private:
+    Ui::ResearcherWizardAuthPage *ui;
+    ResearcherModel *m_researcher_model;
+
+private slots:
+    void refresh();
+    void on_copyToClipboardButton_clicked();
+};
+
+#endif // RESEARCHERWIZARDAUTHPAGE_H

--- a/src/qt/researcher/researcherwizardbeaconpage.cpp
+++ b/src/qt/researcher/researcherwizardbeaconpage.cpp
@@ -1,0 +1,114 @@
+#include "qt/forms/ui_researcherwizardbeaconpage.h"
+#include "qt/researcher/researchermodel.h"
+#include "qt/researcher/researcherwizard.h"
+#include "qt/researcher/researcherwizardbeaconpage.h"
+#include "qt/walletmodel.h"
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherWizardBeaconPage
+// -----------------------------------------------------------------------------
+
+ResearcherWizardBeaconPage::ResearcherWizardBeaconPage(QWidget *parent)
+    : QWizardPage(parent)
+    , ui(new Ui::ResearcherWizardBeaconPage)
+    , m_researcher_model(nullptr)
+    , m_wallet_model(nullptr)
+{
+    ui->setupUi(this);
+}
+
+ResearcherWizardBeaconPage::~ResearcherWizardBeaconPage()
+{
+    delete ui;
+}
+
+void ResearcherWizardBeaconPage::setModel(
+    ResearcherModel* researcher_model,
+    WalletModel* wallet_model)
+{
+    this->m_researcher_model = researcher_model;
+    this->m_wallet_model = wallet_model;
+
+    if (!m_researcher_model || !m_wallet_model) {
+        return;
+    }
+
+    connect(m_researcher_model, SIGNAL(researcherChanged()), this, SLOT(refresh()));
+    connect(ui->sendBeaconButton, SIGNAL(clicked()), this, SLOT(advertiseBeacon()));
+}
+
+void ResearcherWizardBeaconPage::initializePage()
+{
+    if (!m_researcher_model) {
+        return;
+    }
+
+    refresh();
+    updateBeaconIcon(m_researcher_model->getBeaconStatusIcon());
+    updateBeaconStatus(m_researcher_model->formatBeaconStatus());
+}
+
+bool ResearcherWizardBeaconPage::isComplete() const
+{
+    return m_researcher_model->hasActiveBeacon()
+        || m_researcher_model->hasPendingBeacon();
+}
+
+int ResearcherWizardBeaconPage::nextId() const
+{
+    if (m_researcher_model->needsBeaconAuth()) {
+        return ResearcherWizard::PageAuth;
+    }
+
+    return ResearcherWizard::PageSummary;
+}
+
+bool ResearcherWizardBeaconPage::isEnabled() const
+{
+    return !isComplete() || m_researcher_model->hasRenewableBeacon();
+}
+
+void ResearcherWizardBeaconPage::refresh()
+{
+    if (!m_researcher_model) {
+        return;
+    }
+
+    ui->cpidLabel->setText(m_researcher_model->formatCpid());
+    ui->sendBeaconButton->setVisible(isEnabled());
+    ui->continuePromptWrapper->setVisible(!isEnabled());
+}
+
+void ResearcherWizardBeaconPage::advertiseBeacon()
+{
+    if (!m_researcher_model || !m_wallet_model) {
+        return;
+    }
+
+    const WalletModel::UnlockContext unlock_context(m_wallet_model->requestUnlock());
+
+    if (!unlock_context.isValid()) {
+        // Unlock wallet was cancelled
+        return;
+    }
+
+    const BeaconStatus status = m_researcher_model->advertiseBeacon();
+
+    refresh();
+    updateBeaconStatus(ResearcherModel::mapBeaconStatus(status));
+    updateBeaconIcon(ResearcherModel::mapBeaconStatusIcon(status));
+
+    emit completeChanged();
+}
+
+void ResearcherWizardBeaconPage::updateBeaconStatus(const QString& status)
+{
+    ui->beaconStatusLabel->setText(status);
+}
+
+void ResearcherWizardBeaconPage::updateBeaconIcon(const QIcon& icon)
+{
+    const int icon_size = ui->beaconIconLabel->width();
+
+    ui->beaconIconLabel->setPixmap(icon.pixmap(icon_size, icon_size));
+}

--- a/src/qt/researcher/researcherwizardbeaconpage.h
+++ b/src/qt/researcher/researcherwizardbeaconpage.h
@@ -1,0 +1,42 @@
+#ifndef RESEARCHERWIZARDBEACONPAGE_H
+#define RESEARCHERWIZARDBEACONPAGE_H
+
+#include <QWizardPage>
+
+class QIcon;
+class ResearcherModel;
+class WalletModel;
+
+namespace Ui {
+class ResearcherWizardBeaconPage;
+}
+
+class ResearcherWizardBeaconPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ResearcherWizardBeaconPage(QWidget *parent = nullptr);
+    ~ResearcherWizardBeaconPage();
+
+    void setModel(ResearcherModel *researcher_model, WalletModel *wallet_model);
+
+    void initializePage() override;
+    bool isComplete() const override;
+    int nextId() const override;
+
+    bool isEnabled() const;
+
+private:
+    Ui::ResearcherWizardBeaconPage *ui;
+    ResearcherModel *m_researcher_model;
+    WalletModel *m_wallet_model;
+
+private slots:
+    void refresh();
+    void advertiseBeacon();
+    void updateBeaconStatus(const QString& status);
+    void updateBeaconIcon(const QIcon& icon);
+};
+
+#endif // RESEARCHERWIZARDBEACONPAGE_H

--- a/src/qt/researcher/researcherwizardemailpage.cpp
+++ b/src/qt/researcher/researcherwizardemailpage.cpp
@@ -1,0 +1,33 @@
+#include "qt/forms/ui_researcherwizardemailpage.h"
+#include "qt/researcher/researchermodel.h"
+#include "qt/researcher/researcherwizardemailpage.h"
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherWizardEmailPage
+// -----------------------------------------------------------------------------
+
+ResearcherWizardEmailPage::ResearcherWizardEmailPage(QWidget *parent)
+    : QWizardPage(parent)
+    , ui(new Ui::ResearcherWizardEmailPage)
+    , m_model(nullptr)
+{
+    ui->setupUi(this);
+
+    // The asterisk denotes a mandatory field:
+    registerField("emailAddress*", ui->emailAddressLineEdit);
+}
+
+ResearcherWizardEmailPage::~ResearcherWizardEmailPage()
+{
+    delete ui;
+}
+
+void ResearcherWizardEmailPage::setModel(ResearcherModel *model)
+{
+    this->m_model = model;
+}
+
+void ResearcherWizardEmailPage::initializePage()
+{
+    ui->emailAddressLineEdit->setText(m_model->email());
+}

--- a/src/qt/researcher/researcherwizardemailpage.h
+++ b/src/qt/researcher/researcherwizardemailpage.h
@@ -1,0 +1,29 @@
+#ifndef RESEARCHERWIZARDEMAILPAGE_H
+#define RESEARCHERWIZARDEMAILPAGE_H
+
+#include <QWizardPage>
+
+class ResearcherModel;
+
+namespace Ui {
+class ResearcherWizardEmailPage;
+}
+
+class ResearcherWizardEmailPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ResearcherWizardEmailPage(QWidget *parent = nullptr);
+    ~ResearcherWizardEmailPage();
+
+    void setModel(ResearcherModel *model);
+
+    void initializePage() override;
+
+private:
+    Ui::ResearcherWizardEmailPage *ui;
+    ResearcherModel *m_model;
+};
+
+#endif // RESEARCHERWIZARDEMAILPAGE_H

--- a/src/qt/researcher/researcherwizardprojectspage.cpp
+++ b/src/qt/researcher/researcherwizardprojectspage.cpp
@@ -1,0 +1,94 @@
+#include "qt/forms/ui_researcherwizardprojectspage.h"
+#include "qt/researcher/projecttablemodel.h"
+#include "qt/researcher/researchermodel.h"
+#include "qt/researcher/researcherwizardprojectspage.h"
+
+#include <QMessageBox>
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherWizardProjectsPage
+// -----------------------------------------------------------------------------
+
+ResearcherWizardProjectsPage::ResearcherWizardProjectsPage(QWidget *parent)
+    : QWizardPage(parent)
+    , ui(new Ui::ResearcherWizardProjectsPage)
+    , m_researcher_model(nullptr)
+    , m_table_model(nullptr)
+{
+    ui->setupUi(this);
+    ui->projectTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+}
+
+ResearcherWizardProjectsPage::~ResearcherWizardProjectsPage()
+{
+    delete ui;
+    delete m_table_model;
+}
+
+void ResearcherWizardProjectsPage::setModel(ResearcherModel *model)
+{
+    this->m_researcher_model = model;
+
+    if (!m_researcher_model) {
+        return;
+    }
+
+    m_table_model = new ProjectTableModel(model, false);
+
+    if (!m_table_model) {
+        return;
+    }
+
+    ui->projectTableView->setModel(m_table_model);
+    ui->projectTableView->hideColumn(ProjectTableModel::Magnitude);
+
+    connect(ui->refreshButton, SIGNAL(clicked()), this, SLOT(refresh()));
+}
+
+void ResearcherWizardProjectsPage::initializePage()
+{
+    if (!m_researcher_model) {
+        return;
+    }
+
+    // Process the email address input from the previous page:
+    if (!m_researcher_model->updateEmail(field("emailAddress").toString())) {
+        QMessageBox::warning(
+            this,
+            windowTitle(),
+            tr("An error occured while saving the email address to the "
+                "configuration file. Please see debug.log for details."),
+            QMessageBox::Ok,
+            QMessageBox::Ok);
+    }
+
+    refresh();
+}
+
+bool ResearcherWizardProjectsPage::isComplete() const
+{
+    return m_researcher_model->hasEligibleProjects();
+}
+
+void ResearcherWizardProjectsPage::refresh()
+{
+    m_researcher_model->reload();
+
+    ui->emailLabel->setText(m_researcher_model->email());
+    ui->boincPathLabel->setText(m_researcher_model->formatBoincPath());
+    ui->selectedCpidLabel->setText(m_researcher_model->formatCpid());
+
+    const int icon_size = ui->selectedCpidIconLabel->width();
+
+    if (m_researcher_model->hasEligibleProjects()) {
+        ui->selectedCpidIconLabel->setPixmap(
+            QIcon(":/icons/synced").pixmap(icon_size, icon_size));
+    } else {
+        ui->selectedCpidIconLabel->setPixmap(
+            QIcon(":/icons/white_and_red_x").pixmap(icon_size, icon_size));
+    }
+
+    m_table_model->refresh();
+
+    emit completeChanged();
+}

--- a/src/qt/researcher/researcherwizardprojectspage.h
+++ b/src/qt/researcher/researcherwizardprojectspage.h
@@ -1,0 +1,35 @@
+#ifndef RESEARCHERWIZARDPROJECTSPAGE_H
+#define RESEARCHERWIZARDPROJECTSPAGE_H
+
+#include <QWizardPage>
+
+class ProjectTableModel;
+class ResearcherModel;
+
+namespace Ui {
+class ResearcherWizardProjectsPage;
+}
+
+class ResearcherWizardProjectsPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ResearcherWizardProjectsPage(QWidget *parent = nullptr);
+    ~ResearcherWizardProjectsPage();
+
+    void setModel(ResearcherModel *model);
+
+    void initializePage() override;
+    bool isComplete() const override;
+
+private:
+    Ui::ResearcherWizardProjectsPage *ui;
+    ResearcherModel *m_researcher_model;
+    ProjectTableModel *m_table_model;
+
+private slots:
+    void refresh();
+};
+
+#endif // RESEARCHERWIZARDPROJECTSPAGE_H

--- a/src/qt/researcher/researcherwizardsummarypage.cpp
+++ b/src/qt/researcher/researcherwizardsummarypage.cpp
@@ -1,0 +1,155 @@
+#include "qt/bitcoinunits.h"
+#include "qt/forms/ui_researcherwizardsummarypage.h"
+#include "qt/researcher/projecttablemodel.h"
+#include "qt/researcher/researchermodel.h"
+#include "qt/researcher/researcherwizardsummarypage.h"
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherWizardSummaryPage
+// -----------------------------------------------------------------------------
+
+ResearcherWizardSummaryPage::ResearcherWizardSummaryPage(QWidget *parent)
+    : QWizardPage(parent)
+    , ui(new Ui::ResearcherWizardSummaryPage)
+    , m_researcher_model(nullptr)
+    , m_table_model(nullptr)
+{
+    ui->setupUi(this);
+    ui->projectTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+}
+
+ResearcherWizardSummaryPage::~ResearcherWizardSummaryPage()
+{
+    delete ui;
+}
+
+void ResearcherWizardSummaryPage::setModel(ResearcherModel *model)
+{
+    this->m_researcher_model = model;
+
+    if (!m_researcher_model) {
+        return;
+    }
+
+    m_table_model = new ProjectTableModel(model);
+
+    if (!m_table_model) {
+        return;
+    }
+
+    ui->projectTableView->setModel(m_table_model);
+
+    connect(model, SIGNAL(researcherChanged()), this, SLOT(refreshSummary()));
+    connect(ui->refreshButton, SIGNAL(clicked()), this, SLOT(reloadProjects()));
+    connect(ui->tabWidget, SIGNAL(currentChanged(int)), this, SLOT(onTabChanged(int)));
+}
+
+void ResearcherWizardSummaryPage::initializePage()
+{
+    if (!m_researcher_model) {
+        return;
+    }
+
+    refreshSummary();
+}
+
+void ResearcherWizardSummaryPage::onTabChanged(int index)
+{
+    switch (index) {
+        case TabSummary:
+            refreshSummary();
+            break;
+        case TabProjects:
+            refreshProjects();
+            break;
+    }
+}
+
+void ResearcherWizardSummaryPage::refreshSummary()
+{
+    if (ui->tabWidget->currentIndex() != TabSummary) {
+        return;
+    }
+
+    const BitcoinUnits::Unit unit = BitcoinUnits::BTC;
+    const int icon_size = ui->beaconDetailsIconLabel->width();
+
+    ui->cpidLabel->setText(m_researcher_model->formatCpid());
+    ui->statusLabel->setText(m_researcher_model->formatStatus());
+    ui->magnitudeLabel->setText(m_researcher_model->formatMagnitude());
+    ui->accrualLabel->setText(m_researcher_model->formatAccrual(unit));
+
+    ui->beaconDetailsIconLabel->setPixmap(
+        m_researcher_model->getBeaconStatusIcon().pixmap(icon_size, icon_size));
+    ui->beaconStatusLabel->setText(m_researcher_model->formatBeaconStatus());
+    ui->beaconAgeLabel->setText(m_researcher_model->formatBeaconAge());
+    ui->beaconExpiresLabel->setText(m_researcher_model->formatTimeToBeaconExpiration());
+    ui->rainAddressLabel->setText(m_researcher_model->formatBeaconAddress());
+    ui->renewBeaconButton->setEnabled(m_researcher_model->hasRenewableBeacon());
+
+    refreshOverallStatus();
+}
+
+void ResearcherWizardSummaryPage::refreshOverallStatus()
+{
+    const int icon_size = ui->overallStatusIconLabel->width();
+
+    QString status;
+    QIcon icon;
+
+    if (m_researcher_model->hasPendingBeacon()) {
+        status = tr("Beacon awaiting confirmation.");
+        icon = QIcon(":/icons/notsynced");
+    } else if (m_researcher_model->hasRenewableBeacon()) {
+        status = tr("Beacon renewal available.");
+        icon = QIcon(":/icons/warning");
+    } else if (!m_researcher_model->hasMagnitude()) {
+        status = tr("Waiting for magnitude.");
+        icon = QIcon(":/icons/notsynced");
+    } else {
+        status = tr("Everything looks good.");
+        icon = QIcon(":/icons/synced");
+    }
+
+    ui->overallStatusLabel->setText(status);
+    ui->overallStatusIconLabel->setPixmap(icon.pixmap(icon_size, icon_size));
+}
+
+void ResearcherWizardSummaryPage::refreshProjects()
+{
+    if (ui->tabWidget->currentIndex() != TabProjects) {
+        return;
+    }
+
+    ui->emailLabel->setText(m_researcher_model->email());
+    ui->boincPathLabel->setText(m_researcher_model->formatBoincPath());
+    ui->selectedCpidLabel->setText(m_researcher_model->formatCpid());
+
+    const int icon_size = ui->selectedCpidIconLabel->width();
+
+    if (m_researcher_model->hasEligibleProjects()) {
+        ui->selectedCpidIconLabel->setPixmap(
+            QIcon(":/icons/synced").pixmap(icon_size, icon_size));
+    } else {
+        ui->selectedCpidIconLabel->setPixmap(
+            QIcon(":/icons/white_and_red_x").pixmap(icon_size, icon_size));
+    }
+
+    m_table_model->refresh();
+}
+
+void ResearcherWizardSummaryPage::reloadProjects()
+{
+    m_researcher_model->reload();
+    refreshProjects();
+}
+
+void ResearcherWizardSummaryPage::on_renewBeaconButton_clicked()
+{
+    // This enables the page's beacon "renew" button to switch the current page
+    // back to beacon page. Since a wizard page cannot set the wizard's current
+    // index directly, this emits a signal that the wizard connects to the slot
+    // that changes the page for us:
+    //
+    emit renewBeaconButtonClicked();
+}

--- a/src/qt/researcher/researcherwizardsummarypage.h
+++ b/src/qt/researcher/researcherwizardsummarypage.h
@@ -1,0 +1,48 @@
+#ifndef RESEARCHERWIZARDSUMMARYPAGE_H
+#define RESEARCHERWIZARDSUMMARYPAGE_H
+
+#include <QWizardPage>
+
+class ProjectTableModel;
+class ResearcherModel;
+
+namespace Ui {
+class ResearcherWizardSummaryPage;
+}
+
+class ResearcherWizardSummaryPage : public QWizardPage
+{
+    Q_OBJECT
+
+    enum Tab
+    {
+        TabSummary,
+        TabProjects,
+    };
+
+public:
+    explicit ResearcherWizardSummaryPage(QWidget *parent = nullptr);
+    ~ResearcherWizardSummaryPage();
+
+    void setModel(ResearcherModel *model);
+
+    void initializePage() override;
+
+private:
+    Ui::ResearcherWizardSummaryPage *ui;
+    ResearcherModel *m_researcher_model;
+    ProjectTableModel *m_table_model;
+
+signals:
+    void renewBeaconButtonClicked();
+
+private slots:
+    void onTabChanged(int index);
+    void refreshSummary();
+    void refreshOverallStatus();
+    void refreshProjects();
+    void reloadProjects();
+    void on_renewBeaconButton_clicked();
+};
+
+#endif // RESEARCHERWIZARDSUMMARYPAGE_H

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -37,7 +37,6 @@ bool ForceReorganizeToHash(uint256 NewHash);
 extern UniValue MagnitudeReport(const NN::Cpid cpid);
 extern UniValue SuperblockReport(int lookback = 14, bool displaycontract = false, std::string cpid = "");
 extern bool ScraperSynchronizeDPOR();
-std::string ExplainMagnitude(std::string sCPID);
 
 extern ScraperPendingBeaconMap GetPendingBeaconsForReport();
 extern ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = false);
@@ -934,33 +933,52 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
 
 UniValue explainmagnitude(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
+    if (fHelp || params.size() > 1)
         throw runtime_error(
-                "explainmagnitude\n"
+                "explainmagnitude ( cpid )\n"
+                "\n"
+                "[cpid] -> Optional CPID to explain magnitude for\n"
                 "\n"
                 "Itemize your CPID magnitudes by project.\n");
 
-    UniValue res(UniValue::VOBJ);
+    const NN::MiningId mining_id = params.size() > 0
+        ? NN::MiningId::Parse(params[0].get_str())
+        : NN::Researcher::Get()->Id();
 
-    LOCK(cs_main);
-
-    const std::string primary_cpid = NN::GetPrimaryCpid();
-    std::string sNeuralResponse = ExplainMagnitude(primary_cpid);
-
-    if (sNeuralResponse.length() < 25)
-    {
-        res.pushKV("Neural Response", "false; Try again at a later time");
-
+    if (!mining_id.Valid()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid CPID.");
     }
-    else
-    {
-        res.pushKV("Neural Response", "true (from THIS node)");
 
-        std::vector<std::string> vMag = split(sNeuralResponse.c_str(),"<ROW>");
+    const NN::CpidOption cpid = mining_id.TryCpid();
 
-        for (unsigned int i = 0; i < vMag.size(); i++)
-            res.pushKV(RoundToString(i+1,0),vMag[i].c_str());
+    if (!cpid) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "No data for investor.");
     }
+
+    UniValue res(UniValue::VARR);
+    double total_rac = 0;
+    double total_magnitude = 0;
+
+    for (const auto& project : NN::Quorum::ExplainMagnitude(*cpid)) {
+        total_rac += project.m_rac;
+        total_magnitude += project.m_magnitude;
+
+        UniValue entry(UniValue::VOBJ);
+
+        entry.pushKV("project", project.m_name);
+        entry.pushKV("rac", project.m_rac);
+        entry.pushKV("magnitude", project.m_magnitude);
+
+        res.push_back(entry);
+    }
+
+    UniValue total(UniValue::VOBJ);
+
+    total.pushKV("project", "total");
+    total.pushKV("rac", total_rac);
+    total.pushKV("magnitude", total_magnitude);
+
+    res.push_back(total);
 
     return res;
 }

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -67,12 +67,12 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
     // Receive HTTP reply status
     int nProto = 0;
     int nStatus = ReadHTTPStatus(stream, nProto);
-    
+
     // Receive HTTP reply message headers and body
     map<string, string> mapHeaders;
     string strReply;
     ReadHTTPMessage(stream, mapHeaders, strReply, nProto);
-    
+
     if (nStatus == HTTP_UNAUTHORIZED)
         throw runtime_error("incorrect rpcuser or rpcpassword (authorization failed)");
     else if (nStatus >= 400 && nStatus != HTTP_BAD_REQUEST && nStatus != HTTP_NOT_FOUND && nStatus != HTTP_INTERNAL_SERVER_ERROR)
@@ -160,7 +160,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "walletpassphrase"       , 2 },
 
     // Mining
-    { "explainmagnitude"       , 0 },
     { "superblocks"            , 0 },
     { "superblocks"            , 1 },
 

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -115,7 +115,6 @@ CCriticalSection cs_mScrapersExt;
 
 uint256 GetFileHash(const fs::path& inputfile);
 ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
-std::string ExplainMagnitude(std::string sCPID);
 bool IsScraperAuthorized();
 bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& KeyOut);
 bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
@@ -159,7 +158,7 @@ double MagRound(double dMag)
 unsigned int NumScrapersForSupermajority(unsigned int nScraperCount)
 {
     unsigned int nRequired = std::max(SCRAPER_CONVERGENCE_MINIMUM, (unsigned int)std::ceil(SCRAPER_CONVERGENCE_RATIO * nScraperCount));
-    
+
     return nRequired;
 }
 

--- a/src/test/neuralnet/researcher_tests.cpp
+++ b/src/test/neuralnet/researcher_tests.cpp
@@ -1025,6 +1025,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_requirement_dynamically)
     WriteCache(Section::PROTOCOL, "REQUIRE_TEAM_WHITELIST_MEMBERSHIP", "false", 1);
 
     // Rescan in-memory projects for previously-ineligible teams:
+    NN::Researcher::MarkDirty();
     NN::Researcher::Refresh();
 
     BOOST_CHECK(NN::Researcher::Get()->IsInvestor() == false);
@@ -1041,6 +1042,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_requirement_dynamically)
     WriteCache(Section::PROTOCOL, "REQUIRE_TEAM_WHITELIST_MEMBERSHIP", "true", 1);
 
     // Rescan in-memory projects for previously-eligible teams:
+    NN::Researcher::MarkDirty();
     NN::Researcher::Refresh();
 
     BOOST_CHECK(NN::Researcher::Get()->IsInvestor() == true);
@@ -1119,6 +1121,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_dynamically)
     WriteCache(Section::PROTOCOL, "TEAM_WHITELIST", "Team 1|Team 2", 1);
 
     // Rescan in-memory projects for previously-ineligible teams:
+    NN::Researcher::MarkDirty();
     NN::Researcher::Refresh();
 
     if (const NN::ProjectOption project = NN::Researcher::Get()->Project("p1")) {
@@ -1149,6 +1152,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_dynamically)
     WriteCache(Section::PROTOCOL, "TEAM_WHITELIST", "", 1);
 
     // Rescan in-memory projects for previously-eligible teams:
+    NN::Researcher::MarkDirty();
     NN::Researcher::Refresh();
 
     if (const NN::ProjectOption project = NN::Researcher::Get()->Project("p1")) {
@@ -1216,6 +1220,7 @@ BOOST_AUTO_TEST_CASE(it_ignores_the_team_whitelist_without_the_team_requirement)
     WriteCache(Section::PROTOCOL, "TEAM_WHITELIST", "Team 1|Team 2", 1);
 
     // Rescan in-memory projects for previously-eligible teams:
+    NN::Researcher::MarkDirty();
     NN::Researcher::Refresh();
 
     BOOST_CHECK(NN::Researcher::Get()->Eligible() == true);
@@ -1233,6 +1238,7 @@ BOOST_AUTO_TEST_CASE(it_ignores_the_team_whitelist_without_the_team_requirement)
     WriteCache(Section::PROTOCOL, "REQUIRE_TEAM_WHITELIST_MEMBERSHIP", "true", 1);
 
     // Rescan in-memory projects for previously-eligible teams:
+    NN::Researcher::MarkDirty();
     NN::Researcher::Refresh();
 
     BOOST_CHECK(NN::Researcher::Get()->Eligible() == false);

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -99,6 +99,12 @@ public:
     /** Ban list changed. */
     boost::signals2::signal<void ()> BannedListChanged;
 
+    /** Researcher context changed */
+    boost::signals2::signal<void ()> ResearcherChanged;
+
+    /** Beacon changed */
+    boost::signals2::signal<void ()> BeaconChanged;
+
     /**
      * New, updated or cancelled alert.
      * @note called with lock cs_mapAlerts held.


### PR DESCRIPTION
This adds a GUI wizard-style component that guides a new user through the initial on-boarding process to advertise a beacon. It replaces the old email address prompt and adds new features. This component depends on a sizable amount of enrichment of core APIs to supply data for the user interface. Please read the commit descriptions for details. The rest of this post describes the behavior of the wizard. 

---

In the latest version of the software, there currently exists no useful graphical interface for Gridcoin's researcher context (#562). The GUI displays little information about the state of the wallet's integration with BOINC and the research reward protocol, and it lacks the controls needed to manage that context. Although a user can access most of the relevant functionality through RPCs, the need to learn about these commands degrades the experience and confuses new participants (#903). For example, a user cannot begin to earn research rewards without executing the `advertisebeacon` RPC from the debug console unless the wallet is unencrypted and funded (the timer will eventually send a beacon after three hours). 

This PR introduces a dialog component that provides access to tasks and information needed for typical participation in the research reward protocol. It behaves like a wizard for the initial onboarding process and serves as a secondary summary view after that. 

A user opens the dialog by clicking on the "Beacon" button on the main page:

![overview](https://user-images.githubusercontent.com/4282384/84857774-699bef80-b02f-11ea-9742-72842012e857.png)

The wallet will prompt the user with an "Action needed" label next to the button when it needs the user to review something for the research reward system (#443, #447, #1552). This includes:

  - Initial email address configuration
  - BOINC CPID detection problems
  - Beacon advertisement or renewal

This is less intrusive than the pop-up and system notification produced by the old email prompt (#333).

I also tweaked the layout of the overview screen sections to better organize the information and added a pending research rewards field (#302, #1076).

The dialog is also accessible from the settings menu, the system tray icon menu, and the beacon status bar icon (#1646).

---

For a new participant, the wizard will open to a page that prompts for a BOINC account email address:

![emailpage](https://user-images.githubusercontent.com/4282384/84859018-df08bf80-b031-11ea-92b5-62b32f7ad17c.png)

From this screen, a user can set or update their email address without changing the configuration file. The wallet will rewrite the directive as needed.

---

The next screen displays information about the BOINC projects on the same computer that the wallet examined to select a CPID:

![projectspage_valid](https://user-images.githubusercontent.com/4282384/84859600-19269100-b033-11ea-91f0-c27d1a6ca1ea.png)

The "Eligible" column provides feedback about projects that do not satisfy the requirements for participation to help users choose projects and diagnose problems. The refresh button enables a user to attach projects during this step without restarting the wallet. 

A future enhancement will allow for selecting one of these rows to explicitly choose a CPID to resolve split-CPID problems. 

---

Once the wallet detects a valid CPID, a user can proceed to the next page to advertise a beacon:

![beaconpage_initial](https://user-images.githubusercontent.com/4282384/84859872-96ea9c80-b033-11ea-8cd3-38f7fcbe4bb8.png)

This page will prompt the user for an encrypted wallet's passphrase when pressing the "Advertise Beacon" button. The status message changes to provide feedback if an error occurs. On success, the page indicates that the beacon transaction is waiting for confirmation in a block and instructs the user to continue:

![beaconpage_pending](https://user-images.githubusercontent.com/4282384/84860138-1f693d00-b034-11ea-8df5-40327a47caa1.png)

---

After sending a beacon, a user arrives at the summary page. At this point, the user completed the initial onboarding process. The dialog will now open to this page directly when pressing the "Beacon" button on the wallet's main screen:

![summarypage_pending](https://user-images.githubusercontent.com/4282384/84860635-04e39380-b035-11ea-83e6-3a258d6a0f2d.png)

When a beacon activates, the network will assign magnitude for the CPID in a superblock. The summary page updates to reflect these changes:

![summarypage_valid](https://user-images.githubusercontent.com/4282384/84860917-9226e800-b035-11ea-8759-4bfba2ea995e.png)

Users can renew their beacons from this page by pressing the "Renew" button. Pressing "Start Over" will walk the user through the steps again (if the email address changed, for example). The wizard understands the state of the core, so it is safe to restart even if nothing needs to be changed.

---

The "Projects" tab on the summary page provides a way for a user to review the status of their attached BOINC projects and the network's whitelisted projects on demand. It displays the same information as the second page of the wizard, but it also includes a magnitude breakdown by project produced from scraper data:

![summarypage_projects](https://user-images.githubusercontent.com/4282384/84907653-1484cb80-b079-11ea-87c4-6857ff7e475a.png)

---

I created a view model for presenting researcher context information that abstracts the core APIs from the GUI components. This should make wizard easier to port to the new UI design (#847).

There is certainly more information and functionality that we can build into this component. Because of the size of this change, I chose to build a reasonably minimal initial implementation. Suggestions for future enhancements are welcome, but I do not wish to expand the scope of this PR beyond the features presented here so that we can focus on reviewing the essential use cases first. 