### PR TITLE
gui: Diagnostics refresh

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -811,17 +811,16 @@ AdvertiseBeaconResult RenewBeacon(const Cpid& cpid, const Beacon& beacon)
 // Class: MiningProject
 // -----------------------------------------------------------------------------
 
-MiningProject::MiningProject(
-    std::string name,
+MiningProject::MiningProject(std::string name,
     Cpid cpid,
     std::string team,
     std::string url,
-    std::string s_rac)
+    double rac)
     : m_name(LowerUnderscore(std::move(name)))
     , m_cpid(std::move(cpid))
     , m_team(std::move(team))
     , m_url(std::move(url))
-    , m_s_rac(std::move(s_rac))
+    , m_rac(std::move(rac))
     , m_error(Error::NONE)
 {
     boost::to_lower(m_team);
@@ -834,20 +833,8 @@ MiningProject MiningProject::Parse(const std::string& xml)
         Cpid::Parse(ExtractXML(xml, "<external_cpid>", "</external_cpid>")),
         ExtractXML(xml, "<team_name>", "</team_name>"),
         ExtractXML(xml, "<master_url>", "</master_url>"),
-        ExtractXML(xml, "<user_expavg_credit>", "</user_expavg_credit>"));
-
-    // Parse the RAC. This is used for diagnostics to be able to give people
-    // confidence that they will get magnitude before magnitude goes above zero
-    // from beacon registration and the superblock stake, which could take
-    // 24 hours or more.
-    try
-    {
-        project.m_rac = std::stod(project.m_s_rac);
-    }
-    catch (std::exception& e)
-    {
-        project.m_rac = 0;
-    }
+        std::strtold(ExtractXML(xml, "<user_expavg_credit>",
+                                "</user_expavg_credit>").c_str(), nullptr));
 
     if (IsPoolCpid(project.m_cpid) && !GetBoolArg("-pooloperator", false)) {
         project.m_error = MiningProject::Error::POOL;

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -836,6 +836,19 @@ MiningProject MiningProject::Parse(const std::string& xml)
         ExtractXML(xml, "<master_url>", "</master_url>"),
         ExtractXML(xml, "<user_expavg_credit>", "</user_expavg_credit>"));
 
+    // Parse the RAC. This is used for diagnostics to be able to give people
+    // confidence that they will get magnitude before magnitude goes above zero
+    // from beacon registration and the superblock stake, which could take
+    // 24 hours or more.
+    try
+    {
+        project.m_rac = std::stod(project.m_s_rac);
+    }
+    catch (std::exception& e)
+    {
+        project.m_rac = 0;
+    }
+
     if (IsPoolCpid(project.m_cpid) && !GetBoolArg("-pooloperator", false)) {
         project.m_error = MiningProject::Error::POOL;
         return project;
@@ -877,19 +890,6 @@ MiningProject MiningProject::Parse(const std::string& xml)
         Researcher::Email()))
     {
         project.m_error = MiningProject::Error::MISMATCHED_CPID;
-    }
-
-    // Parse the RAC. This is used for diagnostics to be able to give people
-    // confidence that they will get magnitude before magnitude goes above zero
-    // from beacon registration and the superblock stake, which could take
-    // 24 hours or more.
-    try
-    {
-        project.m_rac = std::stod(project.m_s_rac);
-    }
-    catch (std::exception& e)
-    {
-        project.m_rac = 0;
     }
 
     return project;

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -78,7 +78,7 @@ struct MiningProject
     //! \param team Associated team parsed from the \c <team_name> element.
     //! \param url  Project website URL parsed from the \c <master_url> element.
     //!
-    MiningProject(std::string name, Cpid cpid, std::string team, std::string url);
+    MiningProject(std::string name, Cpid cpid, std::string team, std::string url, std::string s_rac);
 
     //!
     //! \brief Initialize a MiningProject instance by parsing the project XML
@@ -93,6 +93,8 @@ struct MiningProject
     Cpid m_cpid;        //!< CPID of the BOINC account for the project.
     std::string m_team; //!< Name of the team joined for the project.
     std::string m_url;  //!< URL of the project website.
+    std::string m_s_rac;//!< RAC string of the project.
+    double m_rac;       //!< RAC of the project.
     Error m_error;      //!< May describe why a project is ineligible.
 
     //!
@@ -481,6 +483,15 @@ public:
     //! investor mode.
     //!
     GRC::Magnitude Magnitude() const;
+
+    //!
+    //! \brief Determine whether the CPID has positive RAC for whitelisted
+    //! projects.
+    //!
+    //! \return true if the client_state.xml file shows positive RAC for the
+    //! whitelisted projects associated with the CPID.
+    //!
+    bool HasRAC() const;
 
     //!
     //! \brief Get the current research reward accrued for the CPID loaded by

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -78,7 +78,7 @@ struct MiningProject
     //! \param team Associated team parsed from the \c <team_name> element.
     //! \param url  Project website URL parsed from the \c <master_url> element.
     //!
-    MiningProject(std::string name, Cpid cpid, std::string team, std::string url, std::string s_rac);
+    MiningProject(std::string name, Cpid cpid, std::string team, std::string url, double rac);
 
     //!
     //! \brief Initialize a MiningProject instance by parsing the project XML
@@ -93,7 +93,6 @@ struct MiningProject
     Cpid m_cpid;        //!< CPID of the BOINC account for the project.
     std::string m_team; //!< Name of the team joined for the project.
     std::string m_url;  //!< URL of the project website.
-    std::string m_s_rac;//!< RAC string of the project.
     double m_rac;       //!< RAC of the project.
     Error m_error;      //!< May describe why a project is ineligible.
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -652,6 +652,7 @@ void BitcoinGUI::setResearcherModel(ResearcherModel *researcherModel)
     }
 
     overviewPage->setResearcherModel(researcherModel);
+    diagnosticsDialog->SetResearcherModel(researcherModel);
 
     updateBeaconIcon();
     connect(researcherModel, SIGNAL(beaconChanged()), this, SLOT(updateBeaconIcon()));

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -38,6 +38,43 @@ void DiagnosticsDialog::SetResearcherModel(ResearcherModel *researcherModel)
     m_researcher_model = researcherModel;
 }
 
+void DiagnosticsDialog::SetResultLabel(QLabel *label, DiagnosticTestStatus test_status,
+                                       DiagnosticResult test_result, QString override_text)
+{
+    switch (test_status)
+    {
+    case DiagnosticTestStatus::unknown:
+        label->setText(tr(""));
+        label->setStyleSheet("");
+        break;
+    case DiagnosticTestStatus::pending:
+        label->setText(tr("Testing..."));
+        label->setStyleSheet("");
+        break;
+    case DiagnosticTestStatus::completed:
+        switch (test_result)
+        {
+        case DiagnosticResult::NA:
+            label->setText(tr("N/A"));
+            label->setStyleSheet("color:black;background-color:grey");
+            break;
+        case DiagnosticResult::passed:
+            label->setText(tr("Passed"));
+            label->setStyleSheet("color:white;background-color:green");
+            break;
+        case DiagnosticResult::warning:
+            label->setText(tr("Warning"));
+            label->setStyleSheet("color:black;background-color:yellow");
+            break;
+        case DiagnosticResult::failed:
+            label->setText(tr("Failed"));
+            label->setStyleSheet("color:white;background-color:red");
+        }
+    }
+
+    if (override_text.size()) label->setText(override_text);
+}
+
 unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
 {
     LOCK(cs_diagnostictests);
@@ -68,11 +105,17 @@ DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetTestStatus(std::st
     }
 }
 
-unsigned int DiagnosticsDialog::UpdateTestStatus(std::string test_name, DiagnosticTestStatus test_status)
+unsigned int DiagnosticsDialog::UpdateTestStatus(std::string test_name, QLabel *label,
+                                                 DiagnosticTestStatus test_status, DiagnosticResult test_result,
+                                                 QString override_text)
 {
     LOCK(cs_diagnostictests);
 
     test_status_map[test_name] = test_status;
+
+    SetResultLabel(label, test_status, test_result, override_text);
+
+    UpdateOverallDiagnosticResult(test_result);
 
     return test_status_map.size();
 }
