### PR TITLE
gui: Implement consolidateunspent wizard

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -75,6 +75,10 @@ QT_FORMS_UI = \
   qt/forms/aboutdialog.ui \
   qt/forms/coincontroldialog.ui \
   qt/forms/consolidateunspentdialog.ui \
+  qt/forms/consolidateunspentwizard.ui \
+  qt/forms/consolidateunspentwizardselectdestinationpage.ui \
+  qt/forms/consolidateunspentwizardselectinputspage.ui \
+  qt/forms/consolidateunspentwizardsendpage.ui \
   qt/forms/diagnosticsdialog.ui \
   qt/forms/optionsdialog.ui \
   qt/forms/rpcconsole.ui \
@@ -113,6 +117,10 @@ QT_MOC_CPP = \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
   qt/moc_consolidateunspentdialog.cpp \
+  qt/moc_consolidateunspentwizard.cpp \
+  qt/moc_consolidateunspentwizardselectdestinationpage.cpp \
+  qt/moc_consolidateunspentwizardselectinputspage.cpp \
+  qt/moc_consolidateunspentwizardsendpage.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_diagnosticsdialog.cpp \
   qt/moc_editaddressdialog.cpp \
@@ -184,6 +192,10 @@ GRIDCOINRESEARCH_QT_H = \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \
   qt/consolidateunspentdialog.h \
+  qt/consolidateunspentwizard.h \
+  qt/consolidateunspentwizardselectdestinationpage.h \
+  qt/consolidateunspentwizardselectinputspage.h \
+  qt/consolidateunspentwizardsendpage.h \
   qt/csvmodelwriter.h \
   qt/decoration.h \
   qt/diagnosticsdialog.h \
@@ -247,6 +259,10 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/coincontroldialog.cpp \
   qt/coincontroltreewidget.cpp \
   qt/consolidateunspentdialog.cpp \
+  qt/consolidateunspentwizard.cpp \
+  qt/consolidateunspentwizardselectdestinationpage.cpp \
+  qt/consolidateunspentwizardselectinputspage.cpp \
+  qt/consolidateunspentwizardsendpage.cpp \
   qt/csvmodelwriter.cpp \
   qt/decoration.cpp \
   qt/diagnosticsdialog.cpp \

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -24,17 +24,16 @@ class CoinControlDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CoinControlDialog(QWidget *parent = 0);
+    explicit CoinControlDialog(QWidget *parent = 0,
+                               CCoinControl *coinControl = nullptr,
+                               QList<qint64> *payAmounts = nullptr);
     ~CoinControlDialog();
 
     void setModel(WalletModel *model);
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, QDialog*);
+    static void updateLabels(WalletModel*, CCoinControl*, QList<qint64>*, QDialog*);
     static QString getPriorityLabel(double);
-
-    static QList<qint64> payAmounts;
-    static CCoinControl *coinControl;
 
     // This is based on what will guarantee a successful transaction.
     const size_t m_inputSelectionLimit;
@@ -47,6 +46,8 @@ public slots:
 
 private:
     Ui::CoinControlDialog *ui;
+    CCoinControl *coinControl;
+    QList<qint64> *payAmounts;
     WalletModel *model;
     int sortColumn;
     Qt::SortOrder sortOrder;

--- a/src/qt/consolidateunspentdialog.h
+++ b/src/qt/consolidateunspentdialog.h
@@ -14,7 +14,7 @@ class ConsolidateUnspentDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ConsolidateUnspentDialog(QWidget *parent = 0, size_t inputSelectionLimit = 600);
+    explicit ConsolidateUnspentDialog(QWidget *parent = nullptr, size_t inputSelectionLimit = 600);
     ~ConsolidateUnspentDialog();
 
     void SetAddressList(const std::map<QString, QString>& addressList);

--- a/src/qt/consolidateunspentwizard.cpp
+++ b/src/qt/consolidateunspentwizard.cpp
@@ -1,0 +1,50 @@
+#include "coincontroldialog.h"
+#include "consolidateunspentwizard.h"
+#include "consolidateunspentdialog.h"
+#include "ui_consolidateunspentwizard.h"
+
+#include "util.h"
+
+
+ConsolidateUnspentWizard::ConsolidateUnspentWizard(QWidget *parent,
+                                                   CCoinControl *coinControl,
+                                                   QList<qint64> *payAmounts) :
+    QWizard(parent),
+    ui(new Ui::ConsolidateUnspentWizard),
+    coinControl(coinControl),
+    payAmounts(payAmounts)
+{
+    ui->setupUi(this);
+    this->setStartId(SelectInputsPage);
+
+    ui->selectInputsPage->setCoinControl(coinControl);
+    ui->selectInputsPage->setPayAmounts(payAmounts);
+
+    connect(ui->selectInputsPage, SIGNAL(setAddressListSignal(std::map<QString, QString>)),
+            ui->selectDestinationPage, SLOT(SetAddressList(const std::map<QString, QString>)));
+
+    connect(ui->selectInputsPage, SIGNAL(setDefaultAddressSignal(QString)),
+            ui->selectDestinationPage, SLOT(setDefaultAddressSelection(QString)));
+
+    connect(this->button(QWizard::FinishButton), SIGNAL(clicked()), ui->sendPage, SLOT(onFinishButtonClicked()));
+    connect(ui->sendPage, SIGNAL(selectedConsolidationRecipientSignal(SendCoinsRecipient)),
+            this, SIGNAL(selectedConsolidationRecipientSignal(SendCoinsRecipient)));
+}
+
+ConsolidateUnspentWizard::~ConsolidateUnspentWizard()
+{
+    delete ui;
+}
+
+void ConsolidateUnspentWizard::accept()
+{
+    QDialog::accept();
+}
+
+void ConsolidateUnspentWizard::setModel(WalletModel *model)
+{
+    this->model = model;
+
+    ui->selectInputsPage->setModel(model);
+    ui->sendPage->setModel(model);
+}

--- a/src/qt/consolidateunspentwizard.h
+++ b/src/qt/consolidateunspentwizard.h
@@ -1,0 +1,51 @@
+#ifndef CONSOLIDATEUNSPENTWIZARD_H
+#define CONSOLIDATEUNSPENTWIZARD_H
+
+#include "walletmodel.h"
+
+#include <QDialogButtonBox>
+#include <QDialog>
+#include <QWizard>
+#include <QString>
+#include <QLabel>
+
+namespace Ui {
+    class ConsolidateUnspentWizard;
+}
+
+class CoinControlDialog;
+
+class ConsolidateUnspentWizard : public QWizard
+{
+    Q_OBJECT
+
+public:
+    enum Pages
+    {
+        SelectInputsPage,
+        SelectDestinationPage,
+        SendPage
+    };
+
+    explicit ConsolidateUnspentWizard(QWidget *parent = nullptr,
+                                      CCoinControl *coinControl = nullptr,
+                                      QList<qint64> *payAmounts = nullptr);
+    ~ConsolidateUnspentWizard();
+
+    void setModel(WalletModel *model);
+
+    void accept() override;
+
+signals:
+    void passCoinControlSignal(CCoinControl*);
+    void selectedConsolidationRecipientSignal(SendCoinsRecipient);
+    void sendConsolidationTransactionSignal();
+
+private:
+    Ui::ConsolidateUnspentWizard *ui;
+    CCoinControl *coinControl;
+    QList<qint64> *payAmounts;
+    WalletModel *model;
+};
+
+#endif // CONSOLIDATEUNSPENTWIZARD_H

