### PR TITLE
rpc: Add boolean option to report active beacons only in beaconreport

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -166,6 +166,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
     // Mining
     { "advertisebeacon"        , 0 },
+    { "beaconreport"           , 0 },
     { "superblocks"            , 0 },
     { "superblocks"            , 1 },
 


### PR DESCRIPTION
This commit adds a boolean that defaults to false, but when set true causes only active beacons to be reported. The parameter is
optional and defaults to false, which is the original behavior, and includes expired beacons.