### PR TITLE
util, rpc, gui: Changes for snapshotdownload and add feature sync from zero

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -379,7 +379,7 @@ void ScheduleBeaconDBPassivation(CScheduler& scheduler)
 
 std::unique_ptr<Upgrade> g_UpdateChecker;
 bool fSnapshotRequest = false;
-bool fSyncfromzeroRequest = false;
+bool fResetBlockchainRequest = false;
 
 // -----------------------------------------------------------------------------
 // Functions

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -379,6 +379,7 @@ void ScheduleBeaconDBPassivation(CScheduler& scheduler)
 
 std::unique_ptr<Upgrade> g_UpdateChecker;
 bool fSnapshotRequest = false;
+bool fSyncfromzeroRequest = false;
 
 // -----------------------------------------------------------------------------
 // Functions

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -356,12 +356,12 @@ void ScheduleUpdateChecks(CScheduler& scheduler)
     LogPrintf("Gridcoin: checking for updates every %" PRId64 " hours", hours);
 
     scheduler.scheduleEvery([]{
-        g_UpdateChecker->CheckForLatestUpdate();
+        g_UpdateChecker->ScheduledUpdateCheck();
     }, hours * 60 * 60 * 1000);
 
     // Schedule a start-up check one minute from now:
     scheduler.scheduleFromNow([]{
-        g_UpdateChecker->CheckForLatestUpdate();
+        g_UpdateChecker->ScheduledUpdateCheck();
     }, 60 * 1000);
 }
 

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -190,7 +190,6 @@ void Upgrade::SnapshotMain()
 
     if (CheckForLatestUpdate(VersionResponse, false, true))
     {
-        std::cout << std::endl;
         std::cout << _("Unable to perform a Snapshot download as the wallet has detected that a new mandatory version is available for download.") << std::endl;
         std::cout << _("Latest Version github data response:") << std::endl;
         std::cout << VersionResponse << std::endl;
@@ -366,7 +365,7 @@ bool Upgrade::VerifySHA256SUM()
     }
 }
 
-bool Upgrade::CleanupBlockchainData()
+bool Upgrade::CleanupBlockchainData(bool snapshotreq)
 {
     fs::path CleanupPath = GetDataDir();
 
@@ -421,7 +420,7 @@ bool Upgrade::CleanupBlockchainData()
 
     catch (fs::filesystem_error &ex)
     {
-        LogPrintf("Snapshot (CleanupBlockchainData): Exception occurred: %s", ex.what());
+        LogPrintf("%s: Exception occurred: %s", snapshotreq ? "Snapshot (CleanupBlockchainData)" : "SyncFromZero (CleanupBlockchainData)", ex.what());
 
         return false;
     }
@@ -591,4 +590,9 @@ void Upgrade::DeleteSnapshot()
     {
         LogPrintf("Snapshot Downloader: Exception occurred while attempting to delete snapshot (%s)", e.code().message());
     }
+}
+
+bool Upgrade::SyncFromZero()
+{
+    return CleanupBlockchainData(false);
 }

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -48,14 +48,13 @@ void Upgrade::ScheduledUpdateCheck()
 bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dialog, bool snapshotrequest)
 {
     // If testnet skip this || If the user changes this to disable while wallet running just drop out of here now. (need a way to remove items from scheduler)
-    if (fTestNet || GetBoolArg("-disableupdatecheck", false))
+    if (fTestNet || (GetBoolArg("-disableupdatecheck", false) && !snapshotrequest))
         return false;
 
     Http VersionPull;
 
     std::string GithubResponse = "";
     std::string VersionResponse = "";
-    std::string UpdateCheckType = snapshotrequest ? "Snapshot Request" : "Update Checker";
 
     // We receive the response and it's in a json reply
     UniValue Response(UniValue::VOBJ);
@@ -593,4 +592,33 @@ void Upgrade::DeleteSnapshot()
 bool Upgrade::SyncFromZero()
 {
     return CleanupBlockchainData();
+}
+
+std::string Upgrade::BlockchainCleanupInstructions()
+{
+    std::stringstream stream;
+
+    // Little more work then needed but we should be translation friendly imo
+    stream << _("Datadir: ");
+    stream << GetDataDir().string();
+    stream << "\r\n\r\n";
+    stream << _("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.");
+    stream << "\r\n";
+    stream << _("Failure to do so will result in undefined behaviour or failure to start wallet.");
+    stream << "\r\n\r\n";
+    stream << _("You will need to delete the following.");
+    stream << "\r\n\r\n";
+    stream << _("Files:");
+    stream << "\r\n";
+    stream << "blk000*.dat";
+    stream << "\r\n\r\n";
+    stream << _("Directories:");
+    stream << "\r\n";
+    stream << "txleveldb";
+    stream << "\r\n";
+    stream << "accrual";
+
+    const std::string& output = stream.str();
+
+    return output;
 }

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -67,14 +67,12 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     catch (const std::runtime_error& e)
     {
-        LogPrintf("%s: Exception occurred while checking for latest update. (%s)", UpdateCheckType, e.what());
-
-        return false;
+        return error("%s: Exception occurred while checking for latest update. (%s)", __func__, e.what());
     }
 
     if (VersionResponse.empty())
     {
-        LogPrintf("%s: No Response from github", UpdateCheckType);
+        LogPrintf("%s: No Response from github", __func__);
 
         return false;
     }
@@ -99,7 +97,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     catch (std::exception& ex)
     {
-        LogPrintf("%s: Exception occurred while parsing json response (%s)", UpdateCheckType, ex.what());
+        LogPrintf("%s: Exception occurred while parsing json response (%s)", __func__, ex.what());
 
         return false;
     }
@@ -126,7 +124,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     if (GithubVersion.size() != 4)
     {
-        LogPrintf("%s: Got malformed version (%s)", UpdateCheckType, GithubReleaseData);
+        LogPrintf("%s: Got malformed version (%s)", __func__, GithubReleaseData);
 
         return false;
     }
@@ -152,7 +150,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
     }
     catch (std::exception& ex)
     {
-        LogPrintf("%s: Exception occurred checking client version against github version (%s)", UpdateCheckType, ToString(ex.what()));
+        LogPrintf("%s: Exception occurred checking client version against github version (%s)", __func__, ToString(ex.what()));
 
         return false;
     }
