### PR TITLE
refactor: Convert beacon and backup timers to scheduled jobs

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -243,7 +243,7 @@ bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::strin
                "The retention will follow whichever results in the greater number of files "
                "retained.", retention_by_num, retention_by_days);
 
-    int64_t retention_cutoff_time = GetAdjustedTime() - retention_by_days * 86400;
+    int64_t retention_cutoff_time = GetSystemTimeInSeconds() - retention_by_days * 86400;
 
     // Iterate through the log archive directory and delete the oldest files beyond the retention rules.
     // The names are in format <file type>-YYYY-MM-DDTHH-MM-SS for the backup entries, so iterate

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -43,12 +43,25 @@ std::string GetBackupFilename(const std::string& basename, const std::string& su
 
 bool BackupsEnabled()
 {
-    return GetArg("-walletbackupinterval", 1) > 0;
+    // If either of these configuration options is explicitly set to zero,
+    // disable backups completely:
+    return GetArg("-walletbackupinterval", 1) > 0
+        && GetArg("-walletbackupintervalsecs", 1) > 0;
 }
 
 int64_t GetBackupInterval()
 {
-    return GetArg("-walletbackupinterval", 900) * 90;
+    int64_t backup_interval_secs = GetArg("-walletbackupintervalsecs", 86400);
+
+    // The deprecated -walletbackupinterval option specifies the backup interval
+    // as the number of blocks that pass. If someone still uses this in a config
+    // file, we'll honor it for now:
+    //
+    if (mapArgs.count("-walletbackupinterval")) {
+        backup_interval_secs = GetArg("-walletbackupinterval", 900) * 90;
+    }
+
+    return backup_interval_secs;
 }
 
 void RunBackupJob()

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -190,16 +190,16 @@ bool BackupWallet(const CWallet& wallet, const std::string& strDest)
 bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::string> backup_file_type,
                    unsigned int retention_by_num, unsigned int retention_by_days, std::vector<std::string>& files_removed)
 {
-    // Backup file retention manager. Adapted from the scraper/main log archiver core.
+    // Backup file retention maintainer. Adapted from the scraper/main log archiver core.
     // This is count three for this type code:
     // TODO: Probably a good idea to encapsulate it into its own function that can be
     //used by backups and both loggers.
 
-    bool manage_backup_retention = GetBoolArg("-managebackupretention", false);
+    bool maintain_backup_retention = GetBoolArg("-maintainbackupretention", false);
 
-    // Nothing to do if manage_backup_retention is not set, which is the default to be
+    // Nothing to do if maintain_backup_retention is not set, which is the default to be
     // safe (i.e. retain backups indefinitely is the default behavior).
-    if (!manage_backup_retention) return true;
+    if (!maintain_backup_retention) return true;
 
     // Zeroes for both incoming retention arguments mean that the config file settings should be used.
       if (!retention_by_num && !retention_by_days)
@@ -222,7 +222,7 @@ bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::strin
      }
 
      // This is a conditional clamp that checks for nonsensical values to protect people.
-     // If -managebackupretention is set, but the other two are not, they both will default to
+     // If -maintainbackupretention is set, but the other two are not, they both will default to
      // 365, which will pass this check. What this does is detect a scenario where both are
      // set to something less than 7, which is probably not a good idea. One of them can be set
      // to less than seven, or even not set (which is the same as zero), as long as the other
