### PR TITLE
gui: Update diagnostics

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,6 +87,7 @@ int nBestHeight = -1;
 uint256 hashBestChain;
 CBlockIndex* pindexBest = NULL;
 std::atomic<int64_t> g_previous_block_time;
+std::atomic_bool g_synced_before;
 std::atomic<int64_t> g_nTimeBestReceived;
 CMedianFilter<int> cPeerBlockCounts(5, 0); // Amount of blocks that other nodes claim to have
 
@@ -944,7 +945,12 @@ bool OutOfSyncByAge()
     // rules that Bitcoin uses.
     constexpr int64_t maxAge = 90 * 10;
 
-    return GetAdjustedTime() - g_previous_block_time >= maxAge;
+    bool out_of_sync = (GetAdjustedTime() - g_previous_block_time >= maxAge);
+
+    // g_synced_before is an atomic boolean global that keeps track of whether the wallet was ever in sync in this run.
+    if (!out_of_sync) g_synced_before = true;
+
+    return out_of_sync;
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,6 @@ int nBestHeight = -1;
 uint256 hashBestChain;
 CBlockIndex* pindexBest = NULL;
 std::atomic<int64_t> g_previous_block_time;
-std::atomic_bool g_synced_before;
 std::atomic<int64_t> g_nTimeBestReceived;
 CMedianFilter<int> cPeerBlockCounts(5, 0); // Amount of blocks that other nodes claim to have
 
@@ -945,12 +944,7 @@ bool OutOfSyncByAge()
     // rules that Bitcoin uses.
     constexpr int64_t maxAge = 90 * 10;
 
-    bool out_of_sync = (GetAdjustedTime() - g_previous_block_time >= maxAge);
-
-    // g_synced_before is an atomic boolean global that keeps track of whether the wallet was ever in sync in this run.
-    if (!out_of_sync) g_synced_before = true;
-
-    return out_of_sync;
+    return GetAdjustedTime() - g_previous_block_time >= maxAge;
 }
 
 

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -618,14 +618,17 @@ void DiagnosticsDialog::TCPFailed(QAbstractSocket::SocketError socket_error)
 
         break;
 
+    // SSL errors will NOT be triggered unless we implement a test and site to actually do an SSL connection test. This
+    // is put here for completeness.
     case QAbstractSocket::SocketError::SslHandshakeFailedError:
     case QAbstractSocket::SocketError::SslInternalError:
     case QAbstractSocket::SocketError::SslInvalidUserDataError:
         test_result = failed;
 
         // This does not include the common text above on purpose.
-        tooltip = tr("The network is reporting an SSL error. Gridcoin does not use SSL for normal wallet connections, "
-                     "so this error is extremely unusual. Please check your computer's network configuration.");
+        tooltip = tr("The network is reporting an SSL error. If you also failed or got a warning on your clock test, you "
+                     "should check your clock settings, including your time and time zone. If your clock is ok, please "
+                     "check your computer's network configuration.");
 
         break;
 

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -229,7 +229,7 @@ void DiagnosticsDialog::on_testButton_clicked()
     ResetOverallDiagnosticResult();
     DisplayOverallDiagnosticResult();
 
-    // Tests that are common to both investor and researcher mode.
+    m_researcher_mode = !(m_researcher_model->configuredForInvestorMode() || m_researcher_model->detectedPoolMode());
 
     VerifyWalletIsSynced();
 
@@ -245,34 +245,15 @@ void DiagnosticsDialog::on_testButton_clicked()
 
     CheckClientVersion();
 
-    if (m_researcher_model->configuredForInvestorMode() || m_researcher_model->detectedPoolMode())
-    {
-        // N/A tests for investor/pool mode
-        UpdateTestStatus("boincPath", ui->verifyBoincPathResultLabel, completed, NA);
-        UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, completed, NA);
-        UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, completed, NA);
-        UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, completed, NA);
-        UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, NA);
-    }
-    else
-    {
-        // Tests that are just for researchers
+    VerifyBoincPath();
 
-        // BOINC path
-        VerifyBoincPath();
+    VerifyCPIDValid();
 
-        // CPID valid
-        VerifyCPIDValid();
+    VerifyCPIDHasRAC();
 
-        // CPID has rac
-        VerifyCPIDHasRAC();
+    VerifyCPIDIsActive();
 
-        // cpid is active
-        VerifyCPIDIsActive();
-
-        // check ETTS
-        CheckETTS(diff);
-    }
+    CheckETTS(diff);
 
     DisplayOverallDiagnosticResult();
 }
@@ -762,6 +743,14 @@ void DiagnosticsDialog::CheckClientVersion()
 
 void DiagnosticsDialog::VerifyBoincPath()
 {
+    // This test is only applicable if the wallet is in researcher mode.
+    if (!m_researcher_mode)
+    {
+        UpdateTestStatus(__func__, ui->verifyBoincPathResultLabel, completed, NA);
+
+        return;
+    }
+
     UpdateTestStatus(__func__, ui->verifyBoincPathResultLabel, pending, NA);
 
     fs::path boincPath = (fs::path) GRC::GetBoincDataDir();
@@ -786,6 +775,14 @@ void DiagnosticsDialog::VerifyBoincPath()
 
 void DiagnosticsDialog::VerifyCPIDValid()
 {
+    // This test is only applicable if the wallet is in researcher mode.
+    if (!m_researcher_mode)
+    {
+        UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, completed, NA);
+
+        return;
+    }
+
     UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, pending, NA);
 
     if (m_researcher_model->hasEligibleProjects())
@@ -816,6 +813,14 @@ void DiagnosticsDialog::VerifyCPIDValid()
 
 void DiagnosticsDialog::VerifyCPIDHasRAC()
 {
+    // This test is only applicable if the wallet is in researcher mode.
+    if (!m_researcher_mode)
+    {
+        UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, completed, NA);
+
+        return;
+    }
+
     UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, pending, NA);
 
     if (m_researcher_model->hasRAC())
@@ -845,6 +850,14 @@ void DiagnosticsDialog::VerifyCPIDHasRAC()
 
 void DiagnosticsDialog::VerifyCPIDIsActive()
 {
+    // This test is only applicable if the wallet is in researcher mode.
+    if (!m_researcher_mode)
+    {
+        UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, completed, NA);
+
+        return;
+    }
+
     UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, pending, NA);
 
     if (m_researcher_model->hasActiveBeacon())
