### PR TITLE
qt: Add option to choose not to start the wallet minimized

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -439,10 +439,6 @@ int StartGridcoinQt(int argc, char *argv[])
 
     try
     {
-        // Regenerate startup link, to fix links to old versions
-        if (GUIUtil::GetStartOnSystemStartup())
-            GUIUtil::SetStartOnSystemStartup(true);
-
         BitcoinGUI window;
         guiref = &window;
 
@@ -503,6 +499,9 @@ int StartGridcoinQt(int argc, char *argv[])
 #endif
 
                 LogPrintf("GUI loaded.");
+
+                // Regenerate startup link, to fix links to old versions
+                GUIUtil::SetStartOnSystemStartup(optionsModel.getStartAtStartup(), optionsModel.getStartMin());
 
                 app.exec();
 

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>540</width>
-    <height>380</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -77,30 +77,25 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="gridcoinAtStartup">
-         <property name="toolTip">
-          <string>Automatically start Gridcoin after logging in to the system.</string>
-         </property>
-         <property name="text">
-          <string>&amp;Start Gridcoin on system login</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="hw_renderer_group" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_5">
-          <item>
-           <widget class="QCheckBox" name="gridcoinAtStartupMinimised">
-            <property name="toolTip">
-             <string>Chooses to hide the wallet on startup.</string>
-            </property>
-            <property name="text">
-             <string>&amp;Minimized</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayoutGridcoinStartup">
+         <item>
+          <widget class="QCheckBox" name="gridcoinAtStartup">
+           <property name="toolTip">
+            <string>Automatically start Gridcoin after logging in to the system.</string>
+           </property>
+           <property name="text">
+            <string>&amp;Start Gridcoin on system login</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="gridcoinAtStartupMinimised">
+           <property name="text">
+            <string>Start minimized</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QCheckBox" name="detachDatabases">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -87,6 +87,22 @@
         </widget>
        </item>
        <item>
+        <widget class="QWidget" name="hw_renderer_group" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="gridcoinAtStartupMinimised">
+            <property name="toolTip">
+             <string>Chooses to hide the wallet on startup.</string>
+            </property>
+            <property name="text">
+             <string>&amp;Minimized</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="detachDatabases">
          <property name="toolTip">
           <string>Detach block and address databases at shutdown. This means they can be moved to another data directory, but it slows down shutdown. The wallet is always detached.</string>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -423,7 +423,6 @@ for (const auto& flag : { "-scraper", "-explorer", "-usenewnn" })
     if (GetBoolArg(flag)) 
     {
         (result.arguments += " ") += flag;
-        result.link_name_suffix += flag;
     }
 }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -600,7 +600,7 @@ bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
 
         if (!autostartup.data_dir.empty())
         {
-            optionFile << " -datadir='" << autostartup.data_dir << "'";
+            optionFile << " -datadir=" << autostartup.data_dir;
         }
 
         optionFile << " " << autostartup.arguments << "\n";

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -4,6 +4,7 @@
 #include "bitcoinunits.h"
 #include "util.h"
 #include "init.h"
+#include "optionsmodel.h"
 #include <codecvt>
 
 #include <QString>
@@ -401,8 +402,17 @@ AutoStartupArguments GetAutoStartupArguments()
     // We do NOT want testnet appended here for the path in the autostart
     // shortcut, so use false in GetDataDir().
     result.data_dir = GetDataDir(false);