@@ -140,36 +183,7 @@ void DiagnosticsDialog::DisplayOverallDiagnosticResult()
 {
     LOCK(cs_diagnostictests);
 
-    if (GetOverallDiagnosticStatus() == pending)
-    {
-        ui->overallResultResultLabel->setText(tr("Testing..."));
-        ui->overallResultResultLabel->setStyleSheet("");
-    }
-    else
-    {
-        // Overall status must be completed, so display overall result
-        switch (GetOverallDiagnosticResult())
-        {
-        case NA:
-            ui->overallResultResultLabel->clear();
-            ui->overallResultResultLabel->setStyleSheet("");
-            break;
-
-        case passed:
-            ui->overallResultResultLabel->setText(tr("Passed"));
-            ui->overallResultResultLabel->setStyleSheet("color:white;background-color:green");
-            break;
-
-        case warning:
-            ui->overallResultResultLabel->setText(tr("Warning"));
-            ui->overallResultResultLabel->setStyleSheet("color:black;background-color:yellow");
-            break;
-
-        case failed:
-            ui->overallResultResultLabel->setText(tr("Failed"));
-            ui->overallResultResultLabel->setStyleSheet("color:white;background-color:red");
-        }
-    }
+    SetResultLabel(ui->overallResultResultLabel, GetOverallDiagnosticStatus(), GetOverallDiagnosticResult());
 
     this->repaint();
 }
@@ -261,121 +275,71 @@ void DiagnosticsDialog::on_testButton_clicked()
     if (m_researcher_model->configuredForInvestorMode() || m_researcher_model->detectedPoolMode())
     {
         // N/A tests for investor/pool mode
-        ui->boincPathResultLabel->setText(tr("N/A"));
-        ui->boincPathResultLabel->setStyleSheet("color:black;background-color:grey");
-        UpdateTestStatus("boincPath", completed);
-
-        ui->verifyCPIDValidResultLabel->setText(tr("N/A"));
-        ui->verifyCPIDValidResultLabel->setStyleSheet("color:black;background-color:grey");
-        UpdateTestStatus("verifyCPIDValid", completed);
-
-        ui->verifyCPIDHasRACResultLabel->setText(tr("N/A"));
-        ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:black;background-color:grey");
-        UpdateTestStatus("verifyCPIDHasRAC", completed);
-
-        ui->verifyCPIDIsInNNResultLabel->setText(tr("N/A"));
-        ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:black;background-color:grey");
-        UpdateTestStatus("verifyCPIDIsInNN", completed);
-
-        ui->checkETTSResultLabel->setText(tr("N/A"));
-        ui->checkETTSResultLabel->setStyleSheet("color:black;background-color:grey");
-        UpdateTestStatus("checkETTS", completed);
-
+        UpdateTestStatus("boincPath", ui->boincPathResultLabel, completed, NA);
+        UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, completed, NA);
+        UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, completed, NA);
+        UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, completed, NA);
+        UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, NA);
     }
     else
     {
         //BOINC path
-        ui->boincPathResultLabel->setStyleSheet("");
-        ui->boincPathResultLabel->setText(tr("Testing..."));
-        UpdateTestStatus("boincPath", pending);
+        UpdateTestStatus("boincPath", ui->boincPathResultLabel, pending, NA);
         this->repaint();
 
         if (VerifyBoincPath())
         {
-            ui->boincPathResultLabel->setText(tr("Passed"));
-            ui->boincPathResultLabel->setStyleSheet("color:white;background-color:green");
-            UpdateTestStatus("boincPath", completed);
-            UpdateOverallDiagnosticResult(passed);
+            UpdateTestStatus("boincPath", ui->boincPathResultLabel, completed, passed);
         }
         else
         {
-            ui->boincPathResultLabel->setText(tr("Failed"));
-            ui->boincPathResultLabel->setStyleSheet("color:white;background-color:red");
-            UpdateTestStatus("boincPath", completed);
-            UpdateOverallDiagnosticResult(failed);
+            UpdateTestStatus("boincPath", ui->boincPathResultLabel, completed, failed);
         }
 
         //CPID valid
-        ui->verifyCPIDValidResultLabel->setStyleSheet("");
-        ui->verifyCPIDValidResultLabel->setText(tr("Testing..."));
-        UpdateTestStatus("verifyCPIDValid", pending);
+        UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, pending, NA);
         this->repaint();
 
         if (VerifyIsCPIDValid())
         {
-            ui->verifyCPIDValidResultLabel->setText(tr("Passed"));
-            ui->verifyCPIDValidResultLabel->setStyleSheet("color:white;background-color:green");
-            UpdateTestStatus("verifyCPIDValid", completed);
-            UpdateOverallDiagnosticResult(passed);
+            UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, completed, passed);
         }
         else
         {
-            ui->verifyCPIDValidResultLabel->setText(tr("Failed: BOINC CPID does not match CPID"));
-            ui->verifyCPIDValidResultLabel->setStyleSheet("color:white;background-color:red");
-            UpdateTestStatus("verifyCPIDValid", completed);
-            UpdateOverallDiagnosticResult(failed);
+            UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, completed, failed);
         }
 
         //CPID has rac
-        ui->verifyCPIDHasRACResultLabel->setStyleSheet("");
-        ui->verifyCPIDHasRACResultLabel->setText(tr("Testing..."));
-        UpdateTestStatus("verifyCPIDHasRAC", pending);
+        UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, pending, NA);
         this->repaint();
 
         if (VerifyCPIDHasRAC())
         {
-            ui->verifyCPIDHasRACResultLabel->setText(tr("Passed"));
-            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:white;background-color:green");
-            UpdateTestStatus("verifyCPIDHasRAC", completed);
-            UpdateOverallDiagnosticResult(passed);
-
+            UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, completed, passed);
         }
         else
         {
-            ui->verifyCPIDHasRACResultLabel->setText(tr("Failed"));
-            ui->verifyCPIDHasRACResultLabel->setStyleSheet("color:white;background-color:red");
-            UpdateTestStatus("verifyCPIDHasRAC", completed);
-            UpdateOverallDiagnosticResult(failed);
+            UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, completed, failed);
         }
 
-        //cpid is in nn
-        ui->verifyCPIDIsInNNResultLabel->setStyleSheet("");
-        ui->verifyCPIDIsInNNResultLabel->setText(tr("Testing..."));
-        UpdateTestStatus("verifyCPIDIsInNN", pending);
+        //cpid is active
+        UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, pending, NA);
         this->repaint();
 
         if (VerifyCPIDIsEligible())
         {
-            ui->verifyCPIDIsInNNResultLabel->setText(tr("Passed"));
-            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:white;background-color:green");
-            UpdateTestStatus("verifyCPIDIsInNN", completed);
-            UpdateOverallDiagnosticResult(passed);
+            UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, completed, passed);
         }
         else
         {
-            ui->verifyCPIDIsInNNResultLabel->setText(tr("Failed"));
-            ui->verifyCPIDIsInNNResultLabel->setStyleSheet("color:white;background-color:red");
-            UpdateTestStatus("verifyCPIDIsInNN", completed);
-            UpdateOverallDiagnosticResult(failed);
+            UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, completed, failed);
         }
 
         // verify reasonable ETTS
         // This is only checked if wallet is a researcher wallet because the purpose is to
         // alert the owner that his stake time is too long and therefore there is a chance
         // of research rewards loss between stakes due to the 180 day limit.
-        ui->checkETTSResultLabel->setStyleSheet("");
-        ui->checkETTSResultLabel->setText(tr("Testing..."));
-        UpdateTestStatus("checkETTS", pending);
+        UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, pending, NA);
 
         double ETTS = VerifyETTSReasonable() / (24.0 * 60.0 * 60.0);
 
@@ -398,156 +362,110 @@ void DiagnosticsDialog::on_testButton_clicked()
         // ETTS of zero actually means no coins, i.e. infinite.
         if (ETTS == 0.0)
         {
-            ui->checkETTSResultLabel->setText(tr("Failed: ETTS is infinite. No coins to stake."));
-            ui->checkETTSResultLabel->setStyleSheet("color:white;background-color:red");
-            UpdateTestStatus("checkETTS", completed);
-            UpdateOverallDiagnosticResult(failed);
+            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, failed,
+                             tr("Failed: ETTS is infinite. No coins to stake."));
         }
         else if (ETTS > 90.0)
         {
-            ui->checkETTSResultLabel->setText(tr("Failed: ETTS = %1 > 90 days")
-                                              .arg(QString(rounded_ETTS.c_str())));
-            ui->checkETTSResultLabel->setStyleSheet("color:white;background-color:red");
-            UpdateTestStatus("checkETTS", completed);
-            UpdateOverallDiagnosticResult(failed);
+            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, failed,
+                             tr("Failed: ETTS is infinite. No coins to stake."));
         }
         else if (ETTS > 45.0 && ETTS <= 90.0)
         {
-            ui->checkETTSResultLabel->setText(tr("Warning: 45 days < ETTS = %1 <= 90 days")
-                                              .arg(QString(rounded_ETTS.c_str())));
-            ui->checkETTSResultLabel->setStyleSheet("color:black;background-color:yellow");
-            UpdateTestStatus("checkETTS", completed);
-            UpdateOverallDiagnosticResult(warning);
+            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, warning,
+                             tr("Warning: 45 days < ETTS = %1 <= 90 days").arg(QString(rounded_ETTS.c_str())));
         }
         else
         {
-            ui->checkETTSResultLabel->setText(tr("Passed: ETTS = %1 <= 45 days")
-                                              .arg(QString(rounded_ETTS.c_str())));
-            ui->checkETTSResultLabel->setStyleSheet("color:white;background-color:green");
-            UpdateTestStatus("checkETTS", completed);
-            UpdateOverallDiagnosticResult(passed);
+            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, passed,
+                             tr("Passed: ETTS = %1 <= 45 days").arg(QString(rounded_ETTS.c_str())));
         }
     }
 
     // Tests that are common to both investor and researcher mode.
     // wallet synced
