### PR TITLE
consensus: Set Hilda mainnet hardfork height to 2197000

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -138,5 +138,5 @@ inline int GetOrigNewbieSnapshotFixHeight()
 
 inline int GetNewbieSnapshotFixHeight()
 {
-    return fTestNet ? 1480000 : std::numeric_limits<int>::max();
+    return fTestNet ? 1480000 : 2197000;
 }

--- a/src/version.h
+++ b/src/version.h
@@ -43,9 +43,9 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 ///////////////////////////////////////////////////////////
 // network protocol versioning                           //
 //                                                       //
-static const int PROTOCOL_VERSION =       180325;        //
+static const int PROTOCOL_VERSION =       180326;        //
 // disconnect from peers older than this proto version   //
-static const int MIN_PEER_PROTO_VERSION = 180324;        //
+static const int MIN_PEER_PROTO_VERSION = 180325;        //
 ///////////////////////////////////////////////////////////
 // initial proto version, to be increased after          //
 // version/verack negotiation                            //


### PR DESCRIPTION
This also raises the protocol version to 180326, and as with Gladys, will cause nodes to disconnect peers older than 180326 after a grace period of 2k blocks above 2197000 (i.e. 2199000), and also immediately disconnect peers less than 180325.