### PR TITLE
refactor: [Memory optimization] Separate chain trust from the block index

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -103,6 +103,7 @@ GRIDCOIN_CORE_H = \
     gridcoin/scraper/http.h \
     gridcoin/scraper/scraper.h \
     gridcoin/scraper/scraper_net.h \
+    gridcoin/staking/chain_trust.h \
     gridcoin/staking/difficulty.h \
     gridcoin/staking/exceptions.h \
     gridcoin/staking/kernel.h \

--- a/src/gridcoin/staking/chain_trust.h
+++ b/src/gridcoin/staking/chain_trust.h
@@ -1,0 +1,360 @@
+// Copyright (c) 2014-2020 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "arith_uint256.h"
+
+#include <array>
+#include <vector>
+
+namespace GRC {
+//!
+//! \brief Calculates and stores chain trust values.
+//!
+//! Chain trust is a metric that represents the difficulty sum of a chain. We
+//! calculate it for a particular block by adding that block's own difficulty
+//! value to the total difficulty of all the blocks below it. The trust value
+//! of a chain protects against some attack types by enabling nodes to select
+//! the chain that required the most effort to produce. For Gridcoin, this is
+//! the chain with the greatest amount of staked coins over time. A node will
+//! reorganize to a competing chain only if the fork exhibits a greater chain
+//! trust value.
+//!
+//! This class caches chain trust values to determine when a block produces a
+//! chain with greater trust. It replaces the chain trust fields in the block
+//! index to conserve memory.
+//!
+class ChainTrustCache
+{
+public:
+    ChainTrustCache()
+        : m_best_pindex(new CBlockIndex()) // Genesis bootstrap placeholder
+    {
+    }
+
+    //!
+    //! \brief Fill the cache from the block index and calculate the trust of
+    //! the best chain.
+    //!
+    //! \param genesis Blockchain index for the genesis block.
+    //! \param tip     Blockchain index for the highest known block.
+    //!
+    void Initialize(const CBlockIndex* genesis, const CBlockIndex* tip)
+    {
+        int64_t start_time = GetTimeMillis();
+
+        if (m_best_pindex->phashBlock == nullptr) {
+            delete m_best_pindex; // Free genesis bootstrap placeholder
+        }
+
+        m_best_pindex = tip;
+        m_best_trust = 0;
+        m_long_cache.Reserve(tip);
+
+        for (const CBlockIndex* pindex = genesis; pindex; pindex = pindex->pnext) {
+            m_best_trust += pindex->GetBlockTrust();
+
+            if (m_long_cache.Expects(pindex)) {
+                m_long_cache.Push(m_best_trust);
+            }
+        }
+
+        LogPrintf(
+            "Gridcoin: Time to calculate chain trust %15" PRId64 "ms",
+            GetTimeMillis() - start_time);
+    }
+
+    //!
+    //! \brief Get the chain trust value of the current chain.
+    //!
+    //! \return Chain trust value at the current best block.
+    //!
+    arith_uint256 Best() const
+    {
+        return m_best_trust;
+    }
+
+    //!
+    //! \brief Determine whether a block exhibits greater chain trust than the
+    //! current best.
+    //!
+    //! \param pindex Points to the block index entry to compare.
+    //!
+    //! \return \c true if the specified block exhibits greater chain trust.
+    //!
+    bool Favors(const CBlockIndex* pindex) const
+    {
+        return GetTrust(pindex) > Best();
+    }
+
+    //!
+    //! \brief Calculate the chain trust value of the specified block.
+    //!
+    //! \param pindex Points to the block index entry to calculate trust for.
+    //!
+    //! \return Chain trust value for the specified block.
+    //!
+    arith_uint256 GetTrust(const CBlockIndex* pindex) const
+    {
+        arith_uint256 chain_trust;
+
+        if (pindex == nullptr) {
+            return chain_trust;
+        }
+
+        // First, look for a cached chain trust value near the chain tip:
+        //
+        if (pindex->nHeight >= m_best_pindex->nHeight
+            || m_short_cache.MightContain(pindex))
+        {
+            for (; pindex != nullptr; pindex = pindex->pprev) {
+                if (pindex == m_best_pindex) {
+                    return chain_trust + m_best_trust;
+                } else if (const auto trust_option = m_short_cache.Try(pindex)) {
+                    return chain_trust + *trust_option;
+                }
+
+                chain_trust += pindex->GetBlockTrust();
+            }
+        }
+
+        // Otherwise, calculate chain trust up to one of the cached snapshots:
+        //
+        for (; pindex != nullptr; pindex = pindex->pprev) {
+            if (m_long_cache.Expects(pindex)) {
+                return chain_trust + m_long_cache.Fetch(pindex);
+            }
+
+            chain_trust += pindex->GetBlockTrust();
+        }
+
+        return chain_trust;
+    }
+
+    //!
+    //! \brief Remember the specified block as the tip of the best chain.
+    //!
+    //! \param pindex Points to the block index entry selected as the tip of
+    //! the chain.
+    //!
+    void SetBest(const CBlockIndex* pindex)
+    {
+        m_best_trust = pindex->GetBlockTrust() + GetTrust(pindex->pprev);
+        m_best_pindex = pindex;
+
+        if (m_long_cache.Expects(pindex)) {
+            m_long_cache.Store(pindex, m_best_trust);
+        } else {
+            m_short_cache.Store(pindex, m_best_trust);
+        }
+    }
+
+private:
+    //!
+    //! \brief A circular buffer that caches chain trust values for blocks
+    //! recently-connected to the chain.
+    //!
+    //! This cache speeds up access to chain trust values for rapid changes to
+    //! the blocks at the chain tip. It retains the chain trust for forks that
+    //! occur to reduce the overhead of trust calculation triggered by a chain
+    //! reorganization.
+    //!
+    class ShortTrustCache
+    {
+        //!
+        //! \brief Number of entries to store in the cache.
+        //!
+        static constexpr size_t SIZE = 32;
+
+    public:
+        //!
+        //! \brief Determine whether the cache may contain the specified block.
+        //!
+        //! \param pindex Points the block index entry to check.
+        //!
+        //! \return \c true if the block height falls within the cached range.
+        //!
+        bool MightContain(const CBlockIndex* const pindex) const
+        {
+            for (const auto& slot : m_index_cache) {
+                if (slot != nullptr && slot->nHeight <= pindex->nHeight) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        //!
+        //! \brief Get the cached chain trust value for the specified block if
+        //! it exists in the cache.
+        //!
+        //! \param pindex Points to the block index entry to fetch trust for.
+        //!
+        //! \return Either contains a trust value for the block or does not.
+        //!
+        boost::optional<arith_uint256> Try(const CBlockIndex* const pindex) const
+        {
+            for (size_t i = 0; i < SIZE; ++i) {
+                if (m_index_cache[i] == pindex) {
+                    return m_trust_cache[i];
+                }
+            }
+
+            return boost::none;
+        }
+
+        //!
+        //! \brief Store a trust value in the cache.
+        //!
+        //! \param pindex Points to the block index entry of the trust value.
+        //! \param trust  Chain trust value to associate with the block.
+        //!
+        void Store(const CBlockIndex* const pindex, const arith_uint256 trust)
+        {
+            const size_t offset = m_position % SIZE;
+
+            m_index_cache[offset] = pindex;
+            m_trust_cache[offset] = trust;
+
+            ++m_position;
+        }
+
+    private:
+        //!
+        //! \brief Circular buffer that stores block index entries of the chain
+        //! trust values in the cache.
+        //!
+        //! Since we scan the block index entries far more than we access the
+        //! trust values, the cache splits storage into two arrays to improve
+        //! CPU cache friendliness somewhat.
+        //!
+        std::array<const CBlockIndex*, SIZE> m_index_cache;
+
+        //!
+        //! \brief Circular buffer that stores chain trust values in the cache.
+        //!
+        std::array<arith_uint256, SIZE> m_trust_cache;
+
+        size_t m_position = 0; //!< Circular buffer counter
+    }; // ShortTrustCache
+
+    //!
+    //! \brief A persistent cache of historical chain trust snapshots created
+    //! at regular intervals in the blockchain.
+    //!
+    //! This cache reduces the effort needed to calculate the chain trust for
+    //! historical blocks by providing the aggregated trust for points in the
+    //! chain. A trust calculation can start with one of these points instead
+    //! of scanning the entire chain.
+    //!
+    class LongTrustCache
+    {
+        //!
+        //! \brief Height interval to store chain trust snapshots at.
+        //!
+        //! TODO: make this configurable for users and services that want a
+        //! more dense cache to improve "getblock" RPC performance.
+        //!
+        static constexpr size_t LONG_CACHE_INTERVAL = 10000;
+
+    public:
+        //!
+        //! \brief Determine whether the cache stores a chain trust snapshot
+        //! for the specified block.
+        //!
+        //! \param pindex Points to the block index entry to check.
+        //!
+        //! \return \c true if the block height matches the cache interval.
+        //!
+        bool Expects(const CBlockIndex* const pindex) const
+        {
+            return pindex->nHeight % LONG_CACHE_INTERVAL == 0;
+        }
+
+        //!
+        //! \brief Get the cached chain trust value for the specified block.
+        //!
+        //! \param pindex Points to a block index entry for an interval height.
+        //!
+        //! \return Chain trust value for the block.
+        //!
+        arith_uint256 Fetch(const CBlockIndex* const pindex) const
+        {
+            return m_cache[GetOffset(pindex)];
+        }
+
+        //!
+        //! \brief Store a trust value in the cache.
+        //!
+        //! \param pindex Points to the block index entry of the trust value.
+        //! \param trust  Chain trust value to associate with the block.
+        //!
+        void Store(const CBlockIndex* const pindex, const arith_uint256 trust)
+        {
+            const size_t offset = GetOffset(pindex);
+
+            if (offset >= m_cache.size()) {
+                assert(offset == m_cache.size());
+                Reserve(pindex); // Just grow by 1. This doesn't happen often.
+                Push(trust);
+            } else {
+                m_cache[offset] = trust;
+
+                // Invalidate cached snapshots greater than this height:
+                m_cache.erase(m_cache.begin() + offset + 1, m_cache.end());
+            }
+        }
+
+        //!
+        //! \brief Reallocate storage for the cache if needed.
+        //!
+        //! \param pindex The height that determines the size of the cache.
+        //!
+        void Reserve(const CBlockIndex* const pindex)
+        {
+            m_cache.reserve(GetOffset(pindex) + 1);
+        }
+
+        //!
+        //! \brief Append a chain trust value directly to the end of the cache.
+        //!
+        //! \param trust Chain trust value for the block height at the tip of
+        //! the cache.
+        //!
+        void Push(const arith_uint256 trust)
+        {
+            m_cache.emplace_back(trust);
+        }
+
+    private:
+        //!
+        //! \brief Get the cache offset for the height of the specified block.
+        //!
+        //! \param pindex Block index entry with a height to map to an offset.
+        //!
+        //! \return Offset to store a trust value at for the specified block.
+        //!
+        static size_t GetOffset(const CBlockIndex* const pindex)
+        {
+            return pindex->nHeight / LONG_CACHE_INTERVAL;
+        }
+
+        //!
+        //! \brief Maps block heights to cached chain trust values.
+        //!
+        //! This stores chain trust values only for blocks that occur at each
+        //! height interval. We scale the height by the interval to determine
+        //! the offset in the container.
+        //!
+        std::vector<arith_uint256> m_cache;
+    }; // LongTrustCache
+
+    const CBlockIndex* m_best_pindex; //!< Block index entry for the chain tip.
+    arith_uint256 m_best_trust;       //!< Chain trust value for the chain tip.
+    ShortTrustCache m_short_cache;    //!< Caches chain trust at the chain tip.
+    LongTrustCache m_long_cache;      //!< Caches chain trust at height intervals.
+}; // ChainTrustCache
+} // namespace GRC

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3059,12 +3059,17 @@ bool CBlock::AcceptBlock(bool generated_by_me)
 
 arith_uint256 CBlockIndex::GetBlockTrust() const
 {
-    CBigNum bnTarget;
-    bnTarget.SetCompact(nBits);
-    if (bnTarget <= 0) return 0;
-    int64_t block_mag = 0;
-    uint256 chaintrust = (((CBigNum(1)<<256) / (bnTarget+1)) - (block_mag)).getuint256();
-    return UintToArith256(chaintrust);
+    arith_uint256 bnTarget;
+    bool fNegative;
+    bool fOverflow;
+    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
+    if (fNegative || fOverflow || bnTarget == 0)
+        return 0;
+    // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256
+    // as it's too large for an arith_uint256. However, as 2**256 is at least as large
+    // as bnTarget+1, it is equal to ((2**256 - bnTarget - 1) / (bnTarget+1)) + 1,
+    // or ~bnTarget / (bnTarget+1) + 1.
+    return (~bnTarget / (bnTarget + 1)) + 1;
 }
 
 bool GridcoinServices()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,6 @@ CBlockIndex* pindexGenesisBlock = NULL;
 int nBestHeight = -1;
 
 arith_uint256 nBestChainTrust = 0;
-arith_uint256 nBestInvalidTrust = 0;
 uint256 hashBestChain;
 CBlockIndex* pindexBest = NULL;
 std::atomic<int64_t> g_previous_block_time;
@@ -1260,13 +1259,6 @@ bool IsInitialBlockDownload()
 
 void static InvalidChainFound(CBlockIndex* pindexNew)
 {
-    if (pindexNew->nChainTrust > nBestInvalidTrust)
-    {
-        nBestInvalidTrust = pindexNew->nChainTrust;
-        CTxDB().WriteBestInvalidTrust(CBigNum(ArithToUint256(nBestInvalidTrust)));
-        uiInterface.NotifyBlocksChanged();
-    }
-
     arith_uint256 nBestInvalidBlockTrust = pindexNew->nChainTrust - pindexNew->pprev->nChainTrust;
     arith_uint256 nBestBlockTrust = pindexBest->nHeight != 0
         ? (pindexBest->nChainTrust - pindexBest->pprev->nChainTrust)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2513,7 +2513,6 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
         }
 
         uint256 hash = block.GetHash(true);
-        arith_uint256 nBestBlockTrust;
 
         LogPrint(BCLog::LogFlags::VERBOSE, "ReorganizeChain: connect %s",hash.ToString());
 
@@ -2565,10 +2564,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
         {
             assert( !pindex->pprev->pnext );
             pindex->pprev->pnext = pindex;
-            nBestBlockTrust = pindex->nChainTrust - pindex->pprev->nChainTrust;
         }
-        else
-            nBestBlockTrust = pindex->nChainTrust;
 
         // update best block
         hashBestChain = hash;

--- a/src/main.h
+++ b/src/main.h
@@ -78,7 +78,6 @@ extern unsigned int nNodeLifespan;
 extern int nCoinbaseMaturity;
 extern int nBestHeight;
 extern arith_uint256 nBestChainTrust;
-extern arith_uint256 nBestInvalidTrust;
 extern uint256 hashBestChain;
 extern CBlockIndex* pindexBest;
 extern const std::string strMessageMagic;

--- a/src/main.h
+++ b/src/main.h
@@ -1299,7 +1299,6 @@ public:
     CBlockIndex* pnext;
     unsigned int nFile;
     unsigned int nBlockPos;
-    arith_uint256 nChainTrust; // ppcoin: trust score of block chain
     int nHeight;
     int64_t nMoneySupply;
     GRC::ResearcherContext* m_researcher;
@@ -1359,7 +1358,6 @@ public:
         nFile = 0;
         nBlockPos = 0;
         nHeight = 0;
-        nChainTrust = 0;
         nMoneySupply = 0;
         nFlags = EMPTY_CPID;
         nStakeModifier = 0;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -37,12 +37,10 @@ bool ForceReorganizeToHash(uint256 NewHash);
 extern UniValue MagnitudeReport(const GRC::Cpid cpid);
 extern UniValue SuperblockReport(int lookback = 14, bool displaycontract = false, std::string cpid = "");
 extern GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
-
 extern ScraperPendingBeaconMap GetPendingBeaconsForReport();
 extern ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = false);
-
 extern UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version);
