### PR TITLE
build: Suppress -Wdeprecated-copy warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -278,7 +278,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[CXXFLAGS="$CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
   dnl For Qt versions < 5.14 with GCC 9+:
-  AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 
 enable_hwcrc32=no


### PR DESCRIPTION
Should have been fixed with https://github.com/gridcoin-community/Gridcoin-Research/pull/1702

I'm not sure why we're still getting spammed, but maybe this will do the trick...

Ref: https://github.com/bitcoin/bitcoin/pull/18738