@@ -877,6 +890,14 @@ void DiagnosticsDialog::VerifyCPIDIsActive()
 // of research rewards loss between stakes due to the 180 day limit.
 void DiagnosticsDialog::CheckETTS(const double& diff)
 {
+    // This test is only applicable if the wallet is in researcher mode.
+    if (!m_researcher_mode)
+    {
+        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, NA);
+
+        return;
+    }
+
     UpdateTestStatus(__func__, ui->checkETTSResultLabel, pending, NA);
 
     double ETTS = GRC::GetEstimatedTimetoStake(true, diff) / (24.0 * 60.0 * 60.0);

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -38,7 +38,7 @@ void DiagnosticsDialog::SetResearcherModel(ResearcherModel *researcherModel)
 }
 
 void DiagnosticsDialog::SetResultLabel(QLabel *label, DiagnosticTestStatus test_status,
-                                       DiagnosticResult test_result, QString override_text)
+                                       DiagnosticResult test_result, QString override_text, QString tooltip_text)
 {
     switch (test_status)
     {
@@ -72,6 +72,9 @@ void DiagnosticsDialog::SetResultLabel(QLabel *label, DiagnosticTestStatus test_
     }
 
     if (override_text.size()) label->setText(override_text);
+    label->setToolTip(tooltip_text);
+
+    this->repaint();
 }
 
 unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
@@ -80,7 +83,7 @@ unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
 
     unsigned int pending_count = 0;
 
-    for (const auto& entry : test_status_map)
+    for (const auto& entry : m_test_status_map)
     {
         if (entry.second == pending) pending_count++;
     }
@@ -92,9 +95,9 @@ DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetTestStatus(std::st
 {
     LOCK(cs_diagnostictests);
 
-    auto entry = test_status_map.find(test_name);
+    auto entry = m_test_status_map.find(test_name);
 
-    if (entry != test_status_map.end())
+    if (entry != m_test_status_map.end())
     {
         return entry->second;
     }
@@ -106,31 +109,29 @@ DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetTestStatus(std::st
 
 unsigned int DiagnosticsDialog::UpdateTestStatus(std::string test_name, QLabel *label,
                                                  DiagnosticTestStatus test_status, DiagnosticResult test_result,
-                                                 QString override_text)
+                                                 QString override_text, QString tooltip_text)
 {
     LOCK(cs_diagnostictests);
 
-    test_status_map[test_name] = test_status;
+    m_test_status_map[test_name] = test_status;
 
-    SetResultLabel(label, test_status, test_result, override_text);
+    SetResultLabel(label, test_status, test_result, override_text, tooltip_text);
 
     UpdateOverallDiagnosticResult(test_result);
 
-    return test_status_map.size();
+    return m_test_status_map.size();
 }
 
 
-void DiagnosticsDialog::ResetOverallDiagnosticResult(unsigned int& number_of_tests_in)
+void DiagnosticsDialog::ResetOverallDiagnosticResult()
 {
     LOCK(cs_diagnostictests);
 
-    number_of_tests = number_of_tests_in;
+    m_test_status_map.clear();
 
-    test_status_map.clear();
+    m_overall_diagnostic_result_status = pending;
 
-    diagnostic_result_status = pending;
-
-    diagnostic_result = NA;
+    m_overall_diagnostic_result = NA;
 }
 
 void DiagnosticsDialog::UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in)
@@ -138,27 +139,27 @@ void DiagnosticsDialog::UpdateOverallDiagnosticResult(DiagnosticResult diagnosti
     LOCK(cs_diagnostictests);
 
     // Set diagnostic_result_status to completed. This is under lock, so no one can snoop.
-    diagnostic_result_status = completed;
+    m_overall_diagnostic_result_status = completed;
 
     // If the total number of registered tests is less than the initialized number, then
     // the overall status is pending by default.
-    if (test_status_map.size() < number_of_tests)
+    if (m_test_status_map.size() < m_number_of_tests)
     {
-        diagnostic_result_status = pending;
+        m_overall_diagnostic_result_status = pending;
     }
 
-    diagnostic_result = (DiagnosticResult) std::max<int>(diagnostic_result_in,  diagnostic_result);
+    m_overall_diagnostic_result = (DiagnosticResult) std::max<int>(diagnostic_result_in,  m_overall_diagnostic_result);
 
     // If diagnostic_result_status is still set to completed, then at least all tests
     // are registered. Walk through the map of tests one by one and check the status.
     // The first one encountered that is pending means the overall status is pending.
-    if (diagnostic_result_status == completed)
+    if (m_overall_diagnostic_result_status == completed)
     {
-        for (const auto& entry : test_status_map)
+        for (const auto& entry : m_test_status_map)
         {
             if (entry.second == pending)
             {
-                diagnostic_result_status = pending;
+                m_overall_diagnostic_result_status = pending;
                 break;
             }
         }
@@ -168,13 +169,13 @@ void DiagnosticsDialog::UpdateOverallDiagnosticResult(DiagnosticResult diagnosti
 // Lock should be taken on cs_diagnostictests before calling this function.
 DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetOverallDiagnosticResult()
 {
-    return diagnostic_result;
+    return m_overall_diagnostic_result;
 }
 
 // Lock should be taken on cs_diagnostictests before calling this function.
 DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetOverallDiagnosticStatus()
 {
-    return diagnostic_result_status;
+    return m_overall_diagnostic_result_status;
 }
 
 
@@ -182,74 +183,32 @@ void DiagnosticsDialog::DisplayOverallDiagnosticResult()
 {
     LOCK(cs_diagnostictests);
 
-    SetResultLabel(ui->overallResultResultLabel, GetOverallDiagnosticStatus(), GetOverallDiagnosticResult());
+    DiagnosticsDialog::DiagnosticTestStatus overall_diagnostic_status = GetOverallDiagnosticStatus();
+    DiagnosticsDialog::DiagnosticResult overall_diagnostic_result = GetOverallDiagnosticResult();
 
-    this->repaint();
-}
+    QString tooltip;
 
-bool DiagnosticsDialog::VerifyBoincPath()
-{
-    fs::path boincPath = (fs::path) GRC::GetBoincDataDir();
+    if (overall_diagnostic_result == warning)
+    {
+        tooltip = tr("One or more tests have generated a warning status. Wallet operation may be degraded. Please see "
+                     "the individual test tooltips for details and recommended action(s).");
+    }
+    else if (overall_diagnostic_result == failed)
+    {
+        tooltip = tr("One or more tests have failed. Proper wallet operation may be significantly degraded or impossible. "
+                     "Please see the individual test tooltips for details and recommended action(s).");
+    }
+    else if (overall_diagnostic_result == passed)
+    {
+        tooltip = tr("All tests passed. Your wallet operation is normal.");
+    }
+    else
+    {
+        tooltip = QString();
+    }
 
-    if (boincPath.empty())
-        boincPath = (fs::path) GetArgument("boincdatadir", "");
-
-    boincPath = boincPath / "client_state.xml";
-
-    return fs::exists(boincPath);
-}
-
-bool DiagnosticsDialog::VerifyIsCPIDValid()
-{
-    return m_researcher_model->hasEligibleProjects();
-}
-
-bool DiagnosticsDialog::VerifyCPIDIsEligible()
-{
-    return m_researcher_model->hasActiveBeacon();
-}
-
-bool DiagnosticsDialog::VerifyWalletIsSynced()
-{
-    return !OutOfSyncByAge();
-}
-
-bool DiagnosticsDialog::VerifyCPIDHasRAC()
-{
-    return m_researcher_model->hasRAC();
-}
-
-double DiagnosticsDialog::VerifyETTSReasonable()
-{
-    // We are going to compute the ETTS with ignore_staking_status set to true
-    // and also use a 960 block diff as the input, which smooths out short
-    // term fluctuations. The standard 1-1/e confidence (mean) is used.
-
-    double diff = GRC::GetAverageDifficulty(960);
-
-    double result = GRC::GetEstimatedTimetoStake(true, diff);
-
-    return result;
-}
-
-int DiagnosticsDialog::VerifyCountSeedNodes()
-{
-    LOCK(cs_vNodes);
-
-    int count = 0;
-
-    for (auto const& vnodes : vNodes)
-        if (!vnodes->fInbound)
-            count++;
-
-    return count;
-}
-
-int DiagnosticsDialog::VerifyCountConnections()
-{
-    LOCK(cs_vNodes);
-
-    return (int)vNodes.size();
+    SetResultLabel(ui->overallResultResultLabel, overall_diagnostic_status, overall_diagnostic_result,
+                   QString(), tooltip);
 }
 
 void DiagnosticsDialog::on_testButton_clicked()
@@ -259,22 +218,35 @@ void DiagnosticsDialog::on_testButton_clicked()
 
     if (GetNumberOfTestsPending())
     {
-        LogPrintf("INFO: DiagnosticsDialog::on_testButton_clicked: Tests still in progress from a prior run: %u", GetNumberOfTestsPending());
-        this->repaint();
+        LogPrintf("INFO: DiagnosticsDialog::on_testButton_clicked: Tests still in progress from a prior run: %u",
+                  GetNumberOfTestsPending());
+
         return;
     }
 
-    // This needs to be updated if there are more tests added.
-    unsigned int number_of_tests = 11;
-
-    ResetOverallDiagnosticResult(number_of_tests);
+    ResetOverallDiagnosticResult();
     DisplayOverallDiagnosticResult();
 
-    // Tests that are N/A if in investor or pool mode.
+    // Tests that are common to both investor and researcher mode.
+
+    VerifyWalletIsSynced();
+
+    unsigned int connections = CheckConnectionCount();
+
+    CheckOutboundConnectionCount();
+
+    VerifyClock(connections);
+
+    VerifyTCPPort();
+
+    double diff = CheckDifficulty();
+
+    CheckClientVersion();
+
     if (m_researcher_model->configuredForInvestorMode() || m_researcher_model->detectedPoolMode())
     {
         // N/A tests for investor/pool mode
-        UpdateTestStatus("boincPath", ui->boincPathResultLabel, completed, NA);
+        UpdateTestStatus("boincPath", ui->verifyBoincPathResultLabel, completed, NA);
         UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, completed, NA);
         UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, completed, NA);
         UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, completed, NA);
@@ -282,196 +254,153 @@ void DiagnosticsDialog::on_testButton_clicked()
     }
     else
     {
-        //BOINC path
-        UpdateTestStatus("boincPath", ui->boincPathResultLabel, pending, NA);
-        this->repaint();
+        // Tests that are just for researchers
 
-        if (VerifyBoincPath())
-        {
-            UpdateTestStatus("boincPath", ui->boincPathResultLabel, completed, passed);
-        }
-        else
-        {
-            UpdateTestStatus("boincPath", ui->boincPathResultLabel, completed, failed);
-        }
+        // BOINC path
+        VerifyBoincPath();
 
-        //CPID valid
-        UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, pending, NA);
-        this->repaint();
+        // CPID valid
+        VerifyCPIDValid();
 
-        if (VerifyIsCPIDValid())
-        {
-            UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, completed, passed);
-        }
-        else
-        {
-            UpdateTestStatus("verifyCPIDValid", ui->verifyCPIDValidResultLabel, completed, failed);
-        }
+        // CPID has rac
+        VerifyCPIDHasRAC();
 
-        //CPID has rac
-        UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, pending, NA);
-        this->repaint();
+        // cpid is active
+        VerifyCPIDIsActive();
 
