### PR TITLE
scraper: Optimization of manifest and parts sharing between ConvergedScraperStatsCache, mapManifest, and mapParts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4805,14 +4805,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                         auto iter = CScraperManifest::mapManifest.find(inv.hash);
                         if (iter != CScraperManifest::mapManifest.end())
                         {
-                            CScraperManifest& manifest = *iter->second;
+                            CScraperManifest_shared_ptr manifest = iter->second;
 
                             // We are not going to do anything with the banscore here, because this is the sending node,
                             // but it is an out parameter of IsManifestAuthorized.
                             unsigned int banscore_out = 0;
 
                             // Also don't send a manifest that is not current.
-                            if (CScraperManifest::IsManifestAuthorized(manifest.nTime, manifest.pubkey, banscore_out) && manifest.IsManifestCurrent())
+                            if (CScraperManifest::IsManifestAuthorized(manifest->nTime, manifest->pubkey, banscore_out) && manifest->IsManifestCurrent())
                             {
                                 CScraperManifest::SendManifestTo(pfrom, inv.hash);
                             }

--- a/src/scraper/fwd.h
+++ b/src/scraper/fwd.h
@@ -57,6 +57,8 @@ typedef std::multimap<int64_t, std::pair<uint256, uint256>, std::greater <int64_
 // See the ScraperID typedef above.
 typedef std::map<ScraperID, mCSManifest> mmCSManifestsBinnedByScraper;
 
+typedef std::shared_ptr<CScraperManifest> CScraperManifest_shared_ptr;
+
 // Note the CParts pointed to by this map are safe to access, because the pointers are guaranteed valid
 // as long as the holding CScraperManifests (both in the CScaperManifest global map, and this cache)
 // still exist. So the safety of these pointers is coincident with the lifespan of CScraperManifests
@@ -98,35 +100,35 @@ struct ConvergedManifest
     }
 
     // For constructing a dummy converged manifest from a single manifest
-    ConvergedManifest(CScraperManifest& in)
+    ConvergedManifest(CScraperManifest_shared_ptr& in)
     {
-        ConsensusBlock = in.ConsensusBlock;
+        ConsensusBlock = in->ConsensusBlock;
         timestamp = GetAdjustedTime();
         bByParts = false;
 
-        CScraperConvergedManifest_ptr = std::make_shared<CScraperManifest>(in);
+        CScraperConvergedManifest_ptr = in;
 
         PopulateConvergedManifestPartPtrsMap();
 
         ComputeConvergedContentHash();
 
-        nUnderlyingManifestContentHash = in.nContentHash;
+        nUnderlyingManifestContentHash = in->nContentHash;
     }
 
     // Call operator to update an already initialized ConvergedManifest with a passed in CScraperManifest
-    bool operator()(const CScraperManifest& in)
+    bool operator()(const CScraperManifest_shared_ptr& in)
     {
-        ConsensusBlock = in.ConsensusBlock;
+        ConsensusBlock = in->ConsensusBlock;
         timestamp = GetAdjustedTime();
         bByParts = false;
 
-        CScraperConvergedManifest_ptr = std::make_shared<CScraperManifest>(in);
+        CScraperConvergedManifest_ptr = in;
 
         bool bConvergedContentHashMatches = PopulateConvergedManifestPartPtrsMap();
 
         ComputeConvergedContentHash();
 
-        nUnderlyingManifestContentHash = in.nContentHash;
+        nUnderlyingManifestContentHash = in->nContentHash;
 
         return bConvergedContentHashMatches;
     }
@@ -139,7 +141,7 @@ struct ConvergedManifest
     int64_t timestamp;
     bool bByParts;
 
-    std::shared_ptr<CScraperManifest> CScraperConvergedManifest_ptr;
+    CScraperManifest_shared_ptr CScraperConvergedManifest_ptr;
 
     mConvergedManifestPart_ptrs ConvergedManifestPartPtrsMap;
 

--- a/src/scraper_net.h
+++ b/src/scraper_net.h
@@ -78,10 +78,10 @@ class CScraperManifest
 public: /* static methods */
 
     /** map from index hash to scraper Index, so we can process Inv messages */
-    static std::map<uint256, std::unique_ptr<CScraperManifest>> mapManifest;
+    static std::map<uint256, std::shared_ptr<CScraperManifest>> mapManifest;
 
     // ------------ hash -------------- nTime ------- pointer to CScraperManifest
-    static std::map<uint256, std::pair<int64_t, std::unique_ptr<CScraperManifest>>> mapPendingDeletedManifest;
+    static std::map<uint256, std::pair<int64_t, std::shared_ptr<CScraperManifest>>> mapPendingDeletedManifest;
 
     // Protects both mapManifest and MapPendingDeletedManifest
     static CCriticalSection cs_mapManifest;
@@ -108,7 +108,7 @@ public: /* static methods */
     static bool SendManifestTo(CNode* pfrom, const uint256& hash);
 
     /** Add new manifest object into list of known manifests */
-    static bool addManifest(std::unique_ptr<CScraperManifest>&& m, CKey& keySign);
+    static bool addManifest(std::shared_ptr<CScraperManifest>&& m, CKey& keySign);
 
     /** Validate whether received manifest is authorized */
     static bool IsManifestAuthorized(int64_t& nTime, CPubKey& PubKey, unsigned int& banscore_out);
@@ -117,8 +117,8 @@ public: /* static methods */
     static bool DeleteManifest(const uint256& nHash, const bool& fImmediate = false);
 
     /** Delete Manifest (iterator version) **/
-    static std::map<uint256, std::unique_ptr<CScraperManifest>>::iterator
-        DeleteManifest(std::map<uint256, std::unique_ptr<CScraperManifest>>::iterator& iter, const bool& fImmediate = false);
+    static std::map<uint256, std::shared_ptr<CScraperManifest>>::iterator
+        DeleteManifest(std::map<uint256, std::shared_ptr<CScraperManifest>>::iterator& iter, const bool& fImmediate = false);
 
     /** Delete PendingDeletedManifests **/
     static unsigned int DeletePendingDeletedManifests();

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -424,7 +424,7 @@ ConvergedScraperStats GetTestConvergence(
     const ScraperStatsAndVerifiedBeacons stats = GetTestScraperStats(meta);
     ConvergedScraperStats convergence;
 
-    auto CScraperConvergedManifest_ptr = std::unique_ptr<CScraperManifest>(new CScraperManifest());
+    auto CScraperConvergedManifest_ptr = std::shared_ptr<CScraperManifest>(new CScraperManifest());
 
     convergence.mScraperConvergedStats = stats.mScraperStats;
 


### PR DESCRIPTION
This fully implements pointer sharing between the scraper's ConvergedScraperStatsCache, mapManifest, and mapParts and completes the scraper memory optimization started by #1837.