### PR TITLE
refactor: Use new clamp in util.h

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -154,9 +154,9 @@ void ThreadScraperSubscriber(void* parg)
 void InitializeScraper(ThreadHandlerPtr threads)
 {
     // Default to 300 sec (5 min), clamp to 60 minimum, 600 maximum - converted to milliseconds.
-    nScraperSleep = std::min<int64_t>(std::max<int64_t>(GetArg("-scrapersleep", 300), 60), 600) * 1000;
-    // Default to 7200 sec (4 hrs), clamp to 300 minimum, 86400 maximum (meaning active all of the time).
-    nActiveBeforeSB = std::min<int64_t>(std::max<int64_t>(GetArg("-activebeforesb", 14400), 300), 86400);
+    nScraperSleep = clamp<int64_t>(GetArg("-scrapersleep", 300), 60, 600) * 1000;
+    // Default to 14400 sec (4 hrs), clamp to 300 minimum, 86400 maximum (meaning active all of the time).
+    nActiveBeforeSB = clamp<int64_t>(GetArg("-activebeforesb", 14400), 300, 86400);
 
     // Run the scraper or subscriber housekeeping thread, but not both. The
     // subscriber housekeeping thread checks if the flag for the scraper thread

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -573,7 +573,7 @@ public:
     SuperblockValidator(const SuperblockPtr& superblock, size_t hint_bits = 32)
         : m_superblock(superblock)
         , m_quorum_hash(superblock->GetHash())
-        , m_hint_shift(32 + std::max<size_t>(0, std::min<size_t>(32, 32 - hint_bits)))
+        , m_hint_shift(32 + clamp<size_t>(32 - hint_bits, 0, 32))
     {
     }
 

--- a/src/gridcoin/staking/reward.cpp
+++ b/src/gridcoin/staking/reward.cpp
@@ -49,8 +49,7 @@ CAmount GRC::GetConstantBlockReward(const CBlockIndex* index)
         reward = atoi64(oCBReward.value);
     }
 
-    reward = std::max(reward, MIN_CBR);
-    reward = std::min(reward, MAX_CBR);
+    reward = clamp(reward, MIN_CBR, MAX_CBR);
 
     return reward;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -266,7 +266,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
     // Largest block you're willing to create:
     unsigned int nBlockMaxSize = GetArg("-blockmaxsize", MAX_BLOCK_SIZE_GEN/2);
     // Limit to between 1K and MAX_BLOCK_SIZE-1K for sanity:
-    nBlockMaxSize = std::max((unsigned int)1000, std::min((unsigned int)(MAX_BLOCK_SIZE-1000), nBlockMaxSize));
+    nBlockMaxSize = clamp<unsigned int>(nBlockMaxSize, 1000, MAX_BLOCK_SIZE - 1000);
 
     // How much of the block should be dedicated to high-priority transactions,
     // included regardless of the fees they pay

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -112,7 +112,7 @@ struct Legacy
             // Ensure we do not blow out the binary space (technically we can handle 0-65535)
             double magnitude_d = strtod(ExtractValue(entry, ",", 1).c_str(), NULL);
             // Changed to 65535 for the new NN. This will still be able to be successfully unpacked by any node.
-            magnitude_d = std::max(0.0, std::min(magnitude_d, 65535.0));
+            magnitude_d = clamp(magnitude_d, 0.0, 65535.0);
             researcher.magnitude = htobe16(roundint(magnitude_d));
 
             stream.write((const char*) &researcher, sizeof(BinaryResearcher));


### PR DESCRIPTION
This is a simple refactor to use the newly implemented clamp in util.h. No functionality change, just beautification.