### PR TITLE
voting: Fix title in "gettransaction" RPC for legacy poll contracts

### DIFF
--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -746,7 +746,8 @@ ContractPayload Contract::Body::ConvertFromLegacy(const ContractType type) const
             // stored in the CTransaction::hashBoinc field:
             assert(false && "Attempted to convert legacy message contract.");
         case ContractType::POLL:
-            return ContractPayload::Make<PollPayload>(Poll::Parse(legacy.m_value));
+            return ContractPayload::Make<PollPayload>(
+                Poll::Parse(legacy.m_key, legacy.m_value));
         case ContractType::PROJECT:
             return ContractPayload::Make<Project>(legacy.m_key, legacy.m_value, 0);
         case ContractType::PROTOCOL:

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -119,7 +119,7 @@ Poll::Poll(
 {
 }
 
-Poll Poll::Parse(const std::string& contract)
+Poll Poll::Parse(const std::string& title, const std::string& contract)
 {
     return Poll(
         PollType::SURVEY,
@@ -127,7 +127,7 @@ Poll Poll::Parse(const std::string& contract)
         // Legacy contracts only behaved as multiple-choice polls:
         PollResponseType::MULTIPLE_CHOICE,
         ParseDurationDays(ExtractXML(contract, "<DAYS>", "</DAYS>")),
-        ExtractXML(contract, "<TITLE>", "</TITLE>"),
+        title,
         ExtractXML(contract, "<URL>", "</URL>"),
         ExtractXML(contract, "<QUESTION>", "</QUESTION>"),
         ParseChoices(ExtractXML(contract, "<ANSWERS>", "</ANSWERS>")),

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -243,12 +243,13 @@ public:
     //! \brief Initialize a poll instance from a contract that contains poll
     //! data in the legacy, XML-like string format.
     //!
+    //! \param title    Poll title extracted from the legacy contract key.
     //! \param contract Contains the poll data in a legacy, serialized format.
     //!
     //! \return A poll matching the data in the contract, or an invalid poll
     //! instance if the contract is malformed.
     //!
-    static Poll Parse(const std::string& contract);
+    static Poll Parse(const std::string& title, const std::string& contract);
 
     //!
     //! \brief Determine whether a poll contains each of the required elements.


### PR DESCRIPTION
Contracts that delete legacy polls contain (practically) an empty contract value, but the poll title in the contract key is used to match the poll to delete. The compatibility layer that parsed legacy polls only extracted data in the contract value so the `gettransaction` RPC didn't output titles for contracts with a delete action.

Since explorers may need those titles to process legacy polls properly, this updates the contract system to parse a legacy poll title from that contract key.

Closes #1965.