--- a/src/qt/consolidateunspentwizardselectdestinationpage.cpp
+++ b/src/qt/consolidateunspentwizardselectdestinationpage.cpp
@@ -1,0 +1,132 @@
+#include "consolidateunspentwizardselectdestinationpage.h"
+#include "ui_consolidateunspentwizardselectdestinationpage.h"
+
+#include "util.h"
+
+ConsolidateUnspentWizardSelectDestinationPage::ConsolidateUnspentWizardSelectDestinationPage(QWidget *parent) :
+    QWizardPage(parent),
+    ui(new Ui::ConsolidateUnspentWizardSelectDestinationPage)
+{
+    ui->setupUi(this);
+
+    ui->addressTableWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // destination address selection
+    connect(ui->addressTableWidget, SIGNAL(itemSelectionChanged()), this, SLOT(addressSelectionChanged()));
+
+    ui->isCompleteCheckBox->hide();
+
+    // This is to provide a convenient way to populate the fields shown on the last page ("send" screen).
+    registerField("selectedAddressLabelField", ui->selectedAddressLabel, "text", "updateFieldsSignal()");
+    registerField("selectedAddressField", ui->selectedAddress, "text", "updateFieldsSignal()");
+
+    //This is used to control the disable/enable of the next button on this page.
+    registerField("isCompleteSelectDestination*", ui->isCompleteCheckBox);
+}
+
+ConsolidateUnspentWizardSelectDestinationPage::~ConsolidateUnspentWizardSelectDestinationPage()
+{
+    delete ui;
+}
+
+void ConsolidateUnspentWizardSelectDestinationPage::initializePage()
+{
+    // This fills the selected address fields out again if this page is reaccessed by back and then next
+    // from the select inputs page without any changes.
+    if (m_selectedDestinationAddress.first.size())
+    {
+        ui->selectedAddressLabel->setText(m_selectedDestinationAddress.first);
+        ui->selectedAddress->setText(m_selectedDestinationAddress.second);
+
+        ui->isCompleteCheckBox->setChecked(true);
+    }
+}
+
+// ----------------------------------------------------------------------- address - label
+void ConsolidateUnspentWizardSelectDestinationPage::SetAddressList(std::map<QString, QString> addressList)
+{
+    ui->addressTableWidget->setSortingEnabled(false);
+
+    ui->addressTableWidget->setRowCount(addressList.size());
+
+    int row = 0;
+    for (const auto& iter : addressList)
+    {
+        QTableWidgetItem* label = new QTableWidgetItem(iter.second);
+        QTableWidgetItem* address = new QTableWidgetItem(iter.first);
+
+        if (label != nullptr) ui->addressTableWidget->setItem(row, 0, label);
+        if (address != nullptr) ui->addressTableWidget->setItem(row, 1, address);
+
+        ++row;
+    }
+
+    ui->addressTableWidget->setSortingEnabled(true);
+}
+
+void ConsolidateUnspentWizardSelectDestinationPage::setDefaultAddressSelection(QString address)
+{
+    if (!address.size())
+    {
+        ui->addressTableWidget->clearSelection();
+
+        m_selectedDestinationAddress = {};
+
+        LogPrint(BCLog::LogFlags::QT, "INFO: %s: Cleared (default) address selection", __func__);
+
+        ui->isCompleteCheckBox->setChecked(false);
+
+        return;
+    }
+
+    QList<QTableWidgetItem*> defaultAddress = ui->addressTableWidget->findItems(address, Qt::MatchExactly);
+
+    defaultAddress[0]->setSelected(true);
+
+    LogPrint(BCLog::LogFlags::QT, "INFO: %s: Set default address to %s, QTableWidgetItem %s",
+              __func__,
+              address.toStdString(),
+              defaultAddress[0]->text().toStdString());
+
+    ui->addressTableWidget->setCurrentItem(defaultAddress[0]);
+
+    LogPrintf("INFO: %s: currentRow = %i", __func__, ui->addressTableWidget->currentRow());
+
+    emit updateFieldsSignal();
+}
+
+void ConsolidateUnspentWizardSelectDestinationPage::addressSelectionChanged()
+{
+
+    if (!ui->addressTableWidget->selectedItems().size())
+    {
+        ui->selectedAddressLabel->setText(QString());
+        ui->selectedAddress->setText(QString());
+
+        ui->isCompleteCheckBox->setChecked(false);
+
+        return;
+    }
+
+    ui->addressTableWidget->selectedItems()[0]->row();
+
+    int selectedRow = ui->addressTableWidget->selectedItems()[0]->row();
+
+    if (selectedRow < 0) return;
+
+    QTableWidgetItem* selectedLabel = ui->addressTableWidget->item(selectedRow, 0);
+    QTableWidgetItem* selectedAddress = ui->addressTableWidget->item(selectedRow, 1);
+
+    ui->selectedAddressLabel->setText(selectedLabel->text());
+    ui->selectedAddress->setText(selectedAddress->text());
+
+    m_selectedDestinationAddress = std::make_pair(selectedLabel->text(), selectedAddress->text());
+
+    LogPrint(BCLog::LogFlags::QT, "INFO: %s: Label %, Address %s selected.", __func__,
+             m_selectedDestinationAddress.first.toStdString(),
+             m_selectedDestinationAddress.second.toStdString());
+
+    ui->isCompleteCheckBox->setChecked(true);
+
+    emit updateFieldsSignal();
+}