@@ -190,11 +188,11 @@ void Upgrade::SnapshotMain()
 
     if (CheckForLatestUpdate(VersionResponse, false, true))
     {
-        std::cout << _("Unable to perform a Snapshot download as the wallet has detected that a new mandatory version is available for download.") << std::endl;
+        std::cout << _("Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.") << std::endl;
         std::cout << _("Latest Version github data response:") << std::endl;
         std::cout << VersionResponse << std::endl;
 
-        throw std::runtime_error("Failed to download snapshot as mandatory client is available for download.");
+        throw std::runtime_error(_("Failed to download snapshot as mandatory client is available for download."));
     }
 
     // Create a thread for snapshot to be downloaded
@@ -365,7 +363,7 @@ bool Upgrade::VerifySHA256SUM()
     }
 }
 
-bool Upgrade::CleanupBlockchainData(bool snapshotreq)
+bool Upgrade::CleanupBlockchainData()
 {
     fs::path CleanupPath = GetDataDir();
 
@@ -420,7 +418,7 @@ bool Upgrade::CleanupBlockchainData(bool snapshotreq)
 
     catch (fs::filesystem_error &ex)
     {
-        LogPrintf("%s: Exception occurred: %s", snapshotreq ? "Snapshot (CleanupBlockchainData)" : "SyncFromZero (CleanupBlockchainData)", ex.what());
+        LogPrintf("%s: Exception occurred: %s", __func__, ex.what());
 
         return false;
     }
@@ -594,5 +592,5 @@ void Upgrade::DeleteSnapshot()
 
 bool Upgrade::SyncFromZero()
 {
-    return CleanupBlockchainData(false);
+    return CleanupBlockchainData();
 }

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -187,8 +187,8 @@ void Upgrade::SnapshotMain()
 
     if (CheckForLatestUpdate(VersionResponse, false, true))
     {
-        std::cout << _("Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.") << std::endl;
-        std::cout << _("Latest Version github data response:") << std::endl;
+        std::cout << this->ResetBlockchainMessages(UpdateAvailable) << std::endl;
+        std::cout << this->ResetBlockchainMessages(GithubResponse) << std::endl;
         std::cout << VersionResponse << std::endl;
 
         throw std::runtime_error(_("Failed to download snapshot as mandatory client is available for download."));
@@ -589,34 +589,43 @@ void Upgrade::DeleteSnapshot()
     }
 }
 
-bool Upgrade::SyncFromZero()
+bool Upgrade::ResetBlockchainData()
 {
     return CleanupBlockchainData();
 }
 
-std::string Upgrade::BlockchainCleanupInstructions()
+std::string Upgrade::ResetBlockchainMessages(ResetBlockchainMsg _msg)
 {
     std::stringstream stream;
 
-    // Little more work then needed but we should be translation friendly imo
-    stream << _("Datadir: ");
-    stream << GetDataDir().string();
-    stream << "\r\n\r\n";
-    stream << _("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.");
-    stream << "\r\n";
-    stream << _("Failure to do so will result in undefined behaviour or failure to start wallet.");
-    stream << "\r\n\r\n";
-    stream << _("You will need to delete the following.");
-    stream << "\r\n\r\n";
-    stream << _("Files:");
-    stream << "\r\n";
-    stream << "blk000*.dat";
-    stream << "\r\n\r\n";
-    stream << _("Directories:");
-    stream << "\r\n";
-    stream << "txleveldb";
-    stream << "\r\n";
-    stream << "accrual";
+    switch (_msg) {
+        case CleanUp:
+        {
+            stream << _("Datadir: ");
+            stream << GetDataDir().string();
+            stream << "\r\n\r\n";
+            stream << _("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.");
+            stream << "\r\n";
+            stream << _("Failure to do so will result in undefined behaviour or failure to start wallet.");
+            stream << "\r\n\r\n";
+            stream << _("You will need to delete the following.");
+            stream << "\r\n\r\n";
+            stream << _("Files:");
+            stream << "\r\n";
+            stream << "blk000*.dat";
+            stream << "\r\n\r\n";
+            stream << _("Directories:");
+            stream << "\r\n";
+            stream << "txleveldb";
+            stream << "\r\n";
+            stream << "accrual";
+
+            break;
+        }
+
+        case UpdateAvailable: stream << _("Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied."); break;
+        case GithubResponse: stream << _("Latest Version github data response:"); break;
+    }
 
     const std::string& output = stream.str();
 

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -43,6 +43,15 @@ public:
     Upgrade();
 
     //!
+    //! \brief Enum for determining the type of message to be returned for ResetBlockchainData functions
+    //!
+    enum ResetBlockchainMsg {
+        CleanUp,
+        UpdateAvailable,
+        GithubResponse
+    };
+
+    //!
     //! \brief Scheduler call to CheckForLatestUpdate
     //!
     static void ScheduledUpdateCheck();
@@ -96,14 +105,14 @@ public:
     //!
     //! \returns Bool on the success of blockchain cleanup
     //!
-    static bool SyncFromZero();
+    static bool ResetBlockchainData();
 
     //!
-    //! \brief Small function to return manual erase of blockchain data in event of a syncfromzero clean up of blockchain data
+    //! \brief Small function to return translated messages.
     //!
-    //! \returns String containing manual erase instructions of blockchain data
+    //! \returns String containing message.
     //!
-    static std::string BlockchainCleanupInstructions();
+    static std::string ResetBlockchainMessages(ResetBlockchainMsg _msg);
 };
 
 //!

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -63,7 +63,7 @@ public:
     //!
     //! \return Bool on the success of cleanup
     //!
