### PR TITLE
voting: Remove double increment in loop

### DIFF
--- a/src/neuralnet/voting/poll.cpp
+++ b/src/neuralnet/voting/poll.cpp
@@ -338,7 +338,6 @@ std::string ChoiceList::ToString() const
     for (; iter != m_choices.end(); ++iter) {
         out += ";";
         out += iter->m_label;
-        ++iter;
     }
 
     return out;


### PR DESCRIPTION
This fixes a case that can cause a segfault in `Poll::ChoiceList::ToString()`.