### PR TITLE
wallet: Change Assert To Error Message In kernel.cpp

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -379,7 +379,7 @@ unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
         throw std::runtime_error(
             "Error: blockchain data corrupted.\n" 
             "Go to the wallet's data directory and delete the folder txleveldb and the files blk000x.dat (x is any number).\n" 
-            "This requires you to sync again and will temporaily show a balance of 0 GRC\n"
+            "This requires you to sync again from the beginning and your wallet will temporarily show a balance of 0 GRC\n"
         );
     }
     // Hash previous checksum with flags, hashProofOfStake and nStakeModifier

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -373,17 +373,14 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
 // Get stake modifier checksum
 unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
 {
-    if (pindex->pprev == nullptr) 
+    if (pindex->pprev == nullptr && pindex != pindexGenesisBlock) 
     {
-        if(pindex->GetBlockHash() != (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet)) 
-        {
-            //Error on non-genesis blocks that don't have a previous block
-            throw std::runtime_error(
-                "Error: blockchain data corrupted.\n" 
-                "Go to the wallet's data directory and delete the folder txleveldb and the files blk000x.dat (x is any number).\n" 
-                "This requires you to sync again and will temporaily show a balance of 0 GRC\n"
-            );
-        }
+        //Error on non-genesis blocks that don't have a previous block
+        throw std::runtime_error(
+            "Error: blockchain data corrupted.\n" 
+            "Go to the wallet's data directory and delete the folder txleveldb and the files blk000x.dat (x is any number).\n" 
+            "This requires you to sync again and will temporaily show a balance of 0 GRC\n"
+        );
     }
     // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
     CDataStream ss(SER_GETHASH, 0);

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -380,7 +380,8 @@ unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
             //Error on non-genesis blocks that don't have a previous block
             throw std::runtime_error(
                 "Error: blockchain data corrupted.\n" 
-                "Go to the wallet's data directory and delete the folder txleveldb and the files starting with blk\n" 
+                "Go to the wallet's data directory and delete the folder txleveldb and the files blk000x.dat (x is any number).\n" 
+                "This requires you to sync again and will temporaily show a balance of 0 GRC\n"
             );
         }
     }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -373,7 +373,17 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
 // Get stake modifier checksum
 unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
 {
-    assert (pindex->pprev || pindex->GetBlockHash() == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet));
+    if (pindex->pprev == nullptr) 
+    {
+        if(pindex->GetBlockHash() != (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet)) 
+        {
+            //Error on non-genesis blocks that don't have a previous block
+            throw std::runtime_error(
+                "Error: blockchain data corrupted.\n" 
+                "Go to the wallet's data directory and delete the folder txleveldb and the files starting with blk\n" 
+            );
+        }
+    }
     // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
     CDataStream ss(SER_GETHASH, 0);
     if (pindex->pprev)


### PR DESCRIPTION
Replaces the confusing assertion failed message to one that displays an error telling that blockchain data is corrupted. Expands out the expression to be a bit more readable as well. 

I wasn't able to test on invalid block data, but I was able to verify that the assertion and this code both fail on the same conditions.