### PR TITLE
gui: Fix duplicate time in GUIUtil::dateTimeStr()

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -42,7 +42,7 @@ namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)
 {
-    return QLocale::system().toString(date, QLocale::ShortFormat) + QString(" ") + date.toString("hh:mm");
+    return QLocale::system().toString(date.date(), QLocale::ShortFormat) + QString(" ") + date.toString("hh:mm");
 }
 
 QString dateTimeStr(qint64 nTime)


### PR DESCRIPTION
Missed that the update to remove deprecated `Qt::SystemLocaleShortDate` caused the `GUIUtil::dateTimeStr()` function to display two time components: 

![image](https://user-images.githubusercontent.com/4282384/118725904-2aa18b80-b7f6-11eb-9a93-4357149b6ecc.png)
