### PR TITLE
gui: Normalize button and input control appearance

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -368,7 +368,9 @@ RES_ICONS = \
   qt/res/icons/icons_light/transactions.svg \
   qt/res/icons/icons_native/transactions.svg \
   qt/res/icons/icons_light/chevron_down.svg \
-  qt/res/icons/icons_dark/chevron_down.svg
+  qt/res/icons/icons_light/chevron_up.svg \
+  qt/res/icons/icons_dark/chevron_down.svg \
+  qt/res/icons/icons_dark/chevron_up.svg
 
 RES_IMAGES = \
   qt/res/images/about.svg \

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -80,6 +80,7 @@
         <file alias="tx_por_ss_sent">res/icons/tx_por_ss_sent.svg</file>
         <file alias="message">res/icons/message.svg</file>
         <file alias="light_chevron_down">res/icons/icons_light/chevron_down.svg</file>
+        <file alias="light_chevron_up">res/icons/icons_light/chevron_up.svg</file>
         <file alias="dark_chevron_down">res/icons/icons_dark/chevron_down.svg</file>
     </qresource>
     <qresource prefix="/images">

--- a/src/qt/res/icons/icons_dark/chevron_up.svg
+++ b/src/qt/res/icons/icons_dark/chevron_up.svg
@@ -1,0 +1,1 @@
+<svg height="12" viewBox="0 0 12 12" width="12" xmlns="http://www.w3.org/2000/svg"><path d="m6 4-3 3 .705.705 2.295-2.29 2.295 2.29.705-.705z" fill="#fff" fill-rule="evenodd"/></svg>

--- a/src/qt/res/icons/icons_light/chevron_up.svg
+++ b/src/qt/res/icons/icons_light/chevron_up.svg
@@ -1,0 +1,1 @@
+<svg height="12" viewBox="0 0 12 12" width="12" xmlns="http://www.w3.org/2000/svg"><path d="m6 4-3 3 .705.705 2.295-2.29 2.295 2.29.705-.705z" fill="#3a465d" fill-rule="evenodd"/></svg>

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -279,22 +279,49 @@ QWidget{
     color: white;
 }
 
-QPushButton{
-    background-color: rgb(64,68,82);
+QPushButton {
+    background: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 rgb(44, 160, 247),
+        stop: 1 rgb(26, 145, 235));
+    border: 0.065em solid rgb(23, 137, 223);
+    border-radius: 0.26em;
+    padding: 0.2em 1.25em;
+    color: rgb(225, 241, 253);
 }
 
-QPushButton:selected{
-    background-color: rgb(65,0,127);
-    color: white;
+QPushButton:hover,
+QPushButton:focus {
+    background: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 rgb(63, 169, 248),
+        stop: 1 rgb(26, 145, 235));
+    border-color: rgb(21, 126, 205);
+    color: rgb(255, 255, 255);
 }
 
