### PR TITLE
scraper: Correct update for verified beacons

### DIFF
--- a/src/scraper/fwd.h
+++ b/src/scraper/fwd.h
@@ -159,6 +159,7 @@ struct ScraperPendingBeaconEntry
     }
 };
 
+// --------- address as string ---- cpid, timestamp
 typedef std::map<std::string, ScraperPendingBeaconEntry> ScraperPendingBeaconMap;
 
 struct BeaconConsensus


### PR DESCRIPTION
The scraper was updating a local copy of the verified beacons map and code was missing to update the global.

This moves the locking block to after the while loop and inside that block, the global map is updated from the local copy.