### PR TITLE
gui: Port Bitcoin Intro class (implement the ability to choose a data directory via the GUI)

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -95,7 +95,8 @@ QT_FORMS_UI = \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/transactiondescdialog.ui \
   qt/forms/askpassphrasedialog.ui \
-  qt/forms/sendcoinsentry.ui
+  qt/forms/sendcoinsentry.ui \
+  qt/forms/intro.ui
 
 QT_MOC_CPP = \
   qt/moc_aboutdialog.cpp \
@@ -114,6 +115,7 @@ QT_MOC_CPP = \
   qt/moc_diagnosticsdialog.cpp \
   qt/moc_editaddressdialog.cpp \
   qt/moc_guiutil.cpp \
+  qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
   qt/moc_monitoreddatamapper.cpp \
@@ -155,6 +157,7 @@ GRIDCOIN_MM = \
   qt/macnotificationhandler.mm
 
 QT_MOC = \
+  qt/intro.moc \
   qt/overviewpage.moc \
   qt/rpcconsole.moc
 
@@ -182,6 +185,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/editaddressdialog.h \
   qt/guiconstants.h \
   qt/guiutil.h \
+  qt/intro.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
   qt/monitoreddatamapper.h \
@@ -240,6 +244,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/diagnosticsdialog.cpp \
   qt/editaddressdialog.cpp \
   qt/guiutil.cpp \
+  qt/intro.cpp \
   qt/monitoreddatamapper.cpp \
   qt/notificator.cpp \
   qt/optionsdialog.cpp \

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -67,7 +67,7 @@ extern bool bGridcoinCoreInitComplete;
 static BitcoinGUI *guiref;
 static QSplashScreen *splashref;
 
-int StartGridcoinQt(int argc, char *argv[]);
+int StartGridcoinQt(int argc, char *argv[], OptionsModel &optionsModel);
 
 static void ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style)
 {
@@ -230,8 +230,11 @@ int main(int argc, char *argv[])
     // Before this would of been done in main then config file loaded.
     // We will load config file here as well.
     ParseParameters(argc, argv);
-
     SelectParams(CBaseChainParams::MAIN);
+
+    // We need to early load the optionsModel to get the dataDir that could be stored there.
+    OptionsModel optionsModel;
+
     ReadConfigFile(mapArgs, mapMultiArgs);
     SelectParams(mapArgs.count("-testnet") ? CBaseChainParams::TESTNET : CBaseChainParams::MAIN);
 
@@ -276,7 +279,7 @@ int main(int argc, char *argv[])
     }
 
     /** Start Qt as normal before it was moved into this function **/
-    StartGridcoinQt(argc, argv);
+    StartGridcoinQt(argc, argv, optionsModel);
 
     // We got a request to apply snapshot from GUI Menu selection
     // We got this request and everything should be shutdown now.
@@ -322,7 +325,7 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-int StartGridcoinQt(int argc, char *argv[])
+int StartGridcoinQt(int argc, char *argv[], OptionsModel& optionsModel)
 {
     // Set global boolean to indicate intended presence of GUI to core.
     fQtActive = true;
@@ -374,7 +377,7 @@ int StartGridcoinQt(int argc, char *argv[])
         app.setApplicationName("Gridcoin-Qt");
 
     // ... then GUI settings:
-    OptionsModel optionsModel;
+    //OptionsModel optionsModel;
 
     // Get desired locale (e.g. "de_DE") from command line or use system locale
     QString lang_territory = QString::fromStdString(GetArg("-lang", QLocale::system().name().toStdString()));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -104,8 +104,12 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     rpcConsole(0),
     nWeight(0)
 {
-
-    setGeometry(QStyle::alignedRect(Qt::LeftToRight,Qt::AlignCenter,QDesktopWidget().availableGeometry(this).size() * 0.6,QDesktopWidget().availableGeometry(this)));
+    QSettings settings;
+    if (!restoreGeometry(settings.value("MainWindowGeometry").toByteArray())) {
+        // Restore failed (perhaps missing setting), center the window
+        setGeometry(QStyle::alignedRect(Qt::LeftToRight,Qt::AlignCenter,QDesktopWidget().availableGeometry(this).size()
+                                        * 0.4,QDesktopWidget().availableGeometry(this)));
+    }
 
     QFontDatabase::addApplicationFont(":/fonts/inter-bold");
     QFontDatabase::addApplicationFont(":/fonts/inter-regular");
@@ -199,6 +203,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
 
 BitcoinGUI::~BitcoinGUI()
 {
+    QSettings settings;
+    settings.setValue("MainWindowGeometry", saveGeometry());
     if(trayIcon) // Hide tray icon, as deleting will let it linger until quit (on Ubuntu)
         trayIcon->hide();
 #ifdef Q_OS_MAC

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -748,18 +748,24 @@ void BitcoinGUI::openConfigClicked()
     boost::filesystem::path pathConfig = GetConfigFile();
     /* Open gridcoinresearch.conf with the associated application */
     bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathConfig.string())));
