### PR TITLE
refactor: Implement std::atomic_bool OutOfSyncByAge

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -38,6 +38,8 @@ bool IsConfigFileEmpty();
 
 namespace NN { void ReplayContracts(const CBlockIndex* pindex); }
 
+extern void UpdateOutOfSyncByAge();
+
 #ifndef WIN32
 #include <signal.h>
 #include <sys/stat.h>
@@ -939,6 +941,8 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
     LogPrintf(" block index %15" PRId64 "ms", GetTimeMillis() - nStart);
 
+    UpdateOutOfSyncByAge();
+
     if (IsV9Enabled(pindexBest->nHeight)) {
         uiInterface.InitMessage(_("Loading superblock cache..."));
         LogPrintf("Loading superblock cache...");
@@ -1092,8 +1096,9 @@ bool AppInit2(ThreadHandlerPtr threads)
         for (auto const& strFile : mapMultiArgs["-loadblock"])
         {
             FILE *file = fsbridge::fopen(strFile, "rb");
-            if (file)
+            if (file) {
                 LoadExternalBlockFile(file);
+            }
         }
         exit(0);
     }

--- a/src/main.h
+++ b/src/main.h
@@ -168,6 +168,7 @@ extern arith_uint256 nBestChainTrust;
 extern arith_uint256 nBestInvalidTrust;
 extern uint256 hashBestChain;
 extern CBlockIndex* pindexBest;
+extern std::atomic_bool g_fOutOfSyncByAge;
 extern const std::string strMessageMagic;
 extern int64_t nTimeBestReceived;
 extern CCriticalSection cs_setpwalletRegistered;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -957,7 +957,7 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
 
 void AddNeuralContractOrVote(CBlock& blocknew)
 {
-    if (OutOfSyncByAge()) {
+    if (g_fOutOfSyncByAge) {
         LogPrintf("AddNeuralContractOrVote: Out of sync.");
         return;
     }

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -631,7 +631,7 @@ public:
 
         LogPrintf("ValidateSuperblock(): No match by project.");
 
-        if (OutOfSyncByAge()) {
+        if (g_fOutOfSyncByAge) {
             LogPrintf("ValidateSuperblock(): No validation achieved, but node is"
                       "not in sync - skipping validation.");
 

--- a/src/neuralnet/researcher.cpp
+++ b/src/neuralnet/researcher.cpp
@@ -1211,7 +1211,7 @@ int64_t Researcher::Accrual() const
         return 0;
     }
 
-    const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
+    const int64_t now = g_fOutOfSyncByAge ? pindexBest->nTime : GetAdjustedTime();
 
     LOCK(cs_main);
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1925,7 +1925,7 @@ UniValue MagnitudeReport(const NN::Cpid cpid)
 {
     UniValue json(UniValue::VOBJ);
 
-    const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
+    const int64_t now = g_fOutOfSyncByAge ? pindexBest->nTime : GetAdjustedTime();
     const NN::ResearchAccount& account = NN::Tally::GetAccount(cpid);
     const NN::AccrualComputer calc = NN::Tally::GetComputer(cpid, now, pindexBest);
 

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -973,22 +973,14 @@ void Scraper(bool bSingleShot)
         // We do NOT want to filter statistics with an out-of-date beacon list or project whitelist.
         // If called in singleshot mode, wallet will most likely be in sync, because the calling functions check
         // beforehand.
-        while (OutOfSyncByAge())
+        while (g_fOutOfSyncByAge)
         {
-            // Set atomic out of sync flag to true.
-            fOutOfSyncByAge = true;
-
             // Signal stats event to UI.
             uiInterface.NotifyScraperEvent(scrapereventtypes::OutOfSync, CT_UPDATING, {});
 
             _log(logattribute::INFO, "Scraper", "Wallet not in sync. Sleeping for 8 seconds.");
             MilliSleep(8000);
         }
-
-        // Set atomic out of sync flag to false.
-        fOutOfSyncByAge = false;
-
-        nSyncTime = GetAdjustedTime();
 
         // Now that we are in sync, refresh from the AppCache and check for proper directory/file structure.
         // Also delete any unauthorized CScraperManifests received before the wallet was in sync.
@@ -1223,22 +1215,14 @@ void NeuralNetwork()
     {
         // Only proceed if wallet is in sync. Check every 8 seconds since no callback is available.
         // We do NOT want to filter statistics with an out-of-date beacon list or project whitelist.
-        while (OutOfSyncByAge())
+        while (g_fOutOfSyncByAge)
         {
-            // Set atomic out of sync flag to true.
-            fOutOfSyncByAge = true;
-
             // Signal stats event to UI.
             uiInterface.NotifyScraperEvent(scrapereventtypes::OutOfSync, CT_NEW, {});
 
             _log(logattribute::INFO, "NeuralNetwork", "Wallet not in sync. Sleeping for 8 seconds.");
             MilliSleep(8000);
         }
-
-        // Set atomic out of sync flag to false.
-        fOutOfSyncByAge = false;
-
-        nSyncTime = GetAdjustedTime();
 
         // ScraperHousekeeping items are only run in this thread if not handled by the Scraper() thread.
         if (!fScraperActive)
@@ -4806,7 +4790,7 @@ mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests()
 
     // First check for unauthorized manifests just in case a scraper has been deauthorized.
     // This is only done if in sync.
-    if (!fOutOfSyncByAge)
+    if (!g_fOutOfSyncByAge)
     {
         unsigned int nDeleted = ScraperDeleteUnauthorizedCScraperManifests();
         if (nDeleted) _log(logattribute::WARNING, "ScraperDeleteCScraperManifests", "Deleted " + std::to_string(nDeleted) + " unauthorized manifests.");
@@ -5061,7 +5045,7 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bCon
     // NOTE - OutOfSyncByAge calls PreviousBlockAge(), which takes a lock on cs_main. This is likely a deadlock culprit if called from here
     // and the scraper or neuralnet loop nearly simultaneously. So we use an atomic flag updated by the scraper or neuralnet loop.
     // If not in sync then immediately bail with an empty superblock.
-    if (fOutOfSyncByAge) return empty_superblock;
+    if (g_fOutOfSyncByAge) return empty_superblock;
 
     // Check the age of the ConvergedScraperStats cache. If less than nScraperSleep / 1000 old (for seconds) or clean, then simply report back the cache contents.
     // This prevents the relatively heavyweight stats computations from running too often. The time here may not exactly align with

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -100,11 +100,7 @@ int64_t SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD = 300;
 
 AppCacheSectionExt mScrapersExt = {};
 
-// Lets try to start using some lockless synchronization.
-std::atomic<int64_t> nSyncTime {0};
-// Starting state is always out of sync. This atomic is to avoid multiple threads calling
-// OutOfSyncByAge(), which takes a lock on cs_main and can cause deadlocks.
-std::atomic<bool> fOutOfSyncByAge {true};
+extern std::atomic_bool g_fOutOfSyncByAge;
 
 CCriticalSection cs_mScrapersExt;
 


### PR DESCRIPTION
This commit replaces the function call OutOfSyncByAge() with a void UpdateOutOfSyncByAge() that updates an atomic boolean fOutOfSyncByAge and an atomic int64_t nSyncTime. This function is called in the "main loop" in init and main in the block processing functions where a lock on cs_main is essentially already taken at the only points where pindexBest is updated.

This allows us to change the old OutOfSyncByAge() function into simply the fOutOfSyncByAge atomic boolean flag itself, which requires no cs_main lock. This eliminates a possible source of deadlocks, since a number of threads use OutOfSyncByAge and also take other locks.