### PR TITLE
scraper: Fix scraper etag header case sensitivity

### DIFF
--- a/src/scraper/http.cpp
+++ b/src/scraper/http.cpp
@@ -211,10 +211,20 @@ std::string Http::GetEtag(
     std::istringstream iss(header);
     for (std::string line; std::getline(iss, line);)
     {
-        if (size_t pos = line.find("ETag: ") != std::string::npos)
+        size_t pos = line.find(":");
+
+        if (pos != 4)
         {
-            etag = line.substr(pos+6, line.size());
-            etag = etag.substr(1, etag.size() - 3);
+            continue;
+        }
+
+        std::string header_name = line.substr(0, 4);
+        boost::to_lower(header_name);
+
+        if (header_name == "etag" && line.size() >= 9)
+        {
+            etag = line.substr(6); // extract header value
+            etag = etag.substr(1, etag.size() - 2); // strip quotes
 
             _log(logattribute::INFO, "curl_http_header", "Captured ETag for project url <urlfile=" + url + ", ETag=" + etag + ">");
 

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -1607,7 +1607,7 @@ bool DownloadProjectHostFiles(const NN::WhitelistSnapshot& projectWhitelist)
         }
         catch (const std::runtime_error& e)
         {
-            _log(logattribute::ERR, "DownloadProjectHostFiles", "Failed to pull host header file for " + prjs.m_name);
+            _log(logattribute::ERR, "DownloadProjectHostFiles", "Failed to pull host header file for " + prjs.m_name + ": " + e.what());
             continue;
         }
 
@@ -1650,7 +1650,7 @@ bool DownloadProjectHostFiles(const NN::WhitelistSnapshot& projectWhitelist)
         }
         catch(const std::runtime_error& e)
         {
-            _log(logattribute::ERR, "DownloadProjectHostFiles", "Failed to download project host file for " + prjs.m_name);
+            _log(logattribute::ERR, "DownloadProjectHostFiles", "Failed to download project host file for " + prjs.m_name + ": " + e.what());
             continue;
         }
 
@@ -1733,7 +1733,7 @@ bool DownloadProjectTeamFiles(const NN::WhitelistSnapshot& projectWhitelist)
         }
         catch (const std::runtime_error& e)
         {
-            _log(logattribute::ERR, "DownloadProjectTeamFiles", "Failed to pull team header file for " + prjs.m_name);
+            _log(logattribute::ERR, "DownloadProjectTeamFiles", "Failed to pull team header file for " + prjs.m_name + ": " + e.what());
             continue;
         }
 
@@ -1822,7 +1822,7 @@ bool DownloadProjectTeamFiles(const NN::WhitelistSnapshot& projectWhitelist)
             }
             catch(const std::runtime_error& e)
             {
-                _log(logattribute::ERR, "DownloadProjectTeamFiles", "Failed to download project team file for " + prjs.m_name);
+                _log(logattribute::ERR, "DownloadProjectTeamFiles", "Failed to download project team file for " + prjs.m_name + ": " + e.what());
                 continue;
             }
         }
@@ -2037,7 +2037,7 @@ bool DownloadProjectRacFilesByCPID(const NN::WhitelistSnapshot& projectWhitelist
             sRacETag = http.GetEtag(prjs.StatsUrl("user"), userpass);
         } catch (const std::runtime_error& e)
         {
-            _log(logattribute::ERR, "DownloadProjectRacFiles", "Failed to pull rac header file for " + prjs.m_name);
+            _log(logattribute::ERR, "DownloadProjectRacFiles", "Failed to pull rac header file for " + prjs.m_name + ": " + e.what());
             continue;
         }
 
@@ -2105,7 +2105,7 @@ bool DownloadProjectRacFilesByCPID(const NN::WhitelistSnapshot& projectWhitelist
         }
         catch(const std::runtime_error& e)
         {
-            _log(logattribute::ERR, "DownloadProjectRacFiles", "Failed to download project rac file for " + prjs.m_name);
+            _log(logattribute::ERR, "DownloadProjectRacFiles", "Failed to download project rac file for " + prjs.m_name + ": " + e.what());
             continue;
         }
 


### PR DESCRIPTION
This changes the scraper's search for the `etag` headers to a case-insensitive comparison. It fixes an issue observed for projects that respond with lowercase HTTP headers. 