### PR TITLE
gui: Fix OP_RETURN filter to avoid hiding transactions with messages

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -35,10 +35,16 @@ bool TransactionRecord::showTransaction(const CWalletTx &wtx, bool datetime_limi
 
     // Suppress OP_RETURN transactions if they did not originate from you.
     // This is not "very" taxing but necessary since the transaction is in the wallet already.
-    // We only do this for version 1 transactions, because this legacy error does not occur
+    // We only do this for older transactions, because this legacy error does not occur
     // anymore, and we can't filter entire transactions that have OP_RETURNs, since
-    // some outputs are relevent with the new contract types, such as messages.
-    if (wtx.nVersion == 1 && !wtx.IsFromMe())
+    // some outputs are relevant with the new contract types, such as messages.
+    //
+    // The selected timestamp represents 2018-11-12, a date that shortly follows
+    // the next mandatory release (v4.0.0) hard-fork after the fix for OP_RETURN
+    // filtering merged. No wallet databases should contain transactions for any
+    // !IsFromMe() OP_RETURN outputs created after that time.
+    //
+    if (wtx.nTime < 1542000000 && !wtx.IsFromMe())
     {
         for (auto const& txout : wtx.vout)
         {


### PR DESCRIPTION
This changes the criteria for the GUI filter that hides transactions that contain `OP_RETURN` outputs to avoid squelching transactions that occur after the v4.0.0 hard-fork. The filter fixes an old issue (#1282) that caused a wallet to display transactions that it did not send itself when those transactions contain `OP_RETURN` outputs. Since contracts in version 2+ transactions use `OP_RETURN` outputs to burn the contract fee, we added an additional constraint on the filter that limits it to version 1 only. As a side effect, the constraint hides legacy transactions with message contracts during the transition period to block version 11 because these also contain an `OP_RETURN` output now. 

I adjusted the constraint to filter by timestamps instead of version, so the filter will only check transactions that occur before the time of the previous mandatory release hard-fork. By this time, every node ran a version of the wallet that ignores a transaction with `OP_RETURN` outputs properly. 

This issue only affects the display of transactions created with a user-supplied message for a receiving wallet during the transition period to block version 11.