### PR TITLE
beacon: Fix a subtle error in renewal chain walker

### DIFF
--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1055,7 +1055,7 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
     // than here.
     while (beacon_ptr->Renewed())
     {
-        beacon_ptr = std::make_shared<Beacon>(beacons.GetBeaconDB().find(beacon->m_prev_beacon_hash)->second);
+        beacon_ptr = std::make_shared<Beacon>(beacons.GetBeaconDB().find(beacon_ptr->m_prev_beacon_hash)->second);
     }
 
     const CBlockIndex* pindex_baseline = GRC::Tally::GetBaseline();


### PR DESCRIPTION
In GetNewbieSuperblockAccrualCorrection the while loop that walks the beacon chain backwards to the original advertisement has a mistake and uses beacon instead of beacon_ptr in the find. As a result it will not work for more than one renewal cycle.

This is not a consensus issue, because this function is not called for beacons that have more than one renewal cycle. In fact, now that the newbie bug is out of the way, it will not be called for beacons with any renewal at all. So this is merely for correctness.

@tomasbrod deserves credit for pointing this out. Thanks!