### PR TITLE
scraper: Shorten display representation of verification codes

### DIFF
--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -148,6 +148,13 @@ CBitcoinAddress Beacon::GetAddress() const
     return CBitcoinAddress(CTxDestination(m_public_key.GetID()));
 }
 
+std::string Beacon::GetVerificationCode() const
+{
+    const CKeyID key_id = GetId();
+
+    return EncodeBase58(key_id.begin(), key_id.end());
+}
+
 std::string Beacon::ToString() const
 {
     return EncodeBase64(

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -150,6 +150,17 @@ public:
     CBitcoinAddress GetAddress() const;
 
     //!
+    //! \brief Get the code that the scrapers use to verify the beacon.
+    //!
+    //! World Community Grid allows no more than 30 characters for an account's
+    //! username field so we format the key ID using base58 encoding to produce
+    //! a shorter verification code.
+    //!
+    //! \return Base58 representation of the RIPEMD-160 hash of the public key.
+    //!
+    std::string GetVerificationCode() const;
+
+    //!
     //! \brief Get the legacy string representation of a version 1 beacon
     //! contract.
     //!

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -322,13 +322,13 @@ QString ResearcherModel::formatBeaconAddress() const
     return QString::fromStdString(m_beacon->GetAddress().ToString());
 }
 
-QString ResearcherModel::formatBeaconKeyId() const
+QString ResearcherModel::formatBeaconVerificationCode() const
 {
     if (!m_pending_beacon) {
         return QString();
     }
 
-    return QString::fromStdString(m_pending_beacon->GetId().ToString());
+    return QString::fromStdString(m_pending_beacon->GetVerificationCode());
 }
 
 std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool with_mag) const

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -99,7 +99,7 @@ public:
     QString formatBeaconAge() const;
     QString formatTimeToBeaconExpiration() const;
     QString formatBeaconAddress() const;
-    QString formatBeaconKeyId() const;
+    QString formatBeaconVerificationCode() const;
 
     std::vector<ProjectRow> buildProjectTable(bool with_mag = true) const;
 

--- a/src/qt/researcher/researcherwizardauthpage.cpp
+++ b/src/qt/researcher/researcherwizardauthpage.cpp
@@ -47,7 +47,7 @@ void ResearcherWizardAuthPage::refresh()
         return;
     }
 
-    ui->verificationCodeLabel->setText(m_researcher_model->formatBeaconKeyId());
+    ui->verificationCodeLabel->setText(m_researcher_model->formatBeaconVerificationCode());
 }
 
 void ResearcherWizardAuthPage::on_copyToClipboardButton_clicked()

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -610,15 +610,17 @@ UniValue advertisebeacon(const UniValue& params, bool fHelp)
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    const NN::AdvertiseBeaconResult result = NN::Researcher::Get()->AdvertiseBeacon();
+    NN::AdvertiseBeaconResult result = NN::Researcher::Get()->AdvertiseBeacon();
 
     if (auto public_key_option = result.TryPublicKey()) {
+        const NN::Beacon beacon(std::move(*public_key_option));
+
         UniValue res(UniValue::VOBJ);
 
         res.pushKV("result", "SUCCESS");
         res.pushKV("cpid", NN::Researcher::Get()->Id().ToString());
-        res.pushKV("public_key", public_key_option->ToString());
-        res.pushKV("verification_code", public_key_option->GetID().ToString());
+        res.pushKV("public_key", beacon.m_public_key.ToString());
+        res.pushKV("verification_code", beacon.GetVerificationCode());
 
         return res;
     }
@@ -905,7 +907,7 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
         entry.pushKV("address", beacon->GetAddress().ToString());
         entry.pushKV("public_key", beacon->m_public_key.ToString());
         entry.pushKV("magnitude", NN::Quorum::GetMagnitude(*cpid).Floating());
-        entry.pushKV("verification_code", beacon->GetId().ToString());
+        entry.pushKV("verification_code", beacon->GetVerificationCode());
         entry.pushKV("is_mine", is_mine);
 
         active.push_back(entry);
@@ -922,7 +924,7 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
         entry.pushKV("address", beacon->GetAddress().ToString());
         entry.pushKV("public_key", beacon->m_public_key.ToString());
         entry.pushKV("magnitude", 0);
-        entry.pushKV("verification_code", beacon->GetId().ToString());
+        entry.pushKV("verification_code", beacon->GetVerificationCode());
         entry.pushKV("is_mine", is_mine);
 
         pending.push_back(entry);

--- a/src/scraper/fwd.h
+++ b/src/scraper/fwd.h
@@ -143,6 +143,7 @@ typedef std::map<std::string, ScraperBeaconEntry> ScraperBeaconMap;
 struct ScraperPendingBeaconEntry
 {
     std::string cpid;
+    uint160 key_id;
     int64_t timestamp;
 
     template<typename Stream>
@@ -150,6 +151,7 @@ struct ScraperPendingBeaconEntry
     {
         stream << cpid;
         stream << timestamp;
+        stream << key_id;
     }
 
     template<typename Stream>
@@ -157,6 +159,7 @@ struct ScraperPendingBeaconEntry
     {
         stream >> cpid;
         stream >> timestamp;
+        stream >> key_id;
     }
 };
 

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -3359,7 +3359,14 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const Converge
     {
         CDataStream part(iter->second, SER_NETWORK, 1);
 
-        part >> VerifiedBeaconMap;
+        try
+        {
+            part >> VerifiedBeaconMap;
+        }
+        catch (const std::exception& e)
+        {
+            _log(logattribute::WARNING, __func__, "failed to deserialize verified beacons part: " + std::string(e.what()));
+        }
 
         ++exclude_parts_from_count;
     }
