### PR TITLE
beacon: Change beacon map to pointers.

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -204,7 +204,7 @@ const CBlockIndex* GetBeaconConsensusHeight()
 BeaconConsensus GetConsensusBeaconList()
 {
     BeaconConsensus consensus;
-    std::vector<std::pair<Cpid, Beacon>> beacons;
+    std::vector<std::pair<Cpid, Beacon_ptr>> beacon_ptrs;
     std::vector<std::pair<CKeyID, PendingBeacon>> pending_beacons;
     int64_t max_time;
 
@@ -223,16 +223,16 @@ BeaconConsensus GetConsensusBeaconList()
         // Copy the set of beacons out of the registry so we can release the
         // lock on cs_main before stringifying them:
         //
-        beacons.reserve(beacon_map.size());
-        beacons.assign(beacon_map.begin(), beacon_map.end());
+        beacon_ptrs.reserve(beacon_map.size());
+        beacon_ptrs.assign(beacon_map.begin(), beacon_map.end());
         pending_beacons.reserve(pending_beacon_map.size());
         pending_beacons.assign(pending_beacon_map.begin(), pending_beacon_map.end());
     }
 
-    for (const auto& beacon_pair : beacons)
+    for (const auto& beacon_pair : beacon_ptrs)
     {
         const Cpid& cpid = beacon_pair.first;
-        const Beacon& beacon = beacon_pair.second;
+        const Beacon& beacon = *beacon_pair.second;
 
         if (beacon.Expired(max_time) || beacon.m_timestamp >= max_time)
         {
@@ -3926,8 +3926,8 @@ bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& Pub
     nAvgTimeBetweenManifests = nTotalTime / nIntervals;
 
     // nScraperSleep is in milliseconds. If the average interval is less than 25% of nScraperSleep in seconds, ban the scraper.
-    // Note that this is at least a factor of 12 faster than the expected rate given usual project update velocity.
-    if (nAvgTimeBetweenManifests < nScraperSleep / 4000)
+    // Note that this is a factor of 24 faster than the expected rate given usual project update velocity.
+    if (nAvgTimeBetweenManifests < nScraperSleep / 8000)
     {
         _log(logattribute::CRITICAL, "IsScraperMaximumManifestPublishingRateExceeded", "Scraper " + sManifestAddress +
              " has published too many manifests in too short a time:\n" +

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -745,7 +745,7 @@ UniValue beaconreport(const UniValue& params, bool fHelp)
 
     UniValue results(UniValue::VARR);
 
-    std::vector<std::pair<GRC::Cpid, GRC::Beacon>> active_beacons;
+    std::vector<std::pair<GRC::Cpid, GRC::Beacon_ptr>> active_beacon_ptrs;
 
     // Minimize the lock on cs_main.
     {
@@ -753,17 +753,17 @@ UniValue beaconreport(const UniValue& params, bool fHelp)
 
         const auto& beacon_map = GRC::GetBeaconRegistry().Beacons();
 
-        active_beacons.reserve(beacon_map.size());
-        active_beacons.assign(beacon_map.begin(), beacon_map.end());
+        active_beacon_ptrs.reserve(beacon_map.size());
+        active_beacon_ptrs.assign(beacon_map.begin(), beacon_map.end());
     }
 
-    for (const auto& beacon_pair : active_beacons)
+    for (const auto& beacon_pair : active_beacon_ptrs)
     {
         UniValue entry(UniValue::VOBJ);
 
         entry.pushKV("cpid", beacon_pair.first.ToString());
-        entry.pushKV("address", beacon_pair.second.GetAddress().ToString());
-        entry.pushKV("timestamp", beacon_pair.second.m_timestamp);
+        entry.pushKV("address", beacon_pair.second->GetAddress().ToString());
+        entry.pushKV("timestamp", beacon_pair.second->m_timestamp);
 
         results.push_back(entry);
     }

--- a/src/test/gridcoin/beacon_tests.cpp
+++ b/src/test/gridcoin/beacon_tests.cpp
@@ -158,32 +158,32 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_the_beacon_is_well_formed)
 BOOST_AUTO_TEST_CASE(it_calculates_the_age_of_the_beacon)
 {
     const int64_t now = 100;
-    const GRC::Beacon beacon(CPubKey(), 99);
+    const GRC::Beacon beacon(CPubKey(), 99, uint256 {});
 
     BOOST_CHECK_EQUAL(beacon.Age(now), 1);
 }
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_beacon_expired)
 {
-    const GRC::Beacon valid(CPubKey(), GRC::Beacon::MAX_AGE);
+    const GRC::Beacon valid(CPubKey(), GRC::Beacon::MAX_AGE, uint256 {});
     BOOST_CHECK(valid.Expired(GRC::Beacon::MAX_AGE) == false);
 
-    const GRC::Beacon almost(CPubKey(), 1);
+    const GRC::Beacon almost(CPubKey(), 1, uint256 {});
     BOOST_CHECK(almost.Expired(GRC::Beacon::MAX_AGE + 1) == false);
 
-    const GRC::Beacon expired(CPubKey(), 1);
+    const GRC::Beacon expired(CPubKey(), 1, uint256 {});
     BOOST_CHECK(expired.Expired(GRC::Beacon::MAX_AGE + 2) == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_determines_whether_a_beacon_is_renewable)
 {
-    const GRC::Beacon not_needed(CPubKey(), GRC::Beacon::RENEWAL_AGE);
+    const GRC::Beacon not_needed(CPubKey(), GRC::Beacon::RENEWAL_AGE, uint256 {});
     BOOST_CHECK(not_needed.Renewable(GRC::Beacon::RENEWAL_AGE) == false);
 
-    const GRC::Beacon almost(CPubKey(), 1);
+    const GRC::Beacon almost(CPubKey(), 1, uint256 {});
     BOOST_CHECK(almost.Renewable(GRC::Beacon::RENEWAL_AGE) == false);
 
-    const GRC::Beacon renewable(CPubKey(), 1);
+    const GRC::Beacon renewable(CPubKey(), 1, uint256 {});
     BOOST_CHECK(renewable.Renewable(GRC::Beacon::RENEWAL_AGE + 2) == true);
 }
 


### PR DESCRIPTION
This changes the beacon map used for the active set of beacons to point to the beacons in the historical map to save memory (since more memory is being used for the transaction hashes).

This also corrects the hash used to store the elements in the historical map.

Note that std::shared_pointer smart pointers are used to ensure the validity of a pointer to a given beacon in the historical map, which is now where all beacons that are not pending are stored, although the beacon class is supposed to be protected by cs_main, so it probably isn't strictly necessary, but not harmful.

Note this is really the first part to implement a beacon storage cache in leveldb as a separate index type to be able to store the entire beacon set since the original Fern hardfork and reload rapidly on restart, plus only keep a subset in memory perhaps.

This is 100% compatible with the previous accrual work in #2004.