### PR TITLE
refactor: Add transaction context to contract handlers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1332,7 +1332,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
     // Verify beacon contract in tx if found
     for (const auto& contract : tx.GetContracts()) {
         if (contract.m_type == NN::ContractType::BEACON
-            && !NN::GetBeaconRegistry().Validate(contract))
+            && !NN::GetBeaconRegistry().Validate(contract, tx))
         {
             return tx.DoS(25, error("%s: bad beacon contract in tx %s", __func__, tx.GetHash().ToString()));
         }
@@ -3618,7 +3618,7 @@ bool CBlock::AcceptBlock(bool generated_by_me)
         if (nVersion >= 9) {
             for (const auto& contract : tx.GetContracts()) {
                 if (contract.m_type == NN::ContractType::BEACON
-                    && !NN::GetBeaconRegistry().Validate(contract))
+                    && !NN::GetBeaconRegistry().Validate(contract, tx))
                 {
                     return tx.DoS(25, error("%s: bad beacon contract in tx %s", __func__, tx.GetHash().ToString()));
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2232,7 +2232,7 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
 
         if (pindex->nIsContract == 1)
         {
-            NN::RevertContracts(vtx[i].GetContracts());
+            NN::RevertContracts(vtx[i]);
         }
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -640,12 +640,6 @@ public:
 
         if (nVersion >= 2) {
             READWRITE(vContracts);
-
-            if (ser_action.ForRead()) {
-                for (auto& contract : REF(vContracts)) {
-                    contract.m_tx_timestamp = nTime;
-                }
-            }
         }
     }
 
@@ -904,7 +898,7 @@ public:
     const std::vector<NN::Contract>& GetContracts() const
     {
         if (nVersion == 1 && vContracts.empty() && NN::Contract::Detect(hashBoinc)) {
-            REF(vContracts).emplace_back(NN::Contract::Parse(hashBoinc, nTime));
+            REF(vContracts).emplace_back(NN::Contract::Parse(hashBoinc));
         }
 
         return vContracts;

--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -318,7 +318,7 @@ bool BeaconRegistry::ContainsActive(const Cpid& cpid) const
     return ContainsActive(cpid, GetAdjustedTime());
 }
 
-void BeaconRegistry::Add(Contract contract)
+void BeaconRegistry::Add(Contract contract, const CTransaction& tx)
 {
     BeaconPayload payload = contract.CopyPayloadAs<BeaconPayload>();
 
@@ -346,7 +346,7 @@ void BeaconRegistry::Add(Contract contract)
     m_pending.emplace(pending.GetId(), std::move(pending));
 }
 
-void BeaconRegistry::Delete(const Contract& contract)
+void BeaconRegistry::Delete(const Contract& contract, const CTransaction& tx)
 {
     const auto payload = contract.SharePayloadAs<BeaconPayload>();
 

--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -1,5 +1,6 @@
 #include "base58.h"
 #include "logging.h"
+#include "main.h"
 #include "neuralnet/beacon.h"
 #include "neuralnet/contract/contract.h"
 #include "util.h"
@@ -322,7 +323,7 @@ void BeaconRegistry::Add(Contract contract, const CTransaction& tx)
 {
     BeaconPayload payload = contract.CopyPayloadAs<BeaconPayload>();
 
-    payload.m_beacon.m_timestamp = contract.m_tx_timestamp;
+    payload.m_beacon.m_timestamp = tx.nTime;
 
     // Legacy beacon contracts before block version 11--just load the beacon:
     //
@@ -357,7 +358,7 @@ void BeaconRegistry::Delete(const Contract& contract, const CTransaction& tx)
     m_beacons.erase(payload->m_cpid);
 }
 
-bool BeaconRegistry::Validate(const Contract& contract) const
+bool BeaconRegistry::Validate(const Contract& contract, const CTransaction& tx) const
 {
     // For legacy beacons, check that the unused parts contain non-empty values
     // for compatibility with the existing protocol to prevent a fork.
@@ -405,7 +406,7 @@ bool BeaconRegistry::Validate(const Contract& contract) const
 
     const BeaconOption current_beacon = Try(payload->m_cpid);
 
-    if (!current_beacon || current_beacon->Expired(contract.m_tx_timestamp)) {
+    if (!current_beacon || current_beacon->Expired(tx.nTime)) {
         return true;
     }
 
@@ -432,12 +433,12 @@ bool BeaconRegistry::Validate(const Contract& contract) const
         return false;
     }
 
-    if (!current_beacon->Renewable(contract.m_tx_timestamp)) {
+    if (!current_beacon->Renewable(tx.nTime)) {
         LogPrint(LogFlags::CONTRACT,
             "%s: Beacon for CPID %s is not renewable. Age: %" PRId64,
             __func__,
             payload->m_cpid.ToString(),
-            current_beacon->Age(contract.m_tx_timestamp));
+            current_beacon->Age(tx.nTime));
 
         return false;
     }

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -477,15 +477,17 @@ public:
     //! \brief Register a beacon from contract data.
     //!
     //! \param contract Contains information about the beacon to add.
+    //! \param tx       Transaction that contains the contract.
     //!
-    void Add(Contract contract) override;
+    void Add(Contract contract, const CTransaction& tx) override;
 
     //!
     //! \brief Deregister the beacon specified by contract data.
     //!
     //! \param contract Contains information about the beacon to remove.
+    //! \param tx       Transaction that contains the contract.
     //!
-    void Delete(const Contract& contract) override;
+    void Delete(const Contract& contract, const CTransaction& tx) override;
 
     //!
     //! \brief Activate the set of pending beacons verified in a superblock.

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 class CBitcoinAddress;
+class CTransaction;
 
 namespace NN {
 
@@ -468,10 +469,11 @@ public:
     //! \brief Determine whether a beacon contract is valid.
     //!
     //! \param contract Contains the beacon data to validate.
+    //! \param tx       Transaction that contains the contract.
     //!
     //! \return \c true if the contract contains a valid beacon.
     //!
-    bool Validate(const Contract& contract) const;
+    bool Validate(const Contract& contract, const CTransaction& tx) const;
 
     //!
     //! \brief Register a beacon from contract data.

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -159,7 +159,7 @@ class AppCacheContractHandler : public IContractHandler
             StringToSection(contract.m_type.ToString()),
             std::move(payload.m_key),
             std::move(payload.m_value),
-            contract.m_tx_timestamp);
+            tx.nTime);
     }
 
     void Delete(const Contract& contract, const CTransaction& tx) override
@@ -426,7 +426,6 @@ Contract::Contract()
     , m_body()
     , m_signature()
     , m_public_key()
-    , m_tx_timestamp(0)
 {
 }
 
@@ -440,7 +439,6 @@ Contract::Contract(
     , m_body(std::move(body))
     , m_signature()
     , m_public_key()
-    , m_tx_timestamp(0)
 {
 }
 
@@ -450,15 +448,13 @@ Contract::Contract(
     Contract::Action action,
     Contract::Body body,
     Contract::Signature signature,
-    Contract::PublicKey public_key,
-    int64_t tx_timestamp)
+    Contract::PublicKey public_key)
     : m_version(version)
     , m_type(type)
     , m_action(action)
     , m_body(std::move(body))
     , m_signature(std::move(signature))
     , m_public_key(std::move(public_key))
-    , m_tx_timestamp(tx_timestamp)
 {
 }
 
@@ -535,7 +531,7 @@ bool Contract::Detect(const std::string& message)
         && !Contains(message, "<MT>superblock</MT>");
 }
 
