### PR TITLE
gui: Fix the debug console fonts

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -435,11 +435,19 @@ void RPCConsole::clear()
                     QImage(ICON_MAPPING[i].source).scaled(ICON_SIZE, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
     }
 
-    // Set default style sheet
+    // Set default style sheet. For ui->lineEdit, this overrides the specification
+    // in the .ui file.
+    QFont messagesFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    messagesFont.setPointSize(10);
+
+    ui->lineEdit->setFont(messagesFont);
+
+    ui->messagesWidget->document()->setDefaultFont(messagesFont);
+
     ui->messagesWidget->document()->setDefaultStyleSheet(
                 "table { }"
-                "td.time { color: #808080; padding-top: 3px; } "
-                "td.message { font-family: Monospace; font-size: 12px; } "
+                "td.time { color: #808080; valign: bottom; } "
+                "td.message { valign: bottom; }"
                 "td.cmd-request { color: #006060; } "
                 "td.cmd-error { color: red; } "
                 "b { color: #006060; } "


### PR DESCRIPTION
The debug console fonts have been improperly selected and sized wrong for a while. This commit changes the messages and line edit to use the system provided fixed-width font, which is more appropriate for terminal input/output, and also uses a point size rather than pixel size, which scales the font properly on different DPI displays. This should fix the two main observed issues:

1. Fonts way too small on HiDPI screens, and
2. Proportional spacing fonts, such as Arial, being used for input/output on Windows