### PR TITLE
mining, rpc: Implement staking efficiency measure and improve SelectCoinsForStaking and CreateCoinStake

### DIFF
--- a/src/gridcoin/staking/difficulty.cpp
+++ b/src/gridcoin/staking/difficulty.cpp
@@ -228,10 +228,11 @@ uint64_t GRC::GetStakeWeight(const CWallet& wallet)
 
     std::vector<std::pair<const CWalletTx*, unsigned int>> coins;
     GRC::MinerStatus::ReasonNotStakingCategory unused;
+    int64_t balance = 0;
 
     LOCK2(cs_main, wallet.cs_wallet);
 
-    if (!wallet.SelectCoinsForStaking(now, coins, unused)) {
+    if (!wallet.SelectCoinsForStaking(now, coins, unused, balance)) {
         return 0;
     }
 

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -506,6 +506,11 @@ int64_t GRC::CalculateStakeWeightV8(const CTransaction &CoinTx, unsigned CoinTxN
     return nValueIn;
 }
 
+int64_t GRC::CalculateStakeWeightV8(const CAmount& nValueIn)
+{
+    return nValueIn / 1250000;
+}
+
 // Another version of GetKernelStakeModifier (TomasBrod)
 // Todo: security considerations
 bool GRC::FindStakeModifierRev(uint64_t& nStakeModifier,CBlockIndex* pindexPrev)

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -499,6 +499,24 @@ uint256 GRC::CalculateStakeHashV8(
     return ss.GetHash();
 }
 
+uint256 GRC::CalculateStakeHashV8(
+    unsigned int nBlockTime,
+    const CTransaction& CoinTx,
+    unsigned CoinTxN,
+    unsigned nTimeTx,
+    uint64_t StakeModifier)
+{
+    CHashWriter ss(SER_GETHASH, 0);
+
+    ss << StakeModifier;
+    ss << MaskStakeTime((uint32_t) nBlockTime);
+    ss << CoinTx.GetHash();
+    ss << CoinTxN;
+    ss << MaskStakeTime(nTimeTx);
+
+    return ss.GetHash();
+}
+
 int64_t GRC::CalculateStakeWeightV8(const CTransaction &CoinTx, unsigned CoinTxN)
 {
     CAmount nValueIn = CoinTx.vout[CoinTxN].nValue;
@@ -513,22 +531,23 @@ int64_t GRC::CalculateStakeWeightV8(const CAmount& nValueIn)
 
 // Another version of GetKernelStakeModifier (TomasBrod)
 // Todo: security considerations
-bool GRC::FindStakeModifierRev(uint64_t& nStakeModifier,CBlockIndex* pindexPrev)
+bool GRC::FindStakeModifierRev(uint64_t& nStakeModifier, CBlockIndex* pindexPrev, int& nHeight_mod)
 {
     nStakeModifier = 0;
-    const CBlockIndex* pindex = pindexPrev;
+    CBlockIndex* pindex_mod = pindexPrev;
 
     while (1)
     {
-        if(!pindex)
+        if(!pindex_mod)
             return error("FindStakeModifierRev: no previous block from %d",pindexPrev->nHeight);
 
-        if (pindex->GeneratedStakeModifier())
+        if (pindex_mod->GeneratedStakeModifier())
         {
-            nStakeModifier = pindex->nStakeModifier;
+            nStakeModifier = pindex_mod->nStakeModifier;
+            nHeight_mod = pindex_mod->nHeight;
             return true;
         }
-        pindex = pindex->pprev;
+        pindex_mod = pindex_mod->pprev;
     }
 }
 
@@ -572,7 +591,9 @@ bool GRC::CheckProofOfStakeV8(
         return error("%s: min age violation", __func__);
 
     uint64_t StakeModifier = 0;
-    if (!FindStakeModifierRev(StakeModifier,pindexPrev))
+    int nHeight_mod = 0;
+
+    if (!FindStakeModifierRev(StakeModifier, pindexPrev, nHeight_mod))
         return error("%s: unable to find stake modifier", __func__);
 
     hashProofOfStake = CalculateStakeHashV8(header, txPrev, prevout.n, tx.nTime, StakeModifier);

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -110,4 +110,5 @@ uint256 CalculateStakeHashV8(
     uint64_t StakeModifier);
 
 int64_t CalculateStakeWeightV8(const CTransaction &CoinTx, unsigned CoinTxN);
+int64_t CalculateStakeWeightV8(const CAmount& nValueIn);
 } // namespace GRC

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -99,7 +99,7 @@ bool CheckProofOfStakeV8(
     bool generated_by_me,
     uint256& hashProofOfStake); //proof hash out-parameter
 
-bool FindStakeModifierRev(uint64_t& StakeModifier,CBlockIndex* pindexPrev);
+bool FindStakeModifierRev(uint64_t& StakeModifier, CBlockIndex* pindexPrev, int &nHeight);
 
 // Kernel for V8
 uint256 CalculateStakeHashV8(
@@ -108,6 +108,16 @@ uint256 CalculateStakeHashV8(
     unsigned CoinTxN,
     unsigned nTimeTx,
     uint64_t StakeModifier);
+
+// overload
+// Kernel for V8
+uint256 CalculateStakeHashV8(
+    unsigned int nBlockTime,
+    const CTransaction& CoinTx,
+    unsigned CoinTxN,
+    unsigned nTimeTx,
+    uint64_t StakeModifier);
+
 
 int64_t CalculateStakeWeightV8(const CTransaction &CoinTx, unsigned CoinTxN);
 int64_t CalculateStakeWeightV8(const CAmount& nValueIn);

--- a/src/gridcoin/staking/status.h
+++ b/src/gridcoin/staking/status.h
@@ -41,7 +41,12 @@ public:
     uint64_t KernelsFound;
     int64_t nLastCoinStakeSearchInterval;
     uint256 m_last_pos_tx_hash;
+
     uint64_t masked_time_intervals_covered = 0;
+    uint64_t masked_time_intervals_elapsed = 0;
+
+    double actual_cumulative_weight = 0.0;
+    double ideal_cumulative_weight = 0.0;
 
     void Clear();
     MinerStatus();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -28,7 +28,6 @@
 
 using namespace std;
 
-//////////////////////////////////////////////////////////////////////////////
 //
 // Gridcoin Miner
 //
@@ -38,7 +37,6 @@ double CoinToDouble(double surrogate);
 bool LessVerbose(int iMax1000);
 
 namespace {
-// Some explaining would be appreciated
 class COrphan
 {
 public:
@@ -255,8 +253,8 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
     int nHeight = pindexPrev->nHeight + 1;
 
     // Create coinbase tx
-    CTransaction &CoinBase= block.vtx[0];
-    CoinBase.nTime=block.nTime;
+    CTransaction &CoinBase = block.vtx[0];
+    CoinBase.nTime = block.nTime;
     CoinBase.vin.resize(1);
     CoinBase.vin[0].prevout.SetNull();
     CoinBase.vout.resize(1);
@@ -302,6 +300,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
         // This vector will be sorted into a priority queue:
         vector<TxPriority> vecPriority;
         vecPriority.reserve(mempool.mapTx.size());
+
         for (map<uint256, CTransaction>::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)
         {
             CTransaction& tx = (*mi).second;
@@ -325,6 +324,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             double dPriority = 0;
             int64_t nTotalIn = 0;
             bool fMissingInputs = false;
+
             for (auto const& txin : tx.vin)
             {
                 // Read prev transaction
@@ -341,10 +341,15 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
                     if (!mempool.mapTx.count(txin.prevout.hash))
                     {
                         LogPrintf("ERROR: mempool transaction missing input");
-                        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) assert("mempool transaction missing input" == 0);
+
+                        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
+                        {
+                            assert("mempool transaction missing input" == 0);
+                        }
+
                         fMissingInputs = true;
-                        if (porphan)
-                            vOrphan.pop_back();
+                        if (porphan) vOrphan.pop_back();
+
                         break;
                     }
 
@@ -360,6 +365,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
                     mapDependers[txin.prevout.hash].push_back(porphan);
                     porphan->setDependsOn.insert(txin.prevout.hash);
                     nTotalIn += mempool.mapTx[txin.prevout.hash].vout[txin.prevout.n].nValue;
+
                     continue;
                 }
                 int64_t nValueIn = txPrev.vout[txin.prevout.n].nValue;
@@ -385,7 +391,9 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
                 porphan->dFeePerKb = dFeePerKb;
             }
             else
+            {
                 vecPriority.push_back(TxPriority(dPriority, dFeePerKb, &(*mi).second));
+            }
         }
 
         // Collect transactions into block
@@ -471,7 +479,9 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
             int64_t nTxFees = tx.GetValueIn(mapInputs)-tx.GetValueOut();
             if (nTxFees < nMinFee)
             {
-                LogPrint(BCLog::LogFlags::NOISY, "Not including tx %s  due to TxFees of %" PRId64 ", bare min fee is %" PRId64, tx.GetHash().GetHex(), nTxFees, nMinFee);
+                LogPrint(BCLog::LogFlags::NOISY,
+                         "Not including tx %s  due to TxFees of %" PRId64 ", bare min fee is %" PRId64,
+                         tx.GetHash().GetHex(), nTxFees, nMinFee);
                 msMiningErrorsExcluded += tx.GetHash().GetHex() + ":FeeTooSmall("
                     + RoundToString(CoinToDouble(nFees),8) + "," +RoundToString(CoinToDouble(nMinFee),8) + ");";
                 continue;
@@ -546,9 +556,9 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
 }
 
 
-bool CreateCoinStake( CBlock &blocknew, CKey &key,
+bool CreateCoinStake(CBlock &blocknew, CKey &key,
     vector<const CWalletTx*> &StakeInputs,
-    CWallet &wallet, CBlockIndex* pindexPrev )
+    CWallet &wallet, CBlockIndex* pindexPrev)
 {
     std::string function = __func__;
     function += ": ";
@@ -558,8 +568,8 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
     CTxDB txdb("r");
     int64_t StakeWeightSum = 0;
     double StakeValueSum = 0;
-    int64_t StakeWeightMin=MAX_MONEY;
-    int64_t StakeWeightMax=0;
+    int64_t StakeWeightMin = MAX_MONEY;
+    int64_t StakeWeightMax = 0;
     CTransaction &txnew = blocknew.vtx[1]; // second tx is coinstake
 
     bool kernel_found = false;
@@ -585,42 +595,39 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
 
     g_timer.GetTimes(function + "SelectCoinsForStaking", "miner");
 
-    LogPrint(BCLog::LogFlags::MINER, "CreateCoinStake: Staking nTime/16= %d Bits= %u",
-    txnew.nTime/16,blocknew.nBits);
+    LogPrint(BCLog::LogFlags::MINER, "CreateCoinStake: Staking nTime/16 = %d Bits = %u",
+             txnew.nTime/16, blocknew.nBits);
+
+    uint64_t StakeModifier = 0;
+    int nHeight_mod = 0;
+
+    if (!GRC::FindStakeModifierRev(StakeModifier, pindexPrev, nHeight_mod)) return false;
+
+    LogPrint(BCLog::LogFlags::MISC, "FindStakeModifierRev(): pindex->nHeight = %i, "
+                                    "pindex->nStakeModifier = %" PRId64,
+                                    nHeight_mod, StakeModifier);
 
     for (const auto& pcoin : CoinsToStake)
     {
-        const CTransaction &CoinTx =*pcoin.first; //transaction that produced this coin
-        unsigned int CoinTxN =pcoin.second; //index of this coin inside it
+        const CWalletTx &CoinTx = *pcoin.first; //transaction that produced this coin
+        unsigned int CoinTxN = pcoin.second; //index of this coin inside it
 
-        CTxIndex txindex;
-        {
-            LOCK2(cs_main, wallet.cs_wallet);
-            if (!txdb.ReadTxIndex(pcoin.first->GetHash(), txindex))
-                continue; //error?
-        }
+        unsigned int block_time;
 
-        CBlock CoinBlock; //Block which contains CoinTx
-        {
-            LOCK2(cs_main, wallet.cs_wallet);
-            if (!CoinBlock.ReadFromDisk(txindex.pos.nFile, txindex.pos.nBlockPos, false))
-                continue;
-        }
+        block_time = mapBlockIndex[CoinTx.hashBlock]->nTime;
 
-        StakeValueSum += CoinTx.vout[CoinTxN].nValue / (double)COIN;
+        StakeValueSum += CoinTx.vout[CoinTxN].nValue / (double) COIN;
 
-        uint64_t StakeModifier = 0;
-        if(!GRC::FindStakeModifierRev(StakeModifier,pindexPrev))
-            continue;
-        CoinWeight = GRC::CalculateStakeWeightV8(CoinTx,CoinTxN);
-        StakeKernelHash.setuint256(GRC::CalculateStakeHashV8(CoinBlock,CoinTx,CoinTxN,txnew.nTime,StakeModifier));
+        CoinWeight = GRC::CalculateStakeWeightV8(CoinTx, CoinTxN);
+
+        StakeKernelHash.setuint256(GRC::CalculateStakeHashV8(block_time, CoinTx, CoinTxN, txnew.nTime, StakeModifier));
 
         CBigNum StakeTarget;
         StakeTarget.SetCompact(blocknew.nBits);
-        StakeTarget*=CoinWeight;
+        StakeTarget *= CoinWeight;
         StakeWeightSum += CoinWeight;
-        StakeWeightMin=std::min(StakeWeightMin,CoinWeight);
-        StakeWeightMax=std::max(StakeWeightMax,CoinWeight);
+        StakeWeightMin = std::min(StakeWeightMin, CoinWeight);
+        StakeWeightMax = std::max(StakeWeightMax, CoinWeight);
         double StakeKernelDiff = GRC::GetBlockDifficulty(StakeKernelHash.GetCompact())*CoinWeight;
 
         LogPrint(BCLog::LogFlags::MINER,
@@ -640,23 +647,25 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
         if (StakeKernelHash <= StakeTarget)
         {
             // Found a kernel
-            LogPrintf("CreateCoinStake: Found Kernel;");
+            LogPrintf("CreateCoinStake: Found Kernel");
             vector<valtype> vSolutions;
             txnouttype whichType;
             CScript scriptPubKeyOut;
             CScript scriptPubKeyKernel;
             scriptPubKeyKernel = CoinTx.vout[CoinTxN].scriptPubKey;
+
             if (!Solver(scriptPubKeyKernel, whichType, vSolutions))
             {
                 LogPrintf("CreateCoinStake: failed to parse kernel");
                 break;
             }
+
             if (whichType == TX_PUBKEYHASH) // pay to address type
             {
                 // convert to pay to public key type
                 if (!wallet.GetKey(uint160(vSolutions[0]), key))
                 {
-                    LogPrintf("CreateCoinStake: failed to get key for kernel type=%d", whichType);
+                    LogPrintf("CreateCoinStake: failed to get key for kernel type = %d", whichType);
                     break;  // unable to find corresponding public key
                 }
                 scriptPubKeyOut << key.GetPubKey() << OP_CHECKSIG;
@@ -667,7 +676,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
                 if (!wallet.GetKey(Hash160(vchPubKey), key)
                     || key.GetPubKey() != vchPubKey)
                 {
-                    LogPrintf("CreateCoinStake: failed to get key for kernel type=%d", whichType);
+                    LogPrintf("CreateCoinStake: failed to get key for kernel type = %d", whichType);
                     break;  // unable to find corresponding public key
                 }
 
@@ -675,7 +684,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             }
             else
             {
-                LogPrintf("CreateCoinStake: no support for kernel type=%d", whichType);
+                LogPrintf("CreateCoinStake: no support for kernel type = %d", whichType);
                 break;  // only support pay to public key and pay to address
             }
 
@@ -687,7 +696,7 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
             txnew.vout.push_back(CTxOut(0, CScript())); // First Must be empty
             txnew.vout.push_back(CTxOut(nCredit, scriptPubKeyOut));
 
-            LogPrintf("CreateCoinStake: added kernel type=%d credit=%f", whichType,CoinToDouble(nCredit));
+            LogPrintf("CreateCoinStake: added kernel type = %d credit = %f", whichType, CoinToDouble(nCredit));
 
             kernel_found = true;
 
@@ -719,25 +728,29 @@ bool CreateCoinStake( CBlock &blocknew, CKey &key,
 
         ++g_miner_status.masked_time_intervals_covered;
 
-        // Implicit cast to double so it doesn't overflow. This is effectively sum of the weight of each stake
-        // times the number of stakes. This is the total effective weight for the run time of the miner.
+        // This is effectively sum of the weight of each stake attempt added back to itself for cumulative total stake
+        // weight. This is the total effective weight for the run time of the miner.
         g_miner_status.actual_cumulative_weight += StakeWeightSum;
 
-        g_miner_status.masked_time_intervals_elapsed = (g_timer.GetElapsedTime("uptime", "default") / 1000)
-                                                        / (GRC::STAKE_TIMESTAMP_MASK + 1);
+        // This is effectively the idealized weight equivalent of the balance times the number of quantized
+        // (masked) staking periods that have elapsed since the last trip through, added back for a cumulative total.
+        // the calculation is done this way rather than just using the elapsed time to ensure the masked time
+        // intervals are aligned in the calculations.
+        int64_t masked_time_elapsed = GRC::MaskStakeTime(GetTimeMillis() / 1000 + GetTimeOffset())
+                                      - GRC::MaskStakeTime(g_timer.GetStartTime("default") / 1000 + GetTimeOffset());
 
-        // Implicit cast to double so it doesn't overflow. This is effectively the idealized weight equivalent
-        // of the balance times the number of quantized staking periods that have elapsed since the last trip through,
-        // added back for a cumulative total.
-        g_miner_status.ideal_cumulative_weight += GRC::CalculateStakeWeightV8(balance)
-                                                    * (g_miner_status.masked_time_intervals_elapsed
-                                                             - prev_masked_time_intervals_elapsed);
+        g_miner_status.masked_time_intervals_elapsed = masked_time_elapsed / (GRC::STAKE_TIMESTAMP_MASK + 1);
 
-        // This allows computation of "staking efficiency" in getmininginfo.
+        g_miner_status.ideal_cumulative_weight += (double) GRC::CalculateStakeWeightV8(balance)
+                                                  * (double) (g_miner_status.masked_time_intervals_elapsed
+                                                              - prev_masked_time_intervals_elapsed);
 
+        // masked_time_intervals_covered / masked_time_intervals_elapsed provides a measure of the miner loop
+        // efficiency. actual_cumulative_weight / ideal_cumulative_weight provides a measure of the overall
+        // mining efficiency compared to ideal.
     }
 
-    g_miner_status.nLastCoinStakeSearchInterval= txnew.nTime;
+    g_miner_status.nLastCoinStakeSearchInterval = txnew.nTime;
 
     g_timer.GetTimes(function + "stake UTXO loop", "miner");
 
@@ -832,20 +845,24 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
     {
         // Iterate through passed in SideStake vector until either all elements processed, the maximum number of
         // sidestake outputs is reached, or accumulated allocation will exceed 100%.
-        for(auto iterSideStake = vSideStakeAlloc.begin(); (iterSideStake != vSideStakeAlloc.end()) && (nOutputsUsed <= nMaxSideStakeOutputs); ++iterSideStake)
+        for(auto iterSideStake = vSideStakeAlloc.begin();
+            (iterSideStake != vSideStakeAlloc.end()) && (nOutputsUsed <= nMaxSideStakeOutputs);
+            ++iterSideStake)
         {
             CBitcoinAddress address(iterSideStake->first);
             if (!address.IsValid())
             {
-                LogPrintf("WARN: SplitCoinStakeOutput: ignoring sidestake invalid address %s.", iterSideStake->first.c_str());
+                LogPrintf("WARN: SplitCoinStakeOutput: ignoring sidestake invalid address %s.",
+                          iterSideStake->first.c_str());
                 continue;
             }
 
-            // Do not process a distribution that would result in an output less than 1 CENT. This will flow back into the coinstake below.
-            // Prevents dust build-up.
+            // Do not process a distribution that would result in an output less than 1 CENT. This will flow back into
+            // the coinstake below. Prevents dust build-up.
             if (nReward * iterSideStake->second < CENT)
             {
-                LogPrintf("WARN: SplitCoinStakeOutput: distribution %f too small to address %s.", CoinToDouble(nReward * iterSideStake->second), iterSideStake->first.c_str());
+                LogPrintf("WARN: SplitCoinStakeOutput: distribution %f too small to address %s.",
+                          CoinToDouble(nReward * iterSideStake->second), iterSideStake->first.c_str());
                 continue;
             }
 
@@ -860,10 +877,11 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
 
             SideStakeScriptPubKey.SetDestination(address.Get());
 
-            // It is entirely possible that the coinstake could be from an address that is specified in one of the sidestake entries
-            // if the sidestake address(es) are local to the staking wallet. There is no reason to sidestake in that case. The
-            // coins should flow down to the coinstake outputs and be returned there. This will also simplify the display logic in
-            // the UI, because it makes the sidestake and coinstake outputs disjoint from an address point of view.
+            // It is entirely possible that the coinstake could be from an address that is specified in one of the sidestake
+            // entries if the sidestake address(es) are local to the staking wallet. There is no reason to sidestake in that
+            // case. The coins should flow down to the coinstake outputs and be returned there. This will also simplify the
+            // display logic in the UI, because it makes the sidestake and coinstake outputs disjoint from an address point
+            // of view.
             if (SideStakeScriptPubKey == CoinStakeScriptPubKey)
                 continue;
 
@@ -881,7 +899,8 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
 
             blocknew.vtx[1].vout.push_back(CTxOut(nSideStake, SideStakeScriptPubKey));
 
-            LogPrintf("SplitCoinStakeOutput: create sidestake UTXO %i value %f to address %s", nOutputsUsed, CoinToDouble(nReward * iterSideStake->second), iterSideStake->first.c_str());
+            LogPrintf("SplitCoinStakeOutput: create sidestake UTXO %i value %f to address %s",
+                      nOutputsUsed, CoinToDouble(nReward * iterSideStake->second), iterSideStake->first.c_str());
             dSumAllocation += iterSideStake->second;
             nRemainingStakeOutputValue -= nSideStake;
             nOutputsUsed++;
@@ -891,7 +910,8 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
         // up when the wallet is first started, but also needs to be here, to remind the user periodically that something
         // is amiss.)
         if (dSumAllocation == 0.0)
-            LogPrintf("WARN: SplitCoinStakeOutput: enablesidestaking was set in config but nothing has been allocated for distribution!");
+            LogPrintf("WARN: SplitCoinStakeOutput: enablesidestaking was set in config but nothing has been allocated for"
+                      " distribution!");
     }
 
     // By this point, if SideStaking was used and 100% was allocated nRemainingStakeOutputValue will be
@@ -902,7 +922,10 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
     // Don't do any work here except pushing a single output if flag is false.
     if (fEnableStakeSplit)
     {
-        unsigned int nSplitStakeOutputs = min((nMaxOutputs - nOutputsUsed), GetNumberOfStakeOutputs(nRemainingStakeOutputValue, nMinStakeSplitValue, dEfficiency));
+        unsigned int nSplitStakeOutputs = min((nMaxOutputs - nOutputsUsed),
+                                              GetNumberOfStakeOutputs(nRemainingStakeOutputValue,
+                                                                      nMinStakeSplitValue,
+                                                                      dEfficiency));
         LogPrint(BCLog::LogFlags::MINER, "SplitCoinStakeOutput: nStakeOutputs = %u", nSplitStakeOutputs);
 
         // Set Actual Stake output value for split stakes to remaining output value divided by the number of split
@@ -910,13 +933,15 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
         int64_t nActualStakeOutputValue = nRemainingStakeOutputValue / nSplitStakeOutputs;
 
         LogPrint(BCLog::LogFlags::MINER, "SplitCoinStakeOutput: nSplitStakeOutputs = %f", nSplitStakeOutputs);
-        LogPrint(BCLog::LogFlags::MINER, "SplitCoinStakeOutput: nActualStakeOutputValue = %f", CoinToDouble(nActualStakeOutputValue));
+        LogPrint(BCLog::LogFlags::MINER, "SplitCoinStakeOutput: nActualStakeOutputValue = %f",
+                 CoinToDouble(nActualStakeOutputValue));
 
         int64_t nSumStakeOutputValue = 0;
         for (unsigned int i = 1; i < nSplitStakeOutputs; i++)
         {
             blocknew.vtx[1].vout.push_back(CTxOut(nActualStakeOutputValue, CoinStakeScriptPubKey));
-            LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nOutputsUsed, CoinToDouble(nActualStakeOutputValue));
+            LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nOutputsUsed,
+                      CoinToDouble(nActualStakeOutputValue));
             nOutputsUsed++;
             nSumStakeOutputValue += nActualStakeOutputValue;
         }
@@ -925,7 +950,8 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
         // The reason we go through this trouble is that integer division rounds down, and we don't even want
         // to have the wallet lose 1 Halford.
         blocknew.vtx[1].vout.push_back(CTxOut((nRemainingStakeOutputValue - nSumStakeOutputValue), CoinStakeScriptPubKey));
-        LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nOutputsUsed, CoinToDouble(nRemainingStakeOutputValue - nSumStakeOutputValue));
+        LogPrintf("SplitCoinStakeOutput: create stake UTXO %i value %f", nOutputsUsed,
+                  CoinToDouble(nRemainingStakeOutputValue - nSumStakeOutputValue));
     }
     else
     {
@@ -966,7 +992,8 @@ unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitVal
         nDesiredStakeOutputValue = G * GRC::GetAverageDifficulty(160) * (3.0 / 2.0) * (1 / dEfficiency  - 1) * COIN;
         nDesiredStakeOutputValue = max(nMinStakeSplitValue, nDesiredStakeOutputValue);
 
-        LogPrint(BCLog::LogFlags::MINER, "GetNumberOfStakeOutputs: nDesiredStakeOutputValue = %f", CoinToDouble(nDesiredStakeOutputValue));
+        LogPrint(BCLog::LogFlags::MINER, "GetNumberOfStakeOutputs: nDesiredStakeOutputValue = %f",
+                 CoinToDouble(nDesiredStakeOutputValue));
 
         // Divide nValue by nDesiredStakeUTXOValue. We purposely want this to be integer division to round down.
         nStakeOutputs = max((int64_t) 1, nValue / nDesiredStakeOutputValue);
@@ -974,7 +1001,7 @@ unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitVal
         LogPrint(BCLog::LogFlags::MINER, "GetNumberOfStakeOutputs: nStakeOutputs = %u", nStakeOutputs);
     }
 
-    return(nStakeOutputs);
+    return nStakeOutputs;
 }
 
 bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInputs, CWallet *pwallet)
@@ -1125,6 +1152,7 @@ bool CreateGridcoinReward(
 bool IsMiningAllowed(CWallet *pwallet)
 {
     bool status = true;
+
     if(pwallet->IsLocked())
     {
         LOCK(g_miner_status.lock);
@@ -1220,7 +1248,8 @@ bool GetSideStakingStatusAndAlloc(SideStakeAlloc& vSideStakeAlloc)
                 }
 
                 vSideStakeAlloc.push_back(std::pair<std::string, double>(sAddress, dAllocation));
-                LogPrint(BCLog::LogFlags::MINER, "StakeMiner: SideStakeAlloc Address %s, Allocation %f", sAddress.c_str(), dAllocation);
+                LogPrint(BCLog::LogFlags::MINER, "StakeMiner: SideStakeAlloc Address %s, Allocation %f",
+                         sAddress.c_str(), dAllocation);
 
                 vSubParam.clear();
             }
@@ -1228,7 +1257,8 @@ bool GetSideStakingStatusAndAlloc(SideStakeAlloc& vSideStakeAlloc)
         // If we get here and dSumAllocation is zero then the enablesidestaking flag was set, but no VALID distribution
         // was provided in the config file, so warn in the debug log.
         if (!dSumAllocation)
-            LogPrintf("WARN: StakeMiner: enablesidestaking was set in config but nothing has been allocated for distribution!");
+            LogPrintf("WARN: StakeMiner: enablesidestaking was set in config but nothing has been allocated for"
+                      " distribution!");
     }
 
     return fEnableSideStaking;
@@ -1256,7 +1286,8 @@ bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficie
 
         // Pull Minimum Post Stake UTXO Split Value from config or command line parameter.
         // Default to 800 and do not allow it to be specified below 800 GRC.
-        nMinStakeSplitValue = max(GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC), MIN_STAKE_SPLIT_VALUE_GRC) * COIN;
+        nMinStakeSplitValue = max(GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC), MIN_STAKE_SPLIT_VALUE_GRC)
+                              * COIN;
 
         LogPrint(BCLog::LogFlags::MINER, "StakeMiner: nMinStakeSplitValue = %f", CoinToDouble(nMinStakeSplitValue));
 
@@ -1334,12 +1365,12 @@ void StakeMiner(CWallet *pwallet)
         CBlockIndex* pindexPrev = pindexBest;
 
         // * Create a bare block
-        StakeBlock.nTime= GetAdjustedTime();
-        StakeBlock.nNonce= 0;
+        StakeBlock.nTime = GetAdjustedTime();
+        StakeBlock.nNonce = 0;
         StakeBlock.nBits = GRC::GetNextTargetRequired(pindexPrev);
         StakeBlock.vtx.resize(2);
         //tx 0 is coin_base
-        CTransaction &StakeTX= StakeBlock.vtx[1]; //tx 1 is coin_stake
+        CTransaction &StakeTX = StakeBlock.vtx[1]; //tx 1 is coin_stake
 
         // * Try to create a CoinStake transaction
         CKey BlockKey;
@@ -1352,19 +1383,19 @@ void StakeMiner(CWallet *pwallet)
         g_timer.GetTimes(function + "end", "miner");
 
         if (!createcoinstake_success) continue;
-        StakeBlock.nTime= StakeTX.nTime;
+
+        StakeBlock.nTime = StakeTX.nTime;
 
         // * create rest of the block. This needs to be moved to after CreateGridcoinReward,
         // because stake output splitting needs to be done beforehand for size considerations.
-        if( !CreateRestOfTheBlock(StakeBlock,pindexPrev) )
-            continue;
+        if (!CreateRestOfTheBlock(StakeBlock,pindexPrev)) continue;
+
         LogPrintf("StakeMiner: created rest of the block");
 
         // * add gridcoin reward to coinstake, fill-in nReward
         int64_t nReward = 0;
-        if(!CreateGridcoinReward(StakeBlock, pindexPrev, nReward, pwallet)) {
-            continue;
-        }
+
+        if (!CreateGridcoinReward(StakeBlock, pindexPrev, nReward, pwallet)) continue;
 
         g_timer.GetTimes(function + "CreateGridcoinReward", "miner");
 
@@ -1372,16 +1403,15 @@ void StakeMiner(CWallet *pwallet)
 
         // * If argument is supplied desiring stake output splitting or side staking, then call SplitCoinStakeOutput.
         if (fEnableStakeSplit || fEnableSideStaking)
-            SplitCoinStakeOutput(StakeBlock, nReward, fEnableStakeSplit, fEnableSideStaking, vSideStakeAlloc, nMinStakeSplitValue, dEfficiency);
+            SplitCoinStakeOutput(StakeBlock, nReward, fEnableStakeSplit, fEnableSideStaking,
+                                 vSideStakeAlloc, nMinStakeSplitValue, dEfficiency);
 
         AddSuperblockContractOrVote(StakeBlock);
 
         g_timer.GetTimes(function + "AddSuperblockContractOrVote", "miner");
 
         // * sign boinchash, coinstake, wholeblock
-        if (!SignStakeBlock(StakeBlock, BlockKey, StakeInputs, pwallet)) {
-            continue;
-        }
+        if (!SignStakeBlock(StakeBlock, BlockKey, StakeInputs, pwallet)) continue;
 
         g_timer.GetTimes(function + "SignStakeBlock", "miner");
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -83,13 +83,24 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         // of nLastCoinStakeSearchInterval, but this is not important for the efficiency calculation. It will
         // result in a maximum possible error of 1 interval in the numerator and the relative error will diminish
         // rapidly.
-        int64_t masked_uptime_intervals = (g_timer.GetElapsedTime("uptime", "default") / 1000)
-                                          / (GRC::STAKE_TIMESTAMP_MASK + 1);
-        obj.pushKV("masked_uptime_intervals", masked_uptime_intervals);
+        obj.pushKV("masked_time_intervals_elapsed", g_miner_status.masked_time_intervals_elapsed);
 
         double staking_loop_efficiency = g_miner_status.masked_time_intervals_covered * 100.0
-                                         / (double) masked_uptime_intervals;
+                                         / (double) g_miner_status.masked_time_intervals_elapsed;
+
         obj.pushKV("staking_loop_efficiency", staking_loop_efficiency);
+
+        obj.pushKV("actual_cumulative_weight", g_miner_status.actual_cumulative_weight);
+        obj.pushKV("ideal_cumulative_weight", g_miner_status.ideal_cumulative_weight);
+
+        double staking_efficiency = 0.0;
+
+        if (g_miner_status.ideal_cumulative_weight > 0.0)
+        {
+            staking_efficiency = g_miner_status.actual_cumulative_weight * 100.0
+                                 / g_miner_status.ideal_cumulative_weight;
+        }
+        obj.pushKV("staking_efficiency", staking_efficiency);
     }
 
     int64_t nMinStakeSplitValue = 0;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -78,15 +78,14 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         obj.pushKV("mining-kernels-found", g_miner_status.KernelsFound);
 
         obj.pushKV("masked_time_intervals_covered", g_miner_status.masked_time_intervals_covered);