-Contract Contract::Parse(const std::string& message, const int64_t timestamp)
+Contract Contract::Parse(const std::string& message)
 {
     if (message.empty()) {
         return Contract();
@@ -553,8 +549,7 @@ Contract Contract::Parse(const std::string& message, const int64_t timestamp)
         // user-supplied private key, so we can skip parsing the public keys
         // altogether. We verify contracts with the master and message keys:
         //Contract::PublicKey::Parse(ExtractXML(message, "<MPK>", "</MPK>")),
-        Contract::PublicKey(),
-        timestamp);
+        Contract::PublicKey());
 }
 
 bool Contract::RequiresMasterKey() const
@@ -711,10 +706,9 @@ void Contract::Log(const std::string& prefix) const
 {
     // TODO: temporary... needs better logging
     LogPrint(BCLog::LogFlags::CONTRACT,
-        "<Contract::Log>: %s: v%d, %d, %s, %s, %s, %s, %s, %s",
+        "<Contract::Log>: %s: v%d, %s, %s, %s, %s, %s, %s",
         prefix,
         m_version,
-        m_tx_timestamp,
         m_type.ToString(),
         m_action.ToString(),
         m_body.m_payload->LegacyKeyString(),
@@ -925,8 +919,7 @@ Contract Contract::ToLegacy() const
             m_body.m_payload->LegacyKeyString(),
             m_body.m_payload->LegacyValueString()),
         m_signature,
-        m_public_key,
-        m_tx_timestamp);
+        m_public_key);
 }
 
 std::string Contract::Signature::ToString() const

