### PR TITLE
consensus: Set block version 11 threshold height for mainnet

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -125,7 +125,7 @@ inline int32_t GetV11Threshold()
 {
     return fTestNet
             ? 1301500
-            : std::numeric_limits<int32_t>::max();
+            : 2053000;
 }
 
 inline bool IsV11Enabled(int nHeight)


### PR DESCRIPTION
This sets the mainnet height of the hard-fork to block version 11 for the mandatory version 5.0.0 release to block 2053000&mdash;approximately one month from today. The transition will occur around 2020-10-04.