### PR TITLE
scraper: Scraper global statistics cache optimization

### DIFF
--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -788,11 +788,11 @@ private: // SuperblockValidator classes
         //! \param project_name      Identifies the project to add.
         //! \param project_part_data Serialized project stats of the part.
         //!
-        void AddPart(std::string project_name, CSerializeData project_part_data)
+        void AddPart(std::string project_name, CSplitBlob::CPart* project_part_ptr)
         {
-            m_convergence.ConvergedManifestPartsMap.emplace(
+            m_convergence.ConvergedManifestPartPtrsMap.emplace(
                 std::move(project_name),
-                std::move(project_part_data));
+                std::move(project_part_ptr));
         }
 
         //!
@@ -944,7 +944,7 @@ private: // SuperblockValidator classes
 
                 convergence.AddPart(
                     project_pair.first, // project name
-                    GetResolvedPartData(resolved_part.m_part_hash));
+                    GetResolvedPartPtr(resolved_part.m_part_hash));
 
                 remainder -= part_index * project.m_combiner_mask;
 
@@ -981,7 +981,7 @@ private: // SuperblockValidator classes
         //!
         //! \return Serialized binary data of the part to add to a convergence.
         //!
-        static CSerializeData GetResolvedPartData(const uint256& part_hash)
+        static CSplitBlob::CPart* GetResolvedPartPtr(const uint256& part_hash)
         {
             LOCK(CSplitBlob::cs_mapParts);
 
@@ -991,10 +991,10 @@ private: // SuperblockValidator classes
             // the most recent project part should always exist:
             if (iter == CSplitBlob::mapParts.end()) {
                 LogPrintf("ValidateSuperblock(): project part disappeared.");
-                return CSerializeData();
+                return nullptr;
             }
 
-            return iter->second.data;
+            return &(iter->second);
         }
 
         //!
@@ -1029,7 +1029,7 @@ private: // SuperblockValidator classes
                 return;
             }
 
-            convergence.AddPart("BeaconList", manifest.vParts[0]->data);
+            convergence.AddPart("BeaconList", manifest.vParts[0]);
 
             // Find the offset of the verified beacons project part. Typically
             // this exists at vParts offset 1 when a scraper verified at least
@@ -1054,7 +1054,7 @@ private: // SuperblockValidator classes
                 return;
             }
 
-            convergence.AddPart("VerifiedBeacons", manifest.vParts[part_offset]->data);
+            convergence.AddPart("VerifiedBeacons", manifest.vParts[part_offset]);
         }
     }; // ProjectCombiner
 

