### PR TITLE
researcher: Fix deferment of beacon renewal in superblock window

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1123,9 +1123,10 @@ void Researcher::RunRenewBeaconJob()
     // Do not perform an automated renewal for participants with existing
     // beacons before a superblock is due. This avoids overwriting beacon
     // timestamps in the beacon registry in a way that causes the renewed
-    // beacon to appear ahead of the scraper beacon consensus window.
+    // beacon to appear ahead of the scraper beacon consensus window. The
+    // window begins 4 hours before the next superblock by convention.
     //
-    if (!Quorum::SuperblockNeeded(pindexBest->nTime)) {
+    if (!Quorum::SuperblockNeeded(pindexBest->nTime + (60 * 60 * 4))) {
         TRY_LOCK(pwalletMain->cs_wallet, locked_wallet);
 
         if (!locked_wallet) {


### PR DESCRIPTION
This fixes a guard that was supposed to prevent rare instances of CPIDs disappearing from a superblock for one cycle if a wallet automatically renewed a beacon during the scraper activity period before a superblock is due (21621a675f61d8b3dbabdf1999e8b9064b986d3a).

The original change didn't account for the additional time of the scraper activity window before the superblock.