### PR TITLE
rpc: Add "getlaststake" RPC function

### DIFF
--- a/src/gridcoin/staking/status.h
+++ b/src/gridcoin/staking/status.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "sync.h"
+#include "uint256.h"
 
 #include <string>
 #include <vector>
@@ -39,6 +40,7 @@ public:
     uint64_t AcceptedCnt;
     uint64_t KernelsFound;
     int64_t nLastCoinStakeSearchInterval;
+    uint256 m_last_pos_tx_hash;
 
     void Clear();
     MinerStatus();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -251,8 +251,15 @@ void SyncWithWallets(const CTransaction& tx, const CBlock* pblock, bool fUpdate,
         if (tx.IsCoinStake())
         {
             for (auto const& pwallet : setpwalletRegistered)
+            {
                 if (pwallet->IsFromMe(tx))
+                {
                     pwallet->DisableTransaction(tx);
+
+                    LOCK(g_miner_status.lock);
+                    g_miner_status.m_last_pos_tx_hash.SetNull();
+                }
+            }
         }
         return;
     }

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,6 +8,11 @@
 
 #include "main.h"
 
+#include <boost/optional/optional_fwd.hpp>
+
+class CWallet;
+class CWalletTx;
+
 typedef std::vector< std::pair<std::string, double> > SideStakeAlloc;
 
 extern unsigned int nMinerSleep;
@@ -16,6 +21,8 @@ extern unsigned int nMinerSleep;
 // split UTXO size. It is int64_t but in GRC so that it matches the entry in the config file.
 // It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
 static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
+
+boost::optional<CWalletTx> GetLastStake(CWallet& wallet);
 
 void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStakeSplit, bool &fEnableSideStaking, SideStakeAlloc &vSideStakeAlloc, double &dEfficiency);
 unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -350,6 +350,7 @@ static const CRPCCommand vRPCCommands[] =
     { "beaconreport",            &beaconreport,            cat_mining        },
     { "beaconstatus",            &beaconstatus,            cat_mining        },
     { "explainmagnitude",        &explainmagnitude,        cat_mining        },
+    { "getlaststake",            &getlaststake,            cat_mining        },
     { "getmininginfo",           &getmininginfo,           cat_mining        },
     { "lifetime",                &lifetime,                cat_mining        },
     { "magnitude",               &magnitude,               cat_mining        },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -165,6 +165,7 @@ extern UniValue beaconreport(const UniValue& params, bool fHelp);
 extern UniValue beaconconvergence(const UniValue& params, bool fHelp);
 extern UniValue beaconstatus(const UniValue& params, bool fHelp);
 extern UniValue explainmagnitude(const UniValue& params, bool fHelp);
+extern UniValue getlaststake(const UniValue& params, bool fHelp);
 extern UniValue getmininginfo(const UniValue& params, bool fHelp);
 extern UniValue lifetime(const UniValue& params, bool fHelp);
 extern UniValue magnitude(const UniValue& params, bool fHelp);


### PR DESCRIPTION
This adds an RPC function that responds with information about a wallet's most recently staked block.

The implementation caches the stake to minimize the cost to poll this endpoint since users intend to query the information for status-type applications and scripts.