### PR TITLE
gui: Fix researcher wizard layout on macOS with native theme

### DIFF
--- a/src/qt/forms/researcherwizard.ui
+++ b/src/qt/forms/researcherwizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>660</width>
-    <height>480</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/qt/forms/researcherwizardinvestorpage.ui
+++ b/src/qt/forms/researcherwizardinvestorpage.ui
@@ -88,10 +88,23 @@
      </property>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item alignment="Qt::AlignVCenter">
     <widget class="QLabel" name="investorLabel">
      <property name="text">
-     <string>You opted out of research rewards and will earn staking rewards only.</string>
+      <string>You opted out of research rewards and will earn staking rewards only.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/src/qt/forms/researcherwizardmodepage.ui
+++ b/src/qt/forms/researcherwizardmodepage.ui
@@ -100,13 +100,7 @@
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>12</height>
-      </size>
+      <enum>QSizePolicy::Expanding</enum>
      </property>
     </spacer>
    </item>

--- a/src/qt/forms/researcherwizardpoolpage.ui
+++ b/src/qt/forms/researcherwizardpoolpage.ui
@@ -119,7 +119,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>120</height>
+       <height>180</height>
       </size>
      </property>
      <property name="cursor" stdset="0">

--- a/src/qt/forms/researcherwizardpoolsummarypage.ui
+++ b/src/qt/forms/researcherwizardpoolsummarypage.ui
@@ -91,14 +91,14 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QWidget" name="infoFormLayoutWidget" native="true">
+      <widget class="QWidget" name="infoGridLayoutWidget" native="true">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <layout class="QFormLayout" name="infoFormLayout">
+       <layout class="QGridLayout" name="infoGridLayout" columnstretch="0,1">
         <property name="leftMargin">
          <number>0</number>
         </property>

--- a/src/qt/forms/researcherwizardprojectspage.ui
+++ b/src/qt/forms/researcherwizardprojectspage.ui
@@ -94,7 +94,7 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <layout class="QFormLayout" name="infoFormLayout">
+       <layout class="QGridLayout" name="infoGridLayout" columnstretch="0,1">
         <property name="leftMargin">
          <number>0</number>
         </property>

--- a/src/qt/forms/researcherwizardsummarypage.ui
+++ b/src/qt/forms/researcherwizardsummarypage.ui
@@ -286,7 +286,7 @@
              </widget>
             </item>
             <item>
-             <layout class="QFormLayout" name="summaryDetailsLayout">
+             <layout class="QGridLayout" name="summaryDetailsLayout" columnstretch="0,1">
               <property name="leftMargin">
                <number>6</number>
               </property>
@@ -461,7 +461,7 @@
              </widget>
             </item>
             <item>
-             <layout class="QFormLayout" name="beaconDetailsLayout">
+             <layout class="QGridLayout" name="beaconDetailsLayout" columnstretch="0,1">
               <property name="leftMargin">
                <number>6</number>
               </property>
@@ -647,14 +647,14 @@
        <item>
         <layout class="QHBoxLayout" name="headerHorizontalLayout">
          <item>
-          <widget class="QWidget" name="infoFormLayoutWidget" native="true">
+          <widget class="QWidget" name="infoGridLayoutWidget" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <layout class="QFormLayout" name="infoFormLayout">
+           <layout class="QGridLayout" name="infoGridLayout" columnstretch="0,1">
             <property name="leftMargin">
              <number>0</number>
             </property>

--- a/src/qt/forms/researcherwizardsummarypage.ui
+++ b/src/qt/forms/researcherwizardsummarypage.ui
@@ -202,13 +202,7 @@
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>30</height>
-          </size>
+          <enum>QSizePolicy::Expanding</enum>
          </property>
         </spacer>
        </item>

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -987,6 +987,18 @@ NewPollDialog::NewPollDialog(QWidget *parent)
     shareTypeBox_->setCurrentIndex(2);
     glayout->addWidget(shareTypeBox_, 4, 1);
 
+    // cost
+    QLabel *costLabelLabel = new QLabel(tr("Cost:"));
+    costLabelLabel->setAlignment(Qt::AlignLeft|Qt::AlignVCenter);
+    costLabelLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    glayout->addWidget(costLabelLabel, 5, 0);
+
+    // TODO: make this dynamic when rewriting the voting GUI:
+    QLabel *costLabel = new QLabel(tr("50 GRC + transaction fee"));
+    costLabel->setAlignment(Qt::AlignLeft|Qt::AlignVCenter);
+    costLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    glayout->addWidget(costLabel, 5, 1);
+
     //answers
     answerList_ = new QListWidget(this);
     answerList_->setContextMenuPolicy(Qt::CustomContextMenu);


### PR DESCRIPTION
Some `QFormLayout` wizard pages look funky on macOS with the native stylesheet because macOS typically displays forms with right-aligned labels and centers the content. The change replaces the form layouts with grid layouts.

Before: 
![before](https://user-images.githubusercontent.com/4282384/91935373-2e669f80-ecb3-11ea-8b03-f1ebc5af11e0.png)

After: 
![after](https://user-images.githubusercontent.com/4282384/91935282-ffe8c480-ecb2-11ea-8c56-17a475502f9b.png)
