### PR TITLE
gui: Implement GUI version of consolidateunspent (coin control part)

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -74,6 +74,7 @@ QT_TS = \
 QT_FORMS_UI = \
   qt/forms/aboutdialog.ui \
   qt/forms/coincontroldialog.ui \
+  qt/forms/consolidateunspentdialog.ui \
   qt/forms/diagnosticsdialog.ui \
   qt/forms/optionsdialog.ui \
   qt/forms/rpcconsole.ui \
@@ -111,6 +112,7 @@ QT_MOC_CPP = \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
+  qt/moc_consolidateunspentdialog.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_diagnosticsdialog.cpp \
   qt/moc_editaddressdialog.cpp \
@@ -181,6 +183,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \
+  qt/consolidateunspentdialog.h \
   qt/csvmodelwriter.h \
   qt/decoration.h \
   qt/diagnosticsdialog.h \
@@ -243,6 +246,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/clientmodel.cpp \
   qt/coincontroldialog.cpp \
   qt/coincontroltreewidget.cpp \
+  qt/consolidateunspentdialog.cpp \
   qt/csvmodelwriter.cpp \
   qt/decoration.cpp \
   qt/diagnosticsdialog.cpp \

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -1,6 +1,9 @@
 #ifndef COINCONTROLDIALOG_H
 #define COINCONTROLDIALOG_H
 
+#include "walletmodel.h"
+#include "amount.h"
+
 #include <QAbstractButton>
 #include <QAction>
 #include <QDialog>
@@ -33,6 +36,15 @@ public:
     static QList<qint64> payAmounts;
     static CCoinControl *coinControl;
 
+    // This is based on what will guarantee a successful transaction.
+    const size_t m_inputSelectionLimit;
+
+signals:
+    void selectedConsolidationRecipientSignal(SendCoinsRecipient consolidationRecipient);
+
+public slots:
+    bool filterInputsByValue(const bool& less, const CAmount& inputFilterValue, const unsigned int& inputSelectionLimit);
+
 private:
     Ui::CoinControlDialog *ui;
     WalletModel *model;
@@ -45,9 +57,14 @@ private:
     //QAction *lockAction;
     //QAction *unlockAction;
 
+    std::pair<QString, QString> m_consolidationAddress;
+    Qt::CheckState m_ToState = Qt::Checked;
+    bool m_FilterMode = true;
+
     QString strPad(QString, int, QString);
     void sortView(int, Qt::SortOrder);
     void updateView();
+    void showHideConsolidationReadyToSend();
 
     enum
     {
@@ -61,7 +78,8 @@ private:
         COLUMN_TXHASH,
         COLUMN_VOUT_INDEX,
         COLUMN_AMOUNT_INT64,
-        COLUMN_PRIORITY_INT64
+        COLUMN_PRIORITY_INT64,
+        COLUMN_CHANGE_BOOL
     };
 
 private slots:
@@ -86,6 +104,11 @@ private slots:
     void headerSectionClicked(int);
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
+    void maxMinOutputValueChanged();
+    void buttonFilterModeClicked();
+    void buttonFilterClicked();
+    void buttonConsolidateClicked();
+    void selectedConsolidationAddressSlot(std::pair<QString, QString> address);
     //void updateLabelLocked();
 };
 

