### PR TITLE
net: Clean up mandatory protocol version transition

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3890,28 +3890,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-        int post_newbie_height_disconnect_grace = fTestNet ? 26000 : 2000;
-
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version
             LogPrint(BCLog::LogFlags::NOISY, "partner %s using obsolete version %i; disconnecting",
                      pfrom->addr.ToString(), pfrom->nVersion);
-
-            pfrom->fDisconnect = true;
-            return false;
-        }
-        else if (pfrom->nVersion < PROTOCOL_VERSION
-                 && nBestHeight > GetNewbieSnapshotFixHeight() + post_newbie_height_disconnect_grace)
-        {
-            // Immediately disconnect peers running a protocol version lower than
-            // the latest hard-fork after a grace period for the transition.
-            //
-            // TODO: increment MIN_PEER_PROTO_VERSION and remove this condition in
-            // the release that follows the mandatory version:
-            //
-            LogPrint(BCLog::LogFlags::NOISY, "Disconnecting forked peer protocol version %i: %s",
-                     pfrom->nVersion, pfrom->addr.ToString());
 
             pfrom->fDisconnect = true;
             return false;

--- a/src/version.h
+++ b/src/version.h
@@ -45,7 +45,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 //                                                       //
 static const int PROTOCOL_VERSION =       180326;        //
 // disconnect from peers older than this proto version   //
-static const int MIN_PEER_PROTO_VERSION = 180325;        //
+static const int MIN_PEER_PROTO_VERSION = 180326;        //
 ///////////////////////////////////////////////////////////
 // initial proto version, to be increased after          //
 // version/verack negotiation                            //


### PR DESCRIPTION
This removes the condition used to transition to the latest mandatory protocol version with a grace period and sets the minimum protocol to the version of the latest hard fork.