### PR TITLE
ci: Adopt ci changes from bitcoin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,74 +1,102 @@
-sudo: required
+# Travis caches can be manually removed if necessary. This is one of the very
+# few manual operations that is possible with Travis, and it can be done by a
+# gridcoin-community GitHub member via the Travis web interface [0].
+#
+# Travis CI uploads the cache after the script phase of the build [1].
+# However, the build is terminated without saving the cache if it takes over
+# 50 minutes [2]. Thus, if we spent too much time in early build stages, fail
+# with an error and save the cache.
+#
+# [0] https://travis-ci.org/gridcoin-community/Gridcoin-Research/caches
+# [1] https://docs.travis-ci.com/user/caching/#build-phases
+# [2] https://docs.travis-ci.com/user/customizing-the-build#build-timeouts
+
+version: ~> 1.0
+
 dist: bionic
 os: linux
-language: minimal
+language: shell
+arch: amd64
 cache:
+  ccache: true
   directories:
-  - depends/built
-  - depends/sdk-sources
-  - $HOME/.ccache
+    - $TRAVIS_BUILD_DIR/depends/built
+    - $TRAVIS_BUILD_DIR/depends/sdk-sources
+    - $TRAVIS_BUILD_DIR/ci/scratch/.ccache
+    - $TRAVIS_BUILD_DIR/releases/$HOST
+stages:
+  - test
 env:
   global:
-    - MAKEJOBS=-j3
-    - RUN_TESTS=true
-    - CHECK_DOC=0
-    - BOOST_TEST_RANDOM=1$TRAVIS_BUILD_ID
-    - CCACHE_SIZE=100M
-    - CCACHE_TEMPDIR=/tmp/.ccache-temp
-    - CCACHE_COMPRESS=1
-    - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
-    - SDK_URL=https://bitcoincore.org/depends-sources/sdks
-    - PYTHON_DEBUG=1
-    - WINEDEBUG=fixme-all
-  matrix:
-# Qt5 & system libs
-    - HOST=x86_64-unknown-linux-gnu PACKAGES="libqt5gui5 libqt5core5a qtbase5-dev libqt5dbus5 qttools5-dev qttools5-dev-tools libqt5charts5-dev libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-iostreams-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev protobuf-compiler libqrencode-dev xvfb libzip4 libzip-dev zlib1g zlib1g-dev" NO_DEPENDS=1 NEED_XVFB=1 RUN_TESTS=true GOAL="install" GRIDCOIN_CONFIG=" --with-incompatible-bdb --enable-reduce-exports --with-gui=qt5"
-# 32-bit + dash
-    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib" DEP_OPTS="NO_QT=1" RUN_TESTS=false GOAL="install" GRIDCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
-# Win64
-    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" PACKAGES="python3 nsis g++-mingw-w64-x86-64" DEP_OPTS="NO_QT=1" RUN_TESTS=false GOAL="" GRIDCOIN_CONFIG="--enable-reduce-exports"
-# Win32
-    - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" PACKAGES="python3 nsis g++-mingw-w64-i686" DEP_OPTS="NO_QT=1" RUN_TESTS=false GOAL="" GRIDCOIN_CONFIG="--enable-reduce-exports"
-# ARM
-    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" GCCFLAGS="-fPIC" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" GRIDCOIN_CONFIG="--enable-glibc-back-compat --disable-tests RUN_TESTS=false"
-# Cross-Mac - Qt is disabled for now, since we cannot compile QtSVG with the SDK, also asm optimizations are disabled until we can straighten out scrypt .S files and Clang. Also the deploy stage is disabled until the qt5
-# can be figured out.
-    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" DEP_OPTS="NO_QT=1" GRIDCOIN_CONFIG="--enable-reduce-exports --disable-asm" OSX_SDK=10.11 RUN_TESTS=false GOAL=""
-    
-# Note windows builds may need xvfb package and NEED_XVFB=1 if NO_QT=1 is removed (i.e. QT build is enabled again).
-
+    - CI_RETRY_EXE="travis_retry"
+    - CACHE_ERR_MSG="Error! Initial build successful, but not enough time remains to run later build stages and tests. See https://docs.travis-ci.com/user/customizing-the-build#build-timeouts . Please manually re-run this job by using the travis restart button. The next run should not time out because the build cache has been saved."
 before_install:
-    - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-    #- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    - sudo apt-get update -q
-    #- sudo apt-get install gcc-7 -y
-    #- sudo apt-get install gcc-5-arm-linux-gnueabihf -y
+  - set -o errexit; source ./ci/test/00_setup_env.sh
+  - set -o errexit; source ./ci/test/03_before_install.sh
 install:
-    - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
-    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
-    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
+  - set -o errexit; source ./ci/test/04_install.sh
 before_script:
-    - if [ "$HOST" == "i686-w64-mingw32" ]; then sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix; fi
-    - if [ "$HOST" == "x86_64-w64-mingw32" ]; then sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix; fi
-    - unset CC; unset CXX
-    - mkdir -p depends/SDKs depends/sdk-sources
-    - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
-    - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -zxf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
-    - if [ -z "$NO_DEPENDS" ]; then make $MAKEJOBS -C depends HOST=$HOST GCCFLAGS=$GCCFLAGS $DEP_OPTS; fi
-    # Start xvfb if needed, as documented at https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-    - if [ "$NEED_XVFB" = 1 ]; then export DISPLAY=:99.0; /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac; fi
+  # Temporary workaround for https://github.com/bitcoin/bitcoin/issues/16368
+  - for i in {1..4}; do echo "$(sleep 500)" ; done &
+  - set -o errexit; source ./ci/test/05_before_script.sh # &> "/dev/null"
 script:
-    - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
-    - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
-    - GRIDCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
-    - if [ -z "$NO_DEPENDS" ]; then depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE; fi
-    - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
-    - mkdir build && cd build
-    - ../configure --cache-file=config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( cat config.log && false)
-    - make distdir VERSION=$HOST
-    - cd gridcoin-$HOST
-    - ./configure --cache-file=../config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( cat config.log && false)
-    - make GCCFLAGS=$GCCFLAGS $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make GCCFLAGS=$GCCFLAGS $GOAL V=1 ; false )
-    - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
-    - if [ "$HOST" = "x86_64-unknown-linux-gnu" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
-    - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning,dbcrash"; fi
+  - export CONTINUE=1
+  - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
+  - if [ $CONTINUE = "1" ]; then set -o errexit; source ./ci/test/06_script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
+  - if [ $SECONDS -gt 2000 ]; then export CONTINUE=0; fi  # Likely the build took very long; The tests take about 1000s, so we should abort if we have less than 50*60-1000=2000s left
+  - if [ $CONTINUE = "1" ]; then set -o errexit; source ./ci/test/06_script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
+after_script:
+  - echo $TRAVIS_COMMIT_RANGE
+jobs:
+  include:
+    - stage: test
+      name: 'ARM  [GOAL: install]  [buster]'
+      arch: arm64  # Can disable QEMU_USER_CMD and run the tests natively without qemu
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_arm.sh"
+        QEMU_USER_CMD=""
+        
+    - stage: test
+      name: 'Win32'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_win32.sh"
+
+    - stage: test
+      name: 'Win64'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_win64.sh"
+
+    - stage: test
+      name: 'i386 Linux  [GOAL: install]  [focal]'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_linux_i386.sh"
+
+    - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [GUI]  [focal]  [no depends]'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_native.sh"
+
+    - stage: test
+      name: 'macOS 10.12  [no tests]'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_mac.sh"
+
+    - stage: test
+      name: 'macOS 10.15 native  [GOAL: install]  [GUI]  [no depends]'
+      os: osx
+      # Use the most recent version:
+      # Xcode 12.0, macOS 10.15, SDK 10.16
+      # https://docs.travis-ci.com/user/reference/osx/#macos-version
+      osx_image: xcode12
+      addons:
+        homebrew:
+          packages:
+          - berkeley-db4
+          - miniupnpc
+          - qrencode
+          - ccache
+          - libzip
+      env: >-
+        DANGER_RUN_CI_ON_HOST=true
+        CI_USE_APT_INSTALL=no
+        FILE_ENV="./ci/test/00_setup_env_mac_host.sh"

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -396,14 +396,14 @@ AC_DEFUN([_BITCOIN_QT_FIND_STATIC_PLUGINS],[
          ])
          if test x$bitcoin_cv_need_platformsupport = xyes; then
            if test x$enable_qt59 = xno; then
-             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}PlatformSupport],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXPlatformSupport not found)))
+             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}PlatformSupport],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}PlatformSupport not found)))
            else
-             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}FontDatabaseSupport],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXFontDatabaseSupport not found)))
-             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}EventDispatcherSupport],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXEventDispatcherSupport not found)))
-             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}ThemeSupport],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXThemeSupport not found)))
-             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}FbSupport],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXFbSupport not found)))
-             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}DeviceDiscoverySupport],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXDeviceDiscoverySupport not found)))
-             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AccessibilitySupport],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXAccessibilitySupport not found)))
+             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}FontDatabaseSupport],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}FontDatabaseSupport not found)))
+             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}EventDispatcherSupport],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}EventDispatcherSupport not found)))
+             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}ThemeSupport],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}ThemeSupport not found)))
+             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}FbSupport],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}FbSupport not found)))
+             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}DeviceDiscoverySupport],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}DeviceDiscoverySupport not found)))
+             BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AccessibilitySupport],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}AccessibilitySupport not found)))
              QT_LIBS="$QT_LIBS -lversion -ldwmapi -luxtheme"
            fi
          fi
