### PR TITLE
Generalize enum serialization 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,6 +75,7 @@ GRIDCOIN_CORE_H = \
     compat/endian.h \
     contract/polls.h \
     crypter.h \
+    enumbytes.h \
     filehash.h \
     fs.h \
     fwd.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -33,6 +33,7 @@ GRIDCOIN_TESTS =\
   test/base64_tests.cpp \
   test/bignum_tests.cpp \
   test/block_tests.cpp \
+  test/enumbytes.cpp \
   test/fs_tests.cpp \
   test/getarg_tests.cpp \
   test/gridcoin_tests.cpp \

--- a/src/enumbytes.h
+++ b/src/enumbytes.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include "serialize.h"
+
+//!
+//! \brief A wrapper around an enum type that provides for serialization of the
+//! enum values as unsigned integers.
+//!
+//! This type provides boilerplate useful for preserving the semantics of scoped
+//! enumerations (enum class) while facilitating serialization of the values.
+//!
+//! \tparam E Enum type wrapped by this class.
+//! \tparam U Underlying unsigned integer type to serialize the enum value as.
+//! \tparam B Enum value that describes the upper bound of the enum range.
+//!
+template <typename E, typename U, E B>
+class EnumBytes
+{
+public:
+    //!
+    //! \brief The greatest valid value in the wrapped enum.
+    //!
+    static constexpr size_t MAX = static_cast<size_t>(B) - 1;
+
+    static_assert(std::is_enum<E>::value, "EnumBytes<E,U,B>: E is not an enum");
+    static_assert(std::is_unsigned<U>::value, "EnumBytes<E,U,B>: U is signed");
+    static_assert(MAX <= std::numeric_limits<U>::max(),
+        "EnumBytes<E,U,B>: upper bound B for enum E exceeds range of type U");
+
+    //!
+    //! \brief Serializes and deserializes enum values from a stream.
+    //!
+    //! This type can be used to serialize enums without storing the value as
+    //! an EnumBytes<E, U, B> object.
+    //!
+    class Formatter
+    {
+    public:
+        //!
+        //! \brief Serialize an enum value as a byte to the provided stream.
+        //!
+        //! \param stream The output stream.
+        //!
+        template <typename Stream>
+        void Ser(Stream& s, E e)
+        {
+            ::Serialize(s, EnumBytes<E, U, B>(e).Raw());
+        }
+
+        //!
+        //! \brief Deserialize an enum value from the provided stream.
+        //!
+        //! \param stream The input stream.
+        //!
+        template <typename Stream>
+        void Unser(Stream& s, E& e)
+        {
+            U raw;
+            ::Unserialize(s, raw);
+
+            if (raw > EnumBytes<E, U, B>::MAX) {
+                throw std::ios_base::failure("EnumBytes out of range");
+            }
+
+            e = static_cast<E>(raw);
+        }
+    };
+
+    //!
+    //! \brief Wrap the provided enum value.
+    //!
+    //! \param value The enum value to wrap.
+    //!
+    constexpr EnumBytes(E value) noexcept : m_value(value)
+    {
+    }
+
+    constexpr bool operator==(const E& other) const noexcept { return m_value == other; }
+    constexpr bool operator==(const EnumBytes<E, U, B>& other) const noexcept { return *this == other.m_value; }
+    constexpr bool operator!=(const E& other) const noexcept { return !(*this == other); }
+    constexpr bool operator!=(const EnumBytes<E, U, B>& other) const noexcept { return !(*this == other); }
+    constexpr bool operator<(const E& other) const noexcept { return m_value < other; }
+    constexpr bool operator<(const EnumBytes<E, U, B>& other) const noexcept { return *this < other.m_value; }
+    constexpr bool operator<=(const E& other) const noexcept { return m_value <= other; }
+    constexpr bool operator<=(const EnumBytes<E, U, B>& other) const noexcept { return *this <= other.m_value; }
+    constexpr bool operator>(const E& other) const noexcept { return m_value > other; }
+    constexpr bool operator>(const EnumBytes<E, U, B>& other) const noexcept { return *this > other.m_value; }
+    constexpr bool operator>=(const E& other) const noexcept { return m_value >= other; }
+    constexpr bool operator>=(const EnumBytes<E, U, B>& other) const noexcept { return *this >= other.m_value; }
+
+    //!
+    //! \brief Get the wrapped enum value.
+    //!
+    //! \return A value enumerated on enum \c E.
+    //!
+    constexpr E Value() const noexcept
+    {
+        return m_value;
+    }
+
+    //!
+    //! \brief Get the wrapped enum value as a value of the underlying type.
+    //!
+    //! \return For example, an unsigned char for an enum that represents
+    //! an underlying byte value.
+    //!
+    constexpr uint8_t Raw() const noexcept
+    {
+        return static_cast<uint8_t>(m_value);
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(Using<Formatter>(m_value));
+    }
+
+protected:
+    E m_value; //!< The wrapped enum value.
+}; // EnumBytes<E, U, B>
+
+//!
+//! \brief A wrapper around an enum type that provides for serialization of the
+//! enum values as single bytes.
+//!
+//! This type expects a wrapped enum to contain an OUT_OF_BOUND identifier for
+//! the value greater than the upper bound of the enumerated range. A value of
+//! zero should map to a meaningful identifier in the enum.
+//!
+//! \tparam E Enum type wrapped by this class.
+//!
+template <typename E>
+class EnumByte : public EnumBytes<E, uint8_t, E::OUT_OF_BOUND>
+{
+public:
+    //!
+    //! \brief Initialize an enum wrapper to zero.
+    //!
+    constexpr EnumByte() noexcept
+        : EnumByte(static_cast<E>(0))
+    {
+    }
+
+    //!
+    //! \brief Wrap the provided enum value.
+    //!
+    //! \param value The enum value to wrap.
+    //!
+    constexpr EnumByte(E value) noexcept
+        : EnumBytes<E, uint8_t, E::OUT_OF_BOUND>(value)
+    {
+    }
+};

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -725,7 +725,7 @@ void Contract::Log(const std::string& prefix) const
 // Class: Contract::Type
 // -----------------------------------------------------------------------------
 