-
+arith_uint256 GetChainTrust(const CBlockIndex* pindex);
 double CoinToDouble(double surrogate);
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 UniValue ContractToJson(const GRC::Contract& contract);
@@ -142,7 +140,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
     result.pushKV("bits", strprintf("%08x", block.nBits));
     result.pushKV("difficulty", GRC::GetDifficulty(blockindex));
     result.pushKV("blocktrust", leftTrim(blockindex->GetBlockTrust().GetHex(), '0'));
-    result.pushKV("chaintrust", leftTrim(blockindex->nChainTrust.GetHex(), '0'));
+    result.pushKV("chaintrust", leftTrim(GetChainTrust(blockindex).GetHex(), '0'));
 
     if (blockindex->pprev)
         result.pushKV("previousblockhash", blockindex->pprev->GetBlockHash().GetHex());

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -267,16 +267,6 @@ bool CTxDB::WriteHashBestChain(uint256 hashBestChain)
     return Write(string("hashBestChain"), hashBestChain);
 }
 
-bool CTxDB::ReadBestInvalidTrust(CBigNum& bnBestInvalidTrust)
-{
-    return Read(string("bnBestInvalidTrust"), bnBestInvalidTrust);
-}
-
-bool CTxDB::WriteBestInvalidTrust(CBigNum bnBestInvalidTrust)
-{
-    return Write(string("bnBestInvalidTrust"), bnBestInvalidTrust);
-}
-
 bool CTxDB::ReadGenericData(std::string KeyName, std::string& strValue)
 {
     return Read(string(KeyName.c_str()), strValue);
@@ -438,10 +428,6 @@ bool CTxDB::LoadBlockIndex()
       CBigNum(ArithToUint256(nBestChainTrust)).ToString(),
       DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()));
 
