### PR TITLE
gui: add autocomplete to rpc console

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -405,6 +405,17 @@ void RPCConsole::setClientModel(ClientModel *model)
 		ui->boostVersion->setText(model->formatBoostVersion());
 		ui->porDiff->setText(model->getDifficulty());
 
+        //Setup autocomplete and attach it
+        QStringList wordList;
+        std::vector<std::string> commandList = tableRPC.listCommands();
+        for (size_t i = 0; i < commandList.size(); ++i)
+        {
+            wordList << commandList[i].c_str();
+        }
+
+        autoCompleter = new QCompleter(wordList, this);
+        ui->lineEdit->setCompleter(autoCompleter);
+
     }
 }
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -8,6 +8,7 @@
 
 #include <QDialog>
 #include <QWidget>
+#include <QCompleter>
 #include <QMenu>
 
 namespace Ui {
@@ -109,6 +110,7 @@ private:
     QList<NodeId> cachedNodeids;
     QMenu *peersTableContextMenu = nullptr;
     QMenu *banTableContextMenu = nullptr;
+    QCompleter *autoCompleter;
     static QString FormatBytes(quint64 bytes);
     void setTrafficGraphRange(int mins);
     /** show detailed information on ui about selected node */

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -896,6 +896,17 @@ UniValue CRPCTable::execute(const std::string& strMethod, const UniValue& params
     }
 }
 
+std::vector<std::string> CRPCTable::listCommands() const
+{
+    std::vector<std::string> commandList;
+    typedef std::map<std::string, const CRPCCommand*> commandMap;
+
+    std::transform( mapCommands.begin(), mapCommands.end(),
+                    std::back_inserter(commandList),
+                    boost::bind(&commandMap::value_type::first,_1) );
+    return commandList;
+}
+
 #ifdef TEST
 int main(int argc, char *argv[])
 {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -24,6 +24,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
+#include <algorithm>
 
 #include <memory>
 
@@ -896,6 +897,7 @@ UniValue CRPCTable::execute(const std::string& strMethod, const UniValue& params
     }
 }
 
+constexpr const char* CRPCTable::DEPRECATED_RPCS[];
 std::vector<std::string> CRPCTable::listCommands() const
 {
     std::vector<std::string> commandList;
@@ -904,6 +906,10 @@ std::vector<std::string> CRPCTable::listCommands() const
     std::transform( mapCommands.begin(), mapCommands.end(),
                     std::back_inserter(commandList),
                     boost::bind(&commandMap::value_type::first,_1) );
+    // remove deprecated commands from autocomplete
+    for(auto &command: DEPRECATED_RPCS) {
+        std::remove(commandList.begin(), commandList.end(), command);
+    }
     return commandList;
 }
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -443,6 +443,22 @@ static const CRPCCommand vRPCCommands[] =
     { "votedetails",             &votedetails,             cat_voting        },
 };
 
+static constexpr const char* DEPRECATED_RPCS[] {
+        "debug",
+        "debug10",
+        "execute" ,
+        "getaccount",
+        "getaccountaddress",
+        "getaddressesbyaccount",
+        "getreceivedbyaccount",
+        "listaccounts",
+        "listreceivedbyaccount",
+        "list",
+        "move",
+        "setaccount",
+        "vote",
+};
+
 CRPCTable::CRPCTable()
 {
     unsigned int vcidx;
@@ -897,7 +913,7 @@ UniValue CRPCTable::execute(const std::string& strMethod, const UniValue& params
     }
 }
 
-constexpr const char* CRPCTable::DEPRECATED_RPCS[];
+
 std::vector<std::string> CRPCTable::listCommands() const
 {
     std::vector<std::string> commandList;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -59,22 +59,6 @@ class CRPCTable
 {
 private:
     std::map<std::string, const CRPCCommand*> mapCommands;
-    static constexpr const char* DEPRECATED_RPCS[] {
-            "debug",
-            "debug10",
-            "execute" ,
-            "getaccount",
-            "getaccountaddress",
-            "getaddressesbyaccount",
-            "getreceivedbyaccount",
-            "listaccounts",
-            "listreceivedbyaccount",
-            "list",
-            "move",
-            "setaccount",
-            "vote",
-    };
-
 public:
     CRPCTable();
     const CRPCCommand* operator[](std::string name) const;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -59,6 +59,22 @@ class CRPCTable
 {
 private:
     std::map<std::string, const CRPCCommand*> mapCommands;
+    static constexpr const char* DEPRECATED_RPCS[] {
+            "debug",
+            "debug10",
+            "execute" ,
+            "getaccount",
+            "getaccountaddress",
+            "getaddressesbyaccount",
+            "getreceivedbyaccount",
+            "listaccounts",
+            "listreceivedbyaccount",
+            "list",
+            "move",
+            "setaccount",
+            "vote",
+    };
+
 public:
     CRPCTable();
     const CRPCCommand* operator[](std::string name) const;
@@ -80,7 +96,6 @@ public:
     std::vector<std::string> listCommands() const;
 
 };
-
 extern const CRPCTable tableRPC;
 
 extern int64_t nWalletUnlockTime;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -72,6 +72,13 @@ public:
      * @throws an exception when an error happens.
      */
     UniValue execute(const std::string &method, const UniValue& params) const;
+
+    /**
+    * Returns a list of registered commands
+    * @returns List of registered commands.
+    */
+    std::vector<std::string> listCommands() const;
+
 };
 
 extern const CRPCTable tableRPC;


### PR DESCRIPTION
This is just a cherry-pick of the commit https://github.com/bitcoin/bitcoin/pull/7613

This adds an autocomplete feature to the RPC console (see screenshot). I have tested it on Linux and Windows and it works fine.

![autocomplete](https://user-images.githubusercontent.com/9782029/95487391-8d939000-0994-11eb-9ff8-7e4c2aec962e.png)