@@ -3479,7 +3486,14 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsFromSingleManifest(CScraperManifes
     {
         CDataStream part(iter->second, SER_NETWORK, 1);
 
-        part >> VerifiedBeaconMap;
+        try
+        {
+            part >> VerifiedBeaconMap;
+        }
+        catch (const std::exception& e)
+        {
+            _log(logattribute::WARNING, __func__, "failed to deserialize verified beacons part: " + std::string(e.what()));
+        }
 
         ++exclude_parts_from_count;
     }
@@ -4916,7 +4930,14 @@ std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConverg
     {
         CDataStream part(iter->second, SER_NETWORK, 1);
 
-        part >> VerifiedBeaconMap;
+        try
+        {
+            part >> VerifiedBeaconMap;
+        }
+        catch (const std::exception& e)
+        {
+            _log(logattribute::WARNING, __func__, "failed to deserialize verified beacons part: " + std::string(e.what()));
+        }
 
         for (const auto& entry : VerifiedBeaconMap)
         {
@@ -4957,7 +4978,14 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsAndVerifiedBeacons(const Converged
     {
         CDataStream part(iter->second, SER_NETWORK, 1);
 
-        part >> stats_and_verified_beacons.mVerifiedMap;
+        try
+        {
+            part >> stats_and_verified_beacons.mVerifiedMap;
+        }
+        catch (const std::exception& e)
+        {
+            _log(logattribute::WARNING, __func__, "failed to deserialize verified beacons part: " + std::string(e.what()));
+        }
     }
 
     stats_and_verified_beacons.mScraperStats = stats.mScraperConvergedStats;

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -238,8 +238,9 @@ BeaconConsensus GetConsensusBeaconList()
 
         beaconentry.timestamp = pending_beacon.m_timestamp;
         beaconentry.cpid = pending_beacon.m_cpid.ToString();
+        beaconentry.key_id = key_id;
 
-        consensus.mPendingMap.emplace(key_id.ToString(), std::move(beaconentry));
+        consensus.mPendingMap.emplace(pending_beacon.GetVerificationCode(), std::move(beaconentry));
     }
 
     return consensus;
@@ -1983,7 +1984,7 @@ bool DownloadProjectRacFilesByCPID(const NN::WhitelistSnapshot& projectWhitelist
     {
         for (const auto& entry : Consensus.mPendingMap)
         {
-            _log(logattribute::INFO, "DownloadProjectRacFilesByCPID", "Pending beacon address "
+            _log(logattribute::INFO, "DownloadProjectRacFilesByCPID", "Pending beacon verification code "
                  + entry.first + ", CPID " + entry.second.cpid + ", "
                  + DateTimeStrFormat("%Y%m%d%H%M%S", entry.second.timestamp));
         }
@@ -2189,7 +2190,8 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
             {
                 const std::string username = ExtractXML(data, "<name>", "</name>");
 
-                if (username.size() != 40) continue;
+                // Base58-encoded beacon verification code sizes fall within:
+                if (username.size() < 26 || username.size() > 28) continue;
 
                 // The username has to be temporarily changed to the key, so that
                 // it matches the key of the mPendingMap, which is the string representation

--- a/src/test/neuralnet/beacon_tests.cpp
+++ b/src/test/neuralnet/beacon_tests.cpp
@@ -50,11 +50,29 @@ struct TestKey
     }
 
     //!
+    //! \brief Create a key ID from the test public key.
+    //!
+    static CKeyID KeyId()
+    {
+        return Public().GetID();
+    }
+
+    //!
     //! \brief Create an address from the test public key.
     //!
     static CBitcoinAddress Address()
     {
-        return CBitcoinAddress(CTxDestination(Public().GetID()));
+        return CBitcoinAddress(CTxDestination(KeyId()));
+    }
+
+    //!
+    //! \brief Create a beacon verification code from the test public key.
+    //!
+    static std::string VerificationCode()
+    {
+        const CKeyID key_id = KeyId();
+
+        return EncodeBase58(key_id.begin(), key_id.end());
     }
 
     //!
@@ -165,11 +183,25 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_beacon_is_renewable)
     BOOST_CHECK(renewable.Renewable(NN::Beacon::RENEWAL_AGE + 1) == true);
 }
 
+BOOST_AUTO_TEST_CASE(it_produces_a_key_id)
+{
+    const NN::Beacon beacon(TestKey::Public());
+
+    BOOST_CHECK(beacon.GetId() == TestKey::KeyId());
+}
+
 BOOST_AUTO_TEST_CASE(it_produces_a_rain_address)
 {
     const NN::Beacon beacon(TestKey::Public());
 
     BOOST_CHECK(beacon.GetAddress() == TestKey::Address());
+}
+
+BOOST_AUTO_TEST_CASE(it_produces_a_verification_code)
+{
+    const NN::Beacon beacon(TestKey::Public());
+
+    BOOST_CHECK(beacon.GetVerificationCode() == TestKey::VerificationCode());
 }
 
 BOOST_AUTO_TEST_CASE(it_represents_itself_as_a_legacy_string)


### PR DESCRIPTION
This refactors the encoding for beacon verification codes from hexadecimal notation to base58 to accommodate the 30-character limit for World Community Grid.
