### PR TITLE
rpc: Adds transaction hash and fees paid to consolidateunspent

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -797,10 +797,10 @@ UniValue consolidateunspent(const UniValue& params, bool fHelp)
                  " here.");
 
     result.pushKV("result", true);
-    result.pushKV("UTXOs_consolidated", (uint64_t) iInputCount);
-    result.pushKV("output_UTXO_value", FormatMoney(nAmount - nFeeRequired));
-    result.pushKV("fees_paid", FormatMoney(nFeeRequired));
-    result.pushKV("transaction_hash", wtxNew.GetHash().GetHex());
+    result.pushKV("utxos_consolidated", (uint64_t) iInputCount);
+    result.pushKV("output_utxo_value", FormatMoney(nAmount - nFeeRequired));
+    result.pushKV("fee", FormatMoney(nFeeRequired));
+    result.pushKV("txid", wtxNew.GetHash().GetHex());
 
     return result;
 }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -797,8 +797,10 @@ UniValue consolidateunspent(const UniValue& params, bool fHelp)
                  " here.");
 
     result.pushKV("result", true);
-    result.pushKV("UTXOs consolidated", (uint64_t) iInputCount);
-    result.pushKV("Output UTXO value", (double)(nAmount - nFeeRequired) / COIN);
+    result.pushKV("UTXOs_consolidated", (uint64_t) iInputCount);
+    result.pushKV("output_UTXO_value", FormatMoney(nAmount - nFeeRequired));
+    result.pushKV("fees_paid", FormatMoney(nFeeRequired));
+    result.pushKV("transaction_hash", wtxNew.GetHash().GetHex());
 
     return result;
 }


### PR DESCRIPTION
Also uses FormatMoney() for display of amounts to avoid floating point rounding errors. Closes #2034 ; closes #2035.