-
-        // The alignment of the intervals may be different here than using the boundaries on the advancement
-        // of nLastCoinStakeSearchInterval, but this is not important for the efficiency calculation. It will
-        // result in a maximum possible error of 1 interval in the numerator and the relative error will diminish
-        // rapidly.
         obj.pushKV("masked_time_intervals_elapsed", g_miner_status.masked_time_intervals_elapsed);
 
-        double staking_loop_efficiency = g_miner_status.masked_time_intervals_covered * 100.0
-                                         / (double) g_miner_status.masked_time_intervals_elapsed;
+        double staking_loop_efficiency = 0.0;
+        if (g_miner_status.masked_time_intervals_elapsed > 0)
+        {
+            staking_loop_efficiency = g_miner_status.masked_time_intervals_covered * 100.0
+                    / (double) g_miner_status.masked_time_intervals_elapsed;
+        }
 
         obj.pushKV("staking_loop_efficiency", staking_loop_efficiency);
 
@@ -94,7 +93,6 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
         obj.pushKV("ideal_cumulative_weight", g_miner_status.ideal_cumulative_weight);
 
         double staking_efficiency = 0.0;
-
         if (g_miner_status.ideal_cumulative_weight > 0.0)
         {
             staking_efficiency = g_miner_status.actual_cumulative_weight * 100.0

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -117,6 +117,23 @@ bool MilliTimer::LogTimer(const std::string& label, bool log)
     return false;
 }
 
