### PR TITLE
rpc, wallet: Implement liststakes

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -134,6 +134,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listreceivedbyaddress"  , 2 },
     { "listsinceblock"         , 1 },
     { "listsinceblock"         , 2 },
+    { "liststakes"             , 0 },
     { "listtransactions"       , 1 },
     { "listtransactions"       , 2 },
     { "listtransactions"       , 3 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -318,6 +318,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listreceivedbyaccount",   &listreceivedbyaccount,   cat_wallet        },
     { "listreceivedbyaddress",   &listreceivedbyaddress,   cat_wallet        },
     { "listsinceblock",          &listsinceblock,          cat_wallet        },
+    { "liststakes",              &liststakes,              cat_wallet        },
     { "listtransactions",        &listtransactions,        cat_wallet        },
     { "listunspent",             &listunspent,             cat_wallet        },
     { "consolidateunspent",      &consolidateunspent,      cat_wallet        },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -133,6 +133,7 @@ extern UniValue listaddressgroupings(const UniValue& params, bool fHelp);
 extern UniValue listreceivedbyaccount(const UniValue& params, bool fHelp);
 extern UniValue listreceivedbyaddress(const UniValue& params, bool fHelp);
 extern UniValue listsinceblock(const UniValue& params, bool fHelp);
+extern UniValue liststakes(const UniValue& params, bool fHelp);
 extern UniValue listtransactions(const UniValue& params, bool fHelp);
 extern UniValue listunspent(const UniValue& params, bool fHelp);
 extern UniValue consolidateunspent(const UniValue& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1378,7 +1378,9 @@ UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
     return ListReceived(params, true);
 }
 
- void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter=ISMINE_SPENDABLE)
+ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDepth,
+                       bool fLong, UniValue& ret, const isminefilter& filter = ISMINE_SPENDABLE,
+                       bool stakes_only = false)
  {
     int64_t nFee;
     string strSentAccount;
@@ -1391,7 +1393,7 @@ UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
 
     // List: Sent
-    if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
+    if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount) && !stakes_only)
     {
         for (auto const& s : listSent)
         {
@@ -1489,9 +1491,15 @@ UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
                         case MinedType::POR_SIDE_STAKE_SEND :    entry.pushKV("Type", "POR SIDE STAKE SENT");     break;
                         default                             :    entry.pushKV("Type", "UNKNOWN");                 break;
                     }
+
+                    // Skip posting this entry if stakes only is desired and not an actual stake.
+                    if (stakes_only && gentype != MinedType::POR && gentype != MinedType::POS) continue;
                 }
                 else
                 {
+                    // Skip posting this entry for non-stake receives.
+                    if (stakes_only) continue;
+
                     entry.pushKV("category", "receive");
                 }
                 entry.pushKV("fee", ValueFromAmount(-nFee));