@@ -539,25 +539,25 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
     BITCOIN_QT_CHECK(AC_SEARCH_LIBS([pcre2_match_16], [qtpcre2 libqtpcre2],,AC_MSG_WARN([libqtpcre2 not found. Assuming qt has it built-in])))
   fi
   BITCOIN_QT_CHECK(AC_SEARCH_LIBS([hb_ot_tags_from_script] ,[qtharfbuzzng qtharfbuzz harfbuzz],,AC_MSG_WARN([libharfbuzz not found. Assuming qt has it built-in or support is disabled])))
-  BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Core]   ,[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXCore not found)))
-  BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Gui]    ,[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXGui not found)))
-  BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Network],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXNetwork not found)))
+  BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Core]   ,[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Core not found)))
+  BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Gui]    ,[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Gui not found)))
+  BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Network],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Network not found)))
   if test x$bitcoin_qt_got_major_vers = x5; then
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Widgets],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXWidgets not found)))
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Concurrent],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXConcurrent not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Widgets],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Widgets not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Concurrent],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Concurrent not found)))
   fi
   if test x$enable_qt59 = xyes; then
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Charts],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXCharts not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Charts],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Charts not found)))
     CPPFLAGS="$CPPFLAGS -DQT_CHARTS_LIB"
   fi
   if test x$TARGET_OS = xwindows; then
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AxBase],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXAxBase not found)))
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AxContainer],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXAxContainer not found)))
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AxServer],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXAxServer not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AxBase],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}AxBase not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AxContainer],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}AxContainer not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}AxServer],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}AxServer not found)))
   fi
   _BITCOIN_QT_IS_STATIC
   if test x$bitcoin_cv_static_qt = xyes; then
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Svg],[main],,BITCOIN_QT_FAIL(lib$QT_LIB_PREFIXSvg not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Svg],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Svg not found)))
   fi
   QT_LIBS="$LIBS"
   LIBS="$TEMP_LIBS"
@@ -584,4 +584,3 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   CXXFLAGS="$TEMP_CXXFLAGS"
   LIBS="$TEMP_LIBS"
 ])
-

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,65 @@
+## CI Scripts
+
+This directory contains scripts for each build step in each build stage.
+
+### Running a Stage Locally
+
+Be aware that the tests will be built and run in-place, so please run at your own risk.
+If the repository is not a fresh git clone, you might have to clean files from previous builds or test runs first.
+
+The ci needs to perform various sysadmin tasks such as installing packages or writing to the user's home directory.
+While most of the actions are done inside a docker container, this is not possible for all. Thus, cache directories,
+such as the depends cache, previous release binaries, or ccache, are mounted as read-write into the docker container. While it should be fine to run
+the ci system locally on you development box, the ci scripts can generally be assumed to have received less review and
+testing compared to other parts of the codebase. If you want to keep the work tree clean, you might want to run the ci
+system in a virtual machine with a Linux operating system of your choice.
+
+To allow for a wide range of tested environments, but also ensure reproducibility to some extent, the test stage
+requires `docker` to be installed. To install all requirements on Ubuntu, run
+
+```
+sudo apt install docker.io bash
+```
+
+To run the default test stage,
+
+```
+./ci/test_run_all.sh
+```
+
+To run the test stage with a specific configuration,
+
+```
+FILE_ENV="./ci/test/00_setup_env_arm.sh" ./ci/test_run_all.sh
+```
+
+### Configurations
+
+The test files (`FILE_ENV`) are constructed to test a wide range of
+configurations, rather than a single pass/fail. This helps to catch build
+failures and logic errors that present on platforms other than the ones the
+author has tested.
+
+Some builders use the dependency-generator in `./depends`, rather than using
+the system package manager to install build dependencies. This guarantees that
+the tester is using the same versions as the release builds, which also use
+`./depends`.
+
+If no `FILE_ENV` has been specified or values are left out, `00_setup_env.sh`
+is used as the default configuration with fallback values.
+
+It is also possible to force a specific configuration without modifying the
+file. For example,
+
+```
+MAKEJOBS="-j1" FILE_ENV="./ci/test/00_setup_env_arm.sh" ./ci/test_run_all.sh
+```
+
+The files starting with `0n` (`n` greater than 0) are the scripts that are run
+in order.
+
+### Cache
+
+In order to avoid rebuilding all dependencies for each build, the binaries are
+cached and re-used when possible. Changes in the dependency-generator will
+trigger cache-invalidation and rebuilds as necessary.

--- a/ci/retry/README.md
+++ b/ci/retry/README.md
@@ -1,0 +1,123 @@
+retry - The command line retry tool
+------------------------------------------
+
+Retry any shell command with exponential backoff or constant delay.
+
+### Instructions
+
+Install:
+
+retry is a shell script, so drop it somewhere and make sure it's added to your $PATH. Or you can use the following one-liner:
+
+```sh
+sudo sh -c "curl https://raw.githubusercontent.com/kadwanev/retry/master/retry -o /usr/local/bin/retry && chmod +x /usr/local/bin/retry"
+```
+
+If you're on OS X, retry is also on Homebrew:
+
+```
+brew pull 27283
+brew install retry
+```
+Not popular enough for homebrew-core. Please star this project to help.
+
+### Usage
+
+Help:
+
+`retry -?`
+
+    Usage: retry [options] -- execute command
+        -h, -?, --help
+        -v, --verbose                    Verbose output
+        -t, --tries=#                    Set max retries: Default 10
+        -s, --sleep=secs                 Constant sleep amount (seconds)
+        -m, --min=secs                   Exponential Backoff: minimum sleep amount (seconds): Default 0.3
+        -x, --max=secs                   Exponential Backoff: maximum sleep amount (seconds): Default 60
+        -f, --fail="script +cmds"        Fail Script: run in case of final failure
+
+### Examples
+
+No problem:
+
+`retry echo u work good`
+
+    u work good
+
+Test functionality:
+
+`retry 'echo "y u no work"; false'`
+
+    y u no work
+    Before retry #1: sleeping 0.3 seconds
+    y u no work
+    Before retry #2: sleeping 0.6 seconds
+    y u no work
+    Before retry #3: sleeping 1.2 seconds
+    y u no work
+    Before retry #4: sleeping 2.4 seconds
+    y u no work
+    Before retry #5: sleeping 4.8 seconds
+    y u no work
+    Before retry #6: sleeping 9.6 seconds
+    y u no work
+    Before retry #7: sleeping 19.2 seconds
+    y u no work
+    Before retry #8: sleeping 38.4 seconds
+    y u no work
+    Before retry #9: sleeping 60.0 seconds
+    y u no work
+    Before retry #10: sleeping 60.0 seconds
+    y u no work
+    etc..
+
+Limit retries:
+
+`retry -t 4 'echo "y u no work"; false'`
+
+    y u no work
+    Before retry #1: sleeping 0.3 seconds
+    y u no work
+    Before retry #2: sleeping 0.6 seconds
+    y u no work
+    Before retry #3: sleeping 1.2 seconds
+    y u no work
+    Before retry #4: sleeping 2.4 seconds
+    y u no work
+    Retries exhausted
+
+Bad command:
+
+`retry poop`
+
+    bash: poop: command not found
+
+Fail command:
+
+`retry -t 3 -f 'echo "oh poopsickles"' 'echo "y u no work"; false'`
+
+    y u no work
+    Before retry #1: sleeping 0.3 seconds
+    y u no work
+    Before retry #2: sleeping 0.6 seconds
+    y u no work
+    Before retry #3: sleeping 1.2 seconds
+    y u no work
+    Retries exhausted, running fail script
+    oh poopsickles
+
+Last attempt passed:
+
+`retry -t 3 -- 'if [ $RETRY_ATTEMPT -eq 3 ]; then echo Passed at attempt $RETRY_ATTEMPT; true; else echo Failed at attempt $RETRY_ATTEMPT; false; fi;'`
+
+    Failed at attempt 0
+    Before retry #1: sleeping 0.3 seconds
+    Failed at attempt 1
+    Before retry #2: sleeping 0.6 seconds
+    Failed at attempt 2
+    Before retry #3: sleeping 1.2 seconds
+    Passed at attempt 3
+
+### License
+
+Apache 2.0 - go nuts