-    // Load bnBestInvalidTrust, OK if it doesn't exist
-    CBigNum bnBestInvalidTrust;
-    ReadBestInvalidTrust(bnBestInvalidTrust);
-    nBestInvalidTrust = UintToArith256(bnBestInvalidTrust.getuint256());
     nLoaded = 0;
     // Verify blocks in the best chain
     int nCheckLevel = GetArg("-checklevel", 1);

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -386,29 +386,6 @@ bool CTxDB::LoadBlockIndex()
     nStart = GetTimeMillis();
 
 
-    if (fRequestShutdown)
-        return true;
-
-    // Calculate nChainTrust
-    vector<pair<int, CBlockIndex*> > vSortedByHeight;
-    vSortedByHeight.reserve(mapBlockIndex.size());
-    for (auto const& item : mapBlockIndex)
-    {
-        CBlockIndex* pindex = item.second;
-        vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
-    }
-    sort(vSortedByHeight.begin(), vSortedByHeight.end());
-    for (auto const& item : vSortedByHeight)
-    {
-        CBlockIndex* pindex = item.second;
-        pindex->nChainTrust = (pindex->pprev ? pindex->pprev->nChainTrust : 0) + pindex->GetBlockTrust();
-    }
-
-
-    LogPrintf("Time to calculate Chain Trust %15" PRId64 "ms", GetTimeMillis() - nStart);
-    nStart = GetTimeMillis();
-
-
     // Load hashBestChain pointer to end of best chain
     if (!ReadHashBestChain(hashBestChain))
     {
@@ -420,12 +397,10 @@ bool CTxDB::LoadBlockIndex()
         return error("CTxDB::LoadBlockIndex() : hashBestChain not found in the block index");
     pindexBest = mapBlockIndex[hashBestChain];
     nBestHeight = pindexBest->nHeight;
-    nBestChainTrust = pindexBest->nChainTrust;
 
-    LogPrintf("LoadBlockIndex(): hashBestChain=%s  height=%d  trust=%s  date=%s",
+    LogPrintf("LoadBlockIndex(): hashBestChain=%s  height=%d  date=%s",
       hashBestChain.ToString().substr(0,20),
       nBestHeight,
-      CBigNum(ArithToUint256(nBestChainTrust)).ToString(),
       DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()));
 
     nLoaded = 0;

--- a/src/txdb-leveldb.h
+++ b/src/txdb-leveldb.h
@@ -193,8 +193,6 @@ public:
     bool WriteBlockIndex(const CDiskBlockIndex& blockindex);
     bool ReadHashBestChain(uint256& hashBestChain);
     bool WriteHashBestChain(uint256 hashBestChain);
-    bool ReadBestInvalidTrust(CBigNum& bnBestInvalidTrust);
-    bool WriteBestInvalidTrust(CBigNum bnBestInvalidTrust);
     bool ReadSyncCheckpoint(uint256& hashCheckpoint);
     bool WriteSyncCheckpoint(uint256 hashCheckpoint);
     bool ReadCheckpointPubKey(std::string& strPubKey);


### PR DESCRIPTION
This is part of a series of changes that optimize the memory usage of Gridcoin's block index. According to Valgrind's heap profiler (Massif), these changes will decrease memory usage of the application by over 500 MB after the final PR merges. Because these optimizations apply to every block, memory savings will continue to accrue as the chain grows. I'm breaking-up the commits into separate PRs because the branch has become too unwieldy to review in one submission.

---

This replaces the chain trust state in the block index with a custom cache to save 32 bytes of memory per block. 

The cache contains two levels. The first provides quick access to trust values near the chain tip. Nodes use these values when validating new blocks. The second level stores historical chain trust values at height intervals for reporting. The trust value for a historical block can be recomputed on-demand. By tracking the historical values periodically, we can start calculating chain trust from a cached height to reduce the effort needed to reproduce it for a particular block.