### PR TITLE
gui: Remove useless "Detach databases at shutdown"

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -98,16 +98,6 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="detachDatabases">
-         <property name="toolTip">
-          <string>Detach block and address databases at shutdown. This means they can be moved to another data directory, but it slows down shutdown. The wallet is always detached.</string>
-         </property>
-         <property name="text">
-          <string>&amp;Detach databases at shutdown</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="disableUpdateCheck">
          <property name="enabled">
           <bool>true</bool>


### PR DESCRIPTION
The "Detach databases at shutdown" UI checkbox doesn't do anything, and hasn't in a while, and the state of the checkbox does not even persist in the optionsmodel.

This has to be a throwback to when the blockchain index/transactions were in bdb. Those have been in leveldb for a long while now, and the wallet (which is still in bdb) is always flushed and an LSN_reset (essentially a detach) is issued upon successful shutdown of the wallet.

This closes #932.