### PR TITLE
accrual, rpc: Implement auditsnapshotaccruals

### DIFF
--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -248,5 +248,11 @@ public:
     //! \param pindex Index of the block to start recounting backward from.
     //!
     static void LegacyRecount(const CBlockIndex* pindex);
+
+    //!
+    //! \brief Return the baseline snapshot height for the tally.
+    //!
+    const static CBlockIndex* GetBaseline();
+
 };
 }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -170,6 +170,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "superblocks"            , 1 },
 
     // Developer
+    { "auditsnapshotaccrual"   , 1 },
+    { "auditsnapshotaccruals"  , 0 },
     { "convergencereport"      , 0 },
     { "debug"                  , 0 },
     { "debug10"                , 0 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -363,6 +363,7 @@ static const CRPCCommand vRPCCommands[] =
 
   // Developer commands
     { "auditsnapshotaccrual",    &auditsnapshotaccrual,    cat_developer     },
+    { "auditsnapshotaccruals",   &auditsnapshotaccruals,   cat_developer     },
     { "addkey",                  &addkey,                  cat_developer     },
     { "comparesnapshotaccrual",  &comparesnapshotaccrual,  cat_developer     },
     { "currentcontractaverage",  &currentcontractaverage,  cat_developer     },
@@ -376,6 +377,7 @@ static const CRPCCommand vRPCCommands[] =
     { "inspectaccrualsnapshot",  &inspectaccrualsnapshot,  cat_developer     },
     { "listdata",                &listdata,                cat_developer     },
     { "listprojects",            &listprojects,            cat_developer     },
+    { "listresearcheraccounts",  &listresearcheraccounts,  cat_developer     },
     { "logging",                 &logging,                 cat_developer     },
     { "network",                 &network,                 cat_developer     },
     { "parseaccrualsnapshotfile",&parseaccrualsnapshotfile,cat_developer     },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -184,6 +184,7 @@ extern UniValue superblocks(const UniValue& params, bool fHelp);
 
 // Developers
 extern UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp);
+extern UniValue auditsnapshotaccruals(const UniValue& params, bool fHelp);
 extern UniValue addkey(const UniValue& params, bool fHelp);
 extern UniValue comparesnapshotaccrual(const UniValue& params, bool fHelp);
 extern UniValue currentcontractaverage(const UniValue& params, bool fHelp);
@@ -195,6 +196,7 @@ extern UniValue getlistof(const UniValue& params, bool fHelp);
 extern UniValue inspectaccrualsnapshot(const UniValue& params, bool fHelp);
 extern UniValue listdata(const UniValue& params, bool fHelp);
 extern UniValue listprojects(const UniValue& params, bool fHelp);
+extern UniValue listresearcheraccounts(const UniValue& params, bool fHelp);
 extern UniValue logging(const UniValue& params, bool fHelp);
 extern UniValue network(const UniValue& params, bool fHelp);
 extern UniValue parseaccrualsnapshotfile(const UniValue& params, bool fHelp);


### PR DESCRIPTION
This PR implements auditsnapshotaccruals, which allows a global accrual audit across all active CPID's. It also make changes to auditsnapshotaccrual to start in the v11 regime and improves logging for better troubleshooting.

There may be further improvements to this coming.

This is part of the work to track down the problem indicated in #1999.