--- a/src/neuralnet/quorum.h
+++ b/src/neuralnet/quorum.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include "scraper_net.h"
 
 class CBlockIndex;
 

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -557,11 +557,11 @@ Superblock Superblock::FromConvergence(
     // Add hints created from the hashes of converged manifest parts to each
     // superblock project section to assist receiving nodes with validation:
     //
-    for (const auto& part_pair : stats.Convergence.ConvergedManifestPartsMap) {
+    for (const auto& part_pair : stats.Convergence.ConvergedManifestPartPtrsMap) {
         const std::string& project_name = part_pair.first;
-        const CSerializeData& part_data = part_pair.second;
+        const CSplitBlob::CPart* part_data_ptr = part_pair.second;
 
-        projects.SetHint(project_name, part_data);
+        projects.SetHint(project_name, part_data_ptr);
     }
 
     return superblock;
@@ -954,7 +954,7 @@ void Superblock::ProjectIndex::Add(std::string name, const ProjectStats& stats)
 
 void Superblock::ProjectIndex::SetHint(
     const std::string& name,
-    const CSerializeData& part_data)
+    const CSplitBlob::CPart* part_data_ptr)
 {
     auto iter = std::lower_bound(
         m_projects.begin(),
@@ -966,7 +966,7 @@ void Superblock::ProjectIndex::SetHint(
         return;
     }
 
-    const uint256 part_hash = Hash(part_data.begin(), part_data.end());
+    const uint256 part_hash = Hash(part_data_ptr->data.begin(), part_data_ptr->data.end());
     iter->second.m_convergence_hint = part_hash.GetUint64() >> 32;
 
     m_converged_by_project = true;

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1087,7 +1087,7 @@ public:
         //!
         //! \param part_data The convergence part to create the hint from.
         //!
-        void SetHint(const std::string& name, const CSerializeData& part_data);
+        void SetHint(const std::string& name, const CSplitBlob::CPart *part_data_ptr);
 
         //!
         //! \brief Serialize the object to the provided stream.
@@ -1533,6 +1533,22 @@ struct hash<NN::QuorumHash>
 // This is part of the scraper but is put here, because it needs the complete NN:Superblock class.
 struct ConvergedScraperStats
 {
+    ConvergedScraperStats() : Convergence(), NewFormatSuperblock()
+    {
+        bClean = false;
+
+        nTime = 0;
+        mScraperConvergedStats = {};
+        PastConvergences = {};
+    }
+
+    ConvergedScraperStats(const int64_t nTime_in, const ConvergedManifest& Convergence) : Convergence(Convergence)
+    {
+        bClean = false;
+
+        nTime = nTime_in;
+    }
+
     // Flag to indicate cache is clean or dirty (i.e. state change of underlying statistics has occurred.
     // This flag is marked true in ScraperGetSuperblockContract() and false on receipt or deletion of
     // statistics objects.
@@ -1558,6 +1574,7 @@ struct ConvergedScraperStats
         {
             // This is specifically this form of insert to insure that if there is a hint "collision" the referenced
             // SB Hash and Convergence stored will be the LATER one.
+
             PastConvergences[nReducedContentHash] = std::make_pair(NewFormatSuperblock.GetHash(), Convergence);
         }
     }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -65,7 +65,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     std::map<std::string, std::string> mapValue = wtx.mapValue;
 
     bool fContractPresent = false;
-    NN::ContractType ContractType;
+    // Initialize to unknown to prevent a possible uninitialized warning.
+    NN::ContractType ContractType = NN::ContractType::UNKNOWN;
 
     if (!wtx.GetContracts().empty())
     {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -399,6 +399,7 @@ static const CRPCCommand vRPCCommands[] =
     { "archivelog",              &archivelog,              cat_developer     },
     { "testnewsb",               &testnewsb,               cat_developer     },
     { "convergencereport",       &convergencereport,       cat_developer     },
+    { "scraperreport",           &scraperreport,           cat_developer     },
 
   // Network commands
     { "addnode",                 &addnode,                 cat_network       },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -213,6 +213,7 @@ extern UniValue deletecscrapermanifest(const UniValue& params, bool fHelp);
 extern UniValue archivelog(const UniValue& params, bool fHelp);
 extern UniValue testnewsb(const UniValue& params, bool fHelp);
 extern UniValue convergencereport(const UniValue& params, bool fHelp);
+extern UniValue scraperreport(const UniValue& params, bool fHelp);
 
 // Network
 extern UniValue addnode(const UniValue& params, bool fHelp);


### PR DESCRIPTION
This PR timplements a significant global statistics cache memory optimization for the scraper. Note that this cache is used on all nodes, whether they are scrapers or normal nodes.

The current scraper global ConvergedScraperStatsCache, in the interest of simplicity, was designed to copy the CScraperManifest parts into the ConvergedManifestPartsMap indexed by project to make the ConvergedScraperStatsCache relatively independent of the scraper_net global manifest and parts map. This was to simplify object lifecycle management.

Review of the scraper shows this is an area ripe for optimization, since the number of unique parts is actually quite low in practice (even smaller than the number of manifests that reference them, because of the overlapping nature of the manifests!).

Given that, I have determined that it is worth the effort to convert the ConvergedScraperStatsCache to use pointers to the parts in CSplitBlob::mapParts via ConvergedManifestPartPtrsMap, which is a replacement for ConvergedManifestPartsMap, which actually contained copies of the part data. Note that the index is still the projects, but the element is of type CPart* instead of CSerializeData. This map holds the CPart* pointers directly, while the shared pointer to the CScraperManifest Convergences (both present via ConvergedManifest Convergence and past via std::map<uint32_t, std::pair<NN::QuorumHash, ConvergedManifest>> PastConvergences) hold the "references" to the CParts, indirectly through the vPart vector in the manifests. This safeguards their deletion and ensures the pointers are valid for a read only pattern (which is what is used by both the node side of the scraper AND the quorum/superblock classes) until both the Convergences are purged from the global cache AND the CScraperManifest::mapManifest global cache in scraper_net.cpp (with is the manifest level map that holds inventory system manifests and parts), thereby calling the relevant destructors and allowing removal of the CPart objects from the CSplitBlob::mapParts (and invalidation of the pointers) when the last reference to a given CPart is removed. Adding parts to the global scraper_net parts map CSplitBlob::mapParts is ALWAYS done through CSplitBlob::addPart with a lock held on both CScraperManifest::cs_mapManifest and CSplitBlob::cs_mapParts.

The quorum and superblock classes operate on manifests and parts in the ConvergedScraperStatsCache or directly on the CScraperManifest::mapManifest and CSplitBlob::mapParts via appropriate locks, which are also respected by the scraper thread and the scraper_net thread, so this is thread-safe.

This optimization is completely transparent to the operation of a scraper or a node, except it will lower memory usage.

This also includes the scraperreport RPC to gain visibility into the scraper object internals that are relevant to this PR.

I also slipped in a trivial fix to eliminate a possible uninitialized warning message during compilation.