### PR TITLE
util: Remove old boost hacks/workarounds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -904,11 +904,8 @@ if test x$use_boost = xyes; then
 
 BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_ZLIB_LIB $BOOST_IOSTREAMS_LIB $BOOST_PROGRAM_OPTIONS_LIB $BOOST_THREAD_LIB $BOOST_CHRONO_LIB $BOOST_ZLIB_LIB"
 
-dnl Boost >= 1.50 uses sleep_for rather than the now-deprecated sleep, however
-dnl it was broken from 1.50 to 1.52 when backed by nanosleep. Use sleep_for if
-dnl a working version is available, else fall back to sleep. sleep was removed
-dnl after 1.56.
-dnl If neither is available, abort.
+dnl Boost >= 1.50 uses sleep_for rather than the now-deprecated sleep.
+dnl Use sleep_for if a working version is available. If not, abort.
 TEMP_LIBS="$LIBS"
 LIBS="$BOOST_LIBS $LIBS"
 TEMP_CPPFLAGS="$CPPFLAGS"
@@ -928,28 +925,6 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   [boost_sleep=no])
 LIBS="$TEMP_LIBS"
 CPPFLAGS="$TEMP_CPPFLAGS"
-
-if test x$boost_sleep != xyes; then
-TEMP_LIBS="$LIBS"
-LIBS="$BOOST_LIBS $LIBS"
-TEMP_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <boost/version.hpp>
-  #include <boost/thread.hpp>
-  #include <boost/date_time/posix_time/posix_time_types.hpp>
-  ]],[[
-  #if BOOST_VERSION <= 105600
-      boost::this_thread::sleep(boost::posix_time::milliseconds(0));
-  #else
-   choke me
-  #endif
-  ]])],
-  [boost_sleep=yes; AC_DEFINE(HAVE_WORKING_BOOST_SLEEP, 1, [Define this symbol if boost sleep works])],
-  [boost_sleep=no])
-LIBS="$TEMP_LIBS"
-CPPFLAGS="$TEMP_CPPFLAGS"
-fi
 
 if test x$boost_sleep != xyes; then
   AC_MSG_ERROR(No working boost sleep implementation found.)

--- a/src/gridcoin/backup.cpp
+++ b/src/gridcoin/backup.cpp
@@ -123,10 +123,8 @@ bool GRC::BackupConfigFile(const std::string& strDest)
     {
         #if BOOST_VERSION >= 107400
             fs::copy_file(ConfigSource, ConfigTarget, fs::copy_options::overwrite_existing);
-        #elif BOOST_VERSION >= 104000
-            fs::copy_file(ConfigSource, ConfigTarget, fs::copy_option::overwrite_if_exists);
         #else
-            fs::copy_file(ConfigSource, ConfigTarget);
+            fs::copy_file(ConfigSource, ConfigTarget, fs::copy_option::overwrite_if_exists);
         #endif
         LogPrintf("BackupConfigFile: Copied gridcoinresearch.conf to %s", ConfigTarget.string());
         return true;
@@ -164,10 +162,8 @@ bool GRC::BackupWallet(const CWallet& wallet, const std::string& strDest)
         {
 #if BOOST_VERSION >= 107400
             fs::copy_file(WalletSource, WalletTarget, fs::copy_options::overwrite_existing);
-#elif BOOST_VERSION >= 104000
-            fs::copy_file(WalletSource, WalletTarget, fs::copy_option::overwrite_if_exists);
 #else
-            fs::copy_file(WalletSource, WalletTarget);
+            fs::copy_file(WalletSource, WalletTarget, fs::copy_option::overwrite_if_exists);
 #endif
             LogPrintf("BackupWallet: Copied wallet.dat to %s", WalletTarget.string());
         }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -20,16 +20,6 @@ CScheduler::~CScheduler()
     assert(nThreadsServicingQueue == 0);
 }
 
-
-#if BOOST_VERSION < 105000
-static boost::system_time toPosixTime(const boost::chrono::system_clock::time_point& t)
-{
-    // Creating the posix_time using from_time_t loses sub-second precision. So rather than exporting the time_point to time_t,
-    // start with a posix_time at the epoch (0) and add the milliseconds that have passed since then.
-    return boost::posix_time::from_time_t(0) + boost::posix_time::milliseconds(boost::chrono::duration_cast<boost::chrono::milliseconds>(t.time_since_epoch()).count());
-}
-#endif
-
 void CScheduler::serviceQueue()
 {
     boost::unique_lock<boost::mutex> lock(newTaskMutex);

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -54,13 +54,6 @@ void CScheduler::serviceQueue()
             // Wait until either there is a new task, or until
             // the time of the first item on the queue:
 
-// wait_until needs boost 1.50 or later; older versions have timed_wait:
-#if BOOST_VERSION < 105000
-            while (!shouldStop() && !taskQueue.empty() &&
-                   newTaskScheduled.timed_wait(lock, toPosixTime(taskQueue.begin()->first))) {
-                // Keep waiting until timeout
-            }
-#else
             // Some boost versions have a conflicting overload of wait_until that returns void.
             // Explicitly use a template here to avoid hitting that overload.
             while (!shouldStop() && !taskQueue.empty()) {
@@ -80,7 +73,7 @@ void CScheduler::serviceQueue()
                     throw;
                 }
             }
-#endif
+
             // If there are multiple threads, the queue can empty while we're waiting (another
             // thread may service the task we were waiting on).
             if (shouldStop() || taskQueue.empty())

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -185,18 +185,11 @@ MilliTimer g_timer;
 void MilliSleep(int64_t n)
 {
 
-/**
- * Boost's sleep_for was uninterruptible when backed by nanosleep from 1.50
- * until fixed in 1.52. Use the deprecated sleep method for the broken case.
- * See: https://svn.boost.org/trac/boost/ticket/7238
- */
 #if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
     boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::milliseconds(n));
 #else
 //should never get here
-#error missing boost sleep implementation
+#error missing boost sleep_for implementation
 #endif
 }
 


### PR DESCRIPTION
Our minimum boost version is 1.58 as of #2194.  Remove old hacks and workarounds for versions older than 1.58

~~This is a draft until I finish working on https://github.com/bitcoin/bitcoin/pull/16117.  If this should be a separate PR let me know.
Note that MilliSleep() touches 40 files.~~

We will continue using MilliSleep() for the time being