### PR TITLE
doc: Change copyright years to 2021

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,8 +1,8 @@
 Copyright (c) 2014 Black-Coin Developers
 Copyright (c) 2013-2014 NovaCoin Developers
 Copyright (c) 2011-2012 PPCoin Developers
-Copyright (c) 2009-2019 Bitcoin Developers
-Copyright (c) 2014-2020 Gridcoin Developers
+Copyright (c) 2009-2021 Bitcoin Developers
+Copyright (c) 2014-2021 Gridcoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/qt/res/gridcoinresearch.rc
+++ b/src/qt/res/gridcoinresearch.rc
@@ -23,7 +23,7 @@ BEGIN
             VALUE "FileDescription",    "Gridcoin-Qt (OSS GUI client for Gridcoin)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
             VALUE "InternalName",       "Gridcoin-qt"
-            VALUE "LegalCopyright",     "2009-2019 The Bitcoin developers, 2012-2014 The NovaCoin & PPCoin developers, 2014-2020 The Gridcoin developers"
+            VALUE "LegalCopyright",     "2009-2021 The Bitcoin developers, 2012-2014 The NovaCoin & PPCoin developers, 2014-2021 The Gridcoin developers"
             VALUE "LegalTrademarks1",   "Distributed under the MIT/X11 software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "Gridcoinresearch-qt.exe"
             VALUE "ProductName",        "Gridcoinresearch-Qt"


### PR DESCRIPTION
updates copyright year in COPYING and gridcoinresearch.rc files