-    ui->verifyWalletIsSyncedResultLabel->setStyleSheet("");
-    ui->verifyWalletIsSyncedResultLabel->setText(tr("Testing..."));
-    UpdateTestStatus("verifyWalletIsSynced", pending);
+    UpdateTestStatus("verifyWalletIsSynced", ui->verifyWalletIsSyncedResultLabel, pending, NA);
     this->repaint();
 
     if (VerifyWalletIsSynced())
     {
-        ui->verifyWalletIsSyncedResultLabel->setText(tr("Passed"));
-        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:white;background-color:green");
-        UpdateTestStatus("verifyWalletIsSynced", completed);
-        UpdateOverallDiagnosticResult(passed);
+        UpdateTestStatus("verifyWalletIsSynced", ui->verifyWalletIsSyncedResultLabel, completed, passed);
     }
 
     else
     {
-        ui->verifyWalletIsSyncedResultLabel->setText(tr("Failed"));
-        ui->verifyWalletIsSyncedResultLabel->setStyleSheet("color:white;background-color:red");
-        UpdateTestStatus("verifyWalletIsSynced", completed);
-        UpdateOverallDiagnosticResult(failed);
+        UpdateTestStatus("verifyWalletIsSynced", ui->verifyWalletIsSyncedResultLabel, completed, failed);
     }
 
     // clock
-    ui->verifyClockResultLabel->setStyleSheet("");
-    ui->verifyClockResultLabel->setText(tr("Testing..."));
-    UpdateTestStatus("verifyClockResult", pending);
+    UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel, pending, NA);
     this->repaint();
 
     VerifyClock();
 
     // seed nodes
-    ui->verifySeedNodesResultLabel->setStyleSheet("");
-    ui->verifySeedNodesResultLabel->setText(tr("Testing..."));
-    UpdateTestStatus("verifySeedNodes", pending);
+    UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, pending, NA);
     this->repaint();
 
     unsigned int seed_node_connections = VerifyCountSeedNodes();
 
     if (seed_node_connections >= 1 && seed_node_connections < 3)
     {
-        ui->verifySeedNodesResultLabel->setText(tr("Warning: Count = %1 (Pass = 3+)").arg(QString::number(seed_node_connections)));
-        ui->verifySeedNodesResultLabel->setStyleSheet("color:black;background-color:yellow");
-        UpdateTestStatus("verifySeedNodes", completed);
-        UpdateOverallDiagnosticResult(warning);
+        UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, completed, warning,
+                         tr("Warning: Count = %1 (Pass = 3+)").arg(QString::number(seed_node_connections)));
     }
     else if(seed_node_connections >= 3)
     {
-        ui->verifySeedNodesResultLabel->setText(tr("Passed: Count = %1").arg(QString::number(seed_node_connections)));
-        ui->verifySeedNodesResultLabel->setStyleSheet("color:white;background-color:green");
-        UpdateTestStatus("verifySeedNodes", completed);
-        UpdateOverallDiagnosticResult(passed);
+        UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, completed, passed,
+                         tr("Passed: Count = %1").arg(QString::number(seed_node_connections)));
     }
     else
     {
-        ui->verifySeedNodesResultLabel->setText(tr("Failed: Count = %1").arg(QString::number(seed_node_connections)));
-        ui->verifySeedNodesResultLabel->setStyleSheet("color:white;background-color:red");
-        UpdateTestStatus("verifySeedNodes", completed);
-        UpdateOverallDiagnosticResult(failed);
+        UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, completed, failed,
+                         tr("Failed: Count = %1").arg(QString::number(seed_node_connections)));
     }
 
     // connection count
-    ui->verifyConnectionsResultLabel->setStyleSheet("");
-    ui->verifyConnectionsResultLabel->setText(tr("Testing..."));
-    UpdateTestStatus("verifyConnections", pending);
+    UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, pending, NA);
     this->repaint();
 
     unsigned int connections = VerifyCountConnections();
 
     if (connections <= 7 && connections >= 1)
     {
-        ui->verifyConnectionsResultLabel->setText(tr("Warning: Count = %1 (Pass = 8+)").arg(QString::number(connections)));
-        ui->verifyConnectionsResultLabel->setStyleSheet("color:black;background-color:yellow");
-        UpdateTestStatus("verifyConnections", completed);
-        UpdateOverallDiagnosticResult(warning);
+        UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, completed, warning,
+                         tr("Warning: Count = %1 (Pass = 8+)").arg(QString::number(connections)));
     }
     else if (connections >= 8)
     {
-        ui->verifyConnectionsResultLabel->setText(tr("Passed: Count = %1").arg(QString::number(connections)));
-        ui->verifyConnectionsResultLabel->setStyleSheet("color:white;background-color:green");
-        UpdateTestStatus("verifyConnections", completed);
-        UpdateOverallDiagnosticResult(passed);
+        UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, completed, passed,
+                         tr("Passed: Count = %1").arg(QString::number(connections)));
     }
     else
     {
-        ui->verifyConnectionsResultLabel->setText(tr("Failed: Count = %1").arg(QString::number(connections)));
-        ui->verifyConnectionsResultLabel->setStyleSheet("color:white;background-color:red");
-        UpdateTestStatus("verifyConnections", completed);
-        UpdateOverallDiagnosticResult(failed);
+        UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, completed, failed,
+                         tr("Failed: Count = %1").arg(QString::number(connections)));
     }
 
     // tcp port
-    ui->verifyTCPPortResultLabel->setStyleSheet("");
-    ui->verifyTCPPortResultLabel->setText(tr("Testing..."));
-    UpdateTestStatus("verifyTCPPort", pending);
+    UpdateTestStatus("verifyTCPPort", ui->verifyTCPPortResultLabel, pending, NA);
     this->repaint();
 
     VerifyTCPPort();
 
     // client version
-    ui->checkClientVersionResultLabel->setStyleSheet("");
-    ui->checkClientVersionResultLabel->setText(tr("Testing..."));
-    UpdateTestStatus("checkClientVersion", pending);
+    UpdateTestStatus("checkClientVersion", ui->checkClientVersionResultLabel, pending, NA);
 
     std::string client_message;
 
     if (g_UpdateChecker->CheckForLatestUpdate(false, client_message))
     {
-        ui->checkClientVersionResultLabel->setText(tr("Warning: New Client version available:\n %1").arg(QString(client_message.c_str())));
-        ui->checkClientVersionResultLabel->setStyleSheet("color:black;background-color:yellow;height:2em");
-        UpdateTestStatus("checkClientVersion", completed);
-        UpdateOverallDiagnosticResult(warning);
+        UpdateTestStatus("checkClientVersion", ui->checkClientVersionResultLabel, completed, warning,
+                         tr("Warning: New Client version available:\n %1").arg(QString(client_message.c_str())));
     }
     else
     {
-        ui->checkClientVersionResultLabel->setText(tr("Passed"));
-        ui->checkClientVersionResultLabel->setStyleSheet("color:white;background-color:green");
-        UpdateTestStatus("checkClientVersion", completed);
-        UpdateOverallDiagnosticResult(passed);
+        UpdateTestStatus("checkClientVersion", ui->checkClientVersionResultLabel, completed, passed);
     }
 
     DisplayOverallDiagnosticResult();