--- a/src/neuralnet/contract/contract.h
+++ b/src/neuralnet/contract/contract.h
@@ -350,7 +350,6 @@ public:
     Body m_body;            //!< Payload specific to the contract type.
     Signature m_signature;  //!< Proves authenticity of the contract.
     PublicKey m_public_key; //!< Verifies the contract signature.
-    int64_t m_tx_timestamp; //!< Timestamp of the contract's transaction.
 
     //!
     //! \brief Initialize an empty \c Contract object.
@@ -379,7 +378,6 @@ public:
     //! \param body         The body payload of the contract.
     //! \param signature    Proves authenticity of the contract message.
     //! \param public_key   Optional for some types. Verifies the signature.
-    //! \param tx_timestamp Timestamp of the transaction containing the contract.
     //!
     Contract(
         int version,
@@ -387,8 +385,7 @@ public:
         Action action,
         Body body,
         Signature signature,
-        PublicKey public_key,
-        int64_t tx_timestamp);
+        PublicKey public_key);
 
     //!
     //! \brief Get the message public key used to verify public contracts.
@@ -421,12 +418,11 @@ public:
     //!
     //! \brief Create a contract instance by parsing the supplied message.
     //!
-    //! \param message   Extracted from the \c hashboinc field of a transaction.
-    //! \param timestamp Timestamp of the transaction containing the contract.
+    //! \param message Extracted from the \c hashboinc field of a transaction.
     //!
     //! \return The message parsed into a \c Contract instance.
     //!
-    static Contract Parse(const std::string& message, const int64_t timestamp);
+    static Contract Parse(const std::string& message);
 
     //!
     //! \brief Determine whether the contract shall sign the message or verify

--- a/src/neuralnet/contract/contract.h
+++ b/src/neuralnet/contract/contract.h
@@ -9,6 +9,10 @@
 #include <string>
 #include <vector>
 
+class CBlock;
+class CBlockIndex;
+class CTransaction;
+
 namespace NN {
 //!
 //! \brief Represents a Gridcoin contract embedded in a transaction message.
@@ -709,15 +713,15 @@ void ApplyContracts(const CBlock& block, bool& out_found);
 //! \brief Apply contracts from transactions by passing them to the appropriate
 //! contract handlers.
 //!
-//! \param contracts Received in a transaction.
+//! \param tx Transaction to extract contracts from.
 //!
-void ApplyContracts(const std::vector<Contract>& contracts);
+void ApplyContracts(const CTransaction& tx);
 
 //!
 //! \brief Revert previously-applied contracts from a transaction by passing
 //! them to the appropriate contract handlers.
 //!
-//! \param contracts Received in a transaction.
+//! \param tx Transaction that contains contracts to revert.
 //!
-void RevertContracts(const std::vector<Contract>& contracts);
+void RevertContracts(const CTransaction& tx);
 }

--- a/src/neuralnet/contract/handler.h
+++ b/src/neuralnet/contract/handler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+class CTransaction;
+
 namespace NN {
 
 class Contract;
@@ -29,15 +31,17 @@ struct IContractHandler
     //! \brief Handle an contract addition.
     //!
     //! \param contract A contract message that describes the addition.
+    //! \param tx       Transaction that contains the contract.
     //!
-    virtual void Add(Contract contract) = 0;
+    virtual void Add(Contract contract, const CTransaction& tx) = 0;
 
     //!
     //! \brief Handle a contract deletion.
     //!
     //! \param contract A contract message that describes the deletion.
+    //! \param tx       Transaction that contains the contract.
     //!
-    virtual void Delete(const Contract& contract) = 0;
+    virtual void Delete(const Contract& contract, const CTransaction& tx) = 0;
 
     //!
     //! \brief Revert a contract found in a disconnected block.
@@ -49,6 +53,6 @@ struct IContractHandler
     //!
     //! \param contract A contract message that describes the action to revert.
     //!
-    virtual void Revert(const Contract& contract);
+    virtual void Revert(const Contract& contract, const CTransaction& tx);
 };
 }

