### PR TITLE
voting: Fix nonsense vote weights for legacy polls

### DIFF
--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -620,7 +620,9 @@ public:
     //!
     //! \param poll The poll to count votes for.
     //!
-    LegacyVoteCounterContext(const Poll& poll) : m_poll(poll)
+    LegacyVoteCounterContext(const Poll& poll)
+        : m_poll(poll)
+        , m_magnitude_factor(0)
     {
     }
 


### PR DESCRIPTION
This initializes a missed field in `LegacyVoteCounterContext` to zero to fix absurd vote weight calculations that may occur after the wallet runs for some time. The field was inheriting memory at those addresses which produced invalid vote weights for polls with legacy votes.