### PR TITLE
refactor: Normalize boost::filesystem to fs namespace

### DIFF
--- a/src/gridcoin/backup.cpp
+++ b/src/gridcoin/backup.cpp
@@ -9,17 +9,13 @@
 #include "util.h"
 #include "util/time.h"
 
-#include <boost/filesystem/fstream.hpp>
-
-#include <fstream>
 #include <string>
 
 using namespace GRC;
-using namespace boost;
 
-boost::filesystem::path GRC::GetBackupPath()
+fs::path GRC::GetBackupPath()
 {
-    filesystem::path defaultDir = GetDataDir() / "walletbackups";
+    fs::path defaultDir = GetDataDir() / "walletbackups";
     return GetArg("-backupdir", defaultDir.string());
 }
 
@@ -32,7 +28,7 @@ std::string GRC::GetBackupFilename(const std::string& basename, const std::strin
     char boTime[200];
     strftime(boTime, sizeof(boTime), "%Y-%m-%dT%H-%M-%S", blTime);
     std::string sBackupFilename;
-    filesystem::path rpath;
+    fs::path rpath;
     sBackupFilename = basename + "-" + std::string(boTime);
     if (!suffix.empty())
         sBackupFilename = sBackupFilename + "-" + suffix;
@@ -120,22 +116,22 @@ bool GRC::BackupConfigFile(const std::string& strDest)
 {
     // Check to see if there is a parent_path in strDest to support custom locations by ui - bug fix
 
-    filesystem::path ConfigSource = GetConfigFile();
-    filesystem::path ConfigTarget = strDest;
-    filesystem::create_directories(ConfigTarget.parent_path());
+    fs::path ConfigSource = GetConfigFile();
+    fs::path ConfigTarget = strDest;
+    fs::create_directories(ConfigTarget.parent_path());
     try
     {
         #if BOOST_VERSION >= 107400
-            filesystem::copy_file(ConfigSource, ConfigTarget, filesystem::copy_options::overwrite_existing);
+            fs::copy_file(ConfigSource, ConfigTarget, fs::copy_options::overwrite_existing);
         #elif BOOST_VERSION >= 104000
-            filesystem::copy_file(ConfigSource, ConfigTarget, filesystem::copy_option::overwrite_if_exists);
+            fs::copy_file(ConfigSource, ConfigTarget, fs::copy_option::overwrite_if_exists);
         #else
-            filesystem::copy_file(ConfigSource, ConfigTarget);
+            fs::copy_file(ConfigSource, ConfigTarget);
         #endif
         LogPrintf("BackupConfigFile: Copied gridcoinresearch.conf to %s", ConfigTarget.string());
         return true;
     }
-    catch(const filesystem::filesystem_error &e)
+    catch(const fs::filesystem_error &e)
     {
         LogPrintf("BackupConfigFile: Error copying gridcoinresearch.conf to %s - %s", ConfigTarget.string(), e.what());
         return false;
@@ -159,23 +155,23 @@ bool GRC::BackupWallet(const CWallet& wallet, const std::string& strDest)
         bitdb.mapFileUseCount.erase(wallet.strWalletFile);
 
         // Copy wallet.dat
-        filesystem::path WalletSource = GetDataDir() / wallet.strWalletFile;
-        filesystem::path WalletTarget = strDest;
-        filesystem::create_directories(WalletTarget.parent_path());
-        if (filesystem::is_directory(WalletTarget))
+        fs::path WalletSource = GetDataDir() / wallet.strWalletFile;
+        fs::path WalletTarget = strDest;
+        fs::create_directories(WalletTarget.parent_path());
+        if (fs::is_directory(WalletTarget))
             WalletTarget /= wallet.strWalletFile;
         try
         {
 #if BOOST_VERSION >= 107400
-            filesystem::copy_file(WalletSource, WalletTarget, filesystem::copy_options::overwrite_existing);
+            fs::copy_file(WalletSource, WalletTarget, fs::copy_options::overwrite_existing);
 #elif BOOST_VERSION >= 104000
-            filesystem::copy_file(WalletSource, WalletTarget, filesystem::copy_option::overwrite_if_exists);
+            fs::copy_file(WalletSource, WalletTarget, fs::copy_option::overwrite_if_exists);
 #else
-            filesystem::copy_file(WalletSource, WalletTarget);
+            fs::copy_file(WalletSource, WalletTarget);
 #endif
             LogPrintf("BackupWallet: Copied wallet.dat to %s", WalletTarget.string());
         }
-        catch(const filesystem::filesystem_error &e) {
+        catch(const fs::filesystem_error &e) {
             LogPrintf("BackupWallet: Error copying wallet.dat to %s - %s", WalletTarget.string(), e.what());
             return false;
         }
@@ -186,7 +182,7 @@ bool GRC::BackupWallet(const CWallet& wallet, const std::string& strDest)
     return false;
 }
 
-bool GRC::MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::string> backup_file_type,
+bool GRC::MaintainBackups(fs::path wallet_backup_path, std::vector<std::string> backup_file_type,
                    unsigned int retention_by_num, unsigned int retention_by_days, std::vector<std::string>& files_removed)
 {
     // Backup file retention maintainer. Adapted from the scraper/main log archiver core.
@@ -327,7 +323,7 @@ bool GRC::MaintainBackups(filesystem::path wallet_backup_path, std::vector<std::
             } // end of SortedDirEntries for loop.
         } // end of backup_file_type for loop.
     }
-    catch (const filesystem::filesystem_error &e)
+    catch (const fs::filesystem_error &e)
     {
         LogPrintf("ERROR: MaintainBackups: Error managing backup file retention: %s", e.what());
 
@@ -344,8 +340,8 @@ bool GRC::BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::st
         sErrors = "Wallet needs to be fully unlocked to backup private keys.";
         return false;
     }
-    filesystem::path PrivateKeysTarget = GetBackupFilename("keys.dat");
-    filesystem::create_directories(PrivateKeysTarget.parent_path());
+    fs::path PrivateKeysTarget = GetBackupFilename("keys.dat");
+    fs::create_directories(PrivateKeysTarget.parent_path());
     sTarget = PrivateKeysTarget.string();
     fsbridge::ofstream myBackup;
     myBackup.open(PrivateKeysTarget);

--- a/src/gridcoin/backup.h
+++ b/src/gridcoin/backup.h
@@ -4,21 +4,22 @@
 
 #pragma once
 
+#include "fs.h"
+
 #include <string>
-#include <boost/filesystem.hpp>
 
 class CWallet;
 
 namespace GRC {
 std::string GetBackupFilename(const std::string& basename, const std::string& suffix = "");
-boost::filesystem::path GetBackupPath();
+fs::path GetBackupPath();
 
 bool BackupsEnabled();
 int64_t GetBackupInterval();
 void RunBackupJob();
 
 bool BackupConfigFile(const std::string& strDest);
-bool MaintainBackups(boost::filesystem::path wallet_backup_path, std::vector<std::string> backup_file_type,
+bool MaintainBackups(fs::path wallet_backup_path, std::vector<std::string> backup_file_type,
                    unsigned int retention_by_num, unsigned int retention_by_days, std::vector<std::string>& files_removed);
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
 bool BackupPrivateKeys(const CWallet& wallet, std::string& sTarget, std::string& sErrors);

--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -303,7 +303,7 @@ void Http::DownloadSnapshot()
 {
     std::string url = GetArg("-snapshoturl", "https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip");
 
-    boost::filesystem::path destination = GetDataDir() / "snapshot.zip";
+    fs::path destination = GetDataDir() / "snapshot.zip";
 
     ScopedFile fp(fsbridge::fopen(destination, "wb"), &fclose);
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -21,6 +21,7 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
 #include <boost/serialization/binary_object.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/exception/exception.hpp>
@@ -33,6 +34,7 @@
 #include <random>
 
 using namespace GRC;
+namespace boostio = boost::iostreams;
 
 // These are initialized empty. GetDataDir() cannot be called here. It is too early.
 fs::path pathDataDir = {};
@@ -2401,7 +2403,7 @@ uint256 GetFileHash(const fs::path& inputfile)
         return nHash;
 
     // use file size to size memory buffer
-    int dataSize = boost::filesystem::file_size(inputfile);
+    int dataSize = fs::file_size(inputfile);
     std::vector<unsigned char> vchData;
     vchData.resize(dataSize);
 
@@ -4030,7 +4032,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
         }
 
         // use file size to size memory buffer
-        int dataSize = boost::filesystem::file_size(inputfilewpath);
+        int dataSize = fs::file_size(inputfilewpath);
         std::vector<unsigned char> vchData;
         vchData.resize(dataSize);
 
@@ -4121,7 +4123,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
         }
 
         // use file size to size memory buffer
-        int dataSize = boost::filesystem::file_size(inputfilewpath);
+        int dataSize = fs::file_size(inputfilewpath);
         std::vector<unsigned char> vchData;
         vchData.resize(dataSize);
 

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -5,20 +5,12 @@
 #pragma once
 
 #include <atomic>
-#include <iostream>
 #include <inttypes.h>
 #include <cmath>
 #include <algorithm>
 #include <cctype>
 #include <vector>
 #include <map>
-#include <boost/locale.hpp>
-#include <codecvt>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
-#include <fstream>
-#include <sstream>
 
 #include "sync.h"
 #include "wallet/wallet.h"
@@ -30,14 +22,6 @@
 // See fwd.h for certain forward declarations that need to be included in other areas.
 #include "gridcoin/scraper/fwd.h"
 #include "gridcoin/superblock.h"
-
-/*********************
-* Scraper Namespace  *
-*********************/
-
-namespace fs = boost::filesystem;
-namespace boostio = boost::iostreams;
-
 
 /*********************
 * Global Defaults    *

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -90,7 +90,7 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
 
-        if (!boost::filesystem::is_directory(GetDataDir(false)))
+        if (!fs::is_directory(GetDataDir(false)))
         {
             fprintf(stderr, "Error: Specified directory does not exist\n");
             Shutdown(NULL);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,9 +16,6 @@
 #include "scheduler.h"
 #include "gridcoin/gridcoin.h"
 
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <openssl/crypto.h>
 
@@ -37,7 +34,6 @@ bool IsConfigFileEmpty();
 #endif
 
 using namespace std;
-using namespace boost;
 CWallet* pwalletMain;
 CClientUIInterface uiInterface;
 extern bool fQtActive;
@@ -108,7 +104,7 @@ void Shutdown(void* parg)
         StopNode();
         bitdb.Flush(true);
         StopRPCThreads();
-        boost::filesystem::remove(GetPidFile());
+        fs::remove(GetPidFile());
         UnregisterWallet(pwalletMain);
         delete pwalletMain;
         // close transaction database to prevent lock issue on restart
@@ -744,7 +740,7 @@ bool AppInit2(ThreadHandlerPtr threads)
             return false;
     }
 
-    if (filesystem::exists(GetDataDir() / walletFileName))
+    if (fs::exists(GetDataDir() / walletFileName))
     {
         CDBEnv::VerifyResult r = bitdb.Verify(walletFileName.string(), CWalletDB::Recover);
         if (r == CDBEnv::RECOVER_OK)
@@ -1047,13 +1043,13 @@ bool AppInit2(ThreadHandlerPtr threads)
         exit(0);
     }
 
-    filesystem::path pathBootstrap = GetDataDir() / "bootstrap.dat";
-    if (filesystem::exists(pathBootstrap)) {
+    fs::path pathBootstrap = GetDataDir() / "bootstrap.dat";
+    if (fs::exists(pathBootstrap)) {
         uiInterface.InitMessage(_("Importing bootstrap blockchain data file."));
 
         FILE *file = fsbridge::fopen(pathBootstrap, "rb");
         if (file) {
-            filesystem::path pathBootstrapOld = GetDataDir() / "bootstrap.dat.old";
+            fs::path pathBootstrapOld = GetDataDir() / "bootstrap.dat.old";
             LoadExternalBlockFile(file);
             RenameOver(pathBootstrap, pathBootstrapOld);
         }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/iostreams/stream.hpp>
 #include <boost/iostreams/copy.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3287,7 +3287,7 @@ bool CBlock::CheckBlockSignature() const
 
 bool CheckDiskSpace(uint64_t nAdditionalBytes)
 {
-    uint64_t nFreeBytesAvailable = filesystem::space(GetDataDir()).available;
+    uint64_t nFreeBytesAvailable = fs::space(GetDataDir()).available;
 
     // Check for nMinDiskSpace bytes (currently 50MB)
     if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
@@ -3303,7 +3303,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes)
     return true;
 }
 
-static filesystem::path BlockFilePath(unsigned int nFile)
+static fs::path BlockFilePath(unsigned int nFile)
 {
     string strBlockFn = strprintf("blk%04u.dat", nFile);
     return GetDataDir() / strBlockFn;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -357,7 +357,7 @@ int StartGridcoinQt(int argc, char *argv[])
     app.installNativeEventFilter(new WinShutdownMonitor());
 #endif
 
-    if (!boost::filesystem::is_directory(GetDataDir(false)))
+    if (!fs::is_directory(GetDataDir(false)))
     {
         QMessageBox::critical(0, "Gridcoin",
                               QString("Error: Specified data directory \"%1\" does not exist.").arg(QString::fromStdString(mapArgs["-datadir"])));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -9,8 +9,6 @@
 #include <QProcess>
 #include <QInputDialog>
 
-#include <fstream>
-
 #include "bitcoingui.h"
 #include "transactiontablemodel.h"
 #include "addressbookpage.h"
@@ -83,7 +81,6 @@
 #include "gridcoin/staking/status.h"
 #include "gridcoin/superblock.h"
 
-#include <iostream>
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/join.hpp>
 #include "util.h"

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "fs.h"
 #include "main.h"
 #include "util.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "diagnosticsdialog.h"
@@ -18,7 +18,6 @@
 #include "qt/researcher/researchermodel.h"
 
 #include <numeric>
-#include <fstream>
 
 DiagnosticsDialog::DiagnosticsDialog(QWidget *parent, ResearcherModel* researcher_model) :
     QDialog(parent),
@@ -190,14 +189,14 @@ void DiagnosticsDialog::DisplayOverallDiagnosticResult()
 
 bool DiagnosticsDialog::VerifyBoincPath()
 {
-    boost::filesystem::path boincPath = (boost::filesystem::path) GRC::GetBoincDataDir();
+    fs::path boincPath = (fs::path) GRC::GetBoincDataDir();
 
     if (boincPath.empty())
-        boincPath = (boost::filesystem::path) GetArgument("boincdatadir", "");
+        boincPath = (fs::path) GetArgument("boincdatadir", "");
 
     boincPath = boincPath / "client_state.xml";
 
-    return boost::filesystem::exists(boincPath);
+    return fs::exists(boincPath);
 }
 
 bool DiagnosticsDialog::VerifyIsCPIDValid()

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1,3 +1,4 @@
+#include "fs.h"
 #include "guiutil.h"
 #include "bitcoinaddressvalidator.h"
 #include "walletmodel.h"
@@ -19,9 +20,6 @@
 #include <QFileDialog>
 #include <QDesktopServices>
 #include <QThread>
-
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #ifdef WIN32
 #ifdef _WIN32_WINNT
@@ -326,10 +324,10 @@ bool isObscured(QWidget *w)
 
 void openDebugLogfile()
 {
-    boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
+    fs::path pathDebug = GetDataDir() / "debug.log";
 
     /* Open debug.log with the associated application */
-    if (boost::filesystem::exists(pathDebug))
+    if (fs::exists(pathDebug))
         QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathDebug.string())));
 }
 
