### PR TITLE
util: Create parent directory

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -615,7 +615,7 @@ const fs::path &GetDataDir(bool fNetSpecific)
         path /= "testnet";
     }
 
-    if (!fs::exists(path)) fs::create_directory(path);
+    if (!fs::exists(path)) fs::create_directories(path);
 
     cachedPath[fNetSpecific] = true;
 


### PR DESCRIPTION
`GetDataDir` fails to create `$HOME/.GridcoinResearch/testnet` if `$HOME/.GridcoinResearch` directory is not present, this PR fixes that.