### PR TITLE
gui: Avoid reloading redundant stylesheets

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -279,6 +279,12 @@ std::string FromQString(QString qs)
 
 void BitcoinGUI::setOptionsStyleSheet(QString qssFileName)
 {
+    // Applying a stylesheet can be rather expensive on a wallet with many
+    // transactions. Avoid reloading styles if the theme didn't change:
+    if (qssFileName == sSheet) {
+        return;
+    }
+
     // setting the style sheets for the app
     QFile qss(":/stylesheets/"+qssFileName);
     if (qss.open(QIODevice::ReadOnly)){


### PR DESCRIPTION
This skips the application of theme stylesheets when saving the GUI options if the user doesn't change the theme. Reloading stylesheets can be expensive for a wallet with many transactions.