### PR TITLE
beacon, contracts: Fix sync from zero issue due to ApplyContracts problem in 5.2.1.0

### DIFF
--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -697,6 +697,19 @@ public:
     //!
     void ResetInMemoryOnly();
 
+    //!
+    //! \brief Returns whether IsContract correction is needed in ReplayContracts during initialization
+    //! \return
+    //!
+    bool NeedsIsContractCorrection();
+
+    //!
+    //! \brief Sets the state of the IsContract needs correction flag in memory and leveldb
+    //! \param flag The state to set
+    //! \return
+    //!
+    bool SetNeedsIsContractCorrection(bool flag);
+
 private:
     BeaconMap m_beacons;        //!< Contains the active registered beacons.
     PendingBeaconMap m_pending; //!< Contains beacons awaiting verification.
@@ -713,6 +726,10 @@ private:
         //! CONSENSUS: Increment this value when introducing a breaking change to the beacon db. This
         //! will ensure that when the wallet is restarted, the level db beacon storage will be cleared and
         //! reloaded from the contract replay with the correct lookback scope.
+        //!
+        //! Version 0: <= 5.2.0.0
+        //! Version 1: = 5.2.1.0
+        //! Version 2: 5.2.1.0 with hotfix and > 5.2.1.0
         //!
         static constexpr uint32_t CURRENT_VERSION = 2;
 
@@ -754,6 +771,19 @@ private:
         size_t size();
 
         //!
+        //! \brief Returns whether IsContract correction is needed in ReplayContracts during initialization
+        //! \return
+        //!
+        bool NeedsIsContractCorrection();
+
+        //!
+        //! \brief Sets the state of the IsContract needs correction flag in memory and leveldb
+        //! \param flag The state to set
+        //! \return
+        //!
+        bool SetNeedsIsContractCorrection(bool flag);
+
+        //!
         //! \brief This stores the height to which the database entries are valid (the db scope). Note that it
         //! is not desired to expose this function as a public function, but currently the Revert function
         //! only operates on a single transaction context, and does not encapsulate the post reversion height
@@ -790,22 +820,6 @@ private:
         //! database.
         //!
         bool insert(const uint256& hash, const int& height, const Beacon& beacon);
-
-        //!
-        //! \brief Update a beacon state record into the historical database.
-        //!
-        //! \param hash The hash for the key to the historical record. (This must be unique. It is usually
-        //! the transaction hash that of the transaction that contains the beacon contract, but also can be
-        //! a synthetic hash created from the hash of the superblock hash and the cpid hash if recording
-        //! beacon activations or expired pendings, which are handled in ActivatePending.
-        //! \param height The height of the block from which the beacon state record originates.
-        //! \param beacon The beacon state record to insert (which includes the appropriate status).
-        //!
-        //! \return Success or Failure. This is just like insert but it always succeeds (unless there is a
-        //! problem with the storage layer). If a record already exists it will be replaced. If it is new,
-        //! it will be inserted.
-        //!
-        bool update(const uint256& hash, const int& height, const Beacon& beacon);
 
         //!
         //! \brief Erase a record from the database.
@@ -895,6 +909,11 @@ private:
         //! back during initialization).
         //!
         uint64_t m_recnum_stored = 0;
+
+        //!
+        //! \brief The flag that indicates whether IsContract correction is needed in ReplayContracts during initialization.
+        //!
+        bool m_needs_IsContract_correction = false;
 
         //!
         //! \brief Store a beacon object in leveldb with the provided key value.

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -714,7 +714,7 @@ private:
         //! will ensure that when the wallet is restarted, the level db beacon storage will be cleared and
         //! reloaded from the contract replay with the correct lookback scope.
         //!
-        static constexpr uint32_t CURRENT_VERSION = 1;
+        static constexpr uint32_t CURRENT_VERSION = 2;
 
         //!
         //! \brief Initializes the Beacon Registry map structures from the replay of the beacon states stored

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -411,11 +411,11 @@ Contract GRC::MakeLegacyContract(
     return contract;
 }
 
