### PR TITLE
beacon: Cull beacon db memory (passivation)

### DIFF
--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -1300,6 +1300,21 @@ uint64_t BeaconRegistry::PassivateDB()
     return m_beacon_db.passivate_db();
 }
 
+// This is static and called by the scheduler.
+void BeaconRegistry::RunBeaconDBPassivation()
+{
+    TRY_LOCK(cs_main, locked_main);
+
+    if (!locked_main)
+    {
+        return;
+    }
+
+    BeaconRegistry& beacons = GetBeaconRegistry();
+
+    beacons.PassivateDB();
+}
+
 // Required to make the linker happy.
 constexpr uint32_t BeaconRegistry::BeaconDB::CURRENT_VERSION;
 

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -718,6 +718,12 @@ public:
     //!
     bool SetNeedsIsContractCorrection(bool flag);
 
+    //!
+    //! \brief A static function that is called by the scheduler to run the beacon database passivation.
+    //!
+    static void RunBeaconDBPassivation();
+
+
 private:
     BeaconMap m_beacons;        //!< Contains the active registered beacons.
     PendingBeaconMap m_pending; //!< Contains beacons awaiting verification.

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -514,25 +514,23 @@ class BeaconRegistry : public IContractHandler
 public:
     //!
     //! \brief The type that associates beacons with CPIDs in the registry. This
-    //! is done via smart pointers to save memory, since the actual beacon elements
-    //! are actually stored in the HistoricalBeaconMap.
+    //! is done via smart pointers to save memory.
     //!
     typedef std::unordered_map<Cpid, Beacon_ptr> BeaconMap;
 
     //!
     //! \brief Associates pending beacons with the hash of the beacon public
-    //! keys. This is done via smart pointers to save memory, since the actual beacon
-    //! elements are actually stored in the HistoricalBeaconMap.
-    //!
+    //! keys. This is done via smart pointers to save memory.
     typedef std::map<CKeyID, Beacon_ptr> PendingBeaconMap;
 
     //!
-    //! \brief The type that associates historical beacons with a SHA256 hash. Note that
-    //! most of the time this is the hash of the beacon contract, but in the case of
-    //! beacon activations in the superblock, this is a hash of the superblock hash
-    //! and the cpid to make the records unique.
+    //! \brief The type that associates historical beacons with a SHA256 hash. This is done
+    //! with smart pointers to save memeory. Note that most of the time this is the hash of
+    //! the beacon contract, but in the case of beacon activations in the superblock, this
+    //! is a hash of the superblock hash and the pending beacon that is being activated's hash
+    //! to make the records unique.
     //!
-    typedef std::map<uint256, Beacon> HistoricalBeaconMap;
+    typedef std::map<uint256, Beacon_ptr> HistoricalBeaconMap;
 
     //!
     //! \brief Get the collection of registered beacons.
@@ -698,6 +696,16 @@ public:
     void ResetInMemoryOnly();
 
     //!
+    //! \brief Passivates the elements in the beacon db, which means remove from memory elements in the
+    //! historical map that are not referenced by either the m_beacons or m_pending. The backing store of
+    //! the element removed from memory is retained and will be transparently restored if find()
+    //! is called on the hash key for the element.
+    //!
+    //! \return The number of elements passivated.
+    //!
+    uint64_t PassivateDB();
+
+    //!
     //! \brief Returns whether IsContract correction is needed in ReplayContracts during initialization
     //! \return
     //!
@@ -755,6 +763,12 @@ private:
         //! \return Success or failure.
         //!
         bool clear_leveldb();
+
+        //!
+        //! \brief Removes in memory elements for all historical records not in m_beacons or m_pending.
+        //! \return Number of elements passivated.
+        //!
+        uint64_t passivate_db();
 
         //!
         //! \brief Clear the historical map and leveldb beacon storage area.
@@ -828,7 +842,18 @@ private:
         //!
         //! \return Success or failure.
         //!
-        bool erase(uint256 hash);
+        bool erase(const uint256& hash);
+
+        //!
+        //! \brief Remove an individual in memory element that is backed by leveldb that is not in m_beacons or m_pending.
+        //!
+        //! \param hash The hash that is the key to the element.
+        //!
+        //! \return A pair, the first part of which is an iterator to the next element, or map::end() if the last one, and
+        //! the second is success or failure of the passivation.
+        //!
+        std::pair<BeaconRegistry::HistoricalBeaconMap::iterator, bool>
+            passivate(BeaconRegistry::HistoricalBeaconMap::iterator& iter);
 
         //!
         //! \brief Iterator to the beginning of the database records.
@@ -854,7 +879,7 @@ private:
         //!
         //! \return Iterator.
         //!
-        HistoricalBeaconMap::iterator find(uint256& hash);
+        HistoricalBeaconMap::iterator find(const uint256& hash);
 
         //!
         //! \brief Advances the iterator to the next element.
@@ -862,14 +887,6 @@ private:
         //! \return iter
         //!
         HistoricalBeaconMap::iterator advance(HistoricalBeaconMap::iterator iter);
-
-        //!
-        //! \brief Allows subscript style lookup of an element by hash in the beacon_db. Does not currently support
-        //! subscript style insert.
-        //! \param hash The hash of the element to retrieve.
-        //! \return Beacon
-        //!
-        Beacon& operator[](const uint256& hash);
 
     private:
         //!
@@ -911,6 +928,13 @@ private:
         uint64_t m_recnum_stored = 0;
 
         //!
+        //! \brief The flag that indicates whether memory optimization can occur by passivating the database. This
+        //! flag is set true when find() retrieves a beacon element from leveldb to satisfy a hash search.
+        //! This would typically occur on a beacon renewal or reorganization (revert).
+        //!
+        bool m_needs_passivation = false;
+
+        //!
         //! \brief The flag that indicates whether IsContract correction is needed in ReplayContracts during initialization.
         //!
         bool m_needs_IsContract_correction = false;
@@ -933,7 +957,7 @@ private:
         //!
         //! \return Success or failure.
         //!
-        bool Load(uint256& hash, StorageBeacon& beacon);
+        bool Load(const uint256 &hash, StorageBeacon& beacon);
 
         //!
         //! \brief Delete a beacon object from leveldb with the provided key value (if it exists).
@@ -942,7 +966,7 @@ private:
         //!
         //! \return Success or failure.
         //!
-        bool Delete(uint256& hash);
+        bool Delete(const uint256& hash);
 
     }; // BeaconDB
 

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -364,6 +364,13 @@ void ScheduleUpdateChecks(CScheduler& scheduler)
         g_UpdateChecker->CheckForLatestUpdate();
     }, 60 * 1000);
 }
+
+void ScheduleBeaconDBPassivation(CScheduler& scheduler)
+{
+    // Run beacon database passivation every 5 minutes. This is a very thin call most of the time.
+    // Please see the PassivateDB function and passivate_db.
+    scheduler.scheduleEvery(BeaconRegistry::RunBeaconDBPassivation, 5 * 60 * 1000);
+}
 } // Anonymous namespace
 
 // -----------------------------------------------------------------------------
@@ -422,4 +429,5 @@ void GRC::ScheduleBackgroundJobs(CScheduler& scheduler)
 
     ScheduleBackups(scheduler);
     ScheduleUpdateChecks(scheduler);
+    ScheduleBeaconDBPassivation(scheduler);
 }

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1055,7 +1055,7 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
     // than here.
     while (beacon_ptr->Renewed())
     {
-        beacon_ptr = std::make_shared<Beacon>(beacons.GetBeaconDB().find(beacon_ptr->m_prev_beacon_hash)->second);
+        beacon_ptr = beacons.GetBeaconDB().find(beacon_ptr->m_prev_beacon_hash)->second;
     }
 
     const CBlockIndex* pindex_baseline = GRC::Tally::GetBaseline();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -333,7 +333,7 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
     {
         auto iter = beacons.GetBeaconDB().find(beacon_ptr->m_prev_beacon_hash);
 
-        beacon_ptr = std::make_shared<Beacon>(iter->second);
+        beacon_ptr = iter->second;
 
         LogPrint(BCLog::LogFlags::ACCRUAL, "INFO %s: renewal %u beacon: timestamp = %" PRId64 ", ctx_hash = %s,"
                                            " prev_beacon_ctx_hash = %s.",

--- a/src/test/gridcoin/beacon_tests.cpp
+++ b/src/test/gridcoin/beacon_tests.cpp
@@ -105,6 +105,626 @@ struct TestKey
         return signature;
     }
 }; // TestKey