@@ -231,7 +231,7 @@ bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::strin
      // retained, so the "and" condition is sufficient here.
      if (retention_by_num < 7 && retention_by_days < 7)
      {
-         LogPrintf("ERROR: ManageBackups: Nonsensical values specified for backup retention. "
+         LogPrintf("ERROR: MaintainBackups: Nonsensical values specified for backup retention. "
                    "Clamping both number of files and number of days to 7. Retention will follow "
                    "whichever results in the most retention to be safe.");
 
@@ -239,7 +239,7 @@ bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::strin
          retention_by_days = 7;
      }
 
-    LogPrintf ("INFO: ManageBackups: number of files to retain %i, number of days to retain %i. "
+    LogPrintf ("INFO: MaintainBackups: number of files to retain %i, number of days to retain %i. "
                "The retention will follow whichever results in the greater number of files "
                "retained.", retention_by_num, retention_by_days);
 
@@ -286,7 +286,8 @@ bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::strin
                     // If ParseISO8601DateTime can't parse the imbedded datetime string, it will return 0.
                     if (!imbedded_file_time)
                     {
-                        LogPrintf("WARN: ManageBackups: Unable to parse date-time in backup filename. Ignoring time retention for this file.");
+                        LogPrintf("WARN: MaintainBackups: Unable to parse date-time in backup filename."
+                                  "Ignoring time retention for this file.");
                     }
                 }
 
@@ -320,7 +321,7 @@ bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::strin
 
                     files_removed.push_back(iter.path().filename().string());
 
-                    LogPrintf("INFO: ManageBackups: Removed old backup file %s.", iter.path().filename().string());
+                    LogPrintf("INFO: MaintainBackups: Removed old backup file %s.", iter.path().filename().string());
                 }
 
                 ++i;
@@ -329,7 +330,7 @@ bool MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::strin
     }
     catch (const filesystem::filesystem_error &e)
     {
-        LogPrintf("ERROR: ManageBackups: Error managing backup file retention: %s", e.what());
+        LogPrintf("ERROR: MaintainBackups: Error managing backup file retention: %s", e.what());
 
         return false;
     }

--- a/src/backup.h
+++ b/src/backup.h
@@ -9,6 +9,11 @@ class CWallet;
 
 std::string GetBackupFilename(const std::string& basename, const std::string& suffix = "");
 boost::filesystem::path GetBackupPath();
+
+bool BackupsEnabled();
+int64_t GetBackupInterval();
+void RunBackupJob();
+
 bool BackupConfigFile(const std::string& strDest);
 bool MaintainBackups(boost::filesystem::path wallet_backup_path, std::vector<std::string> backup_file_type,
                    unsigned int retention_by_num, unsigned int retention_by_days, std::vector<std::string>& files_removed);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1207,6 +1207,8 @@ bool AppInit2(ThreadHandlerPtr threads)
         LogInstance().archive(false, plogfile_out);
     }, 300 * 1000);
 
+    scheduler.scheduleEvery(NN::Researcher::RunRenewBeaconJob, 4 * 60 * 60 * 1000);
+
     /** If this is not TestNet we check for updates on startup and daily **/
     /** We still add to the scheduler regardless of the users choice however the choice is respected when they opt out**/
     if (!fTestNet)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -295,6 +295,9 @@ std::string HelpMessage()
         "  -checklevel=<n>        " + _("How thorough the block verification is (0-6, default: 1)") + "\n" +
         "  -loadblock=<file>      " + _("Imports blocks from external blk000?.dat file") + "\n" +
 
+        "  -walletbackupinterval=<n>     " + _("DEPRECATED: Optional: Create a wallet backup every <n> blocks. Zero disables backups") + "\n"
+        "  -walletbackupintervalsecs=<n> " + _("Optional: Create a wallet backup every <n> seconds. Zero disables backups (default: 86400)") + "\n"
+
         "\n" + _("Block creation options:") + "\n" +
         "  -blockminsize=<n>      "   + _("Set minimum block size in bytes (default: 0)") + "\n" +
         "  -blockmaxsize=<n>      "   + _("Set maximum block size in bytes (default: 250000)") + "\n" +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3698,22 +3698,6 @@ bool GridcoinServices()
         LogPrintf("Daily backup results: Wallet -> %s Config -> %s", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
     }
 
