### PR TITLE
Prepare for block version 11 hard-fork on testnet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4101,11 +4101,7 @@ bool LoadBlockIndex(bool fAllowNew)
         // Temporary transition to version 2 beacons after the block version 11
         // hard-fork:
         //
-        try {
-            g_v11_legacy_beacon_days = std::stoi(GetArg("-v11beacondays", ""));
-        } catch (...) {
-            g_v11_legacy_beacon_days = 365 * 100; // Big number that won't wrap.
-        }
+        g_v11_legacy_beacon_days = 7;
     }
 
     LogPrintf("Mode=%s", fTestNet ? "TestNet" : "Prod");

--- a/src/main.h
+++ b/src/main.h
@@ -123,17 +123,9 @@ inline bool IsV10Enabled(int nHeight)
 
 inline int32_t GetV11Threshold()
 {
-    // Returns "never" before planned intro of bv11.
-    try {
-        return fTestNet
-                // Temporary: configure testnet v11 height via parameter before
-                // releasing v11 to regular testnet:
-                //
-                ? std::stoi(GetArg("-v11height", ""))
-                : std::numeric_limits<int32_t>::max();
-    } catch (...) {
-        return std::numeric_limits<int32_t>::max();
-    }
+    return fTestNet
+            ? 1301500
+            : std::numeric_limits<int32_t>::max();
 }
 
 inline bool IsV11Enabled(int nHeight)

--- a/src/main.h
+++ b/src/main.h
@@ -628,10 +628,11 @@ public:
         READWRITE(vin);
         READWRITE(vout);
         READWRITE(nLockTime);
-        READWRITE(hashBoinc);
 
         if (nVersion >= 2) {
             READWRITE(vContracts);
+        } else {
+            READWRITE(hashBoinc);
         }
     }
 

--- a/src/neuralnet/contract/payload.h
+++ b/src/neuralnet/contract/payload.h
@@ -52,6 +52,7 @@ enum class ContractType
     UNKNOWN,      //!< An invalid, non-standard, or empty contract type.
     BEACON,       //!< Beacon advertisement or deletion.
     CLAIM,        //!< Gridcoin block reward claim context.
+    MESSAGE,      //!< A user-supplied string. No associated protocol behavior.
     POLL,         //!< Submission of a new poll.
     PROJECT,      //!< Project whitelist addition or removal.
     PROTOCOL,     //!< Network control message or configuration directive.

--- a/src/test/neuralnet/contract_tests.cpp
+++ b/src/test/neuralnet/contract_tests.cpp
@@ -296,7 +296,7 @@ struct TestMessage
     {
         std::vector<unsigned char> serialized {
             0x02, 0x00, 0x00, 0x00, // Version: 32-bit int (little-endian)
-            0x04,                   // Type: PROJECT
+            0x05,                   // Type: PROJECT
             0x01,                   // Action: ADD
             0x01, 0x00, 0x00, 0x00, // Project contract version
             0x04,                   // Length of the project name


### PR DESCRIPTION
This prepares for the final integration of the block version 11 protocol on testnet. It sets the block height thresholds for the mandatory switch to the new protocol. 

I also removed serialization for the legacy `CTransaction::hashBoinc` field for version 2 transactions. After the hard-fork, nodes will not use this field anymore, so this reduces overhead. 