### PR TITLE
docs: Misc Grammar

### DIFF
--- a/doc/gridcoinresearch.conf.md
+++ b/doc/gridcoinresearch.conf.md
@@ -117,7 +117,7 @@ It is not required for all of the addnodes to be reachable, but at least one
 reliable addnode, and preferably more than one that is reachable, should be
 in your config file.
 
-Ensure you don't have an addnode=your own ip, or you will end up banning
+Ensure you don't have an addnode=your own IP, or you will end up banning
 yourself (because when the node sends itself the first message, the
 local time is far enough off of the network time (which it does not know
 yet) so it will ban itself.

--- a/src/amount.h
+++ b/src/amount.h
@@ -20,7 +20,7 @@ static const CAmount CENT = 1000000;
  * currently happens to be less than 2,000,000,000 GRC for various reasons, but
  * rather a sanity check. As this sanity check is used by consensus-critical
  * validation code, the exact value of the MAX_MONEY constant is consensus
- * critical; in unusual circumstances like a overflow bug that allowed
+ * critical; in unusual circumstances like an overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
 static const CAmount MAX_MONEY = 2000000000 * COIN;

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -445,7 +445,7 @@ public:
     //!
     //! \brief Maps CPIDs to rewards accrued at the time of the snapshot.
     //!
-    //! Accrual values stored in units of of 1/100000000 GRC.
+    //! Accrual values stored in units of 1/100000000 GRC.
     //!
     AccrualMap m_records;
 

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -1513,7 +1513,7 @@ bool BeaconRegistry::BeaconDB::erase(const uint256& hash)
 //
 // Note that this function acts very similarly to the map erase function with an iterator argument, but with a standard
 // pair returned. The first part of the pair a boolean as to whether the element was passivated, and the
-// second is is an iterator to the next element. This is designed to be traversed in a for loop just like map erase.
+// second is an iterator to the next element. This is designed to be traversed in a for loop just like map erase.
 std::pair<BeaconRegistry::HistoricalBeaconMap::iterator, bool>
     BeaconRegistry::BeaconDB::passivate(BeaconRegistry::HistoricalBeaconMap::iterator& iter)
 {

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -387,11 +387,11 @@ void TryProjectCpid(MiningId& mining_id, const MiningProject& project)
 //! A bug in BOINC sometimes results in an empty external CPID element in the
 //! client_state.xml file. For these cases, we'll recompute the external CPID
 //! of the project from the user's internal CPID and email address. This call
-//! validates that the the user's email address hash extracted from a project
+//! validates that the user's email address hash extracted from a project
 //! XML node matches the email set in the Gridcoin configuration file so that
 //! the wallet doesn't inadvertently generate an unowned CPID.
 //!
-//! \param email_hash    MD5 digest of the the email address to compare with
+//! \param email_hash    MD5 digest of the email address to compare with
 //! the configured email.
 //! \param internal_cpid As extracted from client_state.xml. An input to the
 //! hash that generates the external CPID.

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -166,7 +166,7 @@ struct ConvergedManifest
     std::multimap<std::string, ScraperID> mIncludedScrapersbyProject;
     // ----- ScraperID ------- Project
     std::multimap<ScraperID, std::string> mIncludedProjectsbyScraper;
-    // When bByParts (project) level convergence occurs, this records the the count of scrapers in the
+    // When bByParts (project) level convergence occurs, this records the count of scrapers in the
     // convergences by project.
     std::map<std::string, unsigned int> mScraperConvergenceCountbyProject;
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -4580,7 +4580,7 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
     // If we meet the rule of CONVERGENCE_BY_PROJECT_RATIO, then proceed to fill out the rest of the map.
     if ((double)iCountSuccessfulConvergedProjects / (double)projectWhitelist.size() >= CONVERGENCE_BY_PROJECT_RATIO)
     {
-        // Fill out the the rest of the ConvergedManifest structure. Note this assumes one-to-one part to project statistics BLOB. Needs to
+        // Fill out the rest of the ConvergedManifest structure. Note this assumes one-to-one part to project statistics BLOB. Needs to
         // be fixed for more than one part per BLOB. This is easy in this case, because it is all from/referring to one manifest.
 
         // Lets use the BeaconList from the manifest referred to by nManifestHashForConvergedBeaconList. Technically there is no exact answer to
@@ -4679,7 +4679,7 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
                  + " projects at "
                  + DateTimeStrFormat("%x %H:%M:%S",  StructConvergedManifest.timestamp));
 
-            // Fill out the the excluded projects vector and the included scraper count (by project) map
+            // Fill out the excluded projects vector and the included scraper count (by project) map
             for (const auto& iProjects : projectWhitelist)
             {
                 if (StructConvergedManifest.ConvergedManifestPartPtrsMap.find(iProjects.m_name) == StructConvergedManifest.ConvergedManifestPartPtrsMap.end())

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -73,7 +73,7 @@ public:
 
 };
 
-/** A objects holding info about the scraper data file we have or are downloading. */
+/** An objects holding info about the scraper data file we have or are downloading. */
 class CScraperManifest
         : public CSplitBlob
 {

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -100,7 +100,7 @@ private:
     //! \param claim   The claim to verify minimum balance for.
     //! \param message Serialized context for claim signature verification.
     //!
-    //! \return \c true If the resolved amount for the the claim meets the
+    //! \return \c true If the resolved amount for the claim meets the
     //! minimum balance requirement to create a poll.
     //!
     bool VerifyClaim(const AddressClaim& claim, const ClaimMessage& message)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -267,7 +267,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         hex = QString::fromStdString(wtx.GetHash().GetHex());
     }
 
-    // Add addresses / update labels that we've sent to to the address book
+    // Add addresses / update labels that we've sent to the address book
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
         std::string strAddress = rcp.address.toStdString();

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -35,7 +35,7 @@ bool ParseInt32(const std::string& str, int32_t *out)
     errno = 0; // strtol will not set errno if valid
     long int n = strtol(str.c_str(), &endp, 10);
     if(out) *out = (int32_t)n;
-    // Note that strtol returns a *long int*, so even if strtol doesn't report a over/underflow
+    // Note that strtol returns a *long int*, so even if strtol doesn't report an over/underflow
     // we still have to check that the returned value is within the range of an *int32_t*. On 64-bit
     // platforms the size of these types may be different.
     return endp && *endp == 0 && !errno &&
@@ -51,7 +51,7 @@ bool ParseInt64(const std::string& str, int64_t *out)
     errno = 0; // strtoll will not set errno if valid
     long long int n = strtoll(str.c_str(), &endp, 10);
     if(out) *out = (int64_t)n;
-    // Note that strtoll returns a *long long int*, so even if strtol doesn't report a over/underflow
+    // Note that strtoll returns a *long long int*, so even if strtol doesn't report an over/underflow
     // we still have to check that the returned value is within the range of an *int64_t*.
     return endp && *endp == 0 && !errno &&
         n >= std::numeric_limits<int64_t>::min() &&


### PR DESCRIPTION
Remove extraneous "the"
Remove extraneous "to"
Remove extraneous "is"
Remove extraneous "of"
Several cases of "a" to "an"
IP should be capitalized in docs