-void GRC::ReplayContracts(const CBlockIndex* pindex_end, const CBlockIndex* pindex_start)
+void GRC::ReplayContracts(CBlockIndex* pindex_end, CBlockIndex* pindex_start)
 {
     static BlockFinder blockFinder;
 
-    const CBlockIndex*& pindex = pindex_start;
+    CBlockIndex*& pindex = pindex_start;
 
     // If there is no pindex_start (i.e. default value of nullptr), then set standard lookback. A Non-standard lookback
     // where there is a specific pindex_start argument supplied, is only used in the GRC InitializeContracts call for
@@ -440,17 +440,52 @@ void GRC::ReplayContracts(const CBlockIndex* pindex_end, const CBlockIndex* pind
 
     LogPrint(BCLog::LogFlags::BEACON, "Beacon database at height %i", beacon_db_height);
 
+    if (beacons.NeedsIsContractCorrection())
+    {
+        LogPrintf("INFO %s: The NeedsIsContractCorrection flag is set. All blocks within the scan range "
+                  "will be checked to ensure the contains contract flag is set correctly and corrections made. "
+                  "This may take a little longer than the standard replay.",
+                  __func__);
+    }
+
     CBlock block;
 
     // These are memorized consecutively in order from oldest to newest.
     for (; pindex; pindex = pindex->pnext) {
-        if (pindex->IsContract()) {
+
+        // If the NeedsIsContractCorrection flag is set which means all blocks within the scan range
+        // have to be checked, OR the block index entry is already marked to contain contract(s),
+        // then apply the contracts found in the block.
+        if (beacons.NeedsIsContractCorrection() || pindex->IsContract()) {
             if (!block.ReadFromDisk(pindex)) {
                 continue;
             }
 
-            bool unused;
-            ApplyContracts(block, pindex, beacon_db_height, unused);
+            bool found_contract;
+            ApplyContracts(block, pindex, beacon_db_height, found_contract);
+
+            // If a contract was found and the NeedsIsContractCorrection flag is set, then
+            // record that a contract was found in the block index. This corrects the block index
+            // record.
+            if (found_contract && beacons.NeedsIsContractCorrection() && !pindex->IsContract())
+            {
+                LogPrintf("WARNING %s: There were found contract(s) in block %i but IsContract() is false. "
+                          "Correcting IsContract flag to true in the block index.",
+                          __func__,
+                          pindex->nHeight);
+
+                pindex->MarkAsContract();
+
+                CTxDB txdb("rw");
+
+                CDiskBlockIndex disk_block_index(pindex);
+                if (!txdb.WriteBlockIndex(disk_block_index))
+                {
+                    error("%s: Block index correction of IsContract flag for block %i failed.",
+                          __func__,
+                          pindex->nHeight);
+                }
+            }
         }
 
         if (pindex->IsSuperblock() && pindex->nVersion >= 11) {
@@ -482,7 +517,14 @@ void GRC::ReplayContracts(const CBlockIndex* pindex_end, const CBlockIndex* pind
             }
         }
 
-        if (pindex == pindex_end) break;
+        if (pindex == pindex_end)
+        {
+            // Finished the rescan. If the NeedsIsContractCorrection was set to true, then reset
+            // to false.
+            if (beacons.NeedsIsContractCorrection()) beacons.SetNeedsIsContractCorrection(false);
+
+            break;
+        }
     }
 
     Researcher::Refresh();
@@ -510,11 +552,11 @@ void GRC::ApplyContracts(
     bool& out_found_contract)
 {
     for (const auto& contract : tx.GetContracts()) {
-        // Do not (re)apply contracts that have already been stored/loeaded into
+        // Do not (re)apply contracts that have already been stored/loaded into
         // the beacon DB up to the block BEFORE the beacon db height. Because the beacon
         // db height is at the block level, and is updated on each beacon insert, when
         // in a sync from zero situation where the contracts are played as each block is validated,
-        // any beacon contract in the block EQUAL to the beacon db height must pass this test
+        // any beacon contract in the block EQUAL to the beacon db height must fail this test
         // and be inserted again, because otherwise the second and succeeding contracts on the
         // same block will not be inserted and those CPID's will not be recorded properly.
         // This was the cause of the failure to sync through 2069264 that started on 20210312. See

--- a/src/gridcoin/contract/contract.h
+++ b/src/gridcoin/contract/contract.h
@@ -470,7 +470,7 @@ Contract MakeLegacyContract(
 //!
 //! \param pindex Block index to start with.
 //!
-void ReplayContracts(const CBlockIndex* pindex_end, const CBlockIndex* pindex_start = nullptr);
+void ReplayContracts(CBlockIndex *pindex_end, CBlockIndex *pindex_start = nullptr);
 
 //!
 //! \brief Apply contracts from transactions in a block by passing them to the

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -76,7 +76,7 @@ bool InitializeResearchRewardAccounting(CBlockIndex* pindexBest)
 //!
 //! \param pindexBest Block index of the tip of the chain.
 //!
-void InitializeContracts(const CBlockIndex* pindexBest)
+void InitializeContracts(CBlockIndex* pindexBest)
 {
     LogPrintf("Gridcoin: Loading beacon history...");
     uiInterface.InitMessage(_("Loading beacon history..."));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -397,10 +397,6 @@ void InitLogging()
         }
     }
 
-    // TODO: enable tally and accrual debug log categories during Fern testing:
-    LogInstance().EnableCategory("tally");
-    LogInstance().EnableCategory("accrual");
-
     std::vector<std::string> excluded_categories;
 
     if (mapArgs.count("-debugexclude") && mapMultiArgs["-debugexclude"].size() > 0)


### PR DESCRIPTION
This corrects a problem involving the application of multiple contracts to the block index on sync from zero, and also the storage of those in the beacon db. Closes #2045.