### PR TITLE
gui: Fix garbage placeholders in some tx notification localizations

### DIFF
--- a/src/qt/locale/bitcoin_af_ZA.ts
+++ b/src/qt/locale/bitcoin_af_ZA.ts
@@ -776,11 +776,7 @@ Address: %4</source>
         <translation type="unfinished">Datum: %1
 Bedrag: %2
 Tipe: %3
-Adres: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adres: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_ca_ES.ts
+++ b/src/qt/locale/bitcoin_ca_ES.ts
@@ -696,10 +696,7 @@ Expires: %3
 Amount: %2
 Type: %3
 Address: %4</source>
-        <translation type="unfinished">Data: %1\nQuantitat %2\n Tipus: %3\n Adreça: %4\n {1
-?} {2
-?} {3
-?} {4?}</translation>
+        <translation type="unfinished">Data: %1\nQuantitat %2\n Tipus: %3\n Adreça: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -705,11 +705,7 @@ Address: %4</source>
         <translation type="unfinished">Datum: %1
 ?ástka: %2
 Typ: %3
-Adresa: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresa: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -699,11 +699,7 @@ Address: %4</source>
         <translation type="unfinished">Dato: %1
 Beløb: %2
 Type: %3
-Adresse: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresse: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -743,10 +743,7 @@ Address: %4</source>
         <translation type="unfinished">Datum: %1
 Betrag: %2
 Typ: %3
