### PR TITLE
rpc: Remove memorypool RPC Command

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2084,22 +2084,6 @@ UniValue currenttime(const UniValue& params, bool fHelp)
     return res;
 }
 
-UniValue memorypool(const UniValue& params, bool fHelp)
-{
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "memorypool\n"
-                "\n"
-                "Displays included and excluded memory pool txs\n");
-
-    UniValue res(UniValue::VOBJ);
-
-    res.pushKV("Excluded Tx", msMiningErrorsExcluded);
-    res.pushKV("Included Tx", msMiningErrorsIncluded);
-
-    return res;
-}
-
 UniValue networktime(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -427,7 +427,6 @@ static const CRPCCommand vRPCCommands[] =
     { "getpeerinfo",             &getpeerinfo,             cat_network       },
     { "getrawmempool",           &getrawmempool,           cat_network       },
     { "listbanned",              &listbanned,              cat_network       },
-    { "memorypool",              &memorypool,              cat_network       },
     { "networktime",             &networktime,             cat_network       },
     { "ping",                    &ping,                    cat_network       },
     { "setban",                  &setban,                  cat_network       },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -242,7 +242,6 @@ extern UniValue getnetworkinfo(const UniValue& params, bool fHelp);
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);
 extern UniValue getrawmempool(const UniValue& params, bool fHelp);
 extern UniValue listbanned(const UniValue& params, bool fHelp);
-extern UniValue memorypool(const UniValue& params, bool fHelp);
 extern UniValue networktime(const UniValue& params, bool fHelp);
 extern UniValue ping(const UniValue& params, bool fHelp);
 extern UniValue rpc_exportstats(const UniValue& params, bool fHelp);


### PR DESCRIPTION
The `memorypool` command's name is misleading. It does not list out what's in the memorypool - it just displays what transactions were involved in a block you created. This functionality is likely not useful, so it is likely better to remove the command. Marking as draft until there's an agreement or disagreement on that

Closes #2213 