### PR TITLE
doc: Create Basic Readme In contrib

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,5 @@
+This folder is for scripts, other tools, and files that are related to Gridcoin
+but are not directly part of Gridcoin's code. 
+
+These are not restricted to any one programming language so some scripts may need
+Python, Perl, Bash, or other dependencies installed to run.


### PR DESCRIPTION
Creates a README with a few lines to explain what the contrib folder is. It can probably be expanded on in the future 