### PR TITLE
superblock: Optimize superblock size calculation

### DIFF
--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -446,6 +446,27 @@ public:
         }
 
         //!
+        //! \brief Record the serialized size of the magnitude map.
+        //!
+        //! This overload optimizes the size calculation for the small and
+        //! medium magnitude maps in the superblock. These maps only store
+        //! magnitude values fixed to one byte in size so we avoid looping
+        //! over the collections to compute the total. The large magnitude
+        //! map serializes values as either one or two bytes so we need to
+        //! iterate over each item, but a superblock contains far fewer of
+        //! these records.
+        //!
+        //! \param s The size computer instance to record the size with.
+        //!
+        template <typename M = MagnitudeSize>
+        typename std::enable_if<std::is_same<M, uint8_t>::value>::type
+        Serialize(CSizeComputer& s) const
+        {
+            WriteCompactSize(s, m_magnitudes.size());
+            s.seek((sizeof(Cpid) + sizeof(MagnitudeSize)) * m_magnitudes.size());
+        }
+
+        //!
         //! \brief Serialize the object to the provided stream.
         //!
         //! \param stream The output stream.


### PR DESCRIPTION
This improves the performance of the serialization process used to calculate the size of a superblock by removing the need to iterate over most of the CPID/magnitude pairs. Small and medium magnitude mappings comprise the bulk of the superblock data. We can calculate the size of these collections in constant time. 