-Adresse: %4 {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresse: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -580,11 +580,7 @@ Address: %4</source>
         <translation type="unfinished">Date: %1
 Amount: %2
 Type: %3
-Address: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Address: %4</translation>
     </message>
     <message>
         <location line="+16"/>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -709,11 +709,7 @@ Address: %4</source>
         <translation type="unfinished">Dato: %1
 Sumo: %2
 Tipo: %3
-Adreso: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adreso: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -509,11 +509,7 @@ Address: %4</source>
         <translation type="unfinished">Fecha: %1
 Cantidad: %2
 Tipo: %3
-Dirección: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Dirección: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -590,10 +590,7 @@ Address: %4</source>
         <translation type="unfinished">Fecha: %1
 Cantidad: %2
 Tipo: %3
-Dirección: %4 {1
-?} {2
-?} {3
-?} {4?}</translation>
+Dirección: %4</translation>
     </message>
     <message>
         <location line="+190"/>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -641,11 +641,7 @@ Address: %4</source>
         <translation type="unfinished">Fecha: %1
 Cantidad: %2
 Tipo: %3
-Dirección: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Dirección: %4</translation>
     </message>
     <message>
         <location line="+16"/>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -495,10 +495,7 @@ Address: %4</source>
         <translation type="unfinished">Kuupäev: %1?
 Summa: %2?
 Tüüp: %3?
-Aadress: %4? {1
-?} {2
-?} {3
-?} {4?}</translation>
+Aadress: %4</translation>
     </message>
     <message>
         <location line="+190"/>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -701,10 +701,7 @@ Address: %4</source>
         <translation type="unfinished">Päivä: %1
 Määrä: %2
 Tyyppi: %3
-Osoite: %4 {1
-?} {2
-?} {3
-?} {4?}</translation>
+Osoite: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -508,11 +508,7 @@ Address: %4</source>
         <translation type="unfinished">Date : %1
 Montant : %2
 Type : %3
-Adresse : %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresse : %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_fr_CA.ts
+++ b/src/qt/locale/bitcoin_fr_CA.ts
@@ -808,11 +808,7 @@ Address: %4</source>
         <translation type="unfinished">Date&#xa0;: %1
 Montant&#xa0;: %2
 Type&#xa0;: %3
-Adresse&#xa0;: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresse&#xa0;: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -590,11 +590,7 @@ Address: %4</source>
         <translation type="unfinished">Data: %1
 Cantidade: %2
 Tipo: %3
-Dirección: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Dirección: %4</translation>
     </message>
     <message>
         <location line="+190"/>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -702,11 +702,7 @@ Address: %4</source>
         <translation type="unfinished">Datum:%1
 Iznos:%2
 Tip:%3
-Adresa:%4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresa:%4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -700,11 +700,7 @@ Address: %4</source>
         <translation type="unfinished">Dátum: %1
 Összeg: %2
 Típus: %3
-Cím: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Cím: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -504,11 +504,7 @@ Address: %4</source>
         <translation type="unfinished">Tanggal: %1
 Jumlah: %2
 Jenis: %3
-Alamat: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Alamat: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -508,11 +508,7 @@ Address: %4</source>
         <translation type="unfinished">Data: %1
 Quantità: %2
 Tipo: %3
-Indirizzo: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Indirizzo: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -590,11 +590,7 @@ Address: %4</source>
         <translation type="unfinished">Dies: %1
 Quantitas: %2
 Typus: %3
-Inscriptio: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Inscriptio: %4</translation>
     </message>
     <message>
         <location line="+190"/>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -642,10 +642,7 @@ Address: %4</source>
         <translation type="unfinished">Data: %1
 Suma: %2
 Tipas: %3
-Adresas: %4 {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresas: %4</translation>
     </message>
     <message>
         <location line="+16"/>

--- a/src/qt/locale/bitcoin_lv_LV.ts
+++ b/src/qt/locale/bitcoin_lv_LV.ts
@@ -642,11 +642,7 @@ Address: %4</source>
         <translation type="unfinished">Datums: %1
 Daudzums: %2
 Tips: %3
-Adrese: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adrese: %4</translation>
     </message>
     <message>
         <location line="+16"/>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -701,11 +701,7 @@ Address: %4</source>
         <translation type="unfinished">Dato: %1
 Beløp: %2
 Type: %3
-Adresse: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresse: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -508,11 +508,7 @@ Address: %4</source>
         <translation type="unfinished">Datum: %1
 Bedrag: %2
 Type: %3
-Adres: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adres: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_pam.ts
+++ b/src/qt/locale/bitcoin_pam.ts
@@ -630,11 +630,7 @@ Address: %4</source>
         <translation type="unfinished">Aldo: %1
 Alaga: %2
 Type: %3
-Address: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Address: %4</translation>
     </message>
     <message>
         <location line="+446"/>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -517,11 +517,7 @@ Address: %4</source>
         <translation type="unfinished">Data: %1
 Kwota: %2
 Typ: %3
-Adres: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adres: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -508,10 +508,7 @@ Address: %4</source>
         <translation type="unfinished">Data: %1
 Quantidade: %2
 Tipo: %3
-Endereço: %4 {1
-?} {2
-?} {3
-?} {4?}</translation>
+Endereço: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_pt_PT.ts
+++ b/src/qt/locale/bitcoin_pt_PT.ts
@@ -508,11 +508,7 @@ Address: %4</source>
         <translation type="unfinished">Data: %1
 Quantia: %2
 Tipo: %3
-Endereço: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Endereço: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -702,11 +702,7 @@ Address: %4</source>
         <translation type="unfinished">Data: %1
 Suma: %2
 Tipul: %3
-Adresa: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresa: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -513,11 +513,7 @@ Address: %4</source>
         <translation type="unfinished">Дата: %1
 Сумма: %2
 Тип: %3
-Адрес: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Адрес: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -512,10 +512,7 @@ Address: %4</source>
         <translation type="unfinished">Dátum: %1
 Suma: %2
 Typ: %3
-Adresa: %4 {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adresa: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -703,11 +703,7 @@ Address: %4</source>
         <translation type="unfinished">Datum: %1
 Koli?ina: %2
 Vrsta: %3
-Naslov: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Naslov: %4</translation>
     </message>
     <message>
         <location line="+223"/>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -504,11 +504,7 @@ Address: %4</source>
         <translation type="unfinished">Tarih: %1
 Miktar: %2
 Tür: %3
-Adres: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+Adres: %4</translation>
     </message>
     <message>
         <location line="+493"/>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -495,11 +495,7 @@ Address: %4</source>
         <translation type="unfinished">日期: %1
 金额: %2
 类型: %3
-地址: %4
- {1
-?} {2
-?} {3
-?} {4?}</translation>
+地址: %4</translation>
     </message>
     <message>
         <location line="+190"/>


### PR DESCRIPTION
An old Qt Linguist pass left residual template placeholders in the translated strings for a few languages. This is a quick search-and-replace change to remove the noise.

Closes #2065.