@@ -1522,62 +1530,62 @@ void AcentryToJSON(const CAccountingEntry& acentry, const string& strAccount, Un
 
 UniValue listtransactions(const UniValue& params, bool fHelp)
 {
-      if (fHelp || params.size() > 4)
+    if (fHelp || params.size() > 4)
         throw runtime_error(
-                  "listtransactions ( \"account\" count from includeWatchonly)\n"
-                  "\nReturns up to 'count' most recent transactions skipping the first 'from' transactions for account 'account'.\n"
-                  "\nArguments:\n"
-                  "1. \"account\"    (string, optional) The account name. If not included, it will list all transactions for all accounts.\n"
-                  "                                     If \"\" is set, it will list transactions for the default account.\n"
-                  "2. count          (numeric, optional, default=10) The number of transactions to return\n"
-                  "3. from           (numeric, optional, default=0) The number of transactions to skip\n"
-                  "4. includeWatchonly (bool, optional, default=false) Include transactions to watchonly addresses (see 'importaddress')\n"
-                  "                                     If \"\" is set true, it will list sent transactions as well\n"
-                  "\nResult:\n"
-                  "[\n"
-                  "  {\n"
-                  "    \"account\":\"accountname\",       (string) The account name associated with the transaction. \n"
-                  "                                                It will be \"\" for the default account.\n"
-                  "    \"address\":\"bitcoinaddress\",    (string) The bitcoin address of the transaction. Not present for \n"
-                  "                                                move transactions (category = move).\n"
-                  "    \"category\":\"send|receive|move\", (string) The transaction category. 'move' is a local (off blockchain)\n"
-                  "                                                transaction between accounts, and not associated with an address,\n"
-                  "                                                transaction id or block. 'send' and 'receive' transactions are \n"
-                  "                                                associated with an address, transaction id and block details\n"
-                  "    \"amount\": x.xxx,          (numeric) The amount in btc. This is negative for the 'send' category, and for the\n"
-                  "                                         'move' category for moves outbound. It is positive for the 'receive' category,\n"
-                  "                                         and for the 'move' category for inbound funds.\n"
-                  "    \"fee\": x.xxx,             (numeric) The amount of the fee in btc. This is negative and only available for the \n"
-                  "                                         'send' category of transactions.\n"
-                  "    \"confirmations\": n,       (numeric) The number of confirmations for the transaction. Available for 'send' and \n"
-                  "                                         'receive' category of transactions.\n"
-                  "    \"blockhash\": \"hashvalue\", (string) The block hash containing the transaction. Available for 'send' and 'receive'\n"
-                  "                                          category of transactions.\n"
-                  "    \"blockindex\": n,          (numeric) The block index containing the transaction. Available for 'send' and 'receive'\n"
-                  "                                          category of transactions.\n"
-                  "    \"txid\": \"transactionid\", (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n"
-                  "    \"walletconflicts\" : [\n"
-                  "        \"conflictid\",  (string) Ids of transactions, including equivalent clones, that re-spend a txid input.\n"
-                  "    ],\n"
-                  "    \"respendsobserved\" : [\n"
-                  "        \"respendid\",  (string) Ids of transactions, NOT equivalent clones, that re-spend a txid input. \"Double-spends.\"\n"
-                  "    ],\n"
-                  "    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n"
-                  "    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (midnight Jan 1 1970 GMT). Available \n"
-                  "                                          for 'send' and 'receive' category of transactions.\n"
-                  "    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n"
-                  "    \"otheraccount\": \"accountname\",  (string) For the 'move' category of transactions, the account the funds came \n"
-                  "                                          from (for receiving funds, positive amounts), or went to (for sending funds,\n"
-                  "                                          negative amounts).\n"
-                  "  }\n"
-                  "]\n"
+                "listtransactions ( \"account\" count from includeWatchonly)\n"
+                "\nReturns up to 'count' most recent transactions skipping the first 'from' transactions for account 'account'.\n"
+                "\nArguments:\n"
+                "1. \"account\"    (string, optional) The account name. If not included, it will list all transactions for all accounts.\n"
+                "                                     If \"\" is set, it will list transactions for the default account.\n"
+                "2. count          (numeric, optional, default=10) The number of transactions to return\n"
+                "3. from           (numeric, optional, default=0) The number of transactions to skip\n"
+                "4. includeWatchonly (bool, optional, default=false) Include transactions to watchonly addresses (see 'importaddress')\n"
+                "                                     If \"\" is set true, it will list sent transactions as well\n"
+                "\nResult:\n"
+                "[\n"
+                "  {\n"
+                "    \"account\":\"accountname\",       (string) The account name associated with the transaction. \n"
+                "                                                It will be \"\" for the default account.\n"
+                "    \"address\":\"bitcoinaddress\",    (string) The bitcoin address of the transaction. Not present for \n"
+                "                                                move transactions (category = move).\n"
+                "    \"category\":\"send|receive|move\", (string) The transaction category. 'move' is a local (off blockchain)\n"
+                "                                                transaction between accounts, and not associated with an address,\n"
+                "                                                transaction id or block. 'send' and 'receive' transactions are \n"
+                "                                                associated with an address, transaction id and block details\n"
+                "    \"amount\": x.xxx,          (numeric) The amount in btc. This is negative for the 'send' category, and for the\n"
+                "                                         'move' category for moves outbound. It is positive for the 'receive' category,\n"
+                "                                         and for the 'move' category for inbound funds.\n"
+                "    \"fee\": x.xxx,             (numeric) The amount of the fee in btc. This is negative and only available for the \n"
+                "                                         'send' category of transactions.\n"
+                "    \"confirmations\": n,       (numeric) The number of confirmations for the transaction. Available for 'send' and \n"
+                "                                         'receive' category of transactions.\n"
+                "    \"blockhash\": \"hashvalue\", (string) The block hash containing the transaction. Available for 'send' and 'receive'\n"
+                "                                          category of transactions.\n"
+                "    \"blockindex\": n,          (numeric) The block index containing the transaction. Available for 'send' and 'receive'\n"
+                "                                          category of transactions.\n"
+                "    \"txid\": \"transactionid\", (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n"
+                "    \"walletconflicts\" : [\n"
+                "        \"conflictid\",  (string) Ids of transactions, including equivalent clones, that re-spend a txid input.\n"
+                "    ],\n"
+                "    \"respendsobserved\" : [\n"
+                "        \"respendid\",  (string) Ids of transactions, NOT equivalent clones, that re-spend a txid input. \"Double-spends.\"\n"
+                "    ],\n"
+                "    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n"
+                "    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (midnight Jan 1 1970 GMT). Available \n"
+                "                                          for 'send' and 'receive' category of transactions.\n"
+                "    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n"
+                "    \"otheraccount\": \"accountname\",  (string) For the 'move' category of transactions, the account the funds came \n"
+                "                                          from (for receiving funds, positive amounts), or went to (for sending funds,\n"
+                "                                          negative amounts).\n"
+                "  }\n"
+                "]\n"
 
-                  "\nExamples:\n"
-                  "\nList the most recent 10 transactions in the systems\n"
-                  "\nList the most recent 10 transactions for the tabby account\n"
-                  "\nList transactions 100 to 120 from the tabby account\n"
-                  "\nAs a json rpc call\n"
-                  );
+                "\nExamples:\n"
+                "\nList the most recent 10 transactions in the systems\n"
+                "\nList the most recent 10 transactions for the tabby account\n"
+                "\nList transactions 100 to 120 from the tabby account\n"
+                "\nAs a json rpc call\n"
+                );
 
     string strAccount = "*";
     int nCount = 10;
@@ -1645,6 +1653,59 @@ UniValue listtransactions(const UniValue& params, bool fHelp)
     ret.clear();
     ret.setArray();
     ret.push_backV(arrTmp);
+
+    return ret;
+}
+
+UniValue liststakes(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+                "liststakes ( count )\n"
+                "\n"
+                "Returns count most recent stakes."
+                );
+
+    string strAccount = "*";
+    int nCount = 10;
+    isminefilter filter = ISMINE_SPENDABLE;
+    if (params.size() > 0)
+    {
+        nCount = params[0].get_int();
+    }
+
+    if (nCount < 0)
+    {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
+    }
+
+    UniValue ret_superset(UniValue::VARR);
+    UniValue ret(UniValue::VARR);
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    std::list<CAccountingEntry> acentries;
+    CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, strAccount);
+
+    // iterate backwards until we have at least nCount items to return:
+    for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
+    {
+        CWalletTx *const pwtx = it->second.first;
+        if (pwtx != 0)
+            ListTransactions(*pwtx, strAccount, 0, true, ret_superset, filter, true);
+        CAccountingEntry *const pacentry = it->second.second;
+        if (pacentry != 0)
+            AcentryToJSON(*pacentry, strAccount, ret_superset);
+
+        if ((int)ret_superset.size() >= nCount) break;
+    }
+    // ret is newest to oldest, for the stake listings, we will leave in that order.
+    std::vector<UniValue> arrTmp = ret_superset.getValues();
+
+    for (const auto& iter : arrTmp)
+    {
+        ret.push_back(iter);
+    }
 
     return ret;
 }


### PR DESCRIPTION
This implements a thin version of listtransactions which only
lists stakes. It takes one parameter, which is the number of stakes
to return. The output is kept in order of newest to oldest, unlike
listtransactions.

The latest stake can be retrieved by liststakes 1.