--- a/ci/retry/retry
+++ b/ci/retry/retry
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+GETOPT_BIN=$IN_GETOPT_BIN
+GETOPT_BIN=${GETOPT_BIN:-getopt}
+
+__sleep_amount() {
+  if [ -n "$constant_sleep" ]; then 
+    sleep_time=$constant_sleep
+  else
+    #TODO: check for awk
+    #TODO: check if user would rather use one of the other possible dependencies: python, ruby, bc, dc
+    sleep_time=`awk "BEGIN {t = $min_sleep * $(( (1<<($attempts -1)) )); print (t > $max_sleep ? $max_sleep : t)}"`
+  fi
+}
+
+__log_out() {
+  echo "$1" 1>&2
+}
+
+# Parameters: max_tries min_sleep max_sleep constant_sleep fail_script EXECUTION_COMMAND
+retry()
+{
+  local max_tries="$1"; shift
+  local min_sleep="$1"; shift
+  local max_sleep="$1"; shift
+  local constant_sleep="$1"; shift
+  local fail_script="$1"; shift
+  if [ -n "$VERBOSE" ]; then
+    __log_out "Retry Parameters: max_tries=$max_tries min_sleep=$min_sleep max_sleep=$max_sleep constant_sleep=$constant_sleep"
+    if [ -n "$fail_script" ]; then __log_out "Fail script: $fail_script"; fi
+    __log_out ""
+    __log_out "Execution Command: $*"
+    __log_out ""
+  fi
+
+  local attempts=0
+  local return_code=1
+
+
+  while [[ $return_code -ne 0 && $attempts -le $max_tries ]]; do
+    if [ $attempts -gt 0 ]; then
+      __sleep_amount
+      __log_out "Before retry #$attempts: sleeping $sleep_time seconds"
+      sleep $sleep_time
+    fi
+
+    P="$1"
+    for param in "${@:2}"; do P="$P '$param'"; done
+    #TODO: replace single quotes in each arg with '"'"' ?
+    export RETRY_ATTEMPT=$attempts
+    bash -c "$P"
+    return_code=$?
+    #__log_out "Process returned $return_code on attempt $attempts"
+    if [ $return_code -eq 127 ]; then
+      # command not found
+      exit $return_code
+    elif [ $return_code -ne 0 ]; then
+      attempts=$[$attempts +1]
+    fi
+  done
+
+  if [ $attempts -gt $max_tries ]; then
+    if [ -n "$fail_script" ]; then
+      __log_out "Retries exhausted, running fail script"
+      eval $fail_script
+    else
+      __log_out "Retries exhausted"
+    fi
+  fi
+
+  exit $return_code
+}
+
+# If we're being sourced, don't worry about such things
+if [ "$BASH_SOURCE" == "$0" ]; then
+  # Prints the help text
+  help()
+  {
+    local retry=$(basename $0)
+    cat <<EOF
+Usage: $retry [options] -- execute command
+    -h, -?, --help
+    -v, --verbose                    Verbose output
+    -t, --tries=#                    Set max retries: Default 10
+    -s, --sleep=secs                 Constant sleep amount (seconds)
+    -m, --min=secs                   Exponential Backoff: minimum sleep amount (seconds): Default 0.3
+    -x, --max=secs                   Exponential Backoff: maximum sleep amount (seconds): Default 60
+    -f, --fail="script +cmds"        Fail Script: run in case of final failure
+EOF
+  }
+
+  # show help for no arguments if stdin is a terminal
+  if { [ -z "$1" ] && [ -t 0 ] ; } || [ "$1" == '-h' ] || [ "$1" == '-?' ] || [ "$1" == '--help' ]
+  then
+    help
+    exit 0
+  fi
+
+  $GETOPT_BIN --test > /dev/null
+  if [[ $? -ne 4 ]]; then
+      echo "I’m sorry, 'getopt --test' failed in this environment. Please load GNU getopt."
+      exit 1
+  fi
+
+  OPTIONS=vt:s:m:x:f:
+  LONGOPTIONS=verbose,tries:,sleep:,min:,max:,fail:
+
+  PARSED=$($GETOPT_BIN --options="$OPTIONS" --longoptions="$LONGOPTIONS" --name "$0" -- "$@")
+  if [[ $? -ne 0 ]]; then
+    # e.g. $? == 1
+    #  then getopt has complained about wrong arguments to stdout
+    exit 2
+  fi
+  # read getopt’s output this way to handle the quoting right:
+  eval set -- "$PARSED"
+
+  max_tries=10
+  min_sleep=0.3
+  max_sleep=60.0
+  constant_sleep=
+  fail_script=
+
+  # now enjoy the options in order and nicely split until we see --
+  while true; do
+      case "$1" in
+          -v|--verbose)
+              VERBOSE=true
+              shift
+              ;;
+          -t|--tries)
+              max_tries="$2"
+              shift 2
+              ;;
+          -s|--sleep)
+              constant_sleep="$2"
+              shift 2
+              ;;
+          -m|--min)
+              min_sleep="$2"
+              shift 2
+              ;;
+          -x|--max)
+              max_sleep="$2"
+              shift 2
+              ;;
+          -f|--fail)
+              fail_script="$2"
+              shift 2
+              ;;
+          --)
+              shift
+              break
+              ;;
+          *)
+              echo "Programming error"
+              exit 3
+              ;;
+      esac
+  done
+
+  retry "$max_tries" "$min_sleep" "$max_sleep" "$constant_sleep" "$fail_script" "$@"
+
+fi

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+# The root dir.
+# The ci system copies this folder.
+# This is where the depends build is done.
+BASE_ROOT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../ >/dev/null 2>&1 && pwd )
+export BASE_ROOT_DIR
+
+echo "Setting specific values in env"
+if [ -n "${FILE_ENV}" ]; then
+  set -o errexit;
+  # shellcheck disable=SC1090
+  source "${FILE_ENV}"
+fi
+
+echo "Fallback to default values in env (if not yet set)"
+# The number of parallel jobs to pass down to make and test_runner.py
+export MAKEJOBS=${MAKEJOBS:--j4}
+# A folder for the ci system to put temporary files (ccache, datadirs for tests, ...)
+# This folder only exists on the ci host.
+export BASE_SCRATCH_DIR=${BASE_SCRATCH_DIR:-$BASE_ROOT_DIR/ci/scratch}
+# What host to compile for. See also ./depends/README.md
+# Tests that need cross-compilation export the appropriate HOST.
+# Tests that run natively guess the host
+export HOST=${HOST:-$("$BASE_ROOT_DIR/depends/config.guess")}
+# Whether to prefer BusyBox over GNU utilities
+export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
+export RUN_UNIT_TESTS=${RUN_UNIT_TESTS:-true}
+export RUN_FUNCTIONAL_TESTS=${RUN_FUNCTIONAL_TESTS:-false}
+export RUN_SECURITY_TESTS=${RUN_SECURITY_TESTS:-false}
+export TEST_RUNNER_ENV=${TEST_RUNNER_ENV:-}
+export RUN_FUZZ_TESTS=${RUN_FUZZ_TESTS:-false}
+export CONTAINER_NAME=${CONTAINER_NAME:-ci_unnamed}
+export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:18.04}
+# Randomize test order.
+# See https://www.boost.org/doc/libs/1_71_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/random.html
+export BOOST_TEST_RANDOM=${BOOST_TEST_RANDOM:-1}
+# See man 7 debconf
+export DEBIAN_FRONTEND=noninteractive
+export CCACHE_SIZE=${CCACHE_SIZE:-100M}
+export CCACHE_TEMPDIR=${CCACHE_TEMPDIR:-/tmp/.ccache-temp}
+export CCACHE_COMPRESS=${CCACHE_COMPRESS:-1}
+# The cache dir.
+# This folder exists on the ci host and ci guest. Changes are propagated back and forth.
+export CCACHE_DIR=${CCACHE_DIR:-$BASE_SCRATCH_DIR/.ccache}
+# The depends dir.
+# This folder exists on the ci host and ci guest. Changes are propagated back and forth.
+export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}
+# Folder where the build result is put (bin and lib).
+export BASE_OUTDIR=${BASE_OUTDIR:-$BASE_SCRATCH_DIR/out/$HOST}
+# Folder where the build is done (dist and out-of-tree build).
+export BASE_BUILD_DIR=${BASE_BUILD_DIR:-$BASE_SCRATCH_DIR/build}
+export PREVIOUS_RELEASES_DIR=${PREVIOUS_RELEASES_DIR:-$BASE_ROOT_DIR/releases/$HOST}
+export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
+export DOCKER_PACKAGES=${DOCKER_PACKAGES:-build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps}
+export GOAL=${GOAL:-install}
+# export DIR_QA_ASSETS=${DIR_QA_ASSETS:-${BASE_SCRATCH_DIR}/qa-assets}
+export PATH=${BASE_ROOT_DIR}/ci/retry:$PATH
+export CI_RETRY_EXE=${CI_RETRY_EXE:-"retry --"}

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export HOST=arm-linux-gnueabihf
+# The host arch is unknown, so we run the tests through qemu.
+# If the host is arm and wants to run the tests natively, it can set QEMU_USER_CMD to the empty string.
+if [ -z ${QEMU_USER_CMD+x} ]; then export QEMU_USER_CMD="${QEMU_USER_CMD:-"qemu-arm -L /usr/arm-linux-gnueabihf/"}"; fi
+export DPKG_ADD_ARCH="armhf"
+export PACKAGES="g++-arm-linux-gnueabihf busybox libc6:armhf libstdc++6:armhf libfontconfig1:armhf libxcb1:armhf"
+if [ -n "$QEMU_USER_CMD" ]; then
+  # Likely cross-compiling, so install the needed gcc and qemu-user
+  export PACKAGES="$PACKAGES qemu-user"
+fi
+export CONTAINER_NAME=ci_arm_linux
+# Use debian to avoid 404 apt errors when cross compiling
+export DOCKER_NAME_TAG="debian:buster"
+export USE_BUSY_BOX=true
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=false
+export GOAL="install"
+# -Wno-psabi is to disable ABI warnings: "note: parameter passing for argument of type ... changed in GCC 7.1"
+# This could be removed once the ABI change warning does not show up by default
+export GRIDCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports CXXFLAGS=-Wno-psabi --enable-werror"
+# Disable QT as it takes too long to compile on Travis
+export DEP_OPTS="NO_QT=1"

--- a/ci/test/00_setup_env_linux_i386.sh
+++ b/ci/test/00_setup_env_linux_i386.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_linux_i386
+export DOCKER_NAME_TAG=ubuntu:20.04
+export HOST=i686-pc-linux-gnu
+export PACKAGES="python3 g++-multilib"
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=false
+# export RUN_SECURITY_TESTS="true"
+export GOAL="install"
+export GRIDCOIN_CONFIG="--enable-reduce-exports"
+export DEP_OPTS="NO_QT=1"
+export DPKG_ADD_ARCH="i386"

