### PR TITLE
gui: Implement close confirmation.

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1261,7 +1261,9 @@ void BitcoinGUI::resetblockchainClicked()
 
 bool BitcoinGUI::tryQuit()
 {
-    if(clientModel->getOptionsModel()->getConfirmOnClose() &&
+    if(clientModel &&
+       clientModel->getOptionsModel() &&
+       clientModel->getOptionsModel()->getConfirmOnClose() &&
        QMessageBox::question(
            this,
            tr("Close Confirmation"),

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -244,6 +244,7 @@ private slots:
     void peersClicked();
     void snapshotClicked();
     void resetblockchainClicked();
+    bool tryQuit();
 
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -362,6 +362,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="confirmOnClose">
+         <property name="text">
+          <string>&amp;Confirm on close</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="disableTransactionNotifications">
          <property name="text">
           <string>Disable Transaction Notifications</string>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -175,7 +175,8 @@ void OptionsDialog::setMapper()
 #ifndef Q_OS_MAC
     mapper->addMapping(ui->minimizeToTray, OptionsModel::MinimizeToTray);
     mapper->addMapping(ui->minimizeOnClose, OptionsModel::MinimizeOnClose);
-#endif
+    mapper->addMapping(ui->confirmOnClose, OptionsModel::ConfirmOnClose);
+#endif    
 
     /* Display */
     mapper->addMapping(ui->lang, OptionsModel::Language);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -13,6 +13,7 @@
 #include <QIntValidator>
 #include <QLocale>
 #include <QMessageBox>
+#include <QSystemTrayIcon>
 
 OptionsDialog::OptionsDialog(QWidget* parent)
            : QDialog(parent)
@@ -58,6 +59,10 @@ OptionsDialog::OptionsDialog(QWidget* parent)
     ui->verticalLayout_Main->removeWidget(ui->gridcoinAtStartup);
     ui->verticalLayout_Main->removeWidget(ui->gridcoinAtStartupMinimised);
     ui->verticalLayout_Main->removeItem(ui->horizontalLayoutGridcoinStartup);
+
+    /* disable close confirmation on macOS */
+    ui->confirmOnClose->setChecked(false);
+    ui->confirmOnClose->setEnabled(false);
 #endif
 
     if (!QSystemTrayIcon::isSystemTrayAvailable())

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -52,8 +52,21 @@ OptionsDialog::OptionsDialog(QWidget* parent)
 
     /* Window elements init */
 #ifdef Q_OS_MAC
-    ui->tabWindow->setVisible(false);
+    /* hide launch at startup option on macOS */
+    ui->gridcoinAtStartup->setVisible(false);
+    ui->gridcoinAtStartupMinimised->setVisible(false);
+    ui->verticalLayout_Main->removeWidget(ui->gridcoinAtStartup);
+    ui->verticalLayout_Main->removeWidget(ui->gridcoinAtStartupMinimised);
+    ui->verticalLayout_Main->removeItem(ui->horizontalLayoutGridcoinStartup);
 #endif
+
+    if (!QSystemTrayIcon::isSystemTrayAvailable())
+    {
+        ui->minimizeToTray->setChecked(false);
+        ui->minimizeToTray->setEnabled(false);
+        ui->minimizeOnClose->setChecked(false);
+        ui->minimizeOnClose->setEnabled(false);
+    }
 
     /* Display elements init */
     QDir translations(":translations");
@@ -75,10 +88,8 @@ OptionsDialog::OptionsDialog(QWidget* parent)
     }
 
     ui->unit->setModel(new BitcoinUnits(this));
-
     ui->styleComboBox->addItem(tr("Dark"), QVariant("dark"));
     ui->styleComboBox->addItem(tr("Light"), QVariant("light"));
-
 
     /* Widget-to-option mapper */
     mapper = new MonitoredDataMapper(this);
@@ -173,8 +184,10 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->disableTransactionNotifications, OptionsModel::DisableTrxNotifications);
     mapper->addMapping(ui->disablePollNotifications, OptionsModel::DisablePollNotifications);
 #ifndef Q_OS_MAC
-    mapper->addMapping(ui->minimizeToTray, OptionsModel::MinimizeToTray);
-    mapper->addMapping(ui->minimizeOnClose, OptionsModel::MinimizeOnClose);
+    if (QSystemTrayIcon::isSystemTrayAvailable()) {
+        mapper->addMapping(ui->minimizeToTray, OptionsModel::MinimizeToTray);
+        mapper->addMapping(ui->minimizeOnClose, OptionsModel::MinimizeOnClose);
+    }
     mapper->addMapping(ui->confirmOnClose, OptionsModel::ConfirmOnClose);
 #endif    
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -50,6 +50,7 @@ void OptionsModel::Init()
     fDisablePollNotifications = settings.value("fDisablePollNotifications", false).toBool();
     bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
+    fConfirmOnClose = settings.value("fConfirmOnClose", false).toBool();
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
     fLimitTxnDisplay = settings.value("fLimitTxnDisplay", false).toBool();
     limitTxnDate = settings.value("limitTxnDate", QDate()).toDate();
@@ -97,6 +98,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(fStartMin);
         case MinimizeToTray:
             return QVariant(fMinimizeToTray);
+        case ConfirmOnClose:
+            return QVariant(fConfirmOnClose);
         case DisableTrxNotifications:
             return QVariant(fDisableTrxNotifications);
         case DisablePollNotifications:
@@ -189,6 +192,10 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case MinimizeToTray:
             fMinimizeToTray = value.toBool();
             settings.setValue("fMinimizeToTray", fMinimizeToTray);
+            break;
+        case ConfirmOnClose:
+            fConfirmOnClose = value.toBool();
+            settings.setValue("fConfirmOnClose", fConfirmOnClose);
             break;
         case DisableTrxNotifications:
             fDisableTrxNotifications = value.toBool();
@@ -376,6 +383,11 @@ bool OptionsModel::getStartMin()
 bool OptionsModel::getMinimizeToTray()
 {
     return fMinimizeToTray;
+}
+
+bool OptionsModel::getConfirmOnClose()
+{
+    return fConfirmOnClose;
 }
 
 bool OptionsModel::getDisableTrxNotifications()

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -20,6 +20,7 @@ public:
     enum OptionID {
         StartAtStartup,          // bool
         MinimizeToTray,          // bool
+        ConfirmOnClose,          // bool
         StartMin,                // bool
         DisableTrxNotifications, // bool
         DisablePollNotifications,// bool
@@ -58,6 +59,7 @@ public:
     bool getStartAtStartup();
     bool getStartMin();
     bool getMinimizeToTray();
+    bool getConfirmOnClose();
     bool getDisableTrxNotifications();
     bool getDisablePollNotifications();
     bool getMinimizeOnClose();
@@ -84,6 +86,7 @@ private:
     bool fDisablePollNotifications;
 	bool bDisplayAddresses;
     bool fMinimizeOnClose;
+    bool fConfirmOnClose;
     bool fCoinControlFeatures;
     bool fLimitTxnDisplay;
     QDate limitTxnDate;


### PR DESCRIPTION
This adds an optional confirmation on close to avoid accidentally closing the main wallet window. If the user also has enabled minimize on close that will take priority and the confirmation dialog will not show up until the wallet is closed from the system tray.

The existing quit handling was slightly alter to more closely resemble that of the current Bitcoin code base.

**Tested on Linux:**
- X from main window with option enabled/disabled
- X from main window with confirm and minimize enabled
- X from systray with confirm and minimize enabled
- kill process with confirm enabled (no confirmation dialog shown)

**Needs testing:**
- Windows
- OSX

This closes #2211