-QPushButton:hover{
-    background-color: rgb(65,0,127);
-    color: white;
+QPushButton:pressed {
+    background: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 rgb(26, 145, 235),
+        stop: 1 rgb(44, 160, 247));
+    border-color: rgb(21, 126, 205);
+    color: rgb(207, 233, 252);
 }
 
 QPushButton:disabled {
-    color: rgb(160, 160, 160);
+    background: rgb(68, 109, 139);
+    border-color: rgb(38, 124, 188);
+    color: rgb(211, 232, 248);
 }
 
 QTreeWidget{

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -12,8 +12,8 @@ QMainWindow {
     font-family: "Inter";
 }
 
-BitcoinAmountField{
-    background-color: rgb(49,54,59);
+QWidget {
+    color: white;
 }
 
 /* HLine */
@@ -26,21 +26,23 @@ QFrame[frameShape="5"] {
     border-left: 0.065em solid rgb(67, 74, 80);
 }
 
-QToolButton {
+QToolBar#toolbar QToolButton {
     color: white;
     background-color: rgb(49,54,59);
+    border: none;
+    border-radius: 0;
 }
 
-QToolButton:hover {
+QToolBar#toolbar QToolButton:hover {
     color:white;
     background-color: rgb(65,0,127);
 }
 
-QToolButton:checked {
+QToolBar#toolbar QToolButton:checked {
     background-color: rgb(64,68,82);
 }
 
-QToolButton:checked:hover {
+QToolBar#toolbar QToolButton:checked:hover {
     background-color: rgb(65,0,127);
 }
 
@@ -196,42 +198,68 @@ QHeaderView::section:hover {
     color:white;
 }
 
-QComboBox {
-    background-color:rgb(35,38,41);
-    color: white;
+QComboBox,
+QDateTimeEdit,
+QDoubleSpinBox,
+QLineEdit,
+QPlainTextEdit,
+QSpinBox,
+QTextEdit,
+QToolButton {
+    background: rgb(24, 34, 44);
+    border: 0.065em solid rgb(58, 70, 94);
+    padding: 0.25em 0.5em;
+    border-radius: 0.26em;
+    color: rgb(195, 199, 201);
+    selection-background-color: rgb(26, 145, 235);
     selection-color: white;
-    selection-background-color: rgb(65, 0, 127);
-    border: 0.065em solid rgb(20, 20, 20);
-    padding: 0.065em 0em 0.065em 0.26em;
 }
 
-QComboBox::drop-down {
+QComboBox:hover,
+QComboBox:focus,
+QDateTimeEdit:focus,
+QDoubleSpinBox:focus,
+QDoubleSpinBox::up-button:hover,
+QDoubleSpinBox::down-button:hover,
+QLineEdit:focus,
+QPlainTextEdit:focus,
+QSpinBox,
+QSpinBox::up-button:hover,
+QSpinBox::down-button:hover,
+QTextEdit:focus,
+QToolButton:hover,
+QToolButton:focus,
+QToolButton:selected {
+    border-color: rgb(21, 126, 205);
+    color: rgb(195, 199, 201);
+}
+
+QComboBox:disabled,
+QDateTimeEdit:disabled,
+QDoubleSpinBox:disabled,
+QLineEdit:disabled,
+QPlainTextEdit:disabled,
+QSpinBox:disabled,
+QPlainTextEdit:disabled,
+QToolButton:disabled {
+    background-color: rgb(42, 54, 65);
+    color: rgb(174, 180, 182);
+}
+
+QComboBox::drop-down,
+QDateTimeEdit::drop-down {
     background-color: transparent;
     border: none;
 }
 
-QComboBox::down-arrow {
+QComboBox::down-arrow,
+QDateTimeEdit::down-arrow {
     image: url(:/icons/dark_chevron_down);
 }
 
-QComboBox:hover,
-QComboBox:selected {
-    border-color: rgb(120, 20, 255);
-}
-
-QComboBox:selected {
-    background-color: rgb(65, 0, 127);
-}
-
-QComboBox:disabled {
-    background-color: rgb(47, 52, 56);
-    border-color: rgb(30, 40, 45);
-    color: rgb(160, 160, 160);
-}
-
 QComboBox QAbstractItemView {
-    background-color:rgb(35,38,41);
-    color: white;
+    selection-background-color: rgb(26, 145, 235);
+    selection-color: white;
 }
 
 QAbstractItemView::item:selected {
@@ -239,31 +267,19 @@ QAbstractItemView::item:selected {
     color: white;
 }
 
-QAbstractItemView::item:checked {
-    background-color:rgb(65,0,127);
-    color: white;
-}
-
-QLineEdit {
-    background-color:rgb(35,38,41);
-    color: white;
-    selection-color: white;
-    selection-background-color:rgb(65,0,127);
-}
-
-QDateTimeEdit {
-    background-color:rgb(35,38,41);
+QAbstractItemView::item:checked,
+QAbstractItemView::item:hover,
+QAbstractItemView::item:selected {
+    background-color: rgb(33, 44, 58);
     color: white;
 }
 
 QDateTimeEdit QAbstractItemView {
     background-color:rgb(49,54,59);
-    color: white;
 }
 
 QDateTimeEdit QAbstractItemView::item:checked {
     background-color:rgb(65,0,127);
-    color: white;
 }
 
 QDateTimeEdit QAbstractItemView::item:selected {
@@ -275,18 +291,8 @@ QDialog{
     background-color: rgb(49,54,59);
 }
 
-QWidget{
-    color: white;
-}
-
 QPushButton {
-    background: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 rgb(44, 160, 247),
-        stop: 1 rgb(26, 145, 235));
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(44, 160, 247), stop: 1 rgb(26, 145, 235));
     border: 0.065em solid rgb(23, 137, 223);
     border-radius: 0.26em;
     padding: 0.2em 1.25em;
@@ -295,25 +301,13 @@ QPushButton {
 
 QPushButton:hover,
 QPushButton:focus {
-    background: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 rgb(63, 169, 248),
-        stop: 1 rgb(26, 145, 235));
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(63, 169, 248), stop: 1 rgb(26, 145, 235));
     border-color: rgb(21, 126, 205);
     color: rgb(255, 255, 255);
 }
 
 QPushButton:pressed {
-    background: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 rgb(26, 145, 235),
-        stop: 1 rgb(44, 160, 247));
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(26, 145, 235), stop: 1 rgb(44, 160, 247));
     border-color: rgb(21, 126, 205);
     color: rgb(207, 233, 252);
 }
@@ -350,8 +344,44 @@ QListView::item:checked {
     color:white;
 }
 
-QDoubleSpinBox{
-    background-color: rgb(35,38,41);
+QToolButton {
+    padding: 0.25em;
+}
+
+QDateEdit::up-button,
+QDateEdit::down-button,
+QDoubleSpinBox::up-button,
+QDoubleSpinBox::down-button,
+QSpinBox::up-button,
+QSpinBox::down-button {
+    width: 1.5em;
+    height: 0.915em;
+    border-image: none;
+    border-left: 0.065em solid rgb(58, 70, 94);
+}
+
+QDateEdit::up-button,
+QDoubleSpinBox::up-button,
+QSpinBox::up-button {
+    background: transparent;
+}
+
+QDateEdit::down-button,
+QDoubleSpinBox::down-button,
+QSpinBox::down-button {
+    border-bottom-right-radius: 0.26em;
+}
+
+QDateEdit::up-arrow,
+QDoubleSpinBox::up-arrow,
+QSpinBox::up-arrow {
+    image: url(:/icons/light_chevron_up);
+}
+
+QDateEdit::down-arrow,
+QDoubleSpinBox::down-arrow,
+QSpinBox::down-arrow {
+    image: url(:/icons/light_chevron_down);
 }
 
 QTabWidget::tab-bar {
@@ -392,18 +422,10 @@ QTabBar::tab:!selected:hover {
     background-color: rgb(58, 64, 69);
 }
 
-QTextEdit {
-    background-color: rgb(35,38,41);
-}
-
 /* RPC Console */
 #messagesWidget, #lineEdit, #scraper_log {
     font-family: "Inconsolata";
     font-size: 10pt;
-}
-
-QPlainTextEdit{
-    background-color: rgb(35,38,41);
 }
 
 QGroupBox{
@@ -412,16 +434,6 @@ QGroupBox{
 
 QListWidget{
     color:white;
-    background-color:rgb(49,54,59);
-}
-
-QRadioButton{
-    color: white;
-    background-color:rgb(49,54,59);
-}
-
-QCheckBox{
-    color: white;
     background-color:rgb(49,54,59);
 }
 

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -263,21 +263,45 @@ QWidget{
     color: black;
 }
 
-QPushButton{
-    background-color: rgb(230,230,230);
+QPushButton {
+    background: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 rgb(255, 255, 255),
+        stop: 1 rgb(244, 245, 249));
+    border: 0.065em solid rgb(194, 199, 205);
+    border-radius: 0.26em;
+    padding: 0.2em 1.25em;
+    color: rgb(97, 101, 118);
 }
 
-QPushButton:selected{
-    background-color: rgb(65,0,127);
-    color: white;
+QPushButton:hover {
+    background: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 rgb(255, 255, 255),
+        stop: 1 rgb(244, 236, 255));
+    border-color: rgb(120, 20, 255);
+    color: rgb(88, 92, 107);
 }
 
-QPushButton:hover{
-    background-color: rgb(65,0,127);
-    color: white;
+QPushButton:pressed {
+    background: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 rgb(244, 245, 249),
+        stop: 1 rgb(255, 255, 255));
+    border-color: rgb(120, 20, 255);
 }
 
 QPushButton:disabled {
+    background: rgb(240, 240, 240);
     color: rgb(140, 140, 140);
 }
 

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -11,25 +11,27 @@ QMainWindow {
     font-family: "Inter";
 }
 
-BitcoinAmountField{
-    background-color: rgb(240,240,240);
+QWidget {
+    color: rgb(88, 92, 107);
 }
 
-QToolButton {
+QToolBar#toolbar QToolButton {
     color: black;
-    background-color: rgb(240,240,240);
+    background-color: transparent;
+    border: none;
+    border-radius: 0;
 }
 
-QToolButton:hover {
+QToolBar#toolbar QToolButton:hover {
     color:white;
     background-color: rgb(65,0,127);
 }
 
-QToolButton:checked {
+QToolBar#toolbar QToolButton:checked {
     background-color: rgb(200,200,200);
 }
 
-QToolButton:checked:hover {
+QToolBar#toolbar QToolButton:checked:hover {
     background-color: rgb(65,0,127);
 }
 
@@ -182,40 +184,102 @@ QHeaderView::section:hover {
     color:white;
 }
 
-QComboBox {
-    background-color: rgb(230, 225, 230);
-    color: black;
+QComboBox,
+QDateTimeEdit,
+QDoubleSpinBox,
+QLineEdit,
+QPlainTextEdit,
+QPushButton,
+QSpinBox,
+QTextEdit,
+QToolButton {
+    background: white;
+    border: 0.065em solid rgb(194, 199, 205);
+    padding: 0.25em 0.5em;
+    border-radius: 0.26em;
+    color: rgb(88, 92, 107);
     selection-background-color: rgb(250, 240, 255);
-    border: 0.065em solid rgb(173, 173, 173);
-    padding: 0.065em 0em 0.065em 0.26em;
+    selection-color: black;
 }
 
-QComboBox::drop-down {
+QComboBox:hover,
+QComboBox:focus,
+QDateTimeEdit:focus,
+QDoubleSpinBox:focus,
+QDoubleSpinBox::up-button:hover,
+QDoubleSpinBox::down-button:hover,
+QLineEdit:focus,
+QPlainTextEdit:focus,
+QPushButton:hover,
+QPushButton:focus,
+QPushButton:selected,
+QSpinBox,
+QSpinBox::up-button:hover,
+QSpinBox::down-button:hover,
+QTextEdit:focus,
+QToolButton:hover,
+QToolButton:focus,
+QToolButton:selected {
+    border-color: rgb(120, 20, 255);
+    color: rgb(88, 92, 107);
+}
+
+QComboBox:disabled,
+QDateTimeEdit:disabled,
+QDoubleSpinBox:disabled,
+QLineEdit:disabled,
+QPlainTextEdit:disabled,
+QPushButton:disabled,
+QSpinBox:disabled,
+QTextEdit:disabled,
+QToolButton:disabled {
+    background-color: rgb(240, 240, 240);
+    color: rgb(140, 140, 140);
+}
+
+QComboBox,
+QPushButton,
+QDoubleSpinBox::down-button,
+QSpinBox::down-button,
+QToolButton {
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(255, 255, 255), stop: 1 rgb(244, 245, 249));
+}
+
+QComboBox:hover,
+QComboBox:focus,
+QPushButton:hover,
+QPushButton:focus,
+QPushButton:selected,
+QToolButton:hover,
+QToolButton:focus,
+QToolButton:selected {
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(255, 255, 255), stop: 1 rgb(244, 236, 255));
+}
+
+QComboBox:on,
+QPushButton:pressed,
+QToolButton:pressed {
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(244, 245, 249), stop: 1 rgb(255, 255, 255));
+}
+
+QComboBox::drop-down,
+QDateTimeEdit::drop-down {
     background-color: transparent;
     border: none;
 }
 
-QComboBox::down-arrow {
+QComboBox::down-arrow,
+QDateTimeEdit::down-arrow {
     image: url(:/icons/light_chevron_down);
-}
-
-QComboBox:hover,
-QComboBox:selected {
-    border-color: rgb(120, 20, 255);
 }
 
 QComboBox:selected {
     background-color: rgb(250, 240, 255);
 }
 
-QComboBox:disabled {
-    background-color: rgb(220, 220, 220);
-    color: rgb(140, 140, 140);
-}
-
 QComboBox QAbstractItemView {
     background-color:white;
-    color: black;
+    color: rgb(88, 92, 107);
 }
 
 QAbstractItemView::item:selected {
@@ -223,20 +287,10 @@ QAbstractItemView::item:selected {
     color: white;
 }
 
-QAbstractItemView::item:checked {
-    background-color:rgb(65,0,127);
-    color: white;
-}
-
-QLineEdit {
-    background-color:white;
-    color: black;
-    selection-color: white;
-    selection-background-color:rgb(65,0,127);
-}
-
-QDateTimeEdit {
-    background-color:white;
+QAbstractItemView::item:checked,
+QAbstractItemView::item:hover,
+QAbstractItemView::item:selected {
+    background: rgb(241, 245, 247);
     color: black;
 }
 
@@ -259,50 +313,14 @@ QDialog{
     background-color: rgb(240,240,240);
 }
 
-QWidget{
-    color: black;
-}
-
 QPushButton {
-    background: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 rgb(255, 255, 255),
-        stop: 1 rgb(244, 245, 249));
-    border: 0.065em solid rgb(194, 199, 205);
-    border-radius: 0.26em;
     padding: 0.2em 1.25em;
     color: rgb(97, 101, 118);
 }
 
-QPushButton:hover {
-    background: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 rgb(255, 255, 255),
-        stop: 1 rgb(244, 236, 255));
-    border-color: rgb(120, 20, 255);
-    color: rgb(88, 92, 107);
-}
-
-QPushButton:pressed {
-    background: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 rgb(244, 245, 249),
-        stop: 1 rgb(255, 255, 255));
-    border-color: rgb(120, 20, 255);
-}
-
-QPushButton:disabled {
-    background: rgb(240, 240, 240);
-    color: rgb(140, 140, 140);
+QToolButton {
+    padding: 0.25em;
+    color: rgb(97, 101, 118);
 }
 
 QTreeWidget{
@@ -331,8 +349,40 @@ QListView::item:checked {
     color:white;
 }
 
-QDoubleSpinBox{
-    background-color: white;
+QDateEdit::up-button,
+QDateEdit::down-button,
+QDoubleSpinBox::up-button,
+QDoubleSpinBox::down-button,
+QSpinBox::up-button,
+QSpinBox::down-button {
+    width: 1.5em;
+    height: 1em;
+    border-image: none;
+    border-left: 0.065em solid rgb(194, 199, 205);
+}
+
+QDateEdit::up-button,
+QDoubleSpinBox::up-button,
+QSpinBox::up-button {
+    background: transparent;
+}
+
+QDateEdit::down-button,
+QDoubleSpinBox::down-button,
+QSpinBox::down-button {
+    border-bottom-right-radius: 0.26em;
+}
+
+QDateEdit::up-arrow,
+QDoubleSpinBox::up-arrow,
+QSpinBox::up-arrow {
+    image: url(:/icons/light_chevron_up);
+}
+
+QDateEdit::down-arrow,
+QDoubleSpinBox::down-arrow,
+QSpinBox::down-arrow {
+    image: url(:/icons/light_chevron_down);
 }
 
 QTabWidget::tab-bar {
@@ -372,18 +422,10 @@ QTabBar::tab:!selected:hover {
     background: rgb(255, 255, 255);
 }
 
-QTextEdit {
-    background-color: white;
-}
-
 /* RPC Console */
 #messagesWidget, #lineEdit, #scraper_log {
     font-family: "Inconsolata";
     font-size: 10pt;
-}
-
-QPlainTextEdit{
-    background-color: white;
 }
 
 QGroupBox{


### PR DESCRIPTION
This is a quick stylesheet change for the light and dark themes that improves the appearance of the input controls in the GUI. It fixes some contextual state problems and applies a more modern skin that unifies rendering between different types of controls. The appearance is based on the proposed redesign in #847 and should offer some relief until that is finished. I was tired of looking at the old mess.

---

![image](https://user-images.githubusercontent.com/4282384/113997156-7afff380-981d-11eb-852a-0f1fdb49aed5.png)
![image](https://user-images.githubusercontent.com/4282384/113997024-5efc5200-981d-11eb-82f9-b9140a86c8e5.png)

---

Before: 
![image](https://user-images.githubusercontent.com/4282384/113996047-6a02b280-981c-11eb-87d5-74121f174868.png)
![image](https://user-images.githubusercontent.com/4282384/113996207-91597f80-981c-11eb-9e2d-4a06015c2391.png)
