### PR TITLE
gui: Adjust stylesheets and scale icons to improve HiDPI side toolbar display

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -456,7 +456,7 @@ void BitcoinGUI::createToolBars()
     toolbar->setMovable(false);
     toolbar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     toolbar->setContextMenuPolicy(Qt::PreventContextMenu);
-    toolbar->setIconSize(QSize(50, 25));
+    toolbar->setIconSize(QSize(50 * logicalDpiX() / 96, 25 * logicalDpiX() / 96));
     toolbar->addAction(overviewAction);
     toolbar->addAction(sendCoinsAction);
     toolbar->addAction(receiveCoinsAction);

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -28,24 +28,20 @@ QFrame[frameShape="5"] {
 
 QToolButton {
     color: white;
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(49,54,59), stop: 1 rgb(49,54,59));
-    border:none;
+    background-color: rgb(49,54,59);
 }
 
 QToolButton:hover {
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(65,0,127), stop: 1 rgb(65,0,127));
     color:white;
-    border:none;
+    background-color: rgb(65,0,127);
 }
 
 QToolButton:checked {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(64,68,82), stop: 1 rgb(64,68,82));
-    border:none;
+    background-color: rgb(64,68,82);
 }
 
 QToolButton:checked:hover {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(65,0,127), stop: 1 rgb(65,0,127));
-    border:none;
+    background-color: rgb(65,0,127);
 }
 
 QMenuBar {
@@ -407,7 +403,7 @@ QCheckBox{
 #toolbar {
     border:none;
     padding-top:1.25em;
-    min-width:8em;
+    min-width:8.5em;
     height:100%;
     color: white;
 }
@@ -426,8 +422,8 @@ QCheckBox{
 }
 
 QToolBar#toolbar QToolButton {
-    padding-left:1em;
-    padding-right:1em;
+    padding-left:1.25em;
+    padding-right:1.25em;
     padding-top:0.5em;
     padding-bottom:0.5em;
     margin:0.25em;

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -17,24 +17,20 @@ BitcoinAmountField{
 
 QToolButton {
     color: black;
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(240,240,240), stop: 1 rgb(240,240,240));
-    border:none;
+    background-color: rgb(240,240,240);
 }
 
 QToolButton:hover {
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(65,0,127), stop: 1 rgb(65,0,127));
     color:white;
-    border:none;
+    background-color: rgb(65,0,127);
 }
 
 QToolButton:checked {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(200,200,200), stop: 1 rgb(200,200,200));
-    border:none;
+    background-color: rgb(200,200,200);
 }
 
 QToolButton:checked:hover {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 1.0, y2: 1.0,stop: 0 rgb(65,0,127), stop: 1 rgb(65,0,127));
-    border:none;
+    background-color: rgb(65,0,127);
 }
 
 QMenuBar {
@@ -380,7 +376,7 @@ QListWidget{
 #toolbar {
     border:none;
     padding-top:1.25em;
-    min-width:8em;
+    min-width:8.5em;
     height:100%;
     color: black;
 }
@@ -399,8 +395,8 @@ QListWidget{
 }
 
 QToolBar#toolbar QToolButton {
-    padding-left:1em;
-    padding-right:1em;
+    padding-left:1.25em;
+    padding-right:1.25em;
     padding-top:0.5em;
     padding-bottom:0.5em;
     margin:0.25em;

--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -9,6 +9,20 @@ QMainWindow {
     font-family: "Inter";
 }
 
+QMenuBar {
+    background: rgb(240,240,240);
+    color: black;
+}
+
+QMenuBar::item {
+    padding-bottom:0.5em;
+    padding-top:0.5em;
+    padding-left:1em;
+    padding-right:1em;
+    color: black;
+    background-color: rgb(240,240,240);
+}
+
 QTextEdit {
     background-color: white;
 }
@@ -24,7 +38,7 @@ QTextEdit {
 #toolbar {
     border:none;
     padding-top:1.25em;
-    min-width:8em;
+    min-width:8.5em;
     height:100%;
 }
 
@@ -41,8 +55,8 @@ QTextEdit {
 }
 
 QToolBar#toolbar QToolButton {
-    padding-left:1em;
-    padding-right:1em;
+    padding-left:1.25em;
+    padding-right:1.25em;
     padding-top:0.5em;
     padding-bottom:0.5em;
     margin:0.25em;


### PR DESCRIPTION
This PR makes some stylesheet adjustments to make the menu bar consistent, fix truncation of the side toolbar icon labels, and also scale the side toolbar icons on HiDPI displays. Further work will need to be done on the stylesheets as they still are quite bizarre.