### PR TITLE
scraper: Fix order of destruction for global scraper objects

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -92,6 +92,13 @@ std::string urlsanity(const std::string& s, const std::string& type);
 std::string lowercase(std::string s);
 ScraperFileManifest StructScraperFileManifest = {};
 
+// Although scraper_net.h declares these maps, we define them here instead of
+// in scraper_net.cpp to ensure that the executable destroys these objects in
+// order. They need to be destroyed after ConvergedScraperStatsCache:
+//
+std::map<uint256, CSplitBlob::CPart> CSplitBlob::mapParts;
+std::map<uint256, std::shared_ptr<CScraperManifest>> CScraperManifest::mapManifest;
+
 // Global cache for converged scraper stats. Access must be with the lock cs_ConvergedScraperStatsCache taken.
 ConvergedScraperStats ConvergedScraperStatsCache = {};
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -19,9 +19,7 @@
 #include "gridcoin/superblock.h"
 
 //Globals
-std::map<uint256,CSplitBlob::CPart> CSplitBlob::mapParts;
 CCriticalSection CSplitBlob::cs_mapParts;
-std::map<uint256, std::shared_ptr<CScraperManifest>> CScraperManifest::mapManifest;
 std::map<uint256, std::pair<int64_t, std::shared_ptr<CScraperManifest>>> CScraperManifest::mapPendingDeletedManifest;
 CCriticalSection CScraperManifest::cs_mapManifest;
 extern unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -90,6 +90,7 @@
 
 extern CWallet* pwalletMain;
 extern std::string FromQString(QString qs);
+extern CCriticalSection cs_ConvergedScraperStatsCache;
 
 void GetGlobalStatus();
 
@@ -1407,6 +1408,8 @@ void BitcoinGUI::updateStakingIcon()
 
 void BitcoinGUI::updateScraperIcon(int scraperEventtype, int status)
 {
+    LOCK(cs_ConvergedScraperStatsCache);
+
     const ConvergedScraperStats& ConvergedScraperStatsCache = clientModel->getConvergedScraperStatsCache();
 
     int64_t nConvergenceTime = ConvergedScraperStatsCache.nTime;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -20,7 +20,6 @@
 
 static const int64_t nClientStartupTime = GetTime();
 extern ConvergedScraperStats ConvergedScraperStatsCache;
-extern CCriticalSection cs_ConvergedScraperStatsCache;
 
 ClientModel::ClientModel(OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), optionsModel(optionsModel), peerTableModel(nullptr),
@@ -139,11 +138,9 @@ void ClientModel::updateScraper(int scraperEventtype, int status, const QString 
         emit updateScraperStatus(scraperEventtype, status);
 }
 
-ConvergedScraperStats ClientModel::getConvergedScraperStatsCache() const
+// Requires a lock on cs_ConvergedScraperStatsCache
+const ConvergedScraperStats& ClientModel::getConvergedScraperStatsCache() const
 {
-    // May not be necessary to take lock, since this is read only. Consider removing.
-    LOCK(cs_ConvergedScraperStatsCache);
-
     return ConvergedScraperStatsCache;
 }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -54,7 +54,7 @@ public:
 
     QString formatBoostVersion()  const;
     QString getDifficulty() const;
-    ConvergedScraperStats getConvergedScraperStatsCache() const;
+    const ConvergedScraperStats& getConvergedScraperStatsCache() const;
 private:
     OptionsModel *optionsModel;
     PeerTableModel *peerTableModel;


### PR DESCRIPTION
Renaming the source files in #1894 changed the sequence of the global scraper variables emitted by the compiler which reversed the order that the executable destroys the objects in. Since the destruction of `ConvergedScraperStatsCache` depends on valid state in `CSplitBlob::mapParts`, the application can segfault on exit (see #1901).

This PR controls the order by defining the variables in the same translation unit. Eventually, we want to move away from using global variables to avoid problems like this.