### PR TITLE
researcher: Automate beacon advertisement for renewals only

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3789,7 +3789,7 @@ bool GridcoinServices()
         // timestamps in the beacon registry in a way that causes the renewed
         // beacon to appear ahead of the scraper beacon consensus window.
         //
-        if (!researcher->Eligible() || !NN::Quorum::SuperblockNeeded(pindexBest->nTime)) {
+        if (researcher->Eligible() && !NN::Quorum::SuperblockNeeded(pindexBest->nTime)) {
             researcher->AdvertiseBeacon();
         }
     }


### PR DESCRIPTION
This removes the timer-triggered beacon advertisement for new users. The wallet will only send an automatic transaction to renew beacons. A new user is often confused by the initial on-boarding process. When the wallet sends an initial beacon without user action, it adds to the confusion by masking a step in the documented process. The new beacon wizard walks a user through this process so the wallet does not need to send the beacon automatically.