### PR TITLE
contract: Reimplement transaction messages as contracts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ GRIDCOIN_CORE_H = \
     neuralnet/researcher.h \
     neuralnet/superblock.h \
     neuralnet/tally.h \
+    neuralnet/tx_message.h \
     neuralnet/voting/builders.h \
     neuralnet/voting/claims.h \
     neuralnet/voting/fwd.h \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "neuralnet/researcher.h"
 #include "neuralnet/superblock.h"
 #include "neuralnet/tally.h"
+#include "neuralnet/tx_message.h"
 #include "backup.h"
 #include "appcache.h"
 #include "scraper_net.h"
@@ -1181,6 +1182,25 @@ bool CTransaction::HasMasterKeyInput(const MapPrevTx& inputs) const
     }
 
     return false;
+}
+
+std::string CTransaction::GetMessage() const
+{
+    if (nVersion <= 1) {
+        return ExtractXML(hashBoinc, "<MESSAGE>", "</MESSAGE>");
+    }
+
+    if (vContracts.empty()) {
+        return std::string();
+    }
+
+    if (vContracts.front().m_type != NN::ContractType::MESSAGE) {
+        return std::string();
+    }
+
+    const auto payload = vContracts.front().SharePayloadAs<NN::TxMessage>();
+
+    return payload->m_message;
 }
 
 int64_t CTransaction::GetBaseFee(enum GetMinFee_mode mode) const

--- a/src/main.h
+++ b/src/main.h
@@ -901,6 +901,11 @@ public:
         return std::move(vContracts);
     }
 
+    //!
+    //! \brief Get the custom, user-supplied transaction message, if any.
+    //!
+    std::string GetMessage() const;
+
     bool GetCoinAge(CTxDB& txdb, uint64_t& nCoinAge) const;  // ppcoin: get transaction coin age
 
 protected:

--- a/src/neuralnet/contract/contract.h
+++ b/src/neuralnet/contract/contract.h
@@ -716,7 +716,10 @@ void ApplyContracts(
 //! \param tx     Transaction to extract contracts from.
 //! \param pindex Block index for the block that contains the transaction.
 //!
-void ApplyContracts(const CTransaction& tx, const CBlockIndex* const pindex);
+void ApplyContracts(
+    const CTransaction& tx,
+    const CBlockIndex* const pindex,
+    bool& out_found_contract);
 
 //!
 //! \brief Perform contextual validation for the contracts in a transaction.

--- a/src/neuralnet/tx_message.h
+++ b/src/neuralnet/tx_message.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "neuralnet/contract/payload.h"
+
+#include <string>
+
+namespace NN {
+//!
+//! \brief An arbitrary, user-supplied message attached to a transaction.
+//!
+//! This contract type does not have any associated protocol behavior. It
+//! replaces the message feature that stored a transaction message in the
+//! legacy \c hashBoinc field of a transaction object. It allows users to
+//! affix arbitrary data to a transaction.
+//!
+class TxMessage : public IContractPayload
+{
+public:
+    std::string m_message; //!< The content of the transaction message.
+
+    //!
+    //! \brief Initialize an empty, invalid transaction message.
+    //!
+    TxMessage()
+    {
+    }
+
+    //!
+    //! \brief Initialize a transaction message from the supplied string.
+    //!
+    //! \param message An arbitrary, user-supplied string.
+    //!
+    TxMessage(std::string message) : m_message(std::move(message))
+    {
+    }
+
+    //!
+    //! \brief Get the type of contract that this payload contains data for.
+    //!
+    NN::ContractType ContractType() const override
+    {
+        return NN::ContractType::MESSAGE;
+    }
+
+    //!
+    //! \brief Determine whether the object contains a well-formed payload.
+    //!
+    //! \param action The action declared for the contract that contains the
+    //! payload. It may determine how to validate the payload.
+    //!
+    //! \return \c true if the payload is complete.
+    //!
+    bool WellFormed(const ContractAction action) const override
+    {
+        return !m_message.empty();
+    }
+
+    //!
+    //! \brief Get a string for the key used to construct a legacy contract.
+    //!
+    std::string LegacyKeyString() const override
+    {
+        return std::string();
+    }
+
+    //!
+    //! \brief Get a string for the value used to construct a legacy contract.
+    //!
+    std::string LegacyValueString() const override
+    {
+        return m_message;
+    }
+
+    //!
+    //! \brief Get the burn fee amount required to send a particular contract.
+    //!
+    //! \return Burn fee in units of 1/100000000 GRC.
+    //!
+    int64_t RequiredBurnAmount() const override
+    {
+        // Flat rate up to first KB:
+        if (m_message.size() <= 1000) {
+            return 0.001 * COIN;
+        }
+
+        // 0.001 GRC per KB:
+        return m_message.size() * 100;
+    }
+
+    ADD_CONTRACT_PAYLOAD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(
+        Stream& s,
+        Operation ser_action,
+        const NN::ContractAction action)
+    {
+        READWRITE(m_message);
+    }
+}; // TxMessage
+}

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -274,6 +274,15 @@ void SendCoinsDialog::updateRemoveEnabled()
         if(entry)
         {
             entry->setRemoveEnabled(enabled);
+
+            // Transactions can only contain one message. Hide the message field
+            // for all but the first output entry.
+            //
+            // TODO: separate the message field from the context of each output.
+            // Leaving this field in the first output group gives the impression
+            // that only the first recipient can see the message.
+            //
+            entry->setMessageEnabled(i == 0);
         }
     }
     setupTabChain(0);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -81,12 +81,23 @@ void SendCoinsEntry::setRemoveEnabled(bool enabled)
     ui->deleteButton->setEnabled(enabled);
 }
 