--- a/src/neuralnet/contract/message.cpp
+++ b/src/neuralnet/contract/message.cpp
@@ -182,7 +182,6 @@ std::pair<CWalletTx, std::string> NN::SendContract(Contract contract)
         wtx.hashBoinc = contract.ToString();
     }
 
-    contract.m_tx_timestamp = wtx.nTime;
     wtx.vContracts.emplace_back(std::move(contract));
 
     std::string error = SendContractTx(wtx);

--- a/src/neuralnet/project.cpp
+++ b/src/neuralnet/project.cpp
@@ -153,7 +153,7 @@ WhitelistSnapshot Whitelist::Snapshot() const
     return WhitelistSnapshot(std::atomic_load(&m_projects));
 }
 
-void Whitelist::Add(Contract contract)
+void Whitelist::Add(Contract contract, const CTransaction& tx)
 {
     Project project = contract.CopyPayloadAs<Project>();
     project.m_timestamp = contract.m_tx_timestamp;
@@ -166,7 +166,7 @@ void Whitelist::Add(Contract contract)
     std::atomic_store(&m_projects, std::move(copy));
 }
 
-void Whitelist::Delete(const Contract& contract)
+void Whitelist::Delete(const Contract& contract, const CTransaction& tx)
 {
     const auto payload = contract.SharePayloadAs<Project>();
 

--- a/src/neuralnet/project.cpp
+++ b/src/neuralnet/project.cpp
@@ -1,3 +1,4 @@
+#include "main.h"
 #include "neuralnet/contract/contract.h"
 #include "neuralnet/project.h"
 
@@ -156,7 +157,7 @@ WhitelistSnapshot Whitelist::Snapshot() const
 void Whitelist::Add(Contract contract, const CTransaction& tx)
 {
     Project project = contract.CopyPayloadAs<Project>();
-    project.m_timestamp = contract.m_tx_timestamp;
+    project.m_timestamp = tx.nTime;
 
     ProjectListPtr copy = CopyFilteredWhitelist(project.m_name);
 

--- a/src/neuralnet/project.h
+++ b/src/neuralnet/project.h
@@ -284,15 +284,17 @@ public:
     //! \brief Add a project to the whitelist from contract data.
     //!
     //! \param contract Contains information about the project to add.
+    //! \param tx       Transaction that contains the contract.
     //!
-    void Add(Contract contract) override;
+    void Add(Contract contract, const CTransaction& tx) override;
 
     //!
     //! \brief Remove the specified project from the whitelist.
     //!
     //! \param contract Contains information about the project to remove.
+    //! \param tx       Transaction that contains the contract.
     //!
-    void Delete(const Contract& contract) override;
+    void Delete(const Contract& contract, const CTransaction& tx) override;
 
 private:
     // With C++20, use std::atomic<std::shared_ptr<T>> instead:

--- a/src/test/neuralnet/contract_tests.cpp
+++ b/src/test/neuralnet/contract_tests.cpp
@@ -248,8 +248,7 @@ struct TestMessage
             NN::ContractAction::ADD,
             NN::ContractPayload::Make<NN::Project>("test", "test", 123),
             NN::Contract::Signature(),
-            NN::Contract::PublicKey(),
-            123); // Tx timestamp is never part of a message
+            NN::Contract::PublicKey());
     }
 
     //!
@@ -774,7 +773,6 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_an_invalid_contract_by_default)
     BOOST_CHECK(contract.m_body.WellFormed(contract.m_action.Value()) == false);
     BOOST_CHECK(contract.m_signature.Raw().empty() == true);
     BOOST_CHECK(contract.m_public_key.Key() == CPubKey());
