### PR TITLE
scraper: Correct stale verified beacon logic

### DIFF
--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -341,7 +341,7 @@ void UpdateVerifiedBeaconsFromConsensus(BeaconConsensus& Consensus)
 
             ++now_active;
         }
-        else if (Consensus.mPendingMap.find(entry->first) != Consensus.mPendingMap.end())
+        else if (Consensus.mPendingMap.find(entry->first) == Consensus.mPendingMap.end())
         {
             entry = ScraperVerifiedBeacons.mVerifiedMap.erase(entry);
 


### PR DESCRIPTION
The logic was reversed for the check of whether a verified beacon entry has a corresponding pending beacon entry. This fixes that. It has already been tested on the testnet private branch.