### PR TITLE
util: Decouple out-of-sync state from block acceptance

### DIFF
--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -635,7 +635,7 @@ public:
 
         LogPrintf("ValidateSuperblock(): No match by project.");
 
-        if (g_fOutOfSyncByAge) {
+        if (OutOfSyncByAge()) {
             LogPrintf("ValidateSuperblock(): No validation achieved, but node is"
                       "not in sync - skipping validation.");
 

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1073,7 +1073,7 @@ void Researcher::Initialize()
 
 void Researcher::RunRenewBeaconJob()
 {
-    if (g_fOutOfSyncByAge) {
+    if (OutOfSyncByAge()) {
         return;
     }
 
@@ -1274,7 +1274,7 @@ int64_t Researcher::Accrual() const
         return 0;
     }
 
-    const int64_t now = g_fOutOfSyncByAge ? pindexBest->nTime : GetAdjustedTime();
+    const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
 
     LOCK(cs_main);
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -989,7 +989,7 @@ void Scraper(bool bSingleShot)
         // We do NOT want to filter statistics with an out-of-date beacon list or project whitelist.
         // If called in singleshot mode, wallet will most likely be in sync, because the calling functions check
         // beforehand.
-        while (g_fOutOfSyncByAge)
+        while (OutOfSyncByAge())
         {
             // Signal stats event to UI.
             uiInterface.NotifyScraperEvent(scrapereventtypes::OutOfSync, CT_UPDATING, {});
@@ -1231,7 +1231,7 @@ void ScraperSubscriber()
     {
         // Only proceed if wallet is in sync. Check every 8 seconds since no callback is available.
         // We do NOT want to filter statistics with an out-of-date beacon list or project whitelist.
-        while (g_fOutOfSyncByAge)
+        while (OutOfSyncByAge())
         {
             // Signal stats event to UI.
             uiInterface.NotifyScraperEvent(scrapereventtypes::OutOfSync, CT_NEW, {});
@@ -4806,7 +4806,7 @@ mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests()
 
     // First check for unauthorized manifests just in case a scraper has been deauthorized.
     // This is only done if in sync.
-    if (!g_fOutOfSyncByAge)
+    if (!OutOfSyncByAge())
     {
         unsigned int nDeleted = ScraperDeleteUnauthorizedCScraperManifests();
         if (nDeleted) _log(logattribute::WARNING, "ScraperDeleteCScraperManifests", "Deleted " + std::to_string(nDeleted) + " unauthorized manifests.");
@@ -5061,7 +5061,7 @@ Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bContrac
     // NOTE - OutOfSyncByAge calls PreviousBlockAge(), which takes a lock on cs_main. This is likely a deadlock culprit if called from here
     // and the scraper or subscriber loop nearly simultaneously. So we use an atomic flag updated by the scraper or subscriber loop.
     // If not in sync then immediately bail with an empty superblock.
-    if (g_fOutOfSyncByAge) return empty_superblock;
+    if (OutOfSyncByAge()) return empty_superblock;
 
     // Check the age of the ConvergedScraperStats cache. If less than nScraperSleep / 1000 old (for seconds) or clean, then simply report back the cache contents.
     // This prevents the relatively heavyweight stats computations from running too often. The time here may not exactly align with

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -102,8 +102,6 @@ int64_t SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD = 300;
 
 AppCacheSectionExt mScrapersExt = {};
 
-extern std::atomic_bool g_fOutOfSyncByAge;
-
 CCriticalSection cs_mScrapersExt;
 
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -28,7 +28,7 @@ extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME;
 extern double CONVERGENCE_BY_PROJECT_RATIO;
 extern unsigned int nScraperSleep;
 extern AppCacheSectionExt mScrapersExt;
-extern std::atomic<int64_t> g_nSyncTime;
+extern std::atomic<int64_t> g_nTimeBestReceived;
 extern ConvergedScraperStats ConvergedScraperStatsCache;
 extern CCriticalSection cs_mScrapersExt;
 extern CCriticalSection cs_ConvergedScraperStatsCache;
@@ -399,7 +399,7 @@ bool CScraperManifest::IsManifestAuthorized(int64_t& nTime, CPubKey& PubKey, uns
     }
     else
     {
-        nGracePeriodEnd = std::max((int64_t)g_nSyncTime, nLastFalseEntryTime) + SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD;
+        nGracePeriodEnd = std::max<int64_t>(g_nTimeBestReceived, nLastFalseEntryTime) + SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD;
 
         // If the current time is past the grace period end then set SCRAPER_MISBEHAVING_NODE_BANSCORE, otherwise 0.
         if (nGracePeriodEnd < GetAdjustedTime())
@@ -433,7 +433,7 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     // the manifest is authorized, then set the checked flag to true,
     // otherwise terminate the unserializecheck and throw an error,
     // which will also result in an increase in banscore, if past the grace period.
-    if (g_fOutOfSyncByAge)
+    if (OutOfSyncByAge())
     {
         bCheckedAuthorized = false;
     }
@@ -499,7 +499,7 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     unsigned int nMaxProjects = static_cast<unsigned int>(std::ceil(static_cast<double>(GRC::GetWhitelist().Snapshot().size()) /
                                                                     std::max(0.5, CONVERGENCE_BY_PROJECT_RATIO)) + 2);
 
-    if (!g_fOutOfSyncByAge && projects.size() > nMaxProjects)
+    if (!OutOfSyncByAge() && projects.size() > nMaxProjects)
     {
         // Immediately ban the node from which the manifest was received.
         banscore_out = GetArg("-banscore", 100);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -30,7 +30,6 @@ static CScheduler scheduler;
 
 extern void ThreadAppInit2(void* parg);
 bool IsConfigFileEmpty();
-extern void UpdateOutOfSyncByAge();
 
 #ifndef WIN32
 #include <signal.h>
@@ -897,8 +896,6 @@ bool AppInit2(ThreadHandlerPtr threads)
         return false;
     }
     LogPrintf(" block index %15" PRId64 "ms", GetTimeMillis() - nStart);
-
-    UpdateOutOfSyncByAge();
 
     if (GetBoolArg("-printblockindex") || GetBoolArg("-printblocktree"))
     {

--- a/src/main.h
+++ b/src/main.h
@@ -82,9 +82,7 @@ extern arith_uint256 nBestChainTrust;
 extern arith_uint256 nBestInvalidTrust;
 extern uint256 hashBestChain;
 extern CBlockIndex* pindexBest;
-extern std::atomic_bool g_fOutOfSyncByAge;
 extern const std::string strMessageMagic;
-extern int64_t nTimeBestReceived;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
 extern unsigned char pchMessageStart[4];
@@ -153,7 +151,7 @@ void ResendWalletTransactions(bool fForce = false);
 
 std::string DefaultWalletAddress();
 
-int64_t PreviousBlockAge();
+bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -971,7 +971,7 @@ bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInp
 
 void AddSuperblockContractOrVote(CBlock& blocknew)
 {
-    if (g_fOutOfSyncByAge) {
+    if (OutOfSyncByAge()) {
         LogPrintf("AddSuperblockContractOrVote: Out of sync.");
         return;
     }

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -212,7 +212,7 @@ bool DiagnosticsDialog::VerifyCPIDIsEligible()
 
 bool DiagnosticsDialog::VerifyWalletIsSynced()
 {
-    return !g_fOutOfSyncByAge;
+    return !OutOfSyncByAge();
 }
 
 bool DiagnosticsDialog::VerifyCPIDHasRAC()

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1944,7 +1944,7 @@ UniValue MagnitudeReport(const GRC::Cpid cpid)
 {
     UniValue json(UniValue::VOBJ);
 
-    const int64_t now = g_fOutOfSyncByAge ? pindexBest->nTime : GetAdjustedTime();
+    const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
     const GRC::ResearchAccount& account = GRC::Tally::GetAccount(cpid);
     const GRC::AccrualComputer calc = GRC::Tally::GetComputer(cpid, now, pindexBest);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -30,6 +30,7 @@ extern bool fQtActive;
 
 bool fConfChange;
 unsigned int nDerivationMethodIndex;
+extern std::atomic<int64_t> g_nTimeBestReceived;
 
 namespace {
 struct CompareValueOnly
@@ -1200,7 +1201,7 @@ void CWallet::ResendWalletTransactions(bool fForce)
 
         // Only do it if there's been a new block since last time
         static int64_t nLastTime;
-        if (nTimeBestReceived < nLastTime)
+        if (g_nTimeBestReceived < nLastTime)
             return;
         nLastTime =  GetAdjustedTime();
     }
@@ -1216,7 +1217,7 @@ void CWallet::ResendWalletTransactions(bool fForce)
             CWalletTx& wtx = item.second;
             // Don't rebroadcast until it's had plenty of time that
             // it should have gotten in already by now.
-            if (fForce || nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
+            if (fForce || g_nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
                 mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
         }
         for (auto const &item : mapSorted)


### PR DESCRIPTION
This decouples the state transitions for out-of-sync-by-age status from the outcome of block acceptance to avoid an edge-case node stall caused by the inability to update the out-of-sync status due to being out-of-sync.