### PR TITLE
refactor: [Memory optimization] Block index superblock and contract flags

### DIFF
--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -1518,7 +1518,7 @@ public:
         int64_t payment_time = current_superblock.m_timestamp;
 
         for (; pindex && pindex->nHeight > max_depth; pindex = pindex->pprev) {
-            if (pindex->nIsSuperBlock != 1) {
+            if (!pindex->IsSuperblock()) {
                 continue;
             }
 
@@ -1533,7 +1533,7 @@ public:
 
         // If the maximum depth is a superblock, we're done.
         //
-        if (pindex->nIsSuperBlock == 1) {
+        if (pindex->IsSuperblock()) {
             return true;
         }
 
@@ -1547,7 +1547,7 @@ public:
         const CBlockIndex* const pindex_max = pindex;
 
         for (; pindex; pindex = pindex->pprev) {
-            if (pindex->nIsSuperBlock != 1) {
+            if (!pindex->IsSuperblock()) {
                 continue;
             }
 
@@ -1590,7 +1590,7 @@ private:
         const CBlockIndex* const pindex,
         const CBlockIndex* const pindex_bind = nullptr)
     {
-        assert(pindex->nIsSuperBlock == 1);
+        assert(pindex->IsSuperblock());
 
         LogPrint(LogFlags::TALLY, "  Superblock: %" PRId64, pindex->nHeight);
 

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -428,7 +428,7 @@ void GRC::ReplayContracts(const CBlockIndex* pindex)
 
     // These are memorized consecutively in order from oldest to newest.
     for (; pindex; pindex = pindex->pnext) {
-        if (pindex->nIsContract == 1) {
+        if (pindex->IsContract()) {
             if (!block.ReadFromDisk(pindex)) {
                 continue;
             }
@@ -437,7 +437,7 @@ void GRC::ReplayContracts(const CBlockIndex* pindex)
             ApplyContracts(block, pindex, unused);
         }
 
-        if (pindex->nIsSuperBlock == 1 && pindex->nVersion >= 11) {
+        if (pindex->IsSuperblock() && pindex->nVersion >= 11) {
             if (block.hashPrevBlock != pindex->pprev->GetBlockHash()
                 && !block.ReadFromDisk(pindex))
             {

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -179,7 +179,7 @@ public:
             m_cache.clear();
 
             const CBlockIndex* pindex = pindexLast;
-            for (; pindex && pindex->nIsSuperBlock != 1; pindex = pindex->pprev);
+            for (; pindex && !pindex->IsSuperblock(); pindex = pindex->pprev);
 
             m_cache.emplace_front(SuperblockPtr::ReadFromDisk(pindex));
 
@@ -213,7 +213,7 @@ public:
         // better index when we implement superblock windows:
         //
         while (m_pending.size() < CACHE_SIZE) {
-            while (pindexLast->nIsSuperBlock != 1) {
+            while (!pindexLast->IsSuperblock()) {
                 if (!pindexLast->pprev) {
                     return;
                 }

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -970,7 +970,7 @@ SuperblockPtr SuperblockPtr::ReadFromDisk(const CBlockIndex* const pindex)
         return Empty();
     }
 
-    if (pindex->nIsSuperBlock != 1) {
+    if (!pindex->IsSuperblock()) {
         error("%s: %" PRId64 " is not a superblock", __func__, pindex->nHeight);
         return Empty();
     }

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -432,7 +432,7 @@ public:
                 pindex;
                 pindex = pindex->pnext)
             {
-                if (pindex->nIsSuperBlock == 1) {
+                if (pindex->IsSuperblock()) {
                     m_snapshots.AssertMatch(pindex->nHeight);
                 }
 
@@ -584,7 +584,7 @@ private:
             pindex;
             pindex = pindex->pprev)
         {
-            if (pindex->nIsSuperBlock != 1) {
+            if (!pindex->IsSuperblock()) {
                 continue;
             }
 
@@ -665,7 +665,7 @@ private:
             pindex;
             pindex = pindex->pnext)
         {
-            if (pindex->nIsSuperBlock == 1) {
+            if (pindex->IsSuperblock()) {
                 if (!ApplySuperblock(SuperblockPtr::ReadFromDisk(pindex))) {
                     return false;
                 }

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -588,7 +588,7 @@ private:
         for (; pindex && pindex->nTime > max_time; pindex = pindex->pprev);
 
         for (; pindex && pindex->nTime > min_time; pindex = pindex->pprev) {
-            if (pindex->nIsContract != 1) {
+            if (!pindex->IsContract()) {
                 continue;
             }
 

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -1004,7 +1004,7 @@ SuperblockPtr ResolveSuperblockForPoll(const Poll& poll)
 
     // Find the superblock active at the end of the poll:
     for (; pindex; pindex = pindex->pprev) {
-        if (pindex->nIsSuperBlock != 1 || poll.Expired(pindex->nTime)) {
+        if (!pindex->IsSuperblock() || poll.Expired(pindex->nTime)) {
             continue;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2069,7 +2069,7 @@ bool GridcoinConnectBlock(
                 return false;
             }
 
-            pindex->nIsSuperBlock = 1;
+            pindex->MarkAsSuperblock();
         } else if (block.nVersion <= 10) {
             // Block versions 11+ validate superblocks from scraper convergence
             // instead of the legacy quorum system so we only record votes from
@@ -2085,7 +2085,10 @@ bool GridcoinConnectBlock(
     pindex->SetMiningId(claim.m_mining_id);
     pindex->nResearchSubsidy = claim.m_research_subsidy;
     pindex->nInterestSubsidy = claim.m_block_subsidy;
-    pindex->nIsContract = found_contract;
+
+    if (found_contract) {
+        pindex->MarkAsContract();
+    }
 
     if (block.nVersion >= 11) {
         pindex->nMagnitude = GRC::Quorum::GetMagnitude(claim.m_mining_id).Floating();
@@ -2367,7 +2370,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
             GRC::Tally::ForgetRewardBlock(pindexBest);
         }
 
-        if (pindexBest->nIsSuperBlock == 1) {
+        if (pindexBest->IsSuperblock()) {
             GRC::Quorum::PopSuperblock(pindexBest);
             GRC::Quorum::LoadSuperblockIndex(pindexBest->pprev);
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -190,13 +190,13 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
 
     if (LogInstance().WillLogCategory(BCLog::LogFlags::NET)) result.pushKV("BoincHash",block.vtx[0].hashBoinc);
 
-    if (fPrintTransactionDetail && blockindex->nIsSuperBlock == 1) {
+    if (fPrintTransactionDetail && blockindex->IsSuperblock()) {
         result.pushKV("superblock", SuperblockToJson(block.GetSuperblock()));
     }
 
     result.pushKV("fees_collected", ValueFromAmount(GetFeesCollected(block)));
-    result.pushKV("IsSuperBlock", (int)blockindex->nIsSuperBlock);
-    result.pushKV("IsContract", (int)blockindex->nIsContract);
+    result.pushKV("IsSuperBlock", blockindex->IsSuperblock());
+    result.pushKV("IsContract", blockindex->IsContract());
 
     return result;
 }
@@ -1809,7 +1809,7 @@ UniValue SuperblockReport(int lookback, bool displaycontract, std::string cpid)
         pblockindex = pblockindex->pprev;
         if (pblockindex == pindexGenesisBlock) return results;
         if (!pblockindex->IsInMainChain()) continue;
-        if (pblockindex->nIsSuperBlock == 1)
+        if (pblockindex->IsSuperblock())
         {
             const GRC::ClaimOption claim = GetClaimByIndex(pblockindex);
 

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -351,7 +351,7 @@ UniValue rpc_getsupervotes(const UniValue& params, bool fHelp)
             result1.pushKV("error","Superblock not found in block index");
             return result1;
         }
-        if(!pblockindex->nIsSuperBlock)
+        if(!pblockindex->IsSuperblock())
         {
             result1.pushKV("height_cache", height);
             result1.pushKV("block_hash",pblockindex->GetBlockHash().GetHex());
@@ -384,7 +384,7 @@ UniValue rpc_getsupervotes(const UniValue& params, bool fHelp)
 
         CBlockIndex* pblockindex = mapBlockIndex[hash];
 
-        if(!pblockindex->nIsSuperBlock)
+        if(!pblockindex->IsSuperblock())
         {
             result1.pushKV("block_hash",pblockindex->GetBlockHash().GetHex());
             result1.pushKV("error","Requested block is not a Superblock");
@@ -584,7 +584,7 @@ UniValue rpc_exportstats(const UniValue& params, bool fHelp)
         max_spacing=std::max(max_spacing,i_spacing);
 
         cnt_investor += !! (cur->nFlags & CBlockIndex::INVESTOR_CPID);
-        cnt_contract += !! cur->nIsContract;
+        cnt_contract += !! cur->IsContract();
 
         CBlock block;
         if(!block.ReadFromDisk(cur->nFile,cur->nBlockPos,true))
@@ -743,7 +743,7 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
                     + "<|>"+ToString(delta);
 
                 line+= "<|>"
-                    + std::string((cur->nIsSuperBlock?"S":(cur->nIsContract?"C":"-")))
+                    + std::string((cur->IsSuperblock()?"S":(cur->IsContract()?"C":"-")))
                     + (cur->IsUserCPID()? (cur->nResearchSubsidy>0? "R": "U"): "I")
                     //+ (cur->GeneratedStakeModifier()? "M": "-")
                     ;
@@ -761,9 +761,9 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             result2.pushKV("hash", line );
             result2.pushKV("difficulty", diff );
             result2.pushKV("deltatime", (int64_t)delta );
-            result2.pushKV("issuperblock", (bool)cur->nIsSuperBlock );
-            result2.pushKV("iscontract", (bool)cur->nIsContract );
-            result2.pushKV("ismodifier", (bool)cur->GeneratedStakeModifier() );
+            result2.pushKV("issuperblock", cur->IsSuperblock());
+            result2.pushKV("iscontract", cur->IsContract());
+            result2.pushKV("ismodifier", cur->GeneratedStakeModifier());
             result2.pushKV("cpid", cur->GetMiningId().ToString() );
             result2.pushKV("research", ValueFromAmount(cur->nResearchSubsidy));
             result2.pushKV("interest", ValueFromAmount(cur->nInterestSubsidy));

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -260,7 +260,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
         pindex_superblock;
         pindex_superblock = pindex_superblock->pprev)
     {
-        if (pindex_superblock->nIsSuperBlock == 1) {
+        if (pindex_superblock->IsSuperblock()) {
             superblock = SuperblockPtr::ReadFromDisk(pindex_superblock);
             break;
         }
@@ -310,7 +310,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
 
             accrual = 0;
             pindex_low = pindex;
-        } else if (pindex->nIsSuperBlock == 1) {
+        } else if (pindex->IsSuperblock()) {
             tally_accrual_period(
                 "superblock",
                 pindex->nHeight,
@@ -321,7 +321,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
             pindex_low = pindex;
         }
 
-        if (pindex->nIsSuperBlock == 1) {
+        if (pindex->IsSuperblock()) {
             superblock = SuperblockPtr::ReadFromDisk(pindex);
         }
     }

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -375,8 +375,6 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nResearchSubsidy  = diskindex.nResearchSubsidy;
         pindexNew->nInterestSubsidy  = diskindex.nInterestSubsidy;
         pindexNew->nMagnitude        = diskindex.nMagnitude;
-        pindexNew->nIsContract       = diskindex.nIsContract;
-        pindexNew->nIsSuperBlock     = diskindex.nIsSuperBlock;
 
         nBlockCount++;
         // Watch for genesis block

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2718,7 +2718,7 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
     // that corresponds (is integral to) the block. We check whether
     // the block is a superblock, and if so we set the MinedType to
     // SUPERBLOCK if vout is 1 as that should override the others here.
-    if (vout == 1 && blkindex->nIsSuperBlock)
+    if (vout == 1 && blkindex->IsSuperblock())
     {
         return MinedType::SUPERBLOCK;
     }


### PR DESCRIPTION
This is part of a series of changes that optimize the memory usage of Gridcoin's block index. According to Valgrind's heap profiler (Massif), these changes will decrease memory usage of the application by over 500 MB after the final PR merges. Because these optimizations apply to every block, memory savings will continue to accrue as the chain grows. I'm breaking-up the commits into separate PRs because the branch has become too unwieldy to review in one submission.

---

This converts the following block index fields to bits in the `nFlags` field:

  - `nIsSuperBlock`
  - `nIsContract`

...for a memory reduction of 8 bytes per block.