+
+
+class BeaconRegistryTest
+{
+public:
+    BeaconRegistryTest(CDataStream beacon_data
+                       ,int64_t high_height_time
+                       ,int low_height
+                       ,int high_height
+                       ,int num_blocks) :
+        m_high_height_time_check(high_height_time),
+        m_low_height_check(low_height),
+        m_high_height_check(high_height),
+        m_num_blocks_check(num_blocks)
+    {
+        GRC::BeaconRegistry& registry = GRC::GetBeaconRegistry();
+
+        // Make sure the registry is reset.
+        registry.Reset();
+
+        beacon_data >> m_high_height_time;
+        beacon_data >> m_low_height;
+        beacon_data >> m_high_height;
+        beacon_data >> m_num_blocks;
+
+        // Import the blocks in the file and replay the relevant contracts.
+        for (int i = 0; i < m_num_blocks; ++i)
+        {
+            BOOST_TEST_CHECKPOINT("Processing block = " << i);
+
+            GRC::ExportContractElement element;
+
+            beacon_data >> element;
+
+            uint256 block_hash = element.m_disk_block_index.GetBlockHash();
+
+            // Construct block index object. This comes from the guts of CtxDB::LoadBlockIndex()
+            CBlockIndex* pindex    = GRC::MockBlockIndex::InsertBlockIndex(block_hash);
+            // Note the mock CBlockIndex objects created here are SPARSE; therefore the blocks
+            // pointed to by the pprev and pnext hashes will more than likely NOT be present here,
+            // and are not needed anyway for this test, so ensure set to nullptr.
+            pindex->pprev          = nullptr;
+            pindex->pnext          = nullptr;
+            pindex->nFile          = element.m_disk_block_index.nFile;
+            pindex->nBlockPos      = element.m_disk_block_index.nBlockPos;
+            pindex->nHeight        = element.m_disk_block_index.nHeight;
+            pindex->nMoneySupply   = element.m_disk_block_index.nMoneySupply;
+            pindex->nFlags         = element.m_disk_block_index.nFlags;
+            pindex->nStakeModifier = element.m_disk_block_index.nStakeModifier;
+            pindex->hashProof      = element.m_disk_block_index.hashProof;
+            pindex->nVersion       = element.m_disk_block_index.nVersion;
+            pindex->hashMerkleRoot = element.m_disk_block_index.hashMerkleRoot;
+            pindex->nTime          = element.m_disk_block_index.nTime;
+            pindex->nBits          = element.m_disk_block_index.nBits;
+            pindex->nNonce         = element.m_disk_block_index.nNonce;
+            pindex->m_researcher   = element.m_disk_block_index.m_researcher;
+
+            // Update hashBestChain to fixup global for BeaconRegistry::Initialize call.
+            hashBestChain = block_hash;
+
+            // Import and apply all of the contracts from the file for the given block.
+            for (const auto& iter : element.m_ctx)
+            {
+                // ----------------------- contract ------- tx
+                GRC::ContractContext ctx({iter.first, iter.second, pindex});
+
+                // This is the "thin" version of g_dispatcher.Apply in GRC::ApplyContracts for beacons.
+                if (ctx->m_action == GRC::ContractAction::ADD)
+                {
+                    registry.Add(ctx);
+                }
+
+                if (ctx->m_action == GRC::ContractAction::REMOVE)
+                {
+                    registry.Delete(ctx);
+                }
+            }
+
+            // Activate the pending beacons that are now verified, and also mark expired pending beacons expired.
+            if (pindex->IsSuperblock())
+            {
+                registry.ActivatePending(element.m_verified_beacons,
+                                         pindex->nTime,
+                                         block_hash,
+                                         pindex->nHeight);
+            }
+        }
+
+        // Passivate the beacon db to remove unnecessary historical elements in memory.
+        registry.PassivateDB();
+
+        for (const auto& iter : registry.Beacons())
+        {
+            m_beacons_init[iter.first] = *iter.second;
+        }
+
+        m_init_number_beacons = m_beacons_init.size();
+
+        for (const auto& iter : registry.PendingBeacons())
+        {
+            m_pending_beacons_init[iter.first] = *iter.second;
+        }
+
+        m_init_number_pending_beacons = m_pending_beacons_init.size();
+
+        m_init_beacon_db_size = registry.GetBeaconDB().size();
+
+        auto& init_beacon_db = registry.GetBeaconDB();
+
+        auto init_beacon_db_iter = init_beacon_db.begin();
+        while (init_beacon_db_iter != init_beacon_db.end())
+        {
+            const uint256& hash = init_beacon_db_iter->first;
+            const GRC::Beacon_ptr& beacon_ptr = init_beacon_db_iter->second;
+
+            // Create a copy of the referenced beacon object with a shared pointer to it and store.
+            m_local_historical_beacon_map_init[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
+
+            init_beacon_db_iter = init_beacon_db.advance(init_beacon_db_iter);
+        }
+
+        // Reinitialize from leveldb to do comparison checks for reinit integrity.
+
+        // Reset in memory structures only (which leaves leveldb undisturbed).
+        registry.ResetInMemoryOnly();
+
+        // Reinitialize from leveldb.
+        registry.Initialize();
+
+        // Passivate the beacon db to remove unnecessary historical elements in memory.
+        registry.PassivateDB();
+
+        for (const auto& iter : registry.Beacons())
+        {
+            m_beacons_reinit[iter.first] = *iter.second;
+        }
+
+        m_reinit_number_beacons = m_beacons_reinit.size();
+
+        for (const auto& iter : registry.PendingBeacons())
+        {
+            m_pending_beacons_reinit[iter.first] = *iter.second;
+        }
+
+        m_reinit_number_pending_beacons = m_pending_beacons_reinit.size();
+
+        m_reinit_beacon_db_size = registry.GetBeaconDB().size();
+
+        auto& reinit_beacon_db = registry.GetBeaconDB();
+
+        auto reinit_beacon_db_iter = reinit_beacon_db.begin();
+        while (reinit_beacon_db_iter != reinit_beacon_db.end())
+        {
+            const uint256& hash = reinit_beacon_db_iter->first;
+            const GRC::Beacon_ptr& beacon_ptr = reinit_beacon_db_iter->second;
+
+            // Create a copy of the referenced beacon object with a shared pointer to it and store.
+            m_local_historical_beacon_map_reinit[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
+
+            reinit_beacon_db_iter = reinit_beacon_db.advance(reinit_beacon_db_iter);
+        }
+    };
+
+    void RunBasicChecks()
+    {
+        // These should be set to correspond to the dumpcontracts run used to create testnet_beacon.bin
+        BOOST_CHECK(m_high_height_time == m_high_height_time_check);
+        BOOST_CHECK(m_low_height == m_low_height_check);
+        BOOST_CHECK(m_high_height == m_high_height_check);
+        BOOST_CHECK(m_num_blocks == m_num_blocks_check);
+
+        BOOST_TEST_CHECKPOINT("init_beacon_db_size = " << m_init_beacon_db_size << ", "
+                              << "reinit_beacon_db_size = " << m_reinit_beacon_db_size);
+
+        BOOST_CHECK_EQUAL(m_init_beacon_db_size, m_reinit_beacon_db_size);
+    };
+
+    void BeaconDatabaseComparisonChecks_m_historical()
+    {
+        // m_historical checks
+
+        BOOST_CHECK_EQUAL(m_local_historical_beacon_map_init.size(), m_local_historical_beacon_map_reinit.size());
+
+        bool historical_beacon_db_comparison_success = true;
+
+        // left join with init on the left
+        for (const auto& left : m_local_historical_beacon_map_init)
+        {
+            uint256 hash = left.first;
+            GRC::Beacon_ptr left_beacon_ptr = left.second;
+
+            auto right_beacon_iter = m_local_historical_beacon_map_reinit.find(hash);
+
+            if (right_beacon_iter == m_local_historical_beacon_map_reinit.end())
+            {
+                BOOST_TEST_CHECKPOINT("beacon in init beacon db not found in reinit beacon db for cpid "
+                                      << left_beacon_ptr->m_cpid.ToString());
+
+                historical_beacon_db_comparison_success = false;
+
+                std::cout << "MISSING: Reinit record missing for init record: "
+                          << "hash = " << hash.GetHex()
+                          << ", cpid = " << left.second->m_cpid.ToString()
+                          << ", public key = " << left.second->m_public_key.ToString()
+                          << ", address = " << left.second->GetAddress().ToString()
+                          << ", timestamp = " << left.second->m_timestamp
+                          << ", hash = " << left.second->m_hash.GetHex()
+                          << ", prev beacon hash = " << left.second->m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(left.second->m_status.Raw())
+                          << std::endl;
+
+            }
+            else if (*left_beacon_ptr != *right_beacon_iter->second)
+            {
+                BOOST_TEST_CHECKPOINT("beacon in init beacon db does not match corresponding beacon"
+                                      " in reinit beacon db for cpid "
+                                      << left_beacon_ptr->m_cpid.ToString());
+
+                historical_beacon_db_comparison_success = false;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "MISMATCH: beacon in reinit beacon db does not match corresponding beacon"
+                             " in init beacon db for hash = " << hash.GetHex() << std::endl;
+
+                std::cout << "cpid = " << left_beacon_ptr->m_cpid.ToString() << std::endl;
+
+                std::cout << "init_beacon public key = " << left_beacon_ptr->m_public_key.ToString()
+                          << ", reinit_beacon public key = " << right_beacon_iter->second->m_public_key.ToString() << std::endl;
+
+                std::cout << "init_beacon address = " << left_beacon_ptr->GetAddress().ToString()
+                          << ", reinit_beacon address = " << right_beacon_iter->second->GetAddress().ToString() << std::endl;
+
+                std::cout << "init_beacon timestamp = " << left_beacon_ptr->m_timestamp
+                          << ", reinit_beacon timestamp = " << right_beacon_iter->second->m_timestamp << std::endl;
+
+                std::cout << "init_beacon hash = " << left_beacon_ptr->m_hash.GetHex()
+                          << ", reinit_beacon hash = " << right_beacon_iter->second->m_hash.GetHex() << std::endl;
+
+                std::cout << "init_beacon prev beacon hash = " << left_beacon_ptr->m_prev_beacon_hash.GetHex()
+                          << ", reinit_beacon prev beacon hash = " << right_beacon_iter->second->m_prev_beacon_hash.GetHex() << std::endl;
+
+                std::cout << "init_beacon status = " << std::to_string(left_beacon_ptr->m_status.Raw())
+                          << ", reinit_beacon status = " << std::to_string(right_beacon_iter->second->m_status.Raw()) << std::endl;
+            }
+        }
+
+        // left join with reinit on the left
+        for (const auto& left : m_local_historical_beacon_map_reinit)
+        {
+            uint256 hash = left.first;
+            GRC::Beacon_ptr left_beacon_ptr = left.second;
+
+            auto right_beacon_iter = m_local_historical_beacon_map_init.find(hash);
+
+            if (right_beacon_iter == m_local_historical_beacon_map_init.end())
+            {
+                BOOST_TEST_CHECKPOINT("beacon in reinit beacon db not found in init beacon db for cpid "
+                                      << left_beacon_ptr->m_cpid.ToString());
+
+                historical_beacon_db_comparison_success = false;
+
+                std::cout << "MISSING: init record missing for reinit record: "
+                          << "hash = " << hash.GetHex()
+                          << ", cpid = " << left.second->m_cpid.ToString()
+                          << ", public key = " << left.second->m_public_key.ToString()
+                          << ", address = " << left.second->GetAddress().ToString()
+                          << ", timestamp = " << left.second->m_timestamp
+                          << ", hash = " << left.second->m_hash.GetHex()
+                          << ", prev beacon hash = " << left.second->m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(left.second->m_status.Raw())
+                          << std::endl;
+
+            }
+            else if (*left_beacon_ptr != *right_beacon_iter->second)
+            {
+                BOOST_TEST_CHECKPOINT("beacon in init beacon db does not match corresponding beacon"
+                                      " in reinit beacon db for cpid "
+                                      << left_beacon_ptr->m_cpid.ToString());
+
+                historical_beacon_db_comparison_success = false;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "MISMATCH: beacon in init beacon db does not match corresponding beacon"
+                             " in reinit beacon db for hash = " << hash.GetHex() << std::endl;
+
+                std::cout << "cpid = " << left_beacon_ptr->m_cpid.ToString() << std::endl;
+
+                std::cout << "reinit_beacon public key = " << left_beacon_ptr->m_public_key.ToString()
+                          << ", init_beacon public key = " << right_beacon_iter->second->m_public_key.ToString() << std::endl;
+
+                std::cout << "reinit_beacon address = " << left_beacon_ptr->GetAddress().ToString()
+                          << ", init_beacon address = " << right_beacon_iter->second->GetAddress().ToString() << std::endl;
+
+                std::cout << "reinit_beacon timestamp = " << left_beacon_ptr->m_timestamp
+                          << ", init_beacon timestamp = " << right_beacon_iter->second->m_timestamp << std::endl;
+
+                std::cout << "reinit_beacon hash = " << left_beacon_ptr->m_hash.GetHex()
+                          << ", init_beacon hash = " << right_beacon_iter->second->m_hash.GetHex() << std::endl;
+
+                std::cout << "reinit_beacon prev beacon hash = " << left_beacon_ptr->m_prev_beacon_hash.GetHex()
+                          << ", init_beacon prev beacon hash = " << right_beacon_iter->second->m_prev_beacon_hash.GetHex() << std::endl;
+
+                std::cout << "reinit_beacon status = " << std::to_string(left_beacon_ptr->m_status.Raw())
+                          << ", init_beacon status = " << std::to_string(right_beacon_iter->second->m_status.Raw()) << std::endl;
+            }
+        }
+
+        BOOST_CHECK(historical_beacon_db_comparison_success);
+    };
+
+    void BeaconDatabaseComparisonChecks_m_beacons()
+    {
+        BOOST_TEST_CHECKPOINT("init_number_beacons = " << m_init_number_beacons << ", "
+                              << "reinit_number_beacons = " << m_reinit_number_beacons);
+
+        bool number_beacons_equal = (m_init_number_beacons == m_reinit_number_beacons);
+
+        if (!number_beacons_equal)
+        {
+            for (const auto& iter : m_beacons_init)
+            {
+                const GRC::Cpid& cpid = iter.first;
+                const GRC::Beacon& beacon = iter.second;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "init_beacon cpid = " << cpid.ToString()
+                          << ", public key = " << beacon.m_public_key.ToString()
+                          << ", address = " << beacon.GetAddress().ToString()
+                          << ", timestamp = " << beacon.m_timestamp
+                          << ", hash = " << beacon.m_hash.GetHex()
+                          << ", prev beacon hash = " << beacon.m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(beacon.m_status.Raw())
+                          << std::endl;
+            }
+
+            for (const auto& iter : m_beacons_reinit)
+            {
+                const GRC::Cpid& cpid = iter.first;
+                const GRC::Beacon& beacon = iter.second;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "reinit beacon cpid = " << cpid.ToString()
+                          << ", public key = " << beacon.m_public_key.ToString()
+                          << ", address = " << beacon.GetAddress().ToString()
+                          << ", timestamp = " << beacon.m_timestamp
+                          << ", hash = " << beacon.m_hash.GetHex()
+                          << ", prev beacon hash = " << beacon.m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(beacon.m_status.Raw())
+                          << std::endl;
+            }
+        }
+
+        BOOST_CHECK_EQUAL(m_init_number_beacons, m_reinit_number_beacons);
+
+        bool beacon_comparison_success = true;
+
+        // left join with init on the left
+        for (const auto& left : m_beacons_init)
+        {
+            GRC::Beacon left_beacon = left.second;
+            auto right = m_beacons_reinit.find(left.first);
+
+            if (right == m_beacons_reinit.end())
+            {
+                BOOST_TEST_CHECKPOINT("MISSING: beacon in init not found in reinit for cpid "
+                                      << left.first.ToString());
+                beacon_comparison_success = false;
+
+                std::cout << "MISSING: reinit beacon record missing for init beacon record: "
+                          << "hash = " << left.second.m_hash.GetHex()
+                          << ", cpid = " << left.second.m_cpid.ToString()
+                          << ", public key = " << left.second.m_public_key.ToString()
+                          << ", address = " << left.second.GetAddress().ToString()
+                          << ", timestamp = " << left.second.m_timestamp
+                          << ", hash = " << left.second.m_hash.GetHex()
+                          << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(left.second.m_status.Raw())
+                          << std::endl;
+            }
+            else if (left_beacon != right->second)
+            {
+                BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for cpid "
+                                      << left.first.ToString());
+                beacon_comparison_success = false;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "MISMATCH: beacon in reinit mismatches init for cpid = "
+                          << left_beacon.m_cpid.ToString() << std::endl;
+
+                std::cout << "init_beacon public key = " << left_beacon.m_public_key.ToString()
+                          << ", reinit_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
+
+                std::cout << "init_beacon timestamp = " << left_beacon.m_timestamp
+                          << ", reinit_beacon timestamp = " << right->second.m_timestamp << std::endl;
+
+                std::cout << "init_beacon hash = " << left_beacon.m_hash.GetHex()
+                          << ", reinit_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
+
+                std::cout << "init_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
+                          << ", reinit_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex() << std::endl;
+
+                std::cout << "init_beacon status = " << std::to_string(left_beacon.m_status.Raw())
+                          << ", reinit_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
+            }
+        }
+
+
+        // left join with reinit on the left
+        for (const auto& left : m_beacons_reinit)
+        {
+            GRC::Beacon left_beacon = left.second;
+
+            auto right = m_beacons_init.find(left.first);
+
+            if (right == m_beacons_reinit.end())
+            {
+                BOOST_TEST_CHECKPOINT("MISSING: beacon in reinit not found in init for cpid "
+                                      << left.first.ToString());
+                beacon_comparison_success = false;
+
+                std::cout << "MISSING: init beacon record missing for reinit beacon record: "
+                          << "hash = " << left.second.m_hash.GetHex()
+                          << ", cpid = " << left.second.m_cpid.ToString()
+                          << ", public key = " << left.second.m_public_key.ToString()
+                          << ", address = " << left.second.GetAddress().ToString()
+                          << ", timestamp = " << left.second.m_timestamp
+                          << ", hash = " << left.second.m_hash.GetHex()
+                          << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(left.second.m_status.Raw())
+                          << std::endl;
+
+            }
+            else if (left_beacon != right->second)
+            {
+                BOOST_TEST_CHECKPOINT("MISMATCH: beacon in init mismatches reinit for cpid "
+                                      << left.first.ToString());
+                beacon_comparison_success = false;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "MISMATCH: beacon in reinit mismatches init for cpid = "
+                          << left_beacon.m_cpid.ToString() << std::endl;
+
+                std::cout << "reinit_beacon public key = " << left_beacon.m_public_key.ToString()
+                          << ", init_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
+
+                std::cout << "reinit_beacon timestamp = " << left_beacon.m_timestamp
+                          << ", init_beacon timestamp = " << right->second.m_timestamp << std::endl;
+
+                std::cout << "reinit_beacon hash = " << left_beacon.m_hash.GetHex()
+                          << ", init_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
+
+                std::cout << "reinit_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
+                          << ", init_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex() << std::endl;
+
+                std::cout << "reinit_beacon status = " << std::to_string(left_beacon.m_status.Raw())
+                          << ", init_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
+            }
+        }
+
+        BOOST_CHECK(beacon_comparison_success);
+    };
+
+    void BeaconDatabaseComparisonChecks_m_pending()
+    {
+        BOOST_TEST_CHECKPOINT("init_number_pending_beacons.size() = " << m_init_number_pending_beacons << ", "
+                              << "reinit_number_pending_beacons.size() = " << m_reinit_number_pending_beacons);
+
+        BOOST_CHECK_EQUAL(m_init_number_pending_beacons, m_reinit_number_pending_beacons);
+
+        bool pending_beacon_comparison_success = true;
+
+        // left join with init on the left
+        for (const auto& left : m_pending_beacons_init)
+        {
+            GRC::Beacon left_beacon = left.second;
+            auto right = m_pending_beacons_reinit.find(left.first);
+
+            if (right == m_pending_beacons_reinit.end())
+            {
+                BOOST_TEST_CHECKPOINT("MISSING: pending beacon in init not found in reinit for CKeyID "
+                                      << left.first.ToString());
+                pending_beacon_comparison_success = false;
+
+                std::cout << "MISSING: reinit pending beacon record missing for init pending beacon record: "
+                          << "hash = " << left_beacon.m_hash.GetHex()
+                          << ", cpid = " << left_beacon.m_cpid.ToString()
+                          << ", public key = " << left_beacon.m_public_key.ToString()
+                          << ", address = " << left_beacon.GetAddress().ToString()
+                          << ", timestamp = " << left_beacon.m_timestamp
+                          << ", hash = " << left_beacon.m_hash.GetHex()
+                          << ", prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(left_beacon.m_status.Raw())
+                          << std::endl;
+            }
+            else if (left_beacon != right->second)
+            {
+                BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for CKeyID "
+                                      << left.first.ToString());
+                pending_beacon_comparison_success = false;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "MISMATCH: beacon in reinit mismatches init for CKeyID "
+                          << left.first.ToString() << std::endl;
+
+                std::cout << "init_pending_beacon cpid = " << left_beacon.m_cpid.ToString()
+                          << ", reinit_pending_beacon cpid = " << right->second.m_cpid.ToString() << std::endl;
+
+                std::cout << "init_pending_beacon public key = " << left_beacon.m_public_key.ToString()
+                          << ", reinit_pending_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
+
+                std::cout << "init_pending_beacon timestamp = " << left_beacon.m_timestamp
+                          << ", reinit_pending_beacon timestamp = " << right->second.m_timestamp << std::endl;
+
+                std::cout << "init_pending_beacon hash = " << left_beacon.m_hash.GetHex()
+                          << ", reinit_pending_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
+
+                std::cout << "init_pending_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
+                          << ", reinit_pending_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex()
+                          << std::endl;
+
+                std::cout << ", init_pending_beacon status = " << std::to_string(left_beacon.m_status.Raw())
+                          << ", reinit_pending_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
+            }
+        }
+
+        // left join with reinit on the left
+        for (const auto& left : m_pending_beacons_reinit)
+        {
+            GRC::Beacon left_beacon = left.second;
+            auto right = m_pending_beacons_init.find(left.first);
+
+            if (right == m_pending_beacons_init.end())
+            {
+                BOOST_TEST_CHECKPOINT("MISSING: pending beacon in reinit not found in init for CKeyID "
+                                      << left.first.ToString());
+                pending_beacon_comparison_success = false;
+
+                std::cout << "MISSING: init pending beacon record missing for reinit pending beacon record: "
+                          << "hash = " << left.second.m_hash.GetHex()
+                          << ", cpid = " << left.second.m_cpid.ToString()
+                          << ", public key = " << left.second.m_public_key.ToString()
+                          << ", address = " << left.second.GetAddress().ToString()
+                          << ", timestamp = " << left.second.m_timestamp
+                          << ", hash = " << left.second.m_hash.GetHex()
+                          << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
+                          << ", status = " << std::to_string(left.second.m_status.Raw())
+                          << std::endl;
+            }
+            else if (left_beacon != right->second)
+            {
+                BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for CKeyID "
+                                      << left.first.ToString());
+                pending_beacon_comparison_success = false;
+
+                // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
+                // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
+                std::cout << "MISMATCH: beacon in reinit mismatches init for CKeyID "
+                          << left.first.ToString() << std::endl;
+
+                std::cout << "init_pending_beacon cpid = " << left_beacon.m_cpid.ToString()
+                          << ", reinit_pending_beacon cpid = " << right->second.m_cpid.ToString() << std::endl;
+
+                std::cout << "init_pending_beacon public key = " << left_beacon.m_public_key.ToString()
+                          << ", reinit_pending_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
+
+                std::cout << "init_pending_beacon timestamp = " << left_beacon.m_timestamp
+                          << ", reinit_pending_beacon timestamp = " << right->second.m_timestamp << std::endl;
+
+                std::cout << "init_pending_beacon hash = " << left_beacon.m_hash.GetHex()
+                          << ", reinit_pending_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
+
+                std::cout << "init_pending_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
+                          << ", reinit_pending_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex()
+                          << std::endl;
+
+                std::cout << ", init_pending_beacon status = " << std::to_string(left_beacon.m_status.Raw())
+                          << ", reinit_pending_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
+            }
+        }
+
+        BOOST_CHECK(pending_beacon_comparison_success);
+    };
+
+    int64_t m_high_height_time = 0;
+    int m_low_height = 0;
+    int m_high_height = 0;
+    int m_num_blocks = 0;
+
+    int64_t m_high_height_time_check = 0;
+    int m_low_height_check = 0;
+    int m_high_height_check = 0;
+    int m_num_blocks_check = 0;
+
+    // Record the map of beacons and pending beacons after the contract replay. We have to have independent storage
+    // of these, not pointers, because the maps are going to get reset for the second run (reinit).
+    typedef std::unordered_map<GRC::Cpid, GRC::Beacon> LocalBeaconMap;
+    typedef std::map<CKeyID, GRC::Beacon> LocalPendingBeaconMap;
+
+    LocalBeaconMap m_beacons_init;
+    LocalPendingBeaconMap m_pending_beacons_init;
+    GRC::BeaconRegistry::HistoricalBeaconMap m_local_historical_beacon_map_init;
+    size_t m_init_number_beacons = 0;
+    size_t m_init_number_pending_beacons = 0;
+    size_t m_init_beacon_db_size = 0;
+
+    LocalBeaconMap m_beacons_reinit;
+    LocalPendingBeaconMap m_pending_beacons_reinit;
+    GRC::BeaconRegistry::HistoricalBeaconMap m_local_historical_beacon_map_reinit;
+    size_t m_reinit_number_beacons = 0;
+    size_t m_reinit_number_pending_beacons = 0;
+    size_t m_reinit_beacon_db_size = 0;
+};
+
 } // anonymous namespace
 
 // -----------------------------------------------------------------------------
