### PR TITLE
gui: Optimize locks to improve responsiveness

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -178,6 +178,7 @@ GRIDCOIN_CORE_H = \
     version.h \
     wallet/coincontrol.h \
     wallet/db.h \
+    wallet/generated_type.h \
     wallet/walletdb.h \
     wallet/wallet.h \
     wallet/ismine.h

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1513,6 +1513,12 @@ void BitcoinGUI::updateGlobalStatus()
     // This is needed to prevent segfaulting due to early GUI initialization compared to core.
     if (miner_first_pass_complete)
     {
+        TRY_LOCK(cs_main, locked_main);
+
+        if (!locked_main) {
+            return;
+        }
+
         try
         {
             overviewPage->updateGlobalStatus();

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -491,6 +491,12 @@ void ResearcherModel::refresh()
         emit researcherChanged();
     }
 
+    TRY_LOCK(cs_main, lockMain);
+
+    if (!lockMain) {
+        return;
+    }
+
     updateBeacon();
 
     emit magnitudeChanged();

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -406,6 +406,8 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
         {
             status.status = TransactionStatus::Confirmed;
         }
+
+        status.generated_type = wtx.GetGeneratedType(vout);
     }
     else
     {

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -2,6 +2,7 @@
 #define TRANSACTIONRECORD_H
 
 #include "uint256.h"
+#include "wallet/generated_type.h"
 #include "wallet/ismine.h"
 
 #include <QList>
@@ -14,9 +15,15 @@ class CWalletTx;
 class TransactionStatus
 {
 public:
-    TransactionStatus():
-            countsForBalance(false), sortKey(""),
-            matures_in(0), status(Offline), depth(0), open_for(0), cur_num_blocks(-1)
+    TransactionStatus()
+        : countsForBalance(false)
+        , sortKey("")
+        , matures_in(0)
+        , status(Offline)
+        , generated_type(MinedType::UNKNOWN)
+        , depth(0)
+        , open_for(0)
+        , cur_num_blocks(-1)
     { }
 
     enum Status {
@@ -47,6 +54,7 @@ public:
     /** @name Reported status
        @{*/
     Status status;
+    MinedType generated_type;
     int64_t depth;
     int64_t open_for; /**< Timestamp if status==OpenUntilDate, otherwise number
                        of additional blocks that need to be mined before

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -401,9 +401,7 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         {
-            MinedType gentype = GetGeneratedType(wallet, wtx->hash, wtx->vout);
-
-            switch (gentype)
+            switch (wtx->status.generated_type)
             {
             case MinedType::POS:
                 return tr("MINED - POS");
@@ -445,9 +443,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     {
     case TransactionRecord::Generated:
     {
-        MinedType gentype = GetGeneratedType(wallet, wtx->hash, wtx->vout);
-
-        switch (gentype)
+        switch (wtx->status.generated_type)
         {
         case MinedType::POS:
             return QIcon(":/icons/tx_pos");

--- a/src/wallet/generated_type.h
+++ b/src/wallet/generated_type.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2014-2021 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+/** (POS/POR) enums for CoinStake Transactions -- We should never get unknown but just in case!*/
+enum MinedType
+{
+    UNKNOWN = 0,
+    POS = 1,
+    POR = 2,
+    ORPHANED = 3,
+    POS_SIDE_STAKE_RCV = 4,
+    POR_SIDE_STAKE_RCV = 5,
+    POS_SIDE_STAKE_SEND = 6,
+    POR_SIDE_STAKE_SEND = 7,
+    SUPERBLOCK = 8
+};

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -19,6 +19,7 @@
 #include "script.h"
 #include "streams.h"
 #include "ui_interface.h"
+#include "wallet/generated_type.h"
 #include "wallet/walletdb.h"
 #include "wallet/ismine.h"
 
@@ -30,6 +31,8 @@ class CReserveKey;
 class COutput;
 class CCoinControl;
 
+MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout);
+
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {
@@ -37,20 +40,6 @@ enum WalletFeature
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
     FEATURE_LATEST = 60000
-};
-
-/** (POS/POR) enums for CoinStake Transactions -- We should never get unknown but just in case!*/
-enum MinedType
-{
-    UNKNOWN = 0,
-    POS = 1,
-    POR = 2,
-    ORPHANED = 3,
-    POS_SIDE_STAKE_RCV = 4,
-    POR_SIDE_STAKE_RCV = 5,
-    POS_SIDE_STAKE_SEND = 6,
-    POR_SIDE_STAKE_SEND = 7,
-    SUPERBLOCK = 8
 };
 
 /** A key pool entry */
@@ -854,6 +843,11 @@ public:
 
     void RelayWalletTransaction(CTxDB& txdb);
     void RelayWalletTransaction();
+
+    MinedType GetGeneratedType(uint32_t vout_offset) const
+    {
+        return ::GetGeneratedType(pwallet, GetHash(), vout_offset);
+    }
 };
 
 
@@ -1048,5 +1042,4 @@ private:
     std::vector<char> _ssExtra;
 };
 
-MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout);
 #endif


### PR DESCRIPTION
These changes skip periodic update intervals with conditional locking and optimize how the GUI determines the "mined" type of a coinstake transaction (#1390). The `GetGeneratedType()` function was called from presentation routines on the Qt side that did not expect synchronization with the core wallet state. The PR reorganizes the look-ups to avoid the `cs_main` locks if a node is busy with another operation. This avoids GUI sluggishness for recurring updates of the overview and transaction history pages from core state and prevents the long-running polls reload on the voting page from bricking the GUI thread. More optimizations for poll performance will come with caching in a later PR.