### PR TITLE
util: Enhance ETTS calculation

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -240,6 +240,20 @@ inline std::string leftTrim(std::string src, char chr)
     return src;
 }
 
+// This is effectively straight out of C++ 17 <algorithm.h>. When we move to C++ 17 we
+// can get rid of this and use std::clamp.
+template<class T, class Compare>
+constexpr const T& clamp(const T& v, const T& lo, const T& hi, Compare comp)
+{
+    return assert(!comp(hi, lo)), comp(v, lo) ? lo : comp(hi, v) ? hi : v;
+}
+
+template<class T>
+constexpr const T& clamp(const T& v, const T& lo, const T& hi)
+{
+    return clamp(v, lo, hi, std::less<T>());
+}
+
 inline int64_t GetPerformanceCounter()
 {
     int64_t nCounter = 0;


### PR DESCRIPTION
This PR implements a two step process for computing the underlying difficulty used for the GetEstimatedTimetoStake function.

This is meant to address the matching of the appropriate span to use for the difficulty calculation compared to the ETTS (which is a coupled problem). For low balance holders, a long (up to 960 block) averaging interval should be used to compute the difficulty for estimating ETTS, since if someone has an ETTS of 1 month, it makes no sense to be changing that estimate based on difficulty changes during the last hour. Conversely, if someone is staking 6 times a day, a much shorter span for the difficulty is appropriate since changes in the network difficulty should be reflected very quickly with staking frequency.