-
-    result.arguments = "-min";
+    
+    OptionsModel opts;
+    if (opts.getStartMin())
+    {
+        result.arguments = "-min";
+    }
+    else
+    {
+        result.arguments = "";
+    }
+    
 
     if (fTestNet)
     {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -494,7 +494,16 @@ bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
             psl->SetPath(pszExePath);
             PathRemoveFileSpecW(pszExePath);
             psl->SetWorkingDirectory(pszExePath);
-            psl->SetShowCmd(SW_SHOWMINNOACTIVE);
+
+            if (fStartMin)
+            {
+                psl->SetShowCmd(SW_SHOWMINNOACTIVE);
+            }
+            else
+            {
+                psl->SetShowCmd(SW_SHOWNORMAL);
+            }
+
             psl->SetArguments(pszArgs);
 
             // Query IShellLink for the IPersistFile interface for

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -596,7 +596,7 @@ bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
         optionFile << "Name=Gridcoin" + autostartup.link_name_suffix + "\n";
-        optionFile << "Exec=" << pszExePath;
+        optionFile << "Exec=" << static_cast<boost::filesystem::path>(pszExePath);
 
         if (!autostartup.data_dir.empty())
         {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -125,7 +125,7 @@ namespace GUIUtil
 
 
     bool GetStartOnSystemStartup();
-    bool SetStartOnSystemStartup(bool fAutoStart);
+    bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin);
 
     /** Help message for Bitcoin-Qt, shown with --help. */
     class HelpMessageBox : public QMessageBox

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -90,14 +90,12 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     /* setup/change UI elements when proxy IP is invalid/valid */
     connect(this, SIGNAL(proxyIpValid(QValidatedLineEdit *, bool)), this, SLOT(handleProxyIpValid(QValidatedLineEdit *, bool)));
 
-    if (fTestNet)
-        ui->disableUpdateCheck->setHidden(true);
+    if (fTestNet) ui->disableUpdateCheck->setHidden(true);
 
-    ui->gridcoinAtStartupMinimised->setEnabled(false);
-    connect(ui->gridcoinAtStartup, &QCheckBox::toggled, this, [this] {
-        auto checked = ui->gridcoinAtStartup->isChecked();
-        ui->gridcoinAtStartupMinimised->setEnabled(checked);
-    });
+    ui->gridcoinAtStartupMinimised->setHidden(!ui->gridcoinAtStartup->isChecked());
+
+    connect(ui->gridcoinAtStartup, SIGNAL(toggled(bool)), this, SLOT(hideStartMinimized()));
+    connect(ui->gridcoinAtStartupMinimised, SIGNAL(toggled(bool)), this, SLOT(hideStartMinimized()));
 }
 
 OptionsDialog::~OptionsDialog()
@@ -243,6 +241,14 @@ void OptionsDialog::updateStyle()
         if ( index != -1 ) { // -1 for not found
            ui->styleComboBox->setCurrentIndex(index);
         }
+    }
+}
+
+void OptionsDialog::hideStartMinimized()
+{
+    if (model)
+    {
+        ui->gridcoinAtStartupMinimised->setHidden(!ui->gridcoinAtStartup->isChecked());
     }
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -92,6 +92,12 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
 
     if (fTestNet)
         ui->disableUpdateCheck->setHidden(true);
+
+    ui->gridcoinAtStartupMinimised->setEnabled(false);
+    connect(ui->gridcoinAtStartup, &QCheckBox::toggled, this, [this] {
+        auto checked = ui->gridcoinAtStartup->isChecked();
+        ui->gridcoinAtStartupMinimised->setEnabled(checked);
+    });
 }
 
 OptionsDialog::~OptionsDialog()
@@ -129,6 +135,7 @@ void OptionsDialog::setMapper()
     /* Main */
     mapper->addMapping(ui->reserveBalance, OptionsModel::ReserveBalance);
     mapper->addMapping(ui->gridcoinAtStartup, OptionsModel::StartAtStartup);
+    mapper->addMapping(ui->gridcoinAtStartupMinimised, OptionsModel::StartMin);
     mapper->addMapping(ui->disableUpdateCheck, OptionsModel::DisableUpdateCheck);
 
     /* Network */

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -44,6 +44,7 @@ private slots:
     void showRestartWarning_Lang();
     void updateDisplayUnit();
     void updateStyle();
+    void hideStartMinimized();
     void handleProxyIpValid(QValidatedLineEdit *object, bool fState);
 
 signals:

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -40,6 +40,7 @@ void OptionsModel::Init()
 
     // These are Qt-only settings:
     nDisplayUnit = settings.value("nDisplayUnit", BitcoinUnits::BTC).toInt();
+    fStartAtStartup = settings.value("fStartAtStartup", false).toBool();
     fStartMin = settings.value("fStartMin", true).toBool();
     fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
     fDisableTrxNotifications = settings.value("fDisableTrxNotifications", false).toBool();
