### PR TITLE
rpc: Add "getrawwallettransaction" RPC function

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -304,6 +304,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getnewaddress",           &getnewaddress,           cat_wallet        },
     { "getnewpubkey",            &getnewpubkey,            cat_wallet        },
     { "getrawtransaction",       &getrawtransaction,       cat_wallet        },
+    { "getrawwallettransaction", &getrawwallettransaction, cat_wallet        },
     { "getreceivedbyaccount",    &getreceivedbyaccount,    cat_wallet        },
     { "getreceivedbyaddress",    &getreceivedbyaddress,    cat_wallet        },
     { "gettransaction",          &gettransaction,          cat_wallet        },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -119,6 +119,7 @@ extern UniValue getbalancedetail(const UniValue& params, bool fHelp);
 extern UniValue getnewaddress(const UniValue& params, bool fHelp);
 extern UniValue getnewpubkey(const UniValue& params, bool fHelp);
 extern UniValue getrawtransaction(const UniValue& params, bool fHelp);
+extern UniValue getrawwallettransaction(const UniValue& params, bool fHelp);
 extern UniValue getreceivedbyaccount(const UniValue& params, bool fHelp);
 extern UniValue getreceivedbyaddress(const UniValue& params, bool fHelp);
 extern UniValue gettransaction(const UniValue& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1867,6 +1867,31 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
     return entry;
 }
 
+UniValue getrawwallettransaction(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+                "getrawwallettransaction <txid>\n"
+                "\n"
+                "Get a string that is serialized, hex-encoded data for <txid> "
+                "from the wallet.\n");
+
+    const uint256 hash = uint256S(params[0].get_str());
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    const auto iter = pwalletMain->mapWallet.find(hash);
+
+    if (iter == pwalletMain->mapWallet.end()) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in wallet");
+    }
+
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << static_cast<const CTransaction&>(iter->second);
+
+    return HexStr(ssTx.begin(), ssTx.end());
+}
+
 
 UniValue backupwallet(const UniValue& params, bool fHelp)
 {


### PR DESCRIPTION
This adds an RPC function that can dump a transaction from the wallet as a hex-encoded string. It is useful for remotely debugging transactions that fail network relay.