-    BOOST_CHECK(contract.m_tx_timestamp == 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_with_components_for_a_new_contract)
@@ -790,7 +788,6 @@ BOOST_AUTO_TEST_CASE(it_initializes_with_components_for_a_new_contract)
     BOOST_CHECK(contract.m_body.WellFormed(contract.m_action.Value()) == true);
     BOOST_CHECK(contract.m_signature.Raw().empty() == true);
     BOOST_CHECK(contract.m_public_key.Key() == CPubKey());
-    BOOST_CHECK(contract.m_tx_timestamp == 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_with_components_from_a_contract_message)
@@ -801,8 +798,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_with_components_from_a_contract_message)
         NN::ContractAction::ADD,
         NN::ContractPayload::Make<TestPayload>("test data"),
         NN::Contract::Signature(TestSig::V1Bytes()),
-        NN::Contract::PublicKey(TestKey::Public()),
-        789); // Tx timestamp
+        NN::Contract::PublicKey(TestKey::Public()));
 
     BOOST_CHECK(contract.m_version == NN::Contract::CURRENT_VERSION);
     BOOST_CHECK(contract.m_type == NN::ContractType::BEACON);
@@ -810,7 +806,6 @@ BOOST_AUTO_TEST_CASE(it_initializes_with_components_from_a_contract_message)
     BOOST_CHECK(contract.m_body.WellFormed(contract.m_action.Value()) == true);
     BOOST_CHECK(contract.m_signature.Raw() == TestSig::V1Bytes());
     BOOST_CHECK(contract.m_public_key.Key() == TestKey::Public());
-    BOOST_CHECK(contract.m_tx_timestamp == 789);
 }
 
 BOOST_AUTO_TEST_CASE(it_provides_the_legacy_message_keys)
@@ -841,7 +836,7 @@ BOOST_AUTO_TEST_CASE(it_ignores_superblocks_during_legacy_v1_contract_detection)
 
 BOOST_AUTO_TEST_CASE(it_parses_a_legacy_v1_contract_from_a_transaction_message)
 {
-    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String(), 123);
+    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String());
     NN::ContractPayload payload = contract.m_body.AssumeLegacy();
 
     BOOST_CHECK(contract.m_version == 1); // Legacy strings always parse to v1
@@ -851,12 +846,11 @@ BOOST_AUTO_TEST_CASE(it_parses_a_legacy_v1_contract_from_a_transaction_message)
     BOOST_CHECK(payload->LegacyValueString() == "test");
     BOOST_CHECK(contract.m_signature.Raw().size() == 70);
     BOOST_CHECK(contract.m_public_key.Key().Raw().size() == 0);
-    BOOST_CHECK(contract.m_tx_timestamp == 123);
 }
 
 BOOST_AUTO_TEST_CASE(it_gives_an_invalid_contract_when_parsing_an_empty_message)
 {
-    NN::Contract contract = NN::Contract::Parse("", 123);
+    NN::Contract contract = NN::Contract::Parse("");
 
     BOOST_CHECK(contract.m_version == NN::Contract::CURRENT_VERSION);
     BOOST_CHECK(contract.m_type == NN::ContractType::UNKNOWN);
@@ -864,12 +858,11 @@ BOOST_AUTO_TEST_CASE(it_gives_an_invalid_contract_when_parsing_an_empty_message)
     BOOST_CHECK(contract.m_body.WellFormed(contract.m_action.Value()) == false);
     BOOST_CHECK(contract.m_signature.Raw().size() == 0);
     BOOST_CHECK(contract.m_public_key.Key().Raw().size() == 0);
-    BOOST_CHECK(contract.m_tx_timestamp == 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_gives_an_invalid_contract_when_parsing_a_non_contract)
 {
-    NN::Contract contract = NN::Contract::Parse("<MESSAGE></MESSAGE>", 123);
+    NN::Contract contract = NN::Contract::Parse("<MESSAGE></MESSAGE>");
 
     BOOST_CHECK(contract.m_version == 1); // Legacy strings always parse to v1
     BOOST_CHECK(contract.m_type == NN::ContractType::UNKNOWN);
@@ -877,7 +870,6 @@ BOOST_AUTO_TEST_CASE(it_gives_an_invalid_contract_when_parsing_a_non_contract)
     BOOST_CHECK(contract.m_body.WellFormed(contract.m_action.Value()) == false);
     BOOST_CHECK(contract.m_signature.Raw().size() == 0);
     BOOST_CHECK(contract.m_public_key.Key().Raw().size() == 0);
-    BOOST_CHECK(contract.m_tx_timestamp == 123);
 }
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_contract_is_complete)
@@ -893,20 +885,20 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_contract_is_complete)
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_legacy_v1_contract_is_complete)
 {
-    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String(), 123);
+    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String());
     BOOST_CHECK(contract.WellFormed() == true);
 
     // WellFormed() does NOT verify the signature:
