### PR TITLE
log: remove deprecated db log category

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -105,15 +105,7 @@ void BCLog::Logger::EnableCategory(BCLog::LogFlags flag)
 bool BCLog::Logger::EnableCategory(const std::string& str)
 {
     BCLog::LogFlags flag;
-    if (!GetLogCategory(flag, str)) {
-        if (str == "db") {
-            // DEPRECATION: Added in 0.20, should start returning an error in 0.21
-            LogPrintf("Warning: logging category 'db' is deprecated, use 'walletdb' instead\n");
-            EnableCategory(BCLog::WALLETDB);
-            return true;
-        }
-        return false;
-    }
+    if (!GetLogCategory(flag, str)) return false;
     EnableCategory(flag);
     return true;
 }


### PR DESCRIPTION
The db log category was renamed to walletdb and deprecated in a previous upstream commit.

Ref: https://github.com/bitcoin/bitcoin/pull/19202