### PR TITLE
contract: Optimize contract replay after chain reorganization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2226,11 +2226,6 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
         {
             bDiscTxFailed = true;
         }
-
-        if (pindex->nIsContract == 1)
-        {
-            NN::RevertContracts(vtx[i], pindex);
-        }
     }
 
     // Update block index on disk without changing it in memory.

--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -319,6 +319,12 @@ bool BeaconRegistry::ContainsActive(const Cpid& cpid) const
     return ContainsActive(cpid, GetAdjustedTime());
 }
 
+void BeaconRegistry::Reset()
+{
+    m_beacons.clear();
+    m_pending.clear();
+}
+
 void BeaconRegistry::Add(const ContractContext& ctx)
 {
     BeaconPayload payload = ctx->CopyPayloadAs<BeaconPayload>();

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -466,6 +466,12 @@ public:
     bool ContainsActive(const Cpid& cpid) const;
 
     //!
+    //! \brief Destroy the contract handler state to prepare for historical
+    //! contract replay.
+    //!
+    void Reset() override;
+
+    //!
     //! \brief Determine whether a beacon contract is valid.
     //!
     //! \param contract Contains the beacon data to validate.

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -144,6 +144,15 @@ public:
 //!
 class AppCacheContractHandler : public IContractHandler
 {
+public:
+    void Reset() override
+    {
+        ClearCache(Section::POLL);
+        ClearCache(Section::PROTOCOL);
+        ClearCache(Section::SCRAPER);
+        ClearCache(Section::VOTE);
+    }
+
     bool Validate(const Contract& contract, const CTransaction& tx) const override
     {
         return true; // No contextual validation needed yet
@@ -182,6 +191,12 @@ class AppCacheContractHandler : public IContractHandler
 //!
 class UnknownContractHandler : public IContractHandler
 {
+public:
+    void Reset() override
+    {
+        // Nothing to do.
+    }
+
     bool Validate(const Contract& contract, const CTransaction& tx) const override
     {
         return true; // No contextual validation needed yet
@@ -225,6 +240,17 @@ class UnknownContractHandler : public IContractHandler
 class Dispatcher
 {
 public:
+    //!
+    //! \brief Reset the cached state of each contract handler to prepare for
+    //! historical contract replay.
+    //!
+    void ResetHandlers()
+    {
+        GetBeaconRegistry().Reset();
+        GetWhitelist().Reset();
+        m_appcache_handler.Reset();
+    }
+
     //!
     //! \brief Validate the provided contract and forward it to the appropriate
     //! contract handler.
@@ -342,6 +368,8 @@ void NN::ReplayContracts(const CBlockIndex* pindex)
     if (pindex->nHeight < (fTestNet ? 1 : 164618)) {
        return;
     }
+
+    g_dispatcher.ResetHandlers();
 
     CBlock block;
 

--- a/src/neuralnet/contract/handler.h
+++ b/src/neuralnet/contract/handler.h
@@ -78,6 +78,12 @@ struct IContractHandler
     virtual bool Validate(const Contract& contract, const CTransaction& tx) const = 0;
 
     //!
+    //! \brief Destroy the contract handler state to prepare for historical
+    //! contract replay.
+    //!
+    virtual void Reset() = 0;
+
+    //!
     //! \brief Handle an contract addition.
     //!
     //! \param ctx References the contract and associated context.

--- a/src/neuralnet/project.cpp
+++ b/src/neuralnet/project.cpp
@@ -154,6 +154,11 @@ WhitelistSnapshot Whitelist::Snapshot() const
     return WhitelistSnapshot(std::atomic_load(&m_projects));
 }
 
+void Whitelist::Reset()
+{
+    std::atomic_store(&m_projects, std::make_shared<ProjectList>());
+}
+
 void Whitelist::Add(const ContractContext& ctx)
 {
     Project project = ctx->CopyPayloadAs<Project>();

--- a/src/neuralnet/project.h
+++ b/src/neuralnet/project.h
@@ -281,6 +281,12 @@ public:
     WhitelistSnapshot Snapshot() const;
 
     //!
+    //! \brief Destroy the contract handler state to prepare for historical
+    //! contract replay.
+    //!
+    void Reset() override;
+
+    //!
     //! \brief Perform contextual validation for the provided contract.
     //!
     //! \param contract Contract to validate.


### PR DESCRIPTION
This improves the performance of contract replay when the chain reorganizes. Instead of reverting each contract for each of the disconnected blocks, we can just wipe the cached state for each of the contract handlers. Replay fills the caches with 6 months of contract data again afterward.

This partially solves the unnecessary retention of contracts in memory for long-running nodes because the reorganization occurs
often enough that nodes will clear historical data before these caches grow too large. Future improvements will enable contract
handlers to manage historical data more precisely.