--- a/src/qt/consolidateunspentwizardselectdestinationpage.h
+++ b/src/qt/consolidateunspentwizardselectdestinationpage.h
@@ -1,0 +1,36 @@
+#ifndef CONSOLIDATEUNSPENTWIZARDSELECTDESTINATIONPAGE_H
+#define CONSOLIDATEUNSPENTWIZARDSELECTDESTINATIONPAGE_H
+
+#include <QWizard>
+
+namespace Ui {
+    class ConsolidateUnspentWizardSelectDestinationPage;
+}
+
+class ConsolidateUnspentWizardSelectDestinationPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ConsolidateUnspentWizardSelectDestinationPage(QWidget *parent = nullptr);
+    ~ConsolidateUnspentWizardSelectDestinationPage();
+
+    void initializePage();
+
+signals:
+    void updateFieldsSignal();
+
+public slots:
+    void SetAddressList(std::map<QString, QString> addressList);
+    void setDefaultAddressSelection(QString address);
+
+private:
+    Ui::ConsolidateUnspentWizardSelectDestinationPage *ui;
+
+    std::pair<QString, QString> m_selectedDestinationAddress;
+
+private slots:
+    void addressSelectionChanged();
+};
+
+#endif // CONSOLIDATEUNSPENTWIZARDSELECTDESTINATIONPAGE_H

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -1,0 +1,719 @@
+#include "coincontroldialog.h"
+#include "consolidateunspentwizardselectinputspage.h"
+#include "ui_consolidateunspentwizardselectinputspage.h"
+
+#include "init.h"
+#include "bitcoinunits.h"
+#include "addresstablemodel.h"
+#include "optionsmodel.h"
+#include "policy/policy.h"
+#include "policy/fees.h"
+#include "validation.h"
+#include "wallet/coincontrol.h"
+#include "consolidateunspentdialog.h"
+
+using namespace std;
+
+ConsolidateUnspentWizardSelectInputsPage::ConsolidateUnspentWizardSelectInputsPage(QWidget *parent) :
+    QWizardPage(parent),
+    ui(new Ui::ConsolidateUnspentWizardSelectInputsPage)
+{
+    m_InputSelectionLimit = GetMaxInputsForConsolidationTxn();
+
+    ui->setupUi(this);
+
+    // toggle tree/list mode
+    connect(ui->treeModeRadioButton, SIGNAL(toggled(bool)), this, SLOT(treeModeRadioButton(bool)));
+    connect(ui->listModeRadioButton, SIGNAL(toggled(bool)), this, SLOT(listModeRadioButton(bool)));
+
+    // click on checkbox
+    connect(ui->treeWidget, SIGNAL(itemChanged(QTreeWidgetItem*, int)), this, SLOT(viewItemChanged(QTreeWidgetItem*, int)));
+
+    // click on header
+    ui->treeWidget->header()->setSectionsClickable(true);
+    connect(ui->treeWidget->header(), SIGNAL(sectionClicked(int)), this, SLOT(headerSectionClicked(int)));
+
+    // (un)select all
+    connect(ui->selectAllPushButton, SIGNAL(clicked()), this, SLOT(buttonSelectAllClicked()));
+
+    // filter/consolidate button interaction
+    connect(ui->maxMinOutputValue, SIGNAL(textChanged()), this, SLOT(maxMinOutputValueChanged()));
+
+    // filter mode
+    connect(ui->filterModePushButton, SIGNAL(clicked()), this, SLOT(buttonFilterModeClicked()));
+
+    // filter
+    connect(ui->filterPushButton, SIGNAL(clicked()), this, SLOT(buttonFilterClicked()));
+
+    ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 150);
+    ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 170);
+    ui->treeWidget->setColumnWidth(COLUMN_LABEL, 200);
+    ui->treeWidget->setColumnWidth(COLUMN_ADDRESS, 290);
+    ui->treeWidget->setColumnWidth(COLUMN_DATE, 110);
+    ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 100);
+    ui->treeWidget->setColumnWidth(COLUMN_PRIORITY, 100);
+    ui->treeWidget->setColumnHidden(COLUMN_TXHASH, true);         // store transacton hash in this column, but don't show it
+    ui->treeWidget->setColumnHidden(COLUMN_VOUT_INDEX, true);     // store vout index in this column, but don't show it
+    ui->treeWidget->setColumnHidden(COLUMN_AMOUNT_INT64, true);   // store amount int64_t in this column, but don't show it
+    ui->treeWidget->setColumnHidden(COLUMN_PRIORITY_INT64, true); // store priority int64_t in this column, but don't show it
+    ui->treeWidget->setColumnHidden(COLUMN_CHANGE_BOOL, true);    // store change flag but don't show it
+
+    // This is to provide a convenient way to populate the fields shown on the last page ("send" screen).
+    registerField("quantityField", ui->quantityLabel, "text", "updateFieldsSignal()");
+    registerField("feeField", ui->feeLabel, "text", "updateFieldsSignal()");
+    registerField("afterFeeAmountField", ui->afterFeeLabel, "text", "updateFieldsSignal()");
+
+    //This is used to control the disable/enable of the next button on this page.
+    registerField("isCompleteSelectInputs*", ui->isCompleteCheckBox);
+
+    // default view is sorted by amount desc
+    sortView(COLUMN_AMOUNT_INT64, Qt::DescendingOrder);
+
+    ui->outputLimitWarningIconLabel->setToolTip(tr("Note: The number of inputs selected for consolidation has been "
+                                                 "limited to %1 to prevent a transaction failure due to too many "
+                                                 "inputs.").arg(m_InputSelectionLimit));
+    ui->outputLimitStopIconLabel->setToolTip(tr("Note: The number of inputs selected for consolidation is currently more "
+                                                 "than the limit of %1. Please use the filter or manual selection to reduce "
+                                                "the number of inputs to %1 or less to prevent a transaction failure due to "
+                                                "too many inputs.").arg(m_InputSelectionLimit));
+
+    ui->outputLimitWarningIconLabel->setVisible(false);
+    ui->outputLimitStopIconLabel->setVisible(false);
+
+    ui->isCompleteCheckBox->hide();
+}
+
+ConsolidateUnspentWizardSelectInputsPage::~ConsolidateUnspentWizardSelectInputsPage()
+{
+    delete ui;
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::setModel(WalletModel *model)
+{
+    this->model = model;
+
+    if (model && model->getOptionsModel() && model->getAddressTableModel() && coinControl != nullptr)
+    {
+        updateView();
+        updateLabels();
+    }
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::setCoinControl(CCoinControl *coinControl)
+{
+    this->coinControl = coinControl;
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::setPayAmounts(QList<qint64> *payAmounts)
+{
+    this->payAmounts = payAmounts;
+}
+
+// helper function str_pad
+QString ConsolidateUnspentWizardSelectInputsPage::strPad(QString s, int nPadLength, QString sPadding)
+{
+    while (s.length() < nPadLength)
+        s = sPadding + s;
+
+    return s;
+}
+
+// (un)select all
+void ConsolidateUnspentWizardSelectInputsPage::buttonSelectAllClicked()
+{
+    m_InputSelectionLimitedByFilter = false;
+
+    ui->treeWidget->setEnabled(false);
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++)
+            if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != m_ToState)
+                ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, m_ToState);
+    ui->treeWidget->setEnabled(true);
+
+    if (m_ToState == Qt::Checked)
+    {
+        m_ToState = Qt::Unchecked;
+    }
+    else
+    {
+        m_ToState = Qt::Checked;
+    }
+
+    if (m_ToState == Qt::Checked)
+    {
+       ui->selectAllPushButton->setText("Select All");
+    }
+    else
+    {
+       ui->selectAllPushButton->setText("Select None");
+    }
+
+    updateLabels();
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::maxMinOutputValueChanged()
+{
+    ui->maxMinOutputValue->value(&m_FilterValueValid);
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::buttonFilterModeClicked()
+{
+    if (m_FilterMode)
+    {
+        m_FilterMode = false;
+        ui->filterModePushButton->setText(">=");
+    }
+    else
+    {
+        m_FilterMode = true;
+        ui->filterModePushButton->setText("<=");
+    }
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::buttonFilterClicked()
+{
+    m_ViewItemsChangedViaFilter = true;
+
+    m_InputSelectionLimitedByFilter = filterInputsByValue(m_FilterMode, ui->maxMinOutputValue->value(), m_InputSelectionLimit);
+
+    updateLabels();
+
+    m_ViewItemsChangedViaFilter = false;
+}
+
+bool ConsolidateUnspentWizardSelectInputsPage::filterInputsByValue(const bool& less, const CAmount& inputFilterValue,
+                                            const unsigned int& inputSelectionLimit)
+{
+
+    // Disable generating update signals unnecessarily during this filter operation.
+    ui->treeWidget->setEnabled(false);
+
+    QTreeWidgetItemIterator iter(ui->treeWidget);
+
+    // If less is true, then we are choosing the smallest inputs upward, and so the map comparator needs to be "less than".
+    // If less is false, then we are choosing the largest inputs downward, and so the map comparator needs to be "greater
+    // than".
+    auto comp = [less](CAmount a, CAmount b)
+    {
+        if (less)
+        {
+            return (a < b);
+        }
+        else
+        {
+            return (a > b);
+        }
+    };
+
+    std::multimap<CAmount, std::pair<QTreeWidgetItem*, COutPoint>, decltype(comp)> input_map(comp);
+
+    bool culled_inputs = false;
+
+    while (*iter)
+    {
+        CAmount input_value = (*iter)->text(COLUMN_AMOUNT_INT64).toLongLong();
+        COutPoint outpoint(uint256S((*iter)->text(COLUMN_TXHASH).toStdString()), (*iter)->text(COLUMN_VOUT_INDEX).toUInt());
+
+        if ((*iter)->checkState(COLUMN_CHECKBOX) == Qt::Checked)
+        {
+            if ((*iter)->text(COLUMN_TXHASH).length() == 64)
+            {
+                if ((less && input_value <= inputFilterValue) || (!less && input_value >= inputFilterValue))
+                {
+                    input_map.insert(std::make_pair(input_value, std::make_pair(*iter, outpoint)));
+                }
+                else
+                {
+                    (*iter)->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+                    coinControl->UnSelect(outpoint);
+                }
+            }
+        }
+
+        ++iter;
+    }
+
+    // The second loop is to limit the number of selected outputs to the inputCountLimit.
+    unsigned int input_count = 0;
+
+    for (auto& input : input_map)
+    {
+        if (input_count >= inputSelectionLimit)
+        {
+            LogPrint(BCLog::LogFlags::QT, "INFO: %s: Culled input %u with value %f.",
+                     __func__, input_count, (double) input.first / COIN);
+
+            if (coinControl->IsSelected(input.second.second.hash, input.second.second.n))
+            {
+                input.second.first->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+
+                culled_inputs = true;
+                coinControl->UnSelect(input.second.second);
+            }
+        }
+
+        ++input_count;
+    }
+
+    // Reenable update signals.
+    ui->treeWidget->setEnabled(true);
+
+    // If the number of inputs selected was limited, then true is returned.
+    return culled_inputs;
+}
+
+// treeview: sort
+void ConsolidateUnspentWizardSelectInputsPage::sortView(int column, Qt::SortOrder order)
+{
+    sortColumn = column;
+    sortOrder = order;
+    ui->treeWidget->sortItems(column, order);
+    ui->treeWidget->header()->setSortIndicator((sortColumn == COLUMN_AMOUNT_INT64 ?
+                                                    COLUMN_AMOUNT : (sortColumn == COLUMN_PRIORITY_INT64 ?
+                                                                         COLUMN_PRIORITY : sortColumn)),
+                                               sortOrder);
+}
+
+// treeview: clicked on header
+void ConsolidateUnspentWizardSelectInputsPage::headerSectionClicked(int logicalIndex)
+{
+    if (logicalIndex == COLUMN_CHECKBOX) // click on most left column -> do nothing
+    {
+        ui->treeWidget->header()->setSortIndicator((sortColumn == COLUMN_AMOUNT_INT64 ?
+                                                        COLUMN_AMOUNT : (sortColumn == COLUMN_PRIORITY_INT64 ?
+                                                                             COLUMN_PRIORITY : sortColumn)),
+                                                   sortOrder);
+    }
+    else
+    {
+        if (logicalIndex == COLUMN_AMOUNT) // sort by amount
+            logicalIndex = COLUMN_AMOUNT_INT64;
+
+        if (logicalIndex == COLUMN_PRIORITY) // sort by priority
+            logicalIndex = COLUMN_PRIORITY_INT64;
+
+        if (sortColumn == logicalIndex)
+            sortOrder = ((sortOrder == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder);
+        else
+        {
+            sortColumn = logicalIndex;
+
+            // if amount,date,conf,priority then default => desc, else default => asc
+            sortOrder = ((sortColumn == COLUMN_AMOUNT_INT64 || sortColumn == COLUMN_PRIORITY_INT64
+                          || sortColumn == COLUMN_DATE || sortColumn == COLUMN_CONFIRMATIONS) ?
+                             Qt::DescendingOrder : Qt::AscendingOrder);
+        }
+
+        sortView(sortColumn, sortOrder);
+    }
+}
+
+
+// toggle tree mode
+void ConsolidateUnspentWizardSelectInputsPage::treeModeRadioButton(bool checked)
+{
+    if (checked && model)
+        updateView();
+}
+
+// toggle list mode
+void ConsolidateUnspentWizardSelectInputsPage::listModeRadioButton(bool checked)
+{
+    if (checked && model)
+        updateView();
+}
+
+// checkbox clicked by user
+void ConsolidateUnspentWizardSelectInputsPage::viewItemChanged(QTreeWidgetItem* item, int column)
+{
+    if (!m_ViewItemsChangedViaFilter) m_InputSelectionLimitedByFilter = false;
+
+    if (column == COLUMN_CHECKBOX)
+    {
+        // transaction hash is 64 characters (this means its a child node, so its not a parent node in tree mode)
+        if (item->text(COLUMN_TXHASH).length() == 64)
+        {
+            COutPoint outpt(uint256S(item->text(COLUMN_TXHASH).toStdString()), item->text(COLUMN_VOUT_INDEX).toUInt());
+
+            if (item->checkState(COLUMN_CHECKBOX) == Qt::Unchecked)
+            {
+                coinControl->UnSelect(outpt);
+            }
+            else if (item->isDisabled()) // locked (this happens if "check all" through parent node)
+            {
+                item->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+            }
+            else
+            {
+                coinControl->Select(outpt);
+            }
+        }
+
+        // selection changed -> update labels
+        if (ui->treeWidget->isEnabled())
+        {
+            // do not update on every click for (un)select all
+            updateLabels();
+        }
+    }
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::updateLabels()
+{
+    if (!model) return;
+
+    // nPayAmount
+    qint64 nPayAmount = 0;
+    CTransaction txDummy;
+    for (const auto& amount: *payAmounts)
+    {
+        nPayAmount += amount;
+
+        if (amount > 0)
+        {
+            CTxOut txout(amount, (CScript)vector<unsigned char>(24, 0));
+            txDummy.vout.push_back(txout);
+        }
+    }
+
+    QString sPriorityLabel = QString();
+    int64_t nAmount = 0;
+    int64_t nPayFee = 0;
+    int64_t nAfterFee = 0;
+    int64_t nChange = 0;
+    unsigned int nBytes = 0;
+    unsigned int nBytesInputs = 0;
+    unsigned int nQuantity = 0;
+
+    vector<COutPoint> vCoinControl;
+    vector<COutput> vOutputs;
+    coinControl->ListSelected(vCoinControl);
+    model->getOutputs(vCoinControl, vOutputs);
+
+    for (const auto& out : vOutputs)
+    {
+        // Quantity
+        nQuantity++;
+
+        // Amount
+        nAmount += out.tx->vout[out.i].nValue;
+
+        // Bytes
+        CTxDestination address;
+        if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address))
+        {
+            CPubKey pubkey;
+            try {
+                if (model->getPubKey(std::get<CKeyID>(address), pubkey))
+                    nBytesInputs += (pubkey.IsCompressed() ? 148 : 180);
+                else
+                    nBytesInputs += 148; // in all error cases, simply assume 148 here
+            } catch (const std::bad_variant_access&) {
+                nBytesInputs += 148;
+            }
+        }
+        else nBytesInputs += 148;
+    }
+
+    // calculation
+    if (nQuantity > 0)
+    {
+        // Bytes - always assume +1 output for change here
+        nBytes = nBytesInputs + ((payAmounts->size() > 0 ? payAmounts->size() + 1 : 2) * 34) + 10;
+
+        // Fee
+        int64_t nFee = nTransactionFee * (1 + (int64_t)nBytes / 1000);
+
+        // Min Fee
+        int64_t nMinFee = GetMinFee(txDummy, 1000, GMF_SEND, nBytes);
+
+        nPayFee = max(nFee, nMinFee);
+
+        if (nPayAmount > 0)
+        {
+            nChange = nAmount - nPayFee - nPayAmount;
+
+            // if sub-cent change is required, the fee must be raised to at least CTransaction::nMinTxFee
+            if (nPayFee < CENT && nChange > 0 && nChange < CENT)
+            {
+                if (nChange < CENT) // change < 0.01 => simply move all change to fees
+                {
+                    nPayFee = nChange;
+                    nChange = 0;
+                }
+                else
+                {
+                    nChange = nChange + nPayFee - CENT;
+                    nPayFee = CENT;
+                }
+            }
+
+            if (nChange == 0) nBytes -= 34;
+        }
+
+        // after fee
+        nAfterFee = nAmount - nPayFee;
+        if (nAfterFee < 0) nAfterFee = 0;
+    }
+
+    // actually update labels
+    int nDisplayUnit = BitcoinUnits::BTC;
+    if (model && model->getOptionsModel()) nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
+
+    // stats
+    ui->quantityLabel->setText(QString::number(nQuantity));                            // Quantity
+    ui->feeLabel->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nPayFee));        // Fee
+    ui->afterFeeLabel->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAfterFee)); // After Fee
+
+    std::map<QString, QString> addressList;
+    QString defaultAddress;
+    unsigned int numberAddressesWhereOutputsChecked = 0;
+
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i)
+    {
+        QString label = ui->treeWidget->topLevelItem(i)->text(COLUMN_LABEL);
+        QString address = ui->treeWidget->topLevelItem(i)->text(COLUMN_ADDRESS);
+        QString change = ui->treeWidget-> topLevelItem(i)->text(COLUMN_CHANGE_BOOL);
+
+        Qt::CheckState state = ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX);
+
+        // If a not unchecked top level item is not a change address and it results in an insert into the m_AddressList
+        if (!change.toInt() && addressList.insert(std::make_pair(address, label)).second)
+        {
+            if (state == Qt::Checked || state == Qt::PartiallyChecked)
+            {
+                defaultAddress = label;
+
+                ++numberAddressesWhereOutputsChecked;
+            }
+        }
+    }
+
+    if (!addressList.empty()) emit setAddressListSignal(addressList);
+
+    // This covers the 0 case too, where the default address will be an empty QString.
+    if (numberAddressesWhereOutputsChecked < 2)
+    {
+        // This will be an empty QString if the numberAddressesWhereOutputsChecked equals 0. It will be
+        // the above defaultAddress if numberAddressesWhereOutputsChecked equals 1.
+        emit setDefaultAddressSignal(defaultAddress);
+    }
+    else
+    {
+        // If numberAddressesWhereOutputsChecked is 2 or greater, then clear the default address (i.e. set to
+        // empty QString.
+        emit setDefaultAddressSignal(QString());
+    }
+
+    // This provids the trigger to update the fields from the labels, since they are QLabels and don't have appropriate
+    // internal signals.
+    emit updateFieldsSignal();
+
+    if (nQuantity < 2)
+    {
+        SetOutputWarningStop(InputStatus::INSUFFICIENT_OUTPUTS);
+    }
+    else if (nQuantity < m_InputSelectionLimit
+             || (nQuantity == m_InputSelectionLimit && !m_InputSelectionLimitedByFilter))
+    {
+        SetOutputWarningStop(InputStatus::NORMAL);
+    }
+    else if (nQuantity == m_InputSelectionLimit && m_InputSelectionLimitedByFilter)
+    {
+        SetOutputWarningStop(InputStatus::WARNING);
+    }
+    else if (nQuantity > m_InputSelectionLimit)
+    {
+        SetOutputWarningStop(InputStatus::STOP);
+    }
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::updateView()
+{
+    bool treeMode = ui->treeModeRadioButton->isChecked();
+
+    ui->treeWidget->clear();
+    ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox
+    ui->treeWidget->setAlternatingRowColors(!treeMode);
+    QFlags<Qt::ItemFlag> flgCheckbox=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
+    QFlags<Qt::ItemFlag> flgTristate=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
+
+    int nDisplayUnit = BitcoinUnits::BTC;
+
+    if (model && model->getOptionsModel())
+    {
+        nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
+    }
+
+    map<QString, vector<COutput>> mapCoins;
+    model->listCoins(mapCoins);
+
+    for (auto const& coins : mapCoins)
+    {
+        QTreeWidgetItem *itemWalletAddress = new QTreeWidgetItem();
+        QString sWalletAddress = coins.first;
+        QString sWalletLabel = "";
+        if (model->getAddressTableModel())
+            sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
+        if (sWalletLabel.length() == 0)
+            sWalletLabel = tr("(no label)");
+
+        if (treeMode)
+        {
+            // wallet address
+            ui->treeWidget->addTopLevelItem(itemWalletAddress);
+
+            itemWalletAddress->setFlags(flgTristate);
+            itemWalletAddress->setCheckState(COLUMN_CHECKBOX,Qt::Unchecked);
+
+            // label
+            itemWalletAddress->setText(COLUMN_LABEL, sWalletLabel);
+
+            // address
+            itemWalletAddress->setText(COLUMN_ADDRESS, sWalletAddress);
+        }
+
+        int64_t nSum = 0;
+        double dPrioritySum = 0;
+        int nChildren = 0;
+        int nInputSum = 0;
+
+        for (auto const& out : coins.second)
+        {
+            int nInputSize = 148; // 180 if uncompressed public key
+            nSum += out.tx->vout[out.i].nValue;
+            nChildren++;
+
+            QTreeWidgetItem *itemOutput;
+            if (treeMode)    itemOutput = new QTreeWidgetItem(itemWalletAddress);
+            else             itemOutput = new QTreeWidgetItem(ui->treeWidget);
+            itemOutput->setFlags(flgCheckbox);
+            itemOutput->setCheckState(COLUMN_CHECKBOX,Qt::Unchecked);
+
+            // address
+            CTxDestination outputAddress;
+            QString sAddress = "";
+            if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, outputAddress))
+            {
+                sAddress = CBitcoinAddress(outputAddress).ToString().c_str();
+
+                // if listMode or change => show bitcoin address. In tree mode, address is not shown again for direct wallet address outputs
+                if (!treeMode || (!(sAddress == sWalletAddress)))
+                    itemOutput->setText(COLUMN_ADDRESS, sAddress);
+
+                CPubKey pubkey;
+                try {
+                    if (model->getPubKey(std::get<CKeyID>(outputAddress), pubkey) && !pubkey.IsCompressed())
+                        nInputSize = 180;
+                } catch (const std::bad_variant_access&) {}
+            }
+
+            // label
+            if (!(sAddress == sWalletAddress)) // change
+            {
+                // tooltip from where the change comes from
+                itemOutput->setToolTip(COLUMN_LABEL, tr("change from %1 (%2)").arg(sWalletLabel).arg(sWalletAddress));
+                itemOutput->setText(COLUMN_LABEL, tr("(change)"));
+                itemOutput->setText(COLUMN_CHANGE_BOOL, QString::number(1));
+            }
+            else if (!treeMode)
+            {
+                QString sLabel = "";
+                if (model->getAddressTableModel())
+                    sLabel = model->getAddressTableModel()->labelForAddress(sAddress);
+                if (sLabel.length() == 0)
+                    sLabel = tr("(no label)");
+                itemOutput->setText(COLUMN_LABEL, sLabel);
+            }
+
+            // amount
+            itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.tx->vout[out.i].nValue));
+            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.tx->vout[out.i].nValue), 15, " ")); // padding so that sorting works correctly
+
+            // date
+            itemOutput->setText(COLUMN_DATE, QDateTime::fromTime_t(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
+
+            // immature PoS reward
+            {
+                // LOCK on cs_main must be taken for depth and maturity.
+                LOCK(cs_main);
+
+                if (out.tx->IsCoinStake() && out.tx->GetBlocksToMaturity() > 0 && out.tx->GetDepthInMainChain() > 0) {
+                    itemOutput->setBackground(COLUMN_CONFIRMATIONS, Qt::red);
+                    itemOutput->setDisabled(true);
+                }
+            }
+
+            // confirmations
+            itemOutput->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(out.nDepth), 8, " "));
+
+            // priority
+            double dPriority = ((double)out.tx->vout[out.i].nValue  / (nInputSize + 78)) * (out.nDepth+1); // 78 = 2 * 34 + 10
+            itemOutput->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPriority));
+            itemOutput->setText(COLUMN_PRIORITY_INT64, strPad(QString::number((int64_t)dPriority), 20, " "));
+            dPrioritySum += (double)out.tx->vout[out.i].nValue  * (out.nDepth+1);
+            nInputSum    += nInputSize;
+
+            // transaction hash
+            uint256 txhash = out.tx->GetHash();
+            itemOutput->setText(COLUMN_TXHASH, txhash.GetHex().c_str());
+
+            // vout index
+            itemOutput->setText(COLUMN_VOUT_INDEX, QString::number(out.i));
+
+            // set checkbox
+            if (coinControl->IsSelected(txhash, out.i))
+            {
+                itemOutput->setCheckState(COLUMN_CHECKBOX,Qt::Checked);
+            }
+        }
+
+        // amount
+        if (treeMode)
+        {
+            dPrioritySum = dPrioritySum / (nInputSum + 78);
+            itemWalletAddress->setText(COLUMN_CHECKBOX, "(" + QString::number(nChildren) + ")");
+            itemWalletAddress->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
+            itemWalletAddress->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(nSum), 15, " "));
+            itemWalletAddress->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPrioritySum));
+            itemWalletAddress->setText(COLUMN_PRIORITY_INT64, strPad(QString::number((int64_t)dPrioritySum), 20, " "));
+        }
+    }
+
+    // expand all partially selected
+    if (treeMode)
+    {
+        for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++)
+            if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked)
+                ui->treeWidget->topLevelItem(i)->setExpanded(true);
+    }
+
+    // sort view
+    sortView(sortColumn, sortOrder);
+    ui->treeWidget->setEnabled(true);
+}
+
+void ConsolidateUnspentWizardSelectInputsPage::SetOutputWarningStop(InputStatus input_status)
+{
+    switch (input_status)
+    {
+    case InputStatus::INSUFFICIENT_OUTPUTS:
+        ui->outputLimitWarningIconLabel->setVisible(false);
+        ui->outputLimitStopIconLabel->setVisible(false);
+        ui->isCompleteCheckBox->setChecked(false);
+        break;
+    case InputStatus::NORMAL:
+        ui->outputLimitWarningIconLabel->setVisible(false);
+        ui->outputLimitStopIconLabel->setVisible(false);
+        ui->isCompleteCheckBox->setChecked(true);
+        break;
+    case InputStatus::WARNING:
+        ui->outputLimitWarningIconLabel->setVisible(true);
+        ui->outputLimitStopIconLabel->setVisible(false);
+        ui->isCompleteCheckBox->setChecked(true);
+        break;
+    case InputStatus::STOP:
+        ui->outputLimitWarningIconLabel->setVisible(false);
+        ui->outputLimitStopIconLabel->setVisible(true);
+        ui->isCompleteCheckBox->setChecked(false);
+    }
+}

