### PR TITLE
gui, voting: Make some minor adjustments for VotingDialog flow

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1136,7 +1136,7 @@ void BitcoinGUI::gotoSendCoinsPage()
 void BitcoinGUI::gotoVotingPage()
 {
     votingAction->setChecked(true);
-    votingPage->resetData();
+    //votingPage->loadPolls(false);
     centralWidget->setCurrentWidget(votingPage);
 
     exportAction->setEnabled(false);

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -278,6 +278,9 @@ VotingItem* BuildPollItem(const PollRegistry::Sequence::Iterator& iter)
 
 void VotingTableModel::resetData(bool history)
 {
+    std::string function = __func__;
+    function += ": ";
+
     // data: erase
     if (data_.size()) {
         beginRemoveRows(QModelIndex(), 0, data_.size() - 1);
@@ -287,6 +290,8 @@ void VotingTableModel::resetData(bool history)
         data_.clear();
         endRemoveRows();
     }
+
+    g_timer.GetTimes(function + "erase data", "votedialog");
 
     // retrieve data
     std::vector<VotingItem *> items;
@@ -298,8 +303,11 @@ void VotingTableModel::resetData(bool history)
             if (VotingItem* item = BuildPollItem(iter)) {
                 item->rowNumber_ = items.size() + 1;
                 items.push_back(item);
+
             }
         }
+
+        g_timer.GetTimes(function + "populate poll results (cs_main lock)", "votedialog");
     }
 
     // data: populate
@@ -308,6 +316,8 @@ void VotingTableModel::resetData(bool history)
         for(size_t i=0; i < items.size(); i++)
             data_.append(items[i]);
         endInsertRows();
+
+        g_timer.GetTimes(function + "insert data in display table", "votedialog");
     }
 }
 
@@ -434,6 +444,12 @@ VotingDialog::VotingDialog(QWidget *parent)
     chartDialog_ = new VotingChartDialog(this);
     voteDialog_ = new VotingVoteDialog(this);
     pollDialog_ = new NewPollDialog(this);
+
+    loadingIndicator->setText(tr("Press reload to load polls... This can take several minutes, and the wallet may not respond until finished."));
+    tableView_->hide();
+    loadingIndicator->show();
+
+    QObject::connect(vote_update_age_timer, SIGNAL(timeout()), this, SLOT(setStale()));
 }
 
 void VotingDialog::setModel(WalletModel *wallet_model)
@@ -448,13 +464,23 @@ void VotingDialog::setModel(WalletModel *wallet_model)
 
 void VotingDialog::loadPolls(bool history)
 {
+    std::string function = __func__;
+    function += ": ";
+
     bool isRunning = watcher.property("running").toBool();
     if (tableModel_&& !isRunning)
     {
         loadingIndicator->setText(tr("Recalculating voting weights... This can take several minutes, and the wallet may not respond until finished."));
         tableView_->hide();
         loadingIndicator->show();
+
+        g_timer.InitTimer("votedialog", LogInstance().WillLogCategory(BCLog::LogFlags::MISC));
+        vote_update_age_timer->start(STALE);
+
         QFuture<void> future = QtConcurrent::run(tableModel_, &VotingTableModel::resetData, history);
+
+        g_timer.GetTimes(function + "Post future assignment", "votedialog");
+
         watcher.setProperty("running", true);
         watcher.setFuture(future);
     }
@@ -470,6 +496,26 @@ void VotingDialog::loadHistory(void)
     loadPolls(true);
 }
 
+void VotingDialog::setStale(void)
+{
+    LogPrint(BCLog::LogFlags::MISC, "INFO: %s called.", __func__);
+
+    // If the stale flag is not set, but this function is called, it is from the timeout
+    // trigger of the vote_update_age_timer. Therefore set the loading indicator to stale
+    // and set the stale flag to true. The stale flag will be reset and the timer restarted
+    // when the loadPolls is called to refresh.
+    if (!stale)
+    {
+        loadingIndicator->setText(tr("Poll data is more than one hour old. Press reload to update... "
+                                     "This can take several minutes, and the wallet may not respond "
+                                     "until finished."));
+        tableView_->hide();
+        loadingIndicator->show();
+
+        stale = true;
+    }
+}
+
 void VotingDialog::onLoadingFinished(void)
 {
     watcher.setProperty("running", false);
@@ -481,6 +527,8 @@ void VotingDialog::onLoadingFinished(void)
     } else {
         loadingIndicator->setText(tr("No polls !"));
     }
+
+    stale = false;
 }
 
 void VotingDialog::tableColResize(void)

--- a/src/qt/votingdialog.h
+++ b/src/qt/votingdialog.h
@@ -164,6 +164,9 @@ public:
     void setModel(WalletModel *wallet_model);
 
 private:
+    // The number of milliseconds of age at which the poll data is stale. Currently one hour equivalent.
+    static constexpr int64_t STALE = 60 * 60 * 1000;
+
     QLineEdit *filterTQAU;
     QPushButton *resetButton;
     QPushButton *histButton;
@@ -176,6 +179,8 @@ private:
     NewPollDialog *pollDialog_;
     QLabel *loadingIndicator;
     QFutureWatcher<void> watcher;
+    QTimer* vote_update_age_timer = new QTimer(this);
+    bool stale = false;
 
 private:
     virtual void showEvent(QShowEvent *);
@@ -185,6 +190,7 @@ private:
 
 private slots:
     void onLoadingFinished(void);
+    void setStale(void);
 
 public slots:
     void filterTQAUChanged(const QString &);


### PR DESCRIPTION
This commit allows going to the voting dialog page without automatically kicking off calculating the poll results to avoid the long term lock every time the voting page is selected. This is atemporary workaround until the locking around voting calculations can be redone and a cache implemented for voting results.