### PR TITLE
test: Fix tests for _GLIBCXX_ASSERTIONS

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -966,20 +966,20 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                     valtype& vch = stacktop(-1);
                     valtype vchHash((opcode == OP_RIPEMD160 || opcode == OP_SHA1 || opcode == OP_HASH160) ? 20 : 32);
                     if (opcode == OP_RIPEMD160)
-                        CRIPEMD160().Write(&vch[0], vch.size()).Finalize(&vchHash[0]);
+                        CRIPEMD160().Write(vch.data(), vch.size()).Finalize(vchHash.data());
                     else if (opcode == OP_SHA1)
-                        CSHA1().Write(&vch[0], vch.size()).Finalize(&vchHash[0]);
+                        CSHA1().Write(vch.data(), vch.size()).Finalize(vchHash.data());
                     else if (opcode == OP_SHA256)
-                        CSHA256().Write(&vch[0], vch.size()).Finalize(&vchHash[0]);
+                        CSHA256().Write(vch.data(), vch.size()).Finalize(vchHash.data());
                     else if (opcode == OP_HASH160)
                     {
                         uint160 hash160 = Hash160(vch);
-                        memcpy(&vchHash[0], &hash160, sizeof(hash160));
+                        memcpy(vchHash.data(), &hash160, sizeof(hash160));
                     }
                     else if (opcode == OP_HASH256)
                     {
                         uint256 hash = Hash(vch.begin(), vch.end());
-                        memcpy(&vchHash[0], &hash, sizeof(hash));
+                        memcpy(vchHash.data(), &hash, sizeof(hash));
                     }
                     popstack(stack);
                     stack.push_back(vchHash);

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
         std::vector<unsigned char> sourcedata = ParseHex(test[0].get_str());
         std::string base58string = test[1].get_str();
         BOOST_CHECK_MESSAGE(
-                    EncodeBase58(&sourcedata[0], &sourcedata[sourcedata.size()]) == base58string,
+                    EncodeBase58(sourcedata.data(), sourcedata.data() + sourcedata.size()) == base58string,
                     strTest);
     }
 }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -53,7 +53,11 @@ ParseScript(string s)
 
     BOOST_FOREACH(string w, words)
     {
-        if (all(w, is_digit()) ||
+        if (w.empty())
+        {
+            // Empty string, ignore. (boost::split given '' will return one word)
+        }
+        else if (all(w, is_digit()) ||
             (starts_with(w, "-") && all(string(w.begin()+1, w.end()), is_digit())))
         {
             // Number


### PR DESCRIPTION
This fixes some tests to avoid triggering assertions when enabling `_GLIBCXX_ASSERTIONS` or `_GLIBCXX_DEBUG` as observed by Fedora package maintainers. 