-    #ifdef Q_OS_WIN
+
+#ifdef Q_OS_WIN
     // Workaround for windows specific behaviour
     if(!res) {
         res = QProcess::startDetached("C:\\Windows\\system32\\notepad.exe", QStringList{QString::fromStdString(pathConfig.string())});
     }
-    #endif
-    #ifdef Q_OS_MAC
+#endif
+#ifdef Q_OS_MAC
     // Workaround for macOS-specific behaviour; see https://github.com/bitcoin/bitcoin/issues/15409
     if (!res) {
         res = QProcess::startDetached("/usr/bin/open", QStringList{"-t", QString::fromStdString(pathConfig.string())});
     }
-    #endif
+#endif
+
+    if (!res) {
+        error("File Association Error", "Unable to open the config file. Please check your operating system"
+                                        " file associations.", true);
+    }
 }
 
 void BitcoinGUI::researcherClicked()

--- a/src/qt/forms/intro.ui
+++ b/src/qt/forms/intro.ui
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Intro</class>
+ <widget class="QDialog" name="Intro">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Welcome</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="welcomeLabel">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <italic>true</italic>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { font-style:italic; }</string>
+     </property>
+     <property name="text">
+      <string>Welcome to %1.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>15</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="storageLabel">
+     <property name="text">
+      <string>As this is the first time the program is launched, you can choose where %1 will store its data.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="dataDirDefault">
+     <property name="text">
+      <string>Use the default data directory</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="dataDirCustom">
+     <property name="text">
+      <string>Use a custom data directory:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>60</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLineEdit" name="dataDirectory"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="ellipsisButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>30</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true">…</string>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="freeSpace">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="errorMessage">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblExplanation1">
+     <property name="text">
+      <string>When you click OK, %1 will begin to download and process the full %4 block chain (~%2GB), either from genesis in %3, or the last synchronized block, if this was a preexisting data directory.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblExplanation2">
+     <property name="text">
+      <string>The synchronization is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Intro</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Intro</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -140,7 +140,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="stakeTextLabel">
               <property name="text">
-               <string>Stake</string>
+               <string>Stake:</string>
               </property>
              </widget>
             </item>
@@ -163,7 +163,7 @@
             <item row="2" column="0">
              <widget class="QLabel" name="unconfirmedTextLabel">
               <property name="text">
-               <string>Unconfirmed</string>
+               <string>Unconfirmed:</string>
               </property>
              </widget>
             </item>

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -1,6 +1,8 @@
 #ifndef GUICONSTANTS_H
 #define GUICONSTANTS_H
 
+#include <cstdint>
+
 /* Milliseconds between model updates */
 static const int MODEL_UPDATE_DELAY = 2000;
 
@@ -30,5 +32,8 @@ static const int MAX_URI_LENGTH = 255;
 
 /* QRCodeDialog -- size of exported QR Code image */
 #define EXPORT_IMAGE_SIZE 256
+
+/* One gigabyte (GB) in bytes */
+static constexpr uint64_t GB_BYTES{1000000000};
 
 #endif // GUICONSTANTS_H

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1,4 +1,3 @@
-#include "fs.h"
 #include "guiutil.h"
 #include "bitcoinaddressvalidator.h"
 #include "walletmodel.h"
@@ -250,6 +249,21 @@ QList<QModelIndex> getEntryData(QAbstractItemView *view, int column)
     if(!view || !view->selectionModel())
         return QList<QModelIndex>();
     return view->selectionModel()->selectedRows(column);