-    // Attempt to advertise or renew a beacon automatically if the wallet is
-    // unlocked and funded.
-    //
-    if (TimerMain("send_beacon", 180)) {
-        const NN::ResearcherPtr researcher = NN::Researcher::Get();
-
-        // Do not perform an automated renewal for participants with existing
-        // beacons before a superblock is due. This avoids overwriting beacon
-        // timestamps in the beacon registry in a way that causes the renewed
-        // beacon to appear ahead of the scraper beacon consensus window.
-        //
-        if (researcher->Eligible() && !NN::Quorum::SuperblockNeeded(pindexBest->nTime)) {
-            researcher->AdvertiseBeacon();
-        }
-    }
-
     return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,6 @@
 #include "neuralnet/superblock.h"
 #include "neuralnet/tally.h"
 #include "neuralnet/tx_message.h"
-#include "backup.h"
 #include "appcache.h"
 #include "scraper_net.h"
 #include "gridcoin.h"
@@ -3682,20 +3681,6 @@ bool GridcoinServices()
         // after the hard fork.
         //
         g_v11_timestamp = pindexBest->nTime;
-    }
-
-    //Dont perform the following functions if out of sync
-    if (g_fOutOfSyncByAge) {
-        return true;
-    }
-
-    //Backup the wallet once per 900 blocks or as specified in config:
-    int nWBI = GetArg("-walletbackupinterval", 900);
-    if (nWBI && TimerMain("backupwallet", nWBI))
-    {
-        bool bWalletBackupResults = BackupWallet(*pwalletMain, GetBackupFilename("wallet.dat"));
-        bool bConfigBackupResults = BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"));
-        LogPrintf("Daily backup results: Wallet -> %s Config -> %s", (bWalletBackupResults ? "true" : "false"), (bConfigBackupResults ? "true" : "false"));
     }
 
     return true;

--- a/src/main.h
+++ b/src/main.h
@@ -238,8 +238,6 @@ int64_t GetProofOfStakeReward(
     int64_t nTime,
     const CBlockIndex* const pindexLast);
 
-bool OutOfSyncByAge();
-
 double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40);
 double GetDifficulty(const CBlockIndex* blockindex = NULL);
 double GetBlockDifficulty(unsigned int nBits);

--- a/src/neuralnet/researcher.h
+++ b/src/neuralnet/researcher.h
@@ -347,6 +347,14 @@ public:
     static void Initialize();
 
     //!
+    //! \brief Attempt to renew a beacon automatically if the wallet is unlocked
+    //! and funded.
+    //!
+    //! This method is executed by the scheduler.
+    //!
+    static void RunRenewBeaconJob();
+
+    //!
     //! \brief Get the configured BOINC account email address.
     //!
     //! \return Lowercase BOINC email address as set in the configuration file.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1924,7 +1924,7 @@ UniValue backupwallet(const UniValue& params, bool fHelp)
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("Backup wallet success", bWalletBackupResults);
     ret.pushKV("Backup config success", bConfigBackupResults);
-    ret.pushKV("Manage backup file retention success", bMaintainBackupResults);
+    ret.pushKV("Maintain backup file retention success", bMaintainBackupResults);
     ret.pushKV("Number of files removed", (int64_t) files_removed.size());
     ret.pushKV("Files removed", u_files_removed);
 
@@ -1941,8 +1941,8 @@ UniValue maintainbackups(const UniValue& params, bool fHelp)
                 "1. \"retention by number\" (non-negative integer, optional) The number of files to retain\n"
                 "2. \"retention by days\"   (non-negative integer, optional) The number of days to retain\n"
                 "These must be specified as a pair if provided.\n"
-                "To run this command, -managebackupretention must be set as an argument during Gridcoin\n"
-                "startup or given in the config file with managebackupretention=1.\n"
+                "To run this command, -maintainbackupretention must be set as an argument during Gridcoin\n"
+                "startup or given in the config file with maintainbackupretention=1.\n"
                 "WARNING: The default values for number and days is 365 for each. Please ensure this is\n"
                 "what is desired before you execute this command. Note the command will also use\n"
                 "the corresponding walletbackupretainnumfiles= and walletbackupretainnumdays= specified\n"
