### PR TITLE
voting: Add user-facing support for poll response types

### DIFF
--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -222,6 +222,19 @@ std::string Poll::WeightTypeToString() const
     assert(false); // Suppress warning
 }
 
+std::string Poll::ResponseTypeToString() const
+{
+    switch (m_response_type.Value()) {
+        case PollResponseType::UNKNOWN:
+        case PollResponseType::OUT_OF_BOUND:    return _("Unknown");
+        case PollResponseType::YES_NO_ABSTAIN:  return _("Yes/No/Abstain");
+        case PollResponseType::SINGLE_CHOICE:   return _("Single Choice");
+        case PollResponseType::MULTIPLE_CHOICE: return _("Multiple Choice");
+    }
+
+    assert(false); // Suppress warning
+}
+
 // -----------------------------------------------------------------------------
 // Class: Poll::ChoiceList
 // -----------------------------------------------------------------------------

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -318,6 +318,11 @@ public:
     //!
     std::string WeightTypeToString() const;
 
+    //!
+    //! \brief Get the string representation of the poll's response type.
+    //!
+    std::string ResponseTypeToString() const;
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -631,8 +631,8 @@ public:
     const LegacyChoiceMap& GetChoices()
     {
         if (m_legacy_choices_cache.empty()) {
-            for (uint8_t i = 0; i < m_poll.m_choices.size(); ++i) {
-                std::string label = m_poll.m_choices.At(i)->m_label;
+            for (uint8_t i = 0; i < m_poll.Choices().size(); ++i) {
+                std::string label = m_poll.Choices().At(i)->m_label;
                 boost::to_lower(label);
 
                 m_legacy_choices_cache.emplace(std::move(label), i);
@@ -886,7 +886,7 @@ private:
         }
 
         for (const auto choice_offset : candidate.Vote().m_responses) {
-            if (m_poll.m_choices.OffsetInRange(choice_offset)) {
+            if (m_poll.Choices().OffsetInRange(choice_offset)) {
                 detail.m_responses.emplace_back(choice_offset, 0.0);
             } else {
                 LogPrint(LogFlags::VOTE, "%s: invalid response", __func__);
@@ -1068,7 +1068,7 @@ PollResult::PollResult(Poll poll)
     , m_total_weight(0)
     , m_invalid_votes(0)
 {
-    m_responses.resize(m_poll.m_choices.size());
+    m_responses.resize(m_poll.Choices().size());
 }
 
 PollResultOption PollResult::BuildFor(const PollReference& poll_ref)
@@ -1101,7 +1101,7 @@ size_t PollResult::Winner() const
 
 const std::string& PollResult::WinnerLabel() const
 {
-    return m_poll.m_choices.At(Winner())->m_label;
+    return m_poll.Choices().At(Winner())->m_label;
 }
 
 void PollResult::TallyVote(VoteDetail detail)

--- a/src/qt/votingdialog.h
+++ b/src/qt/votingdialog.h
@@ -73,6 +73,7 @@ public:
     QString title_;
     QDateTime expiration_;
     QString shareType_;
+    QString responseType_;
     QString question_;
     std::vector<polling::Vote> vectorOfAnswers_;
     unsigned int totalParticipants_;
@@ -235,6 +236,7 @@ private:
     WalletModel *m_wallet_model;
     QLabel *question_;
     QLabel *url_;
+    QLabel *responseType_;
     QLabel *answer_;
     QLabel *voteNote_;
     QListWidget *answerList_;
@@ -267,6 +269,7 @@ private:
     QLineEdit *question_;
     QLineEdit *url_;
     QComboBox *shareTypeBox_;
+    QComboBox *responseTypeBox_;
     QLabel *pollNote_;
     QListWidget *answerList_;
     QListWidgetItem *answerItem;

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -202,6 +202,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     // Voting
     { "addpoll"                , 1 },
     { "addpoll"                , 4 },
+    { "addpoll"                , 5 },
     { "listpolls"              , 0 },
     { "votebyid"               , 1 },
     { "votebyid"               , 2 },


### PR DESCRIPTION
The v5.0.0 release includes protocol support for different poll response options besides multiple-choice but deferred the corresponding functionality in the user-facing components. This implements support for single-choice and yes/no/abstain poll response types in the GUI and RPC interface.

The proposed implementation relies on the existing validation in the poll and vote builder classes to provide feedback about the construction of single-choice and yes/no/abstain polls and votes. I did not change the multiple-choice behavior of the GUI for these response types because the effort required is better spent redesigning these widgets entirely, and we will likely do so as part of the GUI overhaul.

Versions 5.0 through 5.1 can cast votes for single-choice polls already. Users will need to upgrade to a release that contains the changes in this PR to vote for polls with a yes/no/abstain response type.