### PR TITLE
consensus: Use explicit time to check if superblock needed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3789,7 +3789,7 @@ bool GridcoinServices()
         // timestamps in the beacon registry in a way that causes the renewed
         // beacon to appear ahead of the scraper beacon consensus window.
         //
-        if (!researcher->Eligible() || !NN::Quorum::SuperblockNeeded()) {
+        if (!researcher->Eligible() || !NN::Quorum::SuperblockNeeded(pindexBest->nTime)) {
             researcher->AdvertiseBeacon();
         }
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -930,7 +930,7 @@ void AddNeuralContractOrVote(CBlock& blocknew)
         return;
     }
 
-    if (!NN::Quorum::SuperblockNeeded()) {
+    if (!NN::Quorum::SuperblockNeeded(blocknew.nTime)) {
         LogPrintf("AddNeuralContractOrVote: Not needed.");
         return;
     }

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -593,7 +593,7 @@ public:
             return Result::UNKNOWN;
         }
 
-        if (m_superblock.Age() > SCRAPER_CMANIFEST_RETENTION_TIME) {
+        if (m_superblock.Age(GetAdjustedTime()) > SCRAPER_CMANIFEST_RETENTION_TIME) {
             return Result::HISTORICAL;
         }
 
@@ -1499,7 +1499,7 @@ bool Quorum::ValidateSuperblockClaim(
     const SuperblockPtr& superblock,
     const CBlockIndex* const pindex)
 {
-    if (!SuperblockNeeded()) {
+    if (!SuperblockNeeded(pindex->nTime)) {
         return error("ValidateSuperblockClaim(): superblock too early.");
     }
 
@@ -1656,7 +1656,7 @@ bool Quorum::HasPendingSuperblock()
     return g_superblock_index.HasPending();
 }
 
-bool Quorum::SuperblockNeeded()
+bool Quorum::SuperblockNeeded(const int64_t now)
 {
     if (HasPendingSuperblock()) {
         return false;
@@ -1665,7 +1665,7 @@ bool Quorum::SuperblockNeeded()
     const SuperblockPtr superblock = g_superblock_index.Current();
 
     return !superblock->WellFormed()
-        || superblock.Age() > GetSuperblockAgeSpacing(nBestHeight);
+        || superblock.Age(now) > GetSuperblockAgeSpacing(nBestHeight);
 
 }
 

--- a/src/neuralnet/quorum.h
+++ b/src/neuralnet/quorum.h
@@ -191,10 +191,12 @@ public:
     //!
     //! \brief Determine whether the network expects a new superblock.
     //!
+    //! \param now Timestamp to consider as the current time.
+    //!
     //! \return \c true if the age of the current superblock exceeds the
     //! protocol's superblock spacing parameter.
     //!
-    static bool SuperblockNeeded();
+    static bool SuperblockNeeded(const int64_t now);
 
     //!
     //! \brief Initialze the tally's superblock context.

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1431,11 +1431,13 @@ public:
     //!
     //! \brief Get the current age of the superblock.
     //!
+    //! \param now Timestamp to consider as the current time.
+    //!
     //! \return Superblock age in seconds.
     //!
-    int64_t Age() const
+    int64_t Age(const int64_t now) const
     {
-        return GetAdjustedTime() - m_timestamp;
+        return now - m_timestamp;
     }
 
     ADD_SERIALIZE_METHODS;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1161,7 +1161,7 @@ UniValue superblockage(const UniValue& params, bool fHelp)
 
     const NN::SuperblockPtr superblock = NN::Quorum::CurrentSuperblock();
 
-    res.pushKV("Superblock Age", superblock.Age());
+    res.pushKV("Superblock Age", superblock.Age(GetAdjustedTime()));
     res.pushKV("Superblock Timestamp", TimestampToHRDate(superblock.m_timestamp));
     res.pushKV("Superblock Block Number", superblock.m_height);
     res.pushKV("Pending Superblock Height", NN::Quorum::PendingSuperblock().m_height);
@@ -1717,13 +1717,14 @@ UniValue superblockaverage(const UniValue& params, bool fHelp)
     LOCK(cs_main);
 
     const NN::SuperblockPtr superblock = NN::Quorum::CurrentSuperblock();
+    const int64_t now = GetAdjustedTime();
 
     res.pushKV("beacon_count", (uint64_t)superblock->m_cpids.TotalCount());
     res.pushKV("beacon_participant_count", (uint64_t)superblock->m_cpids.size());
     res.pushKV("average_magnitude", superblock->m_cpids.AverageMagnitude());
     res.pushKV("superblock_valid", superblock->WellFormed());
-    res.pushKV("Superblock Age", superblock.Age());
-    res.pushKV("Dire Need of Superblock", NN::Quorum::SuperblockNeeded());
+    res.pushKV("Superblock Age", superblock.Age(now));
+    res.pushKV("Dire Need of Superblock", NN::Quorum::SuperblockNeeded(now));
 
     return res;
 }

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -705,7 +705,7 @@ int64_t SuperblockAge()
 {
     LOCK(cs_main);
 
-    return NN::Quorum::CurrentSuperblock().Age();
+    return NN::Quorum::CurrentSuperblock().Age(GetAdjustedTime());
 }
 
 std::vector<std::string> GetTeamWhiteList()


### PR DESCRIPTION
The superblock formation process in block version 11+ is more deterministic than the legacy quorum system so the network produces superblocks nearer to the time when the previous superblock expires. This switches the superblock age calculation to use a deterministic timestamp rather than the node's own time to avoid consensus issues.