+}
+
+fs::path qstringToBoostPath(const QString &path)
+{
+    return fs::path(path.toStdString());
+}
+
+QString boostPathToQString(const fs::path &path)
+{
+    return QString::fromStdString(path.string());
+}
+
+QString getDefaultDataDirectory()
+{
+    return boostPathToQString(GetDefaultDataDir());
 }
 
 QString getSaveFileName(QWidget *parent, const QString &caption,

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QObject>
 #include <QMessageBox>
+#include "fs.h"
 
 QT_BEGIN_NAMESPACE
 class QFont;
@@ -27,7 +28,7 @@ namespace GUIUtil
     QString formatPingTime(double dPingTime);
 
     // Format Node Time Offset
-   QString formatTimeOffset(int64_t nTimeOffset);
+    QString formatTimeOffset(int64_t nTimeOffset);
 
     // Format Bytes
     QString formatBytes(uint64_t bytes);
@@ -63,6 +64,12 @@ namespace GUIUtil
     void copyEntryData(QAbstractItemView *view, int column, int role=Qt::EditRole);
 
     QList<QModelIndex> getEntryData(QAbstractItemView *view, int column);
+
+    fs::path qstringToBoostPath(const QString &path);
+
+    QString boostPathToQString(const fs::path &path);
+
+    QString getDefaultDataDirectory();
 
     /** Get save filename, mimics QFileDialog::getSaveFileName, except that it appends a default suffix
         when no suffix is provided by the user.

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -1,0 +1,331 @@
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Copyright (c) 2020 The Gridcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/gridcoin-config.h>
+#endif
+
+#include <chainparams.h>
+#include <fs.h>
+#include <qt/intro.h>
+#include <qt/forms/ui_intro.h>
+
+#include <qt/guiconstants.h>
+#include <qt/guiutil.h>
+#include <qt/optionsmodel.h>
+
+//#include <interfaces/node.h>
+#include <util.h>
+
+#include <QFileDialog>
+#include <QSettings>
+#include <QMessageBox>
+
+#include <cmath>
+
+/* Check free space asynchronously to prevent hanging the UI thread.
+
+   Up to one request to check a path is in flight to this thread; when the check()
+   function runs, the current path is requested from the associated Intro object.
+   The reply is sent back through a signal.
+
+   This ensures that no queue of checking requests is built up while the user is
+   still entering the path, and that always the most recently entered path is checked as
+   soon as the thread becomes available.
+*/
+class FreespaceChecker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit FreespaceChecker(Intro *intro);
+
+    enum Status {
+        ST_OK,
+        ST_ERROR
+    };
+
+public Q_SLOTS:
+    void check();
+
+Q_SIGNALS:
+    void reply(int status, const QString &message, quint64 available);
+
+private:
+    Intro *intro;
+};
+
+#include <qt/intro.moc>
+
+FreespaceChecker::FreespaceChecker(Intro *_intro)
+{
+    this->intro = _intro;
+}
+
+void FreespaceChecker::check()
+{
+    QString dataDirStr = intro->getPathToCheck();
+    fs::path dataDir = GUIUtil::qstringToBoostPath(dataDirStr);
+    uint64_t freeBytesAvailable = 0;
+    int replyStatus = ST_OK;
+    QString replyMessage = tr("A new data directory will be created.");
+
+    /* Find first parent that exists, so that fs::space does not fail */
+    fs::path parentDir = dataDir;
+    fs::path parentDirOld = fs::path();
+    while(parentDir.has_parent_path() && !fs::exists(parentDir))
+    {
+        parentDir = parentDir.parent_path();
+
+        /* Check if we make any progress, break if not to prevent an infinite loop here */
+        if (parentDirOld == parentDir)
+            break;
+
+        parentDirOld = parentDir;
+    }
+
+    try {
+        freeBytesAvailable = fs::space(parentDir).available;
+        if(fs::exists(dataDir))
+        {
+            if(fs::is_directory(dataDir))
+            {
+                replyStatus = ST_OK;
+                replyMessage = tr("Directory already exists. If this directory contains valid data, it will be used.");
+            } else {
+                replyStatus = ST_ERROR;
+                replyMessage = tr("Path already exists, and is not a directory.");
+            }
+        }
+    } catch (const fs::filesystem_error&)
+    {
+        /* Parent directory does not exist or is not accessible */
+        replyStatus = ST_ERROR;
+        replyMessage = tr("Cannot create data directory here.");
+    }
+    Q_EMIT reply(replyStatus, replyMessage, freeBytesAvailable);
+}
+
+Intro::Intro(QWidget *parent, int64_t blockchain_size_gb) :
+    QDialog(parent),
+    ui(new Ui::Intro),
+    thread(nullptr),
+    signalled(false),
+    m_blockchain_size_gb(blockchain_size_gb)
+{
+
+    ui->setupUi(this);
+
+    ui->welcomeLabel->setText(ui->welcomeLabel->text().arg(PACKAGE_NAME));
+    ui->storageLabel->setText(ui->storageLabel->text().arg(PACKAGE_NAME));
+
+    ui->lblExplanation1->setText(ui->lblExplanation1->text()
+        .arg(PACKAGE_NAME)
+        .arg(m_blockchain_size_gb)
+        .arg(2014)
+        .arg(tr("Gridcoin"))
+    );
+
+    ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(PACKAGE_NAME));
+
+    // This is necessary to deal with various dpi displays.
+    this->adjustSize();
+
+    startThread();
+}
+
+Intro::~Intro()
+{
+    delete ui;
+    /* Ensure thread is finished before it is deleted */
+    thread->quit();
+    thread->wait();
+}
+
+QString Intro::getDataDirectory()
+{
+    return ui->dataDirectory->text();
+}
+
+void Intro::setDataDirectory(const QString &dataDir)
+{
+    ui->dataDirectory->setText(dataDir);
+    if(dataDir == GUIUtil::getDefaultDataDirectory())
+    {
+        ui->dataDirDefault->setChecked(true);
+        ui->dataDirectory->setEnabled(false);
+        ui->ellipsisButton->setEnabled(false);
+    } else {
+        ui->dataDirCustom->setChecked(true);
+        ui->dataDirectory->setEnabled(true);
+        ui->ellipsisButton->setEnabled(true);
+    }
+}
+
+bool Intro::showIfNeeded(bool& did_show_intro)
+{
+    did_show_intro = false;
+
+    QSettings settings;
+    /* If data directory provided on command line, no need to look at settings
+       or show a picking dialog */
+    if(!GetArg("-datadir", "").empty())
+        return true;
+    /* 1) Default data directory for operating system */
+    QString dataDir = GUIUtil::getDefaultDataDirectory();
+    /* 2) Allow QSettings to override default dir */
+    dataDir = settings.value("dataDir", dataDir).toString();
+
+    if(!fs::exists(GUIUtil::qstringToBoostPath(dataDir))
+            || GetBoolArg("-choosedatadir", DEFAULT_CHOOSE_DATADIR)
+            || settings.value("fReset", false).toBool()
+            || GetBoolArg("-resetguisettings", false))
+    {
+        /* Use selectParams here to guarantee Params() can be used by node interface when we implement it from
+           Bitcoin. */
+        try {
+            SelectParams(mapArgs.count("-testnet") ? CBaseChainParams::TESTNET : CBaseChainParams::MAIN);
+        } catch (const std::exception&) {
+            return false;
+        }
+
+        /* If current default data directory does not exist, let the user choose one */
+        Intro intro(0, Params().AssumedBlockchainSize());
+        intro.setDataDirectory(dataDir);
+        intro.setWindowIcon(QIcon(":/images/gridcoin"));
+        did_show_intro = true;
+
+        while(true)
+        {
+            if(!intro.exec())
+            {
+                /* Cancel clicked */
+                return false;
+            }
+            dataDir = intro.getDataDirectory();
+            try {
+                TryCreateDirectories(GUIUtil::qstringToBoostPath(dataDir));
+                break;
+            } catch (const fs::filesystem_error&) {
+                QMessageBox::critical(nullptr, PACKAGE_NAME,
+                    tr("Error: Specified data directory \"%1\" cannot be created.").arg(dataDir));
+                /* fall through, back to choosing screen */
+            }
+        }
+
+        settings.setValue("dataDir", dataDir);
+        settings.setValue("fReset", false);
+    }
+    /* Only override -datadir if different from the default, to make it possible to
+     * override -datadir in the bitcoin.conf file in the default data directory
+     * (to be consistent with bitcoind behavior)
+     */
+    if (dataDir != GUIUtil::getDefaultDataDirectory()) {
+        SoftSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).string()); // use OS locale for path setting
+    }
+
+    return true;
+}
+
+void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable)
+{
+    switch(status)
+    {
+    case FreespaceChecker::ST_OK:
+        ui->errorMessage->setText(message);
+        ui->errorMessage->setStyleSheet("");
+        break;
+    case FreespaceChecker::ST_ERROR:
+        ui->errorMessage->setText(tr("Error") + ": " + message);
+        ui->errorMessage->setStyleSheet("QLabel { color: #800000 }");
+        break;
+    }
+    /* Indicate number of bytes available */
+    if(status == FreespaceChecker::ST_ERROR)
+    {
+        ui->freeSpace->setText("");
+    } else {
+        m_bytes_available = bytesAvailable;
+        UpdateFreeSpaceLabel();
+    }
+    /* Don't allow confirm in ERROR state */
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(status != FreespaceChecker::ST_ERROR);
+}
+
+void Intro::UpdateFreeSpaceLabel()
+{
+    QString freeString = tr("%n GB of free space available", "", m_bytes_available / GB_BYTES);
+    if (m_bytes_available < m_required_space_gb * GB_BYTES) {
+        freeString += " " + tr("(of %n GB needed)", "", m_required_space_gb);
+        ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
+    } else if (m_bytes_available / GB_BYTES - m_required_space_gb < 10) {
+        freeString += " " + tr("(%n GB needed for full chain)", "", m_required_space_gb);
+        ui->freeSpace->setStyleSheet("QLabel { color: #999900 }");
+    } else {
+        ui->freeSpace->setStyleSheet("");
+    }
+    ui->freeSpace->setText(freeString + ".");
+}
+
+void Intro::on_dataDirectory_textChanged(const QString &dataDirStr)
+{
+    /* Disable OK button until check result comes in */
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    checkPath(dataDirStr);
+}
+
+void Intro::on_ellipsisButton_clicked()
+{
+    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(nullptr, "Choose data directory", ui->dataDirectory->text()));
+    if(!dir.isEmpty())
+        ui->dataDirectory->setText(dir);
+}
+
+void Intro::on_dataDirDefault_clicked()
+{
+    setDataDirectory(GUIUtil::getDefaultDataDirectory());
+}
+
+void Intro::on_dataDirCustom_clicked()
+{
+    ui->dataDirectory->setEnabled(true);
+    ui->ellipsisButton->setEnabled(true);
+}
+
+void Intro::startThread()
+{
+    thread = new QThread(this);
+    FreespaceChecker *executor = new FreespaceChecker(this);
+    executor->moveToThread(thread);
+
+    connect(executor, &FreespaceChecker::reply, this, &Intro::setStatus);
+    connect(this, &Intro::requestCheck, executor, &FreespaceChecker::check);
+    // make sure executor object is deleted in its own thread
+    connect(thread, &QThread::finished, executor, &QObject::deleteLater);
+
+    thread->start();
+}
+
+void Intro::checkPath(const QString &dataDir)
+{
+    mutex.lock();
+    pathToCheck = dataDir;
+    if(!signalled)
+    {
+        signalled = true;
+        Q_EMIT requestCheck();
+    }
+    mutex.unlock();
+}
+
+QString Intro::getPathToCheck()
+{
+    QString retval;
+    mutex.lock();
+    retval = pathToCheck;
+    signalled = false; /* new request can be queued now */
+    mutex.unlock();
+    return retval;
+}

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2020 The Gridcoin Core Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_INTRO_H
+#define BITCOIN_QT_INTRO_H
+
+#include <QDialog>
+#include <QMutex>
+#include <QThread>
+
+static const bool DEFAULT_CHOOSE_DATADIR = false;
+
+class FreespaceChecker;
+
+namespace Ui {
+    class Intro;
+}
+
+/** Introduction screen (pre-GUI startup).
+  Allows the user to choose a data directory,
+  in which the wallet and block chain will be stored.
+ */
+class Intro : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit Intro(QWidget *parent = nullptr, int64_t blockchain_size_gb = 0);
+    ~Intro();
+
+    QString getDataDirectory();
+    void setDataDirectory(const QString &dataDir);
+
+    /**
+     * Determine data directory. Let the user choose if the current one doesn't exist.
+     * Let the user configure additional preferences such as pruning.
+     *
+     * @returns true if a data directory was selected, false if the user cancelled the selection
+     * dialog.
+     *
+     * @note do NOT call global GetDataDir() before calling this function, this
+     * will cause the wrong path to be cached.
+     */
+    static bool showIfNeeded(bool& did_show_intro);
+
+Q_SIGNALS:
+    void requestCheck();
+
+public Q_SLOTS:
+    void setStatus(int status, const QString &message, quint64 bytesAvailable);
+
+private Q_SLOTS:
+    void on_dataDirectory_textChanged(const QString &arg1);
+    void on_ellipsisButton_clicked();
+    void on_dataDirDefault_clicked();
+    void on_dataDirCustom_clicked();
+
+private:
+    Ui::Intro *ui;
+    QThread *thread;
+    QMutex mutex;
+    bool signalled;
+    QString pathToCheck;
+    const int64_t m_blockchain_size_gb;
+    uint64_t m_bytes_available{0};
+    int64_t m_required_space_gb{0};
+
+    void startThread();
+    void checkPath(const QString &dataDir);
+    QString getPathToCheck();
+    void UpdateFreeSpaceLabel();
+    friend class FreespaceChecker;
+};
+
+#endif // BITCOIN_QT_INTRO_H

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -37,6 +37,7 @@ public:
         LimitTxnDisplay,         // bool
         LimitTxnDate,            // QDate
         DisableUpdateCheck,      // bool
