### PR TITLE
refactor: [Memory optimization] Block index duplicate PoS state

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ GRIDCOIN_CORE_H = \
     gridcoin/staking/exceptions.h \
     gridcoin/staking/kernel.h \
     gridcoin/staking/reward.h \
+    gridcoin/staking/spam.h \
     gridcoin/staking/status.h \
     gridcoin/superblock.h \
     gridcoin/support/block_finder.h \

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -520,10 +520,10 @@ uint256 GRC::CalculateStakeHashV8(
     CHashWriter ss(SER_GETHASH, 0);
 
     ss << StakeModifier;
-    ss << (CoinBlock.nTime & ~STAKE_TIMESTAMP_MASK);
+    ss << MaskStakeTime(CoinBlock.nTime);
     ss << CoinTx.GetHash();
     ss << CoinTxN;
-    ss << (nTimeTx & ~STAKE_TIMESTAMP_MASK);
+    ss << MaskStakeTime(nTimeTx);
 
     return ss.GetHash();
 }

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -20,6 +20,17 @@ extern unsigned int nModifierInterval;
 // ratio of group interval length between the last group and the first group
 static const int MODIFIER_INTERVAL_RATIO = 3;
 
+//!
+//! \brief Apply the stake timestamp mask to the supplied timestamp.
+//!
+//! \param timestamp Usually a coinstake transaction or block timestamp.
+//!
+template <typename TimeType>
+TimeType MaskStakeTime(const TimeType timestamp)
+{
+    return timestamp & (~STAKE_TIMESTAMP_MASK);
+}
+
 // Compute the hash modifier for proof-of-stake
 bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
 

