### PR TITLE
refactor: [Memory optimization] Remove block index subsidy fields

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2102,7 +2102,6 @@ bool GridcoinConnectBlock(
     }
 
     pindex->SetResearcherContext(claim.m_mining_id, claim.m_research_subsidy, magnitude);
-    pindex->nInterestSubsidy = claim.m_block_subsidy;
 
     GRC::Tally::RecordRewardBlock(pindex);
     GRC::Researcher::Refresh();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2264,7 +2264,6 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
         return false;
     }
 
-    pindex->nMint = nValueOut - nValueIn + nFees;
     pindex->nMoneySupply = ReturnCurrentMoneySupply(pindex) + nValueOut - nValueIn;
 
     if (!txdb.WriteBlockIndex(CDiskBlockIndex(pindex)))
@@ -3540,14 +3539,13 @@ void PrintBlockTree()
         // print item
         CBlock block;
         block.ReadFromDisk(pindex);
-        LogPrintf("%d (%u,%u) %s  %08x  %s  mint %7s  tx %" PRIszu "",
+        LogPrintf("%d (%u,%u) %s  %08x  %s  tx %" PRIszu "",
             pindex->nHeight,
             pindex->nFile,
             pindex->nBlockPos,
             block.GetHash(true).ToString().c_str(),
             block.nBits,
             DateTimeStrFormat("%x %H:%M:%S", block.GetBlockTime()).c_str(),
-            FormatMoney(pindex->nMint).c_str(),
             block.vtx.size());
 
         PrintWallets(block);

--- a/src/main.h
+++ b/src/main.h
@@ -1302,10 +1302,7 @@ public:
     unsigned int nBlockPos;
     arith_uint256 nChainTrust; // ppcoin: trust score of block chain
     int nHeight;
-
     int64_t nMoneySupply;
-    int64_t nInterestSubsidy;
-
     GRC::ResearcherContext* m_researcher;
 
     unsigned int nFlags;  // ppcoin: block index flags
@@ -1375,7 +1372,6 @@ public:
         nBits          = 0;
         nNonce         = 0;
 
-        nInterestSubsidy = 0;
         m_researcher = nullptr;
     }
 
@@ -1613,6 +1609,8 @@ public:
         READWRITE(nFile);
         READWRITE(nBlockPos);
         READWRITE(nHeight);
+        int64_t nMint = 0; // removed
+        READWRITE(nMint);
         READWRITE(nMoneySupply);
         READWRITE(nFlags);
         READWRITE(nStakeModifier);
@@ -1640,7 +1638,7 @@ public:
         //7-11-2015 - Gridcoin - New Accrual Fields (Note, Removing the deterministic block number to make this happen all the time):
         std::string cpid_hex = GetMiningId().ToString();
         double research_subsidy_grc = ResearchSubsidy() / (double)COIN;
-        double interest_subsidy_grc = nInterestSubsidy / (double)COIN;
+        double interest_subsidy_grc = 0; // removed
         double magnitude = Magnitude();
 
         READWRITE(cpid_hex);
@@ -1673,8 +1671,6 @@ public:
                 GRC::MiningId::Parse(cpid_hex),
                 research_subsidy_grc * COIN,
                 magnitude);
-
-            nInterestSubsidy = interest_subsidy_grc * COIN;
 
             if (is_superblock == 1) {
                 NCONST_PTR(this)->MarkAsSuperblock();

--- a/src/main.h
+++ b/src/main.h
@@ -1033,6 +1033,19 @@ private:
     }
 };
 
+namespace GRC {
+//!
+//! \brief A report that contains the calculated subsidy claimed in a block.
+//! Produced by the CBlock::GetMint() method.
+//!
+class MintSummary
+{
+public:
+    CAmount m_total = 0; //!< Total value claimed by the block producer.
+    CAmount m_fees = 0;  //!< Fees paid for the block's transactions.
+};
+}
+
 class CBlock : public CBlockHeader
 {
 public:
@@ -1103,6 +1116,7 @@ public:
     GRC::Claim PullClaim();
     GRC::SuperblockPtr GetSuperblock() const;
     GRC::SuperblockPtr GetSuperblock(const CBlockIndex* const pindex) const;
+    GRC::MintSummary GetMint() const;
 
     // entropy bit for stake modifier if chosen by modifier
     unsigned int GetStakeEntropyBit() const
@@ -1888,6 +1902,4 @@ public:
 };
 
 extern CTxMemPool mempool;
-
-int64_t GetFeesCollected(const CBlock& block);
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -1303,7 +1303,6 @@ public:
     arith_uint256 nChainTrust; // ppcoin: trust score of block chain
     int nHeight;
 
-    int64_t nMint;
     int64_t nMoneySupply;
     int64_t nInterestSubsidy;
 
@@ -1365,7 +1364,6 @@ public:
         nBlockPos = 0;
         nHeight = 0;
         nChainTrust = 0;
-        nMint = 0;
         nMoneySupply = 0;
         nFlags = EMPTY_CPID;
         nStakeModifier = 0;
