### PR TITLE
accrual: Apply accrual for new CPIDs from existing snapshots

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -132,5 +132,5 @@ inline int GetSuperblockAgeSpacing(int nHeight)
 
 inline int GetNewbieSnapshotFixHeight()
 {
-    return fTestNet ? 1393000 : std::numeric_limits<int>::max();
+    return fTestNet ? 1393000 : 2090000;
 }

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -1416,6 +1416,15 @@ public:
             account.m_accrual = snapshot.GetAccrual(cpid);
         }
 
+        // Apply snapshot accrual for any CPIDs with no accounting record as
+        // of the last superblock:
+        //
+        for (const auto& cpid_pair : snapshot.m_records) {
+            if (accounts.find(cpid_pair.first) == accounts.end()) {
+                accounts[cpid_pair.first].m_accrual = cpid_pair.second;
+            }
+        }
+
         return true;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3756,6 +3756,18 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->fDisconnect = true;
             return false;
         }
+        else if (pfrom->nVersion < PROTOCOL_VERSION && nBestHeight > GetNewbieSnapshotFixHeight() + 2000)
+        {
+            // Immediately disconnect peers running a protocol version lower than
+            // the latest hard-fork after a grace period for the transition.
+            //
+            // TODO: increment MIN_PEER_PROTO_VERSION and remove this condition in
+            // the release that follows the mandatory version:
+            //
+            LogPrint(BCLog::LogFlags::NOISY, "Disconnecting forked peer protocol version %i: %s", pfrom->nVersion, pfrom->addr.ToString());
+            pfrom->fDisconnect = true;
+            return false;
+        }
 
         if (!vRecv.empty())
             vRecv >> addrFrom >> nNonce;


### PR DESCRIPTION
This fixes a detail that I missed for #1931. It ensures that the snapshot accrual system reloads stored accrual for CPIDs that never staked a block before when applying a snapshot from disk.

A testnet node that synced across the threshold for the original fix will calculate the correct accrual for a new CPID until that node restarts and loads a snapshot from disk. Nodes that do not restart before upgrading to a release that contains the changes in this PR will behave correctly. As such, this is effectively a mandatory change for testnet, but no consensus issue will manifest for nodes that restart until a new CPID stakes a block, so I don't think we need to perform another hard-fork transition. Testnet nodes already rebuilt the accrual snapshots with the correct accrual for new CPIDs. 

I also added a temporary grace period after which nodes will disconnect peers running a version lower than the hard-fork. This should reduce confusion about forked nodes and orphan blocks that users expressed with the previous hard-fork.