### PR TITLE
gui: Fix Inter font rendering on Windows with FreeType

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -166,6 +166,7 @@ $(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cflags) $($(pa
 $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_mingw32 += -pch
+$(package)_config_opts_mingw32 += -qt-freetype
 
 $(package)_config_opts_android = -xplatform android-clang
 $(package)_config_opts_android += -android-sdk $(ANDROID_SDK)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -278,6 +278,20 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+#ifdef Q_OS_WIN
+    // Use Qt's built-in FreeType rendering engine to display text on Windows.
+    // We use the Inter font's OpenType format which doesn't render clearly on
+    // Windows in Qt applications with the default engine. The TrueType format
+    // works fine in either case, but the OpenType appearance is more legible.
+    // Apply this before instantiating QApplication. This environment variable
+    // configures the option for Qt's Windows integration plugin which doesn't
+    // have a C++ API.
+    //
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "windows:fontengine=freetype");
+    }
+#endif
+
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #if QT_VERSION >= 0x050600

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -7,7 +7,7 @@
 
 QWidget {
     color: rgb(204, 208, 209);
-    font-family: "SF Pro Display", "Segoe UI", "Inter";
+    font-family: "SF Pro Display", "Inter";
 }
 
 QMainWindow {

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -7,7 +7,7 @@
 
 QWidget {
     color: rgb(58, 70, 93);
-    font-family: "SF Pro Display", "Segoe UI", "Inter";
+    font-family: "SF Pro Display", "Inter";
 }
 
 QMainWindow {


### PR DESCRIPTION
This switches the font rendering engine for Windows to Qt's built-in FreeType engine and changes the Windows font family from Segoe UI to the Inter version supplied by our embedded font resources. On Windows, the native font engine rendered the OpenType format very poorly&mdash;text looked blurry and distorted. I made a temporary decision to use the system-provided Segoe UI typeface as a stand-in until I had time to investigate. By switching back to Inter, we normalize the text style on Windows with the other supported platforms and more faithfully reproduce the appearance in #847.

Here, we configure the Qt depends recipe to include FreeType support on Windows and activate that feature when the application starts. We could switch the format of the Inter font to TrueType, but we'd need to build it from source for future updates since the Inter project doesn't distribute a non-hinted desktop TTF set, and the OpenType's "weightier" appearance is easier to read on a standard-DPI display. FreeType renders non-Latin glyphs more smoothly on high-DPI desktops as well, I've read.