### PR TITLE
refactor: [Memory optimization] Block index allocation overhead

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,6 +86,7 @@ GRIDCOIN_CORE_H = \
     gridcoin/appcache.h \
     gridcoin/backup.h \
     gridcoin/beacon.h \
+    gridcoin/block_index.h \
     gridcoin/boinc.h \
     gridcoin/claim.h \
     gridcoin/contract/contract.h \

--- a/src/gridcoin/account.h
+++ b/src/gridcoin/account.h
@@ -231,7 +231,7 @@ public:
     uint16_t LastRewardMagnitude() const
     {
         if (const BlockPtrOption pindex = LastRewardBlock()) {
-            return (*pindex)->nMagnitude;
+            return (*pindex)->Magnitude();
         }
 
         return 0;

--- a/src/gridcoin/block_index.h
+++ b/src/gridcoin/block_index.h
@@ -6,6 +6,11 @@
 
 #include "gridcoin/cpid.h"
 
+#include <array>
+#include <forward_list>
+
+class CBlockIndex;
+
 namespace GRC {
 //!
 //! \brief Block index fields specific to research reward claims.
@@ -24,15 +29,110 @@ public:
     Cpid m_cpid;
     int64_t m_research_subsidy;
     double m_magnitude;
-
-    ResearcherContext(
-        const Cpid cpid,
-        const int64_t research_subsidy,
-        const double magnitude)
-        : m_cpid(cpid)
-        , m_research_subsidy(research_subsidy)
-        , m_magnitude(magnitude)
-    {
-    }
 };
+
+//!
+//! \brief Bulk-allocates block index objects to improve heap efficiency.
+//!
+//! Because of the relatively small block spacing, the block index eclipses
+//! the memory usage of every other component in Gridcoin by a wide margin.
+//! This object pool reduces the administrative overhead needed to allocate
+//! objects from the heap when compared to one-off allocations for millions
+//! of instances. Retrieve new entries from this pool instead of allocating
+//! them with the \c new operator.
+//!
+//! The pool does not provide a way to return discarded objects because the
+//! application never removes or destroys block index entries.
+//!
+//! TODO: Consider a specialized hash table implementation for the block index
+//! map with more efficient memory management than \c std::unordered_map. This
+//! pool serves as a crutch until we can address the scalability problems with
+//! the block index on a deeper level.
+//!
+class BlockIndexPool
+{
+public:
+    //!
+    //! \brief Get the next available block index instance from the pool.
+    //!
+    static CBlockIndex* GetNextBlockIndex()
+    {
+        return m_block_index_pool.GetNext();
+    }
+
+    //!
+    //! \brief Get the next available researcher context instance from the pool.
+    //!
+    static ResearcherContext* GetNextResearcherContext()
+    {
+        return m_researcher_context_pool.GetNext();
+    }
+
+private:
+    //!
+    //! \brief Allocates objects in chunks and provides access to unclaimed
+    //! instances.
+    //!
+    template <typename T>
+    class Pool
+    {
+        //!
+        //! \brief Number of objects to allocate per chunk.
+        //!
+        //! For block index objects, this results in about a 5 MB allocation
+        //! per chunk.
+        //!
+        static constexpr size_t CHUNK_SIZE = 32768;
+
+    public:
+        //!
+        //! \brief Initialize a new pool.
+        //!
+        Pool() : m_pool(1), m_offset(0)
+        {
+        }
+
+        //!
+        //! \brief Get the next available instance from the pool.
+        //!
+        T* GetNext()
+        {
+            if (m_offset >= CHUNK_SIZE) {
+                m_pool.emplace_front();
+                m_offset = 0;
+            }
+
+            return &m_pool.front()[m_offset++];
+        }
+
+    private:
+        //!
+        //! \brief The collection of allocated chunks in the pool.
+        //!
+        //! Each element holds a batch of \p T objects, and the front entry
+        //! in the list contains the unclaimed objects in the pool when the
+        //! item offsets follow the offset stored in the \c m_offset field.
+        //!
+        //! For the sake of avoiding a memory leak, we use a linked list to
+        //! manage the allocated chunks. We could allocate the arrays using
+        //! the \c new operator directly like before, and the OS will clean
+        //! up the leak when the program exits. Since the overhead for this
+        //! wrapper list is negligible, we favor the explicit management of
+        //! memory in case we need to reset the pool in the future.
+        //!
+        std::forward_list<std::array<T, CHUNK_SIZE>> m_pool;
+
+        //!
+        //! \brief The offset of the next available instance in the current
+        //! chunk of unclaimed pool objects.
+        //!
+        //! The value advances when claiming an object from the pool and it
+        //! resets to zero when allocating a new chunk.
+        //!
+        size_t m_offset;
+    };
+
+    static Pool<CBlockIndex> m_block_index_pool;
+    static Pool<ResearcherContext> m_researcher_context_pool;
+}; // BlockIndexPool
 } // namespace GRC

