### PR TITLE
gui: Set standard base Qt style on Windows and macOS

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -241,7 +241,7 @@ int main(int argc, char *argv[])
 
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#if QT_VERSION >= 0x050600 && !defined(WIN32)
+#if QT_VERSION >= 0x050600
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
@@ -263,6 +263,20 @@ int main(int argc, char *argv[])
         app.setApplicationName("Gridcoin-Qt-testnet");
     else
         app.setApplicationName("Gridcoin-Qt");
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    // Apply Qt's built-in "Fusion" theme as the application's base styles to
+    // normalize layout discrepancies between platforms and fix some high-DPI
+    // scaling issues on Windows. Gridcoin uses highly-customized stylesheets
+    // which obscure most of the platform's styles anyway. That said, respect
+    // the presence of Qt's "-style" option to bypass this if necessary. Skip
+    // the override on Linux for now so that a user's window manager Qt theme
+    // comes through for widgets without an explicit application style.
+    //
+    if (!IsArgSet("-style")) {
+        app.setStyle("Fusion");
+    }
+#endif
 
     // Install global event filter that makes sure that long tooltips can be word-wrapped
     app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));


### PR DESCRIPTION
This sets the "Fusion" Qt theme as the application's base style for Windows and macOS to normalize some minor appearance issues between the different platforms and more faithfully match the designs in #847. Fusion is the default style used for Linux for desktops without a custom window manager theme. Since Gridcoin's stylesheets override nearly all of the native styles, using a common base style can reduce headaches and maintenance overhead for cross-platform rendering differences.

From what I read, the Windows base theme still has some high-DPI issues, and the Fusion styles support high-DPI displays very well. This should close #2073 by avoiding the checkmark problem that seems to be caused by Qt resolving the legacy Windows theme instead of the "Vista" theme. It also fixes squashed input fields in the "create poll" form on Windows.

I enabled Qt's automatic high-DPI scaling feature for the Windows builds, and I don't see any issues that it causes. @jamescowens, I'd appreciate it if you could double check that because I think you noticed problems with this setting with the old styles. Interesting to note that text scales as expected, but Qt only seems to automatically scale the coordinate system at 50% scale factor intervals, so box sizing/layout spacing at...

 - 125% renders at 100%
 - 150% at 150%, 
 - 150% at 175%
 - 200% at 200%
 -  etc...