### PR TITLE
gui: Adds detection if version is below last mandatory

### DIFF
--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -125,6 +125,7 @@ bool Upgrade::CheckForLatestUpdate(bool ui_dialog, std::string client_message_ou
     }
 
     bool NewVersion = false;
+    bool NewMandatory = false;
 
     try {
         // Left to right version numbers.
@@ -135,7 +136,14 @@ bool Upgrade::CheckForLatestUpdate(bool ui_dialog, std::string client_message_ou
                 break;
 
             if (std::stoi(GithubVersion[x]) > LocalVersion[x])
+            {
                 NewVersion = true;
+
+                if (x < 2)
+                {
+                    NewMandatory = true;
+                }
+            }
         }
     }
     catch (std::exception& ex)
@@ -151,6 +159,11 @@ bool Upgrade::CheckForLatestUpdate(bool ui_dialog, std::string client_message_ou
     client_message_out = _("Local version: ") + strprintf("%d.%d.%d.%d", CLIENT_VERSION_MAJOR, CLIENT_VERSION_MINOR, CLIENT_VERSION_REVISION, CLIENT_VERSION_BUILD) + "\r\n";
     client_message_out.append(_("Github version: ") + GithubReleaseData + "\r\n");
     client_message_out.append(_("This update is ") + GithubReleaseType + "\r\n\r\n");
+
+    if (NewMandatory)
+    {
+        client_message_out.append(_("Your wallet version is LOWER than the latest mandatory. You MUST UPGRADE YOUR WALLET!\n"));
+    }
 
     std::string ChangeLog = GithubReleaseBody;
 

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -162,7 +162,7 @@ bool Upgrade::CheckForLatestUpdate(bool ui_dialog, std::string client_message_ou
 
     if (NewMandatory)
     {
-        client_message_out.append(_("Your wallet version is LOWER than the latest mandatory. You MUST UPGRADE YOUR WALLET!\n"));
+        client_message_out.append(_("WARNING: A mandatory release is available. Please upgrade as soon as possible.\n"));
     }
 
     std::string ChangeLog = GithubReleaseBody;


### PR DESCRIPTION
This closes #1923.

This adds a check to see if the current wallet version is lower than the last mandatory (in addition to the existing check as to whether it is lower than the last release). If the wallet is lower than the last mandatory, a conspicuous warning is made to the user.

Your wallet version is LOWER than the latest mandatory. You MUST UPGRADE YOUR WALLET!

This should be adequate to clear up the confusion when the last update is a leisure, yet the person has a wallet version that is BELOW the last mandatory.