### PR TITLE
gui: Fix translations for port numbers

### DIFF
--- a/src/qt/locale/bitcoin_af_ZA.ts
+++ b/src/qt/locale/bitcoin_af_ZA.ts
@@ -4221,7 +4221,7 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
     <message>
         <location line="+78"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Luister vir verbindings op &lt;port&gt; (verstek: 15714 of testnet: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Luister vir verbindings op &lt;port&gt; (verstek: 32749 of testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_ca_ES.ts
+++ b/src/qt/locale/bitcoin_ca_ES.ts
@@ -3807,7 +3807,7 @@ En aquest cas es requereix una comisió d&apos;almenys 2%.</translation>
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Escoltar connexions en &lt;port&gt; (per defecte: 15714 o testnet: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Escoltar connexions en &lt;port&gt; (per defecte: 32749 o testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -3806,7 +3806,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Naslouchej připojením na &lt;port&gt; (výchozí: 15714 nebo testovací síť: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Naslouchej připojením na &lt;port&gt; (výchozí: 32749 nebo testovací síť: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -3811,7 +3811,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Lyt efter forbindelser på &lt;port&gt; (default: 15714 eller Testnet: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Lyt efter forbindelser på &lt;port&gt; (default: 32749 eller Testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -3812,7 +3812,7 @@ Dieses Label wird rot, wenn die Priorität kleiner ist als Mittel.
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Höre auf Verbindungen auf &lt;port&gt; (default: 15714 oder Testnetz: 25714)  {32749 ?} {32748)?}</translation>
+        <translation>Höre auf Verbindungen auf &lt;port&gt; (default: 32749 oder Testnetz: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -4287,7 +4287,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Listen for connections on &lt;port&gt; (default: 15714 or testnet: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</translation>
     </message>
     <message>
         <location line="-54"/>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -3680,7 +3680,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Kuuntele yhteyksiä portissa &lt;port&gt; (oletus: 15714 tai testiverkko: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Kuuntele yhteyksiä portissa &lt;port&gt; (oletus: 32749 tai testiverkko: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_fr_CA.ts
+++ b/src/qt/locale/bitcoin_fr_CA.ts
@@ -4231,7 +4231,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     <message>
         <location line="+78"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Écouter les connexions sur le &lt;port&gt; (default: 15714 or testnet: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Écouter les connexions sur le &lt;port&gt; (default: 32749 or testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -3643,7 +3643,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">&lt;port&gt; で 接続をリスン (デフォルト: 15714かtestnet は 25714) {32749 ?} {32748)?}</translation>
+        <translation>&lt;port&gt; で 接続をリスン (デフォルト: 32749かtestnet は 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -3681,7 +3681,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Luister voor verbindingen op &lt;poort&gt; (standaard: 15714 of testnet: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Luister voor verbindingen op &lt;poort&gt; (standaard: 32749 of testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -3689,7 +3689,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Ascult? pentru conect?ri pe &lt;port&gt; (implicit:  15714 sau testnet: 25714)  {32749 ?} {32748)?}</translation>
+        <translation>Ascult? pentru conect?ri pe &lt;port&gt; (implicit: 32749 sau testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -3701,7 +3701,7 @@ To znamená, že je potrebný poplatok aspoň %2.</translation>
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Po?úva? pripojenia na &lt;port&gt; (predvolené: 15714 alebo testovacia sie?: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Po?úva? pripojenia na &lt;port&gt; (predvolené: 32749 alebo testovacia sie?: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -3702,7 +3702,7 @@ Ta oznaka se obarva rde?e, ?e je prioriteta manjša kot &quot;srednja&quot;.
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Sprejmi povezave na &lt;port&gt; (privzeta vrata: 15714 ali testnet: 25714)  {32749 ?} {32748)?}</translation>
+        <translation>Sprejmi povezave na &lt;port&gt; (privzeta vrata: 32749 ali testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -3698,7 +3698,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">Lyssna efter anslutningar på &lt;port&gt; (standard: 15714 eller testnät: 25714) {32749 ?} {32748)?}</translation>
+        <translation>Lyssna efter anslutningar på &lt;port&gt; (standard: 32749 eller testnät: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -3680,7 +3680,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation type="unfinished">&lt;port&gt; üzerinde bağlantıları dinle (varsayılan: 15714 veya testnet: 25714) {32749 ?} {32748)?}</translation>
+        <translation>&lt;port&gt; üzerinde bağlantıları dinle (varsayılan: 32749 veya testnet: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -4038,7 +4038,7 @@ rpcpassword=&lt;password&gt;
     <message>
         <location line="-94"/>
         <source>Listen for connections on &lt;port&gt; (default: 32749 or testnet: 32748)</source>
-        <translation>使用&lt;port&gt;端口监听连接 (默认: 15714 或测试网络: 25714) {32749 ?} {32748)?}</translation>
+        <translation>使用&lt;port&gt;端口监听连接 (默认: 32749 或测试网络: 32748)</translation>
     </message>
     <message>
         <location line="+9"/>


### PR DESCRIPTION
Somehow this entry was botched for several locales in a way that prevented the automatic update from applying. This manually fixes the translations for the `-port` option help message. Closes #1790.