### PR TITLE
gui: Fix dark theme link text color visibility

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -143,6 +143,9 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     QPalette pal(qApp->palette());
     pal.setColor(QPalette::Base, QColor(0, 0, 0, 0));
     pal.setColor(QPalette::Mid, pal.color(QPalette::Base));
+    // Set links to a lighter shade of blue for readability in the dark theme:
+    pal.setColor(QPalette::Link, QColor(73, 144, 226));
+    pal.setColor(QPalette::LinkVisited, QColor(73, 144, 226));
     qApp->setPalette(pal);
 
     setWindowTitle(tr("Gridcoin") + " " + tr("Wallet"));


### PR DESCRIPTION
This sets the application's palette color for links to the shade of blue from #847. It improves the visibility of links when using the dark mode. We've received several complaints about this.

Before: 

![image](https://user-images.githubusercontent.com/4282384/115946705-ab37cb00-a488-11eb-9ffc-cd2b580de851.png)

After: 

![image](https://user-images.githubusercontent.com/4282384/115946626-264cb180-a488-11eb-9176-ca6af8ff7db2.png)
