### PR TITLE
test: Remove testnet condition for standard transactions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1324,8 +1324,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
     if (tx.IsCoinStake())
         return tx.DoS(100, error("AcceptToMemoryPool : coinstake as individual tx"));
 
-    // Rather not work on nonstandard transactions (unless -testnet)
-    if (!fTestNet && !IsStandardTx(tx))
+    // Rather not work on nonstandard transactions
+    if (!IsStandardTx(tx))
         return error("AcceptToMemoryPool : nonstandard transaction type");
 
     // Perform contextual validation for any contracts:


### PR DESCRIPTION
Based on feedback, this removes a condition that allows relay of non-standard transactions on testnet. The change enables testnet to more closely match the behavior on mainnet.