### PR TITLE
rpc, util: Remove use of ArgsManager::NETWORK_ONLY for now

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -467,15 +467,15 @@ void SetupServerArgs()
     argsman.AddArg("-dns", "Allow DNS lookups for -addnode, -seednode and -connect",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-port=<port>", "Listen for connections on <port> (default: 32749 or testnet: 32748)",
-                   ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+                   ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-maxconnections=<n>", "Maintain at most <n> connections to peers (default: 125)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-maxoutboundconnections=<n>", "Maximum number of outbound connections (default: 8)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-addnode=<ip>", "Add a node to connect to and attempt to keep the connection open",
-                   ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+                   ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-connect=<ip>", "Connect only to the specified node(s)",
-                   ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+                   ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-seednode=<ip>", "Connect to a node to retrieve peer addresses, and disconnect",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-externalip=<ip>", "Specify your own public address",
@@ -487,7 +487,7 @@ void SetupServerArgs()
     argsman.AddArg("-listen", "Accept connections from outside (default: 1 if no -proxy or -connect)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-bind=<addr>[:<port>][=onion]", "Bind to given address. Use [host]:port notation for IPv6",
-                   ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
+                   ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-dnsseed", "Find peers using DNS lookup (default: 1)",
                    ArgsManager::ALLOW_BOOL, OptionsCategory::CONNECTION);
     argsman.AddArg("-banscore=<n>", "Threshold for disconnecting misbehaving peers (default: 100)",

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1641,6 +1641,8 @@ void ThreadOpenAddedConnections2(void* parg)
     vector<vector<CService> > vservAddressesToAdd(0);
     for (auto const& strAddNode : gArgs.GetArgs("-addnode"))
     {
+        LogPrint(BCLog::LogFlags::NET, "INFO: %s: addnode %s.", __func__, strAddNode);
+
         vector<CService> vservNode(0);
         if(Lookup(strAddNode.c_str(), vservNode, GetDefaultPort(), fNameLookup, 0))
         {

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -115,6 +115,8 @@ public:
          * Setting them as NETWORK_ONLY ensures that sharing a config file
          * between mainnet and regtest/testnet won't cause problems due to these
          * parameters by accident. */
+        // For Gridcoin we really can't use this flag yet, as we are still using separate
+        // config files for mainnet and testnet.
         NETWORK_ONLY = 0x200,
         // This argument's value is sensitive (such as a password).
         SENSITIVE = 0x400,


### PR DESCRIPTION
The port of the ArgsManager was using the NETWORK_ONLY flag for certain args, including addnode. Since Gridcoin still uses separate config files for mainnet and testnet rather than testnet.addnode style in the same config file, the use of the NETWORK_ONLY attribute was filtering out all those args with the flag set, including addnode.

Many thanks to @iFoggz for finding this.