### PR TITLE
gui: Fix display artifact in poll loading indicator

### DIFF
--- a/src/qt/voting/polltab.cpp
+++ b/src/qt/voting/polltab.cpp
@@ -52,6 +52,7 @@ public:
         , m_active(false)
     {
         setRange(0, MAX);
+        setTextVisible(false);
         setGraphicsEffect(&m_opacity_effect);
         hide();
 


### PR DESCRIPTION
Missed this little detail: the progress bar text peeked out from the bottom of the loading indicator and looked like a rendering artifact.

![image](https://user-images.githubusercontent.com/4282384/121816826-70aa0d80-cc43-11eb-822c-d4a9aab8870c.png)
