### PR TITLE
lint: Misc Typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,7 +247,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Reorganize accrual code and fix 6-month cutoff #1630 (@cyrossignol)
  - Update Copyright years #1633 (@barton2526)
  - Change team whitelist delimiter to <> for CPID detection #1634 (@cyrossignol)
- - Change team whitelist separator to <> to accomodate more team names #1632 (@jamescowens)
+ - Change team whitelist separator to <> to accommodate more team names #1632 (@jamescowens)
  - Change Curl download speed type to support older environments #1640 (@cyrossignol)
  - Optimize logo SVGs used for tray icons #1638 (@cyrossignol)
  - Tweak consolidateunspent rpc function #1644 (@jamescowens)

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -82,7 +82,7 @@ A small script to automatically create manpages in ../../doc/man by running the 
 This requires help2man which can be found at: https://www.gnu.org/software/help2man/
 
 With in-tree builds this tool can be run from any directory within the
-repostitory. To use this tool with out-of-tree builds set `BUILDDIR`. For
+repository. To use this tool with out-of-tree builds set `BUILDDIR`. For
 example:
 
 ```bash

--- a/depends/description.md
+++ b/depends/description.md
@@ -12,7 +12,7 @@ Linux or OSX.
 ### No reliance on timestamps
 
 File presence is used to determine what needs to be built. This makes the
-results distributable and easily digestable by automated builders.
+results distributable and easily digestible by automated builders.
 
 ### Each build only has its specified dependencies available at build-time.
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -6,7 +6,7 @@ Below are some notes on how to build Gridcoin for Windows.
 The options known to work for building Gridcoin on Windows are:
 
 * On Linux, using the [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Ubuntu Bionic 18.04 is required
-and is the platform used to build the Gricoin Windows release binaries.
+and is the platform used to build the Gridcoin Windows release binaries.
 * On Windows, using [Windows
 Subsystem for Linux (WSL)](https://docs.microsoft.com/windows/wsl/about) and the Mingw-w64 cross compiler tool chain.
 * On Windows, using a native compiler tool chain such as [Visual Studio](https://www.visualstudio.com).

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -102,7 +102,7 @@ The gbuild invocations below <b>DO NOT DO THIS</b> by default.
     mv build/out/gridcoin-*-win-unsigned.tar.gz inputs/gridcoin-win-unsigned.tar.gz
     mv build/out/gridcoin-*.zip build/out/gridcoin-*.exe ../
 
-    ./bin/gbuild --num-make 2 --memory 3000 --commit gridocin=v${VERSION} ../gridcoin/contrib/gitian-descriptors/gitian-osx.yml
+    ./bin/gbuild --num-make 2 --memory 3000 --commit gridcoin=v${VERSION} ../gridcoin/contrib/gitian-descriptors/gitian-osx.yml
     ./bin/gsign --signer $SIGNER --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../gridcoin/contrib/gitian-descriptors/gitian-osx.yml
     mv build/out/gridcoin-*-osx-unsigned.tar.gz inputs/gridcoin-osx-unsigned.tar.gz
     mv build/out/gridcoin-*.tar.gz build/out/gridcoin-*.dmg ../

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -62,7 +62,7 @@ public:
     //!
     //! CONSENSUS: This method produces a semantic floating-point value for
     //! the magnitude unit. Do not use this value directly to implement any
-    //! consensus-critial routine. Instead, prefer integer arithmetic for a
+    //! consensus-critical routine. Instead, prefer integer arithmetic for a
     //! protocol implementation that needs to avoid floating-point error or
     //! that requires portability between platforms.
     //!
@@ -278,7 +278,7 @@ public:
     //!
     //! CONSENSUS: This method produces a semantic floating-point value for
     //! the magnitude unit. Do not use this value directly to implement any
-    //! consensus-critial routine. Instead, prefer integer arithmetic for a
+    //! consensus-critical routine. Instead, prefer integer arithmetic for a
     //! protocol implementation that needs to avoid floating-point error or
     //! that requires portability between platforms.
     //!

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -678,7 +678,7 @@ void BeaconRegistry::Revert(const ContractContext& ctx)
     //
     // In beacons, the only use-case for contract actions of remove are the beacon revocation or the old style
     // direct deletes for v1 contracts. In this case we need to resurrect the previous record pointed to by the
-    // deleted record in the beacon db. This could be an ACTIVE, RENWAL, or PENDING record. The EXPIRED_PENDING
+    // deleted record in the beacon db. This could be an ACTIVE, RENEWAL, or PENDING record. The EXPIRED_PENDING
     // records are handled in the Deactivate function, which is the block level Revert for the superblock reversion.
     if (ctx->m_action == ContractAction::REMOVE)
     {

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -282,7 +282,7 @@ public:
     //!
     //! Defaults to the most recent version for a new beacon instance.
     //!
-    //! Version 1: Legacy semicolon-delimied string of fields parsed from a
+    //! Version 1: Legacy semicolon-delimited string of fields parsed from a
     //! contract value with the following format:
     //!
     //!    BASE64(HEX(CPIDV2);HEX(RANDOM_HASH);BASE58(ADDRESS);HEX(PUBLIC_KEY))
@@ -470,7 +470,7 @@ public:
 //!
 //! \brief A beacon that uses different serialization for storage to disk via leveldb.
 //! TODO: Change this to inherit from Beacon, although it doesn't matter really,
-//! beacuse the only difference at this point is the Expired function, and that is not
+//! because the only difference at this point is the Expired function, and that is not
 //! used for StorageBeacons.
 //!
 class StorageBeacon : public PendingBeacon

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -30,7 +30,7 @@ class Contract;
 //! expiry triggering problems. Expired pending IS a status, because this is triggered
 //! on superblock acceptance for all pending beacons that have aged beyond the limit without
 //! being verified. Note that the order of the enumeration is IMPORTANT. Do not change the order
-//! of existing entires, and OUT_OF_BOUND must go at the end and be retained for the EnumBytes
+//! of existing entries, and OUT_OF_BOUND must go at the end and be retained for the EnumBytes
 //! wrapper.
 //!
 enum class BeaconStatusForStorage

--- a/src/gridcoin/cpid.h
+++ b/src/gridcoin/cpid.h
@@ -224,7 +224,7 @@ public:
     {
         INVALID  = 0x00, //!< An empty or invalid CPID.
         INVESTOR = 0x01, //!< A CPID that represents a non-researcher.
-        CPID     = 0x02, //!< A valid exernal CPID.
+        CPID     = 0x02, //!< A valid external CPID.
     };
 
     //!

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -83,7 +83,7 @@ void InitializeContracts(CBlockIndex* pindexBest)
 
     BeaconRegistry& beacons = GetBeaconRegistry();
 
-    // If the clearbeaconhistory argument is provided, then clear everthing from the beacon registry,
+    // If the clearbeaconhistory argument is provided, then clear everything from the beacon registry,
     // including the beacon_db and beacon key type elements from leveldb.
     if (GetBoolArg("-clearbeaconhistory", false))
     {

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -212,7 +212,7 @@ public:
     //! \brief Determine whether the whitelist contains any projects.
     //!
     //! This does not guarantee that the whitelist is up-to-date. The caller is
-    //! responsible for verifiying the block height.
+    //! responsible for verifying the block height.
     //!
     //! \return \c true if the whitelist contains at least one project.
     //!

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -296,7 +296,7 @@ public:
     //! \param address Default wallet address of a node in the network.
     //! \param time    Timestamp to check participation at.
     //!
-    //! \return \c true if the address matches the subset of addrsses that
+    //! \return \c true if the address matches the subset of addresses that
     //! particpate in the quorum on the day of the year of \p time.
     //!
     static bool Participating(const std::string& grc_address, const int64_t time)
@@ -828,7 +828,7 @@ private: // SuperblockValidator classes
     //! project parts resolved from the superblock.
     //!
     //! Nodes validate superblocks in by-project fallback convergence cases by
-    //! matching manifest project parts to the convengence hints embedded in a
+    //! matching manifest project parts to the convergence hints embedded in a
     //! superblock project section. These hints are truncated SHA256 hashes so
     //! a hint can qualify more than one manifest part for consideration while
     //! reconstructing a convergence for validation.
@@ -921,7 +921,7 @@ private: // SuperblockValidator classes
         //! the helper as I described in the comments. This allows the outer loop to simply run consecutively through
         //! the permutation index from 0 to n-1 permutations, and then for each permutation index value the repeated
         //! division in the inner loop  “decodes” the index into the selected part for each placeholder (project).
-        //! Since you calculated the permutation index max n by muliplyjng all of the possibilities together for each
+        //! Since you calculated the permutation index max n by multiplying all of the possibilities together for each
         //! place you know you have covered them all. I think it is a pretty elegant approach to the problem with iteration.
         //!
         //! \return A convergence to generate a superblock hash from if a new

--- a/src/gridcoin/quorum.h
+++ b/src/gridcoin/quorum.h
@@ -69,7 +69,7 @@ public:
     //! \param address Default wallet address of a node in the network.
     //! \param time    Timestamp to check participation at.
     //!
-    //! \return \c true if the address matches the subset of addrsses that
+    //! \return \c true if the address matches the subset of addresses that
     //! particpate in the quorum on the day of the year of \p time.
     //!
     static bool Participating(const std::string& address, const int64_t time);

--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -80,7 +80,7 @@ namespace
         struct progress *pg = (struct progress*)ptr;
         CURL *curl = pg->curl;
 
-        // Thread inturrupting
+        // Thread interrupting
         try
         {
             boost::this_thread::interruption_point();

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -194,7 +194,7 @@ const CBlockIndex* GetBeaconConsensusHeight()
 }
 
 //!
-//! \brief Get beacon list with consenus.
+//! \brief Get beacon list with consensus.
 //!
 //! Assembles a list of only active beacons with a consensus lookback from
 //! 6 months ago the current tip minus ~1 hour.

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -476,7 +476,7 @@ void CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_
     // taking the ceiling and then adding 2. The motivation behind this is the corner case where
     // the whitelist has been reduced in size by that ratio as a corrective action in the situation
     // where suddenly a number of projects are not available, and a convergence was not able to be formed.
-    // Then existing manifests on the network would have the reciprocol of that ratio projects. I
+    // Then existing manifests on the network would have the reciprocal of that ratio projects. I
     // take the ceiling and add 2 for a safety measure. For a CONVERGENCE_BY_PROJECT_RATIO of 0.75, which
     // is the network default, and a whitelist count of 20, this would come out to ceil(20.0/0.75)+2 = 29.
     // Or if the whitelist were suddenly reduced from 20 to 15, then it would be ceil(15.0/0.75)+2 = 22.
@@ -767,7 +767,7 @@ void CScraperManifest::Complete()
  * They should only send what we requested, but we do not know what it is,
  * until we have it, let it pass.
  * There is 32MiB message size limit. There is a chance we could hit it, so
- * splitting is necesssary. Index object with list of parts is needed.
+ * splitting is necessary. Index object with list of parts is needed.
  *
  * If inv about index is received, and we do not know about it yet, just
  * getdata it. If it turns out useless, just ban the node. Then getdata the

--- a/src/gridcoin/staking/difficulty.cpp
+++ b/src/gridcoin/staking/difficulty.cpp
@@ -201,7 +201,7 @@ double GRC::GetSmoothedDifficulty(int64_t nStakeableBalance)
     // First estimate the difficulty based on the last 40 blocks.
     dDiff = GetAverageDifficulty(40);
 
-    // Compute an appropriate block span for the second iteration of dificulty computation based on the
+    // Compute an appropriate block span for the second iteration of difficulty computation based on the
     // above diff calc. Clamp to no less than 40 (~1 hour) and no more than 960 (~1 day). Note that those
     // familiar with the thumbrule for ETTS, ETTS = 10000 / Balance * Diff should recognize it in the below
     // expression. Note that the actual constant is 9942.2056 (from the bluepaper, eq. 12), but it suffices to

--- a/src/gridcoin/staking/difficulty.h
+++ b/src/gridcoin/staking/difficulty.h
@@ -11,7 +11,7 @@ class CWallet;
 namespace GRC {
 // Note that dDiff cannot be = 0 normally. This is set as default because you can't specify the output of
 // GetAverageDifficulty(nPosInterval) = to dDiff here.
-// The defeult confidence is 1-1/e which is the mean for the geometric distribution for small probabilities.
+// The default confidence is 1-1/e which is the mean for the geometric distribution for small probabilities.
 const double DEFAULT_ETTS_CONFIDENCE = 1.0 - 1.0 / exp(1.0);
 
 unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast);

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -718,7 +718,7 @@ public:
         //!
         //! This initializes the object in legacy mode for superblock contract
         //! strings that contain the number of zero-magnitude CPIDs. The index
-        //! will not imilicitly count and filter inserted zero-magnitude CPIDs
+        //! will not implicitly count and filter inserted zero-magnitude CPIDs
         //! so that a legacy quorum hash matches that of the string contract.
         //!
         //! \param zero_magnitude_count Number of zero-magnitude CPIDs omitted
@@ -1009,7 +1009,7 @@ public:
     class ProjectIndex
     {
         //!
-        //! \brief A single mapping of a project name to project statistcs.
+        //! \brief A single mapping of a project name to project statistics.
         //!
         typedef std::pair<std::string, ProjectStats> ProjectPair;
 
@@ -1228,7 +1228,7 @@ public:
     uint32_t m_convergence_hint;
     uint32_t m_manifest_content_hint;
 
-    CpidIndex m_cpids;       //!< Maps superblock CPIDs to magntudes.
+    CpidIndex m_cpids;       //!< Maps superblock CPIDs to magnitudes.
     ProjectIndex m_projects; //!< Whitelisted projects statistics.
     VerifiedBeacons m_verified_beacons; //!< Wrapped verified beacons vector
 

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -463,7 +463,7 @@ public:
     //!
     //! \brief Erase the snapshot files and clear the registry.
     //!
-    //! \return \c false if the snapshots and registery deletion failed because
+    //! \return \c false if the snapshots and registry deletion failed because
     //! of an error.
     //!
     bool EraseSnapshots()
@@ -972,7 +972,7 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
 
     CAmount accrual = 0;
 
-    // This lambda is almost a straight lift from the auditsnapshotaccrual RPC function. It is simplifed,
+    // This lambda is almost a straight lift from the auditsnapshotaccrual RPC function. It is simplified,
     // because since the accrual account doesn't exist, there has been no staking for this CPID and no payout,
     // so only superblock to superblock periods need to be considered.
     const auto tally_accrual_period = [&](

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -538,7 +538,7 @@ bool Upgrade::ExtractSnapshot()
         {
             ExtractStatus.SnapshotExtractFailed = true;
 
-            LogPrintf("Sanpshot (ExtractSnapshot): Failed to close snapshot.zip");
+            LogPrintf("Snapshot (ExtractSnapshot): Failed to close snapshot.zip");
 
             return false;
         }

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -102,7 +102,7 @@ public:
     //!
     //! \brief Get a set of outputs to build voting claims with.
     //!
-    //! \return Unspent outputs grouped by address in desecending order by
+    //! \return Unspent outputs grouped by address in descending order by
     //! the total amount of the outputs in each address grouping.
     //!
     //! \throws VotingError If the wallet contains no unspent outputs eligible

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -52,7 +52,7 @@ struct OutPointHasher
 };
 
 //!
-//! \brief Contains an unprocesseed vote contract for a poll extracted from a
+//! \brief Contains an unprocessed vote contract for a poll extracted from a
 //! transaction.
 //!
 class VoteCandidate

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -36,14 +36,14 @@ public:
     //! \brief ErrorMsg box for displaying errors that have occurred during snapshot process.
     //!
     //! \param text Main text displaying on QMessageBox.
-    //! \param informativetext Informative text diaplying on QMessageBox.
+    //! \param informativetext Informative text displaying on QMessageBox.
     //!
     static void ErrorMsg(const std::string& text, const std::string& informativetext);
     //!
     //! \brief Msg box for displaying informative information during snapshot process.
     //!
     //! \param text Main text displaying on QMessageBox.
-    //! \param informativetext Informative text dialaying on QMessageBox.
+    //! \param informativetext Informative text displaying on QMessageBox.
     //! \param question Are we requiring a response from the user other then 'ok'.
     //!
     //! \return Response made by user.

--- a/src/qt/votingdialog.cpp
+++ b/src/qt/votingdialog.cpp
@@ -939,7 +939,7 @@ void VotingVoteDialog::vote(void)
 {
     // This overall try-catch is needed to properly catch the VoteBuilder builder move constructor and assignment,
     // otherwise an expired poll bubbles up all the way to the app level and ends execution with the exception handler
-    // in bitcoin.cpp, which is not what is intended here. It also catchs any thrown VotingError exceptions in
+    // in bitcoin.cpp, which is not what is intended here. It also catches any thrown VotingError exceptions in
     // builder.AddResponse() and SendVoteContract().
     try {
         voteNote_->setStyleSheet("QLabel { color : red; }");

--- a/src/rpc/dataacq.cpp
+++ b/src/rpc/dataacq.cpp
@@ -39,7 +39,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
             "\n"
             "Show stats on what wallets and cpids staked recent blocks.\n"
             "\n"
-            "Mode 0: Startheight is the starting height, endheight is the chain head if not specfied.\n"
+            "Mode 0: Startheight is the starting height, endheight is the chain head if not specified.\n"
             "Mode 1: Startheight is actually the number of blocks back from endheight or the chain \n"
             "        head if not specified.");
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -121,12 +121,12 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
 
     UniValue ret(UniValue::VOBJ);
 
-    list<pair<string, vector<CService> > > laddedAddreses(0);
+    list<pair<string, vector<CService> > > laddedAddresses(0);
     for (auto const& strAddNode : laddedNodes)
     {
         vector<CService> vservNode(0);
         if(Lookup(strAddNode.c_str(), vservNode, GetDefaultPort(), fNameLookup, 0))
-            laddedAddreses.push_back(make_pair(strAddNode, vservNode));
+            laddedAddresses.push_back(make_pair(strAddNode, vservNode));
         else
         {
             UniValue obj(UniValue::VOBJ);
@@ -138,7 +138,7 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
     }
 
     LOCK(cs_vNodes);
-    for (list<pair<string, vector<CService> > >::iterator it = laddedAddreses.begin(); it != laddedAddreses.end(); it++)
+    for (list<pair<string, vector<CService> > >::iterator it = laddedAddresses.begin(); it != laddedAddresses.end(); it++)
     {
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("addednode", it->first);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -605,7 +605,7 @@ UniValue consolidateunspent(const UniValue& params, bool fHelp)
             // The work queue.
             std::queue<std::vector<CTxIn>> vin_queue;
 
-            // The inital population of the queue is the input vector of the transaction that created the change UTXO.
+            // The initial population of the queue is the input vector of the transaction that created the change UTXO.
             vin_queue.push(out.tx->vin);
 
 

--- a/src/test/gridcoin/contract_tests.cpp
+++ b/src/test/gridcoin/contract_tests.cpp
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE(it_determines_whether_a_legacy_v1_contract_is_complete)
     BOOST_CHECK(contract.WellFormed() == false);
 }
 
-BOOST_AUTO_TEST_CASE(it_determines_the_requred_burn_fee)
+BOOST_AUTO_TEST_CASE(it_determines_the_required_burn_fee)
 {
     const GRC::Contract contract = TestMessage::Current();
 

--- a/src/test/gridcoin/enumbytes_tests.cpp
+++ b/src/test/gridcoin/enumbytes_tests.cpp
@@ -25,7 +25,7 @@ enum class TestEnum {
 
 BOOST_AUTO_TEST_SUITE(EnumByte)
 
-BOOST_AUTO_TEST_CASE(it_initalizes_to_zero)
+BOOST_AUTO_TEST_CASE(it_initializes_to_zero)
 {
     const GRC::EnumByte<TestEnum> a;
 

--- a/src/test/gridcoin/magnitude_tests.cpp
+++ b/src/test/gridcoin/magnitude_tests.cpp
@@ -28,8 +28,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_zero_when_rounding_invalid_magnitudes)
     BOOST_CHECK_EQUAL(negative.Scaled(), 0);
 
     // Rounds-down to zero
-    const GRC::Magnitude effectivly_zero = GRC::Magnitude::RoundFrom(0.005);
-    BOOST_CHECK_EQUAL(effectivly_zero.Scaled(), 0);
+    const GRC::Magnitude effectively_zero = GRC::Magnitude::RoundFrom(0.005);
+    BOOST_CHECK_EQUAL(effectively_zero.Scaled(), 0);
 
     // Exceeded maximum
     const GRC::Magnitude overflow = GRC::Magnitude::RoundFrom(32767.123);
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(it_presents_the_compact_magnitude_representation)
     BOOST_CHECK_EQUAL(large.Compact(), 11);
 }
 
-BOOST_AUTO_TEST_CASE(it_presents_the_floatng_point_magnitude_representation)
+BOOST_AUTO_TEST_CASE(it_presents_the_floating_point_magnitude_representation)
 {
     const GRC::Magnitude small = GRC::Magnitude::RoundFrom(0.11);
     BOOST_CHECK_EQUAL(small.Floating(), 0.11);

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -597,7 +597,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
     }
 }
 
-BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergnce)
+BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
 {
     const ScraperStatsMeta meta;
     GRC::Superblock superblock = GRC::Superblock::FromConvergence(GetTestConvergence(meta));
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergnce)
     }
 }
 
-BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergnce)
+BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence)
 {
     const ScraperStatsMeta meta;
     GRC::Superblock superblock = GRC::Superblock::FromConvergence(

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
     for (int mod=2;mod<11;mod++)
     {
         int mask = 1;
-        // Really rough binomal confidence approximation.
+        // Really rough binomial confidence approximation.
         int err = 30*10000./mod*sqrt((1./mod*(1-1./mod))/10000.);
         //mask is 2^ceil(log2(mod))-1
         while(mask<mod-1)mask=(mask<<1)+1;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -47,8 +47,8 @@ void MilliSleep(int64_t n);
  * This is a small class that implements a stopwatch style timer. The class can be used locally (usually using
  * the "default" label) and/or as a global map of timers. If you want to do just a simple single timing, it
  * probably makes more sense to just use GetTimeMillis() directly, as the initialization of a map is a little
- * heavyweight for a single timing that is locally scoped. This class becomes very useful for muliple segments
- * where you need to see the "lap times", and also conveniently control the logging wihout a bunch of repetitive code.
+ * heavyweight for a single timing that is locally scoped. This class becomes very useful for multiple segments
+ * where you need to see the "lap times", and also conveniently control the logging without a bunch of repetitive code.
  *
  * This class becomes essential for tracking the timing processes that span multiple functions/methods, that are
  * critical to measure performance-wise. This includes the init code and miner loop, for example. The default timer,

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1719,7 +1719,7 @@ UniValue listaccounts(const UniValue& params, bool fHelp)
                 "listaccounts ( minconf includeWatchonly)\n"
                 "\n"
                 "Returns UniValue that has account names as keys, account balances as values."
-                "1. minconf          (numeric, optional, default=1) Only onclude transactions with at least this many confirmations\n"
+                "1. minconf          (numeric, optional, default=1) Only include transactions with at least this many confirmations\n"
                 "2. includeWatchonly (bool, optional, default=false) Include balances in watchonly addresses (see 'importaddress')\n"
                 "\nResult:\n"
                 "{                      (json object where keys are account names, and values are numeric balances\n"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2762,7 +2762,7 @@ std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> CWallet::GetAllPrivateKe
     LOCK2(cs_main, cs_wallet);
 
     std::vector<std::pair<CBitcoinAddress, CBitcoinSecret>> res;
-    // Get Privaty Keys from mapAddressBook
+    // Get Private Keys from mapAddressBook
     for (auto const& item : mapAddressBook)
     {
         const CBitcoinAddress& address = item.first;


### PR DESCRIPTION
This was accomplished mainly with simple spellchecking tools.  An effort was made to ignore British/American spelling differences