+        DataDir,                 // QString
         OptionIDRowCount,
     };
 
@@ -62,6 +63,7 @@ public:
     int64_t getLimitTxnDateTime();
     QString getLanguage() { return language; }
     QString getCurrentStyle();
+    QString getDataDir();
 
 private:
     int nDisplayUnit;
@@ -76,6 +78,7 @@ private:
     QDate limitTxnDate;
     QString language;
     QString walletStylesheet;
+    QString dataDir;
 
 signals:
     void displayUnitChanged(int unit);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -56,6 +56,7 @@ private:
     qint64 currentStake;
     qint64 currentUnconfirmedBalance;
     qint64 currentImmatureBalance;
+    int scaledDecorationSize;
 
     TxViewDelegate *txdelegate;
     std::unique_ptr<TransactionFilterProxy> filter;

--- a/src/util.h
+++ b/src/util.h
@@ -133,6 +133,7 @@ bool ParseMoney(const char* pszIn, int64_t& nRet);
 void ParseParameters(int argc, const char*const argv[]);
 bool WildcardMatch(const char* psz, const char* mask);
 bool WildcardMatch(const std::string& str, const std::string& mask);
+bool TryCreateDirectories(const fs::path& p);
 bool FileCommit(FILE *fileout);
 
 std::string TimestampToHRDate(double dtm);