--- a/ci/test/00_setup_env_mac.sh
+++ b/ci/test/00_setup_env_mac.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_macos_cross
+export HOST=x86_64-apple-darwin16
+export PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python python3-dev python3-setuptools python3-distutils"
+export XCODE_VERSION=11.3.1
+export XCODE_BUILD_ID=11C505
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
+export GOAL=""
+export DEP_OPTS="NO_QT=1"
+export GRIDCOIN_CONFIG="--enable-reduce-exports"

--- a/ci/test/00_setup_env_mac_host.sh
+++ b/ci/test/00_setup_env_mac_host.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export HOST=x86_64-apple-darwin16
+export DOCKER_NAME_TAG=ubuntu:18.04  # Check that bionic can cross-compile to macos (bionic is used in the gitian build as well)
+export GOAL="install"
+export GRIDCOIN_CONFIG="--with-gui=qt5 --enable-reduce-exports"
+export NEED_XVFB="true"
+export NO_DEPENDS=1
+export OSX_SDK=""
+export CCACHE_SIZE=300M
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/00_setup_env_native.sh
+++ b/ci/test/00_setup_env_native.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_native
+export DOCKER_NAME_TAG=ubuntu:20.04
+export PACKAGES="libqt5gui5 libqt5core5a qtbase5-dev libqt5dbus5 qttools5-dev qttools5-dev-tools libqt5charts5-dev libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-iostreams-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libqrencode-dev libzip-dev zlib1g zlib1g-dev libcurl4 libcurl4-openssl-dev"
+export RUN_UNIT_TESTS=true
+# export RUN_FUNCTIONAL_TESTS=false
+# export RUN_SECURITY_TESTS="true"
+export GOAL="install"
+export GRIDCOIN_CONFIG="--enable-reduce-exports --with-incompatible-bdb --with-gui=qt5"
+export NEED_XVFB="true"
+export NO_DEPENDS=1

--- a/ci/test/00_setup_env_win32.sh
+++ b/ci/test/00_setup_env_win32.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_win32
+export DOCKER_NAME_TAG=ubuntu:18.04  # Check that bionic can cross-compile to win32 (bionic is used in the gitian build as well)
+export HOST=i686-w64-mingw32
+export PACKAGES="python3 nsis g++-mingw-w64-i686 wine-binfmt wine32"
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=false
+# export RUN_SECURITY_TESTS="true"
+export GOAL=""
+export GRIDCOIN_CONFIG="--enable-reduce-exports"
+export DEP_OPTS="NO_QT=1"
+export DPKG_ADD_ARCH="i386"

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_win64
+export DOCKER_NAME_TAG=ubuntu:18.04  # Check that bionic can cross-compile to win64 (bionic is used in the gitian build as well)
+export HOST=x86_64-w64-mingw32
+export PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
+export GOAL=""
+export GRIDCOIN_CONFIG="--enable-reduce-exports --with-gui=qt5 --enable-qt59"
+export NEED_XVFB="true"

--- a/ci/test/03_before_install.sh
+++ b/ci/test/03_before_install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+BEGIN_FOLD () {
+  echo ""
+  CURRENT_FOLD_NAME=$1
+  echo "travis_fold:start:${CURRENT_FOLD_NAME}"
+}
+
+END_FOLD () {
+  RET=$?
+  echo "travis_fold:end:${CURRENT_FOLD_NAME}"
+  if [ $RET != 0 ]; then
+    echo "${CURRENT_FOLD_NAME} failed with status code ${RET}"
+  fi
+}
+

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+if [[ $DOCKER_NAME_TAG == centos* ]]; then
+  export LC_ALL=en_US.utf8
+fi
+if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
+  export LC_ALL=C
+fi
+
+# Create folders that are mounted into the docker
+mkdir -p "${CCACHE_DIR}"
+mkdir -p "${PREVIOUS_RELEASES_DIR}"
+
+env | grep -E '^(GRIDCOIN_CONFIG|BASE_|QEMU_|CCACHE_|LC_ALL|BOOST_TEST_RANDOM|DEBIAN_FRONTEND|CONFIG_SHELL|(ASAN|LSAN|TSAN|UBSAN)_OPTIONS|PREVIOUS_RELEASES_DIR)' | tee /tmp/env
+if [[ $HOST = *-mingw32 ]]; then
+  DOCKER_ADMIN="--cap-add SYS_ADMIN"
+elif [[ $GRIDCOIN_CONFIG = *--with-sanitizers=*address* ]]; then # If ran with (ASan + LSan), Docker needs access to ptrace (https://github.com/google/sanitizers/issues/764)
+  DOCKER_ADMIN="--cap-add SYS_PTRACE"
+fi
+
+export P_CI_DIR="$PWD"
+
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
+  echo "Creating $DOCKER_NAME_TAG container to run in"
+  ${CI_RETRY_EXE} docker pull "$DOCKER_NAME_TAG"
+
+  DOCKER_ID=$(docker run $DOCKER_ADMIN -idt \
+                  --mount type=bind,src=$BASE_ROOT_DIR,dst=/ro_base,readonly \
+                  --mount type=bind,src=$CCACHE_DIR,dst=$CCACHE_DIR \
+                  --mount type=bind,src=$DEPENDS_DIR,dst=$DEPENDS_DIR \
+                  --mount type=bind,src=$PREVIOUS_RELEASES_DIR,dst=$PREVIOUS_RELEASES_DIR \
+                  -w $BASE_ROOT_DIR \
+                  --env-file /tmp/env \
+                  --name $CONTAINER_NAME \
+                  $DOCKER_NAME_TAG)
+  export DOCKER_CI_CMD_PREFIX="docker exec $DOCKER_ID"
+else
+  echo "Running on host system without docker wrapper"
+fi
+
+DOCKER_EXEC () {
+  $DOCKER_CI_CMD_PREFIX bash -c "export PATH=$BASE_SCRATCH_DIR/bins/:\$PATH && cd $P_CI_DIR && $*"
+}
+export -f DOCKER_EXEC
+
+if [ -n "$DPKG_ADD_ARCH" ]; then
+  DOCKER_EXEC dpkg --add-architecture "$DPKG_ADD_ARCH"
+fi
+
+if [[ $DOCKER_NAME_TAG == centos* ]]; then
+  ${CI_RETRY_EXE} DOCKER_EXEC yum -y install epel-release
+  ${CI_RETRY_EXE} DOCKER_EXEC yum -y install $DOCKER_PACKAGES $PACKAGES
+elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
+  ${CI_RETRY_EXE} DOCKER_EXEC apt-get update
+  ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
+  if [ "$NEED_XVFB" == "true" ]; then
+    ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y xvfb
+  fi
+fi
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  top -l 1 -s 0 | awk ' /PhysMem/ {print}'
+  echo "Number of CPUs: $(sysctl -n hw.logicalcpu)"
+else
+  DOCKER_EXEC free -m -h
+  DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
+  DOCKER_EXEC echo $(lscpu | grep Endian)
+  DOCKER_EXEC echo "Free disk space:"
+  DOCKER_EXEC df -h
+fi
+
+if [ ! -d ${DIR_QA_ASSETS} ]; then
+ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
+  DOCKER_EXEC git clone https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+ fi
+fi
+export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
+
+DOCKER_EXEC mkdir -p "${BASE_SCRATCH_DIR}/sanitizer-output/"
+
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
+  echo "Create $BASE_ROOT_DIR"
+  DOCKER_EXEC rsync -a /ro_base/ $BASE_ROOT_DIR
+fi
+
+if [ "$USE_BUSY_BOX" = "true" ]; then
+  echo "Setup to use BusyBox utils"
+  DOCKER_EXEC mkdir -p $BASE_SCRATCH_DIR/bins/
+  # tar excluded for now because it requires passing in the exact archive type in ./depends (fixed in later BusyBox version)
+  # find excluded for now because it does not recognize the -delete option in ./depends (fixed in later BusyBox version)
+  # ar excluded for now because it does not recognize the -q option in ./depends (unknown if fixed)
+  # shellcheck disable=SC1010
+  DOCKER_EXEC for util in \$\(busybox --list \| grep -v "^ar$" \| grep -v "^tar$" \| grep -v "^find$"\)\; do ln -s \$\(command -v busybox\) $BASE_SCRATCH_DIR/bins/\$util\; done
+  # Print BusyBox version
+  DOCKER_EXEC patch --help
+fi

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+# Make sure default datadir does not exist and is never read
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  mkdir $HOME/Library/Application\ Support/GridcoinResearch
+else
+  DOCKER_EXEC "mkdir $HOME/.GridcoinResearch"
+fi
+
+DOCKER_EXEC mkdir -p ${DEPENDS_DIR}/SDKs ${DEPENDS_DIR}/sdk-sources
+
+OSX_SDK_BASENAME="Xcode-${XCODE_VERSION}-${XCODE_BUILD_ID}-extracted-SDK-with-libcxx-headers.tar.gz"
+OSX_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OSX_SDK_BASENAME}"
+
+if [ -n "$XCODE_VERSION" ] && [ ! -f "$OSX_SDK_PATH" ]; then
+  curl --location --fail "${SDK_URL}/${OSX_SDK_BASENAME}" -o "$OSX_SDK_PATH"
+fi
+if [ -n "$XCODE_VERSION" ] && [ -f "$OSX_SDK_PATH" ]; then
+  DOCKER_EXEC tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
+fi
+if [[ $HOST = *-mingw32 ]]; then
+  DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
+fi
+if [ -z "$NO_DEPENDS" ]; then
+  if [[ $DOCKER_NAME_TAG == centos* ]]; then
+    # CentOS has problems building the depends if the config shell is not explicitly set
+    # (i.e. for libevent a Makefile with an empty SHELL variable is generated, leading to
+    #  an error as the first command is executed)
+    SHELL_OPTS="CONFIG_SHELL=/bin/bash"
+  else
+    SHELL_OPTS="CONFIG_SHELL="
+  fi
+  DOCKER_EXEC $SHELL_OPTS make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+fi
+if [ -n "$PREVIOUS_RELEASES_TO_DOWNLOAD" ]; then
+  BEGIN_FOLD previous-versions
+  DOCKER_EXEC contrib/devtools/previous_release.sh -b -t "$PREVIOUS_RELEASES_DIR" "${PREVIOUS_RELEASES_TO_DOWNLOAD}"
+  END_FOLD
+fi
+if [[ $HOST = x86_64-apple-darwin* ]]; then
+  DOCKER_EXEC "cd src/ && ../contrib/nomacro.pl"
+fi
+if [ "$NEED_XVFB" = "true" ]; then
+  DOCKER_EXEC export DISPLAY=:99.0
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    DOCKER_EXEC "/usr/bin/Xvfb :99 -ac" &
+  else
+    DOCKER_EXEC "/sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac"
+  fi
+fi

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+GRIDCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$DEPENDS_DIR/$HOST --bindir=$BASE_OUTDIR/bin --libdir=$BASE_OUTDIR/lib"
+DOCKER_EXEC "ccache --zero-stats --max-size=$CCACHE_SIZE"
+
+BEGIN_FOLD autogen
+if [ -n "$CONFIG_SHELL" ]; then
+  DOCKER_EXEC "$CONFIG_SHELL" -c "./autogen.sh"
+else
+  DOCKER_EXEC ./autogen.sh
+fi
+END_FOLD
+
+DOCKER_EXEC mkdir -p "${BASE_BUILD_DIR}"
+export P_CI_DIR="${BASE_BUILD_DIR}"
+
+BEGIN_FOLD configure
+DOCKER_EXEC "${BASE_ROOT_DIR}/configure" --cache-file=config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
+END_FOLD
+
+BEGIN_FOLD distdir
+DOCKER_EXEC make distdir VERSION=$HOST
+END_FOLD
+
+export P_CI_DIR="${BASE_BUILD_DIR}/gridcoin-$HOST"
+
+BEGIN_FOLD configure
+DOCKER_EXEC ./configure --cache-file=../config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
+END_FOLD
+
+set -o errtrace
+trap 'DOCKER_EXEC "cat ${BASE_SCRATCH_DIR}/sanitizer-output/* 2> /dev/null"' ERR
+
+BEGIN_FOLD build
+DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false )
+END_FOLD
+
+BEGIN_FOLD cache_stats
+DOCKER_EXEC "ccache --version | head -n 1 && ccache --show-stats"
+DOCKER_EXEC du -sh "${DEPENDS_DIR}"/*/
+DOCKER_EXEC du -sh "${PREVIOUS_RELEASES_DIR}"
+END_FOLD

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+if [ -n "$QEMU_USER_CMD" ]; then
+  BEGIN_FOLD wrap-qemu
+  # Generate all binaries, so that they can be wrapped
+  DOCKER_EXEC make $MAKEJOBS -C src/secp256k1 VERBOSE=1
+  DOCKER_EXEC make $MAKEJOBS -C src/univalue VERBOSE=1
+  DOCKER_EXEC "${BASE_ROOT_DIR}/ci/test/wrap-qemu.sh"
+  END_FOLD
+fi
+
+if [ -n "$USE_VALGRIND" ]; then
+  BEGIN_FOLD wrap-valgrind
+  DOCKER_EXEC "${BASE_ROOT_DIR}/ci/test/wrap-valgrind.sh"
+  END_FOLD
+fi
+
+if [ "$RUN_UNIT_TESTS" = "true" ]; then
+  BEGIN_FOLD unit-tests
+  DOCKER_EXEC LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib make $MAKEJOBS check VERBOSE=1
+  END_FOLD
+fi
+
+if [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
+  BEGIN_FOLD unit-tests-seq
+  DOCKER_EXEC LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib "${BASE_BUILD_DIR}/gridcoin-*/src/test/test_gridcoin*" --catch_system_errors=no -l test_suite
+  END_FOLD
+fi
+
+if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
+  BEGIN_FOLD functional-tests
+  DOCKER_EXEC LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib ${TEST_RUNNER_ENV} test/functional/test_runner.py --ci $MAKEJOBS --tmpdirprefix "${BASE_SCRATCH_DIR}/test_runner/" --ansi --combinedlogslen=4000 ${TEST_RUNNER_EXTRA} --quiet --failfast
+  END_FOLD
+fi
+
+if [ "$RUN_SECURITY_TESTS" = "true" ]; then
+  BEGIN_FOLD security-tests
+  DOCKER_EXEC make test-security-check
+  END_FOLD
+fi
+
+if [ "$RUN_FUZZ_TESTS" = "true" ]; then
+  BEGIN_FOLD fuzz-tests
+  DOCKER_EXEC LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib test/fuzz/test_runner.py ${FUZZ_TESTS_CONFIG} $MAKEJOBS -l DEBUG ${DIR_FUZZ_IN}
+  END_FOLD
+fi

