### PR TITLE
build: Deal with Qt depends .qmake.stash file

### DIFF
--- a/depends/.gitignore
+++ b/depends/.gitignore
@@ -10,3 +10,4 @@ arm*
 aarch64*
 #mac specific
 .DS_Store
+.qmake.stash

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -221,6 +221,10 @@ endef
 
 # Preprocessing steps work as follows:
 #
+# 0. Gridcoin: Remove the qmake stash file generated for the SUBDIRS Qt project
+# in a previous build. It can break builds between different platforms and SDKs
+# because it caches the library paths and variables from the last build.
+#
 # 1. Apply our patches to the extracted source. See each patch for more info.
 #
 # 2. Point to lrelease in qttools/bin/lrelease; otherwise Qt will look for it in
@@ -242,6 +246,7 @@ endef
 # 8. Adjust a regex in toolchain.prf, to accommodate Guix's usage of
 # CROSS_LIBRARY_PATH. See #15277.
 define $(package)_preprocess_cmds
+  rm -f $(BASEDIR)/.qmake.stash && \
   patch -p1 -i $($(package)_patch_dir)/freetype_back_compat.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_powerpc_libpng.patch && \
   patch -p1 -i $($(package)_patch_dir)/drop_lrelease_dependency.patch && \


### PR DESCRIPTION
#2038 added a top-level Qt SUBDIRS-type project in 6f090a0 to the Qt depends recipe to manage auxillary Qt modules needed by the project, and this causes Qt to generate a .qmake.stash file in the depends directory. The file contains a cache of qmake build variables which can cause issues with subsequent static builds that target a different platform or SDK than those selected for the previous depends build.

This ensures that the Qt recipe clears the stash file when rebuilding the Qt packages, and qmake will regenerate it as needed.