--- a/src/gridcoin/block_index.h
+++ b/src/gridcoin/block_index.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "gridcoin/cpid.h"
+
+namespace GRC {
+//!
+//! \brief Block index fields specific to research reward claims.
+//!
+//! Non-researcher nodes produce nearly 75% of Gridcoin's block chain. By
+//! allocating the researcher context only for blocks staked with a CPID,
+//! we conserve 24 bytes for each non-research entry in the block index.
+//!
+//! Testnet exhibits the opposite behavior pattern--researchers stake the
+//! majority of blocks. The memory optimization provides no benefit for a
+//! testnet node, but we prefer to tune performance for mainnet here.
+//!
+class ResearcherContext
+{
+public:
+    Cpid m_cpid;
+    int64_t m_research_subsidy;
+    double m_magnitude;
+
+    ResearcherContext(
+        const Cpid cpid,
+        const int64_t research_subsidy,
+        const double magnitude)
+        : m_cpid(cpid)
+        , m_research_subsidy(research_subsidy)
+        , m_magnitude(magnitude)
+    {
+    }
+};
+} // namespace GRC

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2082,19 +2082,22 @@ bool GridcoinConnectBlock(
     bool found_contract;
     GRC::ApplyContracts(block, pindex, found_contract);
 
-    pindex->SetMiningId(claim.m_mining_id);
-    pindex->nResearchSubsidy = claim.m_research_subsidy;
-    pindex->nInterestSubsidy = claim.m_block_subsidy;
-
     if (found_contract) {
         pindex->MarkAsContract();
     }
 
-    if (block.nVersion >= 11) {
-        pindex->nMagnitude = GRC::Quorum::GetMagnitude(claim.m_mining_id).Floating();
+    double magnitude = 0;
+
+    if (block.nVersion >= 11
+        && claim.m_mining_id.Which() == GRC::MiningId::Kind::CPID)
+    {
+        magnitude = GRC::Quorum::GetMagnitude(claim.m_mining_id).Floating();
     } else {
-        pindex->nMagnitude = claim.m_magnitude;
+        magnitude = claim.m_magnitude;
     }
+
+    pindex->SetResearcherContext(claim.m_mining_id, claim.m_research_subsidy, magnitude);
+    pindex->nInterestSubsidy = claim.m_block_subsidy;
 
     GRC::Tally::RecordRewardBlock(pindex);
     GRC::Researcher::Refresh();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,11 @@ extern double CoinToDouble(double surrogate);
 
 extern int64_t GetCoinYearReward(int64_t nTime);
 
+namespace GRC {
+BlockIndexPool::Pool<CBlockIndex> BlockIndexPool::m_block_index_pool;
+BlockIndexPool::Pool<ResearcherContext> BlockIndexPool::m_researcher_context_pool;
+}
+
 BlockMap mapBlockIndex;
 
 CBigNum bnProofOfWorkLimit(ArithToUint256(~arith_uint256() >> 20)); // "standard" scrypt target limit for proof of work, results with 0,000244140625 proof-of-work difficulty
@@ -2707,7 +2712,9 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos, const u
         return error("AddToBlockIndex() : %s already exists", hash.ToString().substr(0,20).c_str());
 
     // Construct new block index object
-    CBlockIndex* pindexNew = new CBlockIndex(nFile, nBlockPos, *this);
+    CBlockIndex* pindexNew = GRC::BlockIndexPool::GetNextBlockIndex();
+    *pindexNew = CBlockIndex(nFile, nBlockPos, *this);
+
     if (!pindexNew)
         return error("AddToBlockIndex() : new CBlockIndex failed");
     pindexNew->phashBlock = &hash;

--- a/src/main.h
+++ b/src/main.h
@@ -1473,15 +1473,12 @@ public:
         if (const auto cpid_option = mining_id.TryCpid()) {
             if (research_subsidy > 0) {
                 if (!m_researcher) {
-                    m_researcher = new GRC::ResearcherContext(
-                        *cpid_option,
-                        research_subsidy,
-                        magnitude);
-                } else {
-                    m_researcher->m_cpid = *cpid_option;
-                    m_researcher->m_research_subsidy = research_subsidy;
-                    m_researcher->m_magnitude = magnitude;
+                    m_researcher = GRC::BlockIndexPool::GetNextResearcherContext();
                 }
+
+                m_researcher->m_cpid = *cpid_option;
+                m_researcher->m_research_subsidy = research_subsidy;
+                m_researcher->m_magnitude = magnitude;
 
                 return;
             }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -59,12 +59,11 @@ UniValue ClaimToJson(const GRC::Claim& claim, const CBlockIndex* const pindex)
     json.pushKV("organization", claim.m_organization);
 
     json.pushKV("block_subsidy", ValueFromAmount(claim.m_block_subsidy));
-
     json.pushKV("research_subsidy", ValueFromAmount(claim.m_research_subsidy));
 
     // Version 11 blocks remove magnitude and magnitude unit from claims:
     if (pindex->nVersion >= 11) {
-        json.pushKV("magnitude", pindex->nMagnitude);
+        json.pushKV("magnitude", pindex->Magnitude());
         json.pushKV("magnitude_unit", GRC::Tally::GetMagnitudeUnit(pindex));
     } else {
         json.pushKV("magnitude", claim.m_magnitude);
@@ -1046,10 +1045,10 @@ UniValue lifetime(const UniValue& params, bool fHelp)
         pindex;
         pindex = pindex->pnext)
     {
-        if (pindex->nResearchSubsidy > 0 && pindex->GetMiningId() == *cpid) {
+        if (pindex->ResearchSubsidy() > 0 && pindex->GetMiningId() == *cpid) {
             results.pushKV(
                 std::to_string(pindex->nHeight),
-                ValueFromAmount(pindex->nResearchSubsidy));
+                ValueFromAmount(pindex->ResearchSubsidy()));
         }
     }
 
@@ -1465,7 +1464,7 @@ UniValue network(const UniValue& params, bool fHelp)
         pindex = pindex->pprev)
     {
         two_week_block_subsidy += pindex->nInterestSubsidy;
-        two_week_research_subsidy += pindex->nResearchSubsidy;
+        two_week_research_subsidy += pindex->ResearchSubsidy();
     }
 
     res.pushKV("total_magnitude", superblock->m_cpids.TotalMagnitude());

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -614,7 +614,7 @@ UniValue rpc_exportstats(const UniValue& params, bool fHelp)
 
         if(i_research>0)
         {
-            const double i_magnitude = cur->nMagnitude;
+            const double i_magnitude = cur->Magnitude();
             sum_magnitude= sum_magnitude + i_magnitude;
             cnt_research += 1;
         }
@@ -744,7 +744,7 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
 
                 line+= "<|>"
                     + std::string((cur->IsSuperblock()?"S":(cur->IsContract()?"C":"-")))
-                    + (cur->IsUserCPID()? (cur->nResearchSubsidy>0? "R": "U"): "I")
+                    + (cur->IsUserCPID()? (cur->ResearchSubsidy()>0? "R": "U"): "I")
                     //+ (cur->GeneratedStakeModifier()? "M": "-")
                     ;
             }
@@ -752,7 +752,7 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             if(detail>=2 && detail<20)
             {
                 line+="<|>"+cur->GetMiningId().ToString()
-                    + "<|>"+FormatMoney(cur->nResearchSubsidy)
+                    + "<|>"+FormatMoney(cur->ResearchSubsidy())
                     + "<|>"+FormatMoney(cur->nInterestSubsidy);
             }
         }
