### PR TITLE
build: Tweak NSIS Windows installer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -415,9 +415,6 @@ case $host in
 
      CPPFLAGS="$CPPFLAGS -D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -D_WIN32_WINNT=0x0601"
      LEVELDB_TARGET_FLAGS="-DOS_WINDOWS"
-     if test "x$CXXFLAGS_overridden" = "xno"; then
-       CXXFLAGS="$CXXFLAGS -w"
-     fi
      case $host in
        i?86-*) WINDOWS_BITS=32 ;;
        x86_64-*) WINDOWS_BITS=64 ;;

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -68,7 +68,7 @@ VIAddVersionKey CompanyName "${COMPANY}"
 VIAddVersionKey CompanyWebsite "${URL}"
 VIAddVersionKey FileVersion "${VERSION}"
 VIAddVersionKey FileDescription "Installer for @PACKAGE_NAME@"
-VIAddVersionKey LegalCopyright "Copyright (C) 2009-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@"
+VIAddVersionKey LegalCopyright "Copyright (C) 2014-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@"
 InstallDirRegKey HKCU "${REGKEY}" Path
 ShowUninstDetails show
 

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -2,6 +2,7 @@ Name "@PACKAGE_NAME@ (@WINDOWS_BITS@-bit)"
 
 RequestExecutionLevel highest
 SetCompressor /SOLID lzma
+Unicode true
 
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -66,8 +66,8 @@ VIAddVersionKey ProductVersion "${VERSION}"
 VIAddVersionKey CompanyName "${COMPANY}"
 VIAddVersionKey CompanyWebsite "${URL}"
 VIAddVersionKey FileVersion "${VERSION}"
-VIAddVersionKey FileDescription ""
-VIAddVersionKey LegalCopyright ""
+VIAddVersionKey FileDescription "Installer for @PACKAGE_NAME@"
+VIAddVersionKey LegalCopyright "Copyright (C) 2009-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@"
 InstallDirRegKey HKCU "${REGKEY}" Path
 ShowUninstDetails show
 


### PR DESCRIPTION
This tweaks the NSIS Windows installer to enable Unicode and also fill in the copyright information. See https://github.com/bitcoin/bitcoin/pull/18059
https://github.com/bitcoin/bitcoin/pull/21333
https://github.com/bitcoin/bitcoin/pull/18928