### PR TITLE
rpc: Add private_key_available to beaconstatus

### DIFF
--- a/src/neuralnet/beacon.cpp
+++ b/src/neuralnet/beacon.cpp
@@ -4,6 +4,7 @@
 #include "neuralnet/beacon.h"
 #include "neuralnet/contract/contract.h"
 #include "util.h"
+#include "wallet/wallet.h"
 
 #include <algorithm>
 
@@ -168,6 +169,11 @@ std::string Beacon::GetVerificationCode() const
     const CKeyID key_id = GetId();
 
     return EncodeBase58(key_id.begin(), key_id.end());
+}
+
+bool Beacon::WalletHasPrivateKey(const CWallet* const wallet) const
+{
+    return wallet->HaveKey(m_public_key.GetID());
 }
 
 std::string Beacon::ToString() const

--- a/src/neuralnet/beacon.h
+++ b/src/neuralnet/beacon.h
@@ -11,6 +11,7 @@
 
 class CBitcoinAddress;
 class CTransaction;
+class CWallet;
 
 namespace NN {
 
@@ -160,6 +161,16 @@ public:
     //! \return Base58 representation of the RIPEMD-160 hash of the public key.
     //!
     std::string GetVerificationCode() const;
+
+    //!
+    //! \brief Determine whether the given wallet contains a private key for
+    //! this beacon's public key. Because this function is intended to work
+    //! even if the wallet is locked, it does not check whether the keypair is
+    //! actually valid.
+    //!
+    //! \return \c true if the wallet contains a matching private key.
+    //!
+    bool WalletHasPrivateKey(const CWallet* const wallet) const;
 
     //!
     //! \brief Get the legacy string representation of a version 1 beacon

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -908,7 +908,7 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
     UniValue active(UniValue::VARR);
     UniValue pending(UniValue::VARR);
 
-    LOCK(cs_main);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     const NN::BeaconRegistry& beacons = NN::GetBeaconRegistry();
 
@@ -922,6 +922,7 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
         entry.pushKV("timestamp", TimestampToHRDate(beacon->m_timestamp));
         entry.pushKV("address", beacon->GetAddress().ToString());
         entry.pushKV("public_key", beacon->m_public_key.ToString());
+        entry.pushKV("private_key_available", beacon->WalletHasPrivateKey(pwalletMain));
         entry.pushKV("magnitude", NN::Quorum::GetMagnitude(*cpid).Floating());
         entry.pushKV("verification_code", beacon->GetVerificationCode());
         entry.pushKV("is_mine", is_mine);
@@ -939,6 +940,7 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
         entry.pushKV("timestamp", TimestampToHRDate(beacon->m_timestamp));
         entry.pushKV("address", beacon->GetAddress().ToString());
         entry.pushKV("public_key", beacon->m_public_key.ToString());
+        entry.pushKV("private_key_available", beacon->WalletHasPrivateKey(pwalletMain));
         entry.pushKV("magnitude", 0);
         entry.pushKV("verification_code", beacon->GetVerificationCode());
         entry.pushKV("is_mine", is_mine);


### PR DESCRIPTION
While updating my small monitoring script to testnet, I noticed there is now no way to find out whether the beacon's private key is actually in the wallet from the output of the `beaconstatus` rpc, so I added a boolean `private_key_known` field. It assumes the key to be valid if it is in the wallet's keystore as verifying would require the wallet to be fully unlocked.