### PR TITLE
rpc: Cleanup Help Message and Fix Typo

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -427,7 +427,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
                 "rainbymagnitude <whitelisted project> <amount> [message]\n"
                 "\n"
                 "<whitelisted project> --> Required: If a project is specified, rain will be limited to that project. Use * for network-wide.\n"
-                "<amount> --> Required: Specify amount of coints in double to be rained\n"
+                "<amount> --> Required: Specify amount of coins to be rained in double precision float\n"
                 "[message] -> Optional: Provide a message rained to all rainees\n"
                 "\n"
                 "rain coins by magnitude on network");

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -54,7 +54,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     diff.pushKV("target", nTargetDiff);
 
     { LOCK(MinerStatus.lock);
-        // not using real weigh to not break calculation
+        // not using real weight to not break calculation
         bool staking = MinerStatus.nLastCoinStakeSearchInterval && MinerStatus.WeightSum;
         diff.pushKV("last-search-interval", MinerStatus.nLastCoinStakeSearchInterval);
         weight.pushKV("minimum",    MinerStatus.WeightMin);

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -180,7 +180,9 @@ UniValue setban(const UniValue& params, bool fHelp)
     if (fHelp || params.size() < 2 || params.size() > 4 || (strCommand != "add" && strCommand != "remove"))
     {
         throw runtime_error(
-                    "setban <ip or subnet> <command> [bantime] [absolute]: add or remove an IP/Subnet from the banned list.\n"
+                    "setban <ip or subnet> <command> [bantime] [absolute]\n"
+                    "\n"
+                    "add or remove an IP/Subnet from the banned list.\n"
                     "subnet: The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask (default is /32 = single IP) \n"
                     "command: 'add' to add an IP/Subnet to the list, 'remove' to remove an IP/Subnet from the list \n"
                     "bantime: time in seconds how long (or until when if [absolute] is set) the IP is banned \n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -763,7 +763,9 @@ UniValue getbalance(const UniValue& params, bool fHelp)
 UniValue getunconfirmedbalance(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() > 0)
-        throw runtime_error("getunconfirmedbalance: returns unconfirmed balance in wallet\n");
+        throw runtime_error("getunconfirmedbalance\n"
+                            "\n"
+                            "returns the unconfirmed balance in the wallet\n");
 
     return ValueFromAmount(pwalletMain->GetUnconfirmedBalance());
 }


### PR DESCRIPTION
Adds newlines to some help messages that were missing them. Fixes a typo in a comment and in a help message. Changes rainbymagnitude's help message to clarify `coins in double` means double precision float since otherwise you might think that it means 2x the coins.