### PR TITLE
neuralnet, scraper: Fix compilation with gcc5 and older libcurl

### DIFF
--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -263,7 +263,7 @@ public:
     //!
     NN::ContractType ContractType() const override
     {
-        return ContractType::BEACON;
+        return NN::ContractType::BEACON;
     }
 
     //!

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -31,7 +31,7 @@ class EmptyPayload : public IContractPayload
 public:
     NN::ContractType ContractType() const override
     {
-        return ContractType::UNKNOWN;
+        return NN::ContractType::UNKNOWN;
     }
 
     bool WellFormed(const ContractAction action) const override
@@ -100,7 +100,7 @@ public:
 
     NN::ContractType ContractType() const override
     {
-        return ContractType::UNKNOWN;
+        return NN::ContractType::UNKNOWN;
     }
 
     bool WellFormed(const ContractAction action) const override

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -1043,7 +1043,7 @@ BeaconError AdvertiseBeaconResult::Error() const
 
 Researcher::Researcher()
     : m_mining_id(MiningId::ForInvestor())
-    , m_beacon_error(BeaconError::NONE)
+    , m_beacon_error(NN::BeaconError::NONE)
 {
 }
 
@@ -1312,7 +1312,7 @@ AdvertiseBeaconResult Researcher::AdvertiseBeacon(const bool force)
     const CpidOption cpid = m_mining_id.TryCpid();
 
     if (!cpid) {
-        return BeaconError::NO_CPID;
+        return NN::BeaconError::NO_CPID;
     }
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
@@ -1320,13 +1320,13 @@ AdvertiseBeaconResult Researcher::AdvertiseBeacon(const bool force)
     const BeaconRegistry& beacons = GetBeaconRegistry();
     const BeaconOption current_beacon = beacons.Try(*cpid);
 
-    AdvertiseBeaconResult result(BeaconError::NONE);
+    AdvertiseBeaconResult result(NN::BeaconError::NONE);
 
     if (force) {
         result = SendNewBeacon(*cpid);
     } else if (g_recent_beacons.Try(*cpid)) {
         LogPrintf("%s: Beacon awaiting confirmation already", __func__);
-        return BeaconError::PENDING;
+        return NN::BeaconError::PENDING;
     } else if (!current_beacon) {
         result = SendNewBeacon(*cpid);
     } else {
@@ -1339,11 +1339,11 @@ AdvertiseBeaconResult Researcher::AdvertiseBeacon(const bool force)
         }
     }
 
-    if (result.Error() == BeaconError::NONE) {
+    if (result.Error() == NN::BeaconError::NONE) {
         g_recent_beacons.Remember(*cpid, result);
     }
 
-    if (result.Error() != BeaconError::NOT_NEEDED) {
+    if (result.Error() != NN::BeaconError::NOT_NEEDED) {
         m_beacon_error = result.Error();
     }
 
@@ -1360,7 +1360,7 @@ AdvertiseBeaconResult Researcher::RevokeBeacon(const Cpid cpid)
 
     if (!beacon) {
         LogPrintf("ERROR: %s: No active beacon for %s", __func__, cpid.ToString());
-        return BeaconError::NO_CPID;
+        return NN::BeaconError::NO_CPID;
     }
 
     return SendBeaconContract(cpid, *beacon, ContractAction::REMOVE);

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -339,7 +339,7 @@ public:
     Researcher(
         MiningId mining_id,
         MiningProjectMap projects,
-        const BeaconError beacon_error = BeaconError::NONE);
+        const BeaconError beacon_error = NN::BeaconError::NONE);
 
     //!
     //! \brief Set up the local researcher context.
@@ -405,7 +405,7 @@ public:
     //!
     static void Reload(
         MiningProjectMap projects,
-        BeaconError beacon_error = BeaconError::NONE);
+        BeaconError beacon_error = NN::BeaconError::NONE);
 
     //!
     //! \brief Rescan the set of in-memory projects for eligible CPIDs without

--- a/src/scraper/http.cpp
+++ b/src/scraper/http.cpp
@@ -133,7 +133,7 @@ namespace
 #if LIBCURL_VERSION_NUM < 0x072000
     static int olderprogress_callback(void *ptr, double downtotal, double downnow, double uptotal, double upnow)
     {
-        return newerprogress_callback(ptr, (curl_off_t)downtotal, (curl_off_t)downnow, (curl_off_t)uptotal, (curl_off_t)uptotal, (curl_off_t)upnow);
+        return newerprogress_callback(ptr, (curl_off_t)downtotal, (curl_off_t)downnow, (curl_off_t)uptotal, (curl_off_t)upnow);
     };
 
 #endif
@@ -342,7 +342,7 @@ void Http::DownloadSnapshot()
     curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &fileprogress);
 #else
     curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, olderprogress_callback);
-    curl_east_setopt(curl, CURLOPT_PROGRESSDATA, &fileprogress);
+    curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &fileprogress);
 #endif
 
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);


### PR DESCRIPTION
With gcc5, the `NN::` namespace needs to be stated explicitly in these cases for compilation to succeed.

Also fixed typos in the scraper's compatibility code for older libcurl versions.