### PR TITLE
scraper: Fix global object destruction order for macOS

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -100,6 +100,8 @@ ScraperFileManifest StructScraperFileManifest = {};
 // in scraper_net.cpp to ensure that the executable destroys these objects in
 // order. They need to be destroyed after ConvergedScraperStatsCache:
 //
+CCriticalSection CSplitBlob::cs_mapParts;
+CCriticalSection CScraperManifest::cs_mapManifest;
 std::map<uint256, CSplitBlob::CPart> CSplitBlob::mapParts;
 std::map<uint256, std::shared_ptr<CScraperManifest>> CScraperManifest::mapManifest;
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -21,9 +21,7 @@
 #include "gridcoin/superblock.h"
 
 //Globals
-CCriticalSection CSplitBlob::cs_mapParts;
 std::map<uint256, std::pair<int64_t, std::shared_ptr<CScraperManifest>>> CScraperManifest::mapPendingDeletedManifest;
-CCriticalSection CScraperManifest::cs_mapManifest;
 extern unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE;
 extern int64_t SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD;
 extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME;


### PR DESCRIPTION
@div72 noticed that the macOS builds failed after merging #1904. Apparently, we also need to control the destruction order of the synchronization objects for clang/macOS. This uses the same solution for `cs_mapParts` and `cs_mapManifest`.