-        if (VerifyCPIDHasRAC())
-        {
-            UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, completed, passed);
-        }
-        else
-        {
-            UpdateTestStatus("verifyCPIDHasRAC", ui->verifyCPIDHasRACResultLabel, completed, failed);
-        }
-
-        //cpid is active
-        UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, pending, NA);
-        this->repaint();
-
-        if (VerifyCPIDIsEligible())
-        {
-            UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, completed, passed);
-        }
-        else
-        {
-            UpdateTestStatus("verifyCPIDIsActive", ui->verifyCPIDIsActiveResultLabel, completed, failed);
-        }
-
-        // verify reasonable ETTS
-        // This is only checked if wallet is a researcher wallet because the purpose is to
-        // alert the owner that his stake time is too long and therefore there is a chance
-        // of research rewards loss between stakes due to the 180 day limit.
-        UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, pending, NA);
-
-        double ETTS = VerifyETTSReasonable() / (24.0 * 60.0 * 60.0);
-
-        std::string rounded_ETTS;
-
-        //round appropriately for display.
-        if (ETTS >= 100)
-        {
-            rounded_ETTS = RoundToString(ETTS, 0);
-        }
-        else if (ETTS >= 10)
-        {
-            rounded_ETTS = RoundToString(ETTS, 1);
-        }
-        else
-        {
-            rounded_ETTS = RoundToString(ETTS, 2);
-        }
-
-        // ETTS of zero actually means no coins, i.e. infinite.
-        if (ETTS == 0.0)
-        {
-            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, failed,
-                             tr("Failed: ETTS is infinite. No coins to stake."));
-        }
-        else if (ETTS > 90.0)
-        {
-            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, failed,
-                             tr("Failed: ETTS is infinite. No coins to stake."));
-        }
-        else if (ETTS > 45.0 && ETTS <= 90.0)
-        {
-            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, warning,
-                             tr("Warning: 45 days < ETTS = %1 <= 90 days").arg(QString(rounded_ETTS.c_str())));
-        }
-        else
-        {
-            UpdateTestStatus("checkETTS", ui->checkETTSResultLabel, completed, passed,
-                             tr("Passed: ETTS = %1 <= 45 days").arg(QString(rounded_ETTS.c_str())));
-        }
-    }
-
-    // Tests that are common to both investor and researcher mode.
-    // wallet synced
-    UpdateTestStatus("verifyWalletIsSynced", ui->verifyWalletIsSyncedResultLabel, pending, NA);
-    this->repaint();
-
-    if (VerifyWalletIsSynced())
-    {
-        UpdateTestStatus("verifyWalletIsSynced", ui->verifyWalletIsSyncedResultLabel, completed, passed);
-    }
-
-    else
-    {
-        UpdateTestStatus("verifyWalletIsSynced", ui->verifyWalletIsSyncedResultLabel, completed, failed);
-    }
-
-    // clock
-    UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel, pending, NA);
-    this->repaint();
-
-    VerifyClock();
-
-    // seed nodes
-    UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, pending, NA);
-    this->repaint();
-
-    unsigned int seed_node_connections = VerifyCountSeedNodes();
-
-    if (seed_node_connections >= 1 && seed_node_connections < 3)
-    {
-        UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, completed, warning,
-                         tr("Warning: Count = %1 (Pass = 3+)").arg(QString::number(seed_node_connections)));
-    }
-    else if(seed_node_connections >= 3)
-    {
-        UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, completed, passed,
-                         tr("Passed: Count = %1").arg(QString::number(seed_node_connections)));
-    }
-    else
-    {
-        UpdateTestStatus("verifySeedNodes", ui->verifySeedNodesResultLabel, completed, failed,
-                         tr("Failed: Count = %1").arg(QString::number(seed_node_connections)));
-    }
-
-    // connection count
-    UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, pending, NA);
-    this->repaint();
-
-    unsigned int connections = VerifyCountConnections();
-
-    if (connections <= 7 && connections >= 1)
-    {
-        UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, completed, warning,
-                         tr("Warning: Count = %1 (Pass = 8+)").arg(QString::number(connections)));
-    }
-    else if (connections >= 8)
-    {
-        UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, completed, passed,
-                         tr("Passed: Count = %1").arg(QString::number(connections)));
-    }
-    else
-    {
-        UpdateTestStatus("verifyConnections", ui->verifyConnectionsResultLabel, completed, failed,
-                         tr("Failed: Count = %1").arg(QString::number(connections)));
-    }
-
-    // tcp port
-    UpdateTestStatus("verifyTCPPort", ui->verifyTCPPortResultLabel, pending, NA);
-    this->repaint();
-
-    VerifyTCPPort();
-
-    // client version
-    UpdateTestStatus("checkClientVersion", ui->checkClientVersionResultLabel, pending, NA);
-
-    std::string client_message;
-
-    if (g_UpdateChecker->CheckForLatestUpdate(client_message, false))
-    {
-        UpdateTestStatus("checkClientVersion", ui->checkClientVersionResultLabel, completed, warning,
-                         tr("Warning: New Client version available:\n %1").arg(QString(client_message.c_str())));
-    }
-    else
-    {
-        UpdateTestStatus("checkClientVersion", ui->checkClientVersionResultLabel, completed, passed);
+        // check ETTS
+        CheckETTS(diff);
     }
 
     DisplayOverallDiagnosticResult();
 }
 
