### PR TITLE
superblock: Fix regression for superblock builder optimization

### DIFF
--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -87,10 +87,15 @@ public:
                 // sections into the superblock, we can exit this loop.
                 //
                 default:
-                    break;
+                    goto end_build_from_stats_loop;
             }
         }
 
+        // ScraperStatsQuorumHasher expects the verified beacons data after the
+        // CPID and project data, so we use a goto statement to break the above
+        // loop instead or reordering the logic to use a return statement:
+        //
+        end_build_from_stats_loop:
         m_superblock.m_verified_beacons.Reset(stats_and_verified_beacons.mVerifiedMap);
     }
 private:


### PR DESCRIPTION
This fixes a regression in the superblock builder that optimizes the construction of a superblock from scraper statistics. The change
that added the beacon IDs to the superblock altered the loop for the scraper stats import in a way that reverted the optimization
that skips the unneeded `byCPIDbyProject` entries (the bulk of the data structure).