-    static bool CleanupBlockchainData(bool snapshotreq = true);
+    static bool CleanupBlockchainData();
 
     //!
     //! \brief Extracts the snapshot zip file

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -43,9 +43,15 @@ public:
     Upgrade();
 
     //!
+    //! \brief Scheduler call to CheckForLatestUpdate
+    //!
+
+    static void ScheduledUpdateCheck();
+
+    //!
     //! \brief Check for latest updates on github.
     //!
-    static bool CheckForLatestUpdate(bool ui_dialog = true, std::string client_message_out = "");
+    static bool CheckForLatestUpdate(std::string& client_message_out, bool ui_dialog = true, bool snapshotrequest = false);
 
     //!
     //! \brief Function that will be threaded to download snapshot

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -97,6 +97,13 @@ public:
     //! \returns Bool on the success of blockchain cleanup
     //!
     static bool SyncFromZero();
+
+    //!
+    //! \brief Small function to return manual erase of blockchain data in event of a syncfromzero clean up of blockchain data
+    //!
+    //! \returns String containing manual erase instructions of blockchain data
+    //!
+    static std::string BlockchainCleanupInstructions();
 };
 
 //!

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -45,7 +45,6 @@ public:
     //!
     //! \brief Scheduler call to CheckForLatestUpdate
     //!
-
     static void ScheduledUpdateCheck();
 
     //!
@@ -64,7 +63,7 @@ public:
     //!
     //! \return Bool on the success of cleanup
     //!
-    static bool CleanupBlockchainData();
+    static bool CleanupBlockchainData(bool snapshotreq = true);
 
     //!
     //! \brief Extracts the snapshot zip file
@@ -91,6 +90,13 @@ public:
     //! \brief Small function to delete the snapshot.zip file
     //!
     static void DeleteSnapshot();
+
+    //!
+    //! \brief Small function to allow wallet user to clear blockchain data and sync from 0 while keeping a clean look
+    //!
+    //! \returns Bool on the success of blockchain cleanup
+    //!
+    static bool SyncFromZero();
 };
 
 //!

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -164,23 +164,7 @@ bool AppInit(int argc, char* argv[])
                 {
                     LogPrintf("Syncfromzero: Failed to clean up blockchain data");
 
-                    std::string inftext = "";
-                    // Little more work then needed but we should be translation friendly imo
-                    inftext.append(_("Sync from zero: Blockchain data removal was a Failure"));
-                    inftext.append("\r\n\r\n");
-                    inftext.append(_("Datadir: "));
-                    inftext.append(GetDataDir().string());
-                    inftext.append("\r\n\r\n");
-                    inftext.append(_("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet."));
-                    inftext.append("\r\n");
-                    inftext.append(_("Failure to do so will result in undefined behaviour or failure to start wallet."));
-                    inftext.append("\r\n\r\n");
-                    inftext.append(_("You will need to delete the following."));
-                    inftext.append("\r\n\r\n");
-                    inftext.append(_("Files:"));
-                    inftext.append("\r\nblk000*.dat\r\n\r\n");
-                    inftext.append(_("Directories:"));
-                    inftext.append("\r\ntxleveldb\r\naccrual\r\n");
+                    std::string inftext = syncfromzero.BlockchainCleanupInstructions();
 
                     fprintf(stderr, "%s", inftext.c_str());
 

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -99,10 +99,10 @@ bool AppInit(int argc, char* argv[])
         // Initialize logging as early as possible.
         InitLogging();
 
-        // Make sure a user does not request snapshotdownload and syncfromzero at same time!
-        if (mapArgs.count("-snapshotdownload") && mapArgs.count("-syncfromzero"))
+        // Make sure a user does not request snapshotdownload and resetblockchaindata at same time!
+        if (mapArgs.count("-snapshotdownload") && mapArgs.count("-resetblockchaindata"))
         {
-            fprintf(stderr, "-snapshotdownload and -syncfromzero cannot be used in conjunction");
+            fprintf(stderr, "-snapshotdownload and -resetblockchaindata cannot be used in conjunction");
 
             exit(1);
         }
@@ -142,10 +142,10 @@ bool AppInit(int argc, char* argv[])
             snapshot.DeleteSnapshot();
         }
 
