### PR TITLE
test, ci: xenial support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,11 @@ jobs:
         FILE_ENV="./ci/test/00_setup_env_native.sh"
 
     - stage: test
+      name: 'x86_64 Linux  [no tests]  [GUI]  [xenial]  [no depends]'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_native_old.sh"
+
+    - stage: test
       name: 'macOS 10.12  [no tests]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_mac.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   - export CONTINUE=1
   - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
   - if [ $CONTINUE = "1" ]; then set -o errexit; source ./ci/test/06_script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
-  - if [ $SECONDS -gt 2000 ]; then export CONTINUE=0; fi  # Likely the build took very long; The tests take about 1000s, so we should abort if we have less than 50*60-1000=2000s left
+  - if [ $SECONDS -gt 2700 ]; then export CONTINUE=0; fi  # Likely the build took very long
   - if [ $CONTINUE = "1" ]; then set -o errexit; source ./ci/test/06_script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 after_script:
   - echo $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
         FILE_ENV="./ci/test/00_setup_env_native.sh"
 
     - stage: test
-      name: 'x86_64 Linux  [no tests]  [GUI]  [xenial]  [no depends]'
+      name: 'x86_64 Linux  [GOAL: install]  [GUI]  [xenial]  [no depends]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_old.sh"
 

--- a/ci/test/00_setup_env_native_old.sh
+++ b/ci/test/00_setup_env_native_old.sh
@@ -9,10 +9,10 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_old
 export DOCKER_NAME_TAG=ubuntu:16.04
 export PACKAGES="libqt5gui5 libqt5core5a qtbase5-dev libqt5dbus5 qttools5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-iostreams-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libqrencode-dev libzip-dev zlib1g zlib1g-dev libcurl4-openssl-dev"
-export RUN_UNIT_TESTS=false
+export RUN_UNIT_TESTS=true
 # export RUN_FUNCTIONAL_TESTS=false
 # export RUN_SECURITY_TESTS="true"
-export GOAL=""
+export GOAL="install"
 export GRIDCOIN_CONFIG="--enable-reduce-exports --with-incompatible-bdb --with-gui=qt5"
 export NEED_XVFB="true"
 export NO_DEPENDS=1

--- a/ci/test/00_setup_env_native_old.sh
+++ b/ci/test/00_setup_env_native_old.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_native_old
+export DOCKER_NAME_TAG=ubuntu:16.04
+export PACKAGES="libqt5gui5 libqt5core5a qtbase5-dev libqt5dbus5 qttools5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-iostreams-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libqrencode-dev libzip-dev zlib1g zlib1g-dev libcurl4-openssl-dev"
+export RUN_UNIT_TESTS=false
+# export RUN_FUNCTIONAL_TESTS=false
+# export RUN_SECURITY_TESTS="true"
+export GOAL=""
+export GRIDCOIN_CONFIG="--enable-reduce-exports --with-incompatible-bdb --with-gui=qt5"
+export NEED_XVFB="true"
+export NO_DEPENDS=1

--- a/src/test/neuralnet/researcher_tests.cpp
+++ b/src/test/neuralnet/researcher_tests.cpp
@@ -52,22 +52,6 @@ boost::filesystem::path ResolveStubDir()
 }
 
 //!
-//! \brief Precondition that skips tests that read a client_state.xml stub from
-//! disk if it does not exist.
-//!
-boost::test_tools::assertion_result ClientStateStubExists(boost::unit_test::test_unit_id)
-{
-    if (boost::filesystem::exists(ResolveStubDir() / "client_state.xml")) {
-        return true;
-    }
-
-    boost::test_tools::assertion_result result(false);
-    result.message() << "client_state.xml test stub not found";
-
-    return result;
-}
-
-//!
 //! \brief Register an active beacon for testing.
 //!
 //! \param cpid External CPID used in the test.
@@ -1405,12 +1389,8 @@ BOOST_AUTO_TEST_CASE(it_ignores_the_team_whitelist_without_the_team_requirement)
 }
 
 // Note: the precondition skips this test case when the test harness cannot
-// resolve the client_state.xml stub. Autotools' "make check" target counts
-// this skip as a failure, so the test harness must be run from a supported
-// path within the source tree.
-//
-BOOST_AUTO_TEST_CASE(it_parses_project_xml_from_a_client_state_xml_file,
-    *boost::unit_test::precondition(ClientStateStubExists))
+// resolve the client_state.xml stub.
+void it_parses_project_xml_from_a_client_state_xml_file()
 {
     // This test case reads a client_state.xml stub file in test/data/ and loads
     // the projects and CPIDs into the global researcher context.
@@ -1478,12 +1458,8 @@ BOOST_AUTO_TEST_CASE(it_parses_project_xml_from_a_client_state_xml_file,
 }
 
 // Note: the precondition skips this test case when the test harness cannot
-// resolve the client_state.xml stub. Autotools' "make check" target counts
-// this skip as a failure, so the test harness must be run from a supported
-// path within the source tree.
-//
-BOOST_AUTO_TEST_CASE(it_resets_to_investor_mode_when_explicitly_configured,
-    *boost::unit_test::precondition(ClientStateStubExists))
+// resolve the client_state.xml stub.
+void it_resets_to_investor_mode_when_explicitly_configured()
 {
     SetArgument("investor", "1");
 
@@ -1505,6 +1481,20 @@ BOOST_AUTO_TEST_CASE(it_resets_to_investor_mode_when_explicitly_configured,
     SetArgument("email", "");
     SetArgument("boincdatadir", "");
     NN::Researcher::Reload(NN::MiningProjectMap());
+}
+
+//!
+//! \brief Precondition that skips tests that read a client_state.xml stub from
+//! disk if it does not exist.
+//!
+BOOST_AUTO_TEST_CASE(client_state_stub_exists)
+{
+    if (boost::filesystem::exists(ResolveStubDir() / "client_state.xml")) {
+        boost::unit_test::framework::master_test_suite().add(BOOST_TEST_CASE(&it_parses_project_xml_from_a_client_state_xml_file));
+        boost::unit_test::framework::master_test_suite().add(BOOST_TEST_CASE(&it_resets_to_investor_mode_when_explicitly_configured));
+    } else {
+        BOOST_TEST_MESSAGE("client_state.xml test stub not found");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(it_resets_to_investor_when_it_only_finds_pool_projects)


### PR DESCRIPTION
Increased the test timeout as our tests usually doesn't take a while to run, 5 minutes should be more than enough.

Added a new job for xenial and fixed tests for it in a weird way. `boost::test_tools::assertion_result` was added Boost 1.59 therefore it isn't present in Xenial's Boost(1.58). I made a workaround which adds a new test case that adds the tests which require client_state.xml based on whether the file is present or not, although I am not sure if this is the best solution. I tried to avoid macros but perhaps a simple boost version check and return early with an additional file check could be better.

Ex.
```cpp
#ifdef BOOST_VERSION > 105800
BOOST_AUTO_TEST_CASE(it_parses_project_xml_from_a_client_state_xml_file,
    *boost::unit_test::precondition(ClientStateStubExists))
{
#else 
BOOST_AUTO_TEST_CASE(it_parses_project_xml_from_a_client_state_xml_file)
{
if (boost::filesystem::exists(ResolveStubDir() / "client_state.xml")) {
    BOOST_CHECK(false);
}
#endif
```