### PR TITLE
rpc: Implement getblocksbatch

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -199,6 +199,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblock"               , 1 },
     { "getblockbynumber"       , 0 },
     { "getblockbynumber"       , 1 },
+    { "getblocksbatch"         , 1 },
+    { "getblocksbatch"         , 2 },
     { "getblockhash"           , 0 },
     { "setban"                 , 2 },
     { "setban"                 , 3 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -415,6 +415,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getbestblockhash",        &getbestblockhash,        cat_network       },
     { "getblock",                &getblock,                cat_network       },
     { "getblockbynumber",        &getblockbynumber,        cat_network       },
+    { "getblocksbatch",          &getblocksbatch,          cat_network       },
     { "getblockcount",           &getblockcount,           cat_network       },
     { "getblockhash",            &getblockhash,            cat_network       },
     { "getburnreport",           &getburnreport,           cat_network       },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -228,6 +228,7 @@ extern UniValue getaddednodeinfo(const UniValue& params, bool fHelp);
 extern UniValue getbestblockhash(const UniValue& params, bool fHelp);
 extern UniValue getblock(const UniValue& params, bool fHelp);
 extern UniValue getblockbynumber(const UniValue& params, bool fHelp);
+extern UniValue getblocksbatch(const UniValue& params, bool fHelp);
 extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getblockcount(const UniValue& params, bool fHelp);
 extern UniValue getblockhash(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Usage:
`getblocksbatch <starting block height or hash> <number of blocks> [transaction details]
`

The return value is JSON object consisting of the number of blocks returned, and the array of blocks. The blocks will include transaction details if that boolean is set to true.

Note that the number of blocks must be between 1 and 1000. Also if the starting height is less than the number of blocks away from the head, the number returned will be limited to the range between the specified starting height and the head.

Note this function is primarily a convenience and performance enhancing function for uses that require high throughput reads of block data, such as the blockchain explorers.