### PR TITLE
consensus: Verify hardened checkpoints on start up

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1098,7 +1098,9 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     RandAddSeedPerfmon();
 
-    GRC::Initialize(threads, pindexBest);
+    if (!GRC::Initialize(threads, pindexBest)) {
+        return false;
+    }
 
     //// debug print
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))


### PR DESCRIPTION
This adds a routine that compares the block index entries with the hardened checkpoints when a node starts. It provides user feedback for some forks and database corruption. A node will exit in case of a checkpoint mismatch.