### PR TITLE
scraper: Add disk based state backing for verified beacon list in scraper

### DIFF
--- a/src/scraper/fwd.h
+++ b/src/scraper/fwd.h
@@ -7,6 +7,7 @@
 
 #include "support/allocators/zeroafterfree.h"
 #include "util.h"
+#include "streams.h"
 
 /*********************
 * Scraper ENUMS      *
@@ -174,6 +175,22 @@ struct ScraperVerifiedBeacons
     // Initialize the timestamp to the current adjusted time.
     int64_t timestamp = GetAdjustedTime();
     ScraperPendingBeaconMap mVerifiedMap;
+
+    bool LoadedFromDisk = false;
+
+    template<typename Stream>
+    void Serialize(Stream& stream) const
+    {
+        stream << mVerifiedMap;
+        stream << timestamp;
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& stream)
+    {
+        stream >> mVerifiedMap;
+        stream >> timestamp;
+    }
 };
 
 struct ScraperStatsAndVerifiedBeacons


### PR DESCRIPTION
This PR solves a problem with state management of verified beacons if a scraper is restarted during the active period. Without this PR, when a scraper is restarted, the global that contains the verified beacons is empty. The scraper on the next manifest publishing will NOT regenerate the verified beacon entry, if the next state change is due to the change in ANOTHER project besides the one where the username has been changed.

This is solved by serializing the g_verified_beacons to disk during calls to UpdateVerifiedBeaconsFromConsensus which occur during the first part of DownloadProjectRacFilesByCPID, and then on scraper restart, repopulating the g_verified_beacons from disk using LoadVerifiedBeacons. This is done in the ScraperDirectoryAndConfigSanity function. Note that g_verified_beacons has a boolean flag LoadedFromDisk, which is initialized as false, but is changed to true when LoadVerifiedBeacons is called the first time. This ensures that the initial load from disk only occurs once, and then the rest of the time, the file is simply written to by UpdateVerifiedBeaconsFromConsensus when the g_verified_beacons state changes to ensure the disk is kept up to date with memory.

UpdateVerifiedBeaconsFromConsensus also removes verified beacon entries that are not on the pending list. A beacon remains on the pending list through the verification process until the verified (and pending) beacon is committed to an active beacon as part of the superblock. Eliminating verified beacon entries that do not have a corresponding pending beacon entry eliminates possibly stale verified beacon entries that could happen if the scraper was shut down for an extended period.

Why go to this trouble? Under normal conditions, the scrapers are EXTREMELY reliable. They run for months without trouble. However... I have always designed the scrapers to be hardened and tough.... They should be able to successfully start even after a plug pulling, without a lot of gymnastics, and they should be able to be shut down and restarted DURING the active period without causing problems. Without this PR the verified beacons state is fragile and violates that principle.

Note that this PR uses the CAutoFile class and simple serialization deserialization methods built into the ScraperVerifiedBeacons struct, which is easier than doing another custom CSV storage function. There is no need to be able to read the VerifiedBeacons.dat file directly off of disk in human readable form since there is an rpc function to display the state of the verified beacons, beaconconvergence.