### PR TITLE
gui: Fix debug console traffic graph legend colors

### DIFF
--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -803,3 +803,13 @@ QStatusBar QToolTip {
 #consolidateSendReadyLabel{
     color: rgb(55, 250, 55);
 }
+
+/* Debug Console */
+
+RPCConsole #greenLine {
+    border-top-color: rgb(0, 255, 0);
+}
+
+RPCConsole #redLine {
+    border-top-color: rgb(255, 0, 0);
+}

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -800,3 +800,13 @@ QStatusBar .QFrame QLabel {
 #consolidateSendReadyLabel{
     color: rgb(0, 128, 0);
 }
+
+/* Debug Console */
+
+RPCConsole #greenLine {
+    border-top-color: rgb(0, 255, 0);
+}
+
+RPCConsole #redLine {
+    border-top-color: rgb(255, 0, 0);
+}


### PR DESCRIPTION
The stylesheets override the custom palette colors for line widgets. This sets the colors for the traffic graph legend with style rules.

Closes #2141.