### PR TITLE
gui: Add "review beacon verification" button to wizard summary page

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1089,6 +1089,16 @@ void Researcher::RunRenewBeaconJob()
         return;
     }
 
+    // Do not send a new beacon without manual action during the grace period
+    // for beacon readvertisement after block version 11. This prevents users
+    // from missing the steps needed to verify the new beacon:
+    //
+    if (const auto beacon_option = researcher->TryBeacon()) {
+        if (beacon_option->m_timestamp < g_v11_timestamp) {
+            return;
+        }
+    }
+
     // Do not perform an automated renewal for participants with existing
     // beacons before a superblock is due. This avoids overwriting beacon
     // timestamps in the beacon registry in a way that causes the renewed

--- a/src/qt/forms/researcherwizardsummarypage.ui
+++ b/src/qt/forms/researcherwizardsummarypage.ui
@@ -196,6 +196,19 @@
          </item>
         </layout>
        </item>
+       <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+        <widget class="QPushButton" name="reviewBeaconAuthButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Review Beacon Verification</string>
+         </property>
+        </widget>
+       </item>
        <item>
         <spacer name="headerBottomSpacer">
          <property name="orientation">
@@ -203,6 +216,12 @@
          </property>
          <property name="sizeType">
           <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
         </spacer>
        </item>

--- a/src/qt/researcher/researcherwizard.cpp
+++ b/src/qt/researcher/researcherwizard.cpp
@@ -52,6 +52,14 @@ ResearcherWizard::ResearcherWizard(
     connect(ui->modePage, SIGNAL(detailLinkButtonClicked()),
             this, SLOT(onDetailLinkButtonClicked()));
 
+    // This enables the "review beacon verification" button on the summary page
+    // to switch the current page back to beacon authentication page. Since the
+    // summary page cannot navigate back to specific pages directly, it emits a
+    // signal that we wire up here to change the page when requested:
+    //
+    connect(ui->summaryPage, SIGNAL(reviewBeaconAuthButtonClicked()),
+            this, SLOT(onReviewBeaconAuthButtonClicked()));
+
     // This enables the beacon "renew" button on the summary page to switch the
     // current page back to beacon page. Since the summary page cannot navigate
     // back to a specific page directly, it emits a signal that we wire up here
@@ -109,6 +117,16 @@ void ResearcherWizard::onDetailLinkButtonClicked()
     // and start from it instead:
     //
     setStartId(PageModeDetail);
+    restart();
+}
+
+void ResearcherWizard::onReviewBeaconAuthButtonClicked()
+{
+    // This handles the beacon "renew" button on the summary page. Qt doesn't
+    // give us a good way to switch directly to the beacon page, so we rewind
+    // and start from it instead:
+    //
+    setStartId(PageAuth);
     restart();
 }
 

--- a/src/qt/researcher/researcherwizard.h
+++ b/src/qt/researcher/researcherwizard.h
@@ -63,6 +63,7 @@ private slots:
     void setStartOverButtonVisibility(int page_id);
     void onCustomButtonClicked(int which);
     void onDetailLinkButtonClicked();
+    void onReviewBeaconAuthButtonClicked();
     void onRenewBeaconButtonClicked();
 };
 

--- a/src/qt/researcher/researcherwizardsummarypage.cpp
+++ b/src/qt/researcher/researcherwizardsummarypage.cpp
@@ -91,6 +91,7 @@ void ResearcherWizardSummaryPage::refreshSummary()
     ui->statusLabel->setText(m_researcher_model->formatStatus());
     ui->magnitudeLabel->setText(m_researcher_model->formatMagnitude());
     ui->accrualLabel->setText(m_researcher_model->formatAccrual(unit));
+    ui->reviewBeaconAuthButton->setVisible(m_researcher_model->needsBeaconAuth());
 
     ui->beaconDetailsIconLabel->setPixmap(
         m_researcher_model->getBeaconStatusIcon().pixmap(icon_size, icon_size));
@@ -155,6 +156,16 @@ void ResearcherWizardSummaryPage::reloadProjects()
 {
     m_researcher_model->reload();
     refreshProjects();
+}
+
+void ResearcherWizardSummaryPage::on_reviewBeaconAuthButton_clicked()
+{
+    // This enables the "review beacon auth" button to switch the current page
+    // back to verify beacon page. Since a wizard page cannot set the wizard's
+    // current index directly, this emits a signal that the wizard connects to
+    // the slot that changes the page for us:
+    //
+    emit reviewBeaconAuthButtonClicked();
 }
 
 void ResearcherWizardSummaryPage::on_renewBeaconButton_clicked()

--- a/src/qt/researcher/researcherwizardsummarypage.h
+++ b/src/qt/researcher/researcherwizardsummarypage.h
@@ -39,6 +39,7 @@ private:
     ProjectTableModel *m_table_model;
 
 signals:
+    void reviewBeaconAuthButtonClicked();
     void renewBeaconButtonClicked();
 
 private slots:
@@ -47,6 +48,7 @@ private slots:
     void refreshOverallStatus();
     void refreshProjects();
     void reloadProjects();
+    void on_reviewBeaconAuthButton_clicked();
     void on_renewBeaconButton_clicked();
 };
 


### PR DESCRIPTION
This adds a button to the researcher wizard summary page that returns the user to the beacon verification instructions. It enables users to review their beacon verification code if needed.

This also includes a change that disables unintended automatic advertisement of a new beacon during the transition for block version 11. Unlocked wallets (including those unlocked for staking only) sent new beacons for the v11 protocol automatically. This causes users to miss the verification code and the instructions for beacon verification in the GUI.