--- a/src/qt/consolidateunspentdialog.cpp
+++ b/src/qt/consolidateunspentdialog.cpp
@@ -1,0 +1,83 @@
+#include "consolidateunspentdialog.h"
+#include "ui_consolidateunspentdialog.h"
+
+#include "util.h"
+
+using namespace std;
+
+ConsolidateUnspentDialog::ConsolidateUnspentDialog(QWidget *parent, size_t inputSelectionLimit) :
+    QDialog(parent),
+    ui(new Ui::ConsolidateUnspentDialog),
+    m_inputSelectionLimit(inputSelectionLimit)
+{
+    ui->setupUi(this);
+
+    ui->addressTableWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // ok button
+    connect(ui->buttonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(buttonBoxClicked(QAbstractButton*)));
+
+    // destination address selection
+    connect(ui->addressTableWidget, SIGNAL(itemSelectionChanged()), this, SLOT(addressSelectionChanged()));
+
+    ui->outputLimitWarningLabel->setText(tr("Note: The number of inputs selected for consolidation has been "
+                                                 "limited to %1 to prevent a transaction failure due to too many "
+                                                 "inputs.").arg(m_inputSelectionLimit));
+    SetOutputWarningVisible(false);
+}
+
+ConsolidateUnspentDialog::~ConsolidateUnspentDialog()
+{
+    delete ui;
+}
+
+// --------------------------------------------------------- address - label
+void ConsolidateUnspentDialog::SetAddressList(const std::map<QString, QString>& addressList)
+{
+    ui->addressTableWidget->setSortingEnabled(false);
+
+    int row = 0;
+    for (const auto& iter : addressList)
+    {
+        ui->addressTableWidget->insertRow(row);
+
+        QTableWidgetItem* label = new QTableWidgetItem(iter.second);
+        QTableWidgetItem* address = new QTableWidgetItem(iter.first);
+
+        if (label != nullptr) ui->addressTableWidget->setItem(row, 0, label);
+        if (address != nullptr) ui->addressTableWidget->setItem(row, 1, address);
+
+        ++row;
+    }
+
+    ui->addressTableWidget->setCurrentItem(ui->addressTableWidget->item(0, 1));
+}
+
+void ConsolidateUnspentDialog::SetOutputWarningVisible(bool status)
+{
+    ui->outputLimitWarningIconLabel->setVisible(status);
+    ui->outputLimitWarningLabel->setVisible(status);
+}
+
+// ok button
+void ConsolidateUnspentDialog::buttonBoxClicked(QAbstractButton* button)
+{
+    emit selectedConsolidationAddressSignal(m_selectedDestinationAddress);
+
+    // closes the dialog
+    if (ui->buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) done(QDialog::Accepted);
+}
+
+void ConsolidateUnspentDialog::addressSelectionChanged()
+{
+    int currentRow = ui->addressTableWidget->currentRow();
+
+    QTableWidgetItem* selectedLabel = ui->addressTableWidget->item(currentRow, 0);
+    QTableWidgetItem* selectedAddress = ui->addressTableWidget->item(currentRow, 1);
+
+    m_selectedDestinationAddress = std::make_pair(selectedLabel->text(), selectedAddress->text());
+
+    LogPrint(BCLog::LogFlags::MISC, "INFO: %s: Label %, Address %s selected.", __func__,
+             m_selectedDestinationAddress.first.toStdString(),
+             m_selectedDestinationAddress.second.toStdString());
+}

--- a/src/qt/consolidateunspentdialog.h
+++ b/src/qt/consolidateunspentdialog.h
@@ -1,0 +1,38 @@
+#ifndef CONSOLIDATEUNSPENTDIALOG_H
+#define CONSOLIDATEUNSPENTDIALOG_H
+
+#include <QDialogButtonBox>
+#include <QDialog>
+#include <QString>
+
+namespace Ui {
+    class ConsolidateUnspentDialog;
+}
+
+class ConsolidateUnspentDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ConsolidateUnspentDialog(QWidget *parent = 0, size_t inputSelectionLimit = 600);
+    ~ConsolidateUnspentDialog();
+
+    void SetAddressList(const std::map<QString, QString>& addressList);
+    void SetOutputWarningVisible(bool status);
+
+signals:
+    void selectedConsolidationAddressSignal(std::pair<QString, QString> address);
+
+private:
+    Ui::ConsolidateUnspentDialog *ui;
+
+    std::pair<QString, QString> m_selectedDestinationAddress;
+
+    size_t m_inputSelectionLimit;
+
+private slots:
+    void buttonBoxClicked(QAbstractButton *button);
+    void addressSelectionChanged();
+};
+
+#endif // CONSOLIDATEUNSPENTDIALOG_H

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
-    <height>500</height>
+    <width>1172</width>
+    <height>547</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -285,90 +285,149 @@
     </layout>
    </item>
    <item>