--- a/src/gridcoin/staking/spam.h
+++ b/src/gridcoin/staking/spam.h
@@ -1,0 +1,218 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "kernel.h"
+#include "uint256.h"
+
+#include <array>
+#include <cmath>
+#include <map>
+#include <vector>
+
+namespace GRC {
+//!
+//! \brief Records proof-of-stake claims for spam protection.
+//!
+//! This type provides support for spam mitigation at the chain tip by tracking
+//! the staking kernel proofs used to generate a new block. Nodes reject blocks
+//! with staked inputs spent for another block to prevent a malicious or broken
+//! node from spamming multiple blocks that compete for the best chain.
+//!
+//! This problem is a characteristic of proof-of-stake consensus protocols. The
+//! outputs used to create the kernel proof have no practical link to the block
+//! generated for that stake. If they did, the protocol would incentivize block
+//! producers to manipulate new blocks to synthesize suitable proofs--a process
+//! that looks a lot like proof-of-work consensus.
+//!
+//! Because a particular block does not depend on the properties of a stake, an
+//! actor can theoretically produce an unlimited set of blocks from an eligible
+//! proof and submit all of those blocks as candidates for next in the chain to
+//! flood the network and disrupt consensus. By disallowing nodes to generate a
+//! block with the same proof as another near the chain tip, we can depress the
+//! threat posed by this type of attack.
+//!
+//! This class replaces the original \c setStakeSeen sets to relieve the memory
+//! pressure from the block index. For now, a node will use it to reproduce the
+//! original behavior, but we may want to revisit spam mitigation techniques in
+//! the future.
+//!
+class SeenStakes
+{
+public:
+    //!
+    //! \brief Store a kernel proof hash from a block.
+    //!
+    //! \param Proof hash of the stake used to generate a block.
+    //!
+    void Remember(uint256 hashProof)
+    {
+        m_proofs_seen[GetOffset(hashProof)] = hashProof;
+    }
+
+    //!
+    //! \brief Store a kernel proof from an orphan block.
+    //!
+    //! \param coinstake Coinstake transaction from the block.
+    //!
+    void RememberOrphan(const CTransaction& coinstake)
+    {
+        const COutPoint& stake_prevout = coinstake.vin[0].prevout;
+        const int64_t stake_time = MaskStakeTime(coinstake.nTime);
+
+        m_orphan_proofs_seen[stake_prevout].emplace_back(stake_time);
+    }
+
+    //!
+    //! \brief Determine whether a node sent a block with a kernel proof hash
+    //! seen in another block.
+    //!
+    //! \param Proof hash of the stake used to generate a block.
+    //!
+    //! \return \c true if this container holds a matching proof hash.
+    //!
+    bool ContainsProof(const uint256& hashProof) const
+    {
+        return m_proofs_seen[GetOffset(hashProof)] == hashProof;
+    }
+
+    //!
+    //! \brief Determine whether a node sent an orphan block with a kernel proof
+    //! seen in another orphan block.
+    //!
+    //! \param Proof hash of the stake used to generate a block.
+    //!
+    //! \return \c true if this container holds a matching proof hash.
+    //!
+    bool ContainsOrphan(const CTransaction& coinstake) const
+    {
+        const COutPoint& stake_prevout = coinstake.vin[0].prevout;
+        const auto iter_pair = m_orphan_proofs_seen.find(stake_prevout);
+
+        if (iter_pair == m_orphan_proofs_seen.end()) {
+            return false;
+        }
+
+        const int64_t stake_time = MaskStakeTime(coinstake.nTime);
+        const auto& timestamps = iter_pair->second;
+        const auto end = timestamps.end();
+
+        return std::find(timestamps.begin(), end, stake_time) != end;
+    }
+
+    //!
+    //! \brief Remove a kernel proof for an orphan block.
+    //!
+    //! \param coinstake Coinstake transaction from the block.
+    //!
+    void ForgetOrphan(const CTransaction& coinstake)
+    {
+        const COutPoint& stake_prevout = coinstake.vin[0].prevout;
+        auto iter_pair = m_orphan_proofs_seen.find(stake_prevout);
+
+        if (iter_pair == m_orphan_proofs_seen.end()) {
+            return;
+        }
+
+        const int64_t stake_time = MaskStakeTime(coinstake.nTime);
+        auto& timestamps = iter_pair->second;
+        auto end = timestamps.end();
+
+        timestamps.erase(std::remove(timestamps.begin(), end, stake_time), end);
+
+        if (timestamps.empty()) {
+            m_orphan_proofs_seen.erase(iter_pair);
+        }
+    }
+
+    //!
+    //! \brief Fill the container with proof hashes near the chain tip.
+    //!
+    //! \param pindex Points to the block index for the chain tip.
+    //!
+    void Refill(const CBlockIndex* pindex)
+    {
+        for (size_t i = 0; pindex && i < m_proofs_seen.size(); ++i) {
+            pindex = pindex->pprev;
+        }
+
+        for (; pindex; pindex = pindex->pnext) {
+            Remember(pindex->hashProof);
+        }
+    }
+
+private:
+    //!
+    //! \brief A hash table of recently-observed kernel proof hashes.
+    //!
+    //! The size of the container must be a power of 2. Realistically, the 2048
+    //! entries are likely overkill since a block must:
+    //!
+    //!  - satisfy the requirements of the staking protocol
+    //!  - contain a valid coinstake transaction (previously unspent input)
+    //!  - produce a proof not already in this collection
+    //!
+    //! The extra wiggle room gives the container more tolerance for collisions
+    //! by increasing the output range of the hash function. The hash table can
+    //! store about two days' volume of staking proofs.
+    //!
+    std::array<uint256, 2048> m_proofs_seen;
+
+    //!
+    //! \brief A set of observed stake inputs from orphan blocks.
+    //!
+    //! Orphan blocks do not undergo proof-of-stake validation, so we cannot
+    //! store the computed proof hash. This collection contains outpoints of
+    //! staked inputs mapped to timestamps of the coinstake transactions.
+    //!
+    std::map<COutPoint, std::vector<int64_t>> m_orphan_proofs_seen;
+
+    //!
+    //! \brief Get the hash table slot offset for a proof hash.
+    //!
+    //! \param Proof hash of the stake used to generate a block.
+    //!
+    //! \return Hash of the proof hash in the range of the size of the proofs
+    //! table.
+    //!
+    size_t GetOffset(const uint256& hashProof) const
+    {
+        // This basic hashing function maps a proof hash value to an offset in
+        // the m_proofs_seen container. It implements the form of:
+        //
+        //   h_a,b(x) = (ax + b) >> (w - M)
+        //
+        // ...where:
+        //
+        //   x   is the input value to hash
+        //   a   is a random odd positive integer
+        //   b   is a random non-negative integer less than 2^(w - M)
+        //   w   is the number of bits in the hashing space (word size)
+        //   M   is the number of bits in the target digest space
+        //
+        // ...as described here:
+        //
+        //   https://en.wikipedia.org/wiki/Universal_hashing#Avoiding_modular_arithmetic
+        //
+        // ...to produce a distribution for values of x with a minimal rate of
+        // collision.
+        //
+        using limit_t = std::numeric_limits<size_t>;
+
+        static const size_t w = sizeof(size_t) * 8;
+        static const size_t M = std::log2(m_proofs_seen.size());
+        static const size_t a = (GetRand(limit_t::max()) * 2) + 1;
+        static const size_t b = GetRand(std::pow(2, w - M) - 1);
+
+        size_t x = 0;
+
+        for (size_t i = 0; i < (256 / sizeof(size_t)); i += sizeof(size_t)) {
+            x += *reinterpret_cast<const size_t*>(hashProof.begin() + i);
+        }
+
+        return (a * x + b) >> (w - M);
+    }
+}; // SeenStakes
+} // namespace GRC

