### PR TITLE
util: Improvements to MilliTimer class and use in the miner and init

### DIFF
--- a/src/gridcoin/staking/status.h
+++ b/src/gridcoin/staking/status.h
@@ -41,6 +41,7 @@ public:
     uint64_t KernelsFound;
     int64_t nLastCoinStakeSearchInterval;
     uint256 m_last_pos_tx_hash;
+    uint64_t masked_time_intervals_covered = 0;
 
     void Clear();
     MinerStatus();

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -183,6 +183,9 @@ bool AppInit(int argc, char* argv[])
 extern void noui_connect();
 int main(int argc, char* argv[])
 {
+    // Reinit default timer to ensure it is zeroed out at the start of main.
+    g_timer.InitTimer("default", false);
+
     bool fRet = false;
 
     // Set global boolean to indicate intended absence of GUI to core...

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -223,6 +223,9 @@ int main(int argc, char *argv[])
     std::tie(argc, argv) = winArgs.get();
 #endif
 
+    // Reinit default timer to ensure it is zeroed out at the start of main.
+    g_timer.InitTimer("default", false);
+
     SetupEnvironment();
 
     // Note every function above the InitLogging() call must use fprintf or similar.

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -45,7 +45,25 @@ void MilliSleep(int64_t n);
  * @brief The MilliTimer class
  *
  * This is a small class that implements a stopwatch style timer. The class can be used locally (usually using
- * the "default" label) or as a global map of timers.
+ * the "default" label) and/or as a global map of timers. If you want to do just a simple single timing, it
+ * probably makes more sense to just use GetTimeMillis() directly, as the initialization of a map is a little
+ * heavyweight for a single timing that is locally scoped. This class becomes very useful for muliple segments
+ * where you need to see the "lap times", and also conveniently control the logging wihout a bunch of repetitive code.
+ *
+ * This class becomes essential for tracking the timing processes that span multiple functions/methods, that are
+ * critical to measure performance-wise. This includes the init code and miner loop, for example. The default timer,
+ * which is started at the main() entry-points, also provides a very convenient uptime timer for getinfo.
+ *
+ * The class uses a single lock which is scoped very tightly to the single map that the lock protects, and is
+ * entirely internal to the class (private). As a result this class is entirely thread-safe. In general the performance
+ * of the timers should be very good down to the millisecond range, even in multi-threaded access situations with
+ * several global timers active in the map. Nevertheless, I would NOT recommend putting a GetTimes or GetElapsedTime
+ * call within a very tight loop that executes at 1000's of times/second, as the lock could become effectively
+ * partially blocking for other threads. As usual, common-sense must be used with any tool.
+ *
+ * I did not implement the "stop" button on the stopwatch style timer, as the "lap" time functionality is more
+ * important here, and implementing a stop/start functionality on the timers makes it more heavyweight and
+ * unnecessarily complicated for our use here.
  *
  */
 class MilliTimer
@@ -53,12 +71,17 @@ class MilliTimer
 public:
     MilliTimer()
     {
-        InitTimer("default");
+        InitTimer("default", false);
     }
 
-    MilliTimer(std::string label)
+    MilliTimer(const std::string& label)
     {
-        InitTimer(label);
+        InitTimer(label, false);
+    }
+
+    MilliTimer(const std::string& label, bool log)
+    {
+        InitTimer(label, log);
     }
 
     struct timer
@@ -67,16 +90,18 @@ public:
         int64_t time_since_last_check = 0;
     };
 
-    void InitTimer(std::string label);
-    bool DeleteTimer(std::string label);
+    void InitTimer(const std::string& label, bool log);
+    bool DeleteTimer(const std::string& label);
+    bool LogTimer(const std::string& label, bool log);
 
-    int64_t GetElapsedTime(std::string label = "default");
-    timer GetTimes(std::string label = "default");
+    const timer GetTimes(const std::string& log_string, const std::string& label = "default");
+    int64_t GetElapsedTime(const std::string& log_string, const std::string& label = "default");
 private:
     CCriticalSection cs_timer_map_lock;
 
     struct internal_timer
     {
+        bool log = false;
         int64_t start_time = 0;
         int64_t checkpoint_time = 0;
     };

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -111,6 +111,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.pushKV("blocks",        nBestHeight);
     obj.pushKV("in_sync",       !OutOfSyncByAge());
     obj.pushKV("timeoffset",    GetTimeOffset());
+    obj.pushKV("uptime",        g_timer.GetElapsedTime("uptime", "default") / 1000);
     obj.pushKV("moneysupply",   ValueFromAmount(pindexBest->nMoneySupply));
     obj.pushKV("connections",   (int)vNodes.size());
     obj.pushKV("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string()));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1633,7 +1633,8 @@ bool CWallet::SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, set<pai
 bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<const CWalletTx*,unsigned int> >& vCoinsRet,
                                     GRC::MinerStatus::ReasonNotStakingCategory& not_staking_error, bool fMiner) const
 {
-    bool log_timer = LogInstance().WillLogCategory(BCLog::LogFlags::MISC);
+    std::string function = __func__;
+    function += ": ";
 
     int64_t BalanceToConsider = GetBalance();
 
@@ -1662,11 +1663,7 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
     vector<COutput> vCoins;
     AvailableCoinsForStaking(vCoins, nSpendTime);
 
-    if (log_timer)
-    {
-        LogPrintf("CWallet::SelectCoinsForStaking(): AvailableCoinsForStaking(): elapsed %" PRId64 "ms",
-                  g_timer.GetElapsedTime("miner"));
-    }
+    g_timer.GetTimes(function + "AvailableCoinsForStaking()", "miner");
 
     if (vCoins.empty())
     {
@@ -1704,11 +1701,7 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
         return false;
     }
 
-    if (log_timer)
-    {
-        LogPrintf("CWallet::SelectCoinsForStaking(): select loop: elapsed %" PRId64 "ms",
-                  g_timer.GetElapsedTime("miner"));
-    }
+    g_timer.GetTimes(function + "select loop", "miner");
 
     // Randomize the vector order to keep PoS truly a roll of dice in which utxo has a chance to stake first
     if (fMiner)
@@ -1718,11 +1711,7 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
         std::shuffle(vCoinsRet.begin(), vCoinsRet.end(), std::default_random_engine(seed));
     }
 
-    if (log_timer)
-    {
-        LogPrintf("CWallet::SelectCoinsForStaking(): shuffle: elapsed %" PRId64 "ms",
-                  g_timer.GetElapsedTime("miner"));
-    }
+    g_timer.GetTimes(function + "shuffle", "miner");
 
     return true;
 }


### PR DESCRIPTION
This modifies the original implementation of the MilliTimer class in the miner in #1983 and makes some improvements, including being able to specify by timer whether the timings should be output to the debug log.

It also uses the improved class to clean up the timing code in the miner and init areas, implement uptime report in getinfo, and implement a stake loop efficiency measure in getmininginfo.