### PR TITLE
consensus: Reimplement checkpoint-based spam protection

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,6 +125,7 @@ public:
                 {1900000,  uint256S("0x352ca52f9a22fbf1d241082d3bec716ea5bef6b82811f737ae6486bd7771e1c7")},
                 {2000000,  uint256S("0x2e1252a6ed6d0e7e556d4d0377b10f4b542ae5d6c9822cb08d68490a2a0bb706")},
                 {2054000,  uint256S("0xfa1342b4076ca65be64abd7f9cea50cbbdb6247a6937f1f02d6e76494aab20bf")},
+                {2200000,  uint256S("0x6e834d0f49cc8c2a76452db9cf72961d44d86a80c6d604aad4a720f38673a93e")},
             }
         };
     }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -168,6 +168,7 @@ public:
 
         checkpointData = {
             {
+                {0, uint256S("00006e037d7b84104208ecf2a8638d23149d712ea810da604ee2f2cb39bae713")},
             }
         };
     }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -17,6 +17,11 @@ typedef std::map<int, uint256> MapCheckpoints;
 
 struct CCheckpointData {
     MapCheckpoints mapCheckpoints;
+
+    int GetHeight() const {
+        const auto& final_checkpoint = mapCheckpoints.rbegin();
+        return final_checkpoint->first /* height */;
+    }
 };
 
 /**

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -19,15 +19,6 @@ namespace Checkpoints
         return hash == i->second;
     }
 
-    int GetTotalBlocksEstimate()
-    {
-        const MapCheckpoints& checkpoints = Params().Checkpoints().mapCheckpoints;
-
-        if (checkpoints.empty())
-            return 0;
-        return checkpoints.rbegin()->first;
-    }
-
     CBlockIndex* GetLastCheckpoint(const BlockMap& mapBlockIndex)
     {
         const MapCheckpoints& checkpoints = Params().Checkpoints().mapCheckpoints;

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -32,14 +32,4 @@ namespace Checkpoints
         }
         return nullptr;
     }
-
-    // Check against synchronized checkpoint
-    bool CheckSync(int nHeight)
-    {
-        const CBlockIndex* pindexSync = GetLastCheckpoint(mapBlockIndex);
-
-        if (pindexSync != nullptr && nHeight <= pindexSync->nHeight)
-            return false;
-        return true;
-    }
 }

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -17,9 +17,6 @@ namespace Checkpoints
     // Returns true if block passes checkpoint checks
     bool CheckHardened(int nHeight, const uint256& hash);
 
-    // Return conservative estimate of total number of blocks, 0 if unknown
-    int GetTotalBlocksEstimate();
-
     // Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
     CBlockIndex* GetLastCheckpoint(const BlockMap& mapBlockIndex);
 

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -19,8 +19,6 @@ namespace Checkpoints
 
     // Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
     CBlockIndex* GetLastCheckpoint(const BlockMap& mapBlockIndex);
-
-    bool CheckSync(int nHeight);
 }
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1296,7 +1296,7 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
 int GetNumBlocksOfPeers()
 {
     LOCK(cs_main);
-    return std::max(cPeerBlockCounts.median(), Checkpoints::GetTotalBlocksEstimate());
+    return std::max(cPeerBlockCounts.median(), Params().Checkpoints().GetHeight());
 }
 
 bool IsInitialBlockDownload()
@@ -1595,7 +1595,7 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, MapPrevTx inputs, map<uint256, CTx
             // before the last blockchain checkpoint. This is safe because block merkle hashes are
             // still computed and checked, and any change will be caught at the next checkpoint.
 
-            if (!(fBlock && (nBestHeight < Checkpoints::GetTotalBlocksEstimate())))
+            if (!(fBlock && (nBestHeight < Params().Checkpoints().GetHeight())))
             {
                 // Verify signature
                 if (!VerifySignature(txPrev, *this, i, 0))
@@ -2447,7 +2447,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
         // We only do this for blocks after the last checkpoint (reorganisation before that
         // point should only happen with -reindex/-loadblock, or a misbehaving peer.
         for (auto const& tx : boost::adaptors::reverse(block.vtx))
-            if (!(tx.IsCoinBase() || tx.IsCoinStake()) && pindexBest->nHeight > Checkpoints::GetTotalBlocksEstimate())
+            if (!(tx.IsCoinBase() || tx.IsCoinStake()) && pindexBest->nHeight > Params().Checkpoints().GetHeight())
                 vResurrect.push_front(tx);
 
         if(pindexBest->IsUserCPID()) {
@@ -3148,7 +3148,7 @@ bool CBlock::AcceptBlock(bool generated_by_me)
         return error("AcceptBlock() : AddToBlockIndex failed");
 
     // Relay inventory, but don't relay old inventory during initial block download
-    int nBlockEstimate = Checkpoints::GetTotalBlocksEstimate();
+    int nBlockEstimate = Params().Checkpoints().GetHeight();
     if (hashBestChain == hash)
     {
         LOCK(cs_vNodes);

--- a/src/test/checkpoints_tests.cpp
+++ b/src/test/checkpoints_tests.cpp
@@ -28,8 +28,6 @@ BOOST_AUTO_TEST_CASE(sanity)
     // ... but any hash not at a checkpoint should succeed:
     BOOST_CHECK(Checkpoints::CheckHardened(40+1, p500000));
     BOOST_CHECK(Checkpoints::CheckHardened(500000+1, p40));
-
-    BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 500000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Commit c949a02 removed Peercoin's broadcasted, dynamic checkpoints system and reimplemented `Checkpoints::CheckSync()` for hardened checkpoints. However, the change did not reapply the validation again for received blocks.

This reimplements the validation using a similar strategy for nodes that finished the initial sync. With this change, nodes will refuse blocks that connect at a height below the highest checkpoint. This provides an earlier, cheaper spam mitigation for forked chains that will never validate against the set of hardened checkpoints.

I added a new checkpoint for block 2200000 (2021-03-18) so that this rule applies to nodes that forked because of the earlier newbie bug. It should eventually help to soften some of the orphan noise indirectly without the need for a more intrusive stale block handling routine at this time.