@@ -77,7 +78,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         switch(index.row())
         {
         case StartAtStartup:
-            return QVariant(GUIUtil::GetStartOnSystemStartup());
+            return QVariant(fStartAtStartup);
         case StartMin:
             return QVariant(fStartMin);
         case MinimizeToTray:
@@ -136,11 +137,20 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         switch(index.row())
         {
         case StartAtStartup:
-            successful = GUIUtil::SetStartOnSystemStartup(value.toBool());
+            if (fStartAtStartup != value.toBool())
+            {
+                fStartAtStartup = value.toBool();
+                settings.setValue("fStartAtStartup", fStartAtStartup);
+                successful = GUIUtil::SetStartOnSystemStartup(fStartAtStartup, fStartMin);
+            }
             break;
         case StartMin:
-            fStartMin = value.toBool();
-            settings.setValue("fStartMin", fStartMin);
+            if (fStartMin != value.toBool())
+            {
+                fStartMin = value.toBool();
+                settings.setValue("fStartMin", fStartMin);
+                successful = GUIUtil::SetStartOnSystemStartup(fStartAtStartup, fStartMin);
+            }
             break;
         case MinimizeToTray:
             fMinimizeToTray = value.toBool();
@@ -250,11 +260,15 @@ bool OptionsModel::getCoinControlFeatures()
     return fCoinControlFeatures;
 }
 
+bool OptionsModel::getStartAtStartup()
+{
+    return fStartAtStartup;
+}
+
 bool OptionsModel::getStartMin()
 {
     return fStartMin;
 }
-
 
 bool OptionsModel::getMinimizeToTray()
 {

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -40,6 +40,7 @@ void OptionsModel::Init()
 
     // These are Qt-only settings:
     nDisplayUnit = settings.value("nDisplayUnit", BitcoinUnits::BTC).toInt();
+    fStartMin = settings.value("fStartMin", true).toBool();
     fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
     fDisableTrxNotifications = settings.value("fDisableTrxNotifications", false).toBool();
     bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
@@ -77,6 +78,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         {
         case StartAtStartup:
             return QVariant(GUIUtil::GetStartOnSystemStartup());
+        case StartMin:
+            return QVariant(fStartMin);
         case MinimizeToTray:
             return QVariant(fMinimizeToTray);
         case DisableTrxNotifications:
@@ -134,6 +137,10 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         {
         case StartAtStartup:
             successful = GUIUtil::SetStartOnSystemStartup(value.toBool());
+            break;
+        case StartMin:
+            fStartMin = value.toBool();
+            settings.setValue("fStartMin", fStartMin);
             break;
         case MinimizeToTray:
             fMinimizeToTray = value.toBool();
@@ -242,6 +249,12 @@ bool OptionsModel::getCoinControlFeatures()
 {
     return fCoinControlFeatures;
 }
+
+bool OptionsModel::getStartMin()
+{
+    return fStartMin;
+}
+
 
 bool OptionsModel::getMinimizeToTray()
 {

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -19,6 +19,7 @@ public:
     enum OptionID {
         StartAtStartup,    // bool
         MinimizeToTray,    // bool
+        StartMin,          // bool
         DisableTrxNotifications, // bool
         MapPortUPnP,       // bool
         MinimizeOnClose,   // bool
@@ -45,6 +46,7 @@ public:
     /* Explicit getters */
     qint64 getTransactionFee();
     qint64 getReserveBalance();
+    bool getStartMin();
     bool getMinimizeToTray();
     bool getDisableTrxNotifications();
     bool getMinimizeOnClose();
@@ -57,6 +59,7 @@ public:
 private:
     int nDisplayUnit;
     bool fMinimizeToTray;
+    bool fStartMin;
     bool fDisableTrxNotifications;
 	bool bDisplayAddresses;
     bool fMinimizeOnClose;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -46,6 +46,7 @@ public:
     /* Explicit getters */
     qint64 getTransactionFee();
     qint64 getReserveBalance();
+    bool getStartAtStartup();
     bool getStartMin();
     bool getMinimizeToTray();
     bool getDisableTrxNotifications();
@@ -59,6 +60,7 @@ public:
 private:
     int nDisplayUnit;
     bool fMinimizeToTray;
+    bool fStartAtStartup;
     bool fStartMin;
     bool fDisableTrxNotifications;
 	bool bDisplayAddresses;


### PR DESCRIPTION
This PR implements a conditional "Start minimized" checkbox that appears if the "Start Gridcoin on system login" is checked. The default for this new checkbox is checked (which is the current default behavior), but may be unchecked. This allows the user to specify whether a wallet started automatically on login starts minimized or normally. This is a rebase and addition to #1786.
![image](https://user-images.githubusercontent.com/7529186/88579062-71c85100-d017-11ea-9e7d-3bbb21ff1f40.png)
![image](https://user-images.githubusercontent.com/7529186/88579118-84428a80-d017-11ea-9c92-e743256c4633.png)
![image](https://user-images.githubusercontent.com/7529186/88579153-97edf100-d017-11ea-9f50-10b6025beeff.png)
