### PR TITLE
beacon, util, gui: Fix small error in beacon db for renewals and fix snapshot download functionality

### DIFF
--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -1456,6 +1456,11 @@ public:
         return m_registry.Deregister(height);
     }
 
+    bool CloseRegistryFile()
+    {
+        return m_registry.Close();
+    }
+
 private:
     AccrualSnapshotRegistry m_registry; //!< Tracks snapshot files state.
 }; // AccrualSnapshotRepository

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -708,6 +708,15 @@ private:
     {
     public:
         //!
+        //! \brief Version number of the beacon db.
+        //!
+        //! CONSENSUS: Increment this value when introducing a breaking change to the beacon db. This
+        //! will ensure that when the wallet is restarted, the level db beacon storage will be cleared and
+        //! reloaded from the contract replay with the correct lookback scope.
+        //!
+        static constexpr uint32_t CURRENT_VERSION = 1;
+
+        //!
         //! \brief Initializes the Beacon Registry map structures from the replay of the beacon states stored
         //! in the beacon database.
         //!

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -463,8 +463,7 @@ void GRC::ReplayContracts(const CBlockIndex* pindex_end, const CBlockIndex* pind
             // Only apply activations that have not already been stored/loaded into
             // the beacon DB. This is at the block level, so we have to be careful here.
             // If the pindex->nHeight is equal to the beacon_db_height, then the ActivatePending
-            // has already been replayed. This is different than below in ApplyContracts, where
-            // there can be more than one contract in a block, so the condition is subtly different.
+            // has already been replayed.
             if (pindex->nHeight > beacon_db_height)
             {
                 GetBeaconRegistry().ActivatePending(
@@ -510,9 +509,8 @@ void GRC::ApplyContracts(
 {
     for (const auto& contract : tx.GetContracts()) {
         // Do not (re)apply contracts that have already been stored/loeaded into
-        // the beacon DB. Note here if pindex->nHeight == beacon_db_height, the contract
-        // will be replayed. This is because there can be more than one contract per block.
-        if ((pindex->nHeight < beacon_db_height) && contract.m_type == ContractType::BEACON)
+        // the beacon DB.
+        if ((pindex->nHeight <= beacon_db_height) && contract.m_type == ContractType::BEACON)
         {
             LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: ApplyContract tx skipped: "
                       "pindex->height = %i <= beacon_db_height = %i and "

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -398,6 +398,11 @@ bool GRC::Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest)
     return true;
 }
 
+void GRC::CloseResearcherRegistryFile()
+{
+    Tally::CloseRegistryFile();
+}
+
 void GRC::ScheduleBackgroundJobs(CScheduler& scheduler)
 {
     scheduler.schedule(CheckBlockIndexJob);

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -19,6 +19,12 @@ namespace GRC {
 bool Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest);
 
 //!
+//! \brief This closes the underlying research file to support the snapshot update
+//! process, which must remove the accrual directory as part of the blockchain cleanup.
+//!
+void CloseResearcherRegistryFile();
+
+//!
 //! \brief Set up Gridcoin-specific background jobs.
 //!
 //! \param scheduler Scheduler instance to register jobs with.

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -792,6 +792,11 @@ public:
 
         return Initialize(GetStartHeight(), SuperblockPtr::Empty());
     }
+
+    bool CloseRegistryFile()
+    {
+        return m_snapshots.CloseRegistryFile();
+    }
 }; // ResearcherTally
 
 ResearcherTally g_researcher_tally; //!< Tracks lifetime research rewards.
@@ -1260,4 +1265,9 @@ void Tally::LegacyRecount(const CBlockIndex* pindex)
 const CBlockIndex* Tally::GetBaseline()
 {
     return g_researcher_tally.GetBaseline();
+}
+
+void Tally::CloseRegistryFile()
+{
+    g_researcher_tally.CloseRegistryFile();
 }

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -261,5 +261,13 @@ public:
     //!
     const static CBlockIndex* GetBaseline();
 
+    //!
+    //! \brief This closes the underlying register file of the researcher repository. It
+    //! is ONLY used in Shutdown() to release the lock on the registry.dat file
+    //! so that a snapshot download process cleanup will succeed, since the accrual directory
+    //! needs to be removed.
+    //!
+    static void CloseRegistryFile();
+
 };
 }

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -376,6 +376,7 @@ bool Upgrade::CleanupBlockchainData()
                         if (!fs::remove_all(*Iter)) return false;
                     }
                 }
+
                 continue;
             }
 