-void DiagnosticsDialog::VerifyClock()
+void DiagnosticsDialog::VerifyWalletIsSynced()
 {
+    UpdateTestStatus(__func__, ui->verifyWalletIsSyncedResultLabel, pending, NA);
+
+    if (!OutOfSyncByAge())
+    {
+        UpdateTestStatus(__func__, ui->verifyWalletIsSyncedResultLabel, completed, passed);
+    }
+    else
+    {
+        QString tooltip = tr("Your wallet is out of sync with the network. This uses the wallet core sync standard and "
+                             "so may be different than the out-of-sync indicator on the overview screen. This is normal "
+                             "to fail if the wallet is being synced for the first time. It is also normal if the wallet "
+                             "was just started a few minutes ago. In that case, just try the diagnostics again in a few "
+                             "minutes.");
+
+        UpdateTestStatus(__func__, ui->verifyWalletIsSyncedResultLabel, completed, failed, QString(), tooltip);
+    }
+}
+
+int DiagnosticsDialog::CheckConnectionCount()
+{
+    UpdateTestStatus(__func__, ui->checkConnectionCountResultLabel, pending, NA);
+
+    int connections = 0;
+    int minimum_connections_to_stake = fTestNet ? 1 : 3;
+    {
+        LOCK(cs_vNodes);
+
+        connections = vNodes.size();
+    }
+
+    if (connections <= 7 && connections >= minimum_connections_to_stake)
+    {
+        QString tooltip = tr("Please check your network and also check the config file and ensure your addnode entries "
+                             "are up-to-date. If you recently started the wallet, you may want to wait another few "
+                             "minutes for connections to build up and test again. Please see "
+                             "https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.");
+
+        UpdateTestStatus(__func__, ui->checkConnectionCountResultLabel, completed, warning,
+                         tr("Warning: Count = %1 (Pass = 8+)").arg(QString::number(connections)), tooltip);
+    }
+    else if (connections >= 8)
+    {
+        UpdateTestStatus(__func__, ui->checkConnectionCountResultLabel, completed, passed,
+                         tr("Passed: Count = %1").arg(QString::number(connections)));
+    }
+    else
+    {
+        QString tooltip = tr("You will not be able to stake because you have less than %1 connection(s). Please check "
+                             "your network and also check the config file and ensure your addnode entries are up-to-date. "
+                             "If you recently started the wallet, you may want to wait another few minutes for connections "
+                             "to build up and then test again. Please see https://gridcoin.us/wiki/config-file.html and "
+                             "https://addnodes.cycy.me/.").arg(QString::number(minimum_connections_to_stake));
+
+        UpdateTestStatus(__func__, ui->checkConnectionCountResultLabel, completed, failed,
+                         tr("Failed: Count = %1").arg(QString::number(connections)), tooltip);
+    }
+
+    return connections;
+}
+
+void DiagnosticsDialog::CheckOutboundConnectionCount()
+{
+    UpdateTestStatus(__func__, ui->checkOutboundConnectionCountResultLabel, pending, NA);
+
+    LOCK(cs_vNodes);
+
+    int outbound_connections = 0;
+
+    for (const auto& vnodes : vNodes)
+    {
+        if (!vnodes->fInbound) ++outbound_connections;
+    }
+
+    if (outbound_connections < 1)
+    {
+        QString tooltip = tr("Your outbound connection count is critically low. Please check your the config file and "
+                             "ensure your addnode entries are up-to-date. If you recently started the wallet, you may "
+                             "want to wait another few minutes for connections to build up and then test again. Please see "
+                             "https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.");
+
+        UpdateTestStatus(__func__, ui->checkOutboundConnectionCountResultLabel, completed, failed,
+                         tr("Failed: Count = %1").arg(QString::number(outbound_connections)), tooltip);
+    }
+    else if (outbound_connections < 3)
+    {
+        QString tooltip = tr("Your outbound connection count is low. Please check your the config file and "
+                             "ensure your addnode entries are up-to-date. If you recently started the wallet, you may "
+                             "want to wait another few minutes for connections to build up and then test again. Please see "
+                             "https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.");
+
+        UpdateTestStatus(__func__, ui->checkOutboundConnectionCountResultLabel, completed, warning,
+                         tr("Warning: Count = %1 (Pass = 3+)").arg(QString::number(outbound_connections)), tooltip);
+
+    }
+    else
+    {
+        UpdateTestStatus(__func__, ui->checkOutboundConnectionCountResultLabel, completed, passed,
+                         tr("Passed: Count = %1").arg(QString::number(outbound_connections)));
+    }
+}
+
+void DiagnosticsDialog::VerifyClock(unsigned int connections)
+{
+    UpdateTestStatus(__func__, ui->verifyClockResultLabel, pending, NA);
+
+    // This is aligned to the minimum sample size in AddTimeData to compute a nTimeOffset from the sampling of
+    // connected nodes. If a sufficient sample exists, use the existing time offset from the node rather than
+    // going through the ntp connection code. The ntp connection code is retained to help people resolve no connection
+    // situations where their node is so far off they are banned and disconnected from the network.
+    if (connections >= 5)
+    {
+        int64_t time_offset = 0;
+
+        {
+            LOCK(cs_main);
+
+            time_offset = GetTimeOffset();
+        }
+
+        clkReportResults(time_offset);
+
+        return;
+    }
+
     QTimer *timerVerifyClock = new QTimer();
 
     // Set up a timeout clock of 10 seconds as a fail-safe.
@@ -479,75 +408,69 @@ void DiagnosticsDialog::VerifyClock()
     timerVerifyClock->start(10 * 1000);
 
     QHostInfo NTPHost = QHostInfo::fromName("pool.ntp.org");
-    udpSocket = new QUdpSocket(this);
+    m_udpSocket = new QUdpSocket(this);
 
-    connect(udpSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this, SLOT(clkStateChanged(QAbstractSocket::SocketState)));
-    connect(udpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(clkSocketError()));
+    connect(m_udpSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this,
+            SLOT(clkStateChanged(QAbstractSocket::SocketState)));
+    connect(m_udpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this,
+            SLOT(clkSocketError()));
 
-    udpSocket->connectToHost(QHostAddress(NTPHost.addresses().first()), 123, QIODevice::ReadWrite);
+    if (!NTPHost.addresses().empty())
+    {
+        m_udpSocket->connectToHost(QHostAddress(NTPHost.addresses().first()), 123, QIODevice::ReadWrite);
+    }
+    else
+    {
+        clkSocketError();
+    }
 }
 
 void DiagnosticsDialog::clkStateChanged(QAbstractSocket::SocketState state)
 {
     if (state == QAbstractSocket::ConnectedState)
     {
-        connect(udpSocket, SIGNAL(readyRead()), this, SLOT(clkFinished()));
+        connect(m_udpSocket, SIGNAL(readyRead()), this, SLOT(clkFinished()));
 
         char NTPMessage[48] = {0x1b, 0, 0, 0 ,0, 0, 0, 0, 0};
 
-        udpSocket->write(NTPMessage, sizeof(NTPMessage));
+        m_udpSocket->write(NTPMessage, sizeof(NTPMessage));
     }
-
-    return;
 }
 
 void DiagnosticsDialog::clkSocketError()
 {
-    udpSocket->close();
+    m_udpSocket->close();
 
-    // Call clkFinished to handle.
-    clkFinished();
-
-    return;
+    clkReportResults(0, true);
 }
 
 void DiagnosticsDialog::clkFinished()
 {
-    if (udpSocket->waitForReadyRead(10 * 1000))
+    if (m_udpSocket->waitForReadyRead(10 * 1000))
     {
         int64_t start_time = GetAdjustedTime();
 
         // Only allow this loop to run for 5 seconds maximum.
-        while (udpSocket->hasPendingDatagrams() && GetAdjustedTime() - start_time <= 5)
+        while (m_udpSocket->hasPendingDatagrams() && GetAdjustedTime() - start_time <= 5)
         {
-            QByteArray BufferSocket = udpSocket->readAll();
+            QByteArray BufferSocket = m_udpSocket->readAll();
 
             if (BufferSocket.size() == 48)
             {
                 int nNTPCount = 40;
-                unsigned long DateTimeIn = uchar(BufferSocket.at(nNTPCount))
+                uint32_t DateTimeIn = uchar(BufferSocket.at(nNTPCount))
                         + (uchar(BufferSocket.at(nNTPCount + 1)) << 8)
                         + (uchar(BufferSocket.at(nNTPCount + 2)) << 16)
                         + (uchar(BufferSocket.at(nNTPCount + 3)) << 24);
-                long tmit = ntohl((time_t)DateTimeIn);
-                tmit -= 2208988800U;
+                time_t tmit = ntohl(DateTimeIn) - 2208988800U;
 
-                udpSocket->close();
+                m_udpSocket->close();
 
                 boost::posix_time::ptime localTime = boost::posix_time::microsec_clock::universal_time();
                 boost::posix_time::ptime networkTime = boost::posix_time::from_time_t(tmit);
                 boost::posix_time::time_duration timeDiff = networkTime - localTime;
 
-                if (timeDiff.minutes() < 3)
-                {
-                    UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel, completed, passed);
-                }
-                else
-                {
-                    UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel, completed, failed);
-                }
-
-                DisplayOverallDiagnosticResult();
+                clkReportResults(timeDiff.total_seconds());
 
                 return;
             }
@@ -557,44 +480,392 @@ void DiagnosticsDialog::clkFinished()
     {
         // This is needed to "cancel" the timeout timer. Essentially if the test was marked completed via the normal exits
         // above, then when the timer calls clkFinished again, it will hit this conditional and be a no-op.
-        if (GetTestStatus("verifyClockResult") != completed)
+        if (GetTestStatus("VerifyClock") != completed)
         {
-            UpdateTestStatus("verifyClockResult", ui->verifyClockResultLabel,completed, warning,
-                             tr("Warning: Cannot connect to NTP server"));
-
-            DisplayOverallDiagnosticResult();
+            clkReportResults(0, true);
         }
 
         return;
     }
 }
 
