### PR TITLE
net: Fix stalled blockchain progression

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3725,14 +3725,14 @@ bool AskForOutstandingBlocks(uint256 hashStart)
                 {
                         if (hashStart==uint256())
                         {
-                            pNode->PushGetBlocks(pindexBest, uint256(), true);
+                            pNode->PushGetBlocks(pindexBest, uint256());
                         }
                         else
                         {
                             CBlockIndex* pblockindex = mapBlockIndex[hashStart];
                             if (pblockindex)
                             {
-                                pNode->PushGetBlocks(pblockindex, uint256(), true);
+                                pNode->PushGetBlocks(pblockindex, uint256());
                             }
                             else
                             {
@@ -3817,7 +3817,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
         mapOrphanBlocksByPrev.insert(make_pair(pblock->hashPrevBlock, pblock2));
 
         // Ask this guy to fill in what we're missing
-        pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(pblock2), true);
+        pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(pblock2));
         // ppcoin: getblocks may not obtain the ancestor block rejected
         // earlier by duplicate-stake check so we ask for it again directly
         if (!IsInitialBlockDownload())
@@ -4480,7 +4480,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
              (nAskedForBlocks < 1 || (vNodes.size() <= 1 && nAskedForBlocks < 1)))
         {
             nAskedForBlocks++;
-            pfrom->PushGetBlocks(pindexBest, uint256(), true);
+            pfrom->PushGetBlocks(pindexBest, uint256());
             LogPrint(BCLog::LogFlags::NET, "Asked For blocks.");
         }
 
@@ -4628,12 +4628,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             if (!fAlreadyHave)
                 pfrom->AskFor(inv);
             else if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
-                pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(mapOrphanBlocks[inv.hash]), true);
+                pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(mapOrphanBlocks[inv.hash]));
             } else if (nInv == nLastBlock) {
                 // In case we are on a very long side-chain, it is possible that we already have
                 // the last block in an inv bundle sent in response to getblocks. Try to detect
                 // this situation and push another getblocks to continue.
-                pfrom->PushGetBlocks(mapBlockIndex[inv.hash], uint256(), true);
+                pfrom->PushGetBlocks(mapBlockIndex[inv.hash], uint256());
                 LogPrint(BCLog::LogFlags::NOISY, "force getblock request: %s", inv.ToString());
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,9 +34,7 @@
 #include <ctime>
 #include <math.h>
 
-extern bool WalletOutOfSync();
 extern bool AskForOutstandingBlocks(uint256 hashStart);
-extern void ResetTimerMain(std::string timer_name);
 extern bool GridcoinServices();
 
 unsigned int nNodeLifespan;
@@ -151,12 +149,6 @@ int64_t g_v11_legacy_beacon_days = 14;
 //
 // dispatching functions
 //
-void ResetTimerMain(std::string timer_name)
-{
-    mvTimers[timer_name] = 0;
-}
-
-
 bool TimerMain(std::string timer_name, int max_ms)
 {
     mvTimers[timer_name] = mvTimers[timer_name] + 1;
@@ -3753,16 +3745,6 @@ bool AskForOutstandingBlocks(uint256 hashStart)
                 }
     }
     return true;
-}
-
-
-bool WalletOutOfSync()
-{
-    LOCK(cs_main);
-
-    // Only trigger an out of sync condition if the node has synced near the best block prior to going out of sync.
-    bool bSyncedCloseToTop = nBestHeight > GetNumBlocksOfPeers() - 1000;
-    return OutOfSyncByAge() && bSyncedCloseToTop;
 }
 
 bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)

--- a/src/main.h
+++ b/src/main.h
@@ -179,11 +179,6 @@ extern std::map<uint256, CBlock*> mapOrphanBlocks;
 extern int64_t nTransactionFee;
 extern int64_t nReserveBalance;
 extern int64_t nMinimumInputValue;
-extern int64_t nLastAskedForBlocks;
-extern int64_t nBootup;
-extern int64_t nCPIDsLoaded;
-extern int64_t nLastGRCtallied;
-extern int64_t nLastCleaned;
 
 extern bool fUseFastIndex;
 extern unsigned int nDerivationMethodIndex;
@@ -197,7 +192,6 @@ extern std::string  msMiningErrors;
 extern std::string  msMiningErrorsIncluded;
 extern std::string  msMiningErrorsExcluded;
 
