### PR TITLE
accrual: Fix snapshot accrual for new CPIDs 

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -129,3 +129,8 @@ inline int GetSuperblockAgeSpacing(int nHeight)
 {
     return (fTestNet ? 86400 : (nHeight > 364500) ? 86400 : 43200);
 }
+
+inline int GetNewbieSnapshotFixHeight()
+{
+    return fTestNet ? 1393000 : std::numeric_limits<int>::max();
+}

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -53,6 +53,16 @@ public:
     static bool ActivateSnapshotAccrual(const CBlockIndex* const pindex);
 
     //!
+    //! \brief Activate the fix for an issue that prevents new CPIDs from
+    //! accruing research rewards earlier than the latest superblock.
+    //!
+    //! \param pindex Index of the block to activate the fix for.
+    //!
+    //! \return \c false if an error occurs while resetting the snapshot system.
+    //!
+    static bool FixNewbieSnapshotAccrual();
+
+    //!
     //! \brief Check whether the height of the specified block matches the
     //! tally granularity.
     //!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3088,6 +3088,19 @@ bool GridcoinServices()
         g_v11_timestamp = pindexBest->nTime;
     }
 
+    // Fix ability for new CPIDs to accrue research rewards earlier than one
+    // superblock.
+    //
+    // A bug in the snapshot accrual system for block version 11+ requires a
+    // consensus change to fix. This activates the solution at the following
+    // height:
+    //
+    if (nBestHeight + 1 == GetNewbieSnapshotFixHeight()) {
+        if (!GRC::Tally::FixNewbieSnapshotAccrual()) {
+            return error("%s: Failed to fix newbie snapshot accrual", __func__);
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
The snapshot accrual system released with mandatory v5.0.0 contains a bug that prevents a CPID from accruing research rewards earlier than the last superblock if that CPID never staked a block before because the system was missing the logic needed to save the accrual for those CPIDs to the snapshot files.

This PR corrects the problem and adds a consensus transition for the activation of the fix, so the release that contains these changes will be mandatory. We need to choose the threshold heights for mainnet and testnet.