+void DiagnosticsDialog::clkReportResults(const int64_t& time_offset, const bool& timeout_during_check)
+{
+    if (!timeout_during_check)
+    {
+        if (abs64(time_offset) < 3 * 60)
+        {
+            UpdateTestStatus("VerifyClock", ui->verifyClockResultLabel, completed, passed);
+        }
+        else if (abs64(time_offset) < 5 * 60)
+        {
+            QString tooltip = tr("You should check your time and time zone settings for your computer.");
+
+            UpdateTestStatus("VerifyClock", ui->verifyClockResultLabel, completed, warning,
+                             tr("Warning: Clock skew is between 3 and 5 minutes. Please check your clock settings."),
+                             tooltip);
+        }
+        else
+        {
+            QString tooltip = tr("Your clock in your computer is significantly off from UTC or network time and "
+                                 "this may seriously degrade the operation of the wallet, including maintaining "
+                                 "connection to the network. You should check your time and time zone settings "
+                                 "for your computer. A very common problem is the off by one hour caused by a time "
+                                 "zone issue or problems with daylight savings time.");
+
+            UpdateTestStatus("VerifyClock", ui->verifyClockResultLabel, completed, failed,
+                             tr("Error: Clock skew is 5 minutes or greater. Please check your clock settings."),
+                             tooltip);
+        }
+    }
+    else
+    {
+        QString tooltip = tr("The wallet has less than five connections to the network and is unable to connect "
+                             "to an NTP server to check your computer clock. This is not necessarily a problem. "
+                             "You can wait a few minutes and try the test again.");
+
+        UpdateTestStatus("VerifyClock", ui->verifyClockResultLabel, completed, warning,
+                         tr("Warning: Cannot connect to NTP server"), tooltip);
+    }
+
+    DisplayOverallDiagnosticResult();
+}
+
 void DiagnosticsDialog::VerifyTCPPort()
 {
-    tcpSocket = new QTcpSocket(this);
+    UpdateTestStatus(__func__, ui->verifyTCPPortResultLabel, pending, NA);
 
-    connect(tcpSocket, SIGNAL(connected()), this, SLOT(TCPFinished()));
-    connect(tcpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(TCPFailed(QAbstractSocket::SocketError)));
+    m_tcpSocket = new QTcpSocket(this);
 
-    tcpSocket->connectToHost("portquiz.net", GetListenPort());
+    connect(m_tcpSocket, SIGNAL(connected()), this, SLOT(TCPFinished()));
+    connect(m_tcpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(TCPFailed(QAbstractSocket::SocketError)));
+
+    m_tcpSocket->connectToHost("portquiz.net", GetListenPort());
 }
 
 void DiagnosticsDialog::TCPFinished()
 {
-    tcpSocket->close();
-    UpdateTestStatus("verifyTCPPort", ui->verifyTCPPortResultLabel, completed, passed);
+    m_tcpSocket->close();
+    UpdateTestStatus("VerifyTCPPort", ui->verifyTCPPortResultLabel, completed, passed);
 
     DisplayOverallDiagnosticResult();
 
     return;
 }
 
-void DiagnosticsDialog::TCPFailed(QAbstractSocket::SocketError socket)
+void DiagnosticsDialog::TCPFailed(QAbstractSocket::SocketError socket_error)
 {
-    UpdateTestStatus("verifyTCPPort", ui->verifyTCPPortResultLabel, completed, warning,
-                     tr("Warning: Port 32749 may be blocked by your firewall"));
+    DiagnosticResult test_result = warning;
+    QString tooltip = tr("Outbound communication to TCP port %1 appears to be blocked. ").arg(GetListenPort());
+
+    switch (socket_error)
+    {
+    case QAbstractSocket::SocketError::ConnectionRefusedError:
+        tooltip += tr("The connection to the port test site was refused. This could be a transient problem with the "
+                      "port test site, but could also be an issue with your firewall. If you are also failing the "
+                      "connection test, your firewall is most likely blocking network communications from the "
+                      "Gridcoin client.");
+
+        break;
+
+    case QAbstractSocket::SocketError::RemoteHostClosedError:
+        tooltip += tr("The port test site is closed on port. This could be a transient problem with the "
+                      "port test site, but could also be an issue with your firewall. If you are also failing the "
+                      "connection test, your firewall is most likely blocking network communications from the "
+                      "Gridcoin client.");
+
+        break;
+
+    case QAbstractSocket::SocketError::HostNotFoundError:
+        // This does not include the common text above on purpose.
+        tooltip = tr("The IP for the port test site is unable to be resolved. This could mean your DNS is not working "
+                     "correctly. The wallet may operate without DNS, but it could be severely degraded, especially if "
+                     "the wallet is new and a database of prior successful connections has not been built up. Please "
+                     "check your computer and ensure name resolution is operating correctly.");
+
+        break;
+
+    case QAbstractSocket::SocketError::SocketAccessError:
+    case QAbstractSocket::SocketError::SocketResourceError:
+    case QAbstractSocket::SocketError::SocketTimeoutError:
+    case QAbstractSocket::SocketError::DatagramTooLargeError:
+    case QAbstractSocket::SocketError::NetworkError:
+    case QAbstractSocket::SocketError::AddressInUseError:
+    case QAbstractSocket::SocketError::SocketAddressNotAvailableError:
+    case QAbstractSocket::SocketError::UnsupportedSocketOperationError:
+    case QAbstractSocket::SocketError::UnfinishedSocketOperationError:
+    case QAbstractSocket::SocketError::OperationError:
+        test_result = failed;
+
+        // This does not include the common text above on purpose.
+        tooltip = tr("The network has experienced a low-level error and this probably means your IP address or other "
+                     "network connection parameters are not configured correctly. Please check your network configuration "
+                     "on your computer.");
+
+        break;
+
+    case QAbstractSocket::SocketError::ProxyAuthenticationRequiredError:
+    case QAbstractSocket::SocketError::ProxyConnectionRefusedError:
+    case QAbstractSocket::SocketError::ProxyConnectionClosedError:
+    case QAbstractSocket::SocketError::ProxyConnectionTimeoutError:
+    case QAbstractSocket::SocketError::ProxyNotFoundError:
+    case QAbstractSocket::SocketError::ProxyProtocolError:
+        test_result = failed;
+
+        tooltip += tr("Your network may be using a proxy server to communicate to public IP addresses on the Internet, and "
+                      "the wallet is not configured properly to use it. Please check the proxy settings under Options -> "
+                      "Network -> Connect through SOCKS proxy.");
+
+        break;
+
+    case QAbstractSocket::SocketError::SslHandshakeFailedError:
+    case QAbstractSocket::SocketError::SslInternalError:
+    case QAbstractSocket::SocketError::SslInvalidUserDataError:
+        test_result = failed;
+
+        // This does not include the common text above on purpose.
+        tooltip = tr("The network is reporting an SSL error. Gridcoin does not use SSL for normal wallet connections, "
+                     "so this error is extremely unusual. Please check your computer's network configuration.");
+
+        break;
+
+    case QAbstractSocket::SocketError::TemporaryError:
+    case QAbstractSocket::SocketError::UnknownSocketError:
+        test_result = failed;
+
+        // This does not include the common text above on purpose.
+        tooltip = tr("The network is reporting an unspecified socket error. If you also are failing the connection test, "
+                     "then please check your computer's network configuration.");
+    }
+
+    UpdateTestStatus("VerifyTCPPort", ui->verifyTCPPortResultLabel, completed, test_result,
+                     QString(), tooltip);
 
     DisplayOverallDiagnosticResult();
 
     return;
 }
