### PR TITLE
gui: Fix fractional scaling for dialog sizes

### DIFF
--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -1,4 +1,5 @@
 #include "aboutdialog.h"
+#include "qt/decoration.h"
 #include "ui_aboutdialog.h"
 #include "clientmodel.h"
 
@@ -8,6 +9,8 @@ AboutDialog::AboutDialog(QWidget *parent) :
 {
     ui->setupUi(this);
     ui->copyrightLabel->setText("Copyright 2009-2021 The Bitcoin/Peercoin/Black-Coin/Gridcoin developers");
+
+    resize(GRC::ScaleSize(this, width(), height()));
 }
 
 void AboutDialog::setModel(ClientModel *model)

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -7,6 +7,7 @@
 #include "editaddressdialog.h"
 #include "csvmodelwriter.h"
 #include "guiutil.h"
+#include "qt/decoration.h"
 
 #include <QSortFilterProxyModel>
 #include <QClipboard>
@@ -17,7 +18,7 @@
 #include "qrcodedialog.h"
 #endif
 
-AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent) 
+AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
              : QDialog(parent)
              , ui(new Ui::AddressBookPage)
              , model(nullptr)
@@ -26,6 +27,8 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
              , tab(tab)
 {
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
 
 #ifdef Q_OS_MAC // Icons on push buttons are very uncommon on Mac
     ui->newAddressButton->setIcon(QIcon());

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_askpassphrasedialog.h"
 
 #include "guiconstants.h"
+#include "qt/decoration.h"
 #include "walletmodel.h"
 
 #include <QMessageBox>
@@ -10,7 +11,7 @@
 
 extern bool fWalletUnlockStakingOnly;
 
-AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent) 
+AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent)
                  : QDialog(parent)
                  , ui(new Ui::AskPassphraseDialog)
                  , mode(mode)