-    <widget class="QFrame" name="frame">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>40</height>
-      </size>
+    <layout class="QHBoxLayout" name="treeHorizontalLayout" stretch="0,0,0,0">
+     <property name="spacing">
+      <number>14</number>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Sunken</enum>
-     </property>
-     <widget class="QWidget" name="horizontalLayoutWidget">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>0</y>
-        <width>781</width>
-        <height>41</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0">
-       <property name="spacing">
-        <number>14</number>
+     <item>
+      <widget class="QPushButton" name="selectAllPushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <item>
-        <widget class="QPushButton" name="selectAllPushButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>(un)select all</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="treeModeRadioButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Tree &amp;mode</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="listModeRadioButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>&amp;List mode</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
+       <property name="toolTip">
+        <string>Toggles between selecting all and selecting none.</string>
+       </property>
+       <property name="text">
+        <string>Select All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="treeModeRadioButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Tree &amp;mode</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="listModeRadioButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;List mode</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="treeHorizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="filterHorizontalLayout" stretch="0,0,3,0,0,0,0">
+     <item>
+      <widget class="QLabel" name="filterLabel">
+       <property name="text">
+        <string>Select inputs</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="filterModePushButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>&lt;=</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="BitcoinAmountField" name="maxMinOutputValue">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="filterPushButton">
+       <property name="toolTip">
+        <string>Filters the already selected inputs.</string>
+       </property>
+       <property name="text">
+        <string>Filter</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="consolidateButton">
+       <property name="toolTip">
+        <string>Pushing this button after making a input selection either manually or with the filter will present a destination address list where you specify a single address as the destination for the consolidated output. The send (Pay To) entry will be filled in with this address and you can finish the consolidation by pressing the send button.</string>
+       </property>
+       <property name="text">
+        <string>Consolidate</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="consolidateSendReadyLabel">
+       <property name="toolTip">
+        <string>The consolidation transaction is ready to send to self. Please press the ok button to go to the send dialog.</string>
+       </property>
+       <property name="text">
+        <string>Ready to consolidate</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="filterHorizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="CoinControlTreeWidget" name="treeWidget">
@@ -470,6 +529,12 @@
    <class>CoinControlTreeWidget</class>
    <extends>QTreeWidget</extends>
    <header>coincontroltreewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QSpinBox</extends>
+   <header>bitcoinamountfield.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/forms/consolidateunspentdialog.ui
+++ b/src/qt/forms/consolidateunspentdialog.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConsolidateUnspentDialog</class>
+ <widget class="QDialog" name="ConsolidateUnspentDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>819</width>
+    <height>513</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Consolidate Unspent Outputs (UTXOs)</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>640</x>
+     <y>440</y>
+     <width>161</width>
+     <height>61</height>
+    </rect>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="addressTableWidgetLabel">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>30</y>
+     <width>171</width>
+     <height>221</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Select Destination Address for Consolidation</string>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="outputLimitWarningLabel">
+   <property name="geometry">
+    <rect>
+     <x>210</x>
+     <y>300</y>
+     <width>591</width>
+     <height>121</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QTableWidget" name="addressTableWidget">
+   <property name="geometry">
+    <rect>
+     <x>210</x>
+     <y>20</y>
+     <width>591</width>
+     <height>241</height>
+    </rect>
+   </property>
+   <property name="horizontalScrollBarPolicy">
+    <enum>Qt::ScrollBarAsNeeded</enum>
+   </property>
+   <property name="sizeAdjustPolicy">
+    <enum>QAbstractScrollArea::AdjustToContents</enum>
+   </property>
+   <property name="editTriggers">
+    <set>QAbstractItemView::NoEditTriggers</set>
+   </property>
+   <property name="alternatingRowColors">
+    <bool>true</bool>
+   </property>
+   <property name="horizontalScrollMode">
+    <enum>QAbstractItemView::ScrollPerPixel</enum>
+   </property>
+   <property name="columnCount">
+    <number>2</number>
+   </property>
+   <attribute name="horizontalHeaderMinimumSectionSize">
+    <number>90</number>
+   </attribute>
+   <attribute name="horizontalHeaderStretchLastSection">
+    <bool>true</bool>
+   </attribute>
+   <attribute name="verticalHeaderVisible">
+    <bool>false</bool>
+   </attribute>
+   <column>
+    <property name="text">
+     <string>Label</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Address</string>
+    </property>
+   </column>
+  </widget>
+  <widget class="QLabel" name="outputLimitWarningIconLabel">
+   <property name="geometry">
+    <rect>
+     <x>50</x>
+     <y>310</y>
+     <width>111</width>
+     <height>101</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="pixmap">
+    <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
+   </property>
+   <property name="scaledContents">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -605,3 +605,9 @@ QStatusBar QToolTip {
 #capsLabel{
     font-weight:bold;
 }