--- a/src/qt/consolidateunspentwizardselectinputspage.h
+++ b/src/qt/consolidateunspentwizardselectinputspage.h
@@ -1,0 +1,91 @@
+#ifndef CONSOLIDATEUNSPENTWIZARDSELECTINPUTS_H
+#define CONSOLIDATEUNSPENTWIZARDSELECTINPUTS_H
+
+#include "walletmodel.h"
+#include "amount.h"
+
+#include <QWizard>
+#include <QTreeWidgetItem>
+
+namespace Ui {
+    class ConsolidateUnspentWizardSelectInputsPage;
+}
+
+class CoinControlDialog;
+
+class ConsolidateUnspentWizardSelectInputsPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ConsolidateUnspentWizardSelectInputsPage(QWidget *parent = nullptr);
+    ~ConsolidateUnspentWizardSelectInputsPage();
+
+    void setModel(WalletModel*);
+    void setCoinControl(CCoinControl* coinControl);
+    void setPayAmounts(QList<qint64> *payAmounts);
+
+signals:
+    void setAddressListSignal(std::map<QString, QString>);
+    void setDefaultAddressSignal(QString);
+    void updateFieldsSignal();
+
+public slots:
+    void updateLabels();
+
+private:
+    Ui::ConsolidateUnspentWizardSelectInputsPage *ui;
+    CCoinControl *coinControl;
+    QList<qint64> *payAmounts;
+    WalletModel *model;
+    int sortColumn;
+    Qt::SortOrder sortOrder;
+    size_t m_InputSelectionLimit;
+    Qt::CheckState m_ToState = Qt::Checked;
+    bool m_FilterMode = true;
+    bool m_FilterValueValid = false;
+    bool m_InputSelectionLimitedByFilter = false;
+    bool m_ViewItemsChangedViaFilter = false;
+
+    QString strPad(QString, int, QString);
+    void sortView(int, Qt::SortOrder);
+    void updateView();
+    bool filterInputsByValue(const bool& less, const CAmount& inputFilterValue, const unsigned int& inputSelectionLimit);
+
+    enum
+    {
+        COLUMN_CHECKBOX,
+        COLUMN_AMOUNT,
+        COLUMN_LABEL,
+        COLUMN_ADDRESS,
+        COLUMN_DATE,
+        COLUMN_CONFIRMATIONS,
+        COLUMN_PRIORITY,
+        COLUMN_TXHASH,
+        COLUMN_VOUT_INDEX,
+        COLUMN_AMOUNT_INT64,
+        COLUMN_PRIORITY_INT64,
+        COLUMN_CHANGE_BOOL
+    };
+
+    enum InputStatus
+    {
+        INSUFFICIENT_OUTPUTS,
+        NORMAL,
+        WARNING,
+        STOP
+    };
+
+private slots:
+    void treeModeRadioButton(bool);
+    void listModeRadioButton(bool);
+    void viewItemChanged(QTreeWidgetItem*, int);
+    void headerSectionClicked(int);
+    void buttonSelectAllClicked();
+    void maxMinOutputValueChanged();
+    void buttonFilterModeClicked();
+    void buttonFilterClicked();
+    void SetOutputWarningStop(InputStatus input_status);
+};
+
+#endif // CONSOLIDATEUNSPENTWIZARDSELECTINPUTS_H

