### PR TITLE
net: Optimize locator construction for "getblocks" messages

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -101,6 +101,25 @@ CCriticalSection CNode::cs_mapMisbehavior;
 
 static CSemaphore *semOutbound = NULL;
 
+// This caches the block locators used to ask for a range of blocks. Due to a
+// sub-optimal workaround in our old net messaging code, a node will ask each
+// peer that advertises a block for the next range. The node generates a sub-
+// set of hashes from the current block chain used as a locator for the block
+// in the chain of the peer. Creating locators is extremely expensive--a node
+// needs to scan the entire chain--so we cache the locators and reuse them if
+// the node sends the same request. For nodes with many connections, this can
+// dramatically improve the performance of the messaging system when it needs
+// to respond to new blocks.
+//
+// This optimization will become unnecessary when we backport newer chain and
+// net messaging code from Bitcoin. For now, this cache can greatly improve a
+// node's ability to serve a higher number of connections.
+//
+namespace {
+    const CBlockIndex* g_getblocks_pindex_begin = nullptr;
+    CBlockLocator g_getblocks_locator;
+}
+
 void AddOneShot(string strDest)
 {
     LOCK(cs_vOneShots);
@@ -115,9 +134,16 @@ unsigned short GetListenPort()
 void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
 {
     if (pindexBegin == pindexLastGetBlocksBegin && hashEnd == hashLastGetBlocksEnd) return;  // Filter out duplicate requests
+
     pindexLastGetBlocksBegin = pindexBegin;
     hashLastGetBlocksEnd = hashEnd;
-    PushMessage("getblocks", CBlockLocator(pindexBegin), hashEnd);
+
+    if (pindexBegin != g_getblocks_pindex_begin) {
+        g_getblocks_pindex_begin = pindexBegin;
+        g_getblocks_locator = CBlockLocator(pindexBegin);
+    }
+
+    PushMessage("getblocks", g_getblocks_locator, hashEnd);
 }
 
 // find 'best' local address for a particular peer


### PR DESCRIPTION
This caches the block locators used to ask for a range of blocks. Due to a sub-optimal workaround in our old net messaging code, a node will ask each peer that advertises a block for the next range. The node generates a subset of hashes from the current blockchain used as a locator for the block in the chain of the peer. Creating locators is extremely expensive&mdash;a node needs to scan the entire chain&mdash;so this PR adds a cache for the locators and reuses them if the node sends the same request. For nodes with many connections, this can dramatically improve the performance of the messaging system when it needs to respond to new blocks.

This optimization will become unnecessary when we backport newer chain and net messaging code from Bitcoin. For now, this cache can greatly improve a node's ability to serve a higher number of connections, and it reduces some CPU usage for non-listening nodes as well.

Here's the observed CPU usage of a VPS that serves almost 400 connections after applying the optimization on 09-11:

![image](https://user-images.githubusercontent.com/4282384/93036476-95664b80-f605-11ea-8461-8184d1255357.png)

This should reduce the huge ping and latency spikes that I see on large listening nodes when a new block arrives (up to 60 seconds sometimes). The same problem causes the high CPU usage when synchronizing blocks near the chain tip. I'm working on a more general solution for that.