### PR TITLE
build: Patch libzip to fix mingw compile regression for mingw 9.2+

### DIFF
--- a/depends/packages/libzip.mk
+++ b/depends/packages/libzip.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://libzip.org/download/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=ab4c34eb6c3a08b678cd0f2450a6c57a13e9618b1ba34ee45d00eb5327316457
 $(package)_dependencies=zlib bzip2
-$(package)_patches=nonrandomopentest.c.patch
+$(package)_patches=nonrandomopentest.c.patch compat.h.patch
 
 
 define $(package)_set_vars
@@ -27,7 +27,8 @@ endif
 
 define $(package)_preprocess_cmds
   sed -i.old 's/\#  ifdef _WIN32/\#  if defined _WIN32 \&\& defined ZIP_DLL/' lib/zip.h && \
-  patch -p1 < $($(package)_patch_dir)/nonrandomopentest.c.patch
+  patch -p1 < $($(package)_patch_dir)/nonrandomopentest.c.patch && \
+  patch -p1 < $($(package)_patch_dir)/compat.h.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/libzip/compat.h.patch
+++ b/depends/patches/libzip/compat.h.patch
@@ -1,0 +1,15 @@
+--- old/lib/compat.h	2017-10-06 07:00:00.000000000 -0400
++++ new/lib/compat.h	2021-03-28 00:19:50.891360075 -0400
+@@ -92,9 +92,9 @@
+ #if defined(HAVE__OPEN)
+ #define open(a, b, c)	_open((a), (b))
+ #endif
+-#if defined(HAVE__SNPRINTF)
+-#define snprintf	_snprintf
+-#endif
++//#if defined(HAVE__SNPRINTF)
++//#define snprintf	_snprintf
++//#endif
+ #if defined(HAVE__STRDUP)
+ #if !defined(HAVE_STRDUP) || defined(_WIN32)
+ #undef strdup


### PR DESCRIPTION
Closes #1929.