@@ -1561,9 +1559,9 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("CBlockIndex(nprev=%p, pnext=%p, nFile=%u, nBlockPos=%-6d nHeight=%d, nMint=%s, nMoneySupply=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016" PRIx64 ", hashProof=%s, merkle=%s, hashBlock=%s)",
+        return strprintf("CBlockIndex(nprev=%p, pnext=%p, nFile=%u, nBlockPos=%-6d nHeight=%d, nMoneySupply=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016" PRIx64 ", hashProof=%s, merkle=%s, hashBlock=%s)",
             pprev, pnext, nFile, nBlockPos, nHeight,
-            FormatMoney(nMint), FormatMoney(nMoneySupply),
+            FormatMoney(nMoneySupply),
             GeneratedStakeModifier() ? "MOD" : "-", GetStakeEntropyBit(), IsProofOfStake()? "PoS" : "PoW",
             nStakeModifier,
             hashProof.ToString(),
@@ -1615,7 +1613,6 @@ public:
         READWRITE(nFile);
         READWRITE(nBlockPos);
         READWRITE(nHeight);
-        READWRITE(nMint);
         READWRITE(nMoneySupply);
         READWRITE(nFlags);
         READWRITE(nStakeModifier);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -135,7 +135,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
     result.pushKV("height", blockindex->nHeight);
     result.pushKV("version", block.nVersion);
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
-    result.pushKV("mint", ValueFromAmount(blockindex->nMint));
+    result.pushKV("mint", ValueFromAmount(mint.m_total));
     result.pushKV("MoneySupply", ValueFromAmount(blockindex->nMoneySupply));
     result.pushKV("time", block.GetBlockTime());
     result.pushKV("nonce", (uint64_t)block.nNonce);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -1458,14 +1458,12 @@ UniValue network(const UniValue& params, bool fHelp)
     const double money_supply = pindexBest->nMoneySupply;
     const GRC::SuperblockPtr superblock = GRC::Quorum::CurrentSuperblock();
 
-    int64_t two_week_block_subsidy = 0;
     int64_t two_week_research_subsidy = 0;
 
     for (const CBlockIndex* pindex = pindexBest;
         pindex && pindex->nTime > two_weeks_ago;
         pindex = pindex->pprev)
     {
-        two_week_block_subsidy += pindex->nInterestSubsidy;
         two_week_research_subsidy += pindex->ResearchSubsidy();
     }
 
@@ -1475,12 +1473,7 @@ UniValue network(const UniValue& params, bool fHelp)
     res.pushKV("research_paid_two_weeks", ValueFromAmount(two_week_research_subsidy));
     res.pushKV("research_paid_daily_average", ValueFromAmount(two_week_research_subsidy / 14));
     res.pushKV("research_paid_daily_limit", ValueFromAmount(GRC::Tally::MaxEmission(now)));
-    res.pushKV("stake_paid_two_weeks", ValueFromAmount(two_week_block_subsidy));
-    res.pushKV("stake_paid_daily_average", ValueFromAmount(two_week_block_subsidy / 14));
     res.pushKV("total_money_supply", ValueFromAmount(money_supply));
-    res.pushKV("network_interest_percent", money_supply > 0
-        ? (two_week_block_subsidy / 14) * 365 / money_supply
-        : 0);
 
     return res;
 }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -125,6 +125,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
 
     result.pushKV("hash", block.GetHash().GetHex());
 
+    const GRC::MintSummary mint = block.GetMint();
+
     CMerkleTx txGen(block.vtx[0]);
     txGen.SetMerkleBranch(&block);
 
@@ -192,7 +194,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
         result.pushKV("superblock", SuperblockToJson(block.GetSuperblock()));
     }
 
-    result.pushKV("fees_collected", ValueFromAmount(GetFeesCollected(block)));
+    result.pushKV("fees_collected", ValueFromAmount(mint.m_fees));
     result.pushKV("IsSuperBlock", blockindex->IsSuperblock());
     result.pushKV("IsContract", blockindex->IsContract());
 

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -105,6 +105,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
     int64_t researchtotal = 0;
     int64_t interesttotal = 0;
     int64_t minttotal = 0;
+    int64_t feetotal = 0;
     int64_t poscount = 0;
     int64_t emptyblockscount = 0;
     int64_t l_first = std::numeric_limits<int>::max();
@@ -181,6 +182,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
         interesttotal += claim.m_block_subsidy;
         researchcount += claim.HasResearchReward();
         minttotal += mint.m_total;
+        feetotal += mint.m_fees;
         unsigned sizeblock = GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
         size_min_blk = std::min(size_min_blk,sizeblock);
         size_max_blk = std::max(size_max_blk,sizeblock);
@@ -243,6 +245,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
         result.pushKV("research", ValueFromAmount(researchtotal));
         result.pushKV("interest", ValueFromAmount(interesttotal));
         result.pushKV("mint", ValueFromAmount(minttotal));
+        result.pushKV("fees", ValueFromAmount(feetotal));
         result.pushKV("blocksizek", size_sum_blk / (double) 1024);
         result.pushKV("posdiff", diff_sum);
         result1.pushKV("totals", result);
