### PR TITLE
gui: Optimize OverviewPage::updateTransactions()

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -179,13 +179,14 @@ void OverviewPage::updateTransactions()
     {
         int numItems = getNumTransactionsForView();
 
-        // This is a "stairstep" approach, using x3 to x6 factors to size the getLimit.
+        // This is a "stairstep" approach, using x3 to x6 factors to size the setLimit.
         // Based on testing with a wallet with a large number of transactions (40k+)
         // Using a factor of three is a good balance between the setRowHidden loop
         // and the very high expense of the getLimit call, which invalidates the filter
-        // and sort, and implicitly redoes the sort, which can take seconds.
+        // and sort, and implicitly redoes the sort, which can take seconds for a large
+        // wallet.
 
-        // Most main window resizes will be done without an actual call to getLimit.
+        // Most main window resizes will be done without an actual call to setLimit.
         if (filter->getLimit() < numItems)
         {
             filter->setLimit(numItems * 3);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -279,6 +279,9 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64, qint64)), this, SLOT(setBalance(qint64, qint64, qint64, qint64)));
 
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+
+        connect(model, SIGNAL(transactionUpdated()), this, SLOT(updateTransactions()));
+
         UpdateBoincUtilization();
     }
 

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -47,6 +47,7 @@ protected:
     void showEvent(QShowEvent *event);
 
 private:
+    int getNumTransactionsForView();
     void updateTransactions();
 
     Ui::OverviewPage *ui;

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -48,7 +48,6 @@ protected:
 
 private:
     int getNumTransactionsForView();
-    void updateTransactions();
 
     Ui::OverviewPage *ui;
     ResearcherModel *researcherModel;
@@ -63,6 +62,7 @@ private:
 
 private slots:
     void updateDisplayUnit();
+    void updateTransactions();
     void updateResearcherStatus();
     void updateMagnitude();
     void updatePendingAccrual();

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -87,6 +87,11 @@ void TransactionFilterProxy::setLimit(int limit)
     invalidate();
 }
 
+int TransactionFilterProxy::getLimit()
+{
+    return this->limitRows;
+}
+
 void TransactionFilterProxy::setShowInactive(bool showInactive)
 {
     this->showInactive = showInactive;

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -31,6 +31,9 @@ public:
     /** Set maximum number of rows returned, -1 if unlimited. */
     void setLimit(int limit);
 
+    /** Get maximum number of rows returned, -1 if unlimited. */
+    int getLimit();
+
     /** Set whether to show conflicted transactions. */
     void setShowInactive(bool showInactive);
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -115,7 +115,8 @@ public:
                     status = CT_DELETED; /* In model, but want to hide, treat as deleted */
             }
 
-            LogPrint(BCLog::LogFlags::VERBOSE, "   inWallet=%i inModel=%i Index=%i-%i showTransaction=%i derivedStatus=%i",                     inWallet, inModel, lowerIndex, upperIndex, showTransaction, status);
+            LogPrint(BCLog::LogFlags::VERBOSE, "   inWallet=%i inModel=%i Index=%i-%i showTransaction=%i derivedStatus=%i",
+                     inWallet, inModel, lowerIndex, upperIndex, showTransaction, status);
 
 
             switch(status)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -126,16 +126,24 @@ void WalletModel::checkBalanceChanged()
 
 void WalletModel::updateTransaction(const QString &hash, int status)
 {
-    if(transactionTableModel)
+    if (transactionTableModel)
+    {
         transactionTableModel->updateTransaction(hash, status);
+
+        // Note this is subtly different than the below. If a resync is being done on a wallet
+        // that already has transactions, the numTransactionsChanged will not be emitted after the
+        // wallet is loaded because the size() does not change. See the comments in the header file.
+        emit transactionUpdated();
+    }
 
     // Balance and number of transactions might have changed
     checkBalanceChanged();
 
     int newNumTransactions = getNumTransactions();
-    if(cachedNumTransactions != newNumTransactions)
+    if (cachedNumTransactions != newNumTransactions)
     {
         cachedNumTransactions = newNumTransactions;
+
         emit numTransactionsChanged(newNumTransactions);
     }
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -163,6 +163,11 @@ public slots:
     void pollBalanceChanged();
 
 signals:
+    // Transaction updated. This is necessary because on a resync from zero with an existing wallet.
+    // the numTransactionsChanged signal will not be emitted, and therefore the overpage transaction list
+    // needs this signal instead.
+    void transactionUpdated();
+
     // Signal that balance in wallet changed
     void balanceChanged(qint64 balance, qint64 stake, qint64 unconfirmedBalance, qint64 immatureBalance);
 


### PR DESCRIPTION
For wallets with a very large number of transactions, the filter->setLimit(numItems) is extremely expensive... on the order of a few seconds, because it also resorts the list if sort is defined (and it is).

This simply stores the number of rows required for the overview page in the filter, and only calls setLimit if the number of rows is changed with a resize, etc. beyond a reasonable point (3x on purpose). Instead the ui->listTransactions->setRowHidden function is called in a for loop that dynamically sets the rows hidden that are not displayable between the actual display limit and the setLimit value (which is sized initially 3x the number of rows displayable). 

This eliminates the delay when flipping back and forth between the overview and the send, receive, or transaction views. It also improves the resize of the window. I have picked scaling parameters on the size of getLimit versus the number of rows displayable that should minimize or eliminate GUI freezes under normal window resizing.

The wallet still does a list resort every time a block is received, because the underlying wallet model is updated, so that will still cause a GUI freeze for wallets with a large number of transactions. (Note that I am talking about 40000+ transactions.)

This cannot be fixed without a major overhaul architecturally.