### PR TITLE
doc: remove duplicate line from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,6 @@ src/config/gridcoin-config.h.in
 src/config/stamp-h1
 share/setup.nsi
 share/qt/Info.plist
-contrib/devtools/split-debug.sh
 
 #libtool object files
 *.lo


### PR DESCRIPTION
The line `contrib/devtools/split-debug.sh` occurred twice in .gitignore.