@@ -608,7 +526,10 @@ void DiagnosticsDialog::clkFinished()
             if (BufferSocket.size() == 48)
             {
                 int nNTPCount = 40;
-                unsigned long DateTimeIn = uchar(BufferSocket.at(nNTPCount)) + (uchar(BufferSocket.at(nNTPCount + 1)) << 8) + (uchar(BufferSocket.at(nNTPCount + 2)) << 16) + (uchar(BufferSocket.at(nNTPCount + 3)) << 24);
+                unsigned long DateTimeIn = uchar(BufferSocket.at(nNTPCount))
+                        + (uchar(BufferSocket.at(nNTPCount + 1)) << 8)
+                        + (uchar(BufferSocket.at(nNTPCount + 2)) << 16)
+                        + (uchar(BufferSocket.at(nNTPCount + 3)) << 24);
                 long tmit = ntohl((time_t)DateTimeIn);
                 tmit -= 2208988800U;
 
@@ -620,24 +541,13 @@ void DiagnosticsDialog::clkFinished()
 
                 if (timeDiff.minutes() < 3)
                 {
-                    ui->verifyClockResultLabel->setText(tr("Passed"));
-                    ui->verifyClockResultLabel->setStyleSheet("color:white;background-color:green");
-                    UpdateTestStatus("verifyClockResult", completed);
-
-                    // We need this here because there is no return call (callback) to the on_testButton_clicked function
-                    UpdateOverallDiagnosticResult(passed);
+                    UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel, completed, passed);
                 }
                 else
                 {
-                    ui->verifyClockResultLabel->setText(tr("Failed: Sync local time with network"));
-                    ui->verifyClockResultLabel->setStyleSheet("color:white;background-color:red");
-                    UpdateTestStatus("verifyClockResult", completed);
-
-                    // We need this here because there is no return call (callback) to the on_testButton_clicked function
-                    UpdateOverallDiagnosticResult(failed);
+                    UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel, completed, failed);
                 }
 
-                // We need this here because there is no return call (callback) to the on_testButton_clicked function
                 DisplayOverallDiagnosticResult();
 
                 return;
@@ -650,12 +560,8 @@ void DiagnosticsDialog::clkFinished()
         // above, then when the timer calls clkFinished again, it will hit this conditional and be a no-op.
         if (GetTestStatus("verifyClockResult") != completed)
         {
-            ui->verifyClockResultLabel->setText(tr("Warning: Cannot connect to NTP server"));
-            ui->verifyClockResultLabel->setStyleSheet("color:black;background-color:yellow");
-            UpdateTestStatus("verifyClockResult", completed);
-
-            // We need this here because there is no return call (callback) to the on_testButton_clicked function
-            UpdateOverallDiagnosticResult(warning);
+            UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel,completed, warning,
+                             tr("Warning: Cannot connect to NTP server"));
 
             DisplayOverallDiagnosticResult();
         }
@@ -677,12 +583,7 @@ void DiagnosticsDialog::VerifyTCPPort()
 void DiagnosticsDialog::TCPFinished()
 {
     tcpSocket->close();
-    ui->verifyTCPPortResultLabel->setText(tr("Passed"));
-    ui->verifyTCPPortResultLabel->setStyleSheet("color:white;background-color:green");
-
-    // We need this here because there is no return call (callback) to the on_testButton_clicked function
-    UpdateTestStatus("verifyTCPPort", completed);
-    UpdateOverallDiagnosticResult(passed);
+    UpdateTestStatus("verifyTCPPort", ui->verifyTCPPortResultLabel, completed, passed);
 
     DisplayOverallDiagnosticResult();
 
@@ -691,12 +592,8 @@ void DiagnosticsDialog::TCPFinished()
 
 void DiagnosticsDialog::TCPFailed(QAbstractSocket::SocketError socket)
 {
-    ui->verifyTCPPortResultLabel->setText(tr("Warning: Port 32749 may be blocked by your firewall"));
-    ui->verifyTCPPortResultLabel->setStyleSheet("color:black;background-color:yellow");
-
-    // We need this here because there is no return call (callback) to the on_testButton_clicked function
-    UpdateTestStatus("verifyTCPPort", completed);
-    UpdateOverallDiagnosticResult(failed);
+    UpdateTestStatus("verifyTCPPort", ui->verifyTCPPortResultLabel, completed, warning,
+                     tr("Warning: Port 32749 may be blocked by your firewall"));
 
     DisplayOverallDiagnosticResult();
 

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -33,6 +33,11 @@ DiagnosticsDialog::~DiagnosticsDialog()
     delete ui;
 }
 
+void DiagnosticsDialog::SetResearcherModel(ResearcherModel *researcherModel)
+{
+    m_researcher_model = researcherModel;
+}
+
 unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
 {
     LOCK(cs_diagnostictests);

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -83,6 +83,7 @@ private:
     QTcpSocket *tcpSocket;
 
 public:
+    void SetResearcherModel(ResearcherModel *researcherModel);
     unsigned int GetNumberOfTestsPending();
     unsigned int UpdateTestStatus(std::string test_name, DiagnosticTestStatus test_status);
     DiagnosticTestStatus GetTestStatus(std::string test_name);

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -13,6 +13,8 @@
 
 #include "sync.h"
 
+class ResearcherModel;
+
 namespace Ui {
 class DiagnosticsDialog;
 }
@@ -22,7 +24,7 @@ class DiagnosticsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit DiagnosticsDialog(QWidget *parent = 0);
+    explicit DiagnosticsDialog(QWidget *parent = 0, ResearcherModel* researcher_model = nullptr);
     ~DiagnosticsDialog();
 
     enum DiagnosticResult
@@ -74,6 +76,8 @@ private:
     // Holds the test status entries
     typedef std::unordered_map<std::string, DiagnosticTestStatus> mDiagnosticTestStatus;
     mDiagnosticTestStatus test_status_map;
+
+    ResearcherModel *m_researcher_model;
 
     QUdpSocket *udpSocket;
     QTcpSocket *tcpSocket;

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -7,6 +7,7 @@
 
 #include <QDialog>
 #include <QtNetwork>
+#include <QtWidgets/QLabel>
 
 #include <string>
 #include <unordered_map>
@@ -85,13 +86,19 @@ private:
 public:
     void SetResearcherModel(ResearcherModel *researcherModel);
     unsigned int GetNumberOfTestsPending();
-    unsigned int UpdateTestStatus(std::string test_name, DiagnosticTestStatus test_status);
+    unsigned int UpdateTestStatus(std::string test_name, QLabel *label,
+                                  DiagnosticTestStatus test_status, DiagnosticResult test_result,
+                                  QString override_text = QString());
     DiagnosticTestStatus GetTestStatus(std::string test_name);
     void ResetOverallDiagnosticResult(unsigned int& number_of_tests);
     void UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in);
     DiagnosticResult GetOverallDiagnosticResult();
     DiagnosticTestStatus GetOverallDiagnosticStatus();
     void DisplayOverallDiagnosticResult();
+
+private:
+    void SetResultLabel(QLabel *label, DiagnosticTestStatus test_status,
+                        DiagnosticResult test_result, QString override_text = QString());
 
 private slots:
     void on_testButton_clicked();

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -50,7 +50,7 @@
       <number>8</number>
      </property>
      <item row="4" column="1">
-      <widget class="QLabel" name="verifyCPIDIsInNNResultLabel">
+      <widget class="QLabel" name="verifyCPIDIsActiveResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -75,7 +75,7 @@
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="verifyCPIDIsInNNLabel">
+      <widget class="QLabel" name="verifyCPIDIsActiveLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -243,6 +243,11 @@ bool ResearcherModel::hasMagnitude() const
     return m_researcher->Magnitude() != 0;
 }
 