+void SendCoinsEntry::setMessageEnabled(bool enabled)
+{
+    ui->messageLabel->setVisible(enabled);
+    ui->messageText->setVisible(enabled);
+
+    if (!enabled) {
+        ui->messageText->clear();
+    }
+}
+
 void SendCoinsEntry::clear()
 {
     ui->payTo->clear();
     ui->addAsLabel->clear();
     ui->payAmount->clear();
     ui->payTo->setFocus();
+    ui->messageText->clear();
     // update the display unit, to not use the default ("BTC")
     updateDisplayUnit();
 }

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -35,6 +35,7 @@ public:
 
 public slots:
     void setRemoveEnabled(bool enabled);
+    void setMessageEnabled(bool enabled);
     void clear();
 
 signals:
@@ -48,7 +49,7 @@ private slots:
     void on_pasteButton_clicked();
     void updateDisplayUnit();
     void updateIcons();
-    
+
 private:
     Ui::SendCoinsEntry *ui;
     WalletModel *model;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -333,9 +333,9 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
         for (auto const& vTxStakeInfo : vTxStakeInfoIn)
         {
             strHTML += "<b>";
-            strHTML += MakeSafeMessage(vTxStakeInfo.first).c_str();
+            strHTML += vTxStakeInfo.first.c_str();
             strHTML += ": </b>";
-            strHTML += MakeSafeMessage(vTxStakeInfo.second).c_str();
+            strHTML += vTxStakeInfo.second.c_str();
             strHTML += "<br>";
         }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -314,6 +314,16 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
     else
         strHTML += "<b>" + tr("Block Hash") + ":</b> " + sHashBlock.c_str() + "<br>";
 
+    const std::string tx_message = wtx.GetMessage();
+
+    if (!tx_message.empty())
+    {
+        strHTML += "<br>";
+        strHTML += "<b>" + tr("Message") + ":</b> ";
+        strHTML += GUIUtil::HtmlEscape(tx_message);
+        strHTML += "<br>";
+    }
+
     if (wtx.IsCoinBase() || wtx.IsCoinStake())
     {
         strHTML += "<hr><br><b>" + tr("Transaction Stake Data") + "</b><br><br>";

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -19,6 +19,7 @@
 #include "neuralnet/researcher.h"
 #include "neuralnet/superblock.h"
 #include "neuralnet/tally.h"
+#include "neuralnet/tx_message.h"
 #include "backup.h"
 #include "appcache.h"
 #include "util.h"
@@ -555,7 +556,9 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
 
     CWalletTx wtx;
     wtx.mapValue["comment"] = "Rain By Magnitude";
-    wtx.hashBoinc = "<NARR>Rain By Magnitude: " + MakeSafeMessage(sMessage) + "</NARR>";
+    wtx.vContracts.emplace_back(NN::MakeContract<NN::TxMessage>(
+        NN::ContractAction::ADD,
+        "Rain By Magnitude: " + sMessage));
 
     EnsureWalletIsUnlocked();
     // Check funds

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -11,6 +11,7 @@
 #include "neuralnet/contract/contract.h"
 #include "neuralnet/project.h"
 #include "neuralnet/superblock.h"
+#include "neuralnet/tx_message.h"
 #include "neuralnet/voting/payloads.h"
 #include "rpcprotocol.h"
 #include "rpcserver.h"
@@ -148,6 +149,13 @@ UniValue RawClaimToJson(const NN::ContractPayload& payload)
     return json;
 }
 
