### PR TITLE
gui: Port Bitcoin MacOS app nap manager

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -96,9 +96,6 @@
 
   <key>NSHighResolutionCapable</key>
     <string>True</string>
-
-  <key>LSAppNapIsDisabled</key>
-    <string>True</string>
   
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -154,7 +154,8 @@ QT_MOC_CPP = \
 
 GRIDCOIN_MM = \
   qt/macdockiconhandler.mm \
-  qt/macnotificationhandler.mm
+  qt/macnotificationhandler.mm \
+  qt/macos_appnap.mm
 
 QT_MOC = \
   qt/intro.moc \
@@ -188,6 +189,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/intro.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
+  qt/macos_appnap.h \
   qt/monitoreddatamapper.h \
   qt/notificator.h \
   qt/optionsdialog.h \

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -8,6 +8,10 @@
 #include <memory>
 #include "guiconstants.h"
 
+#ifdef Q_OS_MAC
+#include <qt/macos_appnap.h>
+#endif
+
 class TransactionTableModel;
 class ClientModel;
 class WalletModel;
@@ -130,6 +134,10 @@ private:
 
     uint64_t nWeight;
 
+#ifdef Q_OS_MAC
+    CAppNapInhibitor* m_app_nap_inhibitor = nullptr;
+    bool app_nap_enabled = true;
+#endif
     // name extension to change icons according to stylesheet
     QString sSheet;
 

--- a/src/qt/macos_appnap.h
+++ b/src/qt/macos_appnap.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MACOS_APPNAP_H
+#define BITCOIN_QT_MACOS_APPNAP_H
+
+#include <memory>
+
+class CAppNapInhibitor final
+{
+public:
+    explicit CAppNapInhibitor();
+    ~CAppNapInhibitor();
+
+    void disableAppNap();
+    void enableAppNap();
+
+private:
+    class CAppNapImpl;
+    std::unique_ptr<CAppNapImpl> impl;
+};
+
+#endif // BITCOIN_QT_MACOS_APPNAP_H

--- a/src/qt/macos_appnap.mm
+++ b/src/qt/macos_appnap.mm
@@ -1,0 +1,71 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "macos_appnap.h"
+
+#include <AvailabilityMacros.h>
+#include <Foundation/NSProcessInfo.h>
+#include <Foundation/Foundation.h>
+
+class CAppNapInhibitor::CAppNapImpl
+{
+public:
+    ~CAppNapImpl()
+    {
+        if(activityId)
+            enableAppNap();
+    }
+
+    void disableAppNap()
+    {
+        if (!activityId)
+        {
+            @autoreleasepool {
+                const NSActivityOptions activityOptions =
+                NSActivityUserInitiatedAllowingIdleSystemSleep &
+                ~(NSActivitySuddenTerminationDisabled |
+                NSActivityAutomaticTerminationDisabled);
+
+                id processInfo = [NSProcessInfo processInfo];
+                if ([processInfo respondsToSelector:@selector(beginActivityWithOptions:reason:)])
+                {
+                    activityId = [processInfo beginActivityWithOptions: activityOptions reason:@"Temporarily disable App Nap for gridcoinresearch."];
+                    [activityId retain];
+                }
+            }
+        }
+    }
+
+    void enableAppNap()
+    {
+        if(activityId)
+        {
+            @autoreleasepool {
+                id processInfo = [NSProcessInfo processInfo];
+                if ([processInfo respondsToSelector:@selector(endActivity:)])
+                    [processInfo endActivity:activityId];
+
+                [activityId release];
+                activityId = nil;
+            }
+        }
+    }
+
+private:
+    NSObject* activityId;
+};
+
+CAppNapInhibitor::CAppNapInhibitor() : impl(new CAppNapImpl()) {}
+
+CAppNapInhibitor::~CAppNapInhibitor() = default;
+
+void CAppNapInhibitor::disableAppNap()
+{
+    impl->disableAppNap();
+}
+
+void CAppNapInhibitor::enableAppNap()
+{
+    impl->enableAppNap();
+}


### PR DESCRIPTION
This is a port of the Bitcoin MacOS app nap manager.

In our port, the triggers for app nap disable are a bit different. Here, if app nap is only enabled if not staking and not out of sync.