### PR TITLE
refactor: [Memory optimization] Eliminate padding between block index fields

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3497,6 +3497,16 @@ bool LoadBlockIndex(bool fAllowNew)
     g_chain_trust.Initialize(pindexGenesisBlock, pindexBest);
     g_seen_stakes.Refill(pindexBest);
 
+    // Close the database after loading the block index. The next instantiation
+    // of CTxDB will reopen it.
+    //
+    // This forces LevelDB to release the pages for all the memory-mapped files
+    // read to load the block index on Linux. Although it's mostly cosmetic, it
+    // may prevent the OOM killer from eyeing the process in memory-constrained
+    // environments after the node starts.
+    //
+    txdb.Close();
+
     return true;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -1299,9 +1299,9 @@ public:
     CBlockIndex* pnext;
     unsigned int nFile;
     unsigned int nBlockPos;
-    int nHeight;
     int64_t nMoneySupply;
     GRC::ResearcherContext* m_researcher;
+    int nHeight;
 
     unsigned int nFlags;  // ppcoin: block index flags
     enum
@@ -1322,10 +1322,10 @@ public:
 
     // block header
     int nVersion;
-    uint256 hashMerkleRoot;
     unsigned int nTime;
     unsigned int nBits;
     unsigned int nNonce;
+    uint256 hashMerkleRoot;
 
     CBlockIndex()
     {


### PR DESCRIPTION
This is part of a series of changes that optimize the memory usage of Gridcoin's block index. According to Valgrind's heap profiler (Massif), these changes will decrease memory usage of the application by over 500 MB after the final PR merges. Because these optimizations apply to every block, memory savings will continue to accrue as the chain grows. I'm breaking-up the commits into separate PRs because the branch has become too unwieldy to review in one submission.

---

This reorders member fields of `CBlockIndex` to avoid extra padding added by the compiler. It saves 16 bytes per block on 64-bit platforms. 

I also include a small tweak that closes LevelDB after loading the block index to free some of the memory used to map the database files on launch. This may help to prevent the OS from killing a node during start-up when memory is tight (I encountered this when running Gridcoin on my phone). 