-Contract::Type::Type(ContractType type) : WrappedEnum(type)
+Contract::Type::Type(ContractType type) : EnumByte(type)
 {
 }
 
@@ -760,7 +760,7 @@ std::string Contract::Type::ToString() const
 // Class: Contract::Action
 // -----------------------------------------------------------------------------
 
-Contract::Action::Action(ContractAction action) : WrappedEnum(action)
+Contract::Action::Action(ContractAction action) : EnumByte(action)
 {
 }
 
@@ -832,6 +832,8 @@ ContractPayload Contract::Body::ConvertFromLegacy(const ContractType type) const
             return m_payload;
         case ContractType::VOTE:
             return m_payload;
+        case ContractType::OUT_OF_BOUND:
+            assert(false);
     }
 
     return ContractPayload::Make<EmptyPayload>();
@@ -864,6 +866,8 @@ void Contract::Body::ResetType(const ContractType type)
         case ContractType::VOTE:
             m_payload.Reset(new LegacyPayload());
             break;
+        case ContractType::OUT_OF_BOUND:
+            assert(false);
     }
 }
 

--- a/src/neuralnet/contract/contract.h
+++ b/src/neuralnet/contract/contract.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "enumbytes.h"
 #include "key.h"
 #include "neuralnet/contract/payload.h"
 #include "serialize.h"