--- a/src/qt/consolidateunspentwizardsendpage.cpp
+++ b/src/qt/consolidateunspentwizardsendpage.cpp
@@ -1,0 +1,53 @@
+#include "consolidateunspentwizardsendpage.h"
+#include "ui_consolidateunspentwizardsendpage.h"
+
+#include "util.h"
+#include "bitcoinunits.h"
+#include "optionsmodel.h"
+
+ConsolidateUnspentWizardSendPage::ConsolidateUnspentWizardSendPage(QWidget *parent) :
+    QWizardPage(parent),
+    ui(new Ui::ConsolidateUnspentWizardSendPage)
+{
+    ui->setupUi(this);
+}
+
+ConsolidateUnspentWizardSendPage::~ConsolidateUnspentWizardSendPage()
+{
+    delete ui;
+}
+
+void ConsolidateUnspentWizardSendPage::initializePage()
+{
+    ui->InputQuantityLabel->setText(field("quantityField").toString());
+    ui->feeLabel->setText(field("feeField").toString());
+    ui->afterFeeAmountLabel->setText(field("afterFeeAmountField").toString());
+    ui->destinationAddressLabelLabel->setText(field("selectedAddressLabelField").toString());
+    ui->destinationAddressLabel->setText(field("selectedAddressField").toString());
+
+    LogPrint(BCLog::LogFlags::QT, "INFO: %s: destinationAddress = %s",
+             __func__, field("selectedAddressField").toString().toStdString());
+
+    qint64 amount = 0;
+    bool parse_status = false;
+
+    m_recipient.label = ui->destinationAddressLabelLabel->text();
+    m_recipient.address = ui->destinationAddressLabel->text();
+
+    parse_status = BitcoinUnits::parse(model->getOptionsModel()->getDisplayUnit(),
+                                       ui->afterFeeAmountLabel->text()
+                                            .left(ui->afterFeeAmountLabel->text().indexOf(" ")),
+                                       &amount);
+
+    if (parse_status) m_recipient.amount = amount;
+}
+
+void ConsolidateUnspentWizardSendPage::setModel(WalletModel *model)
+{
+    this->model = model;
+}
+
+void ConsolidateUnspentWizardSendPage::onFinishButtonClicked()
+{
+    emit selectedConsolidationRecipientSignal(m_recipient);
+}