--- a/ci/test_run_all.sh
+++ b/ci/test_run_all.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+set -o errexit; source ./ci/test/00_setup_env.sh
+set -o errexit; source ./ci/test/03_before_install.sh
+set -o errexit; source ./ci/test/04_install.sh
+set -o errexit; source ./ci/test/05_before_script.sh
+set -o errexit; source ./ci/test/06_script_a.sh
+set -o errexit; source ./ci/test/06_script_b.sh

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -1,17 +1,17 @@
-build_darwin_CC: = $(shell xcrun -f clang)
-build_darwin_CXX: = $(shell xcrun -f clang++)
-build_darwin_AR: = $(shell xcrun -f ar)
-build_darwin_RANLIB: = $(shell xcrun -f ranlib)
-build_darwin_STRIP: = $(shell xcrun -f strip)
-build_darwin_OTOOL: = $(shell xcrun -f otool)
-build_darwin_NM: = $(shell xcrun -f nm)
+build_darwin_CC:=$(shell xcrun -f clang) --sysroot $(shell xcrun --show-sdk-path)
+build_darwin_CXX:=$(shell xcrun -f clang++) --sysroot $(shell xcrun --show-sdk-path)
+build_darwin_AR:=$(shell xcrun -f ar)
+build_darwin_RANLIB:=$(shell xcrun -f ranlib)
+build_darwin_STRIP:=$(shell xcrun -f strip)
+build_darwin_OTOOL:=$(shell xcrun -f otool)
+build_darwin_NM:=$(shell xcrun -f nm)
 build_darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
-build_darwin_SHA256SUM = shasum -a 256
-build_darwin_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
+build_darwin_SHA256SUM=shasum -a 256
+build_darwin_DOWNLOAD=curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
-darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION)
-darwin_CXX:=$(shell xcrun -f clang++) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++
+darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(shell xcrun --show-sdk-path)
+darwin_CXX:=$(shell xcrun -f clang++) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ --sysroot $(shell xcrun --show-sdk-path)
 darwin_AR:=$(shell xcrun -f ar)
 darwin_RANLIB:=$(shell xcrun -f ranlib)
 darwin_STRIP:=$(shell xcrun -f strip)

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -1,9 +1,15 @@
-OSX_MIN_VERSION=10.8
-OSX_SDK_VERSION=10.11
-OSX_SDK=$(SDK_PATH)/MacOSX$(OSX_SDK_VERSION).sdk
-LD64_VERSION=253.9
+OSX_MIN_VERSION=10.11
+OSX_SDK_VERSION=10.15.1
+XCODE_VERSION=11.3.1
+XCODE_BUILD_ID=11C505
+LD64_VERSION=530
+
+OSX_SDK=$(SDK_PATH)/Xcode-$(XCODE_VERSION)-$(XCODE_BUILD_ID)-extracted-SDK-with-libcxx-headers
+
+# When cross-compiling for Darwin using Clang, -mlinker-version must be passed to
+# ensure that modern linker features are enabled.
 darwin_CC=clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION)
-darwin_CXX=clang++ -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION) -stdlib=libc++
+darwin_CXX=clang++ -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -stdlib=libc++ -mlinker-version=$(LD64_VERSION)
 
 darwin_CFLAGS=-pipe
 darwin_CXXFLAGS=$(darwin_CFLAGS)
@@ -15,3 +21,4 @@ darwin_debug_CFLAGS=-O1
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
 darwin_native_toolchain=native_cctools
+darwin_cmake_system=Darwin

--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -1,3 +1,7 @@
+ifneq ($(host),$(build))
+host_toolchain:=$(host)-
+endif
+
 default_host_CC = $(host_toolchain)gcc
 default_host_CXX = $(host_toolchain)g++
 default_host_AR = $(host_toolchain)ar
@@ -9,9 +13,18 @@ default_host_OTOOL = $(host_toolchain)otool
 default_host_NM = $(host_toolchain)nm
 
 define add_host_tool_func
+ifneq ($(filter $(origin $1),undefined default),)
+# Do not consider the well-known var $1 if it is undefined or is taking a value
+# that is predefined by "make" (e.g. the make variable "CC" has a predefined
+# value of "cc")
 $(host_os)_$1?=$$(default_host_$1)
 $(host_arch)_$(host_os)_$1?=$$($(host_os)_$1)
 $(host_arch)_$(host_os)_$(release_type)_$1?=$$($(host_os)_$1)