@@ -1971,7 +1971,7 @@ UniValue maintainbackups(const UniValue& params, bool fHelp)
     std::vector<std::string> files_removed;
     UniValue u_files_removed(UniValue::VARR);
 
-    bool bManageBackupResults = MaintainBackups(GetBackupPath(), backup_file_type,
+    bool bMaintainBackupResults = MaintainBackups(GetBackupPath(), backup_file_type,
                                               retention_by_num, retention_by_days, files_removed);
 
     for (const auto& iter : files_removed)
@@ -1980,7 +1980,7 @@ UniValue maintainbackups(const UniValue& params, bool fHelp)
     }
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("Manage backup file retention success", bManageBackupResults);
+    ret.pushKV("Maintain backup file retention success", bMaintainBackupResults);
     ret.pushKV("Number of files removed", (int64_t) files_removed.size());
     ret.pushKV("Files removed", u_files_removed);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2753,6 +2753,19 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const {
         mapKeyBirth[it->first] = it->second->nTime - 7200; // block times can be 2h off
 }
 
+int64_t CWallet::GetLastBackupTime() const
+{
+    int64_t out_backup_time = 0;
+    CWalletDB(strWalletFile).ReadBackupTime(out_backup_time);
+
+    return out_backup_time;
+}
+
+void CWallet::StoreLastBackupTime(const int64_t backup_time)
+{
+    CWalletDB(strWalletFile).WriteBackupTime(backup_time);
+}
+
 MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout)
 {
     CWalletTx wallettx;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -440,6 +440,21 @@ public:
     void FixSpentCoins(int& nMismatchSpent, int64_t& nBalanceInQuestion, bool fCheckOnly = false);
     void DisableTransaction(const CTransaction &tx);
 
+    //!
+    //! \brief Get the time that the wallet last created a backup.
+    //!
+    //! \return Timestamp of the backup in seconds. Zero if the wallet never
+    //! created a backup before.
+    //!
+    int64_t GetLastBackupTime() const;
+
+    //!
+    //! \brief Save the time that the wallet last created a backup.
+    //!
+    //! \param backup_time Timestamp of the backup in seconds.
+    //!
+    void StoreLastBackupTime(const int64_t backup_time);
+
     /** Address book entry changed.
      * @note called with lock cs_wallet held.
      */

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -171,6 +171,17 @@ public:
 
     bool ReadAccount(const std::string& strAccount, CAccount& account);
     bool WriteAccount(const std::string& strAccount, const CAccount& account);
+
+    bool ReadBackupTime(int64_t& out_backup_time)
+    {
+        return Read(std::string("backuptime"), out_backup_time);
+    }
+
+    bool WriteBackupTime(const int64_t backup_time)
+    {
+        nWalletDBUpdated++;
+        return Write(std::string("backuptime"), backup_time);
+    }
 private:
     bool WriteAccountingEntry(const uint64_t nAccEntryNum, const CAccountingEntry& acentry);
 public:
@@ -180,9 +191,9 @@ public:
 
     DBErrors ReorderTransactions(CWallet*);
 	DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
-   
+
 	DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
-   
+
     DBErrors LoadWallet(CWallet* pwallet);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);


### PR DESCRIPTION
This refactors the block-spacing-based "timers" for beacon renewals and wallet backups into formal background jobs executed by the scheduler.

Since the `-walletbackupinterval` configuration option expects the interval as the number of blocks that need to pass between backups, I added a `-walletbackupintervalsecs` option to allow for specifying the backup interval as a unit of time. This deprecates the old option.

I also added APIs for storage of the last backup timestamp to the wallet so that the backup schedule resumes between node restarts. Before, users that restart the wallet frequently may never see the wallet create a backup because the old interval resets with each launch. 