--- a/src/main.h
+++ b/src/main.h
@@ -1124,11 +1124,6 @@ public:
         return !IsProofOfStake();
     }
 
-    std::pair<COutPoint, unsigned int> GetProofOfStake() const
-    {
-        return IsProofOfStake()? std::make_pair(vtx[1].vin[0].prevout, vtx[1].nTime) : std::make_pair(COutPoint(), (unsigned int)0);
-    }
-
     // ppcoin: get max transaction timestamp
     int64_t GetMaxTransactionTime() const
     {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -558,7 +558,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
     CTransaction &txnew = blocknew.vtx[1]; // second tx is coinstake
 
     //initialize the transaction
-    txnew.nTime = blocknew.nTime & (~GRC::STAKE_TIMESTAMP_MASK);
+    txnew.nTime = GRC::MaskStakeTime(blocknew.nTime);
     txnew.vin.clear();
     txnew.vout.clear();
 

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -363,8 +363,6 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nMoneySupply   = diskindex.nMoneySupply;
         pindexNew->nFlags         = diskindex.nFlags;
         pindexNew->nStakeModifier = diskindex.nStakeModifier;
-        pindexNew->prevoutStake   = diskindex.prevoutStake;
-        pindexNew->nStakeTime     = diskindex.nStakeTime;
         pindexNew->hashProof      = diskindex.hashProof;
         pindexNew->nVersion       = diskindex.nVersion;
         pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
@@ -396,10 +394,6 @@ bool CTxDB::LoadBlockIndex()
                 fprintf(stdout,"%d ",nLoaded); fflush(stdout);
             }
         }
-
-        // NovaCoin: build setStakeSeen
-        if (pindexNew->IsProofOfStake())
-            setStakeSeen.insert(make_pair(pindexNew->prevoutStake, pindexNew->nStakeTime));
 
         iterator->Next();
     }


### PR DESCRIPTION
This is part of a series of changes that optimize the memory usage of Gridcoin's block index. According to Valgrind's heap profiler (Massif), these changes will decrease memory usage of the application by over 500 MB after the final PR merges. Because these optimizations apply to every block, memory savings will continue to accrue as the chain grows. I'm breaking-up the commits into separate PRs because the branch has become too unwieldy to review in one submission. 

---

This refactors the duplicate stake spam mitigation to remove the following fields from the block index:

  - `prevoutStake`
  - `nStakeTime`

...for a memory reduction of 40 bytes per block.

It also replaces the `setStakeSeen` container with a hash table of transient staking proof hashes. The `setStakeSeen` container holds a copy of the block index fields described above.

This saves an additional 40 bytes of memory for every block plus the administrative overhead needed to store each record in a `std::set` container (±28 bytes depending on the platform and library implementation).

I also optimized storage for the original `setStakeSeenOrphan` set by consolidating outpoints seen more than once in orphan blocks. This doesn't have much of an effect under normal circumstances.