### PR TITLE
refactor: Remove msMiningErrorsIncluded & msMiningErrorsExcluded

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,8 +119,6 @@ bool bGridcoinCoreInitComplete = false;
 
 // Mining status variables
 std::string    msMiningErrors;
-std::string    msMiningErrorsIncluded;
-std::string    msMiningErrorsExcluded;
 
 //When syncing, we grandfather block rejection rules up to this block, as rules became stricter over time and fields changed
 int nGrandfather = 1034700;

--- a/src/main.h
+++ b/src/main.h
@@ -103,8 +103,6 @@ extern bool fEnforceCanonical;
 static const uint64_t nMinDiskSpace = 52428800;
 
 extern std::string  msMiningErrors;
-extern std::string  msMiningErrorsIncluded;
-extern std::string  msMiningErrorsExcluded;
 
 extern int nGrandfather;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -387,8 +387,6 @@ bool ConnectInputs(CTransaction& tx, CTxDB& txdb, MapPrevTx inputs, std::map<uin
             {
                 if (fMiner)
                 {
-                    msMiningErrorsExcluded += " ConnectInputs() : " + tx.GetHash().GetHex() + " used at "
-                        + txindex.vSpent[prevout.n].ToString() + ";   ";
                     return false;
                 }
                 if (!txindex.vSpent[prevout.n].IsNull())


### PR DESCRIPTION
These variables are no no longer in use by anything. They are assigned values, but those values are never used or read from. Was missed in #2214