### PR TITLE
script: Shell script cleanups

### DIFF
--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -7,7 +7,6 @@
 sign=true
 verify=false
 build=false
-setupenv=false
 
 # Systems to build
 linux=true
@@ -108,7 +107,7 @@ while :; do
 		fi
 		shift
 	    else
-		echo 'Error: "--os" requires an argument containing an l (for linux), w (for windows), or x (for Mac OSX)\n'
+		echo 'Error: "--os" requires an argument containing an l (for linux), w (for windows), or x (for Mac OSX)'
 		exit 1
 	    fi
 	    ;;
@@ -193,7 +192,7 @@ then
 fi
 
 # Get signer
-if [[ -n"$1" ]]
+if [[ -n "$1" ]]
 then
     SIGNER=$1
     shift

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -113,7 +113,7 @@ script: |
   chmod +x ${WRAP_DIR}/${prog}
   done
 
-  cd bitcoin
+  cd bitcoin || exit
   BASEPREFIX=`pwd`/depends
   # Build dependencies for each host
   for i in $HOSTS; do
@@ -152,7 +152,7 @@ script: |
   for i in ${HOSTS}; do
     export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir -p distsrc-${i}
-    cd distsrc-${i}
+    cd distsrc-${i} || exit
     INSTALLPATH=`pwd`/installed/${DISTNAME}
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf ../$SOURCEDIST
@@ -177,7 +177,7 @@ script: |
     esac
 
     make install DESTDIR=${INSTALLPATH}
-    cd installed
+    cd installed || exit
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -83,7 +83,7 @@ script: |
   create_per-host_faketime_wrappers "2000-01-01 12:00:00"
   export PATH=${WRAP_DIR}:${PATH}
 
-  cd bitcoin
+  cd bitcoin || exit
   BASEPREFIX=`pwd`/depends
 
   mkdir -p ${BASEPREFIX}/SDKs
@@ -122,7 +122,7 @@ script: |
   for i in ${HOSTS}; do
     export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir -p distsrc-${i}
-    cd distsrc-${i}
+    cd distsrc-${i} || exit
     INSTALLPATH=`pwd`/installed/${DISTNAME}
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf ../$SOURCEDIST
@@ -154,7 +154,7 @@ script: |
     make deploy
     ${WRAP_DIR}/dmg dmg "${OSX_VOLNAME}.dmg" ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
 
-    cd installed
+    cd installed || exit
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig

--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -26,7 +26,7 @@ script: |
   tar -C ${UNSIGNED_DIR} -xf bitcoin-win-unsigned.tar.gz
 
   tar xf osslsigncode-1.7.1.tar.gz
-  cd osslsigncode-1.7.1
+  cd osslsigncode-1.7.1 || exit
   patch -p1 < ${BUILD_DIR}/osslsigncode-Backports-to-1.7.1.patch
 
   ./configure --without-gsf --without-curl --disable-dependency-tracking

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -101,7 +101,7 @@ script: |
   create_per-host_linker_wrapper "2000-01-01 12:00:00"
   export PATH=${WRAP_DIR}:${PATH}
 
-  cd bitcoin
+  cd bitcoin || exit
   BASEPREFIX=`pwd`/depends
   # Build dependencies for each host
   for i in $HOSTS; do
@@ -139,7 +139,7 @@ script: |
   for i in ${HOSTS}; do
     export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir -p distsrc-${i}
-    cd distsrc-${i}
+    cd distsrc-${i} || exit
     INSTALLPATH=`pwd`/installed/${DISTNAME}
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf ../$SOURCEDIST
@@ -156,7 +156,7 @@ script: |
     make install DESTDIR=${INSTALLPATH}
     rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
     cp -f bitcoin-*setup*.exe $OUTDIR/
-    cd installed
+    cd installed || exit
     mv ${DISTNAME}/bin/*.dll ${DISTNAME}/lib/
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
@@ -169,7 +169,7 @@ script: |
     rm -rf distsrc-${i}
   done
   cp -rf contrib/windeploy $BUILD_DIR
-  cd $BUILD_DIR/windeploy
+  cd $BUILD_DIR/windeploy || exit
   mkdir unsigned
   cp $OUTDIR/bitcoin-*setup-unsigned.exe unsigned/
   find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz


### PR DESCRIPTION
Add required space to [ -n ].
Exit if cd fails. (lint)
Remove \n which is not handled by echo.

This removes about 100 lines from lint output on my branch.