### PR TITLE
rpc, gui: Fix three divide by zero possibilities

### DIFF
--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -212,6 +212,18 @@ bool UpgradeQt::SnapshotMain()
 
         }
 
+        if (ExtractStatus.SnapshotZipInvalid)
+        {
+            fCancelOperation = true;
+
+            SnapshotDownloadThread.interrupt();
+            SnapshotDownloadThread.join();
+
+            Msg(_("Snapshot operation canceled due to an invalid snapshot zip."), _("The wallet will not shutdown."));
+
+            return false;
+        }
+
         if (ExtractStatus.SnapshotExtractFailed)
         {
             ErrorMsg(_("Snapshot extraction failed! Cleaning up any extracted data"), _("The wallet will now shutdown."));

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -712,6 +712,10 @@ void VotingChartDialog::resetData(const VotingItem *item)
         iShares.push_back(iterAnswer.shares);
         sharesSum += iterAnswer.shares;
     }
+
+    // Protect against possible divide by zero below.
+    if (!sharesSum) return;
+
     for(size_t y=0; y < sAnswerNames.size(); y++)
     {
         answerTable_->setItem(y, 0, new QTableWidgetItem(sAnswerNames[y]));

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -326,6 +326,10 @@ UniValue comparesnapshotaccrual(const UniValue& params, bool fHelp)
         ++active_account_count;
     }
 
+    if (!active_account_count) {
+        throw JSONRPCError(RPC_MISC_ERROR, "There are no active accounts.");
+    }
+
     UniValue summary(UniValue::VOBJ);
 
     summary.pushKV("active_accounts", (uint64_t)active_account_count);

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -426,6 +426,17 @@ bool Upgrade::ExtractSnapshot()
             }
         }
 
+        // This protects against a divide by error below and properly returns false
+        // if the zip file has no entries.
+        if (!totaluncompressedsize)
+        {
+            ExtractStatus.SnapshotZipInvalid = true;
+
+            LogPrintf("Snapshot (ExtractSnapshot): Error - snapshot.zip has no entries");
+
+            return false;
+        }
+
         // Now extract
         for (i = 0; i < (uint64_t)entries; i++)
         {

--- a/src/upgrade.h
+++ b/src/upgrade.h
@@ -12,6 +12,7 @@
 
 /** Snapshot Extraction Status struct **/
 struct struct_SnapshotExtractStatus{
+    bool SnapshotZipInvalid = false;
     bool SnapshotExtractComplete = false;
     bool SnapshotExtractFailed = false;
     int SnapshotExtractProgress;


### PR DESCRIPTION
This does some minor repair in the snapshot download code, the voting dialog, and the comparesnapshotaccrual to protect
against divide by zero errors.