### PR TITLE
wallet: Fix bug in CreateTransaction causing insufficient fees

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -992,9 +992,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         // Don't accept it if it can't get into a block
         int64_t txMinFee = tx.GetMinFee(1000, GMF_RELAY, nSize);
         if (nFees < txMinFee)
-            return error("AcceptToMemoryPool : not enough fees %s, %" PRId64 " < %" PRId64,
+            return error("AcceptToMemoryPool : not enough fees %s, %" PRId64 " < %" PRId64 ", nSize %" PRId64,
                          hash.ToString().c_str(),
-                         nFees, txMinFee);
+                         nFees, txMinFee, nSize);
 
         // Continuously rate-limit free transactions
         // This mitigates 'penny-flooding' -- sending thousands of free transactions just to


### PR DESCRIPTION
CreateTransaction had a major bug where the provided set of coins was conflated with the output set of coins from SelectCoins(). This caused the second and succeeding iterations of the while loop to effectively be a no-op for improved coin selection to try and resolve any insufficient fee issues. (I.e. SelectCoins was never run again because on second and succeeding iterations of the while loop, the output set from the first SelectCoins invocation was then treated as if it was the inputs to the function as a whole and therefore nothing was done and you would end up in a negative change situation.)

Also there was a missing check for negative change, which was a double bug in the sense that if it had been there, it would have at least caught the former error. The check for negative change, in the case where there is a provided coin set, must be done to avoid going through the while loop more than twice. In the case where there is a provided set of coins, AND the change is greater than zero, but it gets to the calculation of the actual fees, and they are higher than the entering value of nTransactionFee, then the second iteration through, the nFeeRet could be higher than the available value from the inputs and therefore there would be negative change at this point. The function must return an error then, since the provided set of coins must be viewed as immutable, so there is no way to cover the fees.