### PR TITLE
rpc: Add "getburnreport" RPC function

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -417,6 +417,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getblockbynumber",        &getblockbynumber,        cat_network       },
     { "getblockcount",           &getblockcount,           cat_network       },
     { "getblockhash",            &getblockhash,            cat_network       },
+    { "getburnreport",           &getburnreport,           cat_network       },
     { "getcheckpoint",           &getcheckpoint,           cat_network       },
     { "getconnectioncount",      &getconnectioncount,      cat_network       },
     { "getdifficulty",           &getdifficulty,           cat_network       },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -236,6 +236,7 @@ extern UniValue getblockbynumber(const UniValue& params, bool fHelp);
 extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getblockcount(const UniValue& params, bool fHelp);
 extern UniValue getblockhash(const UniValue& params, bool fHelp);
+extern UniValue getburnreport(const UniValue& params, bool fHelp);
 extern UniValue getcheckpoint(const UniValue& params, bool fHelp);
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp);
 extern UniValue getdifficulty(const UniValue& params, bool fHelp);

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -332,7 +332,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
     valtype vchPushValue;
     vector<bool> vfExec;
     vector<valtype> altstack;
-    if (script.size() > 10000)
+    if (script.size() > MAX_SCRIPT_SIZE)
         return false;
     int nOpCount = 0;
 

--- a/src/script.h
+++ b/src/script.h
@@ -25,6 +25,9 @@ class CTransaction;
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
 static const unsigned int MAX_OP_RETURN_RELAY = 80;      // bytes
 
+// Maximum script length in bytes
+static const int MAX_SCRIPT_SIZE = 10000;
+
 /** Signature hash types/flags */
 enum
 {
@@ -580,6 +583,16 @@ public:
     CScriptID GetID() const
     {
         return CScriptID(Hash160(*this));
+    }
+
+    /**
+     * Returns whether the script is guaranteed to fail at execution,
+     * regardless of the initial stack. This allows outputs to be pruned
+     * instantly when entering the UTXO set.
+     */
+    bool IsUnspendable() const
+    {
+        return (size() > 0 && *begin() == OP_RETURN) || (size() > MAX_SCRIPT_SIZE);
     }
 };
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -847,7 +847,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
         {
             if (!ExtractDestination(txout.scriptPubKey, address))
             {
-                if (txout.scriptPubKey[0] != OP_RETURN)
+                if (!txout.scriptPubKey.IsUnspendable())
                 {
                     LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                               this->GetHash().ToString().c_str());
@@ -891,7 +891,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
         // If this is my output AND the transaction is not from me, then record the output as received.
         if (fIsMine != ISMINE_NO && !fIsFromMe)
         {
-            if (!ExtractDestination(txout.scriptPubKey, address) && txout.scriptPubKey[0] != OP_RETURN)
+            if (!ExtractDestination(txout.scriptPubKey, address) && !txout.scriptPubKey.IsUnspendable())
             {
                 LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                           this->GetHash().ToString().c_str());
@@ -908,7 +908,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
         {
             if (!ExtractDestination(txout.scriptPubKey, address))
             {
-                if (txout.scriptPubKey[0] != OP_RETURN)
+                if (!txout.scriptPubKey.IsUnspendable())
                 {
                     LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s",
                               this->GetHash().ToString().c_str());


### PR DESCRIPTION
This adds an RPC function that aggregates the amounts of destroyed coins in confirmed transactions for reporting. It categorizes these amounts by contract type: 

```json
{
  "total": 3013.31027220,
  "voluntary": 259.78021420,
  "contracts": {
    "beacon": 1950.00000000,
    "message": 0.46905800,
    "poll": 201.02100000,
    "project": 21.00000000,
    "protocol": 2.00000000,
    "scraper": 4.00000000,
    "vote": 575.04000000
  }
}
```