### PR TITLE
net: Update protocol version and clean up net messaging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5096,24 +5096,22 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if (strCommand == "ping")
     {
         std::string acid = "";
-        if (pfrom->nVersion > BIP0031_VERSION)
-        {
-            uint64_t nonce = 0;
-            vRecv >> nonce >> acid;
+        uint64_t nonce = 0;
 
-            // Echo the message back with the nonce. This allows for two useful features:
-            //
-            // 1) A remote node can quickly check if the connection is operational
-            // 2) Remote nodes can measure the latency of the network thread. If this node
-            //    is overloaded it won't respond to pings quickly and the remote node can
-            //    avoid sending us more work, like chain download requests.
-            //
-            // The nonce stops the remote getting confused between different pings: without
-            // it, if the remote node sends a ping once per second and this node takes 5
-            // seconds to respond to each, the 5th ping the remote sends would appear to
-            // return very quickly.
-            pfrom->PushMessage("pong", nonce);
-        }
+        vRecv >> nonce >> acid;
+
+        // Echo the message back with the nonce. This allows for two useful features:
+        //
+        // 1) A remote node can quickly check if the connection is operational
+        // 2) Remote nodes can measure the latency of the network thread. If this node
+        //    is overloaded it won't respond to pings quickly and the remote node can
+        //    avoid sending us more work, like chain download requests.
+        //
+        // The nonce stops the remote getting confused between different pings: without
+        // it, if the remote node sends a ping once per second and this node takes 5
+        // seconds to respond to each, the 5th ping the remote sends would appear to
+        // return very quickly.
+        pfrom->PushMessage("pong", nonce);
     }
     else if (strCommand == "pong")
     {
@@ -5392,17 +5390,10 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         }
         pto->fPingQueued = false;
         pto->nPingUsecStart = GetTimeMicros();
-        if (pto->nVersion > BIP0031_VERSION)
-        {
-            pto->nPingNonceSent = nonce;
-            std::string acid = GetCommandNonce("ping");
-            pto->PushMessage("ping", nonce, acid);
-        } else
-        {
-            // Peer is too old to support ping command with nonce, pong will never arrive.
-            pto->nPingNonceSent = 0;
-            pto->PushMessage("ping");
-        }
+        pto->nPingNonceSent = nonce;
+
+        std::string acid = GetCommandNonce("ping");
+        pto->PushMessage("ping", nonce, acid);
     }
 
     // Resend wallet transactions that haven't gotten in a block yet

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4563,11 +4563,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
 
             // Get recent addresses
-            if (pfrom->fOneShot || pfrom->nVersion >= CADDR_TIME_VERSION || addrman.size() < 1000)
-            {
-                pfrom->PushMessage("getaddr");
-                pfrom->fGetAddr = true;
-            }
+            pfrom->PushMessage("getaddr");
+            pfrom->fGetAddr = true;
             addrman.Good(pfrom->addr);
         }
         else
@@ -4632,9 +4629,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vector<CAddress> vAddr;
         vRecv >> vAddr;
 
