### PR TITLE
rpc: Display local IP addresses in "getnetworkinfo" output

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -54,19 +54,14 @@ extern void NeuralNetwork();
 
 extern bool fScraperActive;
 
-struct LocalServiceInfo {
-    int nScore;
-    int nPort;
-};
-
 //
 // Global state variables
 //
 bool fDiscover = true;
 bool fUseUPnP = false;
 ServiceFlags nLocalServices = NODE_NETWORK;
-static CCriticalSection cs_mapLocalHost;
-static map<CNetAddr, LocalServiceInfo> mapLocalHost;
+CCriticalSection cs_mapLocalHost;
+std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};
 static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;

--- a/src/net.h
+++ b/src/net.h
@@ -55,6 +55,14 @@ void SocketSendData(CNode *pnode);
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;
 
+struct LocalServiceInfo {
+    int nScore;
+    int nPort;
+};
+
+extern CCriticalSection cs_mapLocalHost;
+extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
+
 enum
 {
     LOCAL_NONE,   // unknown

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -544,6 +544,21 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     res.pushKV("mininput",        ValueFromAmount(nMinimumInputValue));
     res.pushKV("proxy",           (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string()));
     res.pushKV("ip",              addrSeenByPeer.ToStringIP());
+
+    UniValue localAddresses(UniValue::VARR);
+    {
+        LOCK(cs_mapLocalHost);
+        for (const std::pair<const CNetAddr, LocalServiceInfo> &item : mapLocalHost)
+        {
+            UniValue rec(UniValue::VOBJ);
+            rec.pushKV("address", item.first.ToString());
+            rec.pushKV("port", item.second.nPort);
+            rec.pushKV("score", item.second.nScore);
+            localAddresses.push_back(rec);
+        }
+    }
+
+    res.pushKV("localaddresses", localAddresses);
     res.pushKV("errors",          GetWarnings("statusbar"));
 
     return res;


### PR DESCRIPTION
This adds a collection of the IP addresses that a node determined that it can provide peer-to-peer services for to the output of the `getnetworkinfo` RPC function.

It may be useful for testing #1655 (after that rebase).