### PR TITLE
util, rpc, gui: Implement GetMaxInputsForConsolidationTxn()

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -145,8 +145,3 @@ inline int GetNewbieSnapshotFixHeight()
 {
     return fTestNet ? 1480000 : 2197000;
 }
-
-inline unsigned int GetMinimumConnectionsRequiredForStaking()
-{
-    return fTestNet ? 1 : 3;
-}

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -19,6 +19,7 @@
 #include "gridcoin/staking/reward.h"
 #include "gridcoin/staking/status.h"
 #include "gridcoin/tally.h"
+#include "policy/policy.h"
 #include "policy/fees.h"
 #include "util.h"
 #include "validation.h"

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -175,3 +175,14 @@ bool AreInputsStandard(const CTransaction& tx, const MapPrevTx& mapInputs)
 
     return true;
 }
+
+unsigned int GetMinimumConnectionsRequiredForStaking()
+{
+    return fTestNet ? 1 : 3;
+}
+
+unsigned int GetMaxInputsForConsolidationTxn()
+{
+    return (unsigned int) 600;
+}
+

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -23,4 +23,19 @@ bool IsStandardTx(const CTransaction& tx);
 */
 bool AreInputsStandard(const CTransaction& tx, const MapPrevTx& mapInputs);
 
+//!
+//! \brief Gets the minimum number of connections required for a wallet to stake.
+//!
+//! \return unsigned int minimum number of connections to stake
+//!
+unsigned int GetMinimumConnectionsRequiredForStaking();
+
+//!
+//! \brief Gets the maximum number of inputs supported for a UTXO consolidation transaction to ensure
+//! the transaction does not exceed the maximum size and fail as a result.
+//!
+//! \return unsigned int maximum number of consolidation inputs.
+//!
+unsigned int GetMaxInputsForConsolidationTxn();
+
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -5,6 +5,7 @@
 #include "bitcoinunits.h"
 #include "addresstablemodel.h"
 #include "optionsmodel.h"
+#include "policy/policy.h"
 #include "policy/fees.h"
 #include "validation.h"
 #include "wallet/coincontrol.h"
@@ -29,7 +30,7 @@ CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
 
 CoinControlDialog::CoinControlDialog(QWidget *parent) :
     QDialog(parent),
-    m_inputSelectionLimit(600),
+    m_inputSelectionLimit(GetMaxInputsForConsolidationTxn()),
     ui(new Ui::CoinControlDialog),
     model(0)
 {


### PR DESCRIPTION
This implements a chain parameter function to get the maximum number of inputs allowable for a UTXO consolidation transaction with either the RPC consolidateunspent or the GUI "consolidate" button in coin control, which has been set at 600.

The default value for the RPC consolidateunspent function has been changed to be the same as the upper clamp at the value returned by GetMaxInputsForConsolidationTxn(). The help returned for consolidateunspent uses that value as well.

Note that the original values for the consolidateunspent transaction output count limit were a default of 50 and a maximum of 200. The default was based on performance of the consolidateunspent on a GUI version of the wallet on low powered ARM devices and the upper clamp value on the concern about transaction failures due to to too large a transaction. Based on the GUI performance improvements I did which were merged a while back to improve the performance of the wallet when updating the GUI from the core, and a review of transaction size limits, we determined that a default and max of 600 is good.