### PR TITLE
gui: Fix macOS and designer font sizes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -112,6 +112,18 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     QFontDatabase::addApplicationFont(":/fonts/inter-bold");
     QFontDatabase::addApplicationFont(":/fonts/inter-regular");
     QFontDatabase::addApplicationFont(":/fonts/inconsolata-regular");
+
+#ifndef Q_OS_MAC
+    // This slightly enlarges the application's base font size on Windows and
+    // Linux. MacOS often uses a different reference DPI so this can actually
+    // cause the rendered text to appear smaller. On Mac, the default size is
+    // adequate.
+    //
+    QFont appFont = qApp->font();
+    appFont.setPointSize(10);
+    qApp->setFont(appFont);
+#endif
+
     setWindowTitle(tr("Gridcoin") + " " + tr("Wallet"));
 
 #ifndef Q_OS_MAC

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -2,7 +2,6 @@
 
 * {
     font-family: "Inter";
-    font-size: 10pt;
 }
 
 
@@ -425,7 +424,6 @@ QTabBar::tab:!selected:hover {
 /* RPC Console */
 #messagesWidget, #lineEdit, #scraper_log {
     font-family: "Inconsolata";
-    font-size: 10pt;
 }
 
 QGroupBox{

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -2,7 +2,6 @@
 
 * {
     font-family: "Inter";
-    font-size: 10pt;
 }
 
 QMainWindow {
@@ -425,7 +424,6 @@ QTabBar::tab:!selected:hover {
 /* RPC Console */
 #messagesWidget, #lineEdit, #scraper_log {
     font-family: "Inconsolata";
-    font-size: 10pt;
 }
 
 QGroupBox{

--- a/src/qt/res/stylesheets/native_stylesheet.qss
+++ b/src/qt/res/stylesheets/native_stylesheet.qss
@@ -2,7 +2,6 @@
 
 * {
     font-family: "Inter";
-    font-size: 10pt;
 }
 
 QMainWindow {
@@ -30,7 +29,6 @@ QTextEdit {
 /* RPC Console */
 #messagesWidget, #lineEdit, #scraper_log {
     font-family: "Inconsolata";
-    font-size: 10pt;
 }
 
 /* Main Window*/


### PR DESCRIPTION
This change enables an increased font size for Windows and Linux only. Because macOS often uses a different reference DPI, a fixed point-size adjustment like we defined before can actually result in smaller text, and users reported legibility concerns. Instead, we rely on the default font size for macOS builds.

This also fixes a side-effect of the global stylesheet font size value which overrides the custom sizes configured for text in the designer forms.