+else
+$(host_os)_$1=$(or $($1),$($(host_os)_$1),$(default_host_$1))
+$(host_arch)_$(host_os)_$1=$(or $($1),$($(host_arch)_$(host_os)_$1),$$($(host_os)_$1))
+$(host_arch)_$(host_os)_$(release_type)_$1=$(or $($1),$($(host_arch)_$(host_os)_$(release_type)_$1),$$($(host_os)_$1))
+endif
 host_$1=$$($(host_arch)_$(host_os)_$1)
 endef
 

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -7,42 +7,44 @@ $(package)_sha256_hash=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9
 $(package)_dependencies=zlib
 
 define $(package)_set_vars
-  $(package)_config_opts_release=variant=release
-  $(package)_config_opts_debug=variant=debug
-  $(package)_dependencies=zlib
-  $(package)_config_opts=--layout=tagged --build-type=complete --user-config=user-config.jam
-  $(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1 -sZLIB_SOURCE=$(host_prefix)/lib/zlib_source -sZLIB_INCLUDE=$(host_prefix)/include -sZLIB_LIBPATH=$(host_prefix)/lib
-  $(package)_config_opts_linux=threadapi=pthread runtime-link=shared
-  $(package)_config_opts_darwin=--toolset=darwin-4.2.1 runtime-link=shared
-  $(package)_config_opts_mingw32=binary-format=pe target-os=windows threadapi=win32 runtime-link=static
-  $(package)_config_opts_x86_64_mingw32=address-model=64
-  $(package)_config_opts_i686_mingw32=address-model=32
-  $(package)_config_opts_i686_linux=address-model=32 architecture=x86
-  $(package)_toolset_$(host_os)=gcc
-  $(package)_archiver_$(host_os)=$($(package)_ar)
-  $(package)_toolset_darwin=darwin
-  $(package)_archiver_darwin=$($(package)_libtool)
-  $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test,iostreams
-  $(package)_cxxflags=-std=c++11 -fvisibility=hidden
-  $(package)_cxxflags_linux=-fPIC
-  $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
-  $(package)_cflags_aarch64_linux = $(GCCFLAGS)
-  $(package)_cxxflags_arm_linux = $(GCCFLAGS)
-  $(package)_cflags_arm_linux = $(GCCFLAGS)
+$(package)_config_opts_release=variant=release
+$(package)_config_opts_debug=variant=debug
+$(package)_config_opts=--layout=tagged --build-type=complete --user-config=user-config.jam
+$(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1
+$(package)_config_opts_linux=target-os=linux threadapi=pthread runtime-link=shared
+$(package)_config_opts_darwin=target-os=darwin runtime-link=shared
+$(package)_config_opts_mingw32=target-os=windows binary-format=pe threadapi=win32 runtime-link=static
+$(package)_config_opts_x86_64_mingw32=address-model=64
+$(package)_config_opts_i686_mingw32=address-model=32
+$(package)_config_opts_i686_linux=address-model=32 architecture=x86
+$(package)_config_opts_i686_android=address-model=32
+$(package)_config_opts_aarch64_android=address-model=64
+$(package)_config_opts_x86_64_android=address-model=64
+$(package)_config_opts_armv7a_android=address-model=32
+$(package)_toolset_$(host_os)=gcc
+$(package)_toolset_darwin=clang
+ifneq (,$(findstring clang,$($(package)_cxx)))
+   $(package)_toolset_$(host_os)=clang
+endif
+$(package)_archiver_$(host_os)=$($(package)_ar)
+$(package)_config_libraries=chrono,filesystem,program_options,system,thread,test,iostreams
+$(package)_cxxflags=-std=c++11 -fvisibility=hidden
+$(package)_cxxflags_linux=-fPIC
+$(package)_cxxflags_android=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+  echo "using $($(package)_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$($(package)_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 
 define $(package)_config_cmds
-  ./bootstrap.sh --without-icu --with-libraries=$(boost_config_libraries)
+  ./bootstrap.sh --without-icu --with-libraries=$($(package)_config_libraries) --with-toolset=$($(package)_toolset_$(host_os))
 endef
 
 define $(package)_build_cmds
-  ./b2 -d2 -j2 -d1 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) stage
+  ./b2 -d2 -j2 -d1 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) toolset=$($(package)_toolset_$(host_os)) stage
 endef
 
 define $(package)_stage_cmds
-  ./b2 -d0 -j4 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) install
+  ./b2 -d0 -j4 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) toolset=$($(package)_toolset_$(host_os)) install
 endef

--- a/depends/packages/curl.mk
+++ b/depends/packages/curl.mk
@@ -1,9 +1,9 @@
 package=curl
 GCCFLAGS?=
-$(package)_version=7.63.0
+$(package)_version=7.71.1
 $(package)_download_path=https://curl.haxx.se/download/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=d483b89062832e211c887d7cf1b65c902d591b48c11fe7d174af781681580b41
+$(package)_sha256_hash=59ef1f73070de67b87032c72ee6037cedae71dcb1d7ef2d7f59487704aec069d
 $(package)_dependencies=openssl
 
 define $(package)_set_vars
@@ -13,6 +13,10 @@ define $(package)_set_vars
   $(package)_config_opts_linux+=--with-pic
   # Disable OpenSSL for Windows and use native SSL stack (SSPI/Schannel):
   $(package)_config_opts_mingw32+= --with-winssl --without-ssl
+  # This extra flag for macOS is necesarry as curl will append a -mmacosx-version-min=10.8 otherwise
+  # which will cause the linker to fail as it cannot optimize away a __builtin_available(MacOS 10.11...) call
+  # which requires a link to compiler runtime library.
+  $(package)_cflags_darwin=-mmacosx-version-min=$(OSX_MIN_VERSION)
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/native_biplist.mk
+++ b/depends/packages/native_biplist.mk
@@ -1,20 +1,15 @@
 package=native_biplist
-$(package)_version=0.9
-$(package)_download_path=https://pypi.python.org/packages/source/b/biplist
+$(package)_version=1.0.3
+$(package)_download_path=https://bitbucket.org/wooster/biplist/downloads
 $(package)_file_name=biplist-$($(package)_version).tar.gz
-$(package)_sha256_hash=b57cadfd26e4754efdf89e9e37de87885f9b5c847b2615688ca04adfaf6ca604
-$(package)_install_libdir=$(build_prefix)/lib/python/dist-packages
-$(package)_patches=sorted_list.patch
-
-define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/sorted_list.patch
-endef
+$(package)_sha256_hash=4c0549764c5fe50b28042ec21aa2e14fe1a2224e239a1dae77d9e7f3932aa4c6
+$(package)_install_libdir=$(build_prefix)/lib/python3/dist-packages
 
 define $(package)_build_cmds
-    python setup.py build
+    python3 setup.py build
 endef
 
 define $(package)_stage_cmds
     mkdir -p $($(package)_install_libdir) && \
-    python setup.py install --root=$($(package)_staging_dir) --prefix=$(build_prefix) --install-lib=$($(package)_install_libdir)
+    python3 setup.py install --root=$($(package)_staging_dir) --prefix=$(build_prefix) --install-lib=$($(package)_install_libdir)
 endef

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,45 +1,83 @@
 package=native_cctools
-$(package)_version=807d6fd1be5d2224872e381870c0a75387fe05e6
-$(package)_download_path=https://github.com/theuni/cctools-port/archive
+$(package)_version=4da2f3b485bcf4cef526f30c0b8c0bcda99cdbb4
+$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=a09c9ba4684670a0375e42d9d67e7f12c1f62581a27f28f7c825d6d7032ccc6a
+$(package)_sha256_hash=a2d491c0981cef72fee2b833598f20f42a6c44a7614a61c439bda93d56446fec
 $(package)_build_subdir=cctools
-$(package)_clang_version=3.7.1
-$(package)_clang_download_path=http://llvm.org/releases/$($(package)_clang_version)
+ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
+$(package)_clang_version=8.0.0
+$(package)_clang_download_path=https://releases.llvm.org/$($(package)_clang_version)
 $(package)_clang_download_file=clang+llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 $(package)_clang_file_name=clang-llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_clang_sha256_hash=99b28a6b48e793705228a390471991386daa33a9717cd9ca007fcdde69608fd9
-$(package)_extra_sources=$($(package)_clang_file_name)
+$(package)_clang_sha256_hash=9ef854b71949f825362a119bf2597f744836cb571131ae6b721cd102ffea8cd0
+endif
 
+$(package)_libtapi_version=3efb201881e7a76a21e0554906cf306432539cef
+$(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
+$(package)_libtapi_download_file=$($(package)_libtapi_version).tar.gz
+$(package)_libtapi_file_name=$($(package)_libtapi_version).tar.gz
+$(package)_libtapi_sha256_hash=380c1ca37cfa04a8699d0887a8d3ee1ad27f3d08baba78887c73b09485c0fbd3
+
+$(package)_extra_sources=$($(package)_libtapi_file_name)
+ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
+$(package)_extra_sources += $($(package)_clang_file_name)
+endif
+
+ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
-$(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash))
+$(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_libtapi_download_path),$($(package)_libtapi_download_file),$($(package)_libtapi_file_name),$($(package)_libtapi_sha256_hash))
 endef
+else
+define $(package)_fetch_cmds
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_libtapi_download_path),$($(package)_libtapi_download_file),$($(package)_libtapi_file_name),$($(package)_libtapi_sha256_hash))
+endef
+endif
 
+ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
 define $(package)_extract_cmds
   mkdir -p $($(package)_extract_dir) && \
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_clang_sha256_hash)  $($(package)_source_dir)/$($(package)_clang_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_libtapi_sha256_hash)  $($(package)_source_dir)/$($(package)_libtapi_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
-  mkdir -p toolchain/bin toolchain/lib/clang/3.5/include && \
-  tar --strip-components=1 -C toolchain -xf $($(package)_source_dir)/$($(package)_clang_file_name) && \
+  mkdir -p toolchain/bin toolchain/lib/clang/$($(package)_clang_version)/include && \
+  mkdir -p libtapi && \
+  tar --no-same-owner --strip-components=1 -C libtapi -xf $($(package)_source_dir)/$($(package)_libtapi_file_name) && \
+  tar --no-same-owner --strip-components=1 -C toolchain -xf $($(package)_source_dir)/$($(package)_clang_file_name) && \
   rm -f toolchain/lib/libc++abi.so* && \
-  echo "#!/bin/sh" > toolchain/bin/$(host)-dsymutil && \
-  echo "exit 0" >> toolchain/bin/$(host)-dsymutil && \
-  chmod +x toolchain/bin/$(host)-dsymutil && \
-  tar --strip-components=1 -xf $($(package)_source)
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source)
 endef
+else
+define $(package)_extract_cmds
+  mkdir -p $($(package)_extract_dir) && \
+  echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_libtapi_sha256_hash)  $($(package)_source_dir)/$($(package)_libtapi_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  mkdir -p libtapi && \
+  tar --no-same-owner --strip-components=1 -C libtapi -xf $($(package)_source_dir)/$($(package)_libtapi_file_name) && \
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source)
+endef
+endif
 
 define $(package)_set_vars
-$(package)_config_opts=--target=$(host) --disable-lto-support
-$(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
-$(package)_cc=$($(package)_extract_dir)/toolchain/bin/clang
-$(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
+  $(package)_config_opts=--target=$(host) --disable-lto-support --with-libtapi=$($(package)_extract_dir)
+  $(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
+  ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
+  $(package)_cc=$($(package)_extract_dir)/toolchain/bin/clang
+  $(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
+  else
+  $(package)_cc=clang
+  $(package)_cxx=clang++
+  endif
 endef
 
 define $(package)_preprocess_cmds
-  cd $($(package)_build_subdir); ./autogen.sh && \
-  sed -i.old "/define HAVE_PTHREADS/d" ld64/src/ld/InputFiles.h
+  CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/build.sh && \
+  CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/install.sh && \
+  sed -i.old "/define HAVE_PTHREADS/d" $($(package)_build_subdir)/ld64/src/ld/InputFiles.h
 endef
 
 define $(package)_config_cmds
@@ -50,8 +88,12 @@ define $(package)_build_cmds
   $(MAKE)
 endef
 
+ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install && \
+  mkdir -p $($(package)_staging_prefix_dir)/lib/ && \
+  cd $($(package)_extract_dir) && \
+  cp lib/libtapi.so.6 $($(package)_staging_prefix_dir)/lib/ && \
   cd $($(package)_extract_dir)/toolchain && \
   mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include && \
   mkdir -p $($(package)_staging_prefix_dir)/bin $($(package)_staging_prefix_dir)/include && \
@@ -59,7 +101,13 @@ define $(package)_stage_cmds
   cp -P bin/clang++ $($(package)_staging_prefix_dir)/bin/ &&\
   cp lib/libLTO.so $($(package)_staging_prefix_dir)/lib/ && \
   cp -rf lib/clang/$($(package)_clang_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include/ && \
-  cp bin/llvm-dsymutil $($(package)_staging_prefix_dir)/bin/$(host)-dsymutil && \
-  if `test -d include/c++/`; then cp -rf include/c++/ $($(package)_staging_prefix_dir)/include/; fi && \
-  if `test -d lib/c++/`; then cp -rf lib/c++/ $($(package)_staging_prefix_dir)/lib/; fi
+  cp bin/dsymutil $($(package)_staging_prefix_dir)/bin/$(host)-dsymutil
 endef
+else
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install && \
+  mkdir -p $($(package)_staging_prefix_dir)/lib/ && \
+  cd $($(package)_extract_dir) && \
+  cp lib/libtapi.so.6 $($(package)_staging_prefix_dir)/lib/
+endef
+endif

--- a/depends/packages/native_ds_store.mk
+++ b/depends/packages/native_ds_store.mk
@@ -3,14 +3,14 @@ $(package)_version=1.1.2
 $(package)_download_path=https://github.com/al45tair/ds_store/archive/
 $(package)_file_name=v$($(package)_version).tar.gz
 $(package)_sha256_hash=3b3ecb7bf0a5157f5b6010bc3af7c141fb0ad3527084e63336220d22744bc20c
-$(package)_install_libdir=$(build_prefix)/lib/python/dist-packages
+$(package)_install_libdir=$(build_prefix)/lib/python3/dist-packages
 $(package)_dependencies=native_biplist
 
 define $(package)_build_cmds
-    python setup.py build
+    python3 setup.py build
 endef
 
 define $(package)_stage_cmds
     mkdir -p $($(package)_install_libdir) && \
-    python setup.py install --root=$($(package)_staging_dir) --prefix=$(build_prefix) --install-lib=$($(package)_install_libdir)
+    python3 setup.py install --root=$($(package)_staging_dir) --prefix=$(build_prefix) --install-lib=$($(package)_install_libdir)
 endef

--- a/depends/packages/native_mac_alias.mk
+++ b/depends/packages/native_mac_alias.mk
@@ -3,13 +3,13 @@ $(package)_version=2.0.7
 $(package)_download_path=https://github.com/al45tair/mac_alias/archive/
 $(package)_file_name=v$($(package)_version).tar.gz
 $(package)_sha256_hash=6f606d3b6bccd2112aeabf1a063f5b5ece87005a5d7e97c8faca23b916e88838
-$(package)_install_libdir=$(build_prefix)/lib/python/dist-packages
+$(package)_install_libdir=$(build_prefix)/lib/python3/dist-packages
 
 define $(package)_build_cmds
-    python setup.py build
+    python3 setup.py build
 endef
 
 define $(package)_stage_cmds
     mkdir -p $($(package)_install_libdir) && \
-    python setup.py install --root=$($(package)_staging_dir) --prefix=$(build_prefix) --install-lib=$($(package)_install_libdir)
+    python3 setup.py install --root=$($(package)_staging_dir) --prefix=$(build_prefix) --install-lib=$($(package)_install_libdir)
 endef

--- a/depends/packages/qt59.mk
+++ b/depends/packages/qt59.mk
@@ -9,7 +9,7 @@ $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib concurrent xml
-$(package)_patches=0001-Fix-linguist-macro.patch mac-qmake.conf 0005-Make-sure-.pc-files-are-installed-correctly.patch 0008-Fix-linking-against-shared-static-libpng.patch 0011-Fix-linking-against-static-freetype2.patch 0012-Fix-linking-against-static-harfbuzz.patch 0001-Add-profile-for-cross-compilation-with-mingw-w64.patch 0030-Prevent-qmake-from-messing-static-lib-dependencies.patch 0021-Use-.dll.a-as-import-lib-extension.patch fix_qt_pkgconfig.patch 0013-Fix-linking-against-static-pcre.patch
+$(package)_patches=0001-Fix-linguist-macro.patch mac-qmake.conf 0005-Make-sure-.pc-files-are-installed-correctly.patch 0008-Fix-linking-against-shared-static-libpng.patch 0011-Fix-linking-against-static-freetype2.patch 0012-Fix-linking-against-static-harfbuzz.patch 0001-Add-profile-for-cross-compilation-with-mingw-w64.patch 0030-Prevent-qmake-from-messing-static-lib-dependencies.patch 0021-Use-.dll.a-as-import-lib-extension.patch fix_qt_pkgconfig.patch 0013-Fix-linking-against-static-pcre.patch fix_configure_mac.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=9822084f8e2d2939ba39f4af4c0c2320e45d5996762a9423f833055607604ed8
@@ -31,7 +31,7 @@ $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
 $(package)_extra_sources += $($(package)_qtcharts_file_name)
 $(package)_extra_sources += $($(package)_qtactiveqt_file_name)
-$(package)_extra_source += $($(package)_qtsvg)
+$(package)_extra_sources += $($(package)_qtsvg)
 
 define $(package)_set_vars
 $(package)_config_opts_release = -release
@@ -171,6 +171,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/0030-Prevent-qmake-from-messing-static-lib-dependencies.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_qt_pkgconfig.patch &&\
   patch -p1 -i $($(package)_patch_dir)/0013-Fix-linking-against-static-pcre.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/fix_configure_mac.patch &&\
   mv qtbase/mkspecs/linux-arm-gnueabi-g++ qtbase/mkspecs/arm-linux-gnueabi-g++ &&\
   cp -rf qtbase/mkspecs/arm-linux-gnueabi-g++ qtbase/mkspecs/arm-linux-gnueabihf-g++ &&\
   sed -i.old "s/arm-linux-gnueabi/arm-linux-gnueabihf/" qtbase/mkspecs/arm-linux-gnueabihf-g++/qmake.conf

--- a/depends/patches/qt59/fix_configure_mac.patch
+++ b/depends/patches/qt59/fix_configure_mac.patch
@@ -1,0 +1,50 @@
+--- old/qtbase/mkspecs/features/mac/sdk.prf	2018-02-08 10:24:48.000000000 -0800
++++ new/qtbase/mkspecs/features/mac/sdk.prf	2018-03-23 10:38:56.000000000 -0700
+@@ -8,21 +8,21 @@
+ defineReplace(xcodeSDKInfo) {
+     info = $$1
+     equals(info, "Path"): \
+-        info = --show-sdk-path
++        infoarg = --show-sdk-path
+     equals(info, "PlatformPath"): \
+-        info = --show-sdk-platform-path
++        infoarg = --show-sdk-platform-path
+     equals(info, "SDKVersion"): \
+-        info = --show-sdk-version
++        infoarg = --show-sdk-version
+     sdk = $$2
+     isEmpty(sdk): \
+         sdk = $$QMAKE_MAC_SDK
+ 
+     isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}) {
+-        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcrun --sdk $$sdk $$info 2>/dev/null")
++        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcrun --sdk $$sdk $$infoarg 2>/dev/null")
+         # --show-sdk-platform-path won't work for Command Line Tools; this is fine
+         # only used by the XCTest backend to testlib
+-        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}):if(!isEmpty(QMAKE_XCODEBUILD_PATH)|!equals(info, "--show-sdk-platform-path")): \
+-            error("Could not resolve SDK $$info for \'$$sdk\'")
++        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}):if(!isEmpty(QMAKE_XCODEBUILD_PATH)|!equals(infoarg, "--show-sdk-platform-path")): \
++            error("Could not resolve SDK $$info for \'$$sdk\' using $$infoarg")
+         cache(QMAKE_MAC_SDK.$${sdk}.$${info}, set stash, QMAKE_MAC_SDK.$${sdk}.$${info})
+     }
+
+--- old/qtbase/configure	2018-02-08 10:24:48.000000000 -0800
++++ new/qtbase/configure	2018-03-23 05:42:29.000000000 -0700
+@@ -232,8 +232,13 @@
+ 
+     sdk=$(getSingleQMakeVariable "QMAKE_MAC_SDK" "$1")
+     if [ -z "$sdk" ]; then echo "QMAKE_MAC_SDK must be set when building on Mac" >&2; exit 1; fi
+-    sysroot=$(/usr/bin/xcrun --sdk $sdk --show-sdk-path 2>/dev/null)
+-    if [ -z "$sysroot" ]; then echo "Failed to resolve SDK path for '$sdk'" >&2; exit 1; fi
++    sysroot=$(getSingleQMakeVariable "QMAKE_MAC_SDK_PATH" "$1")
++
++    echo "sysroot pre-configured as $sysroot";
++    if [ -z "$sysroot" ]; then
++       sysroot=$(/usr/bin/xcrun --sdk $sdk --show-sdk-path 2>/dev/null)
++       if [ -z "$sysroot" ]; then echo "Failed to resolve SDK path for '$sdk'" >&2; exit 1; fi
++    fi
+ 
+     case "$sdk" in
+         macosx*)
+
+