+
+double DiagnosticsDialog::CheckDifficulty()
+{
+    UpdateTestStatus(__func__, ui->checkDifficultyResultLabel, pending, NA);
+
+    double diff = 0;
+    double scale_factor = 1.0;
+
+    {
+        LOCK(cs_main);
+
+        scale_factor = fTestNet ? 0.1 : 1.0;
+
+        diff = GRC::GetAverageDifficulty(80);
+    }
+
+    double fail_diff = scale_factor;
+    double warn_diff = scale_factor * 5.0;
+
+    if (diff < fail_diff)
+    {
+        QString override_text = tr("Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.")
+                .arg(QString::number(fail_diff, 'f', 1));
+
+        QString tooltip = tr("Your difficulty is extremely low and your wallet is almost certainly forked. Please ensure "
+                             "you are running the latest version and try removing the blockchain database and resyncing "
+                             "from genesis using the menu option. (Note this will take 2-4 hours.)");
+
+        UpdateTestStatus(__func__, ui->checkDifficultyResultLabel, completed, failed,
+                         override_text, tooltip);
+    }
+    else if (diff < warn_diff)
+    {
+        QString override_text = tr("Warning: 80 block difficulty is less than %1. This wallet is probably forked.")
+                .arg(QString::number(warn_diff, 'f', 1));
+
+        QString tooltip = tr("Your difficulty is very low and your wallet is probably forked. Please ensure you are "
+                             "running the latest version and try removing the blockchain database and resyncing from "
+                             "genesis using the menu option. (Note this will take 2-4 hours.)");
+
+        UpdateTestStatus(__func__, ui->checkDifficultyResultLabel, completed, warning,
+                         override_text, tooltip);
+    }
+    else
+    {
+        QString override_text = tr("Passed: 80 block difficulty is %1.")
+                .arg(QString::number(diff, 'f', 1));
+
+        UpdateTestStatus(__func__, ui->checkDifficultyResultLabel, completed, passed, override_text);
+    }
+
+    return diff;
+}
+
+void DiagnosticsDialog::CheckClientVersion()
+{
+    UpdateTestStatus(__func__, ui->checkClientVersionResultLabel, pending, NA);
+
+    std::string client_message;
+
+    if (g_UpdateChecker->CheckForLatestUpdate(client_message, false)
+            && client_message.find("mandatory") != std::string::npos)
+    {
+        QString tooltip = tr("There is a new mandatory version available and you should upgrade as soon as possible to "
+                             "ensure your wallet remains in consensus with the network.");
+
+        UpdateTestStatus(__func__, ui->checkClientVersionResultLabel, completed, failed,
+                         tr("Warning: New Client version available:\n %1").arg(QString(client_message.c_str())));
+    }
+    else if (g_UpdateChecker->CheckForLatestUpdate(client_message, false)
+             && client_message.find("mandatory") == std::string::npos)
+    {
+        QString tooltip = tr("There is a new leisure version available and you should upgrade as soon as practical.");
+
+        UpdateTestStatus(__func__, ui->checkClientVersionResultLabel, completed, warning,
+                         tr("Warning: New Client version available:\n %1").arg(QString(client_message.c_str())));
+    }
+    else
+    {
+        UpdateTestStatus(__func__, ui->checkClientVersionResultLabel, completed, passed);
+    }
+}
+
+void DiagnosticsDialog::VerifyBoincPath()
+{
+    UpdateTestStatus(__func__, ui->verifyBoincPathResultLabel, pending, NA);
+
+    fs::path boincPath = (fs::path) GRC::GetBoincDataDir();
+
+    if (boincPath.empty())
+        boincPath = (fs::path) GetArgument("boincdatadir", "");
+
+    boincPath = boincPath / "client_state.xml";
+
+    if (fs::exists(boincPath))
+    {
+        UpdateTestStatus(__func__, ui->verifyBoincPathResultLabel, completed, passed);
+    }
+    else
+    {
+        QString tooltip = tr("Check that BOINC is installed and that you have the correct path in the config file "
+                             "if you installed it to a nonstandard location.");
+
+        UpdateTestStatus(__func__, ui->verifyBoincPathResultLabel, completed, failed, QString(), tooltip);
+    }
+}
+
+void DiagnosticsDialog::VerifyCPIDValid()
+{
+    UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, pending, NA);
+
+    if (m_researcher_model->hasEligibleProjects())
+    {
+        UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, completed, passed);
+    }
+    else
+    {
+        QString tooltip = tr("Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one "
+                             "whitelisted project, (3) that you advertised your beacon with the same email as you use for "
+                             "your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when "
+                             "you login to your BOINC project(s) online.");
+
+        UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, completed, failed, QString(), tooltip);
+    }
+}
+
+void DiagnosticsDialog::VerifyCPIDHasRAC()
+{
+    UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, pending, NA);
+
+    if (m_researcher_model->hasRAC())
+    {
+        UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, completed, passed);
+    }
+    else
+    {
+        QString tooltip = tr("Verify that you have actually completed workunits for the projects you have attached and "
+                             "that you have authorized the export of statistics. Please see "
+                             "https://gridcoin.us/guides/whitelist.htm.");
+
+        UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, completed, failed, QString(), tooltip);
+    }
+}
+
+void DiagnosticsDialog::VerifyCPIDIsActive()
+{
+    UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, pending, NA);
+
+    if (m_researcher_model->hasActiveBeacon())
+    {
+        UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, completed, passed);
+    }
+    else
+    {
+        QString tooltip = tr("Please ensure that you have followed the process to advertise and verify your beacon. "
+                             "You can use the research wizard (the &quot;Beacon&quot; button on the overview screen).");
+
+        UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, completed, failed, QString(), tooltip);
+    }
+}
+
+// check ETTS
+// This is only checked if wallet is a researcher wallet because the purpose is to
+// alert the owner that his stake time is too long and therefore there is a chance
+// of research rewards loss between stakes due to the 180 day limit.
+void DiagnosticsDialog::CheckETTS(const double& diff)
+{
+    UpdateTestStatus(__func__, ui->checkETTSResultLabel, pending, NA);
+
+    double ETTS = GRC::GetEstimatedTimetoStake(true, diff) / (24.0 * 60.0 * 60.0);
+
+    std::string rounded_ETTS;
+
+    //round appropriately for display.
+    if (ETTS >= 100)
+    {
+        rounded_ETTS = RoundToString(ETTS, 0);
+    }
+    else if (ETTS >= 10)
+    {
+        rounded_ETTS = RoundToString(ETTS, 1);
+    }
+    else
+    {
+        rounded_ETTS = RoundToString(ETTS, 2);
+    }
+
+    // ETTS of zero actually means no coins, i.e. infinite.
+    if (ETTS == 0.0)
+    {
+        QString tooltip = tr("You have no balance and will be unable to retrieve your research rewards when solo mining. "
+                             "You should acquire GRC to stake so you can retrieve your research rewards. Please see "
+                             "https://gridcoin.us/guides/boinc-install.htm.");
+
+        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
+                         tr("Failed: ETTS is infinite. No coins to stake."), tooltip);
+    }
+    else if (ETTS > 90.0)
+    {
+        QString tooltip = tr("Your balance is too low given the current network difficulty to stake in a reasonable "
+                             "period of time to retrieve your research rewards when solo mining. You should acquire more "
+                             "GRC to stake more often.");
+
+        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
+                         tr("Failed: ETTS is > 90 days. It will take a very long time to receive your research rewards."),
+                         tooltip);
+    }
+    else if (ETTS > 45.0 && ETTS <= 90.0)
+    {
+        QString tooltip = tr("Your balance is low given the current network difficulty to stake in a reasonable "
+                             "period of time to retrieve your research rewards when solo mining. You should consider "
+                             "acquiring more GRC to stake more often.");
+
+        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, warning,
+                         tr("Warning: 45 days < ETTS = %1 <= 90 days").arg(QString(rounded_ETTS.c_str())),
+                         tooltip);
+    }
+    else
+    {
+        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, passed,
+                         tr("Passed: ETTS = %1 <= 45 days").arg(QString(rounded_ETTS.c_str())));
+    }
+}
+

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -794,12 +794,23 @@ void DiagnosticsDialog::VerifyCPIDValid()
     }
     else
     {
-        QString tooltip = tr("Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one "
-                             "whitelisted project, (3) that you advertised your beacon with the same email as you use for "
-                             "your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when "
-                             "you login to your BOINC project(s) online.");
+        if (!g_synced_before && OutOfSyncByAge())
+        {
+            QString tooltip = tr("Your wallet is not in sync and has not previously been in sync during this run, please "
+                                 "wait for the wallet to sync and retest. If there are other failures preventing the "
+                                 "wallet from syncing, please correct those items and retest to see if this test passes.");
 
-        UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, completed, failed, QString(), tooltip);
+            UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, completed, warning, QString(), tooltip);
+        }
+        else
+        {
+            QString tooltip = tr("Verify (1) that you have BOINC installed correctly, (2) that you have attached at least "
+                                 "one whitelisted project, (3) that you advertised your beacon with the same email as you "
+                                 "use for your BOINC project(s), and (4) that the CPID on the overview screen matches the "
+                                 "CPID when you login to your BOINC project(s) online.");
+
+            UpdateTestStatus(__func__, ui->verifyCPIDValidResultLabel, completed, failed, QString(), tooltip);
+        }
     }
 }
 