-    contract = NN::Contract::Parse(TestMessage::InvalidV1String(), 123);
+    contract = NN::Contract::Parse(TestMessage::InvalidV1String());
     BOOST_CHECK(contract.WellFormed() == true);
 
-    contract = NN::Contract::Parse(TestMessage::PartialV1String(), 123);
+    contract = NN::Contract::Parse(TestMessage::PartialV1String());
     BOOST_CHECK(contract.WellFormed() == false);
 
-    contract = NN::Contract::Parse("", 123);
+    contract = NN::Contract::Parse("");
     BOOST_CHECK(contract.WellFormed() == false);
 
-    contract = NN::Contract::Parse("<MESSAGE></MESSAGE>", 123);
+    contract = NN::Contract::Parse("<MESSAGE></MESSAGE>");
     BOOST_CHECK(contract.WellFormed() == false);
 }
 
@@ -924,20 +916,20 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_contract_is_valid)
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_legacy_v1_contract_is_valid)
 {
-    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String(), 123);
+    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String());
     BOOST_CHECK(contract.Validate() == true);
 
     // Valid() DOES verify the signature:
-    contract = NN::Contract::Parse(TestMessage::InvalidV1String(), 123);
+    contract = NN::Contract::Parse(TestMessage::InvalidV1String());
     BOOST_CHECK(contract.Validate() == false);
 
-    contract = NN::Contract::Parse(TestMessage::PartialV1String(), 123);
+    contract = NN::Contract::Parse(TestMessage::PartialV1String());
     BOOST_CHECK(contract.Validate() == false);
 
-    contract = NN::Contract::Parse("", 123);
+    contract = NN::Contract::Parse("");
     BOOST_CHECK(contract.Validate() == false);
 
-    contract = NN::Contract::Parse("<MESSAGE></MESSAGE>", 123);
+    contract = NN::Contract::Parse("<MESSAGE></MESSAGE>");
     BOOST_CHECK(contract.Validate() == false);
 }
 
@@ -1118,7 +1110,7 @@ BOOST_AUTO_TEST_CASE(it_refuses_to_sign_a_message_with_an_invalid_private_key)
 BOOST_AUTO_TEST_CASE(it_verifies_a_legacy_v1_contract_signature)
 {
     // Test a message with a valid signature:
-    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String(), 123);
+    NN::Contract contract = NN::Contract::Parse(TestMessage::V1String());
     BOOST_CHECK(contract.VerifySignature() == true);
 
     // Change the previously-signed content:
@@ -1126,7 +1118,7 @@ BOOST_AUTO_TEST_CASE(it_verifies_a_legacy_v1_contract_signature)
     BOOST_CHECK(contract.VerifySignature() == false);
 
     // Test a message with an invalid signature:
-    contract = NN::Contract::Parse(TestMessage::InvalidV1String(), 123);
+    contract = NN::Contract::Parse(TestMessage::InvalidV1String());
     BOOST_CHECK(contract.VerifySignature() == false);
 }
 
@@ -1170,8 +1162,6 @@ BOOST_AUTO_TEST_CASE(it_converts_itself_into_a_new_legacy_contract)
 
     BOOST_CHECK(legacy.m_signature.Raw() == contract.m_signature.Raw());
     BOOST_CHECK(legacy.m_public_key.Key() == contract.m_public_key.Key());
-
-    BOOST_CHECK(legacy.m_tx_timestamp == contract.m_tx_timestamp);
 }
 
 BOOST_AUTO_TEST_CASE(it_represents_itself_as_a_legacy_string)
