### PR TITLE
rpc: Fix balance pre-check in "rainbymagnitude" RPC

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -44,7 +44,6 @@ extern ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = fa
 extern UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version);
 
 bool GetEarliestStakeTime(std::string grcaddress, std::string cpid);
-double GetTotalBalance();
 double CoinToDouble(double surrogate);
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 UniValue ContractToJson(const NN::Contract& contract);
@@ -563,7 +562,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
 
     EnsureWalletIsUnlocked();
     // Check funds
-    double dBalance = GetTotalBalance();
+    double dBalance = pwalletMain->GetBalance();
 
     if (dTotalAmount > dBalance)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");


### PR DESCRIPTION
Minor: the `GetTotalBalance()` function includes the amounts of staked coins for the total. This can misrepresent the available balance because the staked coins are not spendable.

I will remove the custom `GetTotalBalance()` function in a subsequent PR since nothing will use it then. This small refactoring drops the remaining dependency.