+int64_t MilliTimer::GetStartTime(const std::string& label)
+{
+    internal_timer internal_timer;
+
+    try
+    {
+
+        LOCK(cs_timer_map_lock);
+
+        // This will throw an internal exception if the entry specified by label doesn't exist.
+        internal_timer = timer_map.at(label);
+    }
+    catch (std::out_of_range) {}
+
+    return internal_timer.start_time;
+}
+
 const MilliTimer::timer MilliTimer::GetTimes(const std::string& log_string, const std::string& label)
 {
     internal_timer internal_timer;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -94,6 +94,7 @@ public:
     bool DeleteTimer(const std::string& label);
     bool LogTimer(const std::string& label, bool log);
 
+    int64_t GetStartTime(const std::string& label = "default");
     const timer GetTimes(const std::string& log_string, const std::string& label = "default");
     int64_t GetElapsedTime(const std::string& log_string, const std::string& label = "default");
 private:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1631,12 +1631,16 @@ bool CWallet::SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, set<pai
 // Formula Stakable = ((SPENDABLE - RESERVED) > UTXO)
 */
 bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<const CWalletTx*,unsigned int> >& vCoinsRet,
-                                    GRC::MinerStatus::ReasonNotStakingCategory& not_staking_error, bool fMiner) const
+                                    GRC::MinerStatus::ReasonNotStakingCategory& not_staking_error,
+                                    int64_t& balance,
+                                    bool fMiner) const
 {
     std::string function = __func__;
     function += ": ";
 
-    int64_t BalanceToConsider = GetBalance();
+    balance = GetBalance();
+
+    int64_t BalanceToConsider = balance;
 
     // Check if we have a spendable balance
     if (BalanceToConsider <= 0)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -200,7 +200,7 @@ public:
 
 	void AvailableCoinsForStaking(std::vector<COutput>& vCoins, unsigned int nSpendTime) const;
     bool SelectCoinsForStaking(unsigned int nSpendTime, std::vector<std::pair<const CWalletTx*,unsigned int> >& vCoinsRet,
-                               GRC::MinerStatus::ReasonNotStakingCategory& not_staking_error, bool fMiner = false) const;
+                               GRC::MinerStatus::ReasonNotStakingCategory& not_staking_error, int64_t& balance, bool fMiner = false) const;
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, bool fIncludeStakingCoins=false) const;
     bool SelectCoinsMinConf(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
     bool SelectSmallestCoins(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;


### PR DESCRIPTION
This PR refines the calculation of staking_loop_efficiency, which measures the percent of time that the staking loop is staking. It also adds the measure of staking_efficiency, which includes the combined effect of the quantized (masked) intervals covered by the miner, and also the actual weight applied in the staking loop versus the ideal weight. Note that this includes the effect of cooldown and UTXO's that are too small to stake.

It also makes several improvements to the miner loop and the functions called within to reduce the overhead in the situations where the wallet has a high number of transactions (mapwallet size is large) and/or the number of UTXO's is large.