@@ -813,11 +824,22 @@ void DiagnosticsDialog::VerifyCPIDHasRAC()
     }
     else
     {
-        QString tooltip = tr("Verify that you have actually completed workunits for the projects you have attached and "
-                             "that you have authorized the export of statistics. Please see "
-                             "https://gridcoin.us/guides/whitelist.htm.");
+        if (!g_synced_before && OutOfSyncByAge())
+        {
+            QString tooltip = tr("Your wallet is not in sync and has not previously been in sync during this run, please "
+                                 "wait for the wallet to sync and retest. If there are other failures preventing the "
+                                 "wallet from syncing, please correct those items and retest to see if this test passes.");
 
-        UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, completed, failed, QString(), tooltip);
+            UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, completed, warning, QString(), tooltip);
+        }
+        else
+        {
+            QString tooltip = tr("Verify that you have actually completed workunits for the projects you have attached and "
+                                 "that you have authorized the export of statistics. Please see "
+                                 "https://gridcoin.us/guides/whitelist.htm.");
+
+            UpdateTestStatus(__func__, ui->verifyCPIDHasRACResultLabel, completed, failed, QString(), tooltip);
+        }
     }
 }
 
@@ -831,10 +853,21 @@ void DiagnosticsDialog::VerifyCPIDIsActive()
     }
     else
     {
-        QString tooltip = tr("Please ensure that you have followed the process to advertise and verify your beacon. "
-                             "You can use the research wizard (the &quot;Beacon&quot; button on the overview screen).");
+        if (!g_synced_before && OutOfSyncByAge())
+        {
+            QString tooltip = tr("Your wallet is not in sync and has not previously been in sync during this run, please "
+                                 "wait for the wallet to sync and retest. If there are other failures preventing the "
+                                 "wallet from syncing, please correct those items and retest to see if this test passes.");
 
-        UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, completed, failed, QString(), tooltip);
+            UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, completed, warning, QString(), tooltip);
+        }
+        else
+        {
+            QString tooltip = tr("Please ensure that you have followed the process to advertise and verify your beacon. "
+                                 "You can use the research wizard (the beacon button on the overview screen).");
+
+            UpdateTestStatus(__func__, ui->verifyCPIDIsActiveResultLabel, completed, failed, QString(), tooltip);
+        }
     }
 }
 
@@ -864,40 +897,52 @@ void DiagnosticsDialog::CheckETTS(const double& diff)
         rounded_ETTS = RoundToString(ETTS, 2);
     }
 
-    // ETTS of zero actually means no coins, i.e. infinite.
-    if (ETTS == 0.0)
+    if (!g_synced_before && OutOfSyncByAge())
     {
-        QString tooltip = tr("You have no balance and will be unable to retrieve your research rewards when solo mining. "
-                             "You should acquire GRC to stake so you can retrieve your research rewards. Please see "
-                             "https://gridcoin.us/guides/boinc-install.htm.");
+        QString tooltip = tr("Your wallet is not in sync and has not previously been in sync during this run, please "
+                             "wait for the wallet to sync and retest. If there are other failures preventing the "
+                             "wallet from syncing, please correct those items and retest to see if this test passes.");
 
-        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
-                         tr("Failed: ETTS is infinite. No coins to stake."), tooltip);
-    }
-    else if (ETTS > 90.0)
-    {
-        QString tooltip = tr("Your balance is too low given the current network difficulty to stake in a reasonable "
-                             "period of time to retrieve your research rewards when solo mining. You should acquire more "
-                             "GRC to stake more often.");
-
-        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
-                         tr("Failed: ETTS is > 90 days. It will take a very long time to receive your research rewards."),
-                         tooltip);
-    }
-    else if (ETTS > 45.0 && ETTS <= 90.0)
-    {
-        QString tooltip = tr("Your balance is low given the current network difficulty to stake in a reasonable "
-                             "period of time to retrieve your research rewards when solo mining. You should consider "
-                             "acquiring more GRC to stake more often.");
-
-        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, warning,
-                         tr("Warning: 45 days < ETTS = %1 <= 90 days").arg(QString(rounded_ETTS.c_str())),
-                         tooltip);
+        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, warning, QString(), tooltip);
     }
     else
     {
-        UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, passed,
-                         tr("Passed: ETTS = %1 <= 45 days").arg(QString(rounded_ETTS.c_str())));
+        // ETTS of zero actually means no coins, i.e. infinite.
+        if (ETTS == 0.0)
+        {
+            QString tooltip = tr("You have no balance and will be unable to retrieve your research rewards when solo "
+                                 "mining. You should acquire GRC to stake so you can retrieve your research rewards. "
+                                 "Please see https://gridcoin.us/guides/boinc-install.htm.");
+
+            UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
+                             tr("Failed: ETTS is infinite. No coins to stake."), tooltip);
+        }
+        else if (ETTS > 90.0)
+        {
+            QString tooltip = tr("Your balance is too low given the current network difficulty to stake in a reasonable "
+                                 "period of time to retrieve your research rewards when solo mining. You should acquire "
+                                 "more GRC to stake more often.");
+
+            UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
+                             tr("Failed: ETTS is > 90 days. It will take a very long time to receive your research "
+                                "rewards."),
+                             tooltip);
+        }
+        else if (ETTS > 45.0 && ETTS <= 90.0)
+        {
+            QString tooltip = tr("Your balance is low given the current network difficulty to stake in a reasonable "
+                                 "period of time to retrieve your research rewards when solo mining. You should consider "
+                                 "acquiring more GRC to stake more often.");
+
+            UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, warning,
+                             tr("Warning: 45 days < ETTS = %1 <= 90 days").arg(QString(rounded_ETTS.c_str())),
+                             tooltip);
+        }
+        else
+        {
+            UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, passed,
+                             tr("Passed: ETTS = %1 <= 45 days").arg(QString(rounded_ETTS.c_str())));
+        }
     }
 }
 

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -43,54 +43,52 @@ public:
         completed
     };
 
-    //typedef std::atomic<DiagnosticResultCategory> DiagnosticResult;
-
 private:
     Ui::DiagnosticsDialog *ui;
     void GetData();
-    void VerifyClock();
+    void VerifyWalletIsSynced();
+    int CheckConnectionCount();
+    void CheckOutboundConnectionCount();
+    void VerifyClock(unsigned int connections);
     void VerifyTCPPort();
-    bool VerifyBoincPath();
-    bool VerifyCPIDIsEligible();
-    bool VerifyWalletIsSynced();
-    bool VerifyIsCPIDValid();
-    bool VerifyCPIDHasRAC();
-    double VerifyETTSReasonable();
-    int VerifyCountSeedNodes();
-    int VerifyCountConnections();
-    double GetTotalCPIDRAC(std::string cpid);
-    double GetUserRAC(std::string cpid, int *projects);
-    std::string KeyValue(std::string key);
+    double CheckDifficulty();
+    void CheckClientVersion();
+    void VerifyBoincPath();
+    void VerifyCPIDValid();
+    void VerifyCPIDHasRAC();
+    void VerifyCPIDIsActive();
+    void CheckETTS(const double& diff);
 
     // Because some of the tests are "spurs", this object is multithreaded
     CCriticalSection cs_diagnostictests;
 
     // Holds the overall result of all diagnostic tests
-    DiagnosticResult diagnostic_result;
+    DiagnosticResult m_overall_diagnostic_result;
 
     // Holds the status of the overall diagnostic result
-    DiagnosticTestStatus diagnostic_result_status;
+    DiagnosticTestStatus m_overall_diagnostic_result_status;
 
-    // Holds the number of tests registered.
-    unsigned int number_of_tests = 0;
+    // Holds the number of tests to be registered.
+    // This needs to be updated if the number of tests is changed.
+    unsigned int m_number_of_tests = 12;
 
     // Holds the test status entries
-    typedef std::unordered_map<std::string, DiagnosticTestStatus> mDiagnosticTestStatus;
-    mDiagnosticTestStatus test_status_map;
+    typedef std::unordered_map<std::string, DiagnosticTestStatus> DiagnosticTestStatus_map;
+    DiagnosticTestStatus_map m_test_status_map;
 
     ResearcherModel *m_researcher_model;
 