-        // Check to see if the user requested to sync from 0 -- We allow sync from zero on testnet, but not a snapshot download.
-        if (mapArgs.count("-syncfromzero"))
+        // Check to see if the user requested to reset blockchain data -- We allow reset blockchain data on testnet, but not a snapshot download.
+        if (mapArgs.count("-resetblockchaindata"))
         {
-            GRC::Upgrade syncfromzero;
+            GRC::Upgrade resetblockchain;
 
             // Let's check make sure gridcoin is not already running in the data directory.
             if (!LockDirectory(GetDataDir(), ".lock", false))
@@ -157,14 +157,14 @@ bool AppInit(int argc, char* argv[])
 
             else
             {
-                if (syncfromzero.SyncFromZero())
-                    LogPrintf("Syncfromzero: Success");
+                if (resetblockchain.ResetBlockchainData())
+                    LogPrintf("ResetBlockchainData: success");
 
                 else
                 {
-                    LogPrintf("Syncfromzero: Failed to clean up blockchain data");
+                    LogPrintf("ResetBlockchainData: failed to clean up blockchain data");
 
-                    std::string inftext = syncfromzero.BlockchainCleanupInstructions();
+                    std::string inftext = resetblockchain.ResetBlockchainMessages(resetblockchain.CleanUp);
 
                     fprintf(stderr, "%s", inftext.c_str());
 

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -142,7 +142,7 @@ bool AppInit(int argc, char* argv[])
             snapshot.DeleteSnapshot();
         }
 
-        // Check to see if the user requested to sync from 0 -- We allow on testnet.
+        // Check to see if the user requested to sync from 0 -- We allow sync from zero on testnet, but not a snapshot download.
         if (mapArgs.count("-syncfromzero"))
         {
             GRC::Upgrade syncfromzero;
@@ -163,6 +163,26 @@ bool AppInit(int argc, char* argv[])
                 else
                 {
                     LogPrintf("Syncfromzero: Failed to clean up blockchain data");
+
+                    std::string inftext = "";
+                    // Little more work then needed but we should be translation friendly imo
+                    inftext.append(_("Sync from zero: Blockchain data removal was a Failure"));
+                    inftext.append("\r\n\r\n");
+                    inftext.append(_("Datadir: "));
+                    inftext.append(GetDataDir().string());
+                    inftext.append("\r\n\r\n");
+                    inftext.append(_("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet."));
+                    inftext.append("\r\n");
+                    inftext.append(_("Failure to do so will result in undefined behaviour or failure to start wallet."));
+                    inftext.append("\r\n\r\n");
+                    inftext.append(_("You will need to delete the following."));
+                    inftext.append("\r\n\r\n");
+                    inftext.append(_("Files:"));
+                    inftext.append("\r\nblk000*.dat\r\n\r\n");
+                    inftext.append(_("Directories:"));
+                    inftext.append("\r\ntxleveldb\r\naccrual\r\n");
+
+                    fprintf(stderr, "%s", inftext.c_str());
 
                     exit(1);
                 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -310,7 +310,7 @@ std::string HelpMessage()
         "  -disableupdatecheck          " + _("Optional: Disable update checks by wallet") + "\n"
         "  -updatecheckinterval=<n>     " + _("Optional: Check for updates every <n> hours (default: 120, minimum: 1)") + "\n"
         "  -updatecheckurl=<url>        " + _("Optional: URL for the update version checks (ex: https://sub.domain.com/location/latest") + "\n"
-        "  -syncfromzero                " + _("Sync blockchain from zero. This argument will remove all previous blockchain data") + "\n";
+        "  -resetblockchaindata         " + _("Reset blockchain data. This argument will remove all previous blockchain data") + "\n";
 
     return strUsage;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -309,7 +309,8 @@ std::string HelpMessage()
         "  -snapshotsha256url=<url>     " + _("Optional: URL for the snapshot.sha256 file (ex: https://sub.domain.com/location/snapshot.sha256)") + "\n"
         "  -disableupdatecheck          " + _("Optional: Disable update checks by wallet") + "\n"
         "  -updatecheckinterval=<n>     " + _("Optional: Check for updates every <n> hours (default: 120, minimum: 1)") + "\n"
-        "  -updatecheckurl=<url>        " + _("Optional: URL for the update version checks (ex: https://sub.domain.com/location/latest") + "\n";
+        "  -updatecheckurl=<url>        " + _("Optional: URL for the update version checks (ex: https://sub.domain.com/location/latest") + "\n"
+        "  -syncfromzero                " + _("Sync blockchain from zero. This argument will remove all previous blockchain data") + "\n";
 
     return strUsage;
 }

--- a/src/init.h
+++ b/src/init.h
@@ -25,5 +25,5 @@ std::string VersionMessage();
 std::string LogSomething();
 
 extern bool fSnapshotRequest;
-extern bool fSyncfromzeroRequest;
+extern bool fResetBlockchainRequest;
 #endif

--- a/src/init.h
+++ b/src/init.h
@@ -25,4 +25,5 @@ std::string VersionMessage();
 std::string LogSomething();
 
 extern bool fSnapshotRequest;
+extern bool fSyncfromzeroRequest;
 #endif

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -353,10 +353,10 @@ int main(int argc, char *argv[])
     // Do this early as we don't want to bother initializing if we are just calling IPC
     ipcScanRelay(argc, argv);
 
-    // Make sure a user does not request snapshotdownload and syncfromzero at same time!
-    if (mapArgs.count("-snapshotdownload") && mapArgs.count("-syncfromzero"))
+    // Make sure a user does not request snapshotdownload and resetblockchaindata at same time!
+    if (mapArgs.count("-snapshotdownload") && mapArgs.count("-resetblockchaindata"))
     {
-        LogPrintf("-snapshotdownload and -syncfromzero cannot be used in conjunction");
+        LogPrintf("-snapshotdownload and -resetblockchaindata cannot be used in conjunction");
 
         return EXIT_FAILURE;
     }
@@ -384,19 +384,19 @@ int main(int argc, char *argv[])
         snapshot.DeleteSnapshot();
     }
 
-    // Check to see if the user requested to sync from 0 -- We allow on testnet.
-    if (mapArgs.count("-syncfromzero"))
+    // Check to see if the user requested to reset blockchain data -- We allow on testnet.
+    if (mapArgs.count("-resetblockchaindata"))
     {
-        GRC::Upgrade syncfromzero;
+        GRC::Upgrade resetblockchain;
 
-        if (syncfromzero.SyncFromZero())
-            LogPrintf("Syncfromzero: Success");
+        if (resetblockchain.ResetBlockchainData())
+            LogPrintf("ResetBlockchainData: success");
 
         else
         {
-            LogPrintf("Syncfromzero: Failed to clean up blockchain data");
+            LogPrintf("ResetBlockchainData: failed to clean up blockchain data");
 
-            std::string inftext = syncfromzero.BlockchainCleanupInstructions();
+            std::string inftext = resetblockchain.ResetBlockchainMessages(resetblockchain.CleanUp);
 
             ThreadSafeMessageBox(inftext, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::MODAL);
             QMessageBox::critical(nullptr, PACKAGE_NAME, QString::fromStdString(inftext));
@@ -450,9 +450,9 @@ int main(int argc, char *argv[])
     }
 
     // We received a request to remove blockchain data so client user can start to sync from 0
-    if (fSyncfromzeroRequest)
+    if (fResetBlockchainRequest)
     {
-        UpgradeQt Syncfromzero;
+        UpgradeQt resetblockchain;
 
         // Release LevelDB file handles on Windows so we can remove the old
         // blockchain files:
@@ -464,11 +464,11 @@ int main(int argc, char *argv[])
         //
         CTxDB().Close();
 
-        if (Syncfromzero.SyncFromZero(app))
-            LogPrintf("Syncfromzero: Success!");
+        if (resetblockchain.ResetBlockchain(app))
+            LogPrintf("ResetBlockchainData: success");
 
         else
-            LogPrintf("Syncfromzero: Failed!");
+            LogPrintf("ResetBlockchainData: failed");
     }
 
     return EXIT_SUCCESS;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -396,23 +396,7 @@ int main(int argc, char *argv[])
         {
             LogPrintf("Syncfromzero: Failed to clean up blockchain data");
 
-            std::string inftext = "";
-            // Little more work then needed but we should be translation friendly imo
-            inftext.append(_("Sync from zero: Blockchain data removal was a Failure"));
-            inftext.append("\r\n\r\n");
-            inftext.append(_("Datadir: "));
-            inftext.append(GetDataDir().string());
-            inftext.append("\r\n\r\n");
-            inftext.append(_("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet."));
-            inftext.append("\r\n");
-            inftext.append(_("Failure to do so will result in undefined behaviour or failure to start wallet."));
-            inftext.append("\r\n\r\n");
-            inftext.append(_("You will need to delete the following."));
-            inftext.append("\r\n\r\n");
-            inftext.append(_("Files:"));
-            inftext.append("\r\nblk000*.dat\r\n\r\n");
-            inftext.append(_("Directories:"));
-            inftext.append("\r\ntxleveldb\r\naccrual\r\n");
+            std::string inftext = syncfromzero.BlockchainCleanupInstructions();
 
             ThreadSafeMessageBox(inftext, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::MODAL);
             QMessageBox::critical(nullptr, PACKAGE_NAME, QString::fromStdString(inftext));

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -396,6 +396,27 @@ int main(int argc, char *argv[])
         {
             LogPrintf("Syncfromzero: Failed to clean up blockchain data");
 
+            std::string inftext = "";
+            // Little more work then needed but we should be translation friendly imo
+            inftext.append(_("Sync from zero: Blockchain data removal was a Failure"));
+            inftext.append("\r\n\r\n");
+            inftext.append(_("Datadir: "));
+            inftext.append(GetDataDir().string());
+            inftext.append("\r\n\r\n");
+            inftext.append(_("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet."));
+            inftext.append("\r\n");
+            inftext.append(_("Failure to do so will result in undefined behaviour or failure to start wallet."));
+            inftext.append("\r\n\r\n");
+            inftext.append(_("You will need to delete the following."));
+            inftext.append("\r\n\r\n");
+            inftext.append(_("Files:"));
+            inftext.append("\r\nblk000*.dat\r\n\r\n");
+            inftext.append(_("Directories:"));
+            inftext.append("\r\ntxleveldb\r\naccrual\r\n");
+
+            ThreadSafeMessageBox(inftext, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::MODAL);
+            QMessageBox::critical(nullptr, PACKAGE_NAME, QString::fromStdString(inftext));
+
             return EXIT_FAILURE;
         }
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1053,7 +1053,7 @@ void BitcoinGUI::syncfromzeroClicked()
 
     Msg.setIcon(QMessageBox::Question);
     Msg.setText(tr("Do you want to delete blockchain data and sync from zero?"));
-    Msg.setInformativeText(tr("Warning: After the blockchain data is deleted the wallet will shutdown and when restarted will begin syncing from zero. After restart you may continue syncing from zero or use the snapshot download to download the latest snapshot. Your balance will temporarily show as 0 GRC while syncing."));
+    Msg.setInformativeText(tr("Warning: After the blockchain data is deleted the wallet will shutdown and when restarted will begin syncing from zero. Your balance will temporarily show as 0 GRC while syncing."));
     Msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     Msg.setDefaultButton(QMessageBox::No);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -360,8 +360,8 @@ void BitcoinGUI::createActions()
     openRPCConsoleAction->setToolTip(tr("Open debugging and diagnostic console"));
     snapshotAction = new QAction(tr("&Snapshot Download"), this);
     snapshotAction->setToolTip(tr("Download and apply latest snapshot"));
-    syncfromzeroAction = new QAction(tr("Sync from &Zero"), this);
-    syncfromzeroAction->setToolTip(tr("Remove blockchain data and start chain from zero"));
+    resetblockchainAction = new QAction(tr("&Reset blockchain data"), this);
+    resetblockchainAction->setToolTip(tr("Remove blockchain data and start chain from zero"));
 
     connect(quitAction, SIGNAL(triggered()), qApp, SLOT(quit()));
     connect(aboutAction, SIGNAL(triggered()), this, SLOT(aboutClicked()));
@@ -377,7 +377,7 @@ void BitcoinGUI::createActions()
     connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
     connect(diagnosticsAction, SIGNAL(triggered()), this, SLOT(diagnosticsClicked()));
     connect(snapshotAction, SIGNAL(triggered()), this, SLOT(snapshotClicked()));
-    connect(syncfromzeroAction, SIGNAL(triggered()), this, SLOT(syncfromzeroClicked()));
+    connect(resetblockchainAction, SIGNAL(triggered()), this, SLOT(resetblockchainClicked()));
 }
 
 void BitcoinGUI::setIcons()
@@ -412,7 +412,7 @@ void BitcoinGUI::setIcons()
     openRPCConsoleAction->setIcon(QPixmap(":/icons/debugwindow"));
     snapshotAction->setIcon(QPixmap(":/images/gridcoin"));
     openConfigAction->setIcon(QPixmap(":/icons/edit"));
-    syncfromzeroAction->setIcon(QPixmap(":/images/gridcoin"));
+    resetblockchainAction->setIcon(QPixmap(":/images/gridcoin"));
 }
 
 void BitcoinGUI::createMenuBar()
@@ -439,7 +439,7 @@ void BitcoinGUI::createMenuBar()
     }
 
     file->addSeparator();
-    file->addAction(syncfromzeroAction);
+    file->addAction(resetblockchainAction);
 
     file->addSeparator();
     file->addAction(quitAction);
@@ -1047,13 +1047,13 @@ void BitcoinGUI::snapshotClicked()
     }
 }
 