+bool ResearcherModel::hasRAC() const
+{
+    return m_researcher->HasRAC();
+}
+
 bool ResearcherModel::needsBeaconAuth() const
 {
     if (!hasPendingBeacon() || !IsV11Enabled(nBestHeight + 1)) {

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -90,6 +90,7 @@ public:
     bool hasPendingBeacon() const;
     bool hasRenewableBeacon() const;
     bool hasMagnitude() const;
+    bool hasRAC() const;
     bool needsBeaconAuth() const;
     bool needsV2BeaconUpgrade() const;
 

--- a/src/test/data/client_state.xml
+++ b/src/test/data/client_state.xml
@@ -129,7 +129,7 @@ The file also contains invalid project sections for negative test cases.
     <teamid>1806</teamid>
     <hostid>12345</hostid>
     <host_total_credit>0.000000</host_total_credit>
-    <host_expavg_credit>0.000000</host_expavg_credit>
+    <host_expavg_credit>1.100000</host_expavg_credit>
     <host_create_time>1540012345.000000</host_create_time>
     <nrpc_failures>0</nrpc_failures>
     <master_fetch_failures>0</master_fetch_failures>
@@ -187,7 +187,7 @@ The file also contains invalid project sections for negative test cases.
     <external_cpid>8edc235ddcecf9c416a5f9417d56f4fd</external_cpid>
     <cpid_time>1541012345.000000</cpid_time>
     <user_total_credit>0.000000</user_total_credit>
-    <user_expavg_credit>0.000000</user_expavg_credit>
+    <user_expavg_credit>2.200000</user_expavg_credit>
     <user_create_time>1540012345.000000</user_create_time>
     <rpc_seqno>3</rpc_seqno>
     <userid>12345</userid>
@@ -252,7 +252,7 @@ The file also contains invalid project sections for negative test cases.
     <external_cpid>8edc235ddcecf9c416a5f9417d56f4fd</external_cpid>
     <cpid_time>1541012345.000000</cpid_time>
     <user_total_credit>0.000000</user_total_credit>
-    <user_expavg_credit>0.000000</user_expavg_credit>
+    <user_expavg_credit>3.300000</user_expavg_credit>
     <user_create_time>1540012345.000000</user_create_time>
     <rpc_seqno>3</rpc_seqno>
     <userid>12345</userid>
@@ -323,7 +323,7 @@ The file also contains invalid project sections for negative test cases.
     <teamid>1806</teamid>
     <hostid>12345</hostid>
     <host_total_credit>0.000000</host_total_credit>
-    <host_expavg_credit>0.000000</host_expavg_credit>
+    <host_expavg_credit>4.400000</host_expavg_credit>
     <host_create_time>1540012345.000000</host_create_time>
     <nrpc_failures>0</nrpc_failures>
     <master_fetch_failures>0</master_fetch_failures>

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -146,12 +146,13 @@ BOOST_AUTO_TEST_CASE(it_initializes_with_project_data)
         0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
     });
 
-    GRC::MiningProject project("project name", expected, "team name", "url");
+    GRC::MiningProject project("project name", expected, "team name", "url", "0");
 
     BOOST_CHECK(project.m_name == "project name");
     BOOST_CHECK(project.m_cpid == expected);
     BOOST_CHECK(project.m_team == "team name");
     BOOST_CHECK(project.m_url == "url");
+    BOOST_CHECK(project.m_s_rac == "0");
     BOOST_CHECK(project.m_error == GRC::MiningProject::Error::NONE);
 }
 
@@ -170,6 +171,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_project_xml_string)
           <team_name>Team Name</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
+          <user_expavg_credit>123.45</user_expavg_credit>
         </project>
         )XML");
 
@@ -179,6 +181,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_project_xml_string)
     BOOST_CHECK(project.m_cpid == cpid);
     BOOST_CHECK(project.m_team == "team name");
     BOOST_CHECK(project.m_url == "https://example.com/");
+    BOOST_CHECK(project.m_rac == 123.45);
     BOOST_CHECK(project.m_error == GRC::MiningProject::Error::NONE);
 
     // Clean up:
@@ -203,6 +206,7 @@ BOOST_AUTO_TEST_CASE(it_falls_back_to_compute_a_missing_external_cpid)
           <email_hash>b8b58cce3c90c7dc9f3601674202b21c</email_hash>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
           <external_cpid></external_cpid>
+          <user_expavg_credit>123.45</user_expavg_credit>
         </project>
         )XML");
 
@@ -212,6 +216,7 @@ BOOST_AUTO_TEST_CASE(it_falls_back_to_compute_a_missing_external_cpid)
     BOOST_CHECK(project.m_cpid == cpid);
     BOOST_CHECK(project.m_team == "team name");
     BOOST_CHECK(project.m_url == "https://example.com/");
+    BOOST_CHECK(project.m_rac == 123.45);
     BOOST_CHECK(project.m_error == GRC::MiningProject::Error::NONE);
 
     // Clean up:
@@ -220,14 +225,14 @@ BOOST_AUTO_TEST_CASE(it_falls_back_to_compute_a_missing_external_cpid)
 
 BOOST_AUTO_TEST_CASE(it_normalizes_project_names)
 {
-    GRC::MiningProject project("Project_NAME", GRC::Cpid(), "team name", "url");
+    GRC::MiningProject project("Project_NAME", GRC::Cpid(), "team name", "url", "0");
 
     BOOST_CHECK(project.m_name == "project name");
 }
 
 BOOST_AUTO_TEST_CASE(it_converts_team_names_to_lowercase)
 {
-    GRC::MiningProject project("project name", GRC::Cpid(), "TEAM NAME", "url");
+    GRC::MiningProject project("project name", GRC::Cpid(), "TEAM NAME", "url", "0");
 
     BOOST_CHECK(project.m_team == "team name");
 }
@@ -237,7 +242,7 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_project_is_eligible)
     // Eligibility is determined by the absence of an error set while loading
     // the project from BOINC's client_state.xml file.
 
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
 
     BOOST_CHECK(project.Eligible() == true);
 
@@ -267,7 +272,7 @@ BOOST_AUTO_TEST_CASE(it_detects_projects_with_pool_cpids)
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_project_is_whitelisted)
 {
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
 
     GRC::WhitelistSnapshot s(std::make_shared<GRC::ProjectList>(GRC::ProjectList {
         GRC::Project("Enigma", "http://enigma.test/@", 1234567),
@@ -321,7 +326,7 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_project_is_whitelisted)
 
 BOOST_AUTO_TEST_CASE(it_formats_error_messages_for_display)
 {
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
 
     BOOST_CHECK(project.ErrorMessage().empty() == true);
 
@@ -349,8 +354,8 @@ BOOST_AUTO_TEST_CASE(it_is_iterable)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name", "url"));
-    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name", "url"));
+    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name", "url", "0"));
+    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name", "url", "0"));
 
     auto counter = 0;
 
@@ -374,6 +379,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_set_of_project_xml_sections)
           <project_name>Project Name 1</project_name>
           <team_name>Gridcoin</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>123.45</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -383,6 +389,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_set_of_project_xml_sections)
           <project_name>Project Name 2</project_name>
           <team_name>Gridcoin</team_name>
           <cross_project_id>YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY</cross_project_id>
+          <user_expavg_credit>567.89</user_expavg_credit>
           <external_cpid>8edc235ddcecf9c416a5f9417d56f4fd</external_cpid>
         </project>
         )XML",
@@ -398,6 +405,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_set_of_project_xml_sections)
         BOOST_CHECK(project1->m_cpid == cpid_1);
         BOOST_CHECK(project1->m_team == "gridcoin");
         BOOST_CHECK(project1->m_url == "https://example.com/1");
+        BOOST_CHECK(project1->m_rac == 123.45);
         BOOST_CHECK(project1->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project1->Eligible() == true);
     } else {
@@ -409,6 +417,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_set_of_project_xml_sections)
         BOOST_CHECK(project2->m_cpid == cpid_2);
         BOOST_CHECK(project2->m_team == "gridcoin");
         BOOST_CHECK(project2->m_url == "https://example.com/2");
+        BOOST_CHECK(project2->m_rac == 567.89);
         BOOST_CHECK(project2->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project2->Eligible() == true);
     } else {
@@ -430,6 +439,7 @@ BOOST_AUTO_TEST_CASE(it_skips_loading_project_xml_with_empty_project_names)
           <project_name></project_name>
           <team_name>Gridcoin</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>123.45</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -439,6 +449,7 @@ BOOST_AUTO_TEST_CASE(it_skips_loading_project_xml_with_empty_project_names)
           <master_url>https://example.com/</master_url>
           <team_name>Gridcoin</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>123.45</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -454,8 +465,8 @@ BOOST_AUTO_TEST_CASE(it_counts_the_number_of_projects)
 
     BOOST_CHECK(projects.size() == 0);
 
-    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name", "url"));
-    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name", "url"));
+    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name", "url", "0"));
+    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name", "url", "0"));
 
     BOOST_CHECK(projects.size() == 2);
 }
@@ -466,7 +477,7 @@ BOOST_AUTO_TEST_CASE(it_indicates_whether_it_contains_any_projects)
 
     BOOST_CHECK(projects.empty() == true);
 
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url"));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url", "0"));
 
     BOOST_CHECK(projects.empty() == false);
 }