@@ -461,1208 +1081,57 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
 
 BOOST_AUTO_TEST_CASE(beaconstorage_testnet_test)
 {
+    // These should be set to correspond to the dumpcontracts run used to create testnet_beacon.bin
+    int64_t high_height_time = 1613880656;
+    int low_height = 1301500;
+    int high_height = 1497976;
+    int num_blocks = 271;
+
     CDataStream data(SER_DISK, PROTOCOL_VERSION);
 
     data << testnet_beacon_bin;
 
-    GRC::BeaconRegistry& registry = GRC::GetBeaconRegistry();
+    BeaconRegistryTest beacon_registry_test(data,
+                                            high_height_time,
+                                            low_height,
+                                            high_height,
+                                            num_blocks);
 
-    // Make sure the registry is reset.
-    registry.Reset();
+    beacon_registry_test.RunBasicChecks();
 
-    int64_t high_height_time = 0;
-    int low_height = 0;
-    int high_height = 0;
-    int num_blocks = 0;
+    beacon_registry_test.BeaconDatabaseComparisonChecks_m_historical();
 
-    data >> high_height_time;
-    data >> low_height;
-    data >> high_height;
-    data >> num_blocks;
+    beacon_registry_test.BeaconDatabaseComparisonChecks_m_beacons();
 
-    // These should be set to correspond to the dumpcontracts run used to create testnet_beacon.bin
-    BOOST_CHECK(high_height_time == 1613880656);
-    BOOST_CHECK(low_height == 1301500);
-    BOOST_CHECK(high_height == 1497976);
-    BOOST_CHECK(num_blocks == 271);
-
-
-    // Import the blocks in the file and replay the relevant contracts.
-    for (int i = 0; i < num_blocks; ++i)
-    {
-        BOOST_TEST_CHECKPOINT("Processing block = " << i);
-
-        GRC::ExportContractElement element;
-
-        data >> element;
-
-        uint256 block_hash = element.m_disk_block_index.GetBlockHash();
-
-        // Construct block index object. This comes from the guts of CtxDB::LoadBlockIndex()
-        CBlockIndex* pindex    = GRC::MockBlockIndex::InsertBlockIndex(block_hash);
-        // Note the mock CBlockIndex objects created here are SPARSE; therefore the blocks
-        // pointed to by the pprev and pnext hashes will more than likely NOT be present here,
-        // and are not needed anyway for this test, so ensure set to nullptr.
-        pindex->pprev          = nullptr;
-        pindex->pnext          = nullptr;
-        pindex->nFile          = element.m_disk_block_index.nFile;
-        pindex->nBlockPos      = element.m_disk_block_index.nBlockPos;
-        pindex->nHeight        = element.m_disk_block_index.nHeight;
-        pindex->nMoneySupply   = element.m_disk_block_index.nMoneySupply;
-        pindex->nFlags         = element.m_disk_block_index.nFlags;
-        pindex->nStakeModifier = element.m_disk_block_index.nStakeModifier;
-        pindex->hashProof      = element.m_disk_block_index.hashProof;
-        pindex->nVersion       = element.m_disk_block_index.nVersion;
-        pindex->hashMerkleRoot = element.m_disk_block_index.hashMerkleRoot;
-        pindex->nTime          = element.m_disk_block_index.nTime;
-        pindex->nBits          = element.m_disk_block_index.nBits;
-        pindex->nNonce         = element.m_disk_block_index.nNonce;
-        pindex->m_researcher   = element.m_disk_block_index.m_researcher;
-
-        // Update hashBestChain to fixup global for BeaconRegistry::Initialize call.
-        hashBestChain = block_hash;
-
-        // Import and apply all of the contracts from the file for the given block.
-        for (const auto& iter : element.m_ctx)
-        {
-            // ----------------------- contract ------- tx
-            GRC::ContractContext ctx({iter.first, iter.second, pindex});
-
-            // This is the "thin" version of g_dispatcher.Apply in GRC::ApplyContracts for beacons.
-            if (ctx->m_action == GRC::ContractAction::ADD)
-            {
-                registry.Add(ctx);
-            }
-
-            if (ctx->m_action == GRC::ContractAction::REMOVE)
-            {
-                registry.Delete(ctx);
-            }
-        }
-
-        // Activate the pending beacons that are now verified, and also mark expired pending beacons expired.
-        if (pindex->IsSuperblock())
-        {
-            registry.ActivatePending(element.m_verified_beacons,
-                                     pindex->nTime,
-                                     block_hash,
-                                     pindex->nHeight);
-        }
-    }
-
-    // Passivate the beacon db to remove unnecessary historical elements in memory.
-    registry.PassivateDB();
-
-    // Record the map of beacons and pending beacons after the contract replay. We have to have independent storage
-    // of these, not pointers, because the maps are going to get reset for the second run (reinit).
-    typedef std::unordered_map<GRC::Cpid, GRC::Beacon> LocalBeaconMap;
-    typedef std::map<CKeyID, GRC::Beacon> LocalPendingBeaconMap;
-
-    LocalBeaconMap beacons_init;
-
-    for (const auto& iter : registry.Beacons())
-    {
-        beacons_init[iter.first] = *iter.second;
-    }
-
-    size_t init_number_beacons = beacons_init.size();
-
-    LocalPendingBeaconMap pending_beacons_init;
-
-    for (const auto& iter : registry.PendingBeacons())
-    {
-        pending_beacons_init[iter.first] = *iter.second;
-    }
-
-    size_t init_number_pending_beacons = pending_beacons_init.size();
-
-
-    GRC::BeaconRegistry::HistoricalBeaconMap local_historical_beacon_map_init;
-
-    size_t init_beacon_db_size = registry.GetBeaconDB().size();
-
-    auto& init_beacon_db = registry.GetBeaconDB();
-
-    auto init_beacon_db_iter = init_beacon_db.begin();
-    while (init_beacon_db_iter != init_beacon_db.end())
-    {
-        const uint256& hash = init_beacon_db_iter->first;
-        const GRC::Beacon_ptr& beacon_ptr = init_beacon_db_iter->second;
-
-        // Create a copy of the referenced beacon object with a shared pointer to it and store.
-        local_historical_beacon_map_init[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
-
-        init_beacon_db_iter = init_beacon_db.advance(init_beacon_db_iter);
-    }
-
-    // Reset in memory structures only (which leaves leveldb undisturbed).
-    registry.ResetInMemoryOnly();
-
-
-
-    // (Re)initialize the registry from leveldb.
-    registry.Initialize();
-
-    // Passivate the beacon db to remove unnecessary historical elements in memory.
-    registry.PassivateDB();
-
-    LocalBeaconMap beacons_reinit;
-
-    for (const auto& iter : registry.Beacons())
-    {
-        beacons_reinit[iter.first] = *iter.second;
-    }
-
-    size_t reinit_number_beacons = beacons_reinit.size();
-
-    LocalPendingBeaconMap pending_beacons_reinit;
-
-    for (const auto& iter : registry.PendingBeacons())
-    {
-        pending_beacons_reinit[iter.first] = *iter.second;
-    }
-
-    size_t reinit_number_pending_beacons = pending_beacons_reinit.size();
-
-
-    GRC::BeaconRegistry::HistoricalBeaconMap local_historical_beacon_map_reinit;
-
-    size_t reinit_beacon_db_size = registry.GetBeaconDB().size();
-
-    auto& reinit_beacon_db = registry.GetBeaconDB();
-
-    auto reinit_beacon_db_iter = reinit_beacon_db.begin();
-    while (reinit_beacon_db_iter != reinit_beacon_db.end())
-    {
-        const uint256& hash = reinit_beacon_db_iter->first;
-        const GRC::Beacon_ptr& beacon_ptr = reinit_beacon_db_iter->second;
-
-        // Create a copy of the referenced beacon object with a shared pointer to it and store.
-        local_historical_beacon_map_reinit[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
-
-        reinit_beacon_db_iter = reinit_beacon_db.advance(reinit_beacon_db_iter);
-    }
-
-
-    BOOST_TEST_CHECKPOINT("init_beacon_db_size = " << init_beacon_db_size << ", "
-                          << "reinit_beacon_db_size = " << reinit_beacon_db_size);
-
-    BOOST_CHECK_EQUAL(init_beacon_db_size, reinit_beacon_db_size);
-
-
-    bool beacon_db_comparison_success = true;
-
-    // left join with init on the left
-    for (const auto& left : local_historical_beacon_map_init)
-    {
-        uint256 hash = left.first;
-        GRC::Beacon_ptr left_beacon_ptr = left.second;
-
-        auto right_beacon_iter = local_historical_beacon_map_reinit.find(hash);
-
-        if (right_beacon_iter == local_historical_beacon_map_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("beacon in init beacon db not found in reinit beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            std::cout << "MISSING: Reinit record missing for init record: "
-                      << "hash = " << hash.GetHex()
-                      << ", cpid = " << left.second->m_cpid.ToString()
-                      << ", public key = " << left.second->m_public_key.ToString()
-                      << ", address = " << left.second->GetAddress().ToString()
-                      << ", timestamp = " << left.second->m_timestamp
-                      << ", hash = " << left.second->m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second->m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second->m_status.Raw())
-                      << std::endl;
-
-        }
-        else if (*left_beacon_ptr != *right_beacon_iter->second)
-        {
-            BOOST_TEST_CHECKPOINT("beacon in init beacon db does not match corresponding beacon"
-                                  " in reinit beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit beacon db does not match corresponding beacon"
-                         " in init beacon db for hash = " << hash.GetHex() << std::endl;
-
-            std::cout << "cpid = " << left_beacon_ptr->m_cpid.ToString() << std::endl;
-
-            std::cout << "init_beacon public key = " << left_beacon_ptr->m_public_key.ToString()
-                      << ", reinit_beacon public key = " << right_beacon_iter->second->m_public_key.ToString() << std::endl;
-
-            std::cout << "init_beacon address = " << left_beacon_ptr->GetAddress().ToString()
-                      << ", reinit_beacon address = " << right_beacon_iter->second->GetAddress().ToString() << std::endl;
-
-            std::cout << "init_beacon timestamp = " << left_beacon_ptr->m_timestamp
-                      << ", reinit_beacon timestamp = " << right_beacon_iter->second->m_timestamp << std::endl;
-
-            std::cout << "init_beacon hash = " << left_beacon_ptr->m_hash.GetHex()
-                      << ", reinit_beacon hash = " << right_beacon_iter->second->m_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon prev beacon hash = " << left_beacon_ptr->m_prev_beacon_hash.GetHex()
-                      << ", reinit_beacon prev beacon hash = " << right_beacon_iter->second->m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon status = " << std::to_string(left_beacon_ptr->m_status.Raw())
-                      << ", reinit_beacon status = " << std::to_string(right_beacon_iter->second->m_status.Raw()) << std::endl;
-        }
-    }
-
-
-    // left join with reinit on the left
-    for (const auto& left : local_historical_beacon_map_reinit)
-    {
-        uint256 hash = left.first;
-        GRC::Beacon_ptr left_beacon_ptr = left.second;
-
-        auto right_beacon_iter = local_historical_beacon_map_init.find(hash);
-
-        if (right_beacon_iter == local_historical_beacon_map_init.end())
-        {
-            BOOST_TEST_CHECKPOINT("beacon in reinit beacon db not found in init beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            std::cout << "MISSING: init record missing for reinit record: "
-                      << "hash = " << hash.GetHex()
-                      << ", cpid = " << left.second->m_cpid.ToString()
-                      << ", public key = " << left.second->m_public_key.ToString()
-                      << ", address = " << left.second->GetAddress().ToString()
-                      << ", timestamp = " << left.second->m_timestamp
-                      << ", hash = " << left.second->m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second->m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second->m_status.Raw())
-                      << std::endl;
-
-        }
-        else if (*left_beacon_ptr != *right_beacon_iter->second)
-        {
-            BOOST_TEST_CHECKPOINT("beacon in init beacon db does not match corresponding beacon"
-                                  " in reinit beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in init beacon db does not match corresponding beacon"
-                         " in reinit beacon db for hash = " << hash.GetHex() << std::endl;
-
-            std::cout << "cpid = " << left_beacon_ptr->m_cpid.ToString() << std::endl;
-
-            std::cout << "reinit_beacon public key = " << left_beacon_ptr->m_public_key.ToString()
-                      << ", init_beacon public key = " << right_beacon_iter->second->m_public_key.ToString() << std::endl;
-
-            std::cout << "reinit_beacon address = " << left_beacon_ptr->GetAddress().ToString()
-                      << ", init_beacon address = " << right_beacon_iter->second->GetAddress().ToString() << std::endl;
-
-            std::cout << "reinit_beacon timestamp = " << left_beacon_ptr->m_timestamp
-                      << ", init_beacon timestamp = " << right_beacon_iter->second->m_timestamp << std::endl;
-
-            std::cout << "reinit_beacon hash = " << left_beacon_ptr->m_hash.GetHex()
-                      << ", init_beacon hash = " << right_beacon_iter->second->m_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon prev beacon hash = " << left_beacon_ptr->m_prev_beacon_hash.GetHex()
-                      << ", init_beacon prev beacon hash = " << right_beacon_iter->second->m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon status = " << std::to_string(left_beacon_ptr->m_status.Raw())
-                      << ", init_beacon status = " << std::to_string(right_beacon_iter->second->m_status.Raw()) << std::endl;
-        }
-    }
-
-    BOOST_CHECK(beacon_db_comparison_success);
-
-    BOOST_CHECK_EQUAL(local_historical_beacon_map_init.size(), local_historical_beacon_map_reinit.size());
-
-
-
-
-    BOOST_TEST_CHECKPOINT("init_number_beacons = " << init_number_beacons << ", "
-                          << "reinit_number_beacons = " << reinit_number_beacons);
-
-    bool number_beacons_equal = (init_number_beacons == reinit_number_beacons);
-
-    if (!number_beacons_equal)
-    {
-        for (const auto& iter : beacons_init)
-        {
-            const GRC::Cpid& cpid = iter.first;
-            const GRC::Beacon& beacon = iter.second;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "init_beacon cpid = " << cpid.ToString()
-                      << ", public key = " << beacon.m_public_key.ToString()
-                      << ", address = " << beacon.GetAddress().ToString()
-                      << ", timestamp = " << beacon.m_timestamp
-                      << ", hash = " << beacon.m_hash.GetHex()
-                      << ", prev beacon hash = " << beacon.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(beacon.m_status.Raw())
-                      << std::endl;
-        }
-
-        for (const auto& iter : beacons_reinit)
-        {
-            const GRC::Cpid& cpid = iter.first;
-            const GRC::Beacon& beacon = iter.second;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "reinit beacon cpid = " << cpid.ToString()
-                      << ", public key = " << beacon.m_public_key.ToString()
-                      << ", address = " << beacon.GetAddress().ToString()
-                      << ", timestamp = " << beacon.m_timestamp
-                      << ", hash = " << beacon.m_hash.GetHex()
-                      << ", prev beacon hash = " << beacon.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(beacon.m_status.Raw())
-                      << std::endl;
-        }
-    }
-
-    BOOST_CHECK_EQUAL(init_number_beacons, reinit_number_beacons);
-
-
-
-    BOOST_TEST_CHECKPOINT("init_number_pending_beacons.size() = " << init_number_pending_beacons << ", "
-                          << "reinit_number_pending_beacons.size() = " << reinit_number_pending_beacons);
-
-    BOOST_CHECK_EQUAL(init_number_pending_beacons, reinit_number_pending_beacons);
-
-
-
-    bool beacon_comparison_success = true;
-
-    // left join with init on the left
-    for (const auto& left : beacons_init)
-    {
-        GRC::Beacon left_beacon = left.second;
-        auto right = beacons_reinit.find(left.first);
-
-        if (right == beacons_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: beacon in init not found in reinit for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            std::cout << "MISSING: reinit beacon record missing for init beacon record: "
-                      << "hash = " << left.second.m_hash.GetHex()
-                      << ", cpid = " << left.second.m_cpid.ToString()
-                      << ", public key = " << left.second.m_public_key.ToString()
-                      << ", address = " << left.second.GetAddress().ToString()
-                      << ", timestamp = " << left.second.m_timestamp
-                      << ", hash = " << left.second.m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second.m_status.Raw())
-                      << std::endl;
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for cpid = "
-                      << left_beacon.m_cpid.ToString() << std::endl;
-
-            std::cout << "init_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", reinit_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "init_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", reinit_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "init_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", reinit_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", reinit_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", reinit_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-
-    // left join with reinit on the left
-    for (const auto& left : beacons_reinit)
-    {
-        GRC::Beacon left_beacon = left.second;
-
-        auto right = beacons_init.find(left.first);
-
-        if (right == beacons_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: beacon in reinit not found in init for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            std::cout << "MISSING: init beacon record missing for reinit beacon record: "
-                      << "hash = " << left.second.m_hash.GetHex()
-                      << ", cpid = " << left.second.m_cpid.ToString()
-                      << ", public key = " << left.second.m_public_key.ToString()
-                      << ", address = " << left.second.GetAddress().ToString()
-                      << ", timestamp = " << left.second.m_timestamp
-                      << ", hash = " << left.second.m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second.m_status.Raw())
-                      << std::endl;
-
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in init mismatches reinit for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for cpid = "
-                      << left_beacon.m_cpid.ToString() << std::endl;
-
-            std::cout << "reinit_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", init_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "reinit_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", init_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "reinit_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", init_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", init_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", init_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-    BOOST_CHECK(beacon_comparison_success);
-
-
-    bool pending_beacon_comparison_success = true;
-
-    // left join with init on the left
-    for (const auto& left : pending_beacons_init)
-    {
-        GRC::Beacon left_beacon = left.second;
-        auto right = pending_beacons_reinit.find(left.first);
-
-        if (right == pending_beacons_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: pending beacon in init not found in reinit for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            std::cout << "MISSING: reinit pending beacon record missing for init pending beacon record: "
-                      << "hash = " << left_beacon.m_hash.GetHex()
-                      << ", cpid = " << left_beacon.m_cpid.ToString()
-                      << ", public key = " << left_beacon.m_public_key.ToString()
-                      << ", address = " << left_beacon.GetAddress().ToString()
-                      << ", timestamp = " << left_beacon.m_timestamp
-                      << ", hash = " << left_beacon.m_hash.GetHex()
-                      << ", prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left_beacon.m_status.Raw())
-                      << std::endl;
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for CKeyID "
-                      << left.first.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon cpid = " << left_beacon.m_cpid.ToString()
-                      << ", reinit_pending_beacon cpid = " << right->second.m_cpid.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", reinit_pending_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", reinit_pending_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "init_pending_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", reinit_pending_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "init_pending_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", reinit_pending_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex()
-                      << std::endl;
-
-            std::cout << ", init_pending_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", reinit_pending_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-    // left join with reinit on the left
-    for (const auto& left : pending_beacons_reinit)
-    {
-        GRC::Beacon left_beacon = left.second;
-        auto right = pending_beacons_init.find(left.first);
-
-        if (right == pending_beacons_init.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: pending beacon in reinit not found in init for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            std::cout << "MISSING: init pending beacon record missing for reinit pending beacon record: "
-                      << "hash = " << left.second.m_hash.GetHex()
-                      << ", cpid = " << left.second.m_cpid.ToString()
-                      << ", public key = " << left.second.m_public_key.ToString()
-                      << ", address = " << left.second.GetAddress().ToString()
-                      << ", timestamp = " << left.second.m_timestamp
-                      << ", hash = " << left.second.m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second.m_status.Raw())
-                      << std::endl;
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for CKeyID "
-                      << left.first.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon cpid = " << left_beacon.m_cpid.ToString()
-                      << ", reinit_pending_beacon cpid = " << right->second.m_cpid.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", reinit_pending_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", reinit_pending_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "init_pending_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", reinit_pending_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "init_pending_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", reinit_pending_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex()
-                      << std::endl;
-
-            std::cout << ", init_pending_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", reinit_pending_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-    BOOST_CHECK(pending_beacon_comparison_success);
+    beacon_registry_test.BeaconDatabaseComparisonChecks_m_pending();
 }
 
 
 BOOST_AUTO_TEST_CASE(beaconstorage_mainnet_test)
 {
+    // These should be set to correspond to the dumpcontracts run used to create mainnet_beacon.bin
+    int64_t high_height_time = 1613904992;
+    int low_height = 2053000;
+    int high_height = 2177791;
+    int num_blocks = 2370;
+
     CDataStream data(SER_DISK, PROTOCOL_VERSION);
 
     data << mainnet_beacon_bin;
 
-    GRC::BeaconRegistry& registry = GRC::GetBeaconRegistry();
+    BeaconRegistryTest beacon_registry_test(data,
+                                            high_height_time,
+                                            low_height,
+                                            high_height,
+                                            num_blocks);
 
-    // Make sure the registry is reset.
-    registry.Reset();
+    beacon_registry_test.RunBasicChecks();
 
-    int64_t high_height_time = 0;
-    int low_height = 0;
-    int high_height = 0;
-    int num_blocks = 0;
+    beacon_registry_test.BeaconDatabaseComparisonChecks_m_historical();
 
-    data >> high_height_time;
-    data >> low_height;
-    data >> high_height;
-    data >> num_blocks;
+    beacon_registry_test.BeaconDatabaseComparisonChecks_m_beacons();
 
-    // These should be set to correspond to the dumpcontracts run used to create mainnet_beacon.bin
-    BOOST_CHECK(high_height_time == 1613904992);
-    BOOST_CHECK(low_height == 2053000);
-    BOOST_CHECK(high_height == 2177791);
-    BOOST_CHECK(num_blocks == 2370);
-
-    // Import the blocks in the file and replay the relevant contracts.
-    for (int i = 0; i < num_blocks; ++i)
-    {
-        BOOST_TEST_CHECKPOINT("Processing block = " << i);
-
-        GRC::ExportContractElement element;
-
-        data >> element;
-
-        uint256 block_hash = element.m_disk_block_index.GetBlockHash();
-
-        // Construct block index object. This comes from the guts of CtxDB::LoadBlockIndex()
-        CBlockIndex* pindex    = GRC::MockBlockIndex::InsertBlockIndex(block_hash);
-        // Note the mock CBlockIndex objects created here are SPARSE; therefore the blocks
-        // pointed to by the pprev and pnext hashes will more than likely NOT be present here,
-        // and are not needed anyway for this test, so ensure set to nullptr.
-        pindex->pprev          = nullptr;
-        pindex->pnext          = nullptr;
-        pindex->nFile          = element.m_disk_block_index.nFile;
-        pindex->nBlockPos      = element.m_disk_block_index.nBlockPos;
-        pindex->nHeight        = element.m_disk_block_index.nHeight;
-        pindex->nMoneySupply   = element.m_disk_block_index.nMoneySupply;
-        pindex->nFlags         = element.m_disk_block_index.nFlags;
-        pindex->nStakeModifier = element.m_disk_block_index.nStakeModifier;
-        pindex->hashProof      = element.m_disk_block_index.hashProof;
-        pindex->nVersion       = element.m_disk_block_index.nVersion;
-        pindex->hashMerkleRoot = element.m_disk_block_index.hashMerkleRoot;
-        pindex->nTime          = element.m_disk_block_index.nTime;
-        pindex->nBits          = element.m_disk_block_index.nBits;
-        pindex->nNonce         = element.m_disk_block_index.nNonce;
-        pindex->m_researcher   = element.m_disk_block_index.m_researcher;
-
-        // Update hashBestChain to fixup global for BeaconRegistry::Initialize call.
-        hashBestChain = block_hash;
-
-        // Import and apply all of the contracts from the file for the given block.
-        for (const auto& iter : element.m_ctx)
-        {
-            // ----------------------- contract ------- tx
-            GRC::ContractContext ctx({iter.first, iter.second, pindex});
-
-            // This is the "thin" version of g_dispatcher.Apply in GRC::ApplyContracts for beacons.
-            if (ctx->m_action == GRC::ContractAction::ADD)
-            {
-                registry.Add(ctx);
-            }
-
-            if (ctx->m_action == GRC::ContractAction::REMOVE)
-            {
-                registry.Delete(ctx);
-            }
-        }
-
-        // Activate the pending beacons that are now verified, and also mark expired pending beacons expired.
-        if (pindex->IsSuperblock())
-        {
-            registry.ActivatePending(element.m_verified_beacons,
-                                     pindex->nTime,
-                                     block_hash,
-                                     pindex->nHeight);
-        }
-    }
-
-    // Passivate the beacon db to remove unnecessary historical elements in memory.
-    registry.PassivateDB();
-
-    // Record the map of beacons and pending beacons after the contract replay. We have to have independent storage
-    // of these, not pointers, because the maps are going to get reset for the second run (reinit).
-    typedef std::unordered_map<GRC::Cpid, GRC::Beacon> LocalBeaconMap;
-    typedef std::map<CKeyID, GRC::Beacon> LocalPendingBeaconMap;
-
-    LocalBeaconMap beacons_init;
-
-    for (const auto& iter : registry.Beacons())
-    {
-        beacons_init[iter.first] = *iter.second;
-    }
-
-    size_t init_number_beacons = beacons_init.size();
-
-    LocalPendingBeaconMap pending_beacons_init;
-
-    for (const auto& iter : registry.PendingBeacons())
-    {
-        pending_beacons_init[iter.first] = *iter.second;
-    }
-
-    size_t init_number_pending_beacons = pending_beacons_init.size();
-
-
-    GRC::BeaconRegistry::HistoricalBeaconMap local_historical_beacon_map_init;
-
-    size_t init_beacon_db_size = registry.GetBeaconDB().size();
-
-    auto& init_beacon_db = registry.GetBeaconDB();
-
-    auto init_beacon_db_iter = init_beacon_db.begin();
-    while (init_beacon_db_iter != init_beacon_db.end())
-    {
-        const uint256& hash = init_beacon_db_iter->first;
-        const GRC::Beacon_ptr& beacon_ptr = init_beacon_db_iter->second;
-
-        // Create a copy of the referenced beacon object with a shared pointer to it and store.
-        local_historical_beacon_map_init[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
-
-        init_beacon_db_iter = init_beacon_db.advance(init_beacon_db_iter);
-    }
-
-    // Reset in memory structures only (which leaves leveldb undisturbed).
-    registry.ResetInMemoryOnly();
-
-
-
-    // (Re)initialize the registry from leveldb.
-    registry.Initialize();
-
-    // Passivate the beacon db to remove unnecessary historical elements in memory.
-    registry.PassivateDB();
-
-    LocalBeaconMap beacons_reinit;
-
-    for (const auto& iter : registry.Beacons())
-    {
-        beacons_reinit[iter.first] = *iter.second;
-    }
-
-    size_t reinit_number_beacons = beacons_reinit.size();
-
-    LocalPendingBeaconMap pending_beacons_reinit;
-
-    for (const auto& iter : registry.PendingBeacons())
-    {
-        pending_beacons_reinit[iter.first] = *iter.second;
-    }
-
-    size_t reinit_number_pending_beacons = pending_beacons_reinit.size();
-
-
-    GRC::BeaconRegistry::HistoricalBeaconMap local_historical_beacon_map_reinit;
-
-    size_t reinit_beacon_db_size = registry.GetBeaconDB().size();
-
-    auto& reinit_beacon_db = registry.GetBeaconDB();
-
-    auto reinit_beacon_db_iter = reinit_beacon_db.begin();
-    while (reinit_beacon_db_iter != reinit_beacon_db.end())
-    {
-        const uint256& hash = reinit_beacon_db_iter->first;
-        const GRC::Beacon_ptr& beacon_ptr = reinit_beacon_db_iter->second;
-
-        // Create a copy of the referenced beacon object with a shared pointer to it and store.
-        local_historical_beacon_map_reinit[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
-
-        reinit_beacon_db_iter = reinit_beacon_db.advance(reinit_beacon_db_iter);
-    }
-
-
-    BOOST_TEST_CHECKPOINT("init_beacon_db_size = " << init_beacon_db_size << ", "
-                          << "reinit_beacon_db_size = " << reinit_beacon_db_size);
-
-    BOOST_CHECK_EQUAL(init_beacon_db_size, reinit_beacon_db_size);
-
-
-    bool beacon_db_comparison_success = true;
-
-    // left join with init on the left
-    for (const auto& left : local_historical_beacon_map_init)
-    {
-        uint256 hash = left.first;
-        GRC::Beacon_ptr left_beacon_ptr = left.second;
-
-        auto right_beacon_iter = local_historical_beacon_map_reinit.find(hash);
-
-        if (right_beacon_iter == local_historical_beacon_map_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("beacon in init beacon db not found in reinit beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            std::cout << "MISSING: Reinit record missing for init record: "
-                      << "hash = " << hash.GetHex()
-                      << ", cpid = " << left.second->m_cpid.ToString()
-                      << ", public key = " << left.second->m_public_key.ToString()
-                      << ", address = " << left.second->GetAddress().ToString()
-                      << ", timestamp = " << left.second->m_timestamp
-                      << ", hash = " << left.second->m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second->m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second->m_status.Raw())
-                      << std::endl;
-
-        }
-        else if (*left_beacon_ptr != *right_beacon_iter->second)
-        {
-            BOOST_TEST_CHECKPOINT("beacon in init beacon db does not match corresponding beacon"
-                                  " in reinit beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit beacon db does not match corresponding beacon"
-                         " in init beacon db for hash = " << hash.GetHex() << std::endl;
-
-            std::cout << "cpid = " << left_beacon_ptr->m_cpid.ToString() << std::endl;
-
-            std::cout << "init_beacon public key = " << left_beacon_ptr->m_public_key.ToString()
-                      << ", reinit_beacon public key = " << right_beacon_iter->second->m_public_key.ToString() << std::endl;
-
-            std::cout << "init_beacon address = " << left_beacon_ptr->GetAddress().ToString()
-                      << ", reinit_beacon address = " << right_beacon_iter->second->GetAddress().ToString() << std::endl;
-
-            std::cout << "init_beacon timestamp = " << left_beacon_ptr->m_timestamp
-                      << ", reinit_beacon timestamp = " << right_beacon_iter->second->m_timestamp << std::endl;
-
-            std::cout << "init_beacon hash = " << left_beacon_ptr->m_hash.GetHex()
-                      << ", reinit_beacon hash = " << right_beacon_iter->second->m_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon prev beacon hash = " << left_beacon_ptr->m_prev_beacon_hash.GetHex()
-                      << ", reinit_beacon prev beacon hash = " << right_beacon_iter->second->m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon status = " << std::to_string(left_beacon_ptr->m_status.Raw())
-                      << ", reinit_beacon status = " << std::to_string(right_beacon_iter->second->m_status.Raw()) << std::endl;
-        }
-    }
-
-
-    // left join with reinit on the left
-    for (const auto& left : local_historical_beacon_map_reinit)
-    {
-        uint256 hash = left.first;
-        GRC::Beacon_ptr left_beacon_ptr = left.second;
-
-        auto right_beacon_iter = local_historical_beacon_map_init.find(hash);
-
-        if (right_beacon_iter == local_historical_beacon_map_init.end())
-        {
-            BOOST_TEST_CHECKPOINT("beacon in reinit beacon db not found in init beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            std::cout << "MISSING: init record missing for reinit record: "
-                      << "hash = " << hash.GetHex()
-                      << ", cpid = " << left.second->m_cpid.ToString()
-                      << ", public key = " << left.second->m_public_key.ToString()
-                      << ", address = " << left.second->GetAddress().ToString()
-                      << ", timestamp = " << left.second->m_timestamp
-                      << ", hash = " << left.second->m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second->m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second->m_status.Raw())
-                      << std::endl;
-
-        }
-        else if (*left_beacon_ptr != *right_beacon_iter->second)
-        {
-            BOOST_TEST_CHECKPOINT("beacon in init beacon db does not match corresponding beacon"
-                                  " in reinit beacon db for cpid "
-                                  << left_beacon_ptr->m_cpid.ToString());
-
-            beacon_db_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in init beacon db does not match corresponding beacon"
-                         " in reinit beacon db for hash = " << hash.GetHex() << std::endl;
-
-            std::cout << "cpid = " << left_beacon_ptr->m_cpid.ToString() << std::endl;
-
-            std::cout << "reinit_beacon public key = " << left_beacon_ptr->m_public_key.ToString()
-                      << ", init_beacon public key = " << right_beacon_iter->second->m_public_key.ToString() << std::endl;
-
-            std::cout << "reinit_beacon address = " << left_beacon_ptr->GetAddress().ToString()
-                      << ", init_beacon address = " << right_beacon_iter->second->GetAddress().ToString() << std::endl;
-
-            std::cout << "reinit_beacon timestamp = " << left_beacon_ptr->m_timestamp
-                      << ", init_beacon timestamp = " << right_beacon_iter->second->m_timestamp << std::endl;
-
-            std::cout << "reinit_beacon hash = " << left_beacon_ptr->m_hash.GetHex()
-                      << ", init_beacon hash = " << right_beacon_iter->second->m_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon prev beacon hash = " << left_beacon_ptr->m_prev_beacon_hash.GetHex()
-                      << ", init_beacon prev beacon hash = " << right_beacon_iter->second->m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon status = " << std::to_string(left_beacon_ptr->m_status.Raw())
-                      << ", init_beacon status = " << std::to_string(right_beacon_iter->second->m_status.Raw()) << std::endl;
-        }
-    }
-
-    BOOST_CHECK(beacon_db_comparison_success);
-
-    BOOST_CHECK_EQUAL(local_historical_beacon_map_init.size(), local_historical_beacon_map_reinit.size());
-
-
-
-
-    BOOST_TEST_CHECKPOINT("init_number_beacons = " << init_number_beacons << ", "
-                          << "reinit_number_beacons = " << reinit_number_beacons);
-
-    bool number_beacons_equal = (init_number_beacons == reinit_number_beacons);
-
-    if (!number_beacons_equal)
-    {
-        for (const auto& iter : beacons_init)
-        {
-            const GRC::Cpid& cpid = iter.first;
-            const GRC::Beacon& beacon = iter.second;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "init_beacon cpid = " << cpid.ToString()
-                      << ", public key = " << beacon.m_public_key.ToString()
-                      << ", address = " << beacon.GetAddress().ToString()
-                      << ", timestamp = " << beacon.m_timestamp
-                      << ", hash = " << beacon.m_hash.GetHex()
-                      << ", prev beacon hash = " << beacon.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(beacon.m_status.Raw())
-                      << std::endl;
-        }
-
-        for (const auto& iter : beacons_reinit)
-        {
-            const GRC::Cpid& cpid = iter.first;
-            const GRC::Beacon& beacon = iter.second;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "reinit beacon cpid = " << cpid.ToString()
-                      << ", public key = " << beacon.m_public_key.ToString()
-                      << ", address = " << beacon.GetAddress().ToString()
-                      << ", timestamp = " << beacon.m_timestamp
-                      << ", hash = " << beacon.m_hash.GetHex()
-                      << ", prev beacon hash = " << beacon.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(beacon.m_status.Raw())
-                      << std::endl;
-        }
-    }
-
-    BOOST_CHECK_EQUAL(init_number_beacons, reinit_number_beacons);
-
-
-
-    BOOST_TEST_CHECKPOINT("init_number_pending_beacons.size() = " << init_number_pending_beacons << ", "
-                          << "reinit_number_pending_beacons.size() = " << reinit_number_pending_beacons);
-
-    BOOST_CHECK_EQUAL(init_number_pending_beacons, reinit_number_pending_beacons);
-
-
-
-    bool beacon_comparison_success = true;
-
-    // left join with init on the left
-    for (const auto& left : beacons_init)
-    {
-        GRC::Beacon left_beacon = left.second;
-        auto right = beacons_reinit.find(left.first);
-
-        if (right == beacons_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: beacon in init not found in reinit for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            std::cout << "MISSING: reinit beacon record missing for init beacon record: "
-                      << "hash = " << left.second.m_hash.GetHex()
-                      << ", cpid = " << left.second.m_cpid.ToString()
-                      << ", public key = " << left.second.m_public_key.ToString()
-                      << ", address = " << left.second.GetAddress().ToString()
-                      << ", timestamp = " << left.second.m_timestamp
-                      << ", hash = " << left.second.m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second.m_status.Raw())
-                      << std::endl;
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for cpid = "
-                      << left_beacon.m_cpid.ToString() << std::endl;
-
-            std::cout << "init_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", reinit_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "init_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", reinit_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "init_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", reinit_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", reinit_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "init_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", reinit_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-
-    // left join with reinit on the left
-    for (const auto& left : beacons_reinit)
-    {
-        GRC::Beacon left_beacon = left.second;
-
-        auto right = beacons_init.find(left.first);
-
-        if (right == beacons_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: beacon in reinit not found in init for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            std::cout << "MISSING: init beacon record missing for reinit beacon record: "
-                      << "hash = " << left.second.m_hash.GetHex()
-                      << ", cpid = " << left.second.m_cpid.ToString()
-                      << ", public key = " << left.second.m_public_key.ToString()
-                      << ", address = " << left.second.GetAddress().ToString()
-                      << ", timestamp = " << left.second.m_timestamp
-                      << ", hash = " << left.second.m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second.m_status.Raw())
-                      << std::endl;
-
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in init mismatches reinit for cpid "
-                                  << left.first.ToString());
-            beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for cpid = "
-                      << left_beacon.m_cpid.ToString() << std::endl;
-
-            std::cout << "reinit_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", init_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "reinit_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", init_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "reinit_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", init_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", init_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex() << std::endl;
-
-            std::cout << "reinit_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", init_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-    BOOST_CHECK(beacon_comparison_success);
-
-
-    bool pending_beacon_comparison_success = true;
-
-    // left join with init on the left
-    for (const auto& left : pending_beacons_init)
-    {
-        GRC::Beacon left_beacon = left.second;
-        auto right = pending_beacons_reinit.find(left.first);
-
-        if (right == pending_beacons_reinit.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: pending beacon in init not found in reinit for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            std::cout << "MISSING: reinit pending beacon record missing for init pending beacon record: "
-                      << "hash = " << left_beacon.m_hash.GetHex()
-                      << ", cpid = " << left_beacon.m_cpid.ToString()
-                      << ", public key = " << left_beacon.m_public_key.ToString()
-                      << ", address = " << left_beacon.GetAddress().ToString()
-                      << ", timestamp = " << left_beacon.m_timestamp
-                      << ", hash = " << left_beacon.m_hash.GetHex()
-                      << ", prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left_beacon.m_status.Raw())
-                      << std::endl;
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for CKeyID "
-                      << left.first.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon cpid = " << left_beacon.m_cpid.ToString()
-                      << ", reinit_pending_beacon cpid = " << right->second.m_cpid.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", reinit_pending_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", reinit_pending_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "init_pending_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", reinit_pending_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "init_pending_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", reinit_pending_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex()
-                      << std::endl;
-
-            std::cout << ", init_pending_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", reinit_pending_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-    // left join with reinit on the left
-    for (const auto& left : pending_beacons_reinit)
-    {
-        GRC::Beacon left_beacon = left.second;
-        auto right = pending_beacons_init.find(left.first);
-
-        if (right == pending_beacons_init.end())
-        {
-            BOOST_TEST_CHECKPOINT("MISSING: pending beacon in reinit not found in init for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            std::cout << "MISSING: init pending beacon record missing for reinit pending beacon record: "
-                      << "hash = " << left.second.m_hash.GetHex()
-                      << ", cpid = " << left.second.m_cpid.ToString()
-                      << ", public key = " << left.second.m_public_key.ToString()
-                      << ", address = " << left.second.GetAddress().ToString()
-                      << ", timestamp = " << left.second.m_timestamp
-                      << ", hash = " << left.second.m_hash.GetHex()
-                      << ", prev beacon hash = " << left.second.m_prev_beacon_hash.GetHex()
-                      << ", status = " << std::to_string(left.second.m_status.Raw())
-                      << std::endl;
-        }
-        else if (left_beacon != right->second)
-        {
-            BOOST_TEST_CHECKPOINT("MISMATCH: beacon in reinit mismatches init for CKeyID "
-                                  << left.first.ToString());
-            pending_beacon_comparison_success = false;
-
-            // This is for console output in case the test fails and you run test_gridcoin manually from the command line.
-            // You should be in the src directory for that, so the command would be ./test/test_gridcoin.
-            std::cout << "MISMATCH: beacon in reinit mismatches init for CKeyID "
-                      << left.first.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon cpid = " << left_beacon.m_cpid.ToString()
-                      << ", reinit_pending_beacon cpid = " << right->second.m_cpid.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon public key = " << left_beacon.m_public_key.ToString()
-                      << ", reinit_pending_beacon public key = " << right->second.m_public_key.ToString() << std::endl;
-
-            std::cout << "init_pending_beacon timestamp = " << left_beacon.m_timestamp
-                      << ", reinit_pending_beacon timestamp = " << right->second.m_timestamp << std::endl;
-
-            std::cout << "init_pending_beacon hash = " << left_beacon.m_hash.GetHex()
-                      << ", reinit_pending_beacon hash = " << right->second.m_hash.GetHex() << std::endl;
-
-            std::cout << "init_pending_beacon prev beacon hash = " << left_beacon.m_prev_beacon_hash.GetHex()
-                      << ", reinit_pending_beacon prev beacon hash = " << right->second.m_prev_beacon_hash.GetHex()
-                      << std::endl;
-
-            std::cout << ", init_pending_beacon status = " << std::to_string(left_beacon.m_status.Raw())
-                      << ", reinit_pending_beacon status = " << std::to_string(right->second.m_status.Raw()) << std::endl;
-        }
-    }
-
-    BOOST_CHECK(pending_beacon_comparison_success);
+    beacon_registry_test.BeaconDatabaseComparisonChecks_m_pending();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request implements passivation of beacon elements in the beacon db while leaving the leveldb backing store untouched. This was already anticipated in the version of the beacon db that was in 5.2.x, but required some further adjustments to implement.

Some comments on the theory behind this and the implementation...

In general, we have the problem in Gridcoin of certain contracts being linked by protocol logic. Beacon contracts are an example. There is a relatively complex process for beacons that involve several different paths through possible beacon states. The most typical example is

Advertisement (pending) -> Activation (verification) -> Renewal -> Renewal -> ....-> etc.

Each CPID's series of beacons can be thought of as a "chainlet". This was already implemented in the BeaconRegistry/BeaconDB for 5.2.

Without getting into specifics, the beacon registry for renewals and reversions needs to be able to pull up the "prior" beacon. All beacons that are not the original beacon in a beacon chain" have a previous beacon hash entry, which is a form of a one-way linked list by hash (as opposed to CBlockIndex, which is a two-way linked list by pointer). We don't need the forward direction directly in the beacon object, only the reverse linkage, and unlike the the complexity done in CBlockIndex to turn the hash links in CDiskBlockIndex into pointers for absolute speed, we can just use the hashes and map finds, which are slower but ok, because this is not used as much.

The beacon contract fundamentals are recorded in the beacon db IN THE ORDER they were actually encountered originally in the blockchain and applied. This is the only forward state we need and is used in initialization of the beacon state from leveldb at wallet startup to avoid having to replay all of the contracts themselves, which is very heavyweight.

For normal wallet running conditions though, _we do not need all of those beacon records to remain in memory_. The m_historical map nominally would contain an entry for every beacon state encountered for every beacon since 180 days from the head OR from the Fern hard fork point of 2053000, whichever is earlier. (This is true up to and including 5.3.0.0.) It is obvious to see that this grows without bound over time as the back of the window is effectively pinned at the Fern hard fork point, although the size of the beacon maps is very small compared to the block map and block index.

The passivation in this PR essentially removes from memory historical records that are not currently being referred to by either m_beacons (the active map) or m_pending (the pending map). It is a primitive "minimum working set" algorithm, and quite frankly, all we need to do the job here. The find function for the beacon db are extended from the normal find function to first look in memory for the provided hash, and if it is not found, transparently load it from leveldb into the map and then provide the iterator or value. This allows functions, such as renewals, which need to pull up the prior beacon record to match the key/verify to work properly with a prior record that was passivated. As a renewal is processed, it will implicitly load back into memory the prior record. The find and insert will set a flag m_needs_passivation to true if they had to load an element into memory that was already passivated before. This will allow a scheduled passivation function to repassivate the element later if it is no longer needed.

During initialization of the BeaconRegistry/BeaconDB during wallet startup, passivation is called on each historical record pointed to by a newly loaded record's previous beacon hash to minimize the memory footprint on load. (Unfortunately, a major downside in the beacon db implementation from a memory use perspective is the need as discussed earlier to preserve the exact order of the contract application as originally encoded in the blockchain. This requires ordering the records by a record sequence number key rather than the native hash as in memory. This necessitates the use of a temporary map ordered by record sequence number populated by an leveldb iterator, which is then used to populate the m_historical map. This temporarily uses more memory but is unavoidable to preserve leveldb performance, especially using regular disks - a leveldb iterator in natural key order is MUCH faster than an iterative find in leveldb.) The m_needs_passivation flag is set after initialization to run passivation across the entire database on the next scheduled run to catch records that could not be passivated on initial load because they were originally pinned by the beacon workflow.

There is a scheduled job using the global scheduling instance that now calls the database wide passivation every 5 minutes. If the m_needs_passivation is false, it will exit without doing anything. If true, it will run passivate_db(), which will iterate through the beacon_db and call passivate on each record, then set the flag to false.