--- a/src/qt/consolidateunspentwizardsendpage.h
+++ b/src/qt/consolidateunspentwizardsendpage.h
@@ -1,0 +1,39 @@
+#ifndef CONSOLIDATEUNSPENTWIZARDSENDPAGE_H
+#define CONSOLIDATEUNSPENTWIZARDSENDPAGE_H
+
+#include "walletmodel.h"
+#include "amount.h"
+
+#include <QWizard>
+
+namespace Ui {
+    class ConsolidateUnspentWizardSendPage;
+}
+
+class ConsolidateUnspentWizardSendPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ConsolidateUnspentWizardSendPage(QWidget *parent = nullptr);
+    ~ConsolidateUnspentWizardSendPage();
+
+    void initializePage();
+
+    void setModel(WalletModel*);
+
+public slots:
+    void onFinishButtonClicked();
+
+signals:
+    void selectedConsolidationRecipientSignal(SendCoinsRecipient consolidationRecipient);
+
+private:
+    Ui::ConsolidateUnspentWizardSendPage *ui;
+    WalletModel *model;
+    SendCoinsRecipient m_recipient;
+
+    size_t m_inputSelectionLimit;
+};
+
+#endif // CONSOLIDATEUNSPENTWIZARDSENDPAGE_H

--- a/src/qt/forms/consolidateunspentwizard.ui
+++ b/src/qt/forms/consolidateunspentwizard.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConsolidateUnspentWizard</class>
+ <widget class="QWizard" name="ConsolidateUnspentWizard">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>933</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Conolidate Unspent Transaction Outputs (UTXOs)</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <property name="wizardStyle">
+   <enum>QWizard::ClassicStyle</enum>
+  </property>
+  <widget class="ConsolidateUnspentWizardSelectInputsPage" name="selectInputsPage">
+   <attribute name="pageId">
+    <string notr="true">0</string>
+   </attribute>
+  </widget>
+  <widget class="ConsolidateUnspentWizardSelectDestinationPage" name="selectDestinationPage">
+   <attribute name="pageId">
+    <string notr="true">1</string>
+   </attribute>
+  </widget>
+  <widget class="ConsolidateUnspentWizardSendPage" name="sendPage">
+   <attribute name="pageId">
+    <string notr="true">2</string>
+   </attribute>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ConsolidateUnspentWizardSelectInputsPage</class>
+   <extends>QWizardPage</extends>
+   <header>consolidateunspentwizardselectinputspage.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConsolidateUnspentWizardSelectDestinationPage</class>
+   <extends>QWizardPage</extends>
+   <header>consolidateunspentwizardselectdestinationpage.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConsolidateUnspentWizardSendPage</class>
+   <extends>QWizardPage</extends>
+   <header>consolidateunspentwizardsendpage.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/consolidateunspentwizardselectdestinationpage.ui
+++ b/src/qt/forms/consolidateunspentwizardselectdestinationpage.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConsolidateUnspentWizardSelectDestinationPage</class>
+ <widget class="QWizardPage" name="ConsolidateUnspentWizardSelectDestinationPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WizardPage</string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>19</x>
+     <y>19</y>
+     <width>851</width>
+     <height>581</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="selectDestinationIntroLabel">
+      <property name="text">
+       <string>Step 2: Select the destination address for the consolidation transaction. Note that all of the selected inputs will be consolidated to an output on this address. If there is a very small amount of change (due to uncertainty in the fee calculation), it will also be sent to this address. If you selected inputs only from a particular address on the previous page, then that address will already be selected by default.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QTableWidget" name="addressTableWidget">
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAsNeeded</enum>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="horizontalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+        <attribute name="horizontalHeaderMinimumSectionSize">
+         <number>90</number>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Label</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Address</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QLabel" name="selectedLabel">
+        <property name="text">
+         <string>Currently selected:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,1">
+      <item>
+       <widget class="QLabel" name="selectedAddressLabel">
+        <property name="text">
+         <string>Label</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="selectedAddress">
+        <property name="text">
+         <string>Address</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="isCompleteCheckBox">
+      <property name="text">
+       <string>isComplete</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/consolidateunspentwizardselectinputspage.ui
+++ b/src/qt/forms/consolidateunspentwizardselectinputspage.ui
@@ -1,0 +1,371 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConsolidateUnspentWizardSelectInputsPage</class>
+ <widget class="QWizardPage" name="ConsolidateUnspentWizardSelectInputsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WizardPage</string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>20</y>
+     <width>851</width>
+     <height>581</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <layout class="QHBoxLayout" name="instructionsHorizontalLayout">
+      <item>
+       <widget class="QLabel" name="selectInputsIntroLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Step 1: Select the inputs to be consolidated. Remember that the inputs to the consolidation are your unspent outputs (UTXOs) in your wallet.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="treeHorizontalLayout">
+      <item>
+       <widget class="QPushButton" name="selectAllPushButton">
+        <property name="text">
+         <string>Select All</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="treeModeRadioButton">
+        <property name="text">
+         <string>Tree Mode</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="listModeRadioButton">
+        <property name="text">
+         <string>List Mode</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="treehorizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="filterHorizontalLayout">
+      <item>
+       <widget class="QLabel" name="filterLabel">
+        <property name="text">
+         <string>Select inputs</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="filterModePushButton">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="text">
+         <string>&lt;=</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="BitcoinAmountField" name="maxMinOutputValue">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="filterPushButton">
+        <property name="toolTip">
+         <string>Filters the already selected inputs.</string>
+        </property>
+        <property name="text">
+         <string>Filter</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="filterHorizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="CoinControlTreeWidget" name="treeWidget">
+      <property name="contextMenuPolicy">
+       <enum>Qt::CustomContextMenu</enum>
+      </property>
+      <property name="sortingEnabled">
+       <bool>false</bool>
+      </property>
+      <property name="columnCount">
+       <number>11</number>
+      </property>
+      <attribute name="headerShowSortIndicator" stdset="0">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="headerStretchLastSection">
+       <bool>false</bool>
+      </attribute>
+      <column>
+       <property name="text">
+        <string/>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Amount</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Label</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Address</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Date</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Confirmations</string>
+       </property>
+       <property name="toolTip">
+        <string>Confirmed</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Priority</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string/>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string/>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string/>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string/>
+       </property>
+      </column>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="summaryHorizontalLayout">
+      <item>
+       <widget class="QLabel" name="outputLimitWarningIconLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="outputLimitStopIconLabel">
+        <property name="maximumSize">
+         <size>
+          <width>64</width>
+          <height>64</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../bitcoin.qrc">:/icons/white_and_red_x</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="summaryHorizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="quantityTextLabel">
+        <property name="text">
+         <string>Quantity</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="quantityLabel">
+        <property name="text">
+         <string>99999</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="summaryHorizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="feeTextLabel">
+        <property name="text">
+         <string>Fee</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="feeLabel">
+        <property name="text">
+         <string>99.9999</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="summaryHorizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="afterFeeTextLabel">
+        <property name="text">
+         <string>After Fee Amount</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="afterFeeLabel">
+        <property name="text">
+         <string>999999999.9999</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="isCompleteCheckBox">
+        <property name="text">
+         <string>isComplete</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CoinControlTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>coincontroltreewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QSpinBox</extends>
+   <header>bitcoinamountfield.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/forms/consolidateunspentwizardsendpage.ui
+++ b/src/qt/forms/consolidateunspentwizardsendpage.ui
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConsolidateUnspentWizardSendPage</class>
+ <widget class="QWizardPage" name="ConsolidateUnspentWizardSendPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WizardPage</string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>19</x>
+     <y>19</y>
+     <width>851</width>
+     <height>581</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="sendIntroLabel">
+        <property name="text">
+         <string>Step 3: Confirm Consolidation Transaction Details. Transaction will be ready to send when Finish is pressed.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="InputQuantityTextLabel">
+        <property name="text">
+         <string>Number of Inputs</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="InputQuantityLabel">
+        <property name="text">
+         <string>999999</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="feeTextLabel">
+        <property name="text">
+         <string>Transaction Fee</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="feeLabel">
+        <property name="text">
+         <string>99.9999</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="afterFeeAmountTextLabel">
+        <property name="text">
+         <string>Amount</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="afterFeeAmountLabel">
+        <property name="text">
+         <string>999999999.9999</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="destinationAddressTextLabel">
+        <property name="text">
+         <string>Destination Address</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="destinationAddressLabel">
+        <property name="text">
+         <string>address</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="destinationAddressLabelTextLabel">
+        <property name="text">
+         <string>Destination Address Label</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="destinationAddressLabelLabel">
+        <property name="text">
+         <string>label</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -85,7 +85,7 @@
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl2" stretch="0,0,0,0,0">
+         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl2" stretch="0,0,0,0,0,0">
           <property name="spacing">
            <number>8</number>
           </property>
