### PR TITLE
wallet: Stop Error When Starting From Zero

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -373,9 +373,10 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
 // Get stake modifier checksum
 unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
 {
-    if (pindex->pprev == nullptr && pindex != pindexGenesisBlock) 
+    if (pindex->pprev && pindexGenesisBlock && pindex != pindexGenesisBlock) 
     {
         //Error on non-genesis blocks that don't have a previous block
+        //If pindexGenesisBlock is null, then you are starting from zero so don't throw an error
         throw std::runtime_error(
             "Error: blockchain data corrupted.\n" 
             "Go to the wallet's data directory and delete the folder txleveldb and the files blk000x.dat (x is any number).\n" 


### PR DESCRIPTION
Stops the check from throwing an error if starting from zero. Fixes the bug introduced from #1748 