@@ -143,17 +144,20 @@ fs::path GetDefaultDataDir();
 fs::path GetProgramDir();
 
 const fs::path &GetDataDir(bool fNetSpecific = true);
+bool CheckDataDirOption();
+
 fs::path GetConfigFile();
 fs::path GetPidFile();
 #ifndef WIN32
 void CreatePidFile(const fs::path &path, pid_t pid);
 #endif
-void ReadConfigFile(ArgsMap& mapSettingsRet, ArgsMultiMap& mapMultiSettingsRet);
+bool ReadConfigFile(ArgsMap& mapSettingsRet, ArgsMultiMap& mapMultiSettingsRet);
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 bool DirIsWritable(const fs::path& directory);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
+bool TryCreateDirectories(const fs::path& p);
 
 //!
 //! \brief Read the contents of the specified file into memory.


### PR DESCRIPTION
This PR is a port of Bitcoin's Intro class and the associated form to support the choice of a data directory via the GUI. This PR also has implemented stateful management of that choice in the optionsModel, similar to the Bitcoin approach. This should make the choice of non-default data directories much easier for people with GUI wallet installations, especially the MacOS, where it is difficult to supply program arguments to the underlying command line in the icon.

I have also solved the silent exit if the gridcoinresearch.conf file is corrupted/badly formatted. The solution uses a simplified form of the newer Bitcoin config file parsing functions, which needed to be ported anyway to suppport Intro. (Closes #1303.)

Most of the issues with scaling I think I have solved with this PR. (Closes #1952 and closes #1953.)

Also implements an early check for the ability to lock the data directory. Closes #1872.