### PR TITLE
trivial: Add and update copyright headers in Gridcoin files

### DIFF
--- a/src/gridcoin/account.h
+++ b/src/gridcoin/account.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <boost/optional.hpp>

--- a/src/gridcoin/accrual/computer.h
+++ b/src/gridcoin/accrual/computer.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/account.h"

--- a/src/gridcoin/accrual/newbie.h
+++ b/src/gridcoin/accrual/newbie.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/accrual/computer.h"

--- a/src/gridcoin/accrual/null.h
+++ b/src/gridcoin/accrual/null.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/accrual/computer.h"

--- a/src/gridcoin/accrual/research_age.h
+++ b/src/gridcoin/accrual/research_age.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/accrual/computer.h"

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "arith_uint256.h"

--- a/src/gridcoin/appcache.cpp
+++ b/src/gridcoin/appcache.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/appcache.h"
 #include "util.h"
 

--- a/src/gridcoin/appcache.h
+++ b/src/gridcoin/appcache.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <string>

--- a/src/gridcoin/backup.cpp
+++ b/src/gridcoin/backup.cpp
@@ -1,6 +1,6 @@
-
-// Backup related functions are placed here to keep vital sections of
-// code contained while maintaining clean code.
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "gridcoin/backup.h"
 #include "init.h"

--- a/src/gridcoin/backup.h
+++ b/src/gridcoin/backup.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <string>

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "base58.h"
 #include "logging.h"
 #include "main.h"

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "key.h"

--- a/src/gridcoin/boinc.cpp
+++ b/src/gridcoin/boinc.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/boinc.h"
 #include "util.h"
 

--- a/src/gridcoin/boinc.h
+++ b/src/gridcoin/boinc.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <fs.h>

--- a/src/gridcoin/claim.cpp
+++ b/src/gridcoin/claim.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "key.h"
 #include "main.h"
 #include "gridcoin/claim.h"

--- a/src/gridcoin/claim.h
+++ b/src/gridcoin/claim.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/contract/payload.h"

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/appcache.h"
 #include "gridcoin/claim.h"

--- a/src/gridcoin/contract/contract.h
+++ b/src/gridcoin/contract/contract.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "key.h"

--- a/src/gridcoin/contract/handler.h
+++ b/src/gridcoin/contract/handler.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 class CBlockIndex;

--- a/src/gridcoin/contract/message.cpp
+++ b/src/gridcoin/contract/message.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/contract/message.h"
 #include "gridcoin/contract/contract.h"
 #include "script.h"

--- a/src/gridcoin/contract/message.h
+++ b/src/gridcoin/contract/message.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <string>

--- a/src/gridcoin/contract/payload.h
+++ b/src/gridcoin/contract/payload.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "streams.h"

--- a/src/gridcoin/cpid.cpp
+++ b/src/gridcoin/cpid.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/cpid.h"
 #include "util.h"
 

--- a/src/gridcoin/cpid.h
+++ b/src/gridcoin/cpid.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "serialize.h"

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/backup.h"
 #include "gridcoin/contract/contract.h"

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 class CBlockIndex;

--- a/src/gridcoin/magnitude.h
+++ b/src/gridcoin/magnitude.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <tinyformat.h>

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/project.h"

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/contract/handler.h"

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "base58.h"
 #include "main.h"
 #include "gridcoin/claim.h"

--- a/src/gridcoin/quorum.h
+++ b/src/gridcoin/quorum.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <string>

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "init.h"
 #include "gridcoin/appcache.h"
 #include "gridcoin/backup.h"

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "key.h"

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <string>

--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/scraper/http.h"
 #include "tinyformat.h"
 #include "util.h"

