### PR TITLE
accrual: Reset research account when disconnecting first block

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -132,5 +132,5 @@ inline int GetSuperblockAgeSpacing(int nHeight)
 
 inline int GetNewbieSnapshotFixHeight()
 {
-    return fTestNet ? 1393000 : 2090000;
+    return fTestNet ? 1393000 : 2104000;
 }

--- a/src/gridcoin/account.h
+++ b/src/gridcoin/account.h
@@ -44,8 +44,12 @@ public:
     //!
     //! \brief Initialize an empty research account.
     //!
-    ResearchAccount()
-        : m_accrual(0)
+    //! \param accrual Research reward accrued as of the last superblock. New
+    //! accounts may carry pending accrual even though the CPIDs never staked
+    //! a block before.
+    //!
+    ResearchAccount(const CAmount accrual = 0)
+        : m_accrual(accrual)
         , m_total_research_subsidy(0)
         , m_total_magnitude(0)
         , m_accuracy(0)

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -302,16 +302,19 @@ public:
         assert(account.m_first_block_ptr != nullptr);
         assert(pindex == account.m_last_block_ptr);
 
+        // When disconnecting a CPID's first block, reset the account, but
+        // retain the pending snapshot accrual amount:
+        //
+        if (pindex == account.m_first_block_ptr) {
+            account = ResearchAccount(account.m_accrual);
+            return;
+        }
+
         account.m_total_research_subsidy -= pindex->nResearchSubsidy;
 
         if (pindex->nMagnitude > 0) {
             account.m_accuracy--;
             account.m_total_magnitude -= pindex->nMagnitude;
-        }
-
-        if (pindex == account.m_first_block_ptr) {
-            account.m_first_block_ptr = nullptr;
-            return;
         }
 
         pindex = pindex->pprev;


### PR DESCRIPTION
This tweaks the change in #1931 to reset the entire research account instead of just the account's first block while disconnecting the first block that a CPID claimed research rewards for to guarantee that the tally system treats the account as a new CPID.

Only the snapshot accrual information is retained to enable new CPIDs to carry pending accrual before staking the first block.

This also changes the height for the activation of the fix for snapshot accrual for new CPIDs to provide an upgrade grace period of one month instead of two weeks.