### PR TITLE
gui: Fix shutdown response for failed core init

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -81,7 +81,6 @@ bool VerifyCheckpoints(const CBlockIndex* const pindexBest)
             //
             LogPrintf("WARNING: checkpoint mismatch at %d", checkpoint_pair.first);
             ShowChainCorruptedMessage();
-            Shutdown(nullptr);
 
             return false;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -450,7 +450,9 @@ void ThreadAppInit2(ThreadHandlerPtr th)
 
     LogPrintf("Initializing Core...");
 
-    AppInit2(th);
+    if (!AppInit2(th)) {
+        fRequestShutdown = true;
+    }
 
     LogPrintf("Core Initialized...");
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -496,12 +496,12 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 MilliSleep(100);
             }
 
-            {
+            if (splashref)
+                splash.finish(&window);
+
+            if (!fRequestShutdown) {
                 // Put this in a block, so that the Model objects are cleaned up before
                 // calling Shutdown().
-
-                if (splashref)
-                    splash.finish(&window);
 
                 ClientModel clientModel(&optionsModel);
                 WalletModel walletModel(pwalletMain, &optionsModel);


### PR DESCRIPTION
When `AppInit2()` returns `false`, nothing captures the failure status so that the GUI can respond to fatal problems by shutting down. This change sets the `fRequestShutdown` flag and instructs the GUI to check that flag after running the core initialization routine to determine whether it should load the main window.