### PR TITLE
accrual: Fix Outdated Comment And Correct Grammar 

### DIFF
--- a/src/neuralnet/accrual/snapshot.h
+++ b/src/neuralnet/accrual/snapshot.h
@@ -195,7 +195,7 @@ protected:
     //! \brief Calculate the age of the active superblock to determine the
     //! duration of the accrual period.
     //!
-    //! \return Superblock age as days in until to the payment time.
+    //! \return Superblock age as seconds from the payment time.
     //!
     int64_t SuperblockAge() const
     {


### PR DESCRIPTION
Fixes a comment that was missed in #1799. Updates to saying seconds instead of saying days and corrects `in until to` to be `from`