@@ -27,115 +28,6 @@ namespace NN {
 //!
 class Contract
 {
-private:
-    //!
-    //! \brief A wrapper around an enum type.
-    //!
-    //! \tparam E The enum type wrapped by this class.
-    //!
-    template<typename E>
-    struct WrappedEnum
-    {
-        // Replace with E::underlying_type_t when moving to C++14:
-        using EnumUnderlyingType = typename std::underlying_type<E>::type;
-
-        //!
-        //! \brief Compare a supplied enum value for equality.
-        //!
-        //! \param other An enum value to check equality for.
-        //!
-        //! \return \c true if the suppled value matches the wrapped enum value.
-        //!
-        bool operator==(const E& other) const
-        {
-            return m_value == other;
-        }
-
-        //!
-        //! \brief Compare a supplied enum value for inequality.
-        //!
-        //! \param other An enum value to check inequality for.
-        //!
-        //! \return \c true if the suppled value does not match the wrapped
-        //! enum value.
-        //!
-        bool operator!=(const E& other) const
-        {
-            return m_value != other;
-        }
-
-        //!
-        //! \brief Get the wrapped enum value.
-        //!
-        //! \return A value enumerated on enum \c E.
-        //!
-        E Value() const
-        {
-            return m_value;
-        }
-
-        //!
-        //! \brief Get the wrapped enum value as a value of the underlying type.
-        //!
-        //! \return For example, an unsigned char for an enum that represents
-        //! an underlying byte value.
-        //!
-        EnumUnderlyingType Raw() const
-        {
-            return static_cast<EnumUnderlyingType>(m_value);
-        }
-
-        //!
-        //! \brief Get the string representation of the wrapped enum value.
-        //!
-        //! \return The string as it would appear in a transaction message or
-        //! the captured string if parsed from an unrecognized value.
-        //!
-        virtual std::string ToString() const = 0;
-
-        //!
-        //! \brief Serialize the wrapped enum value to the provided stream.
-        //!
-        //! \param stream The output stream.
-        //!
-        template<typename Stream>
-        void Serialize(Stream& stream) const
-        {
-            ::Serialize(stream, Raw());
-        }
-
-        //!
-        //! \brief Deserialize an enum value from the provided stream.
-        //!
-        //! \param stream The input stream.
-        //!
-        template<typename Stream>
-        void Unserialize(Stream& stream)
-        {
-            EnumUnderlyingType value;
-
-            ::Unserialize(stream, value);
-
-            if (value > static_cast<EnumUnderlyingType>(E::MAX_VALUE)) {
-                m_value = E::UNKNOWN;
-            } else {
-                m_value = static_cast<E>(value);
-            }
-        }
-
-    protected:
-        E m_value; //!< The wrapped enum value.
-
-        //!
-        //! \brief Delegated constructor called by child types.
-        //!
-        //! \param value The enum value to wrap.
-        //!
-        WrappedEnum(E value) : m_value(value)
-        {
-        }
-    }; // Contract::WrappedEnum
-
 public:
     //!
     //! \brief Version number of the current format for a serialized contract.
@@ -155,7 +47,7 @@ public:
     //!
     //! \brief A contract type from a transaction message.
     //!
-    struct Type : public WrappedEnum<ContractType>
+    struct Type : public EnumByte<ContractType>
     {
         //!
         //! \brief Initialize an instance for a \c ContractType value.
@@ -180,13 +72,13 @@ public:
         //!
         //! \return The string as it would appear in a legacy transaction message.
         //!
-        std::string ToString() const override;
+        std::string ToString() const;
     }; // Contract::Type
 
     //!
     //! \brief A contract action from a transaction message.
     //!
-    struct Action : public WrappedEnum<ContractAction>
+    struct Action : public EnumByte<ContractAction>
     {
         //!
         //! \brief Initialize an instance for a \c ContractAction value.
@@ -211,7 +103,7 @@ public:
         //!
         //! \return The string as it would appear in a transaction message.
         //!
-        std::string ToString() const override;
+        std::string ToString() const;
     }; // Contract::Action
 
     //!

--- a/src/neuralnet/contract/payload.h
+++ b/src/neuralnet/contract/payload.h
@@ -44,34 +44,34 @@ namespace NN {
 //!
 //! \brief Represents the type of a Gridcoin contract.
 //!
-//! CONSENSUS: Do not remove an item from this enum or change or repurpose the
-//! byte value.
+//! CONSENSUS: Do not remove or reorder items in this enumeration except for
+//! OUT_OF_BOUND which must remain at the end.
 //!
-enum class ContractType : uint8_t
+enum class ContractType
 {
-    UNKNOWN    = 0x00, //!< An invalid, non-standard, or empty contract type.
-    BEACON     = 0x01, //!< Beacon advertisement or deletion.
-    CLAIM      = 0x02, //!< Gridcoin block reward claim context.
-    POLL       = 0x03, //!< Submission of a new poll.
-    PROJECT    = 0x04, //!< Project whitelist addition or removal.
-    PROTOCOL   = 0x05, //!< Network control message or configuration directive.
-    SCRAPER    = 0x06, //!< Scraper node authorization grants and revocations.
-    VOTE       = 0x07, //!< A vote cast by a wallet for a poll.
-    MAX_VALUE  = 0x07, //!< Increment this when adding items to the enum.
+    UNKNOWN,      //!< An invalid, non-standard, or empty contract type.
+    BEACON,       //!< Beacon advertisement or deletion.
+    CLAIM,        //!< Gridcoin block reward claim context.
+    POLL,         //!< Submission of a new poll.
+    PROJECT,      //!< Project whitelist addition or removal.
+    PROTOCOL,     //!< Network control message or configuration directive.
+    SCRAPER,      //!< Scraper node authorization grants and revocations.
+    VOTE,         //!< A vote cast by a wallet for a poll.
+    OUT_OF_BOUND, //!< Marker value for the end of the valid range.
 };
 
 //!
 //! \brief The type of action that a contract declares.
 //!
-//! CONSENSUS: Do not remove an item from this enum or change or repurpose the
-//! byte value.
+//! CONSENSUS: Do not remove or reorder items in this enumeration except for
+//! OUT_OF_BOUND which must remain at the end.
 //!
-enum class ContractAction : uint8_t
+enum class ContractAction
 {
-    UNKNOWN   = 0x00, //!< An invalid, non-standard, or empty contract action.
-    ADD       = 0x01, //!< Handle a new contract addition (A).
-    REMOVE    = 0x02, //!< Remove an existing contract (D).
-    MAX_VALUE = 0x02, //!< Increment this when adding items to the enum.
+    UNKNOWN,      //!< An invalid, non-standard, or empty contract action.
+    ADD,          //!< Handle a new contract addition (A).
+    REMOVE,       //!< Remove an existing contract (D).
+    OUT_OF_BOUND, //!< Marker value for the end of the valid range.
 };
 
 //!

--- a/src/test/enumbytes.cpp
+++ b/src/test/enumbytes.cpp
@@ -1,0 +1,130 @@
+#include "enumbytes.h"
+#include "streams.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+//!
+//! \brief An enumeration to use for testing.
+//!
+enum class TestEnum {
+    A,
+    B,
+    OUT_OF_BOUND,
+};
+} // Anonymous namespace
+
+
+// -----------------------------------------------------------------------------
+// EnumByte
+// -----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(EnumByte_)
+
+BOOST_AUTO_TEST_CASE(it_initalizes_to_zero)
+{
+    const EnumByte<TestEnum> a;
+
+    BOOST_CHECK(a.Value() == TestEnum::A);
+}
+
+BOOST_AUTO_TEST_CASE(it_initializes_to_an_enum_value)
+{
+    const EnumByte<TestEnum> b(TestEnum::B);
+
+    BOOST_CHECK(b.Value() == TestEnum::B);
+}
+
+BOOST_AUTO_TEST_CASE(it_compares_another_enum_wrapper)
+{
+    const EnumByte<TestEnum> a1;
+    const EnumByte<TestEnum> a2;
+    const EnumByte<TestEnum> b(TestEnum::B);
+
+    BOOST_CHECK(a1 == a2);
+    BOOST_CHECK(a1 != b);
+
+    BOOST_CHECK(a1 < b);
+    BOOST_CHECK(!(b < a1));
+
+    BOOST_CHECK(b > a1);
+    BOOST_CHECK(!(a1 > b));
+
+    BOOST_CHECK(a1 <= a2);
+    BOOST_CHECK(a1 <= b);
+    BOOST_CHECK(!(b <= a1));
+
+    BOOST_CHECK(a1 >= a2);
+    BOOST_CHECK(b >= a1);
+    BOOST_CHECK(!(a1 >= b));
+}
+
+BOOST_AUTO_TEST_CASE(it_compares_an_enum_of_the_wrapped_type)
+{
+    const EnumByte<TestEnum> a;
+    const EnumByte<TestEnum> b(TestEnum::B);
+
+    BOOST_CHECK(a == TestEnum::A);
+    BOOST_CHECK(a != TestEnum::B);
+
+    BOOST_CHECK(a < TestEnum::B);
+    BOOST_CHECK(!(b < TestEnum::A));
+
+    BOOST_CHECK(b > TestEnum::A);
+    BOOST_CHECK(!(a > TestEnum::B));
+
+    BOOST_CHECK(a <= TestEnum::A);
+    BOOST_CHECK(a <= TestEnum::B);
+    BOOST_CHECK(!(b <= TestEnum::A));
+
+    BOOST_CHECK(a >= TestEnum::A);
+    BOOST_CHECK(b >= TestEnum::A);
+    BOOST_CHECK(!(a >= TestEnum::B));
+}
+
+BOOST_AUTO_TEST_CASE(it_produces_an_unsigned_integer_for_the_enum_value)
+{
+    const EnumByte<TestEnum> b(TestEnum::B);
+
+    BOOST_CHECK(b.Raw() == static_cast<uint8_t>(TestEnum::B));
+}
+
+BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
+{
+    const EnumByte<TestEnum> b(TestEnum::B);
+
+    const CDataStream expected = CDataStream(SER_NETWORK, 1)
+        << static_cast<uint8_t>(TestEnum::B);
+
+    const CDataStream stream = CDataStream(SER_NETWORK, 1)
+        << b;
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        stream.begin(),
+        stream.end(),
+        expected.begin(),
+        expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
+{
+    CDataStream stream = CDataStream(SER_NETWORK, 1)
+        << static_cast<uint8_t>(TestEnum::B);
+
+    EnumByte<TestEnum> b;
+    stream >> b;
+
+    BOOST_CHECK(b == TestEnum::B);
+}
+
+BOOST_AUTO_TEST_CASE(it_refuses_to_deserialize_out_of_range_values)
+{
+    CDataStream stream = CDataStream(SER_NETWORK, 1)
+        << static_cast<uint8_t>(TestEnum::OUT_OF_BOUND);
+
+    EnumByte<TestEnum> out;
+
+    BOOST_CHECK_THROW(stream >> out, std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/neuralnet/contract_tests.cpp
+++ b/src/test/neuralnet/contract_tests.cpp
@@ -413,17 +413,14 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     BOOST_CHECK(type == NN::ContractType::BEACON); // BEACON == 0x01
 }
 
-BOOST_AUTO_TEST_CASE(it_deserializes_unknown_values_from_a_stream)
+BOOST_AUTO_TEST_CASE(it_refuses_to_deserialize_unknown_types)
 {
-    // Start with a valid contract type:
-    NN::Contract::Type type(NN::ContractType::BEACON);
+    NN::Contract::Type type(NN::ContractType::UNKNOWN);
 
-    std::vector<unsigned char> bytes { 0xEE }; // Invalid
+    std::vector<unsigned char> bytes { 0xFF }; // out-of-range
     CDataStream stream(bytes, SER_NETWORK, 1);
 
-    stream >> type;
-
-    BOOST_CHECK(type == NN::ContractType::UNKNOWN);
+    BOOST_CHECK_THROW(stream >> type, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -502,17 +499,14 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     BOOST_CHECK(action == NN::ContractAction::REMOVE); // REMOVE == 0x02
 }
 
-BOOST_AUTO_TEST_CASE(it_deserializes_unknown_values_from_a_stream)
+BOOST_AUTO_TEST_CASE(it_refuses_to_deserialize_unknown_actions)
 {
-    // Start with a valid contract action:
-    NN::Contract::Action action(NN::ContractAction::ADD);
+    NN::Contract::Action action(NN::ContractAction::UNKNOWN);
 
-    std::vector<unsigned char> bytes { 0xEE }; // Invalid
+    std::vector<unsigned char> bytes { 0xFF }; // out-of-range
     CDataStream stream(bytes, SER_NETWORK, 1);
 
-    stream >> action;
-
-    BOOST_CHECK(action == NN::ContractAction::UNKNOWN);
+    BOOST_CHECK_THROW(stream >> action, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a type that provides boilerplate for serialization of `enum` and `enum class` values as a byte value. It adapts the type originally added for the contract code for use in other areas. We may use this for the voting system refactor.