### PR TITLE
beacon, gui: Add check for presence of beacon private key to updateBeacon()

### DIFF
--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -176,6 +176,10 @@ std::string Beacon::GetVerificationCode() const
 
 bool Beacon::WalletHasPrivateKey(const CWallet* const wallet) const
 {
+    // We need this lock here because this function is being called from
+    // the researcher model for the GUI beacon status.
+    LOCK(wallet->cs_wallet);
+
     return wallet->HaveKey(m_public_key.GetID());
 }
 


### PR DESCRIPTION
This adds a check to ResearcherModel::updateBeacon() to ensure that the private key exists in the wallet for the registered beacon that corresponds to the CPID. Closes #1967.