@@ -1208,7 +1198,6 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     CDataStream stream(TestMessage::V2Serialized(), SER_NETWORK, 1);
 
     stream >> contract;
-    contract.m_tx_timestamp = 123; // So that contract.Validate() passes
 
     NN::ContractPayload payload = contract.SharePayload();
 

--- a/src/test/neuralnet/project_tests.cpp
+++ b/src/test/neuralnet/project_tests.cpp
@@ -1,3 +1,4 @@
+#include "main.h"
 #include "neuralnet/contract/contract.h"
 #include "neuralnet/project.h"
 
@@ -22,6 +23,11 @@ NN::Contract contract(std::string key, std::string value)
         std::move(value),
         1234567); // timestamp
 }
+
+//!
+//! \brief Dummy transaction for contract handler API.
+//!
+CTransaction g_tx;
 } // anonymous namespace
 
 // -----------------------------------------------------------------------------
@@ -299,7 +305,7 @@ BOOST_AUTO_TEST_CASE(it_adds_whitelisted_projects_from_contract_data)
     BOOST_CHECK(whitelist.Snapshot().size() == 0);
     BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == false);
 
-    whitelist.Add(contract("Enigma", "http://enigma.test"));
+    whitelist.Add(contract("Enigma", "http://enigma.test"), g_tx);
 
     BOOST_CHECK(whitelist.Snapshot().size() == 1);
     BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == true);
@@ -308,12 +314,12 @@ BOOST_AUTO_TEST_CASE(it_adds_whitelisted_projects_from_contract_data)
 BOOST_AUTO_TEST_CASE(it_removes_whitelisted_projects_from_contract_data)
 {
     NN::Whitelist whitelist;
-    whitelist.Add(contract("Enigma", "http://enigma.test"));
+    whitelist.Add(contract("Enigma", "http://enigma.test"), g_tx);
 
     BOOST_CHECK(whitelist.Snapshot().size() == 1);
     BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == true);
 
-    whitelist.Delete(contract("Enigma", "http://enigma.test"));
+    whitelist.Delete(contract("Enigma", "http://enigma.test"), g_tx);
 
     BOOST_CHECK(whitelist.Snapshot().size() == 0);
     BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == false);
@@ -322,10 +328,10 @@ BOOST_AUTO_TEST_CASE(it_removes_whitelisted_projects_from_contract_data)
 BOOST_AUTO_TEST_CASE(it_does_not_mutate_existing_snapshots)
 {
     NN::Whitelist whitelist;
-    whitelist.Add(contract("Enigma", "http://enigma.test"));
+    whitelist.Add(contract("Enigma", "http://enigma.test"), g_tx);
 
     auto snapshot = whitelist.Snapshot();
-    whitelist.Delete(contract("Enigma", "http://enigma.test"));
+    whitelist.Delete(contract("Enigma", "http://enigma.test"), g_tx);
 
     BOOST_CHECK(snapshot.Contains("Enigma") == true);
 }
@@ -333,8 +339,8 @@ BOOST_AUTO_TEST_CASE(it_does_not_mutate_existing_snapshots)
 BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
 {
     NN::Whitelist whitelist;
-    whitelist.Add(contract("Enigma", "http://enigma.test"));
-    whitelist.Add(contract("Enigma", "http://new.enigma.test"));
+    whitelist.Add(contract("Enigma", "http://enigma.test"), g_tx);
+    whitelist.Add(contract("Enigma", "http://new.enigma.test"), g_tx);
 
     auto snapshot = whitelist.Snapshot();
     BOOST_CHECK(snapshot.size() == 1);

--- a/src/test/neuralnet/researcher_tests.cpp
+++ b/src/test/neuralnet/researcher_tests.cpp
@@ -68,11 +68,6 @@ boost::test_tools::assertion_result ClientStateStubExists(boost::unit_test::test
 }
 
 //!
-//! \brief Dummy transaction for contract handler API.
-//!
-CTransaction g_tx;
-
-//!
 //! \brief Register an active beacon for testing.
 //!
 //! \param cpid External CPID used in the test.
@@ -86,14 +81,16 @@ void AddTestBeacon(const NN::Cpid cpid)
     const CKeyID key_id = public_key.GetID();
     const int64_t now = GetAdjustedTime();
 
+    // Dummy transaction for the contract handler API:
+    CTransaction tx;
+    tx.nTime = now;
+
     NN::Contract contract = NN::MakeContract<NN::BeaconPayload>(
         NN::ContractAction::ADD,
         cpid,
         std::move(public_key));
 
-    contract.m_tx_timestamp = now;
-
-    NN::GetBeaconRegistry().Add(std::move(contract), g_tx);
+    NN::GetBeaconRegistry().Add(std::move(contract), tx);
     NN::GetBeaconRegistry().ActivatePending({ key_id }, now);
 }
 
