### PR TITLE
gui: Redo global status for overview

### DIFF
--- a/src/gridcoin/staking/difficulty.h
+++ b/src/gridcoin/staking/difficulty.h
@@ -20,6 +20,7 @@ double GetBlockDifficulty(unsigned int nBits);
 double GetCurrentDifficulty();
 double GetTargetDifficulty();
 double GetAverageDifficulty(unsigned int nPoSInterval = 40);
+double GetSmoothedDifficulty(int64_t nStakeableBalance);
 
 uint64_t GetStakeWeight(const CWallet& wallet);
 double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40);

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -167,7 +167,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::REINDEX, "reindex"},
     {BCLog::CMPCTBLOCK, "cmpctblock"},
     {BCLog::RAND, "rand"},
-    {BCLog::PRUNE, "prune"},
+    {BCLog::MISC, "misc"},
     {BCLog::PROXY, "proxy"},
     {BCLog::MEMPOOLREJ, "mempoolrej"},
     {BCLog::LIBEVENT, "libevent"},

--- a/src/logging.h
+++ b/src/logging.h
@@ -69,7 +69,7 @@ namespace BCLog {
         REINDEX     = (1 << 11),
         CMPCTBLOCK  = (1 << 12),
         RAND        = (1 << 13),
-        PRUNE       = (1 << 14),
+        MISC        = (1 << 14),
         PROXY       = (1 << 15),
         MEMPOOLREJ  = (1 << 16),
         LIBEVENT    = (1 << 17),

--- a/src/main.h
+++ b/src/main.h
@@ -107,18 +107,77 @@ extern int nGrandfather;
 extern int nNewIndex;
 extern int nNewIndex2;
 
-struct globalStatusType
+class GlobalStatus
 {
-    CCriticalSection lock;
-    std::string blocks;
-    std::string difficulty;
-    std::string netWeight;
-    std::string coinWeight;
+public:
+    GlobalStatus()
+    {
+        update_time = 0;
+
+        blocks = 0;
+        difficulty = 0.0;
+        netWeight = 0.0;
+        coinWeight = 0.0;
+        etts = 0.0;
+
+        able_to_stake = false;
+        staking = false;
+
+        ReasonNotStaking = std::string();
+        errors = std::string();
+    }
+
+    struct globalStatusType
+    {
+        int64_t update_time;
+
+        int blocks;
+        double difficulty;
+        double netWeight;
+        double coinWeight;
+        double etts;
+
+        bool able_to_stake;
+        bool staking;
+
+        std::string ReasonNotStaking;
+        std::string errors;
+    };
+
+    struct globalStatusStringType
+    {
+        std::string blocks;
+        std::string difficulty;
+        std::string netWeight;
+        std::string coinWeight;
+
+        std::string errors;
+    };
+
+    void SetGlobalStatus(bool force = false);
+    const globalStatusType GetGlobalStatus();
+    const globalStatusStringType GetGlobalStatusStrings();
+
+private:
+    std::atomic<int64_t> update_time;
+
+    std::atomic<int> blocks;
+    std::atomic<double> difficulty;
+    std::atomic<double> netWeight;
+    std::atomic<double> coinWeight;
+    std::atomic<double> etts;
+
+    std::atomic<bool> able_to_stake;
+    std::atomic<bool> staking;
+
+    // This lock is only needed to protect the ReasonNotStaking and errors string.
+    CCriticalSection cs_errors_lock;
+
+    std::string ReasonNotStaking;
     std::string errors;
 };
 
-extern globalStatusType GlobalStatusStruct;
-
+extern GlobalStatus g_GlobalStatus;
 
 class CReserveKey;
 class CTxDB;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -102,7 +102,9 @@ bool TrySignClaim(
     const bool dry_run = false)
 {
     AssertLockHeld(cs_main);
-    AssertLockHeld(pwallet->cs_wallet);
+
+    // lock needs to be taken on pwallet here.
+    LOCK(pwallet->cs_wallet);
 
     const GRC::CpidOption cpid = claim.m_mining_id.TryCpid();
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -236,7 +236,7 @@ static void NotifyBlocksChanged(ClientModel *clientmodel)
 
 static void NotifyNumConnectionsChanged(ClientModel *clientmodel, int newNumConnections)
 {
-    // Too noisy: LogPrintf("NotifyNumConnectionsChanged %i", newNumConnections);
+    LogPrint(BCLog::NOISY, "NotifyNumConnectionsChanged %i", newNumConnections);
     QMetaObject::invokeMethod(clientmodel, "updateNumConnections", Qt::QueuedConnection,
                               Q_ARG(int, newNumConnections));
 }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -673,9 +673,14 @@ void CoinControlDialog::updateView()
             itemOutput->setText(COLUMN_DATE, QDateTime::fromTime_t(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
 
             // immature PoS reward
-            if (out.tx->IsCoinStake() && out.tx->GetBlocksToMaturity() > 0 && out.tx->GetDepthInMainChain() > 0) {
-              itemOutput->setBackground(COLUMN_CONFIRMATIONS, Qt::red);
-              itemOutput->setDisabled(true);
+            {
+                // LOCK on cs_main must be taken for depth and maturity.
+                LOCK(cs_main);
+
+                if (out.tx->IsCoinStake() && out.tx->GetBlocksToMaturity() > 0 && out.tx->GetDepthInMainChain() > 0) {
+                    itemOutput->setBackground(COLUMN_CONFIRMATIONS, Qt::red);
+                    itemOutput->setDisabled(true);
+                }
             }
 
             // confirmations

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 
 /* Milliseconds between model updates */
-static const int MODEL_UPDATE_DELAY = 2000;
+static const int MODEL_UPDATE_DELAY = 4000;
 
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -253,12 +253,17 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
 void OverviewPage::UpdateBoincUtilization()
 {
     {
-        LOCK(GlobalStatusStruct.lock);
-        ui->blocksLabel->setText(QString::fromUtf8(GlobalStatusStruct.blocks.c_str()));
-        ui->difficultyLabel->setText(QString::fromUtf8(GlobalStatusStruct.difficulty.c_str()));
-        ui->netWeightLabel->setText(QString::fromUtf8(GlobalStatusStruct.netWeight.c_str()));
-        ui->coinWeightLabel->setText(QString::fromUtf8(GlobalStatusStruct.coinWeight.c_str()));
-        ui->errorsLabel->setText(QString::fromUtf8(GlobalStatusStruct.errors.c_str()));
+        LogPrint(BCLog::MISC, "OverviewPage::UpdateBoincUtilization()");
+
+        if (miner_first_pass_complete) g_GlobalStatus.SetGlobalStatus(true);
+
+        const GlobalStatus::globalStatusStringType& globalStatusStrings = g_GlobalStatus.GetGlobalStatusStrings();
+
+        ui->blocksLabel->setText(QString::fromUtf8(globalStatusStrings.blocks.c_str()));
+        ui->difficultyLabel->setText(QString::fromUtf8(globalStatusStrings.difficulty.c_str()));
+        ui->netWeightLabel->setText(QString::fromUtf8(globalStatusStrings.netWeight.c_str()));
+        ui->coinWeightLabel->setText(QString::fromUtf8(globalStatusStrings.coinWeight.c_str()));
+        ui->errorsLabel->setText(QString::fromUtf8(globalStatusStrings.errors.c_str()));
     }
 
     // GetCurrentPollTitle() locks cs_main:
@@ -393,7 +398,7 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 	OverviewPage::UpdateBoincUtilization();
 }
 
-void OverviewPage::updateglobalstatus()
+void OverviewPage::updateGlobalStatus()
 {
 	OverviewPage::UpdateBoincUtilization();
 }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -32,7 +32,7 @@ public:
     void setResearcherModel(ResearcherModel *model);
     void setWalletModel(WalletModel *model);
     void showOutOfSyncWarning(bool fShow);
-	void updateglobalstatus();
+	void updateGlobalStatus();
 	void UpdateBoincUtilization();
 
 public slots:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -90,6 +90,8 @@ public:
      */
     void refreshWallet()
     {
+        LogPrint(BCLog::MISC, "refreshWallet()");
+
         parent->beginResetModel();
 
         loadWallet();
@@ -104,7 +106,12 @@ public:
      */
     void updateWallet(const uint256 &hash, int status)
     {
-        LogPrint(BCLog::LogFlags::VERBOSE, "updateWallet %s %i", hash.ToString(), status);
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)
+                || LogInstance().WillLogCategory(BCLog::LogFlags::MISC))
+        {
+            LogPrintf("updateWallet %s %i", hash.ToString(), status);
+        }
+
         {
             LOCK2(cs_main, wallet->cs_wallet);
 
@@ -269,6 +276,8 @@ TransactionTableModel::~TransactionTableModel()
 
 void TransactionTableModel::updateTransaction(const QString &hash, int status)
 {
+    LogPrint(BCLog::MISC, "TransactionTableModel::updateTransaction()");
+
     uint256 updated;
     updated.SetHex(hash.toStdString());
 
@@ -282,6 +291,8 @@ void TransactionTableModel::refreshWallet()
 
 void TransactionTableModel::updateConfirmations()
 {
+    LogPrint(BCLog::MISC, "TransactionTableModel::updateConfirmations()");
+
     // Blocks came in since last poll.
     // Invalidate status (number of confirmations) and (possibly) description
     //  for all rows. Qt is smart enough to only actually request the data for the

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -119,6 +119,8 @@ void WalletModel::checkBalanceChanged()
 
 void WalletModel::updateTransaction(const QString &hash, int status)
 {
+    LogPrint(BCLog::MISC, "WalletModel::updateTransaction()");
+
     if (transactionTableModel)
     {
         transactionTableModel->updateTransaction(hash, status);


### PR DESCRIPTION
This PR reimplements the global status for the overview screen. It cleans up the global struct, reimplementing it into a small class, and reduces/eliminates locks in several places. It is still far from an optimal approach, but is good enough until the GUI rewrite.

It also should eliminate a rare deadlock that was introduced by https://github.com/gridcoin-community/Gridcoin-Research/commit/4176a211c95d2d3e317ec8e36604a4eb9e1831a3.

Also closes #1985.