### PR TITLE
scheduler: Increase default update check interval to 5 days

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -252,7 +252,7 @@ void ScheduleUpdateChecks(CScheduler& scheduler)
         return;
     }
 
-    int64_t hours = GetArg("-updatecheckinterval", 24);
+    int64_t hours = GetArg("-updatecheckinterval", 5 * 24);
 
     if (hours < 1) {
         LogPrintf("ERROR: invalid -updatecheckinterval: %s. Using default...",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -302,7 +302,7 @@ std::string HelpMessage()
         "  -snapshoturl=<url>           " + _("Optional: Specify url of snapshot.zip file (ex: https://sub.domain.com/location/snapshot.zip)") + "\n"
         "  -snapshotsha256url=<url>     " + _("Optional: Specify url of snapshot.sha256 file (ex: https://sub.domain.com/location/snapshot.sha256)") + "\n"
         "  -disableupdatecheck          " + _("Optional: Disable update checks by wallet") + "\n"
-        "  -updatecheckinterval=<hours> " + _("Optional: Specify custom update interval checks in hours (Default: 24 hours (minimum 1 hour))") + "\n"
+        "  -updatecheckinterval=<hours> " + _("Optional: Specify custom update interval checks in hours (Default: 120 hours (minimum 1 hour))") + "\n"
         "  -updatecheckurl=<url>        " + _("Optional: Specify url of update version checks (ex: https://sub.domain.com/location/latest") + "\n";
 
     return strUsage;


### PR DESCRIPTION
This addresses user feedback that complains that the update checker is too annoying. While I believe that the wallet should be persistent, 24 hours does seem excessive to me as well. One week feels too long for something designed to draw attention, so I set the default to 5 days. An update check will continue to run after each start-up.