### PR TITLE
build: Add --without-brotli option to curl.mk

### DIFF
--- a/depends/packages/curl.mk
+++ b/depends/packages/curl.mk
@@ -9,6 +9,7 @@ $(package)_dependencies=openssl
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared
   $(package)_config_opts+= --enable-static
+  $(package)_config_opts+= --without-brotli
   $(package)_config_opts_release+=--disable-debug-mode
   $(package)_config_opts_linux+=--with-pic
   # Disable OpenSSL for Windows and use native SSL stack (SSPI/Schannel):


### PR DESCRIPTION
If the --without-brotli option is not explicitly set in the curl makefile and the system has the brotli dev files installed then depends will try and build curl with brotli enabled. 

Attempting to build curl with brotli enabled currently causes build failure (See  #1898).