@@ -391,6 +392,7 @@ bool Upgrade::CleanupBlockchainData()
                         if (!fs::remove(*Iter))
                             return false;
                 }
+
                 continue;
             }
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -104,6 +104,11 @@ void Shutdown(void* parg)
         StopNode();
         bitdb.Flush(true);
         StopRPCThreads();
+
+        // This is necessary here to prevent a snapshot download from failing at the cleanup
+        // step because of a write lock on accrual/registry.dat.
+        GRC::CloseResearcherRegistryFile();
+
         fs::remove(GetPidFile());
         UnregisterWallet(pwalletMain);
         delete pwalletMain;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -23,6 +23,7 @@
 #include "util.h"
 #include "winshutdownmonitor.h"
 #include "gridcoin/upgrade.h"
+#include "gridcoin/gridcoin.h"
 #include "upgradeqt.h"
 
 #include <QMessageBox>
@@ -404,7 +405,7 @@ int main(int argc, char *argv[])
         //
         CTxDB().Close();
 
-        if (Snapshot.SnapshotMain())
+        if (Snapshot.SnapshotMain(app))
             LogPrintf("Snapshot: Success!");
 
         else
@@ -559,6 +560,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
     threads->interruptAll();
     threads->removeAll();
     threads.reset();
+
 
     return EXIT_SUCCESS;
 }

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -8,7 +8,6 @@
 #include <QtWidgets>
 #include <QProgressDialog>
 #include <QMessageBox>
-#include <QApplication>
 #include <QPixmap>
 #include <QIcon>
 #include <QString>
@@ -23,16 +22,8 @@ QString UpgradeQt::ToQString(const std::string& string)
     return QString::fromStdString(string);
 }
 
-bool UpgradeQt::SnapshotMain()
+bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 {
-    // Keep this separate from the main application
-    int xargc = 1;
-    char *xargv[] = {(char*)"gridcoinresearch"};
-
-    QApplication SnapshotApp(xargc, xargv);
-
-    SnapshotApp.setOrganizationName("Gridcoin");
-    SnapshotApp.setApplicationName("Gridcoin-Qt");
     SnapshotApp.processEvents();
     SnapshotApp.setWindowIcon(QPixmap(":/images/gridcoin"));
 

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <QString>
+#include <QApplication>
 
 class UpgradeQt
 {
@@ -20,7 +21,7 @@ public:
     //!
     //! \return Returns success of snapshot task.
     //!
-    bool SnapshotMain();
+    bool SnapshotMain(QApplication& SnapshotApp);
     //!
     //! \brief Function called via thread to download snapshot and provide realtime updates of progress.
     //!


### PR DESCRIPTION
This PR addresses two items that are going to go into a very small leisure release in the next few days to address a duplicated renewal record in the beacon db leveldb storage on a wallet restart after the leveldb state is reapplied and the contract replay occurs.

This error could result a node getting stuck if a restart were to occur on a block that contains a renewal contract for a beacon, and upon restart, the wallet reorganizes to a block prior to the block that contains that contract, in which case the renewal record would be removed when the renewal contract is encountered again.

The solution is to fix the offending code that was creating the duplicate record error and also version the beacon database leveldb storage. Running a wallet with this code will detect an out of date beacon leveldb storage and automatically rebuild it from a contract replay to remove any bad records created by this problem.

Before this fix, if the wallet got stuck on a reorg after restart, the solution would be to restart it again, and it would proceed.

To see if a wallet has been affected by duplicate records, one can run auditsnapshotaccruals. If the duplicate record problem exists, auditsnapshotaccruals will crash the wallet. The solution will be to install the upgrade with this fix, or start the wallet with the -clearbeaconhistory option to force a rebuild of the beacon records from the contract replay.

It also implements functionality to remove the lock on the registry.dat file of the accrual repository to allow the blockchain file cleaup to proceed properly after the snapshot download.
