### PR TITLE
consensus, accrual: Fix accrual post hard-fork at 2197000

### DIFF
--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1084,7 +1084,7 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
             const GRC::Magnitude magnitude = superblock->m_cpids.MagnitudeOf(cpid);
 
             // Stop the accrual when we get to a superblock that is before the beacon advertisement.
-            if (pindex->nTime < beacon->m_timestamp) break;
+            if (pindex->nTime < beacon_ptr->m_timestamp) break;
 
             CAmount period = tally_accrual_period(pindex->nTime, pindex_high->nTime, magnitude);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -281,6 +281,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
     const int64_t now = GetAdjustedTime();
     const GRC::ResearchAccount& account = GRC::Tally::GetAccount(*cpid);
     const int64_t computed = GRC::Tally::GetAccrual(*cpid, now, pindexBest);
+    const int64_t newbie_correction = Tally::GetNewbieSuperblockAccrualCorrection(*cpid, GRC::Quorum::CurrentSuperblock());
 
     bool accrual_account_exists = true;
 
@@ -506,6 +507,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
     result.pushKV("renewals", renewals);
     result.pushKV("accrual_by_audit", accrual);
     result.pushKV("accrual_by_GetAccrual", computed);
+    result.pushKV("newbie_correction", newbie_correction);
     result.pushKV("accrual_last_period", period);
 
     if (report_details) {


### PR DESCRIPTION
This fixes a very subtle problem that revealed itself after the hardfork and first superblock after the hardfork. 127 out of the 130 newbies that were affected by the newbie bug matched perfectly. The other three did not due to a bug in the correction function. This repairs that bug and also rebuilds the accrual snapshot database to ensure all nodes match. This is an immediate mandatory.