### PR TITLE
util, gui: Fix shutdown segfault and repair broken overview page staking status

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -152,8 +152,6 @@ void ThreadScraperSubscriber(void* parg)
 //!
 //! \brief Configure and initialize the scraper system.
 //!
-//! \param threads Used to start the scraper housekeeping threads.
-//!
 void InitializeScraper()
 {
     // Default to 300 sec (5 min), clamp to 60 minimum, 600 maximum - converted to milliseconds.

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -18,6 +18,8 @@ extern unsigned int nScraperSleep;
 extern unsigned int nActiveBeforeSB;
 extern bool fScraperActive;
 
+extern ThreadHandler* netThreads;
+
 void Scraper(bool bSingleShot = false);
 void ScraperSubscriber();
 
@@ -152,7 +154,7 @@ void ThreadScraperSubscriber(void* parg)
 //!
 //! \param threads Used to start the scraper housekeeping threads.
 //!
-void InitializeScraper(ThreadHandlerPtr threads)
+void InitializeScraper()
 {
     // Default to 300 sec (5 min), clamp to 60 minimum, 600 maximum - converted to milliseconds.
     nScraperSleep = std::min<int64_t>(std::max<int64_t>(GetArg("-scrapersleep", 300), 60), 600) * 1000;
@@ -174,14 +176,14 @@ void InitializeScraper(ThreadHandlerPtr threads)
     if (GetBoolArg("-scraper", false)) {
         LogPrintf("Gridcoin: scraper enabled");
 
-        if (!threads->createThread(ThreadScraper, nullptr, "ThreadScraper")) {
+        if (!netThreads->createThread(ThreadScraper, nullptr, "ThreadScraper")) {
             LogPrintf("ERROR: createThread(ThreadScraper) failed");
         }
     } else {
         LogPrintf("Gridcoin: scraper disabled");
         LogPrintf("Gridcoin: scraper subscriber housekeeping thread enabled");
 
-        if (!threads->createThread(ThreadScraperSubscriber, nullptr, "ScraperSubscriber")) {
+        if (!netThreads->createThread(ThreadScraperSubscriber, nullptr, "ScraperSubscriber")) {
             LogPrintf("ERROR: createThread(ScraperSubscriber) failed");
         }
     }
@@ -279,7 +281,7 @@ bool fSnapshotRequest = false;
 // Functions
 // -----------------------------------------------------------------------------
 
-bool GRC::Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest)
+bool GRC::Initialize(CBlockIndex* pindexBest)
 {
     LogPrintf("Gridcoin: initializing...");
 
@@ -291,7 +293,10 @@ bool GRC::Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest)
 
     InitializeContracts(pindexBest);
     InitializeResearcherContext();
-    InitializeScraper(threads);
+
+    // The scraper is run on the netThreads group, because it shares data structures
+    // with scraper_net, which is run as part of the network node threads.
+    InitializeScraper();
     InitializeExplorerFeatures();
 
     return true;

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -12,7 +12,7 @@ namespace GRC {
 //!
 //! \return \c false if a problem occurs during initialization.
 //!
-bool Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest);
+bool Initialize(CBlockIndex* pindexBest);
 
 //!
 //! \brief Set up Gridcoin-specific background jobs.

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -7,7 +7,6 @@ namespace GRC {
 //!
 //! \brief Initialize Gridcoin-specific components and services.
 //!
-//! \param threads    Used to start Gridcoin threads.
 //! \param pindexBest Block index for the tip of the chain.
 //!
 //! \return \c false if a problem occurs during initialization.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -107,7 +107,9 @@ void Shutdown(void* parg)
         bitdb.Flush(false);
         StopNode();
         bitdb.Flush(true);
+
         StopRPCThreads();
+
         boost::filesystem::remove(GetPidFile());
         UnregisterWallet(pwalletMain);
         delete pwalletMain;
@@ -1079,8 +1081,6 @@ bool AppInit2(ThreadHandlerPtr threads)
         return false;
 
     RandAddSeedPerfmon();
-
-    GRC::Initialize(threads, pindexBest);
 
     //// debug print
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -13,6 +13,7 @@
 #include "init.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "gridcoin/gridcoin.h"
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/thread.hpp>
@@ -2318,6 +2319,9 @@ void StartNode(void* parg)
     else
         if (!netThreads->createThread(ThreadStakeMiner,pwalletMain,"ThreadStakeMiner"))
             LogPrintf("Error: createThread(ThreadStakeMiner) failed");
+
+    // Initialize GRC services.
+    GRC::Initialize(pindexBest);
 }
 
 bool StopNode()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -243,6 +243,8 @@ private slots:
     void updateBeaconIcon();
 
 	QString GetEstimatedStakingFrequency(unsigned int nEstimateTime);
+
+    void updateGlobalStatus();
 };
 
 #endif


### PR DESCRIPTION
#1894 changed the thread group for the scraper and caused a segfault to occur on shutdown, probably due to the shared data structures across the scraper and scraper_net (which really lives in the net code). This restores the scraper to the net thread group.

This PR also repairs the broken overview page staking status, which was broken due to the removal of mvTimers and associated functions. The periodic update functionality is restored via a QTimer approach.