-void BitcoinGUI::syncfromzeroClicked()
+void BitcoinGUI::resetblockchainClicked()
 {
     QMessageBox Msg;
 
     Msg.setIcon(QMessageBox::Question);
     Msg.setText(tr("Do you want to delete blockchain data and sync from zero?"));
-    Msg.setInformativeText(tr("Warning: After the blockchain data is deleted the wallet will shutdown and when restarted will begin syncing from zero. Your balance will temporarily show as 0 GRC while syncing."));
+    Msg.setInformativeText(tr("Warning: After the blockchain data is deleted, the wallet will shutdown and when restarted will begin syncing from zero. Your balance will temporarily show as 0 GRC while syncing."));
     Msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     Msg.setDefaultButton(QMessageBox::No);
 
@@ -1076,7 +1076,7 @@ void BitcoinGUI::syncfromzeroClicked()
 
     else
     {
-        fSyncfromzeroRequest = true;
+        fResetBlockchainRequest = true;
 
         qApp->quit();
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -360,6 +360,8 @@ void BitcoinGUI::createActions()
     openRPCConsoleAction->setToolTip(tr("Open debugging and diagnostic console"));
     snapshotAction = new QAction(tr("&Snapshot Download"), this);
     snapshotAction->setToolTip(tr("Download and apply latest snapshot"));
+    syncfromzeroAction = new QAction(tr("Sync from &Zero"), this);
+    syncfromzeroAction->setToolTip(tr("Remove blockchain data and start chain from zero"));
 
     connect(quitAction, SIGNAL(triggered()), qApp, SLOT(quit()));
     connect(aboutAction, SIGNAL(triggered()), this, SLOT(aboutClicked()));
@@ -375,6 +377,7 @@ void BitcoinGUI::createActions()
     connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
     connect(diagnosticsAction, SIGNAL(triggered()), this, SLOT(diagnosticsClicked()));
     connect(snapshotAction, SIGNAL(triggered()), this, SLOT(snapshotClicked()));
+    connect(syncfromzeroAction, SIGNAL(triggered()), this, SLOT(syncfromzeroClicked()));
 }
 
 void BitcoinGUI::setIcons()
@@ -409,6 +412,7 @@ void BitcoinGUI::setIcons()
     openRPCConsoleAction->setIcon(QPixmap(":/icons/debugwindow"));
     snapshotAction->setIcon(QPixmap(":/images/gridcoin"));
     openConfigAction->setIcon(QPixmap(":/icons/edit"));
+    syncfromzeroAction->setIcon(QPixmap(":/images/gridcoin"));
 }
 
 void BitcoinGUI::createMenuBar()