+UniValue MessagePayloadToJson(const NN::ContractPayload& payload)
+{
+    const auto& tx_message = payload.As<NN::TxMessage>();
+
+    return tx_message.m_message;
+}
+
 UniValue PollPayloadToJson(const NN::ContractPayload& payload)
 {
     const auto& poll = payload.As<NN::PollPayload>();
@@ -236,6 +244,9 @@ UniValue ContractToJson(const NN::Contract& contract)
             break;
         case NN::ContractType::CLAIM:
             out.pushKV("body", RawClaimToJson(contract.SharePayload()));
+            break;
+        case NN::ContractType::MESSAGE:
+            out.pushKV("body", MessagePayloadToJson(contract.SharePayload()));
             break;
         case NN::ContractType::POLL:
             out.pushKV("body", PollPayloadToJson(contract.SharePayload()));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1065,36 +1065,6 @@ bool NewThread(void(*pfn)(void*), void* parg)
     return true;
 }
 
-// Convert characters that can potentially cause problems to safe html
-std::string MakeSafeMessage(const std::string& messagestring)
-{
-    std::string safemessage = "";
-    safemessage.reserve(messagestring.size());
-    try
-    {
-        for (auto chk : messagestring)
-        {
-            switch(chk)
-            {
-                case '&':     safemessage += "&amp;";     break;
-                case '\'':    safemessage += "&apos;";    break;
-                case '\\':    safemessage += "&#92;";     break;
-                case '\"':    safemessage += "&quot;";    break;
-                case '>':     safemessage += "&gt;";      break;
-                case '<':     safemessage += "&lt;";      break;
-                case '\0':                                break;
-                default:      safemessage += chk;         break;
-            }
-        }
-    }
-    catch (...)
-    {
-        LogPrintf("Exception occurred in MakeSafeMessage. Returning an empty message.");
-        safemessage = "";
-    }
-    return safemessage;
-}
-
 bool ThreadHandler::createThread(void(*pfn)(ThreadHandlerPtr), ThreadHandlerPtr parg, const std::string tname)
 {
     try

--- a/src/util.h
+++ b/src/util.h
@@ -229,8 +229,6 @@ std::string ToString(const T& val)
 bool Contains(const std::string& data, const std::string& instring);
 std::vector<std::string> split(const std::string& s, const std::string& delim);
 
-std::string MakeSafeMessage(const std::string& messagestring);
-
 inline int roundint(double d)
 {
     return (int)(d > 0 ? d + 0.5 : d - 0.5);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -13,6 +13,7 @@
 #include "streams.h"
 #include "util.h"
 #include "miner.h"
+#include "neuralnet/tx_message.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #include "wallet/ismine.h"
@@ -396,7 +397,8 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp)
     if (params.size() > 3 && !params[3].isNull() && !params[3].get_str().empty())
         wtx.mapValue["to"]      = params[3].get_str();
     if (params.size() > 4 && !params[4].isNull() && !params[4].get_str().empty())
-        wtx.hashBoinc += "<MESSAGE>" + MakeSafeMessage(params[4].get_str()) + "</MESSAGE>";
+        wtx.vContracts.emplace_back(
+            NN::MakeContract<NN::TxMessage>(NN::ContractAction::ADD, params[4].get_str()));
 
     if (pwalletMain->IsLocked())
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
@@ -832,7 +834,8 @@ UniValue sendfrom(const UniValue& params, bool fHelp)
     if (params.size() > 5 && !params[5].isNull() && !params[5].get_str().empty())
         wtx.mapValue["to"]      = params[5].get_str();
     if (params.size() > 6 && !params[6].isNull() && !params[6].get_str().empty())
-        wtx.hashBoinc += "<MESSAGE>" + MakeSafeMessage(params[6].get_str()) + "</MESSAGE>";
+        wtx.vContracts.emplace_back(
+            NN::MakeContract<NN::TxMessage>(NN::ContractAction::ADD, params[6].get_str()));
 
     EnsureWalletIsUnlocked();
 


### PR DESCRIPTION
Block version 11 removes the `CTransaction::hashBoinc` field from the protocol. This field stored user-supplied transaction messages. This change reimplements the storage as a type of contract.

The GUI "send coins" form displayed a message field for each recipient (output) field set. Gridcoin never properly supported adding a message for each recipient. I updated the form to hide the message field for all but the first recipient. 