@@ -126,6 +126,13 @@
            <widget class="QPushButton" name="coinControlResetPushButton">
             <property name="text">
              <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="coinControlConsolidateWizardPushButton">
+            <property name="text">
+             <string>Consolidate Wizard</string>
             </property>
            </widget>
           </item>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -450,7 +450,7 @@
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLabel" name="coinControlChangeLabel_2">
+                <widget class="QLabel" name="coinControlChangeLabel">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>
@@ -473,7 +473,7 @@
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl4" stretch="0,0,0">
+         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl4" stretch="0,0">
           <property name="spacing">
            <number>12</number>
           </property>
@@ -509,28 +509,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QLabel" name="coinControlChangeLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="margin">
-             <number>3</number>
-            </property>
-           </widget>
-          </item>
          </layout>
         </item>
         <item>
@@ -561,8 +539,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>869</width>
-        <height>112</height>
+        <width>879</width>
+        <height>212</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -43,6 +43,8 @@ public slots:
 
 private:
     Ui::SendCoinsDialog *ui;
+    CCoinControl *coinControl;
+    QList<qint64> *payAmounts;
     WalletModel *model;
     bool fNewRecipientAllowed;
 
@@ -53,6 +55,7 @@ private slots:
     void coinControlFeatureChanged(bool);
     void coinControlButtonClicked();
     void coinControlResetButtonClicked();