@@ -258,6 +261,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
         result.pushKV("research", ValueFromAmount(research_average));
         result.pushKV("interest", ValueFromAmount(interesttotal / blockcount));
         result.pushKV("mint", ValueFromAmount(minttotal / blockcount));
+        result.pushKV("fees", ValueFromAmount(feetotal / blockcount));
 
         double spacing_sec = (l_last_time - l_first_time) / (double) (blockcount - 1);
         result.pushKV("spacing_sec", spacing_sec);

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -754,8 +754,7 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             if(detail>=2 && detail<20)
             {
                 line+="<|>"+cur->GetMiningId().ToString()
-                    + "<|>"+FormatMoney(cur->ResearchSubsidy())
-                    + "<|>"+FormatMoney(cur->nInterestSubsidy);
+                    + "<|>"+FormatMoney(cur->ResearchSubsidy());
             }
         }
         else
@@ -768,7 +767,6 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             result2.pushKV("ismodifier", cur->GeneratedStakeModifier());
             result2.pushKV("cpid", cur->GetMiningId().ToString() );
             result2.pushKV("research", ValueFromAmount(cur->ResearchSubsidy()));
-            result2.pushKV("interest", ValueFromAmount(cur->nInterestSubsidy));
             result2.pushKV("magnitude", cur->Magnitude());
         }
 
@@ -796,6 +794,7 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             }
             else
             {
+                result2.pushKV("interest", ValueFromAmount(claim.m_block_subsidy));
                 result2.pushKV("organization", claim.m_organization);
                 result2.pushKV("cversion", claim.m_client_version);
                 result2.pushKV("quorum_hash", claim.m_quorum_hash.ToString());

--- a/src/rpcdataacq.cpp
+++ b/src/rpcdataacq.cpp
@@ -168,6 +168,8 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
             }
         }
 
+        const GRC::MintSummary mint = block.GetMint();
+
         transactioncount += txcountinblock;
         emptyblockscount += (txcountinblock == 0);
         c_blockversion[block.nVersion]++;
@@ -178,7 +180,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
         researchtotal += claim.m_research_subsidy;
         interesttotal += claim.m_block_subsidy;
         researchcount += claim.HasResearchReward();
-        minttotal += cur->nMint;
+        minttotal += mint.m_total;
         unsigned sizeblock = GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
         size_min_blk = std::min(size_min_blk,sizeblock);
         size_max_blk = std::max(size_max_blk,sizeblock);

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -50,6 +50,7 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
     }
 
     const GRC::Claim& claim = block.GetClaim();
+    const GRC::MintSummary mint = block.GetMint();
 
     res.push_back(std::make_pair(_("Height"), ToString(pindex->nHeight)));
     res.push_back(std::make_pair(_("Block Version"), ToString(block.nVersion)));
@@ -63,7 +64,7 @@ std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const C
         res.push_back(std::make_pair(_("Magnitude"), RoundToString(pindex->Magnitude(), 8)));
     }
 
-    res.push_back(std::make_pair(_("Fees Collected"), FormatMoney(GetFeesCollected(block))));
+    res.push_back(std::make_pair(_("Fees Collected"), FormatMoney(mint.m_fees)));
     res.push_back(std::make_pair(_("Is Superblock"), (claim.ContainsSuperblock() ? "Yes" : "No")));
 
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -359,7 +359,6 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nFile          = diskindex.nFile;
         pindexNew->nBlockPos      = diskindex.nBlockPos;
         pindexNew->nHeight        = diskindex.nHeight;
-        pindexNew->nMint          = diskindex.nMint;
         pindexNew->nMoneySupply   = diskindex.nMoneySupply;
         pindexNew->nFlags         = diskindex.nFlags;
         pindexNew->nStakeModifier = diskindex.nStakeModifier;

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -368,9 +368,7 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nTime          = diskindex.nTime;
         pindexNew->nBits          = diskindex.nBits;
         pindexNew->nNonce         = diskindex.nNonce;
-
-        pindexNew->nInterestSubsidy  = diskindex.nInterestSubsidy;
-        pindexNew->m_researcher = diskindex.m_researcher;
+        pindexNew->m_researcher   = diskindex.m_researcher;
 
         nBlockCount++;
         // Watch for genesis block


### PR DESCRIPTION
This is part of a series of changes that optimize the memory usage of Gridcoin's block index. According to Valgrind's heap profiler (Massif), these changes will decrease memory usage of the application by over 500 MB after the final PR merges. Because these optimizations apply to every block, memory savings will continue to accrue as the chain grows. I'm breaking-up the commits into separate PRs because the branch has become too unwieldy to review in one submission.

---

This removes the `nMint` and `nInterestSubsidy` fields from the block index to save 16 bytes of memory per block. 

These fields were only used for reporting. I expanded the `GetFeesCollected()` function into a `GetMint()` method on `CBlock` that also returns the total reward amount. The method provides a way to retrieve the information on demand so that we don't need to store it in the block index. Since the `getblockstats` RPC function uses this implementation now, I added fee information to the output. 

We cannot remove the `nResearchSubsidy` field at this time, but it may become possible after updating the tally to support MRC.