--- a/depends/patches/qt59/mac-qmake.conf
+++ b/depends/patches/qt59/mac-qmake.conf
@@ -14,6 +14,7 @@ QMAKE_MAC_SDK.macosx.Path = $${MAC_SDK_PATH}
 QMAKE_MAC_SDK.macosx.platform_name = macosx
 QMAKE_MAC_SDK.macosx.SDKVersion = $${MAC_SDK_VERSION}
 QMAKE_MAC_SDK.macosx.PlatformPath = /phony
+QMAKE_APPLE_DEVICE_ARCHS=x86_64
 !host_build: QMAKE_CFLAGS += -target $${MAC_TARGET}
 !host_build: QMAKE_OBJECTIVE_CFLAGS += $$QMAKE_CFLAGS
 !host_build: QMAKE_CXXFLAGS += $$QMAKE_CFLAGS

--- a/src/test/neuralnet/cpid_tests.cpp
+++ b/src/test/neuralnet/cpid_tests.cpp
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(it_is_hashable_to_key_a_lookup_map)
     std::hash<NN::Cpid> hasher;
 
     // 0x0706050403020100 + 0x1514131211100908 (CPID halves, little endian)
-    BOOST_CHECK(hasher(cpid) == 2024957465561532936);
+    BOOST_CHECK_EQUAL(hasher(cpid), 2024957465561532936);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/neuralnet/cpid_tests.cpp
+++ b/src/test/neuralnet/cpid_tests.cpp
@@ -244,8 +244,10 @@ BOOST_AUTO_TEST_CASE(it_is_hashable_to_key_a_lookup_map)
 
     std::hash<NN::Cpid> hasher;
 
-    // 0x0706050403020100 + 0x1514131211100908 (CPID halves, little endian)
-    BOOST_CHECK_EQUAL(hasher(cpid), 2024957465561532936);
+    // CPID halves, little endian
+    const size_t expected = 0x0706050403020100ull + 0x1514131211100908ull;
+
+    BOOST_CHECK_EQUAL(hasher(cpid), expected);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -2300,8 +2300,10 @@ BOOST_AUTO_TEST_CASE(it_is_hashable_to_key_a_lookup_map)
         0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
     });
 
-    // 0x0706050403020100 + 0x1514131211100908 (MD5 halves, little endian)
-    BOOST_CHECK_EQUAL(hasher(hash_md5), 2024957465561532936);
+    // MD5 halves, little endian
+    const size_t expected = 0x0706050403020100ull + 0x1514131211100908ull;
+
+    BOOST_CHECK_EQUAL(hasher(hash_md5), expected);
 }
 
 BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_invalid)

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -504,8 +504,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
 
     auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == meta.cpid_count);
-    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
-    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+    BOOST_CHECK_CLOSE(cpids.TotalMagnitude(), meta.cpid_total_mag, 0.00000001);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
 
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
@@ -549,8 +549,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergnce)
 
     auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == meta.cpid_count);
-    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
-    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+    BOOST_CHECK_CLOSE(cpids.TotalMagnitude(), meta.cpid_total_mag, 0.00000001);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
 
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
@@ -594,8 +594,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergnc
 
     auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == meta.cpid_count);
-    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
-    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+    BOOST_CHECK_CLOSE(cpids.TotalMagnitude(), meta.cpid_total_mag, 0.00000001);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
 
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
@@ -973,8 +973,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     const auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == meta.cpid_count);
     BOOST_CHECK(cpids.Zeros() == 0);
-    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
-    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+    BOOST_CHECK_CLOSE(cpids.TotalMagnitude(), meta.cpid_total_mag, 0.00000001);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
 
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
@@ -1107,8 +1107,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_fallback_convergence)
     const auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == meta.cpid_count);
     BOOST_CHECK(cpids.Zeros() == 0);
-    BOOST_CHECK_EQUAL(cpids.TotalMagnitude(), meta.cpid_total_mag);
-    BOOST_CHECK_EQUAL(cpids.AverageMagnitude(), meta.cpid_average_mag);
+    BOOST_CHECK_CLOSE(cpids.TotalMagnitude(), meta.cpid_total_mag, 0.00000001);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
 
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
@@ -1476,8 +1476,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
     BOOST_CHECK(cpids.At(2)->Cpid() == meta.cpid1);
     BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
-    BOOST_CHECK(cpids.TotalMagnitude() == meta.cpid_total_mag);
-    BOOST_CHECK(cpids.AverageMagnitude() == meta.cpid_average_mag);
+    BOOST_CHECK_CLOSE(cpids.TotalMagnitude(), meta.cpid_total_mag, 0.00000001);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -2301,7 +2301,7 @@ BOOST_AUTO_TEST_CASE(it_is_hashable_to_key_a_lookup_map)
     });
 
     // 0x0706050403020100 + 0x1514131211100908 (MD5 halves, little endian)
-    BOOST_CHECK(hasher(hash_md5) == 2024957465561532936);
+    BOOST_CHECK_EQUAL(hasher(hash_md5), 2024957465561532936);
 }
 
 BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_invalid)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -626,9 +626,9 @@ BOOST_AUTO_TEST_CASE(util_IsLockTimeWithinMinutes)
 
 BOOST_AUTO_TEST_CASE(util_VerifyRound)
 {
-    BOOST_CHECK_EQUAL(1.2346, Round(1.23456789, 4));
-    BOOST_CHECK_EQUAL(1,      Round(1.23456789, 0));
-    BOOST_CHECK_EQUAL(2,      Round(1.5, 0));
+    BOOST_CHECK_CLOSE(1.2346, Round(1.23456789, 4), 0.00000001);
+    BOOST_CHECK_CLOSE(1,      Round(1.23456789, 0), 0.00000001);
+    BOOST_CHECK_CLOSE(2,      Round(1.5, 0), 0.00000001);
 }
 
 BOOST_AUTO_TEST_CASE(util_VerifyRoundToString)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -638,7 +638,7 @@ BOOST_AUTO_TEST_CASE(util_VerifyRoundToString)
 
 BOOST_AUTO_TEST_CASE(util_RoundFromStringShouldRoundToDouble)
 {
-    BOOST_CHECK_EQUAL(3.14, RoundFromString("3.1415", 2));
+    BOOST_CHECK_CLOSE(3.14, RoundFromString("3.1415", 2), 0.00000001);
 }
 
 BOOST_AUTO_TEST_CASE(util_VerifySplit)


### PR DESCRIPTION
This PR aims to adopt the bitcoins CI scripts. This adds a new native macOS gui build and the ability to continue a build if the depends/build steps take too long. Also updates native_biplist, native_cctools, curl and the macOS SDK used by depends.

Enabling Qt Charts on macOS cross compilation fails with:
`make[3]: *** No rule to make target '/xxxxxxx/depends/work/build/x86_64-apple-darwin/qt59/5.9.6-7xxxxxxxx/qtbase/lib/Qt5Widgets.', needed by '../../lib/Qt5Charts.'.  Stop.`

~~While I feel like this is an improvement over the current system, I've pretty much hit a road-block in terms of improving this PR.~~