@@ -765,9 +765,9 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             result2.pushKV("iscontract", cur->IsContract());
             result2.pushKV("ismodifier", cur->GeneratedStakeModifier());
             result2.pushKV("cpid", cur->GetMiningId().ToString() );
-            result2.pushKV("research", ValueFromAmount(cur->nResearchSubsidy));
+            result2.pushKV("research", ValueFromAmount(cur->ResearchSubsidy()));
             result2.pushKV("interest", ValueFromAmount(cur->nInterestSubsidy));
-            result2.pushKV("magnitude", cur->nMagnitude );
+            result2.pushKV("magnitude", cur->Magnitude());
         }
 
         if( (detail<100 && detail>=20) || (detail>=120) )

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -168,7 +168,7 @@ UniValue getlaststake(const UniValue& params, bool fHelp)
 
         height = pindex->nHeight;
         timestamp = pindex->nTime;
-        research_reward_amount = pindex->nResearchSubsidy;
+        research_reward_amount = pindex->ResearchSubsidy();
         confirmations = stake_tx->GetDepthInMainChain();
     }
 
@@ -300,13 +300,13 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
     };
 
     for (; pindex; pindex = pindex->pnext) {
-        if (pindex->nResearchSubsidy > 0 && pindex->GetMiningId() == *cpid) {
+        if (pindex->ResearchSubsidy() > 0 && pindex->GetMiningId() == *cpid) {
             tally_accrual_period(
                 "stake",
                 pindex->nHeight,
                 pindex_low->nTime,
                 pindex->nTime,
-                pindex->nResearchSubsidy);
+                pindex->ResearchSubsidy());
 
             accrual = 0;
             pindex_low = pindex;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -57,10 +57,10 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
     res.push_back(std::make_pair(_("CPID"), claim.m_mining_id.ToString()));
     res.push_back(std::make_pair(_("Interest"), FormatMoney(claim.m_block_subsidy)));
 
-    if (pindex->nMagnitude > 0)
+    if (pindex->Magnitude() > 0)
     {
         res.push_back(std::make_pair(_("Boinc Reward"), FormatMoney(claim.m_research_subsidy)));
-        res.push_back(std::make_pair(_("Magnitude"), RoundToString(pindex->nMagnitude, 8)));
+        res.push_back(std::make_pair(_("Magnitude"), RoundToString(pindex->Magnitude(), 8)));
     }
 
     res.push_back(std::make_pair(_("Fees Collected"), FormatMoney(GetFeesCollected(block))));

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -300,7 +300,7 @@ static CBlockIndex *InsertBlockIndex(const uint256& hash)
         return (*mi).second;
 
     // Create new
-    CBlockIndex* pindexNew = new CBlockIndex();
+    CBlockIndex* pindexNew = GRC::BlockIndexPool::GetNextBlockIndex();
     if (!pindexNew)
         throw runtime_error("LoadBlockIndex() : new CBlockIndex failed");
     mi = mapBlockIndex.insert(make_pair(hash, pindexNew)).first;

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -370,11 +370,8 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nBits          = diskindex.nBits;
         pindexNew->nNonce         = diskindex.nNonce;
 
-        //9-26-2016 - Gridcoin - New Accrual Fields
-        pindexNew->cpid              = diskindex.cpid;
-        pindexNew->nResearchSubsidy  = diskindex.nResearchSubsidy;
         pindexNew->nInterestSubsidy  = diskindex.nInterestSubsidy;
-        pindexNew->nMagnitude        = diskindex.nMagnitude;
+        pindexNew->m_researcher = diskindex.m_researcher;
 
         nBlockCount++;
         // Watch for genesis block

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2726,7 +2726,7 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
     // Basic CoinStake Support
     if (wallettx.vout.size() == 2)
     {
-        if (blkindex->nResearchSubsidy == 0)
+        if (blkindex->ResearchSubsidy() == 0)
             return MinedType::POS;
 
         else
@@ -2744,7 +2744,7 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
         // output 1, it is a split stake return from my stake.
         if (fIsCoinStakeMine && wallettx.vout[vout].scriptPubKey == wallettx.vout[1].scriptPubKey)
         {
-            if (blkindex->nResearchSubsidy == 0)
+            if (blkindex->ResearchSubsidy() == 0)
                 return MinedType::POS;
 
             else
@@ -2758,9 +2758,8 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
                 // ... you can sidestake back to yourself...
                 if (fIsOutputMine)
                 {
-                    if (blkindex->nResearchSubsidy == 0)
+                    if (blkindex->ResearchSubsidy() == 0)
                         return MinedType::POS_SIDE_STAKE_RCV;
-
                     else
                         return MinedType::POR_SIDE_STAKE_RCV;
                 }
@@ -2768,9 +2767,8 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
                 // sidestake sent to someone else.
                 else
                 {
-                    if (blkindex->nResearchSubsidy == 0)
+                    if (blkindex->ResearchSubsidy() == 0)
                         return MinedType::POS_SIDE_STAKE_SEND;
-
                     else
                         return MinedType::POR_SIDE_STAKE_SEND;
                 }
@@ -2782,7 +2780,7 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
                 // received sidestake from the staker.
                 if (fIsOutputMine)
                 {
-                    if (blkindex->nResearchSubsidy == 0)
+                    if (blkindex->ResearchSubsidy() == 0)
                         return MinedType::POS_SIDE_STAKE_RCV;
 
                     else


### PR DESCRIPTION
This is part of a series of changes that optimize the memory usage of Gridcoin's block index. According to Valgrind's heap profiler (Massif), these changes will decrease memory usage of the application by over 500 MB after the final PR merges. Because these optimizations apply to every block, memory savings will continue to accrue as the chain grows. I'm breaking-up the commits into separate PRs because the branch has become too unwieldy to review in one submission.

---

This includes two optimizations that reduce the allocated memory overhead of the block index:

  - Removal of researcher information for blocks without research rewards
  - Allocation of block index objects in batches

By allocating memory for researcher-related fields only for blocks that claim research rewards, we add 8 bytes of overhead on 64-bit systems for researcher blocks, but we save 24 bytes per non-research block. Researchers only produce about 25% of the blocks on mainnet so this change reduces memory usage by dozens of MB.

I also changed the allocation strategy for block index objects to use a pool that pre-allocates these instances in batches. The default allocator implementations likely add at least 8-16 bytes of overhead _per dynamic allocation_ to track the regions of allocated memory on 64-bit platforms and may reserve more memory than requested. When we allocate objects in large chunks, we minimize that administrative state because the allocator tracks only the chunk instead of the memory for individual instances. 

Memory allocation for the block index's `std::unordered_map` suffers from the same problem, but changing that data structure is much more involved. We may address this in the future.