### PR TITLE
voting: Add poll choices to "gettransaction" RPC contract output

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -176,6 +176,18 @@ UniValue PollPayloadToJson(const GRC::ContractPayload& payload)
     out.pushKV("response_type", (int)poll.m_poll.m_response_type.Raw());
     out.pushKV("duration_days", (int)poll.m_poll.m_duration_days);
 
+    UniValue choices(UniValue::VARR);
+
+    for (size_t i = 0; i < poll.m_poll.Choices().size(); ++i) {
+        UniValue choice(UniValue::VOBJ);
+        choice.pushKV("id", (int)i);
+        choice.pushKV("label", poll.m_poll.Choices().At(i)->m_label);
+
+        choices.push_back(choice);
+    }
+
+    out.pushKV("choices", choices);
+
     return out;
 }
 


### PR DESCRIPTION
This adds the available poll answers to the contract information included in the output of the "gettransaction" RPC. This may support services that need the information at the time that the transaction arrives. The change was requested for GridcoinStats.