### PR TITLE
refactor: Combine GetOrphanRoot() and WantedByOrphan() functions

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -257,7 +257,6 @@ int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock);
-uint256 WantedByOrphan(const CBlock* pblockOrphan);
 
 const CBlockIndex* GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfStake);
 void StakeMiner(CWallet *pwallet);


### PR DESCRIPTION
This removes duplicated logic, eliminates redundant ancestor resolution, and enables caching for orphan block hashes.