-extern bool         mbBlocksDownloaded;
 extern int nGrandfather;
 extern int nNewIndex;
 extern int nNewIndex2;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -112,9 +112,8 @@ unsigned short GetListenPort()
     return (unsigned short)(GetArg("-port", GetDefaultPort()));
 }
 
-void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd, bool fForce)
+void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
 {
-    // The line of code below is the line of code that kept us from syncing to the best block (fForce forces the sync to continue).
     if (pindexBegin == pindexLastGetBlocksBegin && hashEnd == hashLastGetBlocksEnd) return;  // Filter out duplicate requests
     pindexLastGetBlocksBegin = pindexBegin;
     hashLastGetBlocksEnd = hashEnd;

--- a/src/net.h
+++ b/src/net.h
@@ -596,7 +596,7 @@ public:
 
 
 
-    void PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd, bool fForce);
+    void PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd);
     bool IsSubscribed(unsigned int nChannel);
     void Subscribe(unsigned int nChannel, unsigned int nHops=0);
     void CancelSubscribe(unsigned int nChannel);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -613,17 +613,6 @@ BOOST_AUTO_TEST_CASE(test_Capitalize)
     BOOST_CHECK_EQUAL(Capitalize("\x00\xfe\xff"), "\x00\xfe\xff");
 }
 
-BOOST_AUTO_TEST_CASE(util_IsLockTimeWithinMinutes)
-{
-    int64_t now = 1494060475;
-    int64_t minutes = 6;
-    int64_t minutesInSeconds = minutes * 60;
-    int64_t time = now - minutesInSeconds;
-
-    BOOST_CHECK(IsLockTimeWithinMinutes(time, minutes, now) == true);
-    BOOST_CHECK(IsLockTimeWithinMinutes(time - 1, minutes, now) == false);
-}
-
 BOOST_AUTO_TEST_CASE(util_VerifyRound)
 {
     BOOST_CHECK_CLOSE(1.2346, Round(1.23456789, 4), 0.00000001);

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -69,12 +69,6 @@ int64_t GetSystemTimeInSeconds()
     return GetTimeMicros()/1000000;
 }
 
-bool IsLockTimeWithinMinutes(int64_t locktime, int minutes, int64_t reference)
-{
-    int64_t cutOff = reference - minutes * 60;
-    return locktime >= cutOff;
-}
-
 void MilliSleep(int64_t n)
 {
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -36,8 +36,6 @@ void SetMockTime(int64_t nMockTimeIn);
 /** For testing */
 int64_t GetMockTime();
 
-bool IsLockTimeWithinMinutes(int64_t locktime, int minutes, int64_t reference);
-
 void MilliSleep(int64_t n);
 
 /** Return system time (or mocked time, if set) */


### PR DESCRIPTION
This attempts to fix a subtle problem observed on listening nodes with many connections. I noticed occasional blockchain stalls on my main listening node that can last for a few minutes to several hours in each case. 

During these periods, the node continues to accept connections and relay messages as usual, but it stores every new block as an orphan, so the node fails to faithfully represent the state of the chain tip. No error appears in the log or in the RPC output when this behavior starts, but the node tries the old emergency sync hammer&mdash;`AskForOutstandingBlocks()`&mdash;continuously without success. Eventually, the node resumes normal operation for about 16-24 hours until it encounters the problem again. 

I tracked the problem to a condition that causes the node to fail to request a particular block and fall into a state that prevents it from recovering until a legacy failsafe workaround wipes the storage for orphan blocks and pending requests. The management of the pending request state in `mapAlreadyAskedFor` is the primary source of the issue. Nodes use this map to follow a back-off strategy to defer retries for failed requests. However, if a peer fails to respond with a new block, subsequent advertisements for that block from other peers will increase the earliest request time for the block so far into the future that the node will never attempt to download it. 

A greater number of connections magnifies this issue because each peer can potentially advertise the new block, and each advertisement processed after the first failed request for the block increases the delay for the next request for any peer by two minutes.

I fixed the issue by resetting the earliest request time in `mapAlreadyAskedFor` for a missing ancestor block when the node receives a child of that block as an orphan. I will annotate this PR to explain the changes more clearly.