### PR TITLE
gui: Prevent multiple update dialogs from being open at the same time

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -847,19 +847,20 @@ void BitcoinGUI::error(const QString &title, const QString &message, bool modal)
 void BitcoinGUI::update(const QString &title, const QString& version, const QString &message)
 {
     // Create our own message box; A dialog can go here in future for qt if we choose
-    QMessageBox* updatemsg = new QMessageBox;
 
-    updatemsg->setAttribute(Qt::WA_DeleteOnClose);
-    updatemsg->setWindowTitle(title);
-    updatemsg->setText(version);
-    updatemsg->setDetailedText(message);
-    updatemsg->setIcon(QMessageBox::Information);
-    updatemsg->setStandardButtons(QMessageBox::Ok);
-    updatemsg->setModal(false);
+    updateMessageDialog.reset(new QMessageBox);
+
+    updateMessageDialog->setWindowTitle(title);
+    updateMessageDialog->setText(version);
+    updateMessageDialog->setDetailedText(message);
+    updateMessageDialog->setIcon(QMessageBox::Information);
+    updateMessageDialog->setStandardButtons(QMessageBox::Ok);
+    updateMessageDialog->setModal(false);
+    connect(updateMessageDialog.get(), &QMessageBox::finished, [this](int) { updateMessageDialog.reset(); });
     // Due to slight delay in gui load this could appear behind the gui ui
     // The only other option available would make the message box stay on top of all applications
 
-    QTimer::singleShot(5000, updatemsg, SLOT(show()));
+    QTimer::singleShot(5000, updateMessageDialog.get(), SLOT(show()));
 }
 
 void BitcoinGUI::changeEvent(QEvent *e)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -5,6 +5,7 @@
 #include <QSystemTrayIcon>
 #include <QMenu>
 #include <stdint.h>
+#include <memory>
 #include "guiconstants.h"
 
 class TransactionTableModel;
@@ -29,6 +30,7 @@ class QAbstractItemModel;
 class QModelIndex;
 class QStackedWidget;
 class QUrl;
+class QMessageBox;
 QT_END_NAMESPACE
 
 /**
@@ -78,6 +80,7 @@ private:
     SendCoinsDialog *sendCoinsPage;
     VotingDialog *votingPage;
     SignVerifyMessageDialog *signVerifyMessageDialog;
+    std::unique_ptr<QMessageBox> updateMessageDialog;
 
     QLabel *labelEncryptionIcon;
     QLabel *labelStakingIcon;


### PR DESCRIPTION
Prior to these changes, if an update is available, a new update notification dialog would be produced every time the check is run, resulting in multiple dialogs if they are not closed between each update interval.

There are many ways this issue could be fixed. I think this solution is a good approach since the dialog is only allocated when it is open (like before), and it also updates the dialog if the version changes between checks while the dialog remains open. However I am open to suggestions if you think this should be done a different way.

I did this because it was really annoying having dozens of these popups pile up for the leisure update on my wallet's computer (which I infrequently check). However I am also participating in Hacktoberfest this year and if you think this is useful I would appreciate if you opted in to it so this contribution can count towards that: https://hacktoberfest.digitalocean.com/hacktoberfest-update.