### PR TITLE
gui: Change research wizard text

### DIFF
--- a/src/qt/forms/researcherwizardinvestorpage.ui
+++ b/src/qt/forms/researcherwizardinvestorpage.ui
@@ -91,7 +91,7 @@
    <item alignment="Qt::AlignVCenter">
     <widget class="QLabel" name="investorLabel">
      <property name="text">
-     <string>You have opted out of research rewards and will only be able to earn staking rewards.</string>
+     <string>You opted out of research rewards and will earn staking rewards only.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -104,7 +104,7 @@
    <item>
     <widget class="QLabel" name="startOverLabel">
      <property name="text">
-      <string>Press &quot;Start Over&quot; to switch modes.</string>
+      <string>Press &quot;Start Over&quot; if you want to switch modes.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/qt/forms/researcherwizardinvestorpage.ui
+++ b/src/qt/forms/researcherwizardinvestorpage.ui
@@ -91,7 +91,7 @@
    <item alignment="Qt::AlignVCenter">
     <widget class="QLabel" name="investorLabel">
      <property name="text">
-      <string>Gridcoin will not participate in the research reward protocol. Your wallet will earn staking rewards only.</string>
+     <string>You have opted out of research rewards and will only be able to earn staking rewards.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -104,7 +104,7 @@
    <item>
     <widget class="QLabel" name="startOverLabel">
      <property name="text">
-      <string>Press &quot;start over&quot; to switch modes.</string>
+      <string>Press &quot;Start Over&quot; to switch modes.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/qt/forms/researcherwizardpoolpage.ui
+++ b/src/qt/forms/researcherwizardpoolpage.ui
@@ -91,7 +91,7 @@
    <item alignment="Qt::AlignVCenter">
     <widget class="QLabel" name="poolParagraphLabel">
      <property name="text">
-      <string>In this mode, the pool will take care of staking research rewards for you. You only need to sign up to the pool (BOINC account and beacon not needed). You will still be able to earn staking rewards regardless. Please choose a pool and follow the instructions on the website to sign up and connect the pool's account manager to BOINC:</string>
+      <string>In this mode, a pool will take care of staking research rewards for you. Your wallet can still earn standard staking rewards on your balance. You do not need a BOINC account, CPID, or beacon. Please choose a pool and follow the instructions on the website to sign up and connect the pool's account manager to BOINC:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -186,7 +186,7 @@
    <item>
     <widget class="QLabel" name="addressParagraphLabel">
      <property name="text">
-      <string>While signing up, the pool may ask for a payment address to send earnings to. Press the button below to generate an address.</string>
+      <string>As you sign up, the pool may ask for a payment address to send earnings to. Press the button below to generate an address.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/qt/forms/researcherwizardpoolpage.ui
+++ b/src/qt/forms/researcherwizardpoolpage.ui
@@ -91,7 +91,7 @@
    <item alignment="Qt::AlignVCenter">
     <widget class="QLabel" name="poolParagraphLabel">
      <property name="text">
-      <string>In pool mode, Gridcoin will not claim research rewards directly. The pool will collect and distribute research rewards on your behalf. Your wallet will earn staking rewards only (you do not need a BOINC account, CPID, or beacon). Please choose a pool and follow the instructions on the website to sign up and connect the pool's account manager to BOINC:</string>
+      <string>In this mode, the pool will take care of staking research rewards for you. You only need to sign up to the pool (BOINC account and beacon not needed). You will still be able to earn staking rewards regardless. Please choose a pool and follow the instructions on the website to sign up and connect the pool's account manager to BOINC:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -186,7 +186,7 @@
    <item>
     <widget class="QLabel" name="addressParagraphLabel">
      <property name="text">
-      <string>When signing up, the pool may ask for a payment address to send earnings to. Press the button to generate an address:</string>
+      <string>While signing up, the pool may ask for a payment address to send earnings to. Press the button below to generate an address.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -267,7 +267,7 @@
    <item>
     <widget class="QLabel" name="startOverLabel">
      <property name="text">
-      <string>Press &quot;next&quot; when finished.</string>
+      <string>Press &quot;Next&quot; when you are done.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/qt/researcher/researcherwizard.cpp
+++ b/src/qt/researcher/researcherwizard.cpp
@@ -3,6 +3,7 @@
 #include "qt/researcher/researcherwizard.h"
 
 #include <cassert>
+#include <QAbstractButton>
 
 namespace {
 //!
@@ -80,6 +81,13 @@ void ResearcherWizard::configureStartOverButton()
     setButtonText(START_OVER_BUTTON, tr("&Start Over"));
     connect(this, SIGNAL(customButtonClicked(int)),
             this, SLOT(onCustomButtonClicked(int)));
+    connect(this, SIGNAL(currentIdChanged(int)),
+            this, SLOT(setStartOverButtonVisibility(int)));
+}
+
+void ResearcherWizard::setStartOverButtonVisibility(int page_id)
+{
+    button(START_OVER_BUTTON)->setVisible(page_id > 0);
 }
 
 void ResearcherWizard::onCustomButtonClicked(int which)

--- a/src/qt/researcher/researcherwizard.h
+++ b/src/qt/researcher/researcherwizard.h
@@ -56,6 +56,7 @@ private:
     void configureStartOverButton();
 
 private slots:
+    void setStartOverButtonVisibility(int page_id);
     void onCustomButtonClicked(int which);
     void onDetailLinkButtonClicked();
     void onRenewBeaconButtonClicked();


### PR DESCRIPTION
Changes the pool and investor research wizard page texts. I feel like the old text feels more like it's written for devs than the end user but I still want to hear @cyrossignol 's opinion.