### PR TITLE
voting: Fix incorrect field returned in ResolveMoneySupplyForPoll()

### DIFF
--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -1037,7 +1037,7 @@ CAmount ResolveMoneySupplyForPoll(const Poll& poll)
 
     for (; pindex && pindex->nTime > poll_expiration; pindex = pindex->pprev);
 
-    return pindex->nTime;
+    return pindex->nMoneySupply;
 }
 } // Anonymous namespace
 


### PR DESCRIPTION
The function returned the block timestamp instead of the money supply for expired polls.