### PR TITLE
gui: Fix missing menu items on macOS

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -310,6 +310,8 @@ void BitcoinGUI::createActions()
 
     aboutAction = new QAction(tr("&About Gridcoin"), this);
     aboutAction->setToolTip(tr("Show information about Gridcoin"));
+    // No more than one action should be given this role to avoid overwriting actions
+    // on platforms which move the actions based on the menu role (ex. macOS)
     aboutAction->setMenuRole(QAction::AboutRole);
 
     diagnosticsAction = new QAction(tr("&Diagnostics"), this);
@@ -318,6 +320,8 @@ void BitcoinGUI::createActions()
 
     optionsAction = new QAction(tr("&Options..."), this);
     optionsAction->setToolTip(tr("Modify configuration options for Gridcoin"));
+    // No more than one action should be given this role to avoid overwriting actions
+    // on platforms which move the actions based on the menu role (ex. macOS)
     optionsAction->setMenuRole(QAction::PreferencesRole);
     openConfigAction = new QAction(tr("Open config &file..."), this);
     optionsAction->setToolTip(tr("Open the config file in your standard editor"));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -321,10 +321,8 @@ void BitcoinGUI::createActions()
     optionsAction->setMenuRole(QAction::PreferencesRole);
     openConfigAction = new QAction(tr("Open config &file..."), this);
     optionsAction->setToolTip(tr("Open the config file in your standard editor"));
-    openConfigAction->setMenuRole(QAction::PreferencesRole);
     researcherAction = new QAction(tr("&Researcher Wizard..."), this);
     researcherAction->setToolTip(tr("Open BOINC and beacon settings for Gridcoin"));
-    researcherAction->setMenuRole(QAction::PreferencesRole);
     toggleHideAction = new QAction(tr("&Show / Hide"), this);
     encryptWalletAction = new QAction(tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setToolTip(tr("Encrypt or decrypt wallet"));


### PR DESCRIPTION
The Preferences menu role on macOS will move the action from its specified location to the default location for Preferences on mac applications, which is under the "Gridcoin" menu (which is otherwise inaccessible with Qt). It is a good idea to use this, but it should not be applied to more than one action as they will overwrite one another and in this case you end up with only the open config file action being accessible on macs. So I have removed these lines for all actions except the options action, which closely fits with the expected behavior of the typical Preferences action on mac applications.