--- a/src/gridcoin/scraper/http.h
+++ b/src/gridcoin/scraper/http.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <fs.h>

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "ui_interface.h"
 

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <atomic>

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -1,4 +1,6 @@
-/* scraper_net.cpp */
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 /* Define this if you want to show pubkey as address, otherwise hex id */
 #define SCRAPER_NET_PK_AS_ADDRESS

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -1,6 +1,8 @@
-#pragma once
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-/* scraper_net.h */
+#pragma once
 
 /* Maybe the parts system will be useful for other things so let's abstract
  * that to parent class. Since it will be all in one file there will not be any

--- a/src/gridcoin/staking/difficulty.cpp
+++ b/src/gridcoin/staking/difficulty.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2011-2012 The PPCoin developers
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "bignum.h"
 #include "init.h"
 #include "gridcoin/staking/difficulty.h"

--- a/src/gridcoin/staking/difficulty.h
+++ b/src/gridcoin/staking/difficulty.h
@@ -1,3 +1,8 @@
+// Copyright (c) 2011-2012 The PPCoin developers
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 class CBlockIndex;

--- a/src/gridcoin/staking/exceptions.cpp
+++ b/src/gridcoin/staking/exceptions.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/staking/exceptions.h"
 
 extern bool fTestNet;

--- a/src/gridcoin/staking/exceptions.h
+++ b/src/gridcoin/staking/exceptions.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <set>

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2013 The PPCoin developers
-// Copyright (c) 2014 The Gridcoin developers
+// Copyright (c) 2014-2020 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -1,6 +1,8 @@
 // Copyright (c) 2012-2013 The PPCoin developers
+// Copyright (c) 2014-2020 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "main.h"

--- a/src/gridcoin/staking/reward.cpp
+++ b/src/gridcoin/staking/reward.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/appcache.h"
 #include "gridcoin/staking/reward.h"
 #include "main.h"

--- a/src/gridcoin/staking/reward.h
+++ b/src/gridcoin/staking/reward.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 class CBlockIndex;

--- a/src/gridcoin/staking/status.cpp
+++ b/src/gridcoin/staking/status.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/staking/status.h"
 
 #include <algorithm>

--- a/src/gridcoin/staking/status.h
+++ b/src/gridcoin/staking/status.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "sync.h"

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "compat/endian.h"
 #include "hash.h"
 #include "main.h"

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/cpid.h"

--- a/src/gridcoin/support/block_finder.cpp
+++ b/src/gridcoin/support/block_finder.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/support/block_finder.h"
 

--- a/src/gridcoin/support/block_finder.h
+++ b/src/gridcoin/support/block_finder.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 class CBlockIndex;

--- a/src/gridcoin/support/enumbytes.h
+++ b/src/gridcoin/support/enumbytes.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "serialize.h"

--- a/src/gridcoin/support/filehash.h
+++ b/src/gridcoin/support/filehash.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "serialize.h"

--- a/src/gridcoin/support/xml.h
+++ b/src/gridcoin/support/xml.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <string>

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/accrual/newbie.h"
 #include "gridcoin/accrual/null.h"

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/account.h"

--- a/src/gridcoin/tx_message.h
+++ b/src/gridcoin/tx_message.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/contract/payload.h"

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/upgrade.h"
 #include "util.h"
 #include "init.h"

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <string>

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "init.h"
 #include "main.h"
 #include "gridcoin/beacon.h"

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/voting/fwd.h"

--- a/src/gridcoin/voting/claims.cpp
+++ b/src/gridcoin/voting/claims.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "hash.h"
 #include "main.h"
 #include "gridcoin/voting/claims.h"

--- a/src/gridcoin/voting/claims.h
+++ b/src/gridcoin/voting/claims.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "key.h"

--- a/src/gridcoin/voting/fwd.h
+++ b/src/gridcoin/voting/fwd.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <boost/optional/optional_fwd.hpp>

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/contract/payload.h"

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/support/xml.h"
 #include "gridcoin/voting/poll.h"

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/support/enumbytes.h"

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/voting/payloads.h"

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/contract/handler.h"

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/beacon.h"
 #include "gridcoin/quorum.h"

--- a/src/gridcoin/voting/result.h
+++ b/src/gridcoin/voting/result.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/cpid.h"

--- a/src/gridcoin/voting/vote.cpp
+++ b/src/gridcoin/voting/vote.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/support/xml.h"
 #include "gridcoin/voting/vote.h"

--- a/src/gridcoin/voting/vote.h
+++ b/src/gridcoin/voting/vote.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include "gridcoin/contract/payload.h"

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "util.h"
 

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef DIAGNOSTICSDIALOG_H
 #define DIAGNOSTICSDIALOG_H
 

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/researcher.h"
 
 #include "qt/researcher/projecttablemodel.h"

--- a/src/qt/researcher/projecttablemodel.h
+++ b/src/qt/researcher/projecttablemodel.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef PROJECTTABLEMODEL_H
 #define PROJECTTABLEMODEL_H
 

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "base58.h"
 #include "main.h"
 #include "gridcoin/beacon.h"

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERMODEL_H
 #define RESEARCHERMODEL_H
 

--- a/src/qt/researcher/researcherwizard.cpp
+++ b/src/qt/researcher/researcherwizard.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizard.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizard.h"

--- a/src/qt/researcher/researcherwizard.h
+++ b/src/qt/researcher/researcherwizard.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARD_H
 #define RESEARCHERWIZARD_H
 

--- a/src/qt/researcher/researcherwizardauthpage.cpp
+++ b/src/qt/researcher/researcherwizardauthpage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardauthpage.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizardauthpage.h"

--- a/src/qt/researcher/researcherwizardauthpage.h
+++ b/src/qt/researcher/researcherwizardauthpage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDAUTHPAGE_H
 #define RESEARCHERWIZARDAUTHPAGE_H
 

--- a/src/qt/researcher/researcherwizardbeaconpage.cpp
+++ b/src/qt/researcher/researcherwizardbeaconpage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardbeaconpage.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizard.h"

--- a/src/qt/researcher/researcherwizardbeaconpage.h
+++ b/src/qt/researcher/researcherwizardbeaconpage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDBEACONPAGE_H
 #define RESEARCHERWIZARDBEACONPAGE_H
 

--- a/src/qt/researcher/researcherwizardemailpage.cpp
+++ b/src/qt/researcher/researcherwizardemailpage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardemailpage.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizardemailpage.h"

--- a/src/qt/researcher/researcherwizardemailpage.h
+++ b/src/qt/researcher/researcherwizardemailpage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDEMAILPAGE_H
 #define RESEARCHERWIZARDEMAILPAGE_H
 

--- a/src/qt/researcher/researcherwizardinvestorpage.cpp
+++ b/src/qt/researcher/researcherwizardinvestorpage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardinvestorpage.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizard.h"

--- a/src/qt/researcher/researcherwizardinvestorpage.h
+++ b/src/qt/researcher/researcherwizardinvestorpage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDINVESTORPAGE_H
 #define RESEARCHERWIZARDINVESTORPAGE_H
 

--- a/src/qt/researcher/researcherwizardmodedetailpage.cpp
+++ b/src/qt/researcher/researcherwizardmodedetailpage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardmodedetailpage.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizard.h"

--- a/src/qt/researcher/researcherwizardmodedetailpage.h
+++ b/src/qt/researcher/researcherwizardmodedetailpage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDMODEDETAILPAGE_H
 #define RESEARCHERWIZARDMODEDETAILPAGE_H
 

--- a/src/qt/researcher/researcherwizardmodepage.cpp
+++ b/src/qt/researcher/researcherwizardmodepage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardmodepage.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizard.h"

--- a/src/qt/researcher/researcherwizardmodepage.h
+++ b/src/qt/researcher/researcherwizardmodepage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDMODEPAGE_H
 #define RESEARCHERWIZARDMODEPAGE_H
 

--- a/src/qt/researcher/researcherwizardpoolpage.cpp
+++ b/src/qt/researcher/researcherwizardpoolpage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "base58.h"
 #include "key.h"
 #include "qt/forms/ui_researcherwizardpoolpage.h"

--- a/src/qt/researcher/researcherwizardpoolpage.h
+++ b/src/qt/researcher/researcherwizardpoolpage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDPOOLPAGE_H
 #define RESEARCHERWIZARDPOOLPAGE_H
 

--- a/src/qt/researcher/researcherwizardpoolsummarypage.cpp
+++ b/src/qt/researcher/researcherwizardpoolsummarypage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardpoolsummarypage.h"
 #include "qt/researcher/projecttablemodel.h"
 #include "qt/researcher/researchermodel.h"

--- a/src/qt/researcher/researcherwizardpoolsummarypage.h
+++ b/src/qt/researcher/researcherwizardpoolsummarypage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDPOOLSUMMARYPAGE_H
 #define RESEARCHERWIZARDPOOLSUMMARYPAGE_H
 

--- a/src/qt/researcher/researcherwizardprojectspage.cpp
+++ b/src/qt/researcher/researcherwizardprojectspage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/forms/ui_researcherwizardprojectspage.h"
 #include "qt/researcher/projecttablemodel.h"
 #include "qt/researcher/researchermodel.h"

--- a/src/qt/researcher/researcherwizardprojectspage.h
+++ b/src/qt/researcher/researcherwizardprojectspage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDPROJECTSPAGE_H
 #define RESEARCHERWIZARDPROJECTSPAGE_H
 

--- a/src/qt/researcher/researcherwizardsummarypage.cpp
+++ b/src/qt/researcher/researcherwizardsummarypage.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "qt/bitcoinunits.h"
 #include "qt/forms/ui_researcherwizardsummarypage.h"
 #include "qt/researcher/projecttablemodel.h"

--- a/src/qt/researcher/researcherwizardsummarypage.h
+++ b/src/qt/researcher/researcherwizardsummarypage.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef RESEARCHERWIZARDSUMMARYPAGE_H
 #define RESEARCHERWIZARDSUMMARYPAGE_H
 

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "upgradeqt.h"
 #include "gridcoin/upgrade.h"
 

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef UPGRADEQT_H
 #define UPGRADEQT_H
 

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <stdlib.h>
 #include <algorithm>
 #include <string>

--- a/src/qt/votingdialog.h
+++ b/src/qt/votingdialog.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef VOTINGDIALOG_H
 #define VOTINGDIALOG_H
 

--- a/src/test/gridcoin/appcache_tests.cpp
+++ b/src/test/gridcoin/appcache_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/appcache.h"
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/gridcoin/beacon_tests.cpp
+++ b/src/test/gridcoin/beacon_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "base58.h"
 #include "gridcoin/beacon.h"
 

--- a/src/test/gridcoin/block_finder_tests.cpp
+++ b/src/test/gridcoin/block_finder_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/support/block_finder.h"
 

--- a/src/test/gridcoin/claim_tests.cpp
+++ b/src/test/gridcoin/claim_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/claim.h"
 
 #include "key.h"

--- a/src/test/gridcoin/contract_tests.cpp
+++ b/src/test/gridcoin/contract_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "hash.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/project.h"

--- a/src/test/gridcoin/cpid_tests.cpp
+++ b/src/test/gridcoin/cpid_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/cpid.h"
 #include "streams.h"
 

--- a/src/test/gridcoin/enumbytes_tests.cpp
+++ b/src/test/gridcoin/enumbytes_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/support/enumbytes.h"
 #include "streams.h"
 

--- a/src/test/gridcoin/magnitude_tests.cpp
+++ b/src/test/gridcoin/magnitude_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "gridcoin/magnitude.h"
 #include "streams.h"
 

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/project.h"

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "main.h"
 #include "gridcoin/appcache.h"
 #include "gridcoin/beacon.h"

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "base58.h"
 #include "compat/endian.h"
 #include "gridcoin/scraper/scraper_net.h"

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "uint256.h"
 #include "util.h"
 #include "main.h"


### PR DESCRIPTION
A quick bit of housekeeping that adds and updates the copyright headers in Gridcoin-specific source files. Most of these were missing.