### PR TITLE
gui: Change GetEstimatedStakingFrequency text

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1356,7 +1356,7 @@ QString BitcoinGUI::GetEstimatedStakingFrequency(unsigned int nEstimateTime)
 
     if (!nEstimateTime)
     {
-        text = tr("undefined");
+        text = tr("not available");
 
         return text;
     }


### PR DESCRIPTION
If nEstimateTime is zero the text returned by GetEstimatedStaking Frequency is now "not available" instead of "undefined."