### PR TITLE
util: Fix Windows API for default data directory with wide characters

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1014,14 +1014,14 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 {
-    char pszPath[MAX_PATH] = "";
+    wchar_t pszPath[MAX_PATH] = L"";
 
-    if(SHGetSpecialFolderPathA(NULL, pszPath, nFolder, fCreate))
+    if (SHGetSpecialFolderPathW(NULL, pszPath, nFolder, fCreate))
     {
         return fs::path(pszPath);
     }
 
-    LogPrintf("SHGetSpecialFolderPathA() failed, could not obtain requested path.");
+    LogPrintf("SHGetSpecialFolderPathW() failed, could not obtain requested path.");
     return fs::path("");
 }
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1016,7 +1016,7 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 {
     wchar_t pszPath[MAX_PATH] = L"";
 
-    if (SHGetSpecialFolderPathW(NULL, pszPath, nFolder, fCreate))
+    if (SHGetSpecialFolderPathW(nullptr, pszPath, nFolder, fCreate))
     {
         return fs::path(pszPath);
     }


### PR DESCRIPTION
This fixes a missed `*A()` to `*W()` conversion (#1571) for the Windows API call that resolves the AppData directory for the default wallet data directory. It may solve crashes reported with v5.0.0 when the default data directory contains wide characters. 

I think this is the last place we need this conversion. The remaining `*A()` API calls do not need to handle Unicode characters.