### PR TITLE
scraper: Add instrumentation to convergencereport

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -51,7 +51,6 @@ UniValue ContractToJson(const NN::Contract& contract);
 
 BlockFinder RPCBlockFinder;
 
-namespace {
 UniValue ClaimToJson(const NN::Claim& claim, const CBlockIndex* const pindex)
 {
     UniValue json(UniValue::VOBJ);
@@ -122,7 +121,6 @@ UniValue SuperblockToJson(const NN::SuperblockPtr& superblock)
 {
     return SuperblockToJson(*superblock);
 }
-} // anonymous namespace
 
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPrintTransactionDetail)
 {

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -164,6 +164,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "superblocks"            , 1 },
 
     // Developer
+    { "convergencereport"      , 0 },
     { "debug"                  , 0 },
     { "debug10"                , 0 },
     { "debug2"                 , 0 },


### PR DESCRIPTION
This adds the option to output details of the contents of the convergence cache as part of the convergencereport. In particular,
the current and past convergences are rendered as superblocks to provide insight.

Also included some very minor cleanup.