### PR TITLE
gui: Fix RPC console auto-complete background color

### DIFF
--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -56,6 +56,18 @@ QFrame[frameShape="5"] {
     border-left: 0.065em solid rgb(58, 70, 94);
 }
 
+QAbstractItemView {
+    background-color: rgb(26, 38, 50);
+    alternate-background-color: rgb(23, 33, 43);
+}
+
+QAbstractItemView::item:checked,
+QAbstractItemView::item:hover,
+QAbstractItemView::item:selected {
+    background-color: rgb(33, 44, 58);
+    color: white;
+}
+
 QMenu {
     border: 0.065em solid rgb(58, 70, 94);
 }
@@ -218,6 +230,10 @@ QTreeWidget QScrollBar:vertical {
     border-bottom-left-radius: 0;
 }
 
+QHeaderView {
+    background: transparent;
+}
+
 QHeaderView::section,
 QTableView QTableCornerButton::section {
     background-color: rgb(23, 30, 38);
@@ -306,17 +322,6 @@ QDateTimeEdit::down-arrow {
 QComboBox QAbstractItemView {
     selection-background-color: rgb(26, 145, 235);
     selection-color: white;
-}
-
-QAbstractItemView {
-    alternate-background-color: rgb(23, 33, 43);
-}
-
-QAbstractItemView::item:checked,
-QAbstractItemView::item:hover,
-QAbstractItemView::item:selected {
-    background-color: rgb(33, 44, 58);
-    color: white;
 }
 
 QPushButton {
@@ -526,6 +531,10 @@ QStatusBar QToolTip {
 #transactionsStatusLabel,
 #researcherAlertLabel {
     color: red;
+}
+
+#listTransactions {
+    background: none;
 }
 
 /* coincontrol dialog*/

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -52,6 +52,20 @@ QFrame[frameShape="5"] {
     border-left: 0.065em solid rgb(234, 237, 237);
 }
 
+QAbstractItemView {
+    background-color: white;
+    alternate-background-color: rgb(248, 248, 250);
+}
+
+QAbstractItemView::item:checked,
+QAbstractItemView::item:hover,
+QAbstractItemView::item:selected,
+QMenu::item:selected,
+QMenuBar::item:selected {
+    background: rgb(241, 245, 247);
+    color: black;
+}
+
 QMenu {
     background-color: white;
     border: 0.065em solid rgb(224, 227, 227);
@@ -217,6 +231,10 @@ QTreeWidget QScrollBar:vertical {
     border-bottom-left-radius: 0;
 }
 
+QHeaderView {
+    background: transparent;
+}
+
 QHeaderView::section,
 QTableView QTableCornerButton::section {
     background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(255, 255, 255), stop: 1 rgb(244, 245, 249));
@@ -335,19 +353,6 @@ QComboBox:selected {
 QComboBox QAbstractItemView {
     background-color: white;
     color: rgb(70, 73, 85);
-}
-
-QAbstractItemView {
-    alternate-background-color: rgb(248, 248, 250);
-}
-
-QAbstractItemView::item:checked,
-QAbstractItemView::item:hover,
-QAbstractItemView::item:selected,
-QMenu::item:selected,
-QMenuBar::item:selected {
-    background: rgb(241, 245, 247);
-    color: black;
 }
 
 QPushButton {
@@ -535,6 +540,10 @@ QStatusBar .QFrame QLabel {
 #transactionsStatusLabel,
 #researcherAlertLabel {
     color: red;
+}
+
+#listTransactions {
+    background: none;
 }
 
 /* coincontrol dialog*/


### PR DESCRIPTION
The background of the pop-up list for the RPC console's command input field auto-complete helper rendered with the operating system theme's base color and caused text visibility issues. This change sets the colors of the wallet's themes for the background and fixes style cascades which prevented the color from filling the list.