### PR TITLE
voting: Decrease poll duration to 90 days

### DIFF
--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -1000,10 +1000,16 @@ PollBuilder PollBuilder::SetDuration(const uint32_t days)
             std::to_string(Poll::MIN_DURATION_DAYS)));
     }
 
-    if (days > Poll::MAX_DURATION_DAYS) {
+    // The protocol allows poll durations up to 180 days. To limit unhelpful
+    // or unintentional poll durations, user-facing pieces discourage a poll
+    // longer than:
+    //
+    constexpr uint32_t max_duration_days = 90;
+
+    if (days > max_duration_days) {
         throw VotingError(strprintf(
             _("Poll duration cannot exceed %s days."),
-            std::to_string(Poll::MAX_DURATION_DAYS)));
+            std::to_string(max_duration_days)));
     }
 
     m_poll->m_duration_days = days;


### PR DESCRIPTION
This decreases the poll duration that user-facing pieces allow to 90 days. The protocol rule does not change. We can examine that rule in-depth when we discuss the voting system as a whole.