### PR TITLE
refactor: Remove obsolete pubsub method definitions

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -601,9 +601,6 @@ public:
 
 
     void PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd);
-    bool IsSubscribed(unsigned int nChannel);
-    void Subscribe(unsigned int nChannel, unsigned int nHops=0);
-    void CancelSubscribe(unsigned int nChannel);
     void CloseSocketDisconnect();
 
     static bool DisconnectNode(const std::string& strNode);


### PR DESCRIPTION
Ref: https://github.com/bitcoin/bitcoin/pull/5832

Long since removed methods