### PR TITLE
voting, rpc, gui: Implement demand loading of historical poll by poll id and AVW calculation

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -32,6 +32,13 @@ extern CCriticalSection cs_main;
 extern std::string msMiningErrors;
 extern unsigned int nActiveBeforeSB;
 
+std::vector<MiningPool> MiningPools::GetMiningPools()
+{
+    return m_mining_pools;
+}
+
+MiningPools g_mining_pools;
+
 namespace {
 //!
 //! \brief Global BOINC researcher mining context.
@@ -160,43 +167,6 @@ const Project* ResolveWhitelistProject(
 }
 
 //!
-//! \brief Represents a Gridcoin pool that stakes on behalf of its users.
-//!
-//! The wallet uses these entries to detect when BOINC is attached to a pool
-//! account so that it can provide more useful information in the UI.
-//!
-class MiningPool
-{
-public:
-    MiningPool(const Cpid cpid, std::string m_name, std::string m_url)
-        : m_cpid(cpid), m_name(std::move(m_name)), m_url(std::move(m_url))
-    {
-    }
-
-    MiningPool(const std::string& cpid, std::string m_name, std::string m_url)
-        : MiningPool(Cpid::Parse(cpid), std::move(m_name), std::move(m_url))
-    {
-    }
-
-    Cpid m_cpid;        //!< The pool's external CPID.
-    std::string m_name; //!< The name of the pool.
-    std::string m_url;  //!< The pool's website URL.
-};
-
-//!
-//! \brief The set of known Gridcoin pools.
-//!
-//! TODO: In the future, we may add a contract type that allows pool operators
-//! to register a pool via the blockchain. The static list gets us by for now.
-//!
-const MiningPool g_pools[] = {
-    { "7d0d73fe026d66fd4ab8d5d8da32a611", "grcpool.com", "https://grcpool.com/" },
-    { "a914eba952be5dfcf73d926b508fd5fa", "grcpool.com-2", "https://grcpool.com/" },
-    { "163f049997e8a2dee054d69a7720bf05", "grcpool.com-3", "https://grcpool.com/" },
-    { "326bb50c0dd0ba9d46e15fae3484af35", "grc.arikado.pool", "https://gridcoinpool.ru/" },
-};
-
-//!
 //! \brief Determine whether the provided CPID belongs to a Gridcoin pool.
 //!
 //! \param cpid An external CPID for a project loaded from BOINC.
@@ -205,7 +175,7 @@ const MiningPool g_pools[] = {
 //!
 bool IsPoolCpid(const Cpid cpid)
 {
-    for (const auto& pool : g_pools) {
+    for (const auto& pool : g_mining_pools.GetMiningPools()) {
         if (pool.m_cpid == cpid) {
             return true;
         }
@@ -223,7 +193,7 @@ bool IsPoolCpid(const Cpid cpid)
 //!
 bool IsPoolUsername(const std::string& username)
 {
-    for (const auto& pool : g_pools) {
+    for (const auto& pool : g_mining_pools.GetMiningPools()) {
         if (pool.m_name == username) {
             return true;
         }

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -48,6 +48,53 @@ enum class ResearcherStatus
 };
 
 //!
+//! \brief Represents a Gridcoin pool that stakes on behalf of its users.
+//!
+//! The wallet uses these entries to detect when BOINC is attached to a pool
+//! account so that it can provide more useful information in the UI.
+//!
+class MiningPool
+{
+public:
+    MiningPool(const Cpid cpid, std::string m_name, std::string m_url)
+        : m_cpid(cpid), m_name(std::move(m_name)), m_url(std::move(m_url))
+    {
+    }
+
+    MiningPool(const std::string& cpid, std::string m_name, std::string m_url)
+        : MiningPool(Cpid::Parse(cpid), std::move(m_name), std::move(m_url))
+    {
+    }
+
+    Cpid m_cpid;        //!< The pool's external CPID.
+    std::string m_name; //!< The name of the pool.
+    std::string m_url;  //!< The pool's website URL.
+};
+
+//!
+//! \brief The set of known Gridcoin pools.
+//!
+//! TODO: Make this into a fully functional class. For right now it is just a skeleton, but
+//! it is a little bit more than the previous simple global array.
+//!
+class MiningPools
+{
+public:
+    MiningPools()
+    {
+        m_mining_pools.push_back({ "7d0d73fe026d66fd4ab8d5d8da32a611", "grcpool.com", "https://grcpool.com/" });
+        m_mining_pools.push_back({ "a914eba952be5dfcf73d926b508fd5fa", "grcpool.com-2", "https://grcpool.com/" });
+        m_mining_pools.push_back({ "163f049997e8a2dee054d69a7720bf05", "grcpool.com-3", "https://grcpool.com/" });
+        m_mining_pools.push_back({ "326bb50c0dd0ba9d46e15fae3484af35", "grc.arikado.pool", "https://gridcoinpool.ru/" });
+    }
+
+    std::vector<MiningPool> GetMiningPools();
+
+private:
+    std::vector<MiningPool> m_mining_pools;
+};
+
+//!
 //! \brief Represents a local BOINC project loaded from client_state.xml.
 //!
 struct MiningProject

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -724,6 +724,11 @@ uint64_t Superblock::CpidIndex::TotalMagnitude() const
     return m_total_magnitude / Magnitude::SCALE_FACTOR;
 }
 
+uint64_t Superblock::CpidIndex::TotalScaledMagnitude() const
+{
+    return m_total_magnitude;
+}
+
 double Superblock::CpidIndex::AverageMagnitude() const
 {
     if (empty()) {

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -783,6 +783,13 @@ public:
         uint64_t TotalMagnitude() const;
 
         //!
+        //! \brief Get the scaled sum of the magnitudes of all the CPIDs in the index.
+        //!
+        //! \return Total scaled magnitude at the time of the superblock from internal scaled member.
+        //!
+        uint64_t TotalScaledMagnitude() const;
+
+        //!
         //! \brief Get the average magnitude of all the CPIDs in the index.
         //!
         //! \return Average magnitude at the time of the superblock.

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -12,6 +12,7 @@
 #include "gridcoin/voting/builders.h"
 #include "gridcoin/voting/claims.h"
 #include "gridcoin/voting/payloads.h"
+#include "gridcoin/voting/registry.h"
 #include "ui_interface.h"
 #include "wallet/wallet.h"
 
@@ -1081,6 +1082,11 @@ CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet)
         if (m_poll->m_choices.size() < 2) {
             throw VotingError(_("Please enter at least two poll choices."));
         }
+    }
+
+    // If a poll of the same title (not case sensitive) is already in the registry, refuse to create the new poll.
+    if (GRC::GetPollRegistry().TryByTitle(boost::to_lower_copy(m_poll->m_title))) {
+        throw VotingError(_("Poll with that title already exists. Please choose another title."));
     }
 
     CWalletTx tx;

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -99,6 +99,34 @@ public:
     int64_t Expiration() const;
 
     //!
+    //! \brief Get the block index pointer for the first block in the poll duration.
+    //!
+    //! \return pointer to block index object.
+    //!
+    CBlockIndex* GetStartingBlockIndexPtr() const;
+
+    //!
+    //! \brief Get the block index pointer for the last block in the poll duration.
+    //!
+    //! \return pointer to block index object.
+    //!
+    CBlockIndex* GetEndingBlockIndexPtr() const;
+
+    //!
+    //! \brief Get the starting block height for the poll.
+    //!
+    //! \return block number if begun or std::nullopt (if skeleton reference - this should never happen).
+    //!
+    std::optional<int> GetStartingHeight() const;
+
+    //!
+    //! \brief Get the ending block height for the poll.
+    //!
+    //! \return block number if ended or std::nullopt if still active.
+    //!
+    std::optional<int> GetEndingHeight() const;
+
+    //!
     //! \brief Record a transaction that contains a response to the poll.
     //!
     //! \param txid Hash of the transaction that contains the vote.
@@ -303,6 +331,17 @@ public:
     //! matching title.
     //!
     const PollReference* TryByTitle(const std::string& title) const;
+
+    //!
+    //! \brief Get an existing poll in the registry, or if not found, demand load a
+    //! poll identified by the provided txid along with its votes. This is a temporary
+    //! workaround to deal with polls beyond the lookback period for contract load
+    //! during wallet init. This should be replaced when the poll caching state machine
+    //! code is implemented.
+    //!
+    //! \return Points to a poll object or \c nullptr if no poll added that matches
+    //! the supplied txid.
+    const PollReference* TryByTxidWithAddHistoricalPollAndVotes(const uint256 txid);
 
     //!
     //! \brief Destroy the contract handler state to prepare for historical

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -126,6 +126,8 @@ public:
     //!
     std::optional<int> GetEndingHeight() const;
 
+    std::optional<CAmount> GetActiveVoteWeight() const;
+
     //!
     //! \brief Record a transaction that contains a response to the poll.
     //!

--- a/src/qt/forms/voting/pollcard.ui
+++ b/src/qt/forms/voting/pollcard.ui
@@ -73,10 +73,17 @@
        </widget>
       </item>
       <item>
-       <layout class="QGridLayout" name="gridLayout" columnstretch="0,10000,0,10000">
+       <layout class="QGridLayout" name="gridLayout" columnstretch="0,10000,0,10000,0,10000">
         <property name="verticalSpacing">
          <number>3</number>
         </property>
+        <item row="1" column="4">
+         <widget class="QLabel" name="votePercentAVWTextLabel">
+          <property name="text">
+           <string>% of AVW:</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="2">
          <widget class="QLabel" name="voteCountTextLabel">
           <property name="text">
@@ -91,13 +98,6 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="3">
-         <widget class="QLabel" name="voteCountLabel">
-          <property name="text">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="expirationTextLabel">
           <property name="text">
@@ -105,10 +105,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="topAnswerTextLabel">
+        <item row="1" column="3">
+         <widget class="QLabel" name="totalWeightLabel">
           <property name="text">
-           <string>Top Answer:</string>
+           <string notr="true"/>
           </property>
          </widget>
         </item>
@@ -125,6 +125,13 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="3">
+         <widget class="QLabel" name="voteCountLabel">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="2">
          <widget class="QLabel" name="totalWeightTextLabel">
           <property name="text">
@@ -132,10 +139,31 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="totalWeightLabel">
+        <item row="0" column="4">
+         <widget class="QLabel" name="activeVoteWeightTextLabel">
           <property name="text">
-           <string notr="true"/>
+           <string>AVW:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="topAnswerTextLabel">
+          <property name="text">
+           <string>Top Answer:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="5">
+         <widget class="QLabel" name="activeVoteWeightLabel">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="5">
+         <widget class="QLabel" name="votePercentAVWLabel">
+          <property name="text">
+           <string/>
           </property>
          </widget>
         </item>

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -22,6 +22,8 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
     ui->expirationLabel->setText(GUIUtil::dateTimeStr(poll_item.m_expiration));
     ui->voteCountLabel->setText(QString::number(poll_item.m_total_votes));
     ui->totalWeightLabel->setText(QString::number(poll_item.m_total_weight));
+    ui->activeVoteWeightLabel->setText(QString::number(poll_item.m_active_weight));
+    ui->votePercentAVWLabel->setText(QString::number(poll_item.m_vote_percent_AVW, 'f', 4) + '\%');
     ui->topAnswerLabel->setText(poll_item.m_top_answer);
 
     if (!poll_item.m_finished) {

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -27,6 +27,7 @@ public:
             << tr("Weight Type")
             << tr("Votes")
             << tr("Total Weight")
+            << tr("% of Active Vote Weight")
             << tr("Top Answer");
     }
 
@@ -63,6 +64,8 @@ public:
                         return row->m_total_votes;
                     case PollTableModel::TotalWeight:
                         return QString::number(row->m_total_weight);
+                    case PollTableModel::VotePercentAVW:
+                        return QString::number(row->m_vote_percent_AVW, 'f', 4);
                     case PollTableModel::TopAnswer:
                         return row->m_top_answer;
                 }
@@ -73,6 +76,8 @@ public:
                     case PollTableModel::TotalVotes:
                         // Pass-through case
                     case PollTableModel::TotalWeight:
+                        // Pass-through case
+                    case PollTableModel::VotePercentAVW:
                         return QVariant(Qt::AlignRight | Qt::AlignVCenter);
                 }
                 break;
@@ -89,6 +94,8 @@ public:
                         return row->m_total_votes;
                     case PollTableModel::TotalWeight:
                         return QVariant::fromValue(row->m_total_weight);
+                    case PollTableModel::VotePercentAVW:
+                        return QVariant::fromValue(row->m_vote_percent_AVW);
                     case PollTableModel::TopAnswer:
                         return row->m_top_answer;
                 }

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -26,6 +26,7 @@ public:
         WeightType,
         TotalVotes,
         TotalWeight,
+        VotePercentAVW,
         TopAnswer,
     };
 

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -36,7 +36,8 @@ void NewPollReceived(VotingModel* model, int64_t poll_time)
 
 std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& iter)
 {
-    const PollResultOption result = PollResult::BuildFor(iter->Ref());
+    const PollReference& ref = iter->Ref();
+    const PollResultOption result = PollResult::BuildFor(ref);
 
     if (!result) {
         return std::nullopt;
@@ -55,6 +56,18 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
     item.m_response_type = QString::fromStdString(poll.ResponseTypeToString());
     item.m_total_votes = result->m_votes.size();
     item.m_total_weight = result->m_total_weight / COIN;
+
+    if (auto active_vote_weight = ref.GetActiveVoteWeight()) {
+        item.m_active_weight = *active_vote_weight / COIN;
+    } else {
+        item.m_active_weight = 0;
+    }
+
+    item.m_vote_percent_AVW = 0;
+    if (item.m_active_weight > 0) {
+        item.m_vote_percent_AVW = (double) item.m_total_weight / (double) item.m_active_weight * 100.0;
+    }
+
     item.m_finished = result->m_finished;
     item.m_multiple_choice = poll.AllowsMultipleChoices();
 

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -58,6 +58,8 @@ public:
     QString m_top_answer;
     uint32_t m_total_votes;
     uint64_t m_total_weight;
+    uint64_t m_active_weight;
+    double m_vote_percent_AVW;
     bool m_finished;
     bool m_multiple_choice;
     std::vector<VoteResultItem> m_choices;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -183,20 +183,41 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
 
 UniValue dumpcontracts(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 4)
-        throw runtime_error(
-                "dumpcontracts <contract_type> <file> <low height> <high height>\n"
+    if (fHelp || params.size() < 2 || params.size() > 5) {
+        std::stringstream help;
+
+        help << "dumpcontracts <contract_type> <file> [txids only] [low height] [high height]\n"
                 "\n"
-                "<contract_type> Contract type to gather data from."
+                "<contract_type> Contract type to gather data from. Use \"*\" for all.\n"
+                "Valid contract types: ";
+
+        // Skip UNKNOWN here.
+        for (int type = static_cast<int>(GRC::ContractType::UNKNOWN) + 1;
+             type < static_cast<int>(GRC::ContractType::OUT_OF_BOUND); ++type) {
+            if (type > 1) help << ", ";
+            help << GRC::Contract::Type(static_cast<GRC::ContractType>(type)).ToString();
+        }
+
+        help << ".\n\n"
                 "<file>          Output file.\n"
+                "<txids only>    Optional txids only. (If specified just output txids and other minimal info in text.)\n"
                 "<low height>    Optional low height. (If not specified then from genesis.)\n"
                 "<high height>   Optional high height. (If not specified then current head.)\n "
                 "\n"
-                "Dump serialized contract data gathered from the chain to a specified file.\n");
+                "Dump serialized or minimal textual contract data gathered from the chain to a specified file.\n";
 
-    GRC::Contract::Type contract_type = GRC::Contract::Type::Parse(params[0].get_str());
-    if (contract_type == GRC::ContractType::UNKNOWN)
-        throw runtime_error("Invalid contract type");
+        throw runtime_error(help.str());
+    }
+
+    std::string contract_type_string = params[0].get_str();
+    std::optional<GRC::Contract::Type> contract_type;
+
+    if (contract_type_string != "*") {
+        contract_type = GRC::Contract::Type::Parse(params[0].get_str());
+
+        if (*contract_type == GRC::ContractType::UNKNOWN)
+            throw runtime_error("Invalid contract type");
+    }
 
     fs::path path = fs::path(params[1].get_str());
     if (path.empty()) throw runtime_error("Invalid path.");
@@ -212,17 +233,22 @@ UniValue dumpcontracts(const UniValue& params, bool fHelp)
         throw runtime_error("File already exists at location. Please delete or rename old file first.");
     }
 
+    bool txids_only = false;
+    if (params.size() > 2) {
+        txids_only = params[2].get_bool();
+    }
+
     int low_height = 0;
     int high_height = 0;
 
-    if (params.size() > 2)
-    {
-        low_height = params[2].get_int();
-    }
-
     if (params.size() > 3)
     {
-        high_height = std::max(low_height, params[3].get_int());
+        low_height = params[3].get_int();
+    }
+
+    if (params.size() > 4)
+    {
+        high_height = std::max(low_height, params[4].get_int());
     }
 
     UniValue report(UniValue::VOBJ);
@@ -232,52 +258,100 @@ UniValue dumpcontracts(const UniValue& params, bool fHelp)
     int num_verified_beacons = 0;
 
     CBlock block;
-    CAutoFile file(fsbridge::fopen(path, "wb"), SER_DISK, PROTOCOL_VERSION);
-    CDataStream ss(SER_DISK, PROTOCOL_VERSION);
 
+    LOCK(cs_main);
+
+    // Set default high_height here if not specified above now that lock on cs_main is taken.
+    if (!high_height)
     {
-        LOCK(cs_main);
+        high_height = pindexBest->nHeight;
+    }
 
-        // Set default high_height here if not specified above now that lock on cs_main is taken.
-        if (!high_height)
-        {
-            high_height = pindexBest->nHeight;
-        }
+    CBlockIndex* pblockindex = pindexBest;
 
-        CBlockIndex* pblockindex = pindexBest;
+    // Rewind to high height to get time.
+    for (; pblockindex; pblockindex = pblockindex->pprev)
+    {
+        if (pblockindex->nHeight == high_height) break;
+    }
 
-        // Rewind to high height to get time.
-        for (; pblockindex; pblockindex = pblockindex->pprev)
-        {
-            if (pblockindex->nHeight == high_height) break;
-        }
+    high_height_time = pblockindex->nTime;
 
-        high_height_time = pblockindex->nTime;
+    // Continue rewinding to low height.
+    for (; pblockindex; pblockindex = pblockindex->pprev)
+    {
+        if (pblockindex->nHeight == low_height) break;
+    }
 
+    // From this point we have to go down two somewhat different paths based on whether a minimalist text output
+    // is desired or the full serialization output.
+    if (txids_only) {
+        fsbridge::ofstream file;
+        file.open(path, std::ios_base::out | std::ios_base::app);
 
-        // Continue rewinding to low height.
-        for (; pblockindex; pblockindex = pblockindex->pprev)
-        {
-            if (pblockindex->nHeight == low_height) break;
-        }
+        std::stringstream ss;
 
-        file << high_height_time;
-        file << low_height;
-        file << high_height;
+        file << "high_height_time,low_height,high_height,num_blocks\n";
+        file << high_height_time << ","
+             << low_height << ","
+             << high_height << ",";
+
+        ss << "txid,contract_type,contract_version,contract_action\n";
 
         while (pblockindex != nullptr && pblockindex->nHeight <= high_height) {
-
-            // Initialize a new export element from the current block index
-            GRC::ExportContractElement element(pblockindex);
 
             block.ReadFromDisk(pblockindex);
 
             bool include_element_in_export = false;
 
+            for (auto& tx : block.vtx) {
+                for (const auto& contract : tx.GetContracts()) {
+                    if (!contract_type || contract.m_type == contract_type) {
+                        LogPrintf("INFO: %s: txid %s, contract type %s, contract version %u, contract action %s\n",
+                                  __func__,
+                                  tx.GetHash().GetHex(),
+                                  contract.m_type.ToString(),
+                                  contract.m_version,
+                                  contract.m_action.ToString());
+                        ss << tx.GetHash().GetHex() << ","
+                           << contract.m_type.ToString() << ","
+                           << contract.m_version << ","
+                           << contract.m_action.ToString() << "\n";
+                        include_element_in_export = true;
+                        ++num_contracts;
+                    }
+                }
+            }
+
+            if (include_element_in_export) ++num_blocks;
+
+            pblockindex = pblockindex->pnext;
+        }
+
+        file << num_blocks << "\n";
+        file << ss.str();
+    } else {
+        CAutoFile file(fsbridge::fopen(path, "wb"), SER_DISK, PROTOCOL_VERSION);
+
+        CDataStream ss(SER_DISK, PROTOCOL_VERSION);
+
+        file << high_height_time
+             << low_height
+             << high_height;
+
+        while (pblockindex != nullptr && pblockindex->nHeight <= high_height) {
+
+            block.ReadFromDisk(pblockindex);
+
+            bool include_element_in_export = false;
+
+            // Initialize a new export element from the current block index
+            GRC::ExportContractElement element(pblockindex);
+
             // Put the contracts and the containing transactions in the export element.
             for (auto& tx : block.vtx) {
                 for (const auto& contract : tx.GetContracts()) {
-                    if (contract.m_type == contract_type) {
+                    if (!contract_type || contract.m_type == contract_type) {
                         element.m_ctx.push_back(std::make_pair(contract, tx));
                         include_element_in_export = true;
                         ++num_contracts;
@@ -285,7 +359,7 @@ UniValue dumpcontracts(const UniValue& params, bool fHelp)
                 }
             }
 
-            if (pblockindex->IsSuperblock() && contract_type == GRC::ContractType::BEACON) {
+            if (pblockindex->IsSuperblock() && (contract_type == GRC::ContractType::BEACON || !contract_type)) {
                 GRC::SuperblockPtr psuperblock = block.GetSuperblock(pblockindex);
 
                 for (const auto& key : psuperblock->m_verified_beacons.m_verified) {
@@ -296,7 +370,6 @@ UniValue dumpcontracts(const UniValue& params, bool fHelp)
                 // We have to include superblocks in the export even if no beacons were activated, because
                 // pending beacons are checked for expiration and marked expired on the same trigger.
                 include_element_in_export = true;
-
             }
 
             if (include_element_in_export)
@@ -318,7 +391,7 @@ UniValue dumpcontracts(const UniValue& params, bool fHelp)
     report.pushKV("timestamp", high_height_time);
     report.pushKV("low_height", low_height);
     report.pushKV("high_height", high_height);
-    report.pushKV("contract_type", params[0].get_str());
+    report.pushKV("contract_type", contract_type_string);
     report.pushKV("number_of_blocks_processed_containing_contract_type", num_blocks);
     report.pushKV("number_of_contracts_exported", num_contracts);
     if (contract_type == GRC::ContractType::BEACON) report.pushKV("number_of_beacons_verified", num_verified_beacons);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -177,6 +177,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "debug"                  , 0 },
     { "dumpcontracts"          , 2 },
     { "dumpcontracts"          , 3 },
+    { "dumpcontracts"          , 4 },
     { "getblockstats"          , 0 },
     { "getblockstats"          , 1 },
     { "getblockstats"          , 2 },

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -98,6 +98,11 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
     json.pushKV("invalid_votes", (uint64_t)result.m_invalid_votes);
     json.pushKV("total_weight", ValueFromAmount(result.m_total_weight));
 
+    if (auto active_vote_weight = poll_ref.GetActiveVoteWeight()) {
+        json.pushKV("active_vote_weight", ValueFromAmount(*active_vote_weight));
+        json.pushKV("vote_percent_avw", (double) result.m_total_weight / (double) *active_vote_weight * 100.0);
+    }
+
     if (!result.m_votes.empty()) {
         json.pushKV("top_choice_id", (uint64_t)result.Winner());
         json.pushKV("top_choice", result.WinnerLabel());

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -1,5 +1,6 @@
 #include "init.h"
 #include "main.h"
+#include "gridcoin/contract/contract.h"
 #include "gridcoin/contract/message.h"
 #include "gridcoin/voting/builders.h"
 #include "gridcoin/voting/payloads.h"
@@ -14,12 +15,14 @@ using namespace GRC;
 namespace {
 const PollReference* TryPollByTitleOrId(const std::string& title_or_id)
 {
-    const PollRegistry& registry = GetPollRegistry();
+    PollRegistry& registry = GetPollRegistry();
 
-    if (title_or_id.size() == sizeof(uint256) * 2) {
+    if (title_or_id.size() == sizeof(uint256) * 2 && IsHex(title_or_id)) {
         const uint256 txid = uint256S(title_or_id);
 
-        if (const PollReference* ref = registry.TryByTxid(txid)) {
+        // This will return a ref to the poll in the registry if found, or, try and load it and return the ref if
+        // the load is successful.
+        if (const PollReference* ref = registry.TryByTxidWithAddHistoricalPollAndVotes(txid)) {
             return ref;
         }
     }
@@ -80,6 +83,17 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
     UniValue json(UniValue::VOBJ);
 
     json.pushKV("poll_id", poll_ref.Txid().ToString());
+    json.pushKV("poll_title", poll_ref.Title());
+    json.pushKV("poll_expired", poll_ref.Expired(GetAdjustedTime()));
+
+    if (auto start_height = poll_ref.GetStartingHeight()) {
+        json.pushKV("starting_block_height", *start_height);
+    }
+
+    if (auto end_height = poll_ref.GetEndingHeight()) {
+        json.pushKV("ending_block_height", *end_height);
+    }
+
     json.pushKV("votes", (uint64_t)poll_ref.Votes().size());
     json.pushKV("invalid_votes", (uint64_t)result.m_invalid_votes);
     json.pushKV("total_weight", ValueFromAmount(result.m_total_weight));


### PR DESCRIPTION
This PR implements a temporary workaround to demand load a poll with the specified (poll transaction) id and the corresponding votes in the chain for the duration of the poll. This allows pulling up old polls in the wallet that are older than the 180 day contract lookback window for contract scanning during wallet init.

This workaround is activated by calling getpollresults poll_id with a valid id that is older than the lookback (i.e. not already in the poll registry). Note that the transaction id containing the poll must be known in advance as this will not work for a poll specified via title.

The old behavior was simply to return poll not found for any poll older than the lookback.

This workaround is very convenient for someone wanting to check a historical poll's information from a historical poll on  gidcoinstats.eu for example.

Once getpollresults is called on a valid historical poll, it will be fully loaded, and then will also appear in the GUI, because it has now been loaded in the poll registry.

Note this is intended to be temporary and should be replaced when the improved poll/vote state machine and caching is implemented.

This PR also implements the calculation of GetActiveVoteWeight() in an expired or active poll. To maximize the efficiency of the calculation, the starting and ending block index pointer for the poll is determined (ending being the current pindexBest if the poll is active), and a single scan through the index is done.

It has been instrumented with a timer, and based on testing, it takes on average 50 - 1000 msec depending on the length of the poll, so the overhead is not too bad.

AVW and the Vote Weight % of AVW (a very important metric for poll validation) have been added to the voting GUI.

Closes #2015.
Closes #2209.