@@ -474,7 +485,7 @@ BOOST_AUTO_TEST_CASE(it_indicates_whether_it_contains_any_projects)
 BOOST_AUTO_TEST_CASE(it_indicates_whether_it_contains_any_pool_projects)
 {
     GRC::MiningProjectMap projects;
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
 
     project.m_error = GRC::MiningProject::Error::POOL;
     projects.Set(std::move(project));
@@ -486,7 +497,7 @@ BOOST_AUTO_TEST_CASE(it_fetches_a_project_by_name)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url"));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url", "0"));
 
     BOOST_CHECK(projects.Try("project name")->m_name == "project name");
     BOOST_CHECK(projects.Try("nonexistent") == nullptr);
@@ -496,8 +507,8 @@ BOOST_AUTO_TEST_CASE(it_does_not_overwrite_projects_with_the_same_name)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 1", "url"));
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 2", "url"));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 1", "url", "0"));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 2", "url", "0"));
 
     BOOST_CHECK(projects.Try("project name")->m_team == "team name 1");
 }
@@ -506,9 +517,9 @@ BOOST_AUTO_TEST_CASE(it_applies_a_provided_team_whitelist)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project 1", GRC::Cpid(), "gridcoin", "url"));
-    projects.Set(GRC::MiningProject("project 2", GRC::Cpid(), "team 1", "url"));
-    projects.Set(GRC::MiningProject("project 3", GRC::Cpid(), "team 2", "url"));
+    projects.Set(GRC::MiningProject("project 1", GRC::Cpid(), "gridcoin", "url", "1.0"));
+    projects.Set(GRC::MiningProject("project 2", GRC::Cpid(), "team 1", "url", "0"));
+    projects.Set(GRC::MiningProject("project 3", GRC::Cpid(), "team 2", "url", "0"));
 
     // Before applying a whitelist, all projects are eligible:
 
@@ -535,6 +546,9 @@ BOOST_AUTO_TEST_CASE(it_applies_a_provided_team_whitelist)
     } else {
         BOOST_FAIL("Project 3 does not exist in the mining project map.");
     }
+
+    // HasRAC should be true.
+    //BOOST_CHECK
 
     // Applying this whitelist disables eligibility for project 1:
     //
@@ -613,7 +627,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_with_researcher_context_data)
 {
     GRC::MiningProjectMap expected;
 
-    expected.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url"));
+    expected.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url", "0"));
 
     GRC::Researcher researcher(GRC::Cpid(), expected);
 
@@ -676,14 +690,14 @@ BOOST_AUTO_TEST_CASE(it_reports_ineligible_when_beacon_missing_or_expired)
     RemoveTestBeacon(GRC::Cpid());
 }
 
-BOOST_AUTO_TEST_CASE(it_provides_an_overall_status_of_the_reseracher_context)
+BOOST_AUTO_TEST_CASE(it_provides_an_overall_status_of_the_researcher_context)
 {
     GRC::Researcher researcher;
 
     BOOST_CHECK(researcher.Status() == GRC::ResearcherStatus::INVESTOR);
 
     GRC::MiningProjectMap projects;
-    projects.Set(GRC::MiningProject("ineligible", GRC::Cpid(), "team name", "url"));
+    projects.Set(GRC::MiningProject("ineligible", GRC::Cpid(), "team name", "url", "0"));
 
     researcher = GRC::Researcher(GRC::MiningId::ForInvestor(), projects);
 
@@ -715,6 +729,7 @@ BOOST_AUTO_TEST_CASE(it_parses_project_xml_to_a_global_researcher_singleton)
           <project_name>Project Name 1</project_name>
           <team_name>Gridcoin</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>1.1</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -724,6 +739,7 @@ BOOST_AUTO_TEST_CASE(it_parses_project_xml_to_a_global_researcher_singleton)
           <project_name>Project Name 2</project_name>
           <team_name>Gridcoin</team_name>
           <cross_project_id>YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY</cross_project_id>
+          <user_expavg_credit>2.2</user_expavg_credit>
           <external_cpid>8edc235ddcecf9c416a5f9417d56f4fd</external_cpid>
         </project>
         )XML",
@@ -743,6 +759,7 @@ BOOST_AUTO_TEST_CASE(it_parses_project_xml_to_a_global_researcher_singleton)
         BOOST_CHECK(project1->m_cpid == cpid_1);
         BOOST_CHECK(project1->m_team == "gridcoin");
         BOOST_CHECK(project1->m_url == "https://example.com/1");
+        BOOST_CHECK(project1->m_rac == 1.1);
         BOOST_CHECK(project1->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project1->Eligible() == true);
     } else {
@@ -754,6 +771,7 @@ BOOST_AUTO_TEST_CASE(it_parses_project_xml_to_a_global_researcher_singleton)
         BOOST_CHECK(project2->m_cpid == cpid_2);
         BOOST_CHECK(project2->m_team == "gridcoin");
         BOOST_CHECK(project2->m_url == "https://example.com/2");
+        BOOST_CHECK(project2->m_rac == 2.2);
         BOOST_CHECK(project2->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project2->Eligible() == true);
     } else {
@@ -777,6 +795,7 @@ BOOST_AUTO_TEST_CASE(it_looks_up_loaded_boinc_projects_by_name)
           <project_name>Name</project_name>
           <team_name>Gridcoin</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>1.1</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -791,6 +810,7 @@ BOOST_AUTO_TEST_CASE(it_looks_up_loaded_boinc_projects_by_name)
         BOOST_CHECK(project->m_cpid == cpid);
         BOOST_CHECK(project->m_team == "gridcoin");
         BOOST_CHECK(project->m_url == "https://example.com/");
+        BOOST_CHECK(project->m_rac == 1.1);
         BOOST_CHECK(project->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project->Eligible() == true);
     } else {
@@ -823,6 +843,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
           <project_name>Project Name 1</project_name>
           <team_name>Not Gridcoin</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>1.1</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -832,6 +853,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 2</project_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>2.2</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -841,6 +863,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 3</project_name>
           <team_name>Gridcoin</team_name>
+          <user_expavg_credit>3.3</user_expavg_credit>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
           <external_cpid>invalid</external_cpid>
         </project>
@@ -851,6 +874,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 4</project_name>
           <team_name>Gridcoin</team_name>
+          <user_expavg_credit>4.4</user_expavg_credit>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
         </project>
         )XML",
@@ -860,6 +884,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 5</project_name>
           <team_name>Gridcoin</team_name>
+          <user_expavg_credit>5.5</user_expavg_credit>
           <cross_project_id>invalid</cross_project_id>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
@@ -870,6 +895,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 6</project_name>
           <team_name>Gridcoin</team_name>
+          <user_expavg_credit>6.6</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -879,7 +905,19 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 7</project_name>
           <team_name>Gridcoin</team_name>
+          <user_expavg_credit>7.7</user_expavg_credit>
           <external_cpid>7d0d73fe026d66fd4ab8d5d8da32a611</external_cpid>
+        </project>
+        )XML",
+        // Malformed RAC:
+        R"XML(
+        <project>
+          <master_url>https://example.com/</master_url>
+          <project_name>Project Name 8</project_name>
+          <team_name>Not Gridcoin</team_name>
+          <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>FOO</user_expavg_credit>
+          <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
     }));
@@ -890,12 +928,13 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
     BOOST_CHECK(GRC::Researcher::Get()->Id() == GRC::MiningId::ForInvestor());
 
     const GRC::MiningProjectMap& projects = GRC::Researcher::Get()->Projects();