@@ -110,12 +107,16 @@ void AddExpiredTestBeacon(const NN::Cpid cpid)
 
     const CKeyID key_id = public_key.GetID();
 
+    // Dummy transaction for the contract handler API:
+    CTransaction tx;
+    tx.nTime = 0;
+
     NN::Contract contract = NN::MakeContract<NN::BeaconPayload>(
         NN::ContractAction::ADD,
         cpid,
         std::move(public_key));
 
-    NN::GetBeaconRegistry().Add(std::move(contract), g_tx);
+    NN::GetBeaconRegistry().Add(std::move(contract), tx);
     NN::GetBeaconRegistry().ActivatePending({ key_id }, 0);
 }
 
@@ -130,7 +131,9 @@ void RemoveTestBeacon(const NN::Cpid cpid)
     CPubKey public_key = CPubKey(ParseHex(
         "111111111111111111111111111111111111111111111111111111111111111111"));
 
-    //const CKeyID key_id = public_key.GetID();
+    // Dummy transaction for the contract handler API:
+    CTransaction tx;
+    tx.nTime = 0;
 
     NN::Contract contract = NN::MakeContract<NN::BeaconPayload>(
         NN::ContractAction::ADD,
@@ -138,7 +141,7 @@ void RemoveTestBeacon(const NN::Cpid cpid)
         std::move(public_key));
 
     NN::GetBeaconRegistry().Deactivate(0);
-    NN::GetBeaconRegistry().Delete(contract, g_tx);
+    NN::GetBeaconRegistry().Delete(contract, tx);
 }
 } // anonymous namespace
 

--- a/src/test/neuralnet/researcher_tests.cpp
+++ b/src/test/neuralnet/researcher_tests.cpp
@@ -1,4 +1,5 @@
 #include "appcache.h"
+#include "main.h"
 #include "neuralnet/beacon.h"
 #include "neuralnet/contract/contract.h"
 #include "neuralnet/project.h"
@@ -67,6 +68,11 @@ boost::test_tools::assertion_result ClientStateStubExists(boost::unit_test::test
 }
 
 //!
+//! \brief Dummy transaction for contract handler API.
+//!
+CTransaction g_tx;
+
+//!
 //! \brief Register an active beacon for testing.
 //!
 //! \param cpid External CPID used in the test.
@@ -87,7 +93,7 @@ void AddTestBeacon(const NN::Cpid cpid)
 
     contract.m_tx_timestamp = now;
 
-    NN::GetBeaconRegistry().Add(std::move(contract));
+    NN::GetBeaconRegistry().Add(std::move(contract), g_tx);
     NN::GetBeaconRegistry().ActivatePending({ key_id }, now);
 }
 
@@ -109,7 +115,7 @@ void AddExpiredTestBeacon(const NN::Cpid cpid)
         cpid,
         std::move(public_key));
 
-    NN::GetBeaconRegistry().Add(std::move(contract));
+    NN::GetBeaconRegistry().Add(std::move(contract), g_tx);
     NN::GetBeaconRegistry().ActivatePending({ key_id }, 0);
 }
 
@@ -132,7 +138,7 @@ void RemoveTestBeacon(const NN::Cpid cpid)
         std::move(public_key));
 
     NN::GetBeaconRegistry().Deactivate(0);
-    NN::GetBeaconRegistry().Delete(contract);
+    NN::GetBeaconRegistry().Delete(contract, g_tx);
 }
 } // anonymous namespace
 


### PR DESCRIPTION
This adds a reference parameter to the contract handler interface that provides the context of the transaction that contains a contract. It will support the upcoming changes to the voting system. The other contract types only need the transaction timestamp.