@@ -18,6 +19,9 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent)
                  , fCapsLock(false)
 {
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
+
     ui->oldPassphraseEdit->setMaxLength(MAX_PASSPHRASE_SIZE);
     ui->newPassphraseEdit->setMaxLength(MAX_PASSPHRASE_SIZE);
     ui->repeatNewPassphraseEdit->setMaxLength(MAX_PASSPHRASE_SIZE);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -10,6 +10,7 @@
 #include "validation.h"
 #include "wallet/coincontrol.h"
 #include "consolidateunspentdialog.h"
+#include "qt/decoration.h"
 
 #include <QApplication>
 #include <QCheckBox>
@@ -37,6 +38,8 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl,
     assert(coinControl != nullptr && payAmounts != nullptr);
 
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
 
     // context menu actions
     QAction *copyAddressAction = new QAction(tr("Copy address"), this);

--- a/src/qt/consolidateunspentdialog.cpp
+++ b/src/qt/consolidateunspentdialog.cpp
@@ -1,4 +1,5 @@
 #include "consolidateunspentdialog.h"
+#include "qt/decoration.h"
 #include "ui_consolidateunspentdialog.h"
 
 #include "util.h"
@@ -11,6 +12,8 @@ ConsolidateUnspentDialog::ConsolidateUnspentDialog(QWidget *parent, size_t input
     m_inputSelectionLimit(inputSelectionLimit)
 {
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
 
     ui->addressTableWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 

--- a/src/qt/consolidateunspentwizard.cpp
+++ b/src/qt/consolidateunspentwizard.cpp
@@ -1,6 +1,7 @@
 #include "coincontroldialog.h"
 #include "consolidateunspentwizard.h"
 #include "consolidateunspentdialog.h"
+#include "qt/decoration.h"
 #include "ui_consolidateunspentwizard.h"
 
 #include "util.h"
@@ -15,6 +16,8 @@ ConsolidateUnspentWizard::ConsolidateUnspentWizard(QWidget *parent,
     payAmounts(payAmounts)
 {
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
     this->setStartId(SelectInputsPage);
 
     ui->selectInputsPage->setCoinControl(coinControl);

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -29,6 +29,8 @@ DiagnosticsDialog::DiagnosticsDialog(QWidget *parent, ResearcherModel* researche
 {
     ui->setupUi(this);
 
+    resize(GRC::ScaleSize(this, width(), height()));
+
     GRC::ScaleFontPointSize(ui->diagnosticsLabel, 14);
     GRC::ScaleFontPointSize(ui->overallResultLabel, 12);
     GRC::ScaleFontPointSize(ui->overallResultResultLabel, 12);

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_editaddressdialog.h"
 #include "addresstablemodel.h"
 #include "guiutil.h"
+#include "qt/decoration.h"
 
 #include <QDataWidgetMapper>
 #include <QMessageBox>
@@ -14,6 +15,8 @@ EditAddressDialog::EditAddressDialog(Mode mode, QWidget* parent)
                , model(nullptr)
 {
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
 
     GUIUtil::setupAddressWidget(ui->addressEdit, this);
 

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>598</width>
-    <height>216</height>
+    <width>600</width>
+    <height>215</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1172</width>
-    <height>547</height>
+    <width>960</width>
+    <height>550</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/qt/forms/consolidateunspentdialog.ui
+++ b/src/qt/forms/consolidateunspentdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>819</width>
-    <height>513</height>
+    <width>820</width>
+    <height>515</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/qt/forms/consolidateunspentwizard.ui
+++ b/src/qt/forms/consolidateunspentwizard.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>933</width>
+    <width>930</width>
     <height>700</height>
    </rect>
   </property>

--- a/src/qt/forms/consolidateunspentwizard.ui
+++ b/src/qt/forms/consolidateunspentwizard.ui
@@ -29,16 +29,34 @@
    <enum>QWizard::ClassicStyle</enum>
   </property>
   <widget class="ConsolidateUnspentWizardSelectInputsPage" name="selectInputsPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <attribute name="pageId">
     <string notr="true">0</string>
    </attribute>
   </widget>
   <widget class="ConsolidateUnspentWizardSelectDestinationPage" name="selectDestinationPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <attribute name="pageId">
     <string notr="true">1</string>
    </attribute>
   </widget>
   <widget class="ConsolidateUnspentWizardSendPage" name="sendPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <attribute name="pageId">
     <string notr="true">2</string>
    </attribute>

--- a/src/qt/forms/consolidateunspentwizardselectdestinationpage.ui
+++ b/src/qt/forms/consolidateunspentwizardselectdestinationpage.ui
@@ -10,122 +10,122 @@
     <height>700</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>WizardPage</string>
   </property>
-  <widget class="QWidget" name="verticalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>19</x>
-     <y>19</y>
-     <width>851</width>
-     <height>581</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QLabel" name="selectDestinationIntroLabel">
-      <property name="text">
-       <string>Step 2: Select the destination address for the consolidation transaction. Note that all of the selected inputs will be consolidated to an output on this address. If there is a very small amount of change (due to uncertainty in the fee calculation), it will also be sent to this address. If you selected inputs only from a particular address on the previous page, then that address will already be selected by default.</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QTableWidget" name="addressTableWidget">
-        <property name="horizontalScrollBarPolicy">
-         <enum>Qt::ScrollBarAsNeeded</enum>
-        </property>
-        <property name="sizeAdjustPolicy">
-         <enum>QAbstractScrollArea::AdjustToContents</enum>
-        </property>
-        <property name="editTriggers">
-         <set>QAbstractItemView::NoEditTriggers</set>
-        </property>
-        <property name="alternatingRowColors">
-         <bool>true</bool>
-        </property>
-        <property name="horizontalScrollMode">
-         <enum>QAbstractItemView::ScrollPerPixel</enum>
-        </property>
-        <attribute name="horizontalHeaderMinimumSectionSize">
-         <number>90</number>
-        </attribute>
-        <attribute name="horizontalHeaderStretchLastSection">
-         <bool>true</bool>
-        </attribute>
-        <attribute name="verticalHeaderVisible">
-         <bool>false</bool>
-        </attribute>
-        <column>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="selectDestinationIntroLabel">
+       <property name="text">
+        <string>Step 2: Select the destination address for the consolidation transaction. Note that all of the selected inputs will be consolidated to an output on this address. If there is a very small amount of change (due to uncertainty in the fee calculation), it will also be sent to this address. If you selected inputs only from a particular address on the previous page, then that address will already be selected by default.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QTableWidget" name="addressTableWidget">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAsNeeded</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="horizontalScrollMode">
+          <enum>QAbstractItemView::ScrollPerPixel</enum>
+         </property>
+         <attribute name="horizontalHeaderMinimumSectionSize">
+          <number>90</number>
+         </attribute>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Label</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Address</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="selectedLabel">
+         <property name="text">
+          <string>Currently selected:</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,1">
+       <item>
+        <widget class="QLabel" name="selectedAddressLabel">
          <property name="text">
           <string>Label</string>
          </property>
-        </column>
-        <column>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="selectedAddress">
          <property name="text">
           <string>Address</string>
          </property>
-        </column>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QLabel" name="selectedLabel">
-        <property name="text">
-         <string>Currently selected:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,1">
-      <item>
-       <widget class="QLabel" name="selectedAddressLabel">
-        <property name="text">
-         <string>Label</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="selectedAddress">
-        <property name="text">
-         <string>Address</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <widget class="QCheckBox" name="isCompleteCheckBox">
-      <property name="text">
-       <string>isComplete</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="isCompleteCheckBox">
+       <property name="text">
+        <string>isComplete</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/qt/forms/consolidateunspentwizardselectinputspage.ui
+++ b/src/qt/forms/consolidateunspentwizardselectinputspage.ui
@@ -10,346 +10,346 @@
     <height>700</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>WizardPage</string>
   </property>
-  <widget class="QWidget" name="verticalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>20</y>
-     <width>851</width>
-     <height>581</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <layout class="QHBoxLayout" name="instructionsHorizontalLayout">
-      <item>
-       <widget class="QLabel" name="selectInputsIntroLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="instructionsHorizontalLayout">
+       <item>
+        <widget class="QLabel" name="selectInputsIntroLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Step 1: Select the inputs to be consolidated. Remember that the inputs to the consolidation are your unspent outputs (UTXOs) in your wallet.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="treeHorizontalLayout">
+       <item>
+        <widget class="QPushButton" name="selectAllPushButton">
+         <property name="text">
+          <string>Select All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="treeModeRadioButton">
+         <property name="text">
+          <string>Tree Mode</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="listModeRadioButton">
+         <property name="text">
+          <string>List Mode</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="treehorizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="filterHorizontalLayout">
+       <item>
+        <widget class="QLabel" name="filterLabel">
+         <property name="text">
+          <string>Select inputs</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="filterModePushButton">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>&lt;=</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="BitcoinAmountField" name="maxMinOutputValue">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="filterPushButton">
+         <property name="toolTip">
+          <string>Filters the already selected inputs.</string>
+         </property>
+         <property name="text">
+          <string>Filter</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="filterHorizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="CoinControlTreeWidget" name="treeWidget">
+       <property name="contextMenuPolicy">
+        <enum>Qt::CustomContextMenu</enum>
+       </property>
+       <property name="sortingEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="columnCount">
+        <number>11</number>
+       </property>
+       <attribute name="headerShowSortIndicator" stdset="0">
+        <bool>true</bool>
+       </attribute>
+       <attribute name="headerStretchLastSection">
+        <bool>false</bool>
+       </attribute>
+       <column>
         <property name="text">
-         <string>Step 1: Select the inputs to be consolidated. Remember that the inputs to the consolidation are your unspent outputs (UTXOs) in your wallet.</string>
+         <string/>
         </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="treeHorizontalLayout">
-      <item>
-       <widget class="QPushButton" name="selectAllPushButton">
+       </column>
+       <column>
         <property name="text">
-         <string>Select All</string>
+         <string>Amount</string>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="treeModeRadioButton">
+       </column>
+       <column>
         <property name="text">
-         <string>Tree Mode</string>
+         <string>Label</string>
         </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="listModeRadioButton">
+       </column>
+       <column>
         <property name="text">
-         <string>List Mode</string>
+         <string>Address</string>
         </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="treehorizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="filterHorizontalLayout">
-      <item>
-       <widget class="QLabel" name="filterLabel">
+       </column>
+       <column>
         <property name="text">
-         <string>Select inputs</string>
+         <string>Date</string>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="filterModePushButton">
+       </column>
+       <column>
+        <property name="text">
+         <string>Confirmations</string>
+        </property>
         <property name="toolTip">
-         <string/>
+         <string>Confirmed</string>
         </property>
+       </column>
+       <column>
         <property name="text">
-         <string>&lt;=</string>
+         <string>Priority</string>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="BitcoinAmountField" name="maxMinOutputValue">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="filterPushButton">
-        <property name="toolTip">
-         <string>Filters the already selected inputs.</string>
-        </property>
-        <property name="text">
-         <string>Filter</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="filterHorizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <widget class="CoinControlTreeWidget" name="treeWidget">
-      <property name="contextMenuPolicy">
-       <enum>Qt::CustomContextMenu</enum>
-      </property>
-      <property name="sortingEnabled">
-       <bool>false</bool>
-      </property>
-      <property name="columnCount">
-       <number>11</number>
-      </property>
-      <attribute name="headerShowSortIndicator" stdset="0">
-       <bool>true</bool>
-      </attribute>
-      <attribute name="headerStretchLastSection">
-       <bool>false</bool>
-      </attribute>
-      <column>
-       <property name="text">
-        <string/>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Amount</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Label</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Address</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Date</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Confirmations</string>
-       </property>
-       <property name="toolTip">
-        <string>Confirmed</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Priority</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string/>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string/>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string/>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string/>
-       </property>
-      </column>
-     </widget>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="summaryHorizontalLayout">
-      <item>
-       <widget class="QLabel" name="outputLimitWarningIconLabel">
+       </column>
+       <column>
         <property name="text">
          <string/>
         </property>
-        <property name="pixmap">
-         <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
-        </property>
-        <property name="scaledContents">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="outputLimitStopIconLabel">
-        <property name="maximumSize">
-         <size>
-          <width>64</width>
-          <height>64</height>
-         </size>
-        </property>
+       </column>
+       <column>
         <property name="text">
          <string/>
         </property>
-        <property name="pixmap">
-         <pixmap resource="../bitcoin.qrc">:/icons/white_and_red_x</pixmap>
-        </property>
-        <property name="scaledContents">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="summaryHorizontalSpacer_1">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="quantityTextLabel">
+       </column>
+       <column>
         <property name="text">
-         <string>Quantity</string>
+         <string/>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="quantityLabel">
+       </column>
+       <column>
         <property name="text">
-         <string>99999</string>
+         <string/>
         </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="summaryHorizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="feeTextLabel">
-        <property name="text">
-         <string>Fee</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="feeLabel">
-        <property name="text">
-         <string>99.9999</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="summaryHorizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="afterFeeTextLabel">
-        <property name="text">
-         <string>After Fee Amount</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="afterFeeLabel">
-        <property name="text">
-         <string>999999999.9999</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="isCompleteCheckBox">
-        <property name="text">
-         <string>isComplete</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-   </layout>
-  </widget>
+       </column>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="summaryHorizontalLayout">
+       <item>
+        <widget class="QLabel" name="outputLimitWarningIconLabel">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="pixmap">
+          <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
+         </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="outputLimitStopIconLabel">
+         <property name="maximumSize">
+          <size>
+           <width>64</width>
+           <height>64</height>
+          </size>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="pixmap">
+          <pixmap resource="../bitcoin.qrc">:/icons/white_and_red_x</pixmap>
+         </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="summaryHorizontalSpacer_1">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="quantityTextLabel">
+         <property name="text">
+          <string>Quantity</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="quantityLabel">
+         <property name="text">
+          <string>99999</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="summaryHorizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="feeTextLabel">
+         <property name="text">
+          <string>Fee</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="feeLabel">
+         <property name="text">
+          <string>99.9999</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="summaryHorizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="afterFeeTextLabel">
+         <property name="text">
+          <string>After Fee Amount</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="afterFeeLabel">
+         <property name="text">
+          <string>999999999.9999</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="isCompleteCheckBox">
+         <property name="text">
+          <string>isComplete</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/qt/forms/consolidateunspentwizardsendpage.ui
+++ b/src/qt/forms/consolidateunspentwizardsendpage.ui
@@ -10,109 +10,109 @@
     <height>700</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>WizardPage</string>
   </property>
-  <widget class="QWidget" name="verticalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>19</x>
-     <y>19</y>
-     <width>851</width>
-     <height>581</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="sendIntroLabel">
-        <property name="text">
-         <string>Step 3: Confirm Consolidation Transaction Details. Transaction will be ready to send when Finish is pressed.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QFormLayout" name="formLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="InputQuantityTextLabel">
-        <property name="text">
-         <string>Number of Inputs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="InputQuantityLabel">
-        <property name="text">
-         <string>999999</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="feeTextLabel">
-        <property name="text">
-         <string>Transaction Fee</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="feeLabel">
-        <property name="text">
-         <string>99.9999</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="afterFeeAmountTextLabel">
-        <property name="text">
-         <string>Amount</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="afterFeeAmountLabel">
-        <property name="text">
-         <string>999999999.9999</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="destinationAddressTextLabel">
-        <property name="text">
-         <string>Destination Address</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="destinationAddressLabel">
-        <property name="text">
-         <string>address</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="destinationAddressLabelTextLabel">
-        <property name="text">
-         <string>Destination Address Label</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="destinationAddressLabelLabel">
-        <property name="text">
-         <string>label</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="sendIntroLabel">
+         <property name="text">
+          <string>Step 3: Confirm Consolidation Transaction Details. Transaction will be ready to send when Finish is pressed.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="InputQuantityTextLabel">
+         <property name="text">
+          <string>Number of Inputs</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="InputQuantityLabel">
+         <property name="text">
+          <string>999999</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="feeTextLabel">
+         <property name="text">
+          <string>Transaction Fee</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="feeLabel">
+         <property name="text">
+          <string>99.9999</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="afterFeeAmountTextLabel">
+         <property name="text">
+          <string>Amount</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="afterFeeAmountLabel">
+         <property name="text">
+          <string>999999999.9999</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="destinationAddressTextLabel">
+         <property name="text">
+          <string>Destination Address</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="destinationAddressLabel">
+         <property name="text">
+          <string>address</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="destinationAddressLabelTextLabel">
+         <property name="text">
+          <string>Destination Address Label</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="destinationAddressLabelLabel">
+         <property name="text">
+          <string>label</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/qt/forms/diagnosticsdialog.ui
+++ b/src/qt/forms/diagnosticsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>866</width>
-    <height>659</height>
+    <width>820</width>
+    <height>660</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/qt/forms/editaddressdialog.ui
+++ b/src/qt/forms/editaddressdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>457</width>
-    <height>126</height>
+    <width>460</width>
+    <height>125</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>709</width>
-    <height>421</height>
+    <width>700</width>
+    <height>420</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -583,15 +583,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QValidatedLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>BitcoinAmountField</class>
    <extends>QSpinBox</extends>
    <header>bitcoinamountfield.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QValueComboBox</class>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
-    <height>944</height>
+    <width>960</width>
+    <height>700</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/qt/forms/transactiondescdialog.ui
+++ b/src/qt/forms/transactiondescdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>767</width>
-    <height>402</height>
+    <width>770</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="maximumSize">

--- a/src/qt/forms/voting/pollresultdialog.ui
+++ b/src/qt/forms/voting/pollresultdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>732</width>
-    <height>524</height>
+    <width>740</width>
+    <height>580</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -58,8 +58,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>710</width>
-           <height>430</height>
+           <width>718</width>
+           <height>486</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="choicesScrollLayout">

--- a/src/qt/forms/voting/pollwizard.ui
+++ b/src/qt/forms/voting/pollwizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>360</height>
+    <width>670</width>
+    <height>580</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/qt/forms/voting/votewizard.ui
+++ b/src/qt/forms/voting/votewizard.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>360</height>
+    <width>740</width>
+    <height>580</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -5,6 +5,7 @@
 #include "bitcoinunits.h"
 #include "monitoreddatamapper.h"
 #include "optionsmodel.h"
+#include "qt/decoration.h"
 #include "init.h"
 #include "miner.h"
 
@@ -25,6 +26,8 @@ OptionsDialog::OptionsDialog(QWidget* parent)
            , fProxyIpValid(true)
 {
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
 
     /* Network elements init */
 #ifndef USE_UPNP

--- a/src/qt/researcher/researcherwizard.cpp
+++ b/src/qt/researcher/researcherwizard.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "qt/decoration.h"
 #include "qt/forms/ui_researcherwizard.h"
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizard.h"
@@ -29,8 +30,9 @@ ResearcherWizard::ResearcherWizard(
     , m_researcher_model(researcher_model)
 {
     ui->setupUi(this);
-    configureStartOverButton();
 
+    resize(GRC::ScaleSize(this, width(), height()));
+    configureStartOverButton();
     setAttribute(Qt::WA_DeleteOnClose, true);
 
     ui->modePage->setModel(researcher_model);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -219,6 +219,7 @@ RPCConsole::RPCConsole(QWidget *parent) :
 {
     ui->setupUi(this);
 
+    resize(GRC::ScaleSize(this, width(), height()));
     GRC::ScaleFontPointSize(ui->banHeading, 12);
 
 #ifndef Q_OS_MAC

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -7,6 +7,7 @@
 #include "init.h"
 #include "main.h"
 #include "optionsmodel.h"
+#include "qt/decoration.h"
 #include "streams.h"
 #include "walletmodel.h"
 #include "wallet/wallet.h"
@@ -22,6 +23,8 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget* parent)
                      , model(nullptr)
 {
     ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
 
     GUIUtil::setupAddressWidget(ui->addressInEdit_SM, this);
     GUIUtil::setupAddressWidget(ui->addressInEdit_VM, this);

--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -1,3 +1,4 @@
+#include "qt/decoration.h"
 #include "transactiondescdialog.h"
 #include "transactiontablemodel.h"
 #include "ui_transactiondescdialog.h"
@@ -13,6 +14,8 @@ TransactionDescDialog::TransactionDescDialog(const QModelIndex &idx, QWidget *pa
     ui(new Ui::TransactionDescDialog)
 {
     ui->setupUi(this);
+    resize(GRC::ScaleSize(this, width(), height()));
+
     QString desc = idx.data(TransactionTableModel::LongDescriptionRole).toString();
     ui->detailText->setHtml(desc);
 }

--- a/src/qt/voting/pollresultdialog.cpp
+++ b/src/qt/voting/pollresultdialog.cpp
@@ -42,7 +42,7 @@ PollResultDialog::PollResultDialog(const PollItem& poll_item, QWidget* parent)
 
     setModal(true);
     setAttribute(Qt::WA_DeleteOnClose, true);
-    resize(GRC::ScaleSize(this, 740, 580));
+    resize(GRC::ScaleSize(this, width(), height()));
 
     GRC::ScaleFontPointSize(ui->idLabel, 8);
 

--- a/src/qt/voting/pollwizard.cpp
+++ b/src/qt/voting/pollwizard.cpp
@@ -19,7 +19,7 @@ PollWizard::PollWizard(VotingModel& voting_model, QWidget* parent)
     ui->setupUi(this);
 
     setAttribute(Qt::WA_DeleteOnClose, true);
-    resize(GRC::ScaleSize(this, 670, 580));
+    resize(GRC::ScaleSize(this, width(), height()));
 
     ui->typePage->setPollTypes(m_poll_types.get());
     ui->projectPage->setModel(&voting_model);

--- a/src/qt/voting/votewizard.cpp
+++ b/src/qt/voting/votewizard.cpp
@@ -18,7 +18,7 @@ VoteWizard::VoteWizard(const PollItem& poll_item, VotingModel& voting_model, QWi
     ui->setupUi(this);
 
     setAttribute(Qt::WA_DeleteOnClose, true);
-    resize(GRC::ScaleSize(this, 740, 580));
+    resize(GRC::ScaleSize(this, width(), height()));
 
     ui->ballotPage->setModel(&voting_model);
     ui->ballotPage->setPoll(poll_item);


### PR DESCRIPTION
This provides a workaround to scale the application's GUI dialogs to the appropriate sizes on desktops with fractional DPI scaling. Using 125% scaling on Windows, for example, Qt does not adjust the coordinate system until versions 5.14 and later so dialogs appear cramped and may obstruct the visibility of the contents.

This solution applies manual scaling to render the expected dialog sizes until we can require a minimum Qt version that fully supports fractional scaling.

Some of the application's dialogs have grown quite large over time to accommodate scaling for high-DPI screens. I adjusted dialog sizes to appear no larger than 960x700 logical pixels for reasonable support of a larger number of common resolutions. While many folks use high-resolution displays these days, and extremely small displays are not really a high-priority audience, popular tablet hybrids and inexpensive wide-screen laptops often impose a size challenge for at least one axis. Since this PR alleviates high-DPI issues, we can better support users with lower resolutions by using more typical dialog sizes. The proposed constraint is based on a logical resolution of 1024x768 with some allowance for system UI elements.

As part of this change, I tweaked the UTXO consolidation wizard layouts to respond to the dialog size and adjustments.

Closes #1958.