### PR TITLE
rpc: Add out-of-sync status to "getinfo" and "getblockchaininfo"

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1815,6 +1815,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     UniValue res(UniValue::VOBJ), diff(UniValue::VOBJ);
 
     res.pushKV("blocks", nBestHeight);
+    res.pushKV("in_sync", !OutOfSyncByAge());
     res.pushKV("moneysupply", ValueFromAmount(pindexBest->nMoneySupply));
     diff.pushKV("current", GRC::GetCurrentDifficulty());
     diff.pushKV("target", GRC::GetTargetDifficulty());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -109,6 +109,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.pushKV("newmint",       ValueFromAmount(pwalletMain->GetNewMint()));
     obj.pushKV("stake",         ValueFromAmount(pwalletMain->GetStake()));
     obj.pushKV("blocks",        nBestHeight);
+    obj.pushKV("in_sync",       !OutOfSyncByAge());
     obj.pushKV("timeoffset",    GetTimeOffset());
     obj.pushKV("moneysupply",   ValueFromAmount(pindexBest->nMoneySupply));
     obj.pushKV("connections",   (int)vNodes.size());


### PR DESCRIPTION
This adds an ~`up_to_date`~ `in_sync` field to the output of the `getinfo` and `getblockchaininfo` RPCs to indicate whether a node is in-sync.

This is a common feature request from headless users.