### PR TITLE
Update researcherwizardemailpage.ui

### DIFF
--- a/src/qt/forms/researcherwizardemailpage.ui
+++ b/src/qt/forms/researcherwizardemailpage.ui
@@ -23,7 +23,7 @@
    <string>BOINC Email Address</string>
   </property>
   <property name="subTitle">
-   <string>Enter the email address that you use for your BOINC project accounts. Gridcoin uses this email address to find BOINC projects on your computer.</string>
+   <string>Enter the email address that you use for your BOINC project accounts. Gridcoin uses this email address to find BOINC projects on your computer. If you are an investor only, i.e. you do not do BOINC research, insert "investor".</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
If you do not have set email=investor or investor=1, the wallet is bugging you with "Action Needed". 
An additional Check Button ([ ] "Investor") may be even more suitable than my proposed change. When checked, "investor=1" is added to the .conf.