-    QUdpSocket *udpSocket;
-    QTcpSocket *tcpSocket;
+    QUdpSocket *m_udpSocket;
+    QTcpSocket *m_tcpSocket;
 
 public:
     void SetResearcherModel(ResearcherModel *researcherModel);
     unsigned int GetNumberOfTestsPending();
     unsigned int UpdateTestStatus(std::string test_name, QLabel *label,
                                   DiagnosticTestStatus test_status, DiagnosticResult test_result,
-                                  QString override_text = QString());
+                                  QString override_text = QString(), QString tooltip_text = QString());
     DiagnosticTestStatus GetTestStatus(std::string test_name);
-    void ResetOverallDiagnosticResult(unsigned int& number_of_tests);
+    void ResetOverallDiagnosticResult();
     void UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in);
     DiagnosticResult GetOverallDiagnosticResult();
     DiagnosticTestStatus GetOverallDiagnosticStatus();
@@ -98,15 +96,17 @@ public:
 
 private:
     void SetResultLabel(QLabel *label, DiagnosticTestStatus test_status,
-                        DiagnosticResult test_result, QString override_text = QString());
+                        DiagnosticResult test_result, QString override_text = QString(),
+                        QString tooltip_text = QString());
 
 private slots:
     void on_testButton_clicked();
     void clkFinished();
     void clkStateChanged(QAbstractSocket::SocketState state);
     void clkSocketError();
+    void clkReportResults(const int64_t& time_offset, const bool& timeout_during_check = false);
     void TCPFinished();
-    void TCPFailed(QAbstractSocket::SocketError socketError);
+    void TCPFailed(QAbstractSocket::SocketError socket_error);
 };
 
 #endif // DIAGNOSTICSDIALOG_H

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -72,6 +72,9 @@ private:
     // This needs to be updated if the number of tests is changed.
     unsigned int m_number_of_tests = 12;
 
+    // Boolean to indicate researcher mode.
+    bool m_researcher_mode = true;
+
     // Holds the test status entries
     typedef std::unordered_map<std::string, DiagnosticTestStatus> DiagnosticTestStatus_map;
     DiagnosticTestStatus_map m_test_status_map;

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>866</width>
-    <height>623</height>
+    <height>659</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,7 +49,151 @@
      <property name="verticalSpacing">
       <number>8</number>
      </property>
-     <item row="4" column="1">
+     <item row="15" column="0">
+      <widget class="QLabel" name="checkETTSLabel">
+       <property name="text">
+        <string>Check estimated time to stake </string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="verifyTCPPortLabel">
+       <property name="text">
+        <string>Verify outbound port works</string>
+       </property>
+      </widget>
+     </item>
+     <item row="28" column="0">
+      <widget class="QLabel" name="overallResultLabel">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Overall Result</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="checkConnectionCountLabel">
+       <property name="text">
+        <string>Check total connections</string>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="1">
+      <widget class="QLabel" name="checkETTSResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="verifyTCPPortResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="verifyWalletIsSyncedLabel">
+       <property name="text">
+        <string>Verify wallet is synced</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="verifyCPIDValidLabel">
+       <property name="text">
+        <string>Verify CPID is valid</string>
+       </property>
+      </widget>
+     </item>
+     <item row="28" column="1">
+      <widget class="QLabel" name="overallResultResultLabel">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="verifyClockResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="1">
       <widget class="QLabel" name="verifyCPIDIsActiveResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -74,27 +218,8 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="verifyCPIDIsActiveLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Verify CPID has valid beacon </string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QLabel" name="verifySeedNodesResultLabel">
+     <item row="13" column="1">
+      <widget class="QLabel" name="verifyCPIDHasRACResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -118,7 +243,40 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="14" column="0">
+      <widget class="QLabel" name="verifyCPIDIsActiveLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Verify CPID has active beacon</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="verifyClockLabel">
+       <property name="text">
+        <string>Verify clock</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="verifyBoincPathLabel">
+       <property name="text">
+        <string>Verify BOINC path</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QLabel" name="verifyWalletIsSyncedResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -143,24 +301,56 @@
        </property>
       </widget>
      </item>
-     <item row="13" column="0">
-      <widget class="QLabel" name="overallResultLabel">
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
+     <item row="4" column="1">
+      <widget class="QLabel" name="checkOutboundConnectionCountResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
        </property>
        <property name="text">
-        <string>Overall Result</string>
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="verifyCPIDHasRACLabel">
+     <item row="11" column="1">
+      <widget class="QLabel" name="verifyBoincPathResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Verify CPID has RAC</string>
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>10</number>
        </property>
       </widget>
      </item>
@@ -178,14 +368,19 @@
        </property>
       </widget>
      </item>
-     <item row="13" column="1">
-      <widget class="QLabel" name="overallResultResultLabel">
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
+     <item row="8" column="1">
+      <widget class="QLabel" name="checkDifficultyResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
        </property>
        <property name="text">
         <string/>
@@ -198,7 +393,53 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
+      <widget class="QLabel" name="checkConnectionCountResultLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="checkOutboundConnectionCountLabel">
+       <property name="text">
+        <string>Check outbound connections</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="checkyDifficultyLabel">
+       <property name="text">
+        <string>Check difficulty</string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="0">
+      <widget class="QLabel" name="verifyCPIDHasRACLabel">
+       <property name="text">
+        <string>Verify CPID has RAC</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1">
       <widget class="QLabel" name="verifyCPIDValidResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -226,224 +467,15 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="boincPathLabel">
-       <property name="text">
-        <string>Verify BOINC path</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QLabel" name="verifyConnectionsResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="indent">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="verifyTCPPortLabel">
-       <property name="text">
-        <string>Verify listen port for full node</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="verifyClockLabel">
-       <property name="text">
-        <string>Verify clock</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="boincPathResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <property name="indent">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
      <item row="9" column="0">
-      <widget class="QLabel" name="verifyConnectionsLabel">
-       <property name="text">
-        <string>Verify connections to network </string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QLabel" name="verifyClockResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="indent">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="verifyCPIDValidLabel">
-       <property name="text">
-        <string>Verify CPID is valid</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
-      <widget class="QLabel" name="verifyTCPPortResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="indent">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="0">
       <widget class="QLabel" name="checkClientVersionLabel">
        <property name="text">
         <string>Check client version</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="verifySeedNodesLabel">
-       <property name="text">
-        <string>Verify connections to seeds</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="verifyCPIDHasRACResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="indent">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="verifyWalletIsSyncedLabel">
-       <property name="text">
-        <string>Verify wallet is synced</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
+     <item row="9" column="1">
       <widget class="QLabel" name="checkClientVersionResultLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="indent">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="checkETTSLabel">
-       <property name="text">
-        <string>Check estimated time to stake </string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="checkETTSResultLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
          <horstretch>0</horstretch>


### PR DESCRIPTION
This is a PR to refresh the diagnostics and fix several bugs.

Currently this fixes the bug in the clock test when using ntp and also improves the clock test to not use the ntp call if enough
connections are present to use the GetTimeOffset().

Note that the code here will fail the clock test if the skew is 5 minutes or greater. I think this is reasonable as the disconnection and banning code in ProcessMessage() for nodes for time difference is

`       int64_t timedrift = std::abs(GetAdjustedTime() - nTime);

        if (timedrift > (8*60))
        {
            LogPrint(BCLog::LogFlags::NOISY, "Disconnecting unauthorized peer with Network Time so far off by %" PRId64 " seconds!", timedrift);
            pfrom->Misbehaving(100);
            pfrom->fDisconnect = true;
            return false;
        }`

I have added a difficulty test. Closes #2071.

For documentation purposes, the difficulty test uses a "scale factor" of 1.0 for mainnet and 0.1 for testnet, and then the values of 1.0 and 5.0 for failure and warning for testnet and mainnet respectively. This means that mainnet will show a warning < 5.0 and a failure  < 1.0. Testnet will show a warning < 0.5 and a failure < 0.1.

The tooltip is context sensitive. For the warning, it reads, "Your difficulty is very low and your wallet is probably forked. Please ensure you are running the latest version and try removing the blockchain database and resyncing from genesis using the menu option. (Note this will take 2-4 hours.)" For the failure, it reads, "Your difficulty is extremely low and your wallet is almost certainly forked. Please ensure you are running the latest version and try removing the blockchain database and resyncing from genesis using the menu option. (Note this will take 2-4 hours.)

Notice this anticipates the merge of #2093.

This also now includes context sensitive tooltips for all the tests to help people take actions to fix warnings and failures.