### PR TITLE
staking: Sign claim contracts with coinstake transaction

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -133,6 +133,12 @@ inline bool IsV11Enabled(int nHeight)
     return nHeight >= GetV11Threshold();
 }
 
+// TODO: remove this after testnet transition completes:
+inline bool IsTemporaryTestnetTransitionComplete(int nHeight)
+{
+    return nHeight >= 1331000;
+}
+
 inline int GetSuperblockAgeSpacing(int nHeight)
 {
     return (fTestNet ? 86400 : (nHeight > 364500) ? 86400 : 43200);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1025,6 +1025,11 @@ bool CreateGridcoinReward(
         claim.m_version = 1;
     }
 
+    // TODO: remove this after testnet transition completes:
+    if (!IsTemporaryTestnetTransitionComplete(pindexPrev->nHeight + 1)) {
+        claim.m_version = 2;
+    }
+
     // If a researcher's beacon expired, generate the block as an investor. We
     // cannot sign a research claim without the beacon key, so this avoids the
     // issue that prevents a researcher from staking blocks if the beacon does

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -82,19 +82,14 @@ bool ReturnMinerError(CMinerStatus& status, CMinerStatus::ReasonNotStakingCatego
 //!
 //! \brief Sign the research reward claim context for a newly-minted block.
 //!
-//! \param pwallet         Supplys beacon private keys for signing.
-//! \param claim           An initialized claim to sign for a block.
-//! \param block_timestamp Creation time of the claim.
-//! \param last_block_hash Hash of the previous block to sign into the claim.
+//! \param pwallet Supplies beacon private keys for signing.
+//! \param claim   An initialized claim to sign for a block.
+//! \param block   Block that contains the claim.
 //!
 //! \return \c true if the miner holds active beacon keys used to successfully
 //! sign the claim.
 //!
-bool SignClaim(
-    CWallet* pwallet,
-    NN::Claim& claim,
-    const int64_t block_timestamp,
-    const uint256& last_block_hash)
+bool SignClaim(CWallet* pwallet, NN::Claim& claim, const CBlock& block)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(pwallet->cs_wallet);
@@ -111,7 +106,7 @@ bool SignClaim(
         return error("%s: No active beacon", __func__);
     }
 
-    if (beacon->Expired(block_timestamp)) {
+    if (beacon->Expired(block.nTime)) {
         return error("%s: Beacon expired", __func__);
     }
 
@@ -125,7 +120,7 @@ bool SignClaim(
         return error("%s: Invalid beacon key", __func__);
     }
 
-    if (!claim.Sign(beacon_key, last_block_hash)) {
+    if (!claim.Sign(beacon_key, block.hashPrevBlock, block.vtx[1])) {
         return error("%s: Signature failed. Check beacon key", __func__);
     }
 
@@ -133,7 +128,7 @@ bool SignClaim(
              "%s: Signed for CPID %s and block hash %s with signature %s",
              __func__,
              cpid->ToString(),
-             last_block_hash.ToString(),
+             block.hashPrevBlock.ToString(),
              HexStr(claim.m_signature));
 
     return true;
@@ -1079,7 +1074,7 @@ bool CreateGridcoinReward(
         claim.m_magnitude_unit = NN::Tally::GetMagnitudeUnit(pindexPrev);
     }
 
-    if (!SignClaim(pwallet, claim, blocknew.nTime, blocknew.hashPrevBlock)) {
+    if (!SignClaim(pwallet, claim, blocknew)) {
         LogPrintf("%s: Failed to sign researcher claim. Staking as investor", __func__);
 
         nReward -= claim.m_research_subsidy;

--- a/src/neuralnet/claim.h
+++ b/src/neuralnet/claim.h
@@ -29,7 +29,7 @@ public:
     //! ensure that the serialization/deserialization routines also handle all
     //! of the previous versions.
     //!
-    static constexpr uint32_t CURRENT_VERSION = 2;
+    static constexpr uint32_t CURRENT_VERSION = 3;
 
     //!
     //! \brief The maximum length of a serialized client version in a claim.
@@ -57,6 +57,8 @@ public:
     //!
     //! Version 2: Claim data serializable in binary format. Stored in a block
     //! as the first contract in the coinbase transaction.
+    //!
+    //! Version 3: Includes the coinstake transaction in the signature.
     //!
     uint32_t m_version = CURRENT_VERSION;
 
@@ -311,11 +313,16 @@ public:
     //! with.
     //! \param last_block_hash Hash of the block that preceeds the block that
     //! contains the claim.
+    //! \param coinstake_tx    Coinstake transaction of the block that contains
+    //! the claim.
     //!
     //! \return \c false if the claim does not contain a valid CPID or if the
     //! signing fails.
     //!
-    bool Sign(CKey& private_key, const uint256& last_block_hash);
+    bool Sign(
+        CKey& private_key,
+        const uint256& last_block_hash,
+        const CTransaction& coinstake_tx);
 
     //!
     //! \brief Validate the authenticity of a research reward claim by verifying
@@ -325,12 +332,15 @@ public:
     //! claim.
     //! \param last_block_hash Hash of the block that preceeds the block that
     //! contains the claim.
+    //! \param coinstake_tx    Coinstake transaction of the block that contains
+    //! the claim.
     //!
     //! \return \c true if the signature check passes using the supplied key.
     //!
     bool VerifySignature(
         const CPubKey& public_key,
-        const uint256& last_block_hash) const;
+        const uint256& last_block_hash,
+        const CTransaction& coinstake_tx) const;
 
     //!
     //! \brief Compute a hash of the claim data.

--- a/src/neuralnet/voting/builders.cpp
+++ b/src/neuralnet/voting/builders.cpp
@@ -1104,6 +1104,11 @@ PollBuilder PollBuilder::AddChoice(std::string label)
 
 CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet)
 {
+    // TODO: remove this after testnet transition completes:
+    if (!IsTemporaryTestnetTransitionComplete(nBestHeight + 1)) {
+        throw VotingError("Voting temporarily disabled.");
+    }
+
     if (!pwallet) {
         throw VotingError(_("No wallet available."));
     }
@@ -1256,6 +1261,11 @@ VoteBuilder VoteBuilder::AddResponse(const std::string& label)
 
 CWalletTx VoteBuilder::BuildContractTx(CWallet* const pwallet)
 {
+    // TODO: remove this after testnet transition completes:
+    if (!IsTemporaryTestnetTransitionComplete(nBestHeight + 1)) {
+        throw VotingError("Voting temporarily disabled.");
+    }
+
     if (!pwallet) {
         throw VotingError(_("No wallet available."));
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1667,8 +1667,13 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
     if (!wtxNew.vContracts.empty()
         && wtxNew.vContracts[0].m_type == NN::ContractType::MESSAGE)
     {
-        message_fee = wtxNew.vContracts[0].RequiredBurnAmount();
-        nValueOut += message_fee;
+        // TODO: remove this after testnet transition completes:
+        if (!IsTemporaryTestnetTransitionComplete(nBestHeight + 1)) {
+            wtxNew.vContracts.pop_back();
+        } else {
+            message_fee = wtxNew.vContracts[0].RequiredBurnAmount();
+            nValueOut += message_fee;
+        }
     }
 
     wtxNew.BindWallet(this);


### PR DESCRIPTION
This adds the coinstake transaction to the signature for research reward claims to more closely associate the claim with a block.

The PR includes temporary transitional code for the final testnet hard fork for voting improvements and transaction messages.