### PR TITLE
scraper, rpc: Correct missing mScraperStats initialization in ConvergedScraperStats

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -5321,8 +5321,6 @@ UniValue ConvergedScraperStatsToJson(ConvergedScraperStats& ConvergedScraperStat
 
         const ConvergedManifest& PastConvergence = iter.second.second;
 
-        ScraperStats mScraperConvergedStats = GetScraperStatsByConvergedManifest(PastConvergence).mScraperStats;
-
         entry.pushKV("past_convergence_timestamp", PastConvergence.timestamp);
         entry.pushKV("past_convergence_datetime", DateTimeStrFormat("%x %H:%M:%S UTC", PastConvergence.timestamp));
 

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -20,6 +20,7 @@ extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME;
 
 extern std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
 extern std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& VerifiedBeaconMap);
+extern ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
 
 class CBlockIndex;
 class ConvergedScraperStats; // Forward for Superblock
@@ -1561,6 +1562,8 @@ struct ConvergedScraperStats
         bClean = false;
 
         nTime = nTime_in;
+
+        mScraperConvergedStats = GetScraperStatsByConvergedManifest(Convergence).mScraperStats;
     }
 
     // Flag to indicate cache is clean or dirty (i.e. state change of underlying statistics has occurred.


### PR DESCRIPTION
The Initialization of the ConvergedScraperStats, which in one of its forms takes an argument of nTime and a ConvergedManifest, was missing the population of the scraper statistics map. This was causing the convergencereport to leave the magnitudes and projects blank in the past convergences rendered as superblocks in detail mode.