### PR TITLE
refactor: Revert init order to fix rejected net messages 

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -23,8 +23,6 @@ extern unsigned int nScraperSleep;
 extern unsigned int nActiveBeforeSB;
 extern bool fScraperActive;
 
-extern ThreadHandler* netThreads;
-
 void Scraper(bool bSingleShot = false);
 void ScraperSubscriber();
 
@@ -155,7 +153,9 @@ void ThreadScraperSubscriber(void* parg)
 //!
 //! \brief Configure and initialize the scraper system.
 //!
-void InitializeScraper()
+//! \param threads Used to start the scraper housekeeping threads.
+//!
+void InitializeScraper(ThreadHandlerPtr threads)
 {
     // Default to 300 sec (5 min), clamp to 60 minimum, 600 maximum - converted to milliseconds.
     nScraperSleep = std::min<int64_t>(std::max<int64_t>(GetArg("-scrapersleep", 300), 60), 600) * 1000;
@@ -174,14 +174,14 @@ void InitializeScraper()
     if (GetBoolArg("-scraper", false)) {
         LogPrintf("Gridcoin: scraper enabled");
 
-        if (!netThreads->createThread(ThreadScraper, nullptr, "ThreadScraper")) {
+        if (!threads->createThread(ThreadScraper, nullptr, "ThreadScraper")) {
             LogPrintf("ERROR: createThread(ThreadScraper) failed");
         }
     } else {
         LogPrintf("Gridcoin: scraper disabled");
         LogPrintf("Gridcoin: scraper subscriber housekeeping thread enabled");
 
-        if (!netThreads->createThread(ThreadScraperSubscriber, nullptr, "ScraperSubscriber")) {
+        if (!threads->createThread(ThreadScraperSubscriber, nullptr, "ScraperSubscriber")) {
             LogPrintf("ERROR: createThread(ScraperSubscriber) failed");
         }
     }
@@ -272,7 +272,7 @@ bool fSnapshotRequest = false;
 // Functions
 // -----------------------------------------------------------------------------
 
-bool GRC::Initialize(CBlockIndex* pindexBest)
+bool GRC::Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest)
 {
     LogPrintf("Gridcoin: initializing...");
 
@@ -284,10 +284,7 @@ bool GRC::Initialize(CBlockIndex* pindexBest)
 
     InitializeContracts(pindexBest);
     InitializeResearcherContext();
-
-    // The scraper is run on the netThreads group, because it shares data structures
-    // with scraper_net, which is run as part of the network node threads.
-    InitializeScraper();
+    InitializeScraper(threads);
     InitializeExplorerFeatures();
 
     return true;

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -11,11 +11,12 @@ namespace GRC {
 //!
 //! \brief Initialize Gridcoin-specific components and services.
 //!
+//! \param threads    Used to start Gridcoin threads.
 //! \param pindexBest Block index for the tip of the chain.
 //!
 //! \return \c false if a problem occurs during initialization.
 //!
-bool Initialize(CBlockIndex* pindexBest);
+bool Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest);
 
 //!
 //! \brief Set up Gridcoin-specific background jobs.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -107,9 +107,7 @@ void Shutdown(void* parg)
         bitdb.Flush(false);
         StopNode();
         bitdb.Flush(true);
-
         StopRPCThreads();
-
         boost::filesystem::remove(GetPidFile());
         UnregisterWallet(pwalletMain);
         delete pwalletMain;
@@ -1086,6 +1084,8 @@ bool AppInit2(ThreadHandlerPtr threads)
         return false;
 
     RandAddSeedPerfmon();
+
+    GRC::Initialize(threads, pindexBest);
 
     //// debug print
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -13,7 +13,6 @@
 #include "init.h"
 #include "ui_interface.h"
 #include "util.h"
-#include "gridcoin/gridcoin.h"
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/thread.hpp>
@@ -2297,9 +2296,6 @@ void StartNode(void* parg)
     else
         if (!netThreads->createThread(ThreadStakeMiner,pwalletMain,"ThreadStakeMiner"))
             LogPrintf("Error: createThread(ThreadStakeMiner) failed");
-
-    // Initialize GRC services.
-    GRC::Initialize(pindexBest);
 }
 
 bool StopNode()


### PR DESCRIPTION
This reverts adjustments to Gridcoin-specific initialization code from #1901 to ensure that a node fully-initializes Gridcoin context before accepting messages from other nodes. By moving Gridcoin start-up after the net message handler thread initialization, nodes cannot handle early messages that depend on the contract and accrual state which may cause a node to reject scraper messages or blocks with research rewards.

#1904 and #1905 address the segfault targeted by #1901. There should be no risk to the scraper data structures now because the global variables are destroyed in controlled order when `main()` exits after every other thread stops. 