### PR TITLE
Don't count empty email as explicit investor

### DIFF
--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -1006,14 +1006,6 @@ bool Researcher::ConfiguredForInvestorMode(bool log)
         return true;
     }
 
-    if (Researcher::Email().empty()) {
-        if (log) LogPrintf(
-            "WARNING: Please set 'email=<your BOINC account email>' in "
-            "gridcoinresearch.conf. Continuing in investor mode.");
-
-        return true;
-    }
-
     return false;
 }
 
@@ -1030,6 +1022,15 @@ void Researcher::MarkDirty()
 void Researcher::Reload()
 {
     if (ConfiguredForInvestorMode(true)) {
+        StoreResearcher(Researcher()); // Investor
+        return;
+    }
+
+    if (Researcher::Email().empty()) {
+        LogPrintf(
+            "WARNING: Please set 'email=<your BOINC account email>' in "
+            "gridcoinresearch.conf. Continuing in investor mode.");
+
         StoreResearcher(Researcher()); // Investor
         return;
     }


### PR DESCRIPTION
If the email address is missing from or empty in the configuration file, don't assume that the wallet is configured for investor mode so that the researcher configuration wizard is accessible with an empty configuration file. 