-        // Don't want addr from older versions unless seeding
-        if (pfrom->nVersion < CADDR_TIME_VERSION && addrman.size() > 1000)
-            return true;
         if (vAddr.size() > 1000)
         {
             pfrom->Misbehaving(10);
@@ -4676,8 +4670,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     multimap<uint256, CNode*> mapMix;
                     for (auto const& pnode : vNodes)
                     {
-                        if (pnode->nVersion < CADDR_TIME_VERSION)
-                            continue;
                         unsigned int nPointer;
                         memcpy(&nPointer, &pnode, sizeof(nPointer));
                         uint256 hashKey = ArithToUint256(UintToArith256(hashRand) ^ nPointer);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4443,20 +4443,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         int64_t timedrift = std::abs(GetAdjustedTime() - nTime);
 
-            if (timedrift > (8*60))
-            {
+        if (timedrift > (8*60))
+        {
             LogPrint(BCLog::LogFlags::NOISY, "Disconnecting unauthorized peer with Network Time so far off by %" PRId64 " seconds!", timedrift);
             pfrom->Misbehaving(100);
-            pfrom->fDisconnect = true;
-            return false;
-        }
-
-
-        // Ensure testnet users are running latest version as of 12-3-2015 (works in conjunction with block spamming)
-        if (pfrom->nVersion < 180321 && fTestNet)
-        {
-            // disconnect from peers older than this proto version
-            LogPrint(BCLog::LogFlags::NOISY, "Testnet partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;
         }
@@ -4469,24 +4459,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-        if (pfrom->nVersion < 180323 && !fTestNet && pindexBest->nHeight > 860500)
-        {
-            // disconnect from peers older than this proto version - Enforce Beacon Age - 3-26-2017
-            LogPrint(BCLog::LogFlags::NOISY, "partner %s using obsolete version %i (before enforcing beacon age); disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
-            pfrom->fDisconnect = true;
-            return false;
-        }
-
-        if (!fTestNet && pfrom->nVersion < 180314)
-        {
-            // disconnect from peers older than this proto version
-            LogPrint(BCLog::LogFlags::NOISY, "ResearchAge: partner %s using obsolete version %i; disconnecting", pfrom->addr.ToString(), pfrom->nVersion);
-            pfrom->fDisconnect = true;
-            return false;
-       }
-
-        if (pfrom->nVersion == 10300)
-            pfrom->nVersion = 300;
         if (!vRecv.empty())
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,6 @@
 #include <ctime>
 #include <math.h>
 
-extern std::string NodeAddress(CNode* pfrom);
 extern bool WalletOutOfSync();
 extern bool AskForOutstandingBlocks(uint256 hashStart);
 extern void ResetTimerMain(std::string timer_name);
@@ -4375,13 +4374,6 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
 // a large 4-byte int at any alignment.
 unsigned char pchMessageStart[4] = { 0x70, 0x35, 0x22, 0x05 };
 
-
-std::string NodeAddress(CNode* pfrom)
-{
-    std::string ip = pfrom->addr.ToString();
-    return ip;
-}
-
 bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived)
 {
     RandAddSeedPerfmon();
@@ -4577,7 +4569,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if (pfrom->nVersion == 0)
     {
         // Must have a version message before anything else 1-10-2015 Halford
-        LogPrintf("Hack attempt from %s - %s (banned) ",pfrom->addrName, NodeAddress(pfrom));
+        LogPrintf("Hack attempt from %s - %s (banned) ", pfrom->addrName, pfrom->addr.ToString());
         pfrom->Misbehaving(100);
         pfrom->fDisconnect=true;
         return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3740,7 +3740,7 @@ bool AskForOutstandingBlocks(uint256 hashStart)
     LOCK(cs_vNodes);
     for (auto const& pNode : vNodes)
     {
-                if (!pNode->fClient && !pNode->fOneShot && (pNode->nStartingHeight > (nBestHeight - 144)) && (pNode->nVersion < NOBLKS_VERSION_START || pNode->nVersion >= NOBLKS_VERSION_END) )
+                if (!pNode->fClient && !pNode->fOneShot && (pNode->nStartingHeight > (nBestHeight - 144)))
                 {
                         if (hashStart==uint256())
                         {
@@ -4588,8 +4588,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         static int nAskedForBlocks = 0;
         if (!pfrom->fClient && !pfrom->fOneShot &&
             (pfrom->nStartingHeight > (nBestHeight - 144)) &&
-            (pfrom->nVersion < NOBLKS_VERSION_START ||
-             pfrom->nVersion >= NOBLKS_VERSION_END) &&
              (nAskedForBlocks < 1 || (vNodes.size() <= 1 && nAskedForBlocks < 1)))
         {
             nAskedForBlocks++;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -34,7 +34,6 @@
 #endif
 
 using namespace std;
-std::string NodeAddress(CNode* pfrom);
 
 extern int nMaxConnections;
 int MAX_OUTBOUND_CONNECTIONS = 8;
@@ -1305,7 +1304,7 @@ void ThreadSocketHandler2(void* parg)
             if ((GetAdjustedTime() - pnode->nTimeConnected) > (60*60*2) && (vNodes.size() > (MAX_OUTBOUND_CONNECTIONS*.75)))
             {
                     LogPrint(BCLog::LogFlags::NOISY, "Node %s connected longer than 2 hours with connection count of %zd, disconnecting. ",
-                             NodeAddress(pnode), vNodes.size());
+                             pnode->addr.ToString(), vNodes.size());
 
                     pnode->fDisconnect = true;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -722,19 +722,39 @@ void CNode::PushVersion()
     LogPrint(BCLog::LogFlags::NOISY, "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s",
         PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), addr.ToString());
 
-    std::string sboinchashargs;
-    std::string nonce;
-    std::string pw1;
-    std::string mycpid;
-    std::string acid;
-
-    //TODO: change `PushMessage()` to use ServiceFlags so we don't need to cast nLocalServices
-    PushMessage("aries", PROTOCOL_VERSION, nonce, pw1,
-                mycpid, mycpid, acid, (uint64_t) nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
-                nBestHeight);
-
-
+    // In the version following 180324 (mandatory v5.0.0 - Fern), we can finally
+    // drop the garbage legacy fields added to the version message:
+    //
+    if (PROTOCOL_VERSION > 180324) {
+        //TODO: change `PushMessage()` to use ServiceFlags so we don't need to cast nLocalServices
+        PushMessage(
+            "aries",
+            PROTOCOL_VERSION,
+            (uint64_t)nLocalServices,
+            nTime,
+            addrYou,
+            addrMe,
+            nLocalHostNonce,
+            FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
+            nBestHeight);
+    } else {
+        const std::string legacy_dummy;
+        PushMessage(
+            "aries",
+            PROTOCOL_VERSION,
+            legacy_dummy, // nonce
+            legacy_dummy, // pw1
+            legacy_dummy, // mycpid
+            legacy_dummy, // enccpid
+            legacy_dummy, // acid
+            (uint64_t)nLocalServices,
+            nTime,
+            addrYou,
+            addrMe,
+            nLocalHostNonce,
+            FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
+            nBestHeight);
+    }
 }
 
 bool CNode::Misbehaving(int howmuch)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -35,7 +35,6 @@
 
 using namespace std;
 std::string NodeAddress(CNode* pfrom);
-extern std::string GetCommandNonce(std::string command);
 
 extern int nMaxConnections;
 int MAX_OUTBOUND_CONNECTIONS = 8;
@@ -113,14 +112,6 @@ unsigned short GetListenPort()
 {
     return (unsigned short)(GetArg("-port", GetDefaultPort()));
 }
-
-
-std::string GetCommandNonce(std::string command)
-{
-    return "deprecated,d,d,d,d,d,d";
-}
-
-
 
 void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd, bool fForce)
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1324,7 +1324,7 @@ void ThreadSocketHandler2(void* parg)
                     continue;
                 }
 
-                else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
+                else if (nTime - pnode->nLastRecv > TIMEOUT_INTERVAL)
                 {
                     LogPrintf("socket receive timeout: %" PRId64 "s", nTime - pnode->nLastRecv);
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -80,7 +80,7 @@ class CAddress : public CService
                 READWRITE(nVersion);
             }
             if ((s.GetType() & SER_DISK) ||
-                (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH))) {
+                (nVersion >= INIT_PROTO_VERSION && !(s.GetType() & SER_GETHASH))) {
                 READWRITE(obj.nTime);
             }
             READWRITE(Using<CustomUintFormatter<8>>(obj.nServices));

--- a/src/version.h
+++ b/src/version.h
@@ -71,10 +71,4 @@ static const int TESTNET_NOBLKS_VERSION_END = 180312;    //
 //
 static const int DATABASE_VERSION = 180015;
 
-// BIP 0031, pong message, is enabled for all versions AFTER this one
-static const int BIP0031_VERSION = 180014;
-
-// "mempool" command, enhanced "getdata" behavior starts with this version:
-static const int MEMPOOL_GD_VERSION = 180014;
-
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -50,12 +50,6 @@ static const int MIN_PEER_PROTO_VERSION = 180323;        //
 // intial proto version, to be increased after           //
 // version/verack negotiation                            //
 static const int INIT_PROTO_VERSION = 180275;            //
-//                                                       //
-// nTime field added to CAddress, starting with this     //
-// version;                                              //
-// if possible, avoid requesting addresses nodes older   //
-// than this                                             //
-static const int CADDR_TIME_VERSION = 180275;            //
 ///////////////////////////////////////////////////////////
 //
 // database format versioning

--- a/src/version.h
+++ b/src/version.h
@@ -56,15 +56,6 @@ static const int INIT_PROTO_VERSION = 180275;            //
 // if possible, avoid requesting addresses nodes older   //
 // than this                                             //
 static const int CADDR_TIME_VERSION = 180275;            //
-//                                                       //
-//                                                       //
-// only request blocks from nodes outside this range of  //
-// versions                                              //
-static const int NOBLKS_VERSION_START = 1;               //
-static const int NOBLKS_VERSION_END = 180283;            //
-// TESTNET:                                              //
-static const int TESTNET_NOBLKS_VERSION_START = 1;       //
-static const int TESTNET_NOBLKS_VERSION_END = 180312;    //
 ///////////////////////////////////////////////////////////
 //
 // database format versioning

--- a/src/version.h
+++ b/src/version.h
@@ -43,9 +43,9 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 ///////////////////////////////////////////////////////////
 // network protocol versioning                           //
 //                                                       //
-static const int PROTOCOL_VERSION =       180323;        //
+static const int PROTOCOL_VERSION =       180324;        //
 // disconnect from peers older than this proto version   //
-static const int MIN_PEER_PROTO_VERSION = 180284;        //
+static const int MIN_PEER_PROTO_VERSION = 180323;        //
 ///////////////////////////////////////////////////////////
 // intial proto version, to be increased after           //
 // version/verack negotiation                            //


### PR DESCRIPTION
This updates the protocol version numbers for the upcoming mandatory release. It also cleans up transitional code for legacy protocol versions that the network does not support as of the previous mandatory release. I also added some new transitional code that enables the removal of some legacy garbage fields from the messages in the release that follows the hard fork. Please read the commit descriptions for details.