-    BOOST_CHECK(projects.size() == 7);
+    BOOST_CHECK(projects.size() == 8);
 
     if (const GRC::ProjectOption project1 = projects.Try("project name 1")) {
         BOOST_CHECK(project1->m_name == "project name 1");
         BOOST_CHECK(project1->m_cpid == cpid);
         BOOST_CHECK(project1->m_team == "not gridcoin");
+        BOOST_CHECK(project1->m_rac == 1.1);
         BOOST_CHECK(project1->m_error == GRC::MiningProject::Error::INVALID_TEAM);
         BOOST_CHECK(project1->Eligible() == false);
     } else {
@@ -906,6 +945,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
         BOOST_CHECK(project2->m_name == "project name 2");
         BOOST_CHECK(project2->m_cpid == cpid);
         BOOST_CHECK(project2->m_team.empty() == true);
+        BOOST_CHECK(project2->m_rac == 2.2);
         BOOST_CHECK(project2->m_error == GRC::MiningProject::Error::INVALID_TEAM);
         BOOST_CHECK(project2->Eligible() == false);
     } else {
@@ -916,6 +956,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
         BOOST_CHECK(project3->m_name == "project name 3");
         BOOST_CHECK(project3->m_cpid == GRC::Cpid());
         BOOST_CHECK(project3->m_team == "gridcoin");
+        BOOST_CHECK(project3->m_rac == 3.3);
         BOOST_CHECK(project3->m_error == GRC::MiningProject::Error::MALFORMED_CPID);
         BOOST_CHECK(project3->Eligible() == false);
     } else {
@@ -926,6 +967,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
         BOOST_CHECK(project4->m_name == "project name 4");
         BOOST_CHECK(project4->m_cpid == GRC::Cpid());
         BOOST_CHECK(project4->m_team == "gridcoin");
+        BOOST_CHECK(project4->m_rac == 4.4);
         BOOST_CHECK(project4->m_error == GRC::MiningProject::Error::MALFORMED_CPID);
         BOOST_CHECK(project4->Eligible() == false);
     } else {
@@ -936,6 +978,7 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
         BOOST_CHECK(project5->m_name == "project name 5");
         BOOST_CHECK(project5->m_cpid == cpid);
         BOOST_CHECK(project5->m_team == "gridcoin");
+        BOOST_CHECK(project5->m_rac == 5.5);
         BOOST_CHECK(project5->m_error == GRC::MiningProject::Error::MISMATCHED_CPID);
         BOOST_CHECK(project5->Eligible() == false);
     } else {
@@ -946,19 +989,35 @@ BOOST_AUTO_TEST_CASE(it_tags_invalid_projects_with_errors_when_parsing_xml)
         BOOST_CHECK(project6->m_name == "project name 6");
         BOOST_CHECK(project6->m_cpid == cpid);
         BOOST_CHECK(project6->m_team == "gridcoin");
+        BOOST_CHECK(project6->m_rac == 6.6);
         BOOST_CHECK(project6->m_error == GRC::MiningProject::Error::MISMATCHED_CPID);
         BOOST_CHECK(project6->Eligible() == false);
     } else {
         BOOST_FAIL("Project 6 does not exist in the mining project map.");
     }
 
-    if (const GRC::ProjectOption project6 = projects.Try("project name 7")) {
-        BOOST_CHECK(project6->m_name == "project name 7");
-        BOOST_CHECK(project6->m_error == GRC::MiningProject::Error::POOL);
-        BOOST_CHECK(project6->Eligible() == false);
+    if (const GRC::ProjectOption project7 = projects.Try("project name 7")) {
+        BOOST_CHECK(project7->m_name == "project name 7");
+        BOOST_CHECK(project7->m_rac == 7.7);
+        BOOST_CHECK(project7->m_error == GRC::MiningProject::Error::POOL);
+        BOOST_CHECK(project7->Eligible() == false);
     } else {
         BOOST_FAIL("Project 7 does not exist in the mining project map.");
     }
+
+    if (const GRC::ProjectOption project8 = projects.Try("project name 8")) {
+        BOOST_CHECK(project8->m_name == "project name 8");
+        BOOST_CHECK(project8->m_cpid == cpid);
+        BOOST_CHECK(project8->m_team == "not gridcoin");
+        BOOST_CHECK(project8->m_rac == 0.0);
+        BOOST_CHECK(project8->m_error == GRC::MiningProject::Error::INVALID_TEAM);
+        BOOST_CHECK(project8->Eligible() == false);
+    } else {
+        BOOST_FAIL("Project 8 does not exist in the mining project map.");
+    }
+
+    // HasRAC should be false.
+    BOOST_CHECK(!GRC::Researcher::Get()->HasRAC());
 
     // Clean up:
     SetArgument("email", "");
@@ -1012,6 +1071,7 @@ BOOST_AUTO_TEST_CASE(it_skips_the_team_requirement_when_set_by_protocol)
           <project_name>Project Name 1</project_name>
           <team_name>! Not Gridcoin !</team_name>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
+          <user_expavg_credit>1.1</user_expavg_credit>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
         )XML",
@@ -1029,11 +1089,15 @@ BOOST_AUTO_TEST_CASE(it_skips_the_team_requirement_when_set_by_protocol)
         BOOST_CHECK(project1->m_name == "project name 1");
         BOOST_CHECK(project1->m_cpid == cpid);
         BOOST_CHECK(project1->m_team == "! not gridcoin !");
+        BOOST_CHECK(project1->m_rac == 1.1);
         BOOST_CHECK(project1->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project1->Eligible() == true);
     } else {
         BOOST_FAIL("Project 1 does not exist in the mining project map.");
     }
+
+    // HasRAC should be true.
+    BOOST_CHECK(GRC::Researcher::Get()->HasRAC());
 
     // Clean up:
     SetArgument("email", "");
@@ -1055,6 +1119,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_when_set_by_the_protocol)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 1</project_name>
           <team_name>! Not Gridcoin !</team_name>
+          <user_expavg_credit>1.1</user_expavg_credit>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
@@ -1064,6 +1129,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_when_set_by_the_protocol)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 2</project_name>
           <team_name>Team 1</team_name>
+          <user_expavg_credit>0</user_expavg_credit>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
@@ -1073,6 +1139,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_when_set_by_the_protocol)
           <master_url>https://example.com/</master_url>
           <project_name>Project Name 3</project_name>
           <team_name>Team 2</team_name>
+          <user_expavg_credit>0</user_expavg_credit>
           <cross_project_id>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</cross_project_id>
           <external_cpid>f5d8234352e5a5ae3915debba7258294</external_cpid>
         </project>
@@ -1091,6 +1158,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_when_set_by_the_protocol)
         BOOST_CHECK(project1->m_name == "project name 1");
         BOOST_CHECK(project1->m_cpid == cpid);
         BOOST_CHECK(project1->m_team == "! not gridcoin !");
+        BOOST_CHECK(project1->m_rac == 1.1);
         BOOST_CHECK(project1->m_error == GRC::MiningProject::Error::INVALID_TEAM);
         BOOST_CHECK(project1->Eligible() == false);
     } else {
@@ -1101,6 +1169,7 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_when_set_by_the_protocol)
         BOOST_CHECK(project2->m_name == "project name 2");
         BOOST_CHECK(project2->m_cpid == cpid);
         BOOST_CHECK(project2->m_team == "team 1");
+        BOOST_CHECK(project2->m_rac == 0);
         BOOST_CHECK(project2->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project2->Eligible() == true);
     } else {
@@ -1111,11 +1180,15 @@ BOOST_AUTO_TEST_CASE(it_applies_the_team_whitelist_when_set_by_the_protocol)
         BOOST_CHECK(project3->m_name == "project name 3");
         BOOST_CHECK(project3->m_cpid == cpid);
         BOOST_CHECK(project3->m_team == "team 2");
+        BOOST_CHECK(project3->m_rac == 0);
         BOOST_CHECK(project3->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project3->Eligible() == true);
     } else {
         BOOST_FAIL("Project 3 does not exist in the mining project map.");
     }
+
+    // HasRAC should be false, because the only eligible projects have zero RAC.
+    BOOST_CHECK(!GRC::Researcher::Get()->HasRAC());
 
     // Clean up:
     SetArgument("email", "");
@@ -1425,6 +1498,7 @@ void it_parses_project_xml_from_a_client_state_xml_file()
         BOOST_CHECK(project1->m_name == "valid project 1");
         BOOST_CHECK(project1->m_cpid == cpid_1);
         BOOST_CHECK(project1->m_team == "gridcoin");
+        BOOST_CHECK(project1->m_rac == 1.1);
         BOOST_CHECK(project1->m_url == "https://project1.example.com/boinc/");
         BOOST_CHECK(project1->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project1->Eligible() == true);
@@ -1436,6 +1510,7 @@ void it_parses_project_xml_from_a_client_state_xml_file()
         BOOST_CHECK(project2->m_name == "valid project 2");
         BOOST_CHECK(project2->m_cpid == cpid_2);
         BOOST_CHECK(project2->m_team == "gridcoin");
+        BOOST_CHECK(project2->m_rac == 2.2);
         BOOST_CHECK(project2->m_url == "https://project2.example.com/boinc/");
         BOOST_CHECK(project2->m_error == GRC::MiningProject::Error::NONE);
         BOOST_CHECK(project2->Eligible() == true);
@@ -1448,12 +1523,16 @@ void it_parses_project_xml_from_a_client_state_xml_file()
         BOOST_CHECK(project3->m_name == "invalid project 3");
         BOOST_CHECK(project3->m_cpid == cpid_2);
         BOOST_CHECK(project3->m_team == "gridcoin");
