### PR TITLE
Add ability to recover beacon in block version 11+

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,10 @@ bool fUseFastIndex = false;
 
 std::map<std::string, int> mvTimers; // Contains event timers that reset after max ms duration iterator is exceeded
 
+// Temporary block version 11 transition helpers:
+int64_t g_v11_timestamp = 0;
+int64_t g_v11_legacy_beacon_days = 14;
+
 // End of Gridcoin Global vars
 
 //////////////////////////////////////////////////////////////////////////////
@@ -3752,6 +3756,12 @@ bool GridcoinServices()
         // legacy transactions that cannot validate:
         //
         mempool.DiscardVersion1();
+
+        // Set the timestamp for the block version 11 threshold. This
+        // is temporary. Remove this variable in a release that comes
+        // after the hard fork.
+        //
+        g_v11_timestamp = pindexBest->nTime;
     }
 
     //Dont perform the following functions if out of sync
@@ -4087,6 +4097,15 @@ bool LoadBlockIndex(bool fAllowNew)
         nNewIndex2 = 36500;
         //1-24-2016
         MAX_OUTBOUND_CONNECTIONS = (int)GetArg("-maxoutboundconnections", 8);
+
+        // Temporary transition to version 2 beacons after the block version 11
+        // hard-fork:
+        //
+        try {
+            g_v11_legacy_beacon_days = std::stoi(GetArg("-v11beacondays", ""));
+        } catch (...) {
+            g_v11_legacy_beacon_days = 365 * 100; // Big number that won't wrap.
+        }
     }
 
     LogPrintf("Mode=%s", fTestNet ? "TestNet" : "Prod");

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -1225,7 +1225,7 @@ bool Researcher::UpdateEmail(std::string email)
     return true;
 }
 