+    void coinControlConsolidateWizardButtonClicked();
     void coinControlChangeChecked(int);
     void coinControlChangeEdited(const QString &);
     void coinControlUpdateLabels();


### PR DESCRIPTION
This implements a three step wizard that leads the user through the process of selecting inputs, selecting a destination, and
then reviewing the overall transaction.

Select Inputs:

The select inputs screen uses similar code to that in coincontroldialog to support the consolidate button there. Pointers to the coincontrol data structures constructed in sendcoinsdialog are passed into both coincontrol and the consolidateunspentwizard to faciliate using the underlying machinery in a unified manner. This is possible because both coincontrol and onsolidateunspendwizard are called with the sendcoinsdialog and are modal.

Note that there is a stop sign and the next button is disabled if more than 600 outputs are selected. The next button is also disabled if less than 2 outputs are selected (as it makes no sense to consolidate when there is no consolidation achievable based on the selection). If a filter operation is applied based on the filter criteria, and that criteria would result in more than 600 inputs being selected, the selection is reduced to 600 inputs and a warning triangle is presented.

Select Destination Address:

If all of the inputs selected in the prior page are from one address, then that address will already be preselected (but allow the opportunity for it to be changed by the user prior to pressing next). If the inputs selected correspond to more than one address, an address will NOT be pre-selected, and the user will be required to pick an address to proceed. The next button will be disabled until a valid address is selected for the destination.

Confirmation:

The final screen presents the details of the intended transaction for review by the user. When the "Finish" button is pressed, the transaction to send is filled in in the send dialog sreen, and the user can review the details again if desired and press the send button to send.

NOTE: I know the appearance needs to be fine-tuned. I am not necessarily the best at making pretty things UI-wise, but the basics are here. I also think we can move the Consolidate Wizard button out of the coincontrol frame, so that it is visible whether or not the advanced coin control is enabled in the config.

This further addresses #1984.