### PR TITLE
gui: Adds menu option to open config

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -742,8 +742,19 @@ void BitcoinGUI::openConfigClicked()
 {
     boost::filesystem::path pathConfig = GetConfigFile();
     /* Open gridcoinresearch.conf with the associated application */
-    if (boost::filesystem::exists(pathConfig))
-        QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathConfig.string())));
+    bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathConfig.string())));
+    #ifdef Q_OS_WIN
+    // Workaround for windows specific behaviour
+    if(!res) {
+        res = QProcess::startDetached("C:\\Windows\\system32\\notepad.exe", QStringList{QString::fromStdString(pathConfig.string())});
+    }
+    #endif
+    #ifdef Q_OS_MAC
+    // Workaround for macOS-specific behaviour; see https://github.com/bitcoin/bitcoin/issues/15409
+    if (!res) {
+        res = QProcess::startDetached("/usr/bin/open", QStringList{"-t", QString::fromStdString(pathConfig.string())});
+    }
+    #endif
 }
 
 void BitcoinGUI::researcherClicked()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -181,7 +181,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     rpcConsole = new RPCConsole(this);
     connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(show()));
 
-     diagnosticsDialog = new DiagnosticsDialog(this);
+    diagnosticsDialog = new DiagnosticsDialog(this);
 
     // Clicking on "Verify Message" in the address book sends you to the verify message tab
     connect(addressBookPage, SIGNAL(verifyMessage(QString)), this, SLOT(gotoVerifyMessageTab(QString)));
@@ -194,6 +194,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     overview_update_timer->start(5 * 1000);
 
     QObject::connect(overview_update_timer, SIGNAL(timeout()), this, SLOT(updateGlobalStatus()));
+
+    connect(openConfigAction, SIGNAL(triggered()), this, SLOT(openConfigClicked()));
 
     gotoOverviewPage();
 }
@@ -320,6 +322,9 @@ void BitcoinGUI::createActions()
     optionsAction = new QAction(tr("&Options..."), this);
     optionsAction->setToolTip(tr("Modify configuration options for Gridcoin"));
     optionsAction->setMenuRole(QAction::PreferencesRole);
+    openConfigAction = new QAction(tr("Open config &file"), this);
+    optionsAction->setToolTip(tr("Open the config file in your standard editor"));
+    openConfigAction->setMenuRole(QAction::PreferencesRole);
     researcherAction = new QAction(tr("&Researcher Wizard..."), this);
     researcherAction->setToolTip(tr("Open BOINC and beacon settings for Gridcoin"));
     researcherAction->setMenuRole(QAction::PreferencesRole);
@@ -392,6 +397,7 @@ void BitcoinGUI::setIcons()
     exportAction->setIcon(QPixmap(":/icons/export"));
     openRPCConsoleAction->setIcon(QPixmap(":/icons/debugwindow"));
     snapshotAction->setIcon(QPixmap(":/images/gridcoin"));
+    openConfigAction->setIcon(QPixmap(":/icons/edit"));
 }
 
 void BitcoinGUI::createMenuBar()
@@ -430,6 +436,7 @@ void BitcoinGUI::createMenuBar()
     settings->addAction(researcherAction);
     settings->addSeparator();
     settings->addAction(optionsAction);
+    settings->addAction(openConfigAction);
 
     QMenu *community = appMenuBar->addMenu(tr("&Community"));
     community->addAction(bxAction);
@@ -729,6 +736,14 @@ void BitcoinGUI::optionsClicked()
     OptionsDialog dlg;
     dlg.setModel(clientModel->getOptionsModel());
     dlg.exec();
+}
+
+void BitcoinGUI::openConfigClicked()
+{
+    boost::filesystem::path pathConfig = GetConfigFile();
+    /* Open gridcoinresearch.conf with the associated application */
+    if (boost::filesystem::exists(pathConfig))
+        QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathConfig.string())));
 }
 
 void BitcoinGUI::researcherClicked()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -322,7 +322,7 @@ void BitcoinGUI::createActions()
     optionsAction = new QAction(tr("&Options..."), this);
     optionsAction->setToolTip(tr("Modify configuration options for Gridcoin"));
     optionsAction->setMenuRole(QAction::PreferencesRole);
-    openConfigAction = new QAction(tr("Open config &file"), this);
+    openConfigAction = new QAction(tr("Open config &file..."), this);
     optionsAction->setToolTip(tr("Open the config file in your standard editor"));
     openConfigAction->setMenuRole(QAction::PreferencesRole);
     researcherAction = new QAction(tr("&Researcher Wizard..."), this);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -96,18 +96,19 @@ private:
     QAction *sendCoinsAction;
     QAction *addressBookAction;
     QAction *signMessageAction;
-	QAction *bxAction;
-	QAction *websiteAction;
-	QAction *boincAction;
-	QAction *chatAction;
-	QAction *exchangeAction;
+    QAction *bxAction;
+    QAction *websiteAction;
+    QAction *boincAction;
+    QAction *chatAction;
+    QAction *exchangeAction;
     QAction *votingAction;
-	QAction *diagnosticsAction;
+    QAction *diagnosticsAction;
     QAction *verifyMessageAction;
     QAction *aboutAction;
     QAction *receiveCoinsAction;
     QAction *researcherAction;
     QAction *optionsAction;
+    QAction *openConfigAction;
     QAction *toggleHideAction;
     QAction *exportAction;
     QAction *encryptWalletAction;
@@ -174,7 +175,7 @@ public slots:
     */
     void askFee(qint64 nFeeRequired, bool *payFee);
 
-	void askQuestion(std::string caption, std::string body, bool *result);
+    void askQuestion(std::string caption, std::string body, bool *result);
 
     void handleURI(QString strURI);
     void setOptionsStyleSheet(QString qssFileName);
@@ -204,13 +205,15 @@ private slots:
     void researcherClicked();
     /** Show about dialog */
     void aboutClicked();
+    /** Open config file */
+    void openConfigClicked();
 
-	void bxClicked();
-	void websiteClicked();
-	void exchangeClicked();
-	void boincClicked();
+    void bxClicked();
+    void websiteClicked();
+    void exchangeClicked();
+    void boincClicked();
     void boincStatsClicked();
-	void chatClicked();
+    void chatClicked();
     void diagnosticsClicked();
     void peersClicked();
     void snapshotClicked();
@@ -245,7 +248,7 @@ private slots:
     void updateScraperIcon(int scraperEventtype, int status);
     void updateBeaconIcon();
 
-	QString GetEstimatedStakingFrequency(unsigned int nEstimateTime);
+    QString GetEstimatedStakingFrequency(unsigned int nEstimateTime);
 
     void updateGlobalStatus();
 };


### PR DESCRIPTION
I added a simple menu option to allow the user to open the config file directly from the wallet.
Currently tested on Windows 10 and Linux.

![image](https://user-images.githubusercontent.com/9782029/93128665-2144aa00-f6d0-11ea-91a3-4b6d2a4c7fd5.png)

closes #1456 
closes #598 