### PR TITLE
doc: Add undocumented "-showorphans" GUI option to help text

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -246,7 +246,8 @@ std::string HelpMessage()
         "  -mininput=<amt>        " + _("When creating transactions, ignore inputs with value less than this (default: 0.01)") + "\n";
 	if(fQtActive)
 		strUsage +=
-        "  -server                " + _("Accept command line and JSON-RPC commands") + "\n";
+        "  -server                " + _("Accept command line and JSON-RPC commands") + "\n" +
+        "  -showorphans=true      " + _("Include stale (orphaned) coinstake transactions in the transaction list (default: false)") + "\n";
 #if !defined(WIN32)
     if(!fQtActive)
 		strUsage +=

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -247,7 +247,7 @@ std::string HelpMessage()
 	if(fQtActive)
 		strUsage +=
         "  -server                " + _("Accept command line and JSON-RPC commands") + "\n" +
-        "  -showorphans=true      " + _("Include stale (orphaned) coinstake transactions in the transaction list (default: false)") + "\n";
+        "  -showorphans           " + _("Include stale (orphaned) coinstake transactions in the transaction list") + "\n";
 #if !defined(WIN32)
     if(!fQtActive)
 		strUsage +=

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -40,8 +40,7 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     if(!showInactive && (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))
         return false;
     //1-2-2015 Halford - Mask Orphans from User View so they do not complain
-    std::string orphan_mask = GetArg("-showorphans", "false");
-    if (orphan_mask != "true")
+    if (!GetBoolArg("-showorphans", false))
         if (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted)
             return false;
     if(!(TYPE(type) & typeFilter))

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -5,20 +5,16 @@
 /* Return positive answer if transaction should be shown in list. */
 bool TransactionRecord::showTransaction(const CWalletTx &wtx, bool datetime_limit_flag, const int64_t &datetime_limit)
 {
-
     // Do not show transactions earlier than the datetime_limit if the flag is set.
     if (datetime_limit_flag && (int64_t) wtx.nTime < datetime_limit)
     {
         return false;
     }
 
-    std::string ShowOrphans = GetArg("-showorphans", "false");
-
-	//R Halford - POS Transactions - If Orphaned follow showorphans directive:
-	if (wtx.IsCoinStake() && !wtx.IsInMainChain())
-	{
-	       //Orphaned tx
-		   return (ShowOrphans=="true" ? true : false);
+    if (wtx.IsCoinStake() && !wtx.IsInMainChain())
+    {
+        // Show stale (orphaned) staking transactions if requested:
+        return GetBoolArg("-showorphans", false);
     }
 
     if (wtx.IsCoinBase())


### PR DESCRIPTION
This documents the `-showorphans` configuration option by adding it to the output of the executable's help message. The option instructs nodes with a GUI to display stale coinstake transactions. This was requested by a comment in #1291.

One can also add this option to gridcoinresearch.conf:

```ini
showorphans=1
```

~Note that the application expects a string for this option. We may want to change it to a real boolean value.~