### PR TITLE
scraper: Add check for minimum housekeeping complete in scraper

### DIFF
--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -98,7 +98,7 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const Converge
 bool IsScraperAuthorized();
 bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& KeyOut);
 bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
-GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
+GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false, bool bFromHousekeeping = false);
 scraperSBvalidationtype ValidateSuperblock(const GRC::Superblock& NewFormatSuperblock, bool bUseCache = true, unsigned int nReducedCacheBits = 32);
 std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
 std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& VerifiedBeaconMap);

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -1551,6 +1551,7 @@ struct ConvergedScraperStats
     ConvergedScraperStats() : Convergence(), NewFormatSuperblock()
     {
         bClean = false;
+        bMinHousekeepingComplete = false;
 
         nTime = 0;
         mScraperConvergedStats = {};
@@ -1560,6 +1561,7 @@ struct ConvergedScraperStats
     ConvergedScraperStats(const int64_t nTime_in, const ConvergedManifest& Convergence) : Convergence(Convergence)
     {
         bClean = false;
+        bMinHousekeepingComplete = false;
 
         nTime = nTime_in;
 
@@ -1569,7 +1571,18 @@ struct ConvergedScraperStats
     // Flag to indicate cache is clean or dirty (i.e. state change of underlying statistics has occurred.
     // This flag is marked true in ScraperGetSuperblockContract() and false on receipt or deletion of
     // statistics objects.
-    bool bClean = false;
+    bool bClean;
+
+    // This flag tracks the completion of at least one iteration of the housekeeping loop. The purpose of this flag
+    // is to ensure enough time has gone by after a (re)start of the wallet that a complete set of manifests/parts
+    // have been collected. Trying to form a contract too early may result in a local convergence that may not
+    // match an incoming superblock that comes in very close to the wallet start, and if enough manifests/parts are
+    // missing the backup validation checks will fail, resulting in a forked client due to failure to validate
+    // the superblock. This should help the difficult corner case of a wallet restarted literally a minute or two
+    // before the superblock is received. This has the effect of allowing a grace period of nScraperSleep after the
+    // wallet start where an incoming superblock will allowed with Result::UNKNOWN, rather than rejected with
+    // Result::INVALID.
+    bool bMinHousekeepingComplete;
 
     int64_t nTime;
     ScraperStats mScraperConvergedStats;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -36,7 +36,9 @@ bool AskForOutstandingBlocks(uint256 hashStart);
 bool ForceReorganizeToHash(uint256 NewHash);
 extern UniValue MagnitudeReport(const GRC::Cpid cpid);
 extern UniValue SuperblockReport(int lookback = 14, bool displaycontract = false, std::string cpid = "");
-extern GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
+extern GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false,
+                                                    bool bContractDirectFromStatsUpdate = false,
+                                                    bool bFromHousekeeping = false);
 extern ScraperPendingBeaconMap GetPendingBeaconsForReport();
 extern ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = false);
 extern UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version);


### PR DESCRIPTION
This PR adds an optional parameter to ScraperGetSuperblockContract, the boolean bFromHousekeeping. This optional parameter is set true when run from the ScraperHousekeeping function, and causes the corresponding bMinHousekeepingComplete flag in the global cache to be set true. The superblock validator will skip validation with the state Result:UNKNOWN if this flag is false, which allows a grace period of nScraperSleep right after wallet startup where a superblock can be accepted without validation.

This is meant to address a difficult corner case of superblock validation which can occur if the wallet is restarted right before a superblock is received from the network, but it has been long enough to collect SOME manifests/parts to form an initial SB contract (convergence).