### PR TITLE
net: Reduce default connection limit back to 125

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -940,11 +940,11 @@ void ThreadSocketHandler2(void* parg)
                 if (nErr != WSAEWOULDBLOCK)
                     LogPrintf("socket error accept INVALID_SOCKET: %d", nErr);
             }
-            else if (nInbound >= GetArg("-maxconnections", 250) - MAX_OUTBOUND_CONNECTIONS)
+            else if (nInbound >= GetArg("-maxconnections", 125) - MAX_OUTBOUND_CONNECTIONS)
             {
                 LogPrint(BCLog::LogFlags::NET,
                          "Surpassed max inbound connections maxconnections:%" PRId64 " minus max_outbound:%i",
-                         GetArg("-maxconnections",250),
+                         GetArg("-maxconnections", 125),
                          MAX_OUTBOUND_CONNECTIONS);
 
                 closesocket(hSocket);


### PR DESCRIPTION
The default value for the `-maxconnections` configuration option was increased from 125 to 250 [back in 2014](https://github.com/gridcoin-community/Gridcoin-Research/commit/69b229a8b3f2b4890e13de16b017b3077236da1e#diff-00021eed586a482abdb09d6cdada1d90115abe988a91421851960e26658bed02R1447) without a documentation change. This decreases the limit back to 125 connections for listening nodes. 250 connections is a bit high as a default for unsuspecting node operators and it might create an unexpected burden for a device with limited resources. 

Since a GUI wallet is a listening node by default, we err on the side of caution. Folks that wish to service a greater number of connections can change the `-maxconnections` option or set the directive in the configuration file:

```ini
maxconnections=250
```