### PR TITLE
scraper, util, qt: Fix several deprecations and warnings

### DIFF
--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -62,7 +62,7 @@ public:
     int addPartData(CDataStream&& vData);
 
     /** Unref all parts referenced by this. Removes parts with no references */
-    ~CSplitBlob();
+    virtual ~CSplitBlob();
 
     /* We could store the parts in mapRelay and have getdata service for free. */
     /** map from part hash to scraper Index, so we can attach incoming Part in Index */

--- a/src/net.h
+++ b/src/net.h
@@ -459,22 +459,22 @@ public:
         mapAskFor.insert(std::make_pair(nRequestTime, inv));
     }
 
+    // A lock on cs_vSend must be taken before calling this function
     void BeginMessage(const char* pszCommand)
     {
-        ENTER_CRITICAL_SECTION(cs_vSend);
         assert(ssSend.size() == 0);
         ssSend << CMessageHeader(pszCommand, 0);
     }
 
+    // A lock on cs_vSend must be taken before calling this function
     void AbortMessage()
     {
         ssSend.clear();
 
-        LEAVE_CRITICAL_SECTION(cs_vSend);
-
         LogPrint(BCLog::LogFlags::NOISY, "(aborted)");
     }
 
+    // A lock on cs_vSend must be taken before calling this function
     void EndMessage()
     {
         if (ssSend.size() == 0)
@@ -500,8 +500,6 @@ public:
         // If write queue empty, attempt "optimistic write"
         if (it == vSendMsg.begin())
             SocketSendData(this);
-
-        LEAVE_CRITICAL_SECTION(cs_vSend);
     }
 
     void PushVersion();
@@ -521,6 +519,8 @@ public:
 
     void PushMessage(const char* pszCommand)
     {
+        LOCK(cs_vSend);
+
         try
         {
             BeginMessage(pszCommand);
@@ -536,6 +536,8 @@ public:
     template<typename... Args>
     void PushMessage(const char* pszCommand, Args... args)
     {
+        LOCK(cs_vSend);
+
         try
         {
             BeginMessage(pszCommand);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -526,7 +526,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
         return EXIT_FAILURE;
     }
 
-    QSplashScreen splash(QPixmap(":/images/splash"), 0);
+    QSplashScreen splash(QPixmap(":/images/splash"));
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min"))
     {
         splash.setEnabled(false);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -42,7 +42,7 @@ namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)
 {
-    return date.date().toString(Qt::SystemLocaleShortDate) + QString(" ") + date.toString("hh:mm");
+    return QLocale::system().toString(date, QLocale::ShortFormat) + QString(" ") + date.toString("hh:mm");
 }
 
 QString dateTimeStr(qint64 nTime)

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -304,7 +304,11 @@ QDate OptionsModel::getLimitTxnDate()
 
 int64_t OptionsModel::getLimitTxnDateTime()
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QDateTime limitTxnDateTime(limitTxnDate);
+#else
+    QDateTime limitTxnDateTime = limitTxnDate.startOfDay();
+#endif
 
     return limitTxnDateTime.toMSecsSinceEpoch() / 1000;
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -351,7 +351,12 @@ void RPCConsole::setClientModel(ClientModel *model)
         connect(banAction24h, &QAction::triggered, signalMapper, static_cast<void (QSignalMapper::*)()>(&QSignalMapper::map));
         connect(banAction7d, &QAction::triggered, signalMapper, static_cast<void (QSignalMapper::*)()>(&QSignalMapper::map));
         connect(banAction365d, &QAction::triggered, signalMapper, static_cast<void (QSignalMapper::*)()>(&QSignalMapper::map));
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
         connect(signalMapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &RPCConsole::banSelectedNode);
+#else
+        connect(signalMapper, &QSignalMapper::mappedInt, this, &RPCConsole::banSelectedNode);
+#endif
 
         // peer table context menu signals
         connect(ui->peerWidget, &QTableView::customContextMenuRequested, this, &RPCConsole::showPeersTableContextMenu);


### PR DESCRIPTION
Closes #2132.

Note that the destructor on the class CSplitBlob should have been virtual because it has virtual members that are overridden in derived classes (CScraperManifest).

The ENTER_CRITICAL_SECTION / LEAVE_CRITICAL_SECTION approach to cs_vSend locking was causing clang threadsafe warnings. I replaced these with the standard LOCK treatment, in this case external to those functions in the only two places that they are called from. I added comments that a lock must be taken on cs_vSend prior to using those functions.

QFlags::Zero is deprecated. Using the default constructor is recommended.

Qt::SystemLocaleShortDate is deprecated. I replaced it with the recommended QLocale call.

For the SignalMapper, this is irritating. The QSignalMapper::mapped is deprecated in Qt 5.15+, but the replacement, mappedInt, is not even available prior to 5.15, so this requires a conditional preprocessor directive to use the correct one.

Constructing a QDateTime from QDate via QDatetime(QDate) is now deprecated. Qt recommends using QDate::startOfDay(), except that method is not available until 5.14+. So this also requires a conditional preprocessor directive.