@@ -380,7 +378,7 @@ bool WindowContextHelpButtonHintFilter::eventFilter (QObject *obj, QEvent *event
 struct AutoStartupArguments
 {
     std::string link_name_suffix;
-    boost::filesystem::path data_dir;
+    fs::path data_dir;
     std::string arguments;
 };
 
@@ -430,12 +428,12 @@ AutoStartupArguments GetAutoStartupArguments(bool fStartMin = true)
 }
 
 #ifdef WIN32
-boost::filesystem::path static StartupShortcutLegacyPath()
+fs::path static StartupShortcutLegacyPath()
 {
     return GetSpecialFolderPath(CSIDL_STARTUP) / "Gridcoin.lnk";
 }
 
-boost::filesystem::path static StartupShortcutPath()
+fs::path static StartupShortcutPath()
 {
     std::string link_name_suffix = GetAutoStartupArguments().link_name_suffix;
     std::string link_name_root = "Gridcoin";
@@ -446,16 +444,16 @@ boost::filesystem::path static StartupShortcutPath()
 bool GetStartOnSystemStartup()
 {
     // check for Gridcoin.lnk
-    return boost::filesystem::exists(StartupShortcutPath());
+    return fs::exists(StartupShortcutPath());
 }
 
 bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
 {
     // Remove the legacy shortcut unconditionally.
-    boost::filesystem::remove(StartupShortcutLegacyPath());
+    fs::remove(StartupShortcutLegacyPath());
 
     // If the shortcut exists already, remove it for updating
-    boost::filesystem::remove(StartupShortcutPath());
+    fs::remove(StartupShortcutPath());
 
     // Get auto startup arguments
     AutoStartupArguments autostartup = GetAutoStartupArguments(fStartMin);
@@ -533,10 +531,8 @@ bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
 // Follow the Desktop Application Autostart Spec:
 //  http://standards.freedesktop.org/autostart-spec/autostart-spec-latest.html
 
-boost::filesystem::path static GetAutostartDir()
+fs::path static GetAutostartDir()
 {
-    namespace fs = boost::filesystem;
-
     char* pszConfigHome = getenv("XDG_CONFIG_HOME");
     if (pszConfigHome) return fs::path(pszConfigHome) / "autostart";
     char* pszHome = getenv("HOME");
@@ -544,12 +540,12 @@ boost::filesystem::path static GetAutostartDir()
     return fs::path();
 }
 
-boost::filesystem::path static GetAutostartLegacyFilePath()
+fs::path static GetAutostartLegacyFilePath()
 {
     return GetAutostartDir() / "gridcoin.desktop";
 }
 
-boost::filesystem::path static GetAutostartFilePath()
+fs::path static GetAutostartFilePath()
 {
     std::string link_name_suffix = GetAutoStartupArguments().link_name_suffix;
     std::string link_name_root = "gridcoin";
@@ -579,13 +575,13 @@ bool GetStartOnSystemStartup()
 bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
 {
     // Remove legacy autostart path if it exists.
-    if (boost::filesystem::exists(GetAutostartLegacyFilePath()))
+    if (fs::exists(GetAutostartLegacyFilePath()))
     {
-        boost::filesystem::remove(GetAutostartLegacyFilePath());
+        fs::remove(GetAutostartLegacyFilePath());
     }
 
     if (!fAutoStart)
-        boost::filesystem::remove(GetAutostartFilePath());
+        fs::remove(GetAutostartFilePath());
     else
     {
         char pszExePath[MAX_PATH+1];
@@ -595,7 +591,7 @@ bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
 
         AutoStartupArguments autostartup = GetAutoStartupArguments(fStartMin);
 
-        boost::filesystem::create_directories(GetAutostartDir());
+        fs::create_directories(GetAutostartDir());
 
         fsbridge::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out|std::ios_base::trunc);
         if (!optionFile.good())
@@ -604,7 +600,7 @@ bool SetStartOnSystemStartup(bool fAutoStart, bool fStartMin)
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
         optionFile << "Name=Gridcoin" + autostartup.link_name_suffix + "\n";
-        optionFile << "Exec=" << static_cast<boost::filesystem::path>(pszExePath);
+        optionFile << "Exec=" << static_cast<fs::path>(pszExePath);
 
         if (!autostartup.data_dir.empty())
         {

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -338,14 +338,14 @@ void UpgradeQt::DeleteSnapshot()
 
     try
     {
-        boost::filesystem::path snapshotpath = GetDataDir() / snapshotfile;
+        fs::path snapshotpath = GetDataDir() / snapshotfile;
 
-        if (boost::filesystem::exists(snapshotpath))
-            if (boost::filesystem::is_regular_file(snapshotpath))
-                boost::filesystem::remove(snapshotpath);
+        if (fs::exists(snapshotpath))
+            if (fs::is_regular_file(snapshotpath))
+                fs::remove(snapshotpath);
     }
 
-    catch (boost::filesystem::filesystem_error& e)
+    catch (fs::filesystem_error& e)
     {
         LogPrintf("Snapshot Downloader: Exception occurred while attempting to delete snapshot (%s)", e.code().message());
     }

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -18,12 +18,10 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
 #include <boost/bind.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
 

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -14,11 +14,8 @@
 #include "gridcoin/support/block_finder.h"
 #include "util.h"
 
-#include <boost/filesystem.hpp>
-#include <iostream>
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string.hpp>
-#include <fstream>
 #include <algorithm>
 
 #include <univalue.h>
@@ -558,8 +555,8 @@ UniValue rpc_exportstats(const UniValue& params, bool fHelp)
     unsigned long points = 0;
     double samples = 0; /* this is double for easy division */
     fsbridge::ofstream Output;
-    boost::filesystem::path o_path = GetDataDir() / "reports" / ( "export_" + std::to_string(GetTime()) + ".txt" );
-    boost::filesystem::create_directories(o_path.parent_path());
+    fs::path o_path = GetDataDir() / "reports" / ( "export_" + std::to_string(GetTime()) + ".txt" );
+    fs::create_directories(o_path.parent_path());
     Output.open (o_path);
     Output.imbue(std::locale::classic());
     Output << std::fixed << std::setprecision(4);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -453,9 +453,9 @@ UniValue parseaccrualsnapshotfile(const UniValue& params, bool fHelp)
 
     UniValue res(UniValue::VOBJ);
 
-    boost::filesystem::path snapshot_path = params[0].get_str();
+    const fs::path snapshot_path = params[0].get_str();
 
-    if (!boost::filesystem::is_regular_file(snapshot_path))
+    if (!fs::is_regular_file(snapshot_path))
     {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid snapshot file specified.");
     }

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -14,12 +14,10 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
 #include <boost/bind.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -1158,7 +1158,7 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
             fsbridge::ofstream dataout;
 
             // We will place this in wallet backups as a safer location then in main data directory
-            boost::filesystem::path exportpath;
+            fs::path exportpath;
 
             time_t biTime;
             struct tm * blTime;
@@ -1177,7 +1177,7 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
             else
                 exportpath = fs::path(backupdir) / exportfile;
 
-            boost::filesystem::create_directory(exportpath.parent_path());
+            fs::create_directory(exportpath.parent_path());
 
             dataout.open(exportpath);
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -16,12 +16,10 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
 #include <boost/bind.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
 #include <algorithm>
@@ -619,14 +617,14 @@ void StartRPCThreads()
     {
         rpc_ssl_context->set_options(ssl::context::no_sslv2);
 
-        filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
-        if (!pathCertFile.is_absolute()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
-        if (filesystem::exists(pathCertFile)) rpc_ssl_context->use_certificate_chain_file(pathCertFile.string());
+        fs::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
+        if (!pathCertFile.is_absolute()) pathCertFile = fs::path(GetDataDir()) / pathCertFile;
+        if (fs::exists(pathCertFile)) rpc_ssl_context->use_certificate_chain_file(pathCertFile.string());
         else LogPrintf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string());
 
-        filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
-        if (!pathPKFile.is_absolute()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
-        if (filesystem::exists(pathPKFile)) rpc_ssl_context->use_private_key_file(pathPKFile.string(), ssl::context::pem);
+        fs::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
+        if (!pathPKFile.is_absolute()) pathPKFile = fs::path(GetDataDir()) / pathPKFile;
+        if (fs::exists(pathPKFile)) rpc_ssl_context->use_private_key_file(pathPKFile.string(), ssl::context::pem);
         else LogPrintf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string());
 
         string strCiphers = GetArg("-rpcsslciphers", "TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH");

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -10,7 +10,6 @@
 #include "gridcoin/researcher.h"
 #include "util.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/test/unit_test.hpp>
 #include <iostream>
@@ -23,31 +22,31 @@ namespace {
 //!
 //! \return Path to the test data directory containing the stub.
 //!
-boost::filesystem::path ResolveStubDir()
+fs::path ResolveStubDir()
 {
-    const boost::filesystem::path cwd = boost::filesystem::current_path();
-    const boost::filesystem::path data_dir("src/test/data");
+    const fs::path cwd = fs::current_path();
+    const fs::path data_dir("src/test/data");
     const std::string stub = "client_state.xml";
 
     // Test harness run from subdirectory of repo root (src/, build/, etc.):
-    if (boost::filesystem::exists(cwd / ".." / data_dir / stub)) {
-        return boost::filesystem::canonical(cwd / ".." / data_dir);
+    if (fs::exists(cwd / ".." / data_dir / stub)) {
+        return fs::canonical(cwd / ".." / data_dir);
     }
 
     // Test harness run from platform-specific build sub-directory
     // (ex: build/gridcoin-x86_64-unknown-linux-gnu/)
-    if (boost::filesystem::exists(cwd / ".." / ".." / data_dir / stub)) {
-        return boost::filesystem::canonical(cwd / ".." / ".." / data_dir);
+    if (fs::exists(cwd / ".." / ".." / data_dir / stub)) {
+        return fs::canonical(cwd / ".." / ".." / data_dir);
     }
 
     // Test harness run from sub-directory in a platform-specific build sub-
     // directory (Travis; ex: build/gridcoin-x86_64-unknown-linux-gnu/src)
-    if (boost::filesystem::exists(cwd / ".." / ".." / ".." / data_dir / stub)) {
-        return boost::filesystem::canonical(cwd / ".." / ".." / ".." / data_dir);
+    if (fs::exists(cwd / ".." / ".." / ".." / data_dir / stub)) {
+        return fs::canonical(cwd / ".." / ".." / ".." / data_dir);
     }
 
     // Test harness run from test directory (src/test/):
-    if (boost::filesystem::exists(cwd / "data" / stub)) {
+    if (fs::exists(cwd / "data" / stub)) {
         return cwd / "data";
     }
 
@@ -1589,7 +1588,7 @@ void it_resets_to_investor_mode_when_explicitly_configured()
 //!
 BOOST_AUTO_TEST_CASE(client_state_stub_exists)
 {
-    if (boost::filesystem::exists(ResolveStubDir() / "client_state.xml")) {
+    if (fs::exists(ResolveStubDir() / "client_state.xml")) {
         boost::unit_test::framework::master_test_suite().add(BOOST_TEST_CASE(&it_parses_project_xml_from_a_client_state_xml_file));
         boost::unit_test::framework::master_test_suite().add(BOOST_TEST_CASE(&it_resets_to_investor_mode_when_explicitly_configured));
     } else {

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-#include <fstream>
 #include <vector>
 #include <sstream>
 #include <boost/algorithm/string/classification.hpp>

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -6,7 +6,6 @@
 #include <map>
 
 #include <boost/version.hpp>
-#include <boost/filesystem.hpp>
 
 #include <leveldb/env.h>
 #include <leveldb/cache.h>
@@ -36,27 +35,27 @@ static leveldb::Options GetOptions() {
 
 void init_blockindex(leveldb::Options& options, bool fRemoveOld = false) {
     // First time init.
-    filesystem::path directory = GetDataDir() / "txleveldb";
+    fs::path directory = GetDataDir() / "txleveldb";
 
     if (fRemoveOld) {
-        filesystem::remove_all(directory); // remove directory
+        fs::remove_all(directory); // remove directory
         unsigned int nFile = 1;
 
         while (true)
         {
-            filesystem::path strBlockFile = GetDataDir() / strprintf("blk%04u.dat", nFile);
+            fs::path strBlockFile = GetDataDir() / strprintf("blk%04u.dat", nFile);
 
             // Break if no such file
-            if( !filesystem::exists( strBlockFile ) )
+            if( !fs::exists( strBlockFile ) )
                 break;
 
-            filesystem::remove(strBlockFile);
+            fs::remove(strBlockFile);
 
             nFile++;
         }
     }
 
-    filesystem::create_directory(directory);
+    fs::create_directory(directory);
     LogPrintf("Opening LevelDB in %s", directory.string());
     leveldb::Status status = leveldb::DB::Open(options, directory.string(), &txdb);
     if (!status.ok()) {

--- a/src/util.h
+++ b/src/util.h
@@ -18,12 +18,9 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <ostream>
 #include <locale>
 #include <strings.h>
 
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/date_time/gregorian/gregorian_types.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/thread.hpp>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-#include <fstream>
-
+#include "fs.h"
 #include "init.h" // for pwalletMain
 #include "rpcserver.h"
 #include "rpcprotocol.h"
@@ -14,7 +12,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 
 using namespace std;
 
@@ -187,8 +184,8 @@ UniValue importwallet(const UniValue& params, bool fHelp)
             "Imports keys from a wallet dump file (see dumpwallet)\n"
             "If a path is not specified in the filename, the data directory is used.");
 
-    boost::filesystem::path PathForImport = boost::filesystem::path(params[0].get_str());
-    boost::filesystem::path DefaultPathDataDir = GetDataDir();
+    fs::path PathForImport = fs::path(params[0].get_str());
+    fs::path DefaultPathDataDir = GetDataDir();
 
     // If provided filename does not have a path, then append parent path, otherwise leave alone.
     if (PathForImport.parent_path().empty())
@@ -320,8 +317,8 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
 
     EnsureWalletIsUnlocked();
 
-    boost::filesystem::path PathForDump = boost::filesystem::path(params[0].get_str());
-    boost::filesystem::path DefaultPathDataDir = GetDataDir();
+    fs::path PathForDump = fs::path(params[0].get_str());
+    fs::path DefaultPathDataDir = GetDataDir();
 
     // If provided filename does not have a path, then append parent path, otherwise leave alone.
     if (PathForDump.parent_path().empty())

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -7,10 +7,8 @@
 #include "wallet/walletdb.h"
 #include "wallet/wallet.h"
 #include "init.h"
-#include <fstream>
 
 using namespace std;
-using namespace boost;
 
 static uint64_t nAccountingEntryNumber = 0;
 extern bool fWalletUnlockStakingOnly;


### PR DESCRIPTION
This replaces remaining references to the `boost::filesystem` namespace with `fs`. The change abstracts filesystem operations from a particular library and prepares the project for newer Bitcoin code. It may also help to facilitate a transition to `std::filesystem` in the future.