### PR TITLE
gui: Fix and improve GUI combo box styles

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -358,7 +358,9 @@ RES_ICONS = \
   qt/res/icons/icons_dark/send.svg \
   qt/res/icons/icons_dark/transactions.svg \
   qt/res/icons/icons_light/transactions.svg \
-  qt/res/icons/icons_native/transactions.svg
+  qt/res/icons/icons_native/transactions.svg \
+  qt/res/icons/icons_light/chevron_down.svg \
+  qt/res/icons/icons_dark/chevron_down.svg
 
 RES_IMAGES = \
   qt/res/images/about.svg \

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -79,6 +79,8 @@
         <file alias="tx_pos_ss_sent">res/icons/tx_pos_ss_sent.svg</file>
         <file alias="tx_por_ss_sent">res/icons/tx_por_ss_sent.svg</file>
         <file alias="message">res/icons/message.svg</file>
+        <file alias="light_chevron_down">res/icons/icons_light/chevron_down.svg</file>
+        <file alias="dark_chevron_down">res/icons/icons_dark/chevron_down.svg</file>
     </qresource>
     <qresource prefix="/images">
         <file alias="splash">res/images/splash3.png</file>

--- a/src/qt/res/icons/icons_dark/chevron_down.svg
+++ b/src/qt/res/icons/icons_dark/chevron_down.svg
@@ -1,0 +1,1 @@
+<svg height="12" viewBox="0 0 12 12" width="12" xmlns="http://www.w3.org/2000/svg"><path d="m8.295 4.295-2.295 2.29-2.295-2.29-.705.705 3 3 3-3z" fill="#fff" fill-rule="evenodd"/></svg>

--- a/src/qt/res/icons/icons_light/chevron_down.svg
+++ b/src/qt/res/icons/icons_light/chevron_down.svg
@@ -1,0 +1,1 @@
+<svg height="12" viewBox="0 0 12 12" width="12" xmlns="http://www.w3.org/2000/svg"><path d="m8.295 4.295-2.295 2.29-2.295-2.29-.705.705 3 3 3-3z" fill="#3a465d" fill-rule="evenodd"/></svg>

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -198,20 +198,33 @@ QComboBox {
     background-color:rgb(35,38,41);
     color: white;
     selection-color: white;
-    selection-background-color:rgb(65,0,127);
-    padding: 0.065em 0em 0.065em 0.19em;
+    selection-background-color: rgb(65, 0, 127);
+    border: 0.065em solid rgb(20, 20, 20);
+    padding: 0.065em 0em 0.065em 0.26em;
 }
 
-QComboBox:!editable:hover,
-QComboBox::drop-down:!editable:hover
-{
-    background-color:rgb(65,0,127);
-    color: white;
+QComboBox::drop-down {
+    background-color: transparent;
+    border: none;
+}
+
+QComboBox::down-arrow {
+    image: url(:/icons/dark_chevron_down);
+}
+
+QComboBox:hover,
+QComboBox:selected {
+    border-color: rgb(120, 20, 255);
 }
 
 QComboBox:selected {
-    background-color:rgb(65,0,127);
-    color: white;
+    background-color: rgb(65, 0, 127);
+}
+
+QComboBox:disabled {
+    background-color: rgb(47, 52, 56);
+    border-color: rgb(30, 40, 45);
+    color: rgb(160, 160, 160);
 }
 
 QComboBox QAbstractItemView {

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -182,23 +182,34 @@ QHeaderView::section:hover {
 }
 
 QComboBox {
-    background-color:white;
+    background-color: rgb(230, 225, 230);
     color: black;
-    selection-color: white;
-    selection-background-color:rgb(65,0,127);
-    padding: 0.065em 0em 0.065em 0.19em;
+    selection-background-color: rgb(250, 240, 255);
+    border: 0.065em solid rgb(173, 173, 173);
+    padding: 0.065em 0em 0.065em 0.26em;
 }
 
-QComboBox:!editable:hover,
-QComboBox::drop-down:!editable:hover
-{
-    background-color:rgb(65,0,127);
-    color: white;
+QComboBox::drop-down {
+    background-color: transparent;
+    border: none;
+}
+
+QComboBox::down-arrow {
+    image: url(:/icons/light_chevron_down);
+}
+
+QComboBox:hover,
+QComboBox:selected {
+    border-color: rgb(120, 20, 255);
 }
 
 QComboBox:selected {
-    background-color:rgb(65,0,127);
-    color: white;
+    background-color: rgb(250, 240, 255);
+}
+
+QComboBox:disabled {
+    background-color: rgb(220, 220, 220);
+    color: rgb(140, 140, 140);
 }
 
 QComboBox QAbstractItemView {


### PR DESCRIPTION
This fixes a display issue on Windows that causes `QComboBox` text to disappear on hover with the light theme. I added some additional tweaks to improve the awful combo box styles for the light and dark themes including a change that gives the disabled state some contrast (they appeared the same as the active controls). 

Before (selected, hover, default): 
![before](https://user-images.githubusercontent.com/4282384/91889834-1d3a7600-ec54-11ea-8a9f-c259127c561a.png)
After: 
![after](https://user-images.githubusercontent.com/4282384/91889854-26c3de00-ec54-11ea-8b2b-83a3269bb3f9.png)

---
Before (selected, hover, default): 
![before_dark](https://user-images.githubusercontent.com/4282384/91889875-2f1c1900-ec54-11ea-9ca9-85ab884a06fa.png)
After: 
![after_dark](https://user-images.githubusercontent.com/4282384/91889890-34796380-ec54-11ea-84dc-42dbf12292c4.png)