+        BOOST_CHECK(project3->m_rac == 3.3);
         BOOST_CHECK(project3->m_url == "https://project3.example.com/boinc/");
         BOOST_CHECK(project3->m_error == GRC::MiningProject::Error::MISMATCHED_CPID);
         BOOST_CHECK(project3->Eligible() == false);
     } else {
         BOOST_FAIL("Project 3 does not exist in the mining project map.");
     }
+
+    // HasRAC should be true.
+    BOOST_CHECK(GRC::Researcher::Get()->HasRAC());
 
     // Clean up:
     SetArgument("email", "");

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -146,13 +146,14 @@ BOOST_AUTO_TEST_CASE(it_initializes_with_project_data)
         0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
     });
 
-    GRC::MiningProject project("project name", expected, "team name", "url", "0");
+    GRC::MiningProject project("project name", expected, "team name", "url",
+                               0.0);
 
     BOOST_CHECK(project.m_name == "project name");
     BOOST_CHECK(project.m_cpid == expected);
     BOOST_CHECK(project.m_team == "team name");
     BOOST_CHECK(project.m_url == "url");
-    BOOST_CHECK(project.m_s_rac == "0");
+    BOOST_CHECK(project.m_rac == 0.0);
     BOOST_CHECK(project.m_error == GRC::MiningProject::Error::NONE);
 }
 
@@ -225,14 +226,16 @@ BOOST_AUTO_TEST_CASE(it_falls_back_to_compute_a_missing_external_cpid)
 
 BOOST_AUTO_TEST_CASE(it_normalizes_project_names)
 {
-    GRC::MiningProject project("Project_NAME", GRC::Cpid(), "team name", "url", "0");
+    GRC::MiningProject project("Project_NAME", GRC::Cpid(), "team name", "url",
+                               0.0);
 
     BOOST_CHECK(project.m_name == "project name");
 }
 
 BOOST_AUTO_TEST_CASE(it_converts_team_names_to_lowercase)
 {
-    GRC::MiningProject project("project name", GRC::Cpid(), "TEAM NAME", "url", "0");
+    GRC::MiningProject project("project name", GRC::Cpid(), "TEAM NAME", "url",
+                               0.0);
 
     BOOST_CHECK(project.m_team == "team name");
 }
@@ -242,7 +245,8 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_project_is_eligible)
     // Eligibility is determined by the absence of an error set while loading
     // the project from BOINC's client_state.xml file.
 
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url",
+                               0.0);
 
     BOOST_CHECK(project.Eligible() == true);
 
@@ -272,7 +276,8 @@ BOOST_AUTO_TEST_CASE(it_detects_projects_with_pool_cpids)
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_project_is_whitelisted)
 {
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url",
+                               0.0);
 
     GRC::WhitelistSnapshot s(std::make_shared<GRC::ProjectList>(GRC::ProjectList {
         GRC::Project("Enigma", "http://enigma.test/@", 1234567),
@@ -326,7 +331,8 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_project_is_whitelisted)
 
 BOOST_AUTO_TEST_CASE(it_formats_error_messages_for_display)
 {
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url",
+                               0.0);
 
     BOOST_CHECK(project.ErrorMessage().empty() == true);
 
@@ -354,8 +360,10 @@ BOOST_AUTO_TEST_CASE(it_is_iterable)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name", "url", "0"));
-    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name", "url", "0"));
+    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name",
+                                    "url", 0.0));
+    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name",
+                                    "url", 0.0));
 
     auto counter = 0;
 
@@ -465,8 +473,10 @@ BOOST_AUTO_TEST_CASE(it_counts_the_number_of_projects)
 
     BOOST_CHECK(projects.size() == 0);
 
-    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name", "url", "0"));
-    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name", "url", "0"));
+    projects.Set(GRC::MiningProject("project name 1", GRC::Cpid(), "team name",
+                                    "url", 0.0));
+    projects.Set(GRC::MiningProject("project name 2", GRC::Cpid(), "team name",
+                                    "url", 0.0));
 
     BOOST_CHECK(projects.size() == 2);
 }
@@ -477,7 +487,8 @@ BOOST_AUTO_TEST_CASE(it_indicates_whether_it_contains_any_projects)
 
     BOOST_CHECK(projects.empty() == true);
 
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url", "0"));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name",
+                                    "url", 0.0));
 
     BOOST_CHECK(projects.empty() == false);
 }
@@ -485,7 +496,8 @@ BOOST_AUTO_TEST_CASE(it_indicates_whether_it_contains_any_projects)
 BOOST_AUTO_TEST_CASE(it_indicates_whether_it_contains_any_pool_projects)
 {
     GRC::MiningProjectMap projects;
-    GRC::MiningProject project("project name", GRC::Cpid(), "team name", "url", "0");
+    GRC::MiningProject project("project name", GRC::Cpid(), "team name",
+                               "url", 0.0);
 
     project.m_error = GRC::MiningProject::Error::POOL;
     projects.Set(std::move(project));
@@ -497,7 +509,8 @@ BOOST_AUTO_TEST_CASE(it_fetches_a_project_by_name)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url", "0"));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name",
+                                    "url", 0.0));
 
     BOOST_CHECK(projects.Try("project name")->m_name == "project name");
     BOOST_CHECK(projects.Try("nonexistent") == nullptr);
@@ -507,8 +520,10 @@ BOOST_AUTO_TEST_CASE(it_does_not_overwrite_projects_with_the_same_name)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 1", "url", "0"));
-    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 2", "url", "0"));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 1",
+                                    "url", 0.0));
+    projects.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name 2",
+                                    "url", 0.0));
 
     BOOST_CHECK(projects.Try("project name")->m_team == "team name 1");
 }
@@ -517,9 +532,12 @@ BOOST_AUTO_TEST_CASE(it_applies_a_provided_team_whitelist)
 {
     GRC::MiningProjectMap projects;
 
-    projects.Set(GRC::MiningProject("project 1", GRC::Cpid(), "gridcoin", "url", "1.0"));
-    projects.Set(GRC::MiningProject("project 2", GRC::Cpid(), "team 1", "url", "0"));
-    projects.Set(GRC::MiningProject("project 3", GRC::Cpid(), "team 2", "url", "0"));
+    projects.Set(GRC::MiningProject("project 1", GRC::Cpid(), "gridcoin",
+                                    "url", 1.0));
+    projects.Set(GRC::MiningProject("project 2", GRC::Cpid(), "team 1",
+                                    "url", 0.0));
+    projects.Set(GRC::MiningProject("project 3", GRC::Cpid(), "team 2",
+                                    "url", 0.0));
 
     // Before applying a whitelist, all projects are eligible:
 
@@ -546,9 +564,6 @@ BOOST_AUTO_TEST_CASE(it_applies_a_provided_team_whitelist)
     } else {
         BOOST_FAIL("Project 3 does not exist in the mining project map.");
     }
-
-    // HasRAC should be true.
-    //BOOST_CHECK
 
     // Applying this whitelist disables eligibility for project 1:
     //
@@ -627,7 +642,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_with_researcher_context_data)
 {
     GRC::MiningProjectMap expected;
 
-    expected.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name", "url", "0"));
+    expected.Set(GRC::MiningProject("project name", GRC::Cpid(), "team name",
+                                    "url", 0.0));
 
     GRC::Researcher researcher(GRC::Cpid(), expected);
 
@@ -697,7 +713,8 @@ BOOST_AUTO_TEST_CASE(it_provides_an_overall_status_of_the_researcher_context)
     BOOST_CHECK(researcher.Status() == GRC::ResearcherStatus::INVESTOR);
 
     GRC::MiningProjectMap projects;
-    projects.Set(GRC::MiningProject("ineligible", GRC::Cpid(), "team name", "url", "0"));
+    projects.Set(GRC::MiningProject("ineligible", GRC::Cpid(), "team name",
+                                    "url", 0.0));
 
     researcher = GRC::Researcher(GRC::MiningId::ForInvestor(), projects);
 


### PR DESCRIPTION
This PR refreshes the diagnostics page code to utilize the researcher model. It also adds parsing of RAC from the client_state.xml file in the underlying researcher. This is needed because the diagnostics will typically be run before someone has magnitude. Magnitude can take more than 24 hours to go above zero, yet when someone attaches one or more eligible projects, especially where they have been crunching before, they will expect diagnostics to pass.

The HasRAC() method follows the eligibility rules in the researcher class, so it simplifies the diagnostics greatly, eliminating a bunch of semi-duplicated code.

The researcher test harness has also been updated to support the parsed RAC and the associated HasRAC() method.

This should also fix reports of diagnostics failing because of the blank external CPID for first project problem.