### PR TITLE
refactor: [Memory optimization] Remove stake modifier checksums

### DIFF
--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -374,35 +374,6 @@ bool GRC::ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nSta
     return true;
 }
 
-// Get stake modifier checksum
-unsigned int GRC::GetStakeModifierChecksum(const CBlockIndex* pindex)
-{
-    if (pindex->pprev == nullptr && pindexGenesisBlock && pindex != pindexGenesisBlock)
-    {
-        //Error on non-genesis blocks that don't have a previous block
-        //If pindexGenesisBlock is null, then you are starting from zero so don't throw an error
-        throw std::runtime_error(
-            "Error: blockchain data corrupted.\n"
-            "Go to the wallet's data directory and delete the folder txleveldb and the files blk000x.dat (x is any number).\n"
-            "This requires you to sync again from the beginning and your wallet will temporarily show a balance of 0 GRC\n"
-        );
-    }
-    // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
-    CDataStream ss(SER_GETHASH, 0);
-    if (pindex->pprev)
-        ss << pindex->pprev->nStakeModifierChecksum;
-    ss << pindex->nFlags << (pindex->IsProofOfStake() ? pindex->hashProof : uint256()) << pindex->nStakeModifier;
-    arith_uint256 hashChecksum = UintToArith256(Hash(ss.begin(), ss.end()));
-    hashChecksum >>= (256 - 32);
-    return hashChecksum.GetLow64();
-}
-
-// Check stake modifier hard checkpoints
-bool GRC::CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum)
-{
-    return true;
-}
-
 bool GRC::ReadStakedInput(
     CTxDB& txdb,
     const uint256 prevout_hash,

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -34,12 +34,6 @@ TimeType MaskStakeTime(const TimeType timestamp)
 // Compute the hash modifier for proof-of-stake
 bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
 
-// Get stake modifier checksum
-unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);
-
-// Check stake modifier hard checkpoints
-bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum);
-
 // Get time weight using supplied timestamps
 int64_t GetWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2132,7 +2132,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 
     bool bIsDPOR = false;
 
-    if (nVersion >= 8 && pindex->nStakeModifier == 0 && pindex->nStakeModifierChecksum == 0)
+    if (nVersion >= 8 && pindex->nStakeModifier == 0)
     {
         uint256 tmp_hashProof;
         if (!GRC::CheckProofOfStakeV8(txdb, pindex->pprev, *this, /*generated_by_me*/ false, tmp_hashProof))
@@ -2733,7 +2733,6 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos, const u
         LogPrintf("AddToBlockIndex() : ComputeNextStakeModifier() failed");
     }
     pindexNew->SetStakeModifier(nStakeModifier, fGeneratedStakeModifier);
-    pindexNew->nStakeModifierChecksum = GRC::GetStakeModifierChecksum(pindexNew);
 
     // Add to mapBlockIndex
     BlockMap::iterator mi = mapBlockIndex.insert(make_pair(hash, pindexNew)).first;

--- a/src/main.h
+++ b/src/main.h
@@ -1314,8 +1314,6 @@ public:
     };
 
     uint64_t nStakeModifier; // hash modifier for proof-of-stake
-    unsigned int nStakeModifierChecksum; // checksum of index; in-memory only
-
     uint256 hashProof;
 
     // block header
@@ -1361,7 +1359,6 @@ public:
         nMoneySupply = 0;
         nFlags = EMPTY_CPID;
         nStakeModifier = 0;
-        nStakeModifierChecksum = 0;
         hashProof.SetNull();
 
         nVersion       = 0;
@@ -1528,11 +1525,11 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("CBlockIndex(nprev=%p, pnext=%p, nFile=%u, nBlockPos=%-6d nHeight=%d, nMint=%s, nMoneySupply=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016" PRIx64 ", nStakeModifierChecksum=%08x, hashProof=%s, merkle=%s, hashBlock=%s)",
+        return strprintf("CBlockIndex(nprev=%p, pnext=%p, nFile=%u, nBlockPos=%-6d nHeight=%d, nMint=%s, nMoneySupply=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016" PRIx64 ", hashProof=%s, merkle=%s, hashBlock=%s)",
             pprev, pnext, nFile, nBlockPos, nHeight,
             FormatMoney(nMint), FormatMoney(nMoneySupply),
             GeneratedStakeModifier() ? "MOD" : "-", GetStakeEntropyBit(), IsProofOfStake()? "PoS" : "PoW",
-            nStakeModifier, nStakeModifierChecksum,
+            nStakeModifier,
             hashProof.ToString(),
             hashMerkleRoot.ToString(),
             GetBlockHash().ToString());

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -162,7 +162,6 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
     result.pushKV("proofhash", blockindex->hashProof.GetHex());
     result.pushKV("entropybit", (int)blockindex->GetStakeEntropyBit());
     result.pushKV("modifier", strprintf("%016" PRIx64, blockindex->nStakeModifier));
-    result.pushKV("modifierchecksum", strprintf("%08x", blockindex->nStakeModifierChecksum));
 
     UniValue txinfo(UniValue::VARR);
 

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -418,10 +418,6 @@ bool CTxDB::LoadBlockIndex()
     {
         CBlockIndex* pindex = item.second;
         pindex->nChainTrust = (pindex->pprev ? pindex->pprev->nChainTrust : 0) + pindex->GetBlockTrust();
-        // NovaCoin: calculate stake modifier checksum
-        pindex->nStakeModifierChecksum = GRC::GetStakeModifierChecksum(pindex);
-        if (!GRC::CheckStakeModifierCheckpoints(pindex->nHeight, pindex->nStakeModifierChecksum))
-            return error("CTxDB::LoadBlockIndex() : Failed stake modifier checkpoint height=%d, modifier=0x%016" PRIx64, pindex->nHeight, pindex->nStakeModifier);
     }
 
 


### PR DESCRIPTION
This is part of a series of changes that optimize the memory usage of Gridcoin's block index. According to Valgrind's heap profiler (Massif), these changes will decrease memory usage of the application by over 500 MB after the final PR merges. Because these optimizations apply to every block, memory savings will continue to accrue as the chain grows. I'm breaking-up the commits into separate PRs because the branch has become too unwieldy to review in one submission.

---

Gridcoin contains some code for stake modifier checksums that carried-over from Peercoin/Blackcoin. However, the checkpoints were never implemented, and I don't think the checksum function ever worked properly. This PR removes the stake modifier checksum/checkpoint system and the `nStakeModifierChecksum` field from the block index.

This saves 4 bytes of memory per block and improves synchronization performance a bit.

The modifier checksum verification process that runs on start-up did produce a useful side-effect: it identified corrupt block index entries after unclean shutdowns or power failures. I re-implemented this heuristic as a formal start-up check.