+
+/* ConsolidateUnspentDialog */
+
+#consolidateSendReadyLabel{
+    color: rgb(55, 250, 55);
+}

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -614,3 +614,9 @@ QStatusBar .QFrame QLabel {
 #capsLabel{
     font-weight:bold;
 }
+
+/* ConsolidateUnspentDialog */
+
+#consolidateSendReadyLabel{
+    color: rgb(0, 128, 0);
+}

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -2,7 +2,6 @@
 #include "ui_sendcoinsdialog.h"
 
 #include "init.h"
-#include "walletmodel.h"
 #include "addresstablemodel.h"
 #include "addressbookpage.h"
 
@@ -432,6 +431,10 @@ void SendCoinsDialog::coinControlButtonClicked()
 {
     CoinControlDialog dlg;
     dlg.setModel(model);
+
+    connect(&dlg, SIGNAL(selectedConsolidationRecipientSignal(SendCoinsRecipient)),
+            this, SLOT(selectedConsolidationRecipient(SendCoinsRecipient)));
+
     dlg.exec();
     coinControlUpdateLabels();
 }
@@ -440,6 +443,24 @@ void SendCoinsDialog::coinControlResetButtonClicked()
 {
     CoinControlDialog::coinControl->SetNull();
     coinControlUpdateLabels();
+}
+
+void SendCoinsDialog::selectedConsolidationRecipient(SendCoinsRecipient consolidationRecipient)
+{
+    ui->coinControlChangeCheckBox->setChecked(true);
+    ui->coinControlChangeEdit->setText(consolidationRecipient.address);
+
+    for (int i = ui->entries->count() - 1; i >= 0; --i)
+    {
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
+
+        if (entry)
+        {
+            removeEntry(entry);
+        }
+    }
+
+    pasteEntry(consolidationRecipient);
 }
 
 // Coin Control: checkbox custom change address

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -4,12 +4,12 @@
 #include <QDialog>
 #include <QString>
 
+#include "walletmodel.h"
+
 namespace Ui {
     class SendCoinsDialog;
 }
-class WalletModel;
 class SendCoinsEntry;
-class SendCoinsRecipient;
 
 QT_BEGIN_NAMESPACE
 class QUrl;
@@ -64,6 +64,7 @@ private slots:
     void coinControlClipboardPriority();
     void coinControlClipboardLowOutput();
     void coinControlClipboardChange();
+    void selectedConsolidationRecipient(SendCoinsRecipient consolidationRecipient);
     void updateIcons();
 };
 


### PR DESCRIPTION
This PR extends coin control to
1. Change the (un)select all button to a true select all/select none filp-flop.
2. Implement an input filter function to allow the selection of inputs either less than or equal to or greater than or equal to a provided input value, with an automatically imposed limit of 200 inputs (to prevent transaction failures).
3. Implementation of a "Consolidate" button which (re)filters the inputs and then presents a pick list to select the destination address for the consolidation, and then automatically fills in the send transaction for convenience.

What is left is the implementation of a wizard for the consolidate unspent which overlays on top of this machinery. I would like to do that in a separate PR.

Closes #1984.