-AdvertiseBeaconResult Researcher::AdvertiseBeacon()
+AdvertiseBeaconResult Researcher::AdvertiseBeacon(const bool force)
 {
     const CpidOption cpid = m_mining_id.TryCpid();
 
@@ -1240,7 +1240,9 @@ AdvertiseBeaconResult Researcher::AdvertiseBeacon()
 
     AdvertiseBeaconResult result(BeaconError::NONE);
 
-    if (!current_beacon) {
+    if (force) {
+        result = SendNewBeacon(*cpid);
+    } else if (!current_beacon) {
         if (g_recent_beacons.Try(*cpid)) {
             LogPrintf("%s: Beacon awaiting confirmation already", __func__);
             return BeaconError::PENDING;

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -512,10 +512,17 @@ public:
     //!  - The wallet is fully unlocked
     //!  - The wallet contains a balance sufficient to send a transaction
     //!
+    //! The \p force parameter instructs the wallet to generate a new beacon
+    //! private key even when a valid beacon exists for the current CPID. It
+    //! allows a user to send a beacon to recover the claim to their CPID if
+    //! they lost the original private key.
+    //!
+    //! \param force Ignore active and pending beacons for the current CPID.
+    //!
     //! \return A variant that contains the new public key if successful or a
     //! description of the error that occurred.
     //!
-    AdvertiseBeaconResult AdvertiseBeacon();
+    AdvertiseBeaconResult AdvertiseBeacon(const bool force = false);
 
     //!
     //! \brief Submit a contract to the network to revoke an existing beacon.

--- a/src/neuralnet/tally.cpp
+++ b/src/neuralnet/tally.cpp
@@ -15,6 +15,8 @@
 using namespace NN;
 using LogFlags = BCLog::LogFlags;
 
+extern int64_t g_v11_timestamp;
+
 namespace {
 //!
 //! \brief Set the correct CPID from the block claim when the block index
@@ -173,6 +175,13 @@ public:
 
         for (; pindex; pindex = pindex->pnext) {
             if (pindex->nHeight + 1 == GetV11Threshold()) {
+                // Set the timestamp for the block version 11 threshold. This
+                // is temporary. Remove this variable in a release that comes
+                // after the hard fork. For now, this is the least cumbersome
+                // place to set the value:
+                //
+                g_v11_timestamp = pindex->nTime;
+
                 // This will finish loading the research accounting context
                 // for snapshot accrual (block version 11+):
                 return ActivateSnapshotAccrual(pindex, current_superblock);

--- a/src/qt/forms/researcherwizardbeaconpage.ui
+++ b/src/qt/forms/researcherwizardbeaconpage.ui
@@ -161,6 +161,23 @@
      </item>
     </layout>
    </item>
+   <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+    <widget class="QLabel" name="v2BeaconNoticeLabel">
+     <property name="font">
+      <font>
+       <pointsize>10</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font-weight: bold;</string>
+     </property>
+     <property name="text">
+      <string>All active beacon holders must send a new beacon for the protocol update.</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QWidget" name="continuePromptWrapper" native="true">
      <layout class="QHBoxLayout" name="continuePromptLayout">

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -223,6 +223,7 @@ void OverviewPage::setResearcherModel(ResearcherModel *researcherModel)
 
     updateResearcherStatus();
     connect(researcherModel, SIGNAL(researcherChanged()), this, SLOT(updateResearcherStatus()));
+    connect(researcherModel, SIGNAL(magnitudeChanged()), this, SLOT(updateMagnitude()));
     connect(researcherModel, SIGNAL(accrualChanged()), this, SLOT(updatePendingAccrual()));
     connect(researcherModel, SIGNAL(beaconChanged()), this, SLOT(updateResearcherAlert()));
     connect(ui->beaconButton, SIGNAL(clicked()), this, SLOT(onBeaconButtonClicked()));
@@ -279,10 +280,19 @@ void OverviewPage::updateResearcherStatus()
 
     ui->statusLabel->setText(researcherModel->formatStatus());
     ui->cpidLabel->setText(researcherModel->formatCpid());
-    ui->magnitudeLabel->setText(researcherModel->formatMagnitude());
 
+    updateMagnitude();
     updatePendingAccrual();
     updateResearcherAlert();
+}
+
+void OverviewPage::updateMagnitude()
+{
+    if (!researcherModel) {
+        return;
+    }
+
+    ui->magnitudeLabel->setText(researcherModel->formatMagnitude());
 }
 
 void OverviewPage::updatePendingAccrual()

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -63,6 +63,7 @@ private:
 private slots:
     void updateDisplayUnit();
     void updateResearcherStatus();
+    void updateMagnitude();
     void updatePendingAccrual();
     void updateResearcherAlert();
     void onBeaconButtonClicked();

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -453,6 +453,7 @@ void ResearcherModel::refresh()
 {
     updateBeacon();
 
+    emit magnitudeChanged();
     emit accrualChanged();
 }
 

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -85,6 +85,7 @@ public:
     bool hasRenewableBeacon() const;
     bool hasMagnitude() const;
     bool needsBeaconAuth() const;
+    bool needsV2BeaconUpgrade() const;
 
     QString email() const;
     QString formatCpid() const;

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -118,6 +118,7 @@ private:
 signals:
     void researcherChanged();
     void beaconChanged();
+    void magnitudeChanged();
     void accrualChanged();
 
 public slots:

--- a/src/qt/researcher/researcherwizardbeaconpage.cpp
+++ b/src/qt/researcher/researcherwizardbeaconpage.cpp
@@ -77,6 +77,7 @@ void ResearcherWizardBeaconPage::refresh()
 
     ui->cpidLabel->setText(m_researcher_model->formatCpid());
     ui->sendBeaconButton->setVisible(isEnabled());
+    ui->v2BeaconNoticeLabel->setVisible(m_researcher_model->needsV2BeaconUpgrade());
     ui->continuePromptWrapper->setVisible(!isEnabled());
 
     emit completeChanged();

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -160,6 +160,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "walletpassphrase"       , 2 },
 
     // Mining
+    { "advertisebeacon"        , 0 },
     { "superblocks"            , 0 },
     { "superblocks"            , 1 },
 

--- a/src/test/neuralnet/beacon_tests.cpp
+++ b/src/test/neuralnet/beacon_tests.cpp
@@ -164,11 +164,11 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_beacon_expired)
     const NN::Beacon valid(CPubKey(), NN::Beacon::MAX_AGE);
     BOOST_CHECK(valid.Expired(NN::Beacon::MAX_AGE) == false);
 
-    const NN::Beacon almost(CPubKey(), 0);
-    BOOST_CHECK(almost.Expired(NN::Beacon::MAX_AGE) == false);
+    const NN::Beacon almost(CPubKey(), 1);
+    BOOST_CHECK(almost.Expired(NN::Beacon::MAX_AGE + 1) == false);
 
-    const NN::Beacon expired(CPubKey(), 0);
-    BOOST_CHECK(expired.Expired(NN::Beacon::MAX_AGE + 1) == true);
+    const NN::Beacon expired(CPubKey(), 1);
+    BOOST_CHECK(expired.Expired(NN::Beacon::MAX_AGE + 2) == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_beacon_is_renewable)
@@ -176,11 +176,11 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_beacon_is_renewable)
     const NN::Beacon not_needed(CPubKey(), NN::Beacon::RENEWAL_AGE);
     BOOST_CHECK(not_needed.Renewable(NN::Beacon::RENEWAL_AGE) == false);
 
-    const NN::Beacon almost(CPubKey(), 0);
+    const NN::Beacon almost(CPubKey(), 1);
     BOOST_CHECK(almost.Renewable(NN::Beacon::RENEWAL_AGE) == false);
 
-    const NN::Beacon renewable(CPubKey(), 0);
-    BOOST_CHECK(renewable.Renewable(NN::Beacon::RENEWAL_AGE + 1) == true);
+    const NN::Beacon renewable(CPubKey(), 1);
+    BOOST_CHECK(renewable.Renewable(NN::Beacon::RENEWAL_AGE + 2) == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_produces_a_key_id)


### PR DESCRIPTION
This updates the `advertisebeacon` RPC with a `force` parameter to enable a user to generate a new beacon even when a valid beacon already exists for their CPID. It allows users to recover the ability to claim to rewards for their CPIDs in case they lose the original wallets or private keys.