### PR TITLE
rpc: Refresh rainbymagnitude

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -148,6 +148,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "move"                   , 2 },
     { "move"                   , 3 },
     { "rainbymagnitude"        , 1 },
+    { "rainbymagnitude"        , 2 },
+    { "rainbymagnitude"        , 3 },
     { "reservebalance"         , 0 },
     { "reservebalance"         , 1 },
     { "scanforunspent"         , 1 },


### PR DESCRIPTION
This fixes the magnitude rounding to agree with the same rounding method used in magnitude storage in the superblock post Fern. It also implements a dust suppressor by suppressing payments less than one CENT and re-normalizing the remaining payments.

It also provides optional booleans for doing a trial run instead of real run, and also provide a detailed output of payments.

Closes #2155.