### PR TITLE
ci: remove python workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
             key: ${{ runner.os }}
         - name: install-packages
           run: |
-            brew upgrade python || brew link --overwrite python
-            brew install autoconf automake berkeley-db4 boost miniupnpc qrencode ccache leveldb librsvg libtool libzip openssl pkg-config qt xquartz
+            brew install autoconf automake berkeley-db4 boost miniupnpc qrencode ccache leveldb librsvg libtool libzip openssl pkg-config python qt xquartz
         - name: test
           run: |
             ./ci/test_run_all.sh


### PR DESCRIPTION
The conflict in #1990 is fixed in Github Actions macOS image, so the workaround is not needed anymore.