### PR TITLE
wallet, rpc: Fix for self-transactions in listtransactions

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -218,11 +218,21 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     {
         bool fAllFromMe = true;
         for (auto const& txin : wtx.vin)
+        {
             fAllFromMe = fAllFromMe && (wallet->IsMine(txin) != ISMINE_NO);
+
+            // Once false, no point in continuing.
+            if (!fAllFromMe) break;
+        }
 
         bool fAllToMe = true;
         for (auto const& txout : wtx.vout)
+        {
             fAllToMe = fAllToMe && (wallet->IsMine(txout) != ISMINE_NO);
+
+            // Once false, no point in continuing.
+            if (!fAllToMe) break;
+        }
 
         if (fAllFromMe && fAllToMe)
         {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -786,6 +786,9 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
     for (auto const& txout : vout)
     {
         fIsAllToMe = fIsAllToMe && (pwallet->IsMine(txout) != ISMINE_NO);
+
+        // Once false, no point in continuing.
+        if (!fIsAllToMe) break;
     }
 
     // Used for coinstake rollup.


### PR DESCRIPTION
Note that the work done earlier on listtransactions to straighten out side stake transactions had the side effect of suppressing an entirely self-transaction (i.e. where the input(s) and output(s) are both IsMine...). The existing behavior of the production wallet is to show the UTXO outputs back to oneself as receives, and also the change. Unfortunately both are wrong in a sense. The change is not supposed to be displayed in listtransactions period. Showing a self-transaction as receive only is misleading, because it should also be shown as a send. That is the approach I take here. There is a side-effect that the fee is shown on both the sends and receives in the self-transaction, which really should more correctly be only on the send side in this case, but there is no good way around it. This has to do with the nature of GetAmounts(), which does too much work in one function, and only has a single nFee parameter that represents all of the fees. To fix this small problem, I would have to put detailed conditionals in ListTransactions () to look for this as a special case, which is really messy for this extremely small issue. I could refactor GetAmounts(), but that takes us farther away from the Bitcoin standard code in this area, something I am loath to do. The innards of GetAmounts() for us are already quite a bit different than Bitcoin's because we have all sorts of things like sidestaking, and POS, POR, that they do not have, but the call structure of GetAmounts is compatible. I would rather keep it that way.