@@ -433,6 +437,9 @@ void BitcoinGUI::createMenuBar()
         file->addSeparator();
         file->addAction(snapshotAction);
     }
+
+    file->addSeparator();
+    file->addAction(syncfromzeroAction);
 
     file->addSeparator();
     file->addAction(quitAction);
@@ -1035,6 +1042,41 @@ void BitcoinGUI::snapshotClicked()
     else
     {
         fSnapshotRequest = true;
+
+        qApp->quit();
+    }
+}
+
+void BitcoinGUI::syncfromzeroClicked()
+{
+    QMessageBox Msg;
+
+    Msg.setIcon(QMessageBox::Question);
+    Msg.setText(tr("Do you wish to remove blockchain data and sync from zero."));
+    Msg.setInformativeText(tr("Warning: Once removing blockchain data has been completed you will have to sync from 0 or use snapshot feature."));
+    Msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    Msg.setDefaultButton(QMessageBox::No);
+
+    int result = Msg.exec();
+    bool fProceed;
+
+    switch (result)
+    {
+        case QMessageBox::Yes    :    fProceed = true;     break;
+        case QMessageBox::No     :    fProceed = false;    break;
+        default                  :    fProceed = false;    break;
+    }
+
+    if (!fProceed)
+    {
+        Msg.close();
+
+        return;
+    }
+
+    else
+    {
+        fSyncfromzeroRequest = true;
 
         qApp->quit();
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1052,8 +1052,8 @@ void BitcoinGUI::syncfromzeroClicked()
     QMessageBox Msg;
 
     Msg.setIcon(QMessageBox::Question);
-    Msg.setText(tr("Do you wish to remove blockchain data and sync from zero."));
-    Msg.setInformativeText(tr("Warning: Once removing blockchain data has been completed you will have to sync from 0 or use snapshot feature."));
+    Msg.setText(tr("Do you want to delete blockchain data and sync from zero?"));
+    Msg.setInformativeText(tr("Warning: After the blockchain data is deleted the wallet will shutdown and when restarted will begin syncing from zero. After restart you may continue syncing from zero or use the snapshot download to download the latest snapshot. Your balance will temporarily show as 0 GRC while syncing."));
     Msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     Msg.setDefaultButton(QMessageBox::No);
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -122,6 +122,7 @@ private:
     QAction *lockWalletAction;
     QAction *openRPCConsoleAction;
     QAction *snapshotAction;
+    QAction *syncfromzeroAction;
 
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
@@ -225,6 +226,7 @@ private slots:
     void diagnosticsClicked();
     void peersClicked();
     void snapshotClicked();
+    void syncfromzeroClicked();
 
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -122,7 +122,7 @@ private:
     QAction *lockWalletAction;
     QAction *openRPCConsoleAction;
     QAction *snapshotAction;
-    QAction *syncfromzeroAction;
+    QAction *resetblockchainAction;
 
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
@@ -226,7 +226,7 @@ private slots:
     void diagnosticsClicked();
     void peersClicked();
     void snapshotClicked();
-    void syncfromzeroClicked();
+    void resetblockchainClicked();
 
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -457,7 +457,7 @@ void DiagnosticsDialog::on_testButton_clicked()
 
     std::string client_message;
 
-    if (g_UpdateChecker->CheckForLatestUpdate(false, client_message))
+    if (g_UpdateChecker->CheckForLatestUpdate(client_message, false))
     {
         UpdateTestStatus("checkClientVersion", ui->checkClientVersionResultLabel, completed, warning,
                          tr("Warning: New Client version available:\n %1").arg(QString(client_message.c_str())));

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -373,21 +373,7 @@ bool UpgradeQt::SyncFromZero(QApplication& SyncfromzeroApp)
 
     else
     {
-        std::string inftext = "";
-        // Little more work then needed but we should be translation friendly imo
-        inftext.append(_("Datadir: "));
-        inftext.append(GetDataDir().string());
-        inftext.append("\r\n\r\n");
-        inftext.append(_("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet."));
-        inftext.append("\r\n");
-        inftext.append(_("Failure to do so will result in undefined behaviour or failure to start wallet."));
-        inftext.append("\r\n\r\n");
-        inftext.append(_("You will need to delete the following."));
-        inftext.append("\r\n\r\n");
-        inftext.append(_("Files:"));
-        inftext.append("\r\nblk000*.dat\r\n\r\n");
-        inftext.append(_("Directories:"));
-        inftext.append("\r\ntxleveldb\r\naccrual");
+        std::string inftext = syncfromzero.BlockchainCleanupInstructions();
 
         ErrorMsg(_("Sync from zero: Blockchain data removal was a Failure"), inftext);
     }

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -34,14 +34,7 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
     if (UpgradeMain.CheckForLatestUpdate(VersionResponse, false, true))
     {
-        QMessageBox Msg;
-
-        Msg.setIcon(QMessageBox::Critical);
-        Msg.setText(ToQString(_("Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.")));
-        Msg.setInformativeText(ToQString(_("Latest Version github data response:\r\n") + VersionResponse));
-        Msg.setStandardButtons(QMessageBox::Ok);
-
-        Msg.exec();
+        ErrorMsg(UpgradeMain.ResetBlockchainMessages(Upgrade::UpdateAvailable), UpgradeMain.ResetBlockchainMessages(Upgrade::GithubResponse) + "\r\n" + VersionResponse);
 
         return false;
     }
@@ -359,23 +352,23 @@ void UpgradeQt::DeleteSnapshot()
     }
 }
 
-bool UpgradeQt::SyncFromZero(QApplication& SyncfromzeroApp)
+bool UpgradeQt::ResetBlockchain(QApplication& ResetBlockchainApp)
 {
-    SyncfromzeroApp.processEvents();
-    SyncfromzeroApp.setWindowIcon(QPixmap(":/images/gridcoin"));
+    ResetBlockchainApp.processEvents();
+    ResetBlockchainApp.setWindowIcon(QPixmap(":/images/gridcoin"));
 
-    Upgrade syncfromzero;
+    Upgrade resetblockchain;
 
-    bool fSuccess = syncfromzero.CleanupBlockchainData();
+    bool fSuccess = resetblockchain.CleanupBlockchainData();
 
     if (fSuccess)
-        Msg(_("Sync from zero: Blockchain data removal was a Success"), _("The wallet will now shutdown. Please start your wallet to begin sync from zero"), false);
+        Msg(_("Reset Blockchain Data: Blockchain data removal was a success"), _("The wallet will now shutdown. Please start your wallet to begin sync from zero"), false);
 
     else
     {
-        std::string inftext = syncfromzero.BlockchainCleanupInstructions();
+        std::string inftext = resetblockchain.ResetBlockchainMessages(Upgrade::CleanUp);
 
-        ErrorMsg(_("Sync from zero: Blockchain data removal was a Failure"), inftext);
+        ErrorMsg(_("Reset Blockchain Data: Blockchain data removal was a failure"), inftext);
     }
 
     return fSuccess;

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -358,3 +358,17 @@ void UpgradeQt::DeleteSnapshot()
         LogPrintf("Snapshot Downloader: Exception occurred while attempting to delete snapshot (%s)", e.code().message());
     }
 }
+
+bool UpgradeQt::SyncFromZero(QApplication& SyncfromzeroApp)
+{
+    SyncfromzeroApp.processEvents();
+    SyncfromzeroApp.setWindowIcon(QPixmap(":/images/gridcoin"));
+
+    Upgrade syncfromzero;
+
+    bool fSuccess = syncfromzero.CleanupBlockchainData(false);
+
+    Msg(_("Sync from zero: Blockchain data removal was a ") + (fSuccess ? _("Success") : _("Failure")), _("The wallet will now shutdown."), false);
+
+    return fSuccess;
+}

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -37,7 +37,7 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
         QMessageBox Msg;
 
         Msg.setIcon(QMessageBox::Critical);
-        Msg.setText(ToQString(_("Unable to perform a Snapshot download as the wallet has detected that a new mandatory version is available for download.")));
+        Msg.setText(ToQString(_("Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.")));
         Msg.setInformativeText(ToQString(_("Latest Version github data response:\r\n") + VersionResponse));
         Msg.setStandardButtons(QMessageBox::Ok);
 
@@ -366,9 +366,31 @@ bool UpgradeQt::SyncFromZero(QApplication& SyncfromzeroApp)
 
     Upgrade syncfromzero;
 
-    bool fSuccess = syncfromzero.CleanupBlockchainData(false);
+    bool fSuccess = syncfromzero.CleanupBlockchainData();
 
-    Msg(_("Sync from zero: Blockchain data removal was a ") + (fSuccess ? _("Success") : _("Failure")), _("The wallet will now shutdown."), false);
+    if (fSuccess)
+        Msg(_("Sync from zero: Blockchain data removal was a Success"), _("The wallet will now shutdown. Please start your wallet to begin sync from zero"), false);
+
+    else
+    {
+        std::string inftext = "";
+        // Little more work then needed but we should be translation friendly imo
+        inftext.append(_("Datadir: "));
+        inftext.append(GetDataDir().string());
+        inftext.append("\r\n\r\n");
+        inftext.append(_("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet."));
+        inftext.append("\r\n");
+        inftext.append(_("Failure to do so will result in undefined behaviour or failure to start wallet."));
+        inftext.append("\r\n\r\n");
+        inftext.append(_("You will need to delete the following."));
+        inftext.append("\r\n\r\n");
+        inftext.append(_("Files:"));
+        inftext.append("\r\nblk000*.dat\r\n\r\n");
+        inftext.append(_("Directories:"));
+        inftext.append("\r\ntxleveldb\r\naccrual");
+
+        ErrorMsg(_("Sync from zero: Blockchain data removal was a Failure"), inftext);
+    }
 
     return fSuccess;
 }

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -29,6 +29,23 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
     Upgrade UpgradeMain;
 
+    // Verify a mandatory release is not available before we continue to snapshot download.
+    std::string VersionResponse = "";
+
+    if (UpgradeMain.CheckForLatestUpdate(VersionResponse, false, true))
+    {
+        QMessageBox Msg;
+
+        Msg.setIcon(QMessageBox::Critical);
+        Msg.setText(ToQString(_("Unable to perform a Snapshot download as the wallet has detected that a new mandatory version is available for download.")));
+        Msg.setInformativeText(ToQString(_("Latest Version github data response:\r\n") + VersionResponse));
+        Msg.setStandardButtons(QMessageBox::Ok);
+
+        Msg.exec();
+
+        return false;
+    }
+
     QProgressDialog Progress("", ToQString(_("Cancel")), 0, 100);
     Progress.setWindowModality(Qt::WindowModal);
 

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -66,6 +66,12 @@ public:
     //! \brief Small function to delete the snapshot.zip file
     //!
     static void DeleteSnapshot();
+    //!
+    //! \brief Main function for sync from zero task.
+    //!
+    //! \return Returns success of blockchain data cleanup task.
+    //!
+    static bool SyncFromZero(QApplication& SyncfromzeroApp);
 
 };
 #endif // UPGRADEQT_H

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -71,7 +71,7 @@ public:
     //!
     //! \return Returns success of blockchain data cleanup task.
     //!
-    static bool SyncFromZero(QApplication& SyncfromzeroApp);
+    static bool ResetBlockchain(QApplication& ResetBlockchainApp);
 
 };
 #endif // UPGRADEQT_H


### PR DESCRIPTION
During the Forking there was a lot of snapshot downloads. From logs of my server there was many from the same ips (redownloads) this is bandwidth intensive and also increase the CDN monthly bill. These changes will improve on that.

This is complete however will be reviewing it and possibly making any changes and/or changes requested. I've tested Syncfromzero and tested the mandatory check.

Snapshotdownload changes:
1) Check to see if there is a new mandatory version of the wallet available for download.
* This is important in case a user does not notice update notifications or has them disabled.
* This will check for an update of a mandatory version and inform the user and will not allow the download of the snapshot to avoid wasted resources and time.

Add Sync from zero feature:
1) Add Arg argument for -syncfromzero
2) Add gui menu option for syncfromzero
3) Functions added
* Add a function in Upgrade to handle the request for -syncfromzero. Function keeps the code neater and separated in a sense.
* Add a function in UpgradeQt to handle gui menu option so we let the user know the result of the task before the wallet is shutdown.

Other changes:
1) Fixed bug that resulted in client_message_out always being empty
2) Do not allow -snapshotdownload and -syncfromzero to be called in conjunction
3) Add unique scheduler function to support the bug fix since the scheduler does not need a reply from Version information from github. Keeps it more simple ex. []{}
4) add bool to CheckForLatestVersion to determine if this call from snapshot or syncfromzero.
* Changes to LogPrintf to log the correct function calling this
* Add check to see if snapshotdownload was request and new mandatory is available
* Add bool to CleanupBlockchainData to determine is syncfromzero or snapshotdownload was called (logging purpose)