### PR TITLE
gui: Avoid refreshing GUI researcher status while out-of-sync

### DIFF
--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -82,6 +82,7 @@ public:
     void showWizard(WalletModel* wallet_model);
 
     bool configuredForInvestorMode() const;
+    bool outOfSync() const;
     bool detectedPoolMode() const;
     bool actionNeeded() const;
     bool hasEligibleProjects() const;
@@ -117,9 +118,15 @@ private:
     BeaconStatus m_beacon_status;
     bool m_configured_for_investor_mode;
     bool m_wizard_open;
+    bool m_out_of_sync;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+    void commitBeacon(const BeaconStatus beacon_status);
+    void commitBeacon(
+        const BeaconStatus beacon_status,
+        std::unique_ptr<GRC::Beacon>& current_beacon,
+        std::unique_ptr<GRC::Beacon>& pending_beacon);
 
 signals:
     void researcherChanged();

--- a/src/qt/researcher/researcherwizardbeaconpage.cpp
+++ b/src/qt/researcher/researcherwizardbeaconpage.cpp
@@ -49,8 +49,6 @@ void ResearcherWizardBeaconPage::initializePage()
     }
 
     refresh();
-    updateBeaconIcon(m_researcher_model->getBeaconStatusIcon());
-    updateBeaconStatus(m_researcher_model->formatBeaconStatus());
 }
 
 bool ResearcherWizardBeaconPage::isComplete() const
@@ -80,8 +78,17 @@ void ResearcherWizardBeaconPage::refresh()
     }
 
     ui->cpidLabel->setText(m_researcher_model->formatCpid());
-    ui->sendBeaconButton->setVisible(isEnabled());
-    ui->continuePromptWrapper->setVisible(!isEnabled());
+
+    if (m_researcher_model->outOfSync()) {
+        ui->sendBeaconButton->setVisible(false);
+        ui->continuePromptWrapper->setVisible(false);
+    } else {
+        ui->sendBeaconButton->setVisible(isEnabled());
+        ui->continuePromptWrapper->setVisible(!isEnabled());
+    }
+
+    updateBeaconStatus(m_researcher_model->formatBeaconStatus());
+    updateBeaconIcon(m_researcher_model->getBeaconStatusIcon());
 
     emit completeChanged();
 }

--- a/src/qt/researcher/researcherwizardsummarypage.cpp
+++ b/src/qt/researcher/researcherwizardsummarypage.cpp
@@ -44,6 +44,7 @@ void ResearcherWizardSummaryPage::setModel(ResearcherModel *model)
     ui->projectTableView->setModel(m_table_model);
 
     connect(model, SIGNAL(researcherChanged()), this, SLOT(refreshSummary()));
+    connect(model, SIGNAL(beaconChanged()), this, SLOT(refreshSummary()));
     connect(ui->refreshButton, SIGNAL(clicked()), this, SLOT(reloadProjects()));
     connect(ui->tabWidget, SIGNAL(currentChanged(int)), this, SLOT(onTabChanged(int)));
 }
@@ -111,7 +112,10 @@ void ResearcherWizardSummaryPage::refreshOverallStatus()
     QString status;
     QIcon icon;
 
-    if (m_researcher_model->hasPendingBeacon()) {
+    if (m_researcher_model->outOfSync()) {
+        status = tr("Waiting for sync...");
+        icon = QIcon(":/icons/notsynced");
+    } else if (m_researcher_model->hasPendingBeacon()) {
         status = tr("Beacon awaiting confirmation.");
         icon = QIcon(":/icons/notsynced");
     } else if (m_researcher_model->hasRenewableBeacon()) {


### PR DESCRIPTION
These changes prevent the GUI from making assumptions about researcher and beacon statuses before a wallet finishes downloading the chain. In this way, we avoid displaying confusing information. Before, someone with an existing beacon might see an "action needed" prompt until the wallet downloads the block that contains the current beacon, and the magnitude and pending accrual fields can jump around wildly until the sync finishes.

Instead, the wallet will display a "waiting for sync..." status label in place of content that needs the context at the chain tip.