### PR TITLE
accrual: Fix snapshot accrual superblock state transitions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3010,6 +3010,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
 
         if (pindexBest->nIsSuperBlock == 1) {
             NN::Quorum::PopSuperblock(pindexBest);
+            NN::Quorum::LoadSuperblockIndex(pindexBest->pprev);
 
             if (pindexBest->nVersion >= 11 && !NN::Tally::RevertSuperblock()) {
                 return false;
@@ -3044,7 +3045,6 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
             return error("DisconnectBlocksBatch: TxnCommit failed"); /*fatal*/
 
         NN::ReplayContracts(pindexBest);
-        NN::Quorum::LoadSuperblockIndex(pindexBest);
 
         // Tally research averages.
         if(IsV9Enabled_Tally(nBestHeight) && !IsV11Enabled(nBestHeight)) {

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -177,10 +177,7 @@ public:
             const CBlockIndex* pindex = pindexLast;
             for (; pindex && pindex->nIsSuperBlock != 1; pindex = pindex->pprev);
 
-            CBlock block;
-            block.ReadFromDisk(pindex);
-
-            m_cache.emplace_front(block.GetSuperblock(pindex));
+            m_cache.emplace_front(SuperblockPtr::ReadFromDisk(pindex));
 
             return;
         }
@@ -220,10 +217,7 @@ public:
                 pindexLast = pindexLast->pprev;
             }
 
-            CBlock block;
-            block.ReadFromDisk(pindexLast);
-
-            PushSuperblock(block.GetSuperblock(pindexLast));
+            PushSuperblock(SuperblockPtr::ReadFromDisk(pindexLast));
 
             pindexLast = pindexLast->pprev;
         }

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -999,6 +999,28 @@ SuperblockPtr::SuperblockPtr(
 {
 }
 
+SuperblockPtr SuperblockPtr::ReadFromDisk(const CBlockIndex* const pindex)
+{
+    if (!pindex) {
+        error("%s: invalid superblock index", __func__);
+        return Empty();
+    }
+
+    if (pindex->nIsSuperBlock != 1) {
+        error("%s: %" PRId64 " is not a superblock", __func__, pindex->nHeight);
+        return Empty();
+    }
+
+    CBlock block;
+
+    if (!block.ReadFromDisk(pindex)) {
+        error("%s: failed to read superblock from disk", __func__);
+        return Empty();
+    }
+
+    return block.GetSuperblock(pindex);
+}
+
 void SuperblockPtr::Rebind(const CBlockIndex* const pindex)
 {
     m_height = pindex->nHeight;

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1398,6 +1398,16 @@ public:
         return SuperblockPtr();
     }
 
+    //!
+    //! \brief Load a superblock from disk.
+    //!
+    //! \param pindex Index of the block that contains the superblock.
+    //!
+    //! \return Wrapped superblock from the specified block or an empty object
+    //! if the block contains no valid superblock.
+    //!
+    static SuperblockPtr ReadFromDisk(const CBlockIndex* const pindex);
+
     const Superblock& operator*() const noexcept { return *m_superblock; }
     const Superblock* operator->() const noexcept { return m_superblock.get(); }
 

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -329,8 +329,11 @@ public:
     {
         if (m_current_superblock->m_version >= 2) {
             try {
-                return m_snapshots.Drop(m_current_superblock.m_height)
-                    && m_snapshots.ApplyLatest(m_researchers);
+                if (!m_snapshots.Drop(m_current_superblock.m_height)
+                    || !m_snapshots.ApplyLatest(m_researchers))
+                {
+                    return false;
+                }
             } catch (const SnapshotStateError& e) {
                 LogPrintf("%s: %s", e.what());
 

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -329,8 +329,8 @@ public:
     {
         if (m_current_superblock->m_version >= 2) {
             try {
-                return m_snapshots.ApplyLatest(m_researchers)
-                    && m_snapshots.Drop(m_current_superblock.m_height);
+                return m_snapshots.Drop(m_current_superblock.m_height)
+                    && m_snapshots.ApplyLatest(m_researchers);
             } catch (const SnapshotStateError& e) {
                 LogPrintf("%s: %s", e.what());
 

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -531,13 +531,8 @@ private:
     SuperblockPtr FindBaselineSuperblock() const
     {
         const CBlockIndex* pindex = FindBaselineSuperblockHeight();
-        CBlock block;
 
-        if (!pindex || !block.ReadFromDisk(pindex)) {
-            return SuperblockPtr::Empty();
-        }
-
-        return block.GetSuperblock(pindex);
+        return SuperblockPtr::ReadFromDisk(pindex);
     }
 
     //!
@@ -600,11 +595,7 @@ private:
             pindex = pindex->pnext)
         {
             if (pindex->nIsSuperBlock == 1) {
-                if (!block.ReadFromDisk(pindex)) {
-                    return false;
-                }
-
-                if (!ApplySuperblock(block.GetSuperblock(pindex))) {
+                if (!ApplySuperblock(SuperblockPtr::ReadFromDisk(pindex))) {
                     return false;
                 }
             }


### PR DESCRIPTION
This reverts a change from #1752 that attempted to fix reorganization across a superblock. The actual issue is caused by a skipped assignment for the current superblock when the tally reverts the disconnected superblock. 