### PR TITLE
net: Don't rely on external IP resolvers.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -781,7 +781,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         for (int n = 0; n < NET_MAX; n++) {
             enum Network net = (enum Network)n;
             if (!nets.count(net))
-                SetLimited(net);
+                SetReachable(net, false);
         }
     }
 
@@ -812,7 +812,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         if (!addrOnion.IsValid())
             return InitError(strprintf(_("Invalid -tor address: '%s'"), mapArgs["-tor"]));
         SetProxy(NET_TOR, addrOnion, 5);
-        SetReachable(NET_TOR);
+        SetReachable(NET_TOR, true);
     }
 
     // see Step 2: parameter interactions for more information about these

--- a/src/net.h
+++ b/src/net.h
@@ -75,7 +75,6 @@ enum
     LOCAL_MAX
 };
 
-void SetLimited(enum Network net, bool fLimited = true);
 bool IsLimited(enum Network net);
 bool IsLimited(const CNetAddr& addr);
 bool AddLocal(const CService& addr, int nScore = LOCAL_NONE);
@@ -84,9 +83,9 @@ bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);
 bool GetLocal(CService &addr, const CNetAddr *paddrPeer = NULL);
 bool IsReachable(const CNetAddr &addr);
-void SetReachable(enum Network net, bool fFlag = true);
+void SetReachable(enum Network net, bool fFlag = false);
 CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
-
+void AdvertiseLocal(CNode *pnode = nullptr);
 
 enum
 {
@@ -226,6 +225,7 @@ public:
     int64_t nLastSend;
     int64_t nLastRecv;
     int64_t nTimeConnected;
+    int64_t nNextRebroadcastTime;
     std::atomic<int64_t> nTimeOffset{0};
     CAddress addr;
     std::string addrName;
@@ -302,6 +302,7 @@ public:
         nLastSend = 0;
         nLastRecv = 0;
         nTimeConnected = GetAdjustedTime();
+        nNextRebroadcastTime = GetAdjustedTime();
         addr = addrIn;
         addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
         nVersion = 0;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -25,6 +25,8 @@ enum Network
     NET_IPV6,
     NET_TOR,
     NET_I2P,
+    NET_CJDNS,
+    NET_INTERNAL,
 
     NET_MAX,
 };


### PR DESCRIPTION
adapts the Bitcoin way of figuring the IP address.

Occasionally the IP address as reported by the peer is reported to them
back. If this leads to more incoming connections, they had better
knowing of our IP than we did.

also changed:
 * Debug from NOISY to NET
 * cleanup of mixed vfLimited and vfReachable.
 * some re-sorting to match the order in bitcoins net.cpp more closely
 * smeared timeout for address broadcasts.