### PR TITLE
researcher: Add -forcecpid configuration option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -290,6 +290,13 @@ std::string HelpMessage()
         "  -blockmaxsize=<n>      "   + _("Set maximum block size in bytes (default: 250000)") + "\n" +
         "  -blockprioritysize=<n> "   + _("Set maximum size of high-priority/low-fee transactions in bytes (default: 27000)") + "\n" +
 
+        "\n" + _("Research reward system options:") + "\n" +
+        "  -email=<email>         "   + _("Email address to use for CPID detection. Must match your BOINC account email") + "\n" +
+        "  -boincdatadir=<path>   "   + _("Path to the BOINC data directory for CPID detection when the BOINC client uses a non-default directory") + "\n" +
+        "  -forcecpid=<cpid>      "   + _("Override automatic CPID detection with the specified CPID") + "\n" +
+        "  -investor              "   + _("Disable CPID detection and do not participate in the research reward system") + "\n" +
+        "  -pooloperator          "   + _("Skip pool CPID checks for staking nodes run by pool administrators") + "\n" +
+
         "\n" + _("SSL options: (see the Bitcoin Wiki for SSL setup instructions)") + "\n" +
         "  -rpcssl                                  " + _("Use OpenSSL (https) for JSON-RPC connections") + "\n" +
         "  -rpcsslcertificatechainfile=<file.cert>  " + _("Server certificate file (default: server.cert)") + "\n" +


### PR DESCRIPTION
This adds a configuration option that overrides the CPIDs detected from a local BOINC installation. It provides support for some split-CPID issues that people struggle with by permitting a user to choose which CPID the wallet sets for the researcher context. The option also enables users to more easily run Gridcoin and BOINC on separate computers.

This is a simple, low-level solution for now. Future improvements to the UI will give users more accessible control for CPID management.