### PR TITLE
wallet: Correct nMinFee fee calculation in CreateTransaction

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1948,7 +1948,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
 
                 // Check that enough fee is included
                 int64_t nPayFee = nTransactionFee * (1 + (int64_t)nBytes / 1000);
-                int64_t nMinFee = wtxNew.GetMinFee(1, GMF_SEND, nBytes);
+                int64_t nMinFee = wtxNew.GetMinFee(1000, GMF_SEND, nBytes);
 
                 if (nFeeRet < max(nPayFee, nMinFee))
                 {


### PR DESCRIPTION
This updates the nMinFee to use the same minimum block size as used in AcceptToMemPool and the miner. This is a short term fix to correct the insufficient fees error, although there are still corner cases where it could happen. A more sophisticated review of the fee calculations will occur in the preparations for the next mandatory after Hilda.