### PR TITLE
util: Update snapshot URLs and add accrual directory

### DIFF
--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -301,7 +301,7 @@ std::string Http::GetLatestVersionResponse()
 
 void Http::DownloadSnapshot()
 {
-    std::string url = GetArg("-snapshoturl", "https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip");
+    std::string url = GetArg("-snapshoturl", "https://snapshot.gridcoin.us/snapshot.zip");
 
     fs::path destination = GetDataDir() / "snapshot.zip";
 
@@ -383,7 +383,7 @@ std::string Http::GetSnapshotSHA256()
 {
     std::string buffer;
     std::string header;
-    std::string url = GetArg("-snapshotsha256url", "https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip.sha256");
+    std::string url = GetArg("-snapshotsha256url", "https://snapshot.gridcoin.us/snapshot.zip.sha256");
 
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Accept: */*");

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -361,14 +361,22 @@ bool Upgrade::CleanupBlockchainData()
         {
             if (fs::is_directory(Iter->path()))
             {
-                size_t DirLoc = Iter->path().string().find("txleveldb");
+                for (const auto& path_segment : Iter->path())
+                {
+                    if (path_segment.string() == "txleveldb")
+                    {
+                        if (!fs::remove_all(*Iter)) return false;
+                    }
+                }
 
-                if (DirLoc != std::string::npos)
-                    if (!fs::remove_all(*Iter))
-                        return false;
-
+                for (const auto& path_segment : Iter->path())
+                {
+                    if (path_segment.string() == "accrual")
+                    {
+                        if (!fs::remove_all(*Iter)) return false;
+                    }
+                }
                 continue;
-
             }
 
             else if (fs::is_regular_file(*Iter))


### PR DESCRIPTION
This updates the URLs to use a CDN and also adds the accrual directory to be deleted before snapshot installation. The snapshot
file does not have to contain an accrual directory, in which case the wallet will rebuild the accrual directory from restart.