### PR TITLE
util: Remove deprecated random number generator functions

### DIFF
--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -22,16 +22,6 @@ bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pM
 
        MSG *pMsg = static_cast<MSG *>(pMessage);
 
-       // Seed OpenSSL PRNG with Windows event data (e.g.  mouse movements and other user interactions)
-       if (RAND_event(pMsg->message, pMsg->wParam, pMsg->lParam) == 0) {
-           // Warn only once as this is performance-critical
-           static bool warned = false;
-           if (!warned) {
-               LogPrintf("%s: OpenSSL RAND_event() failed to seed OpenSSL PRNG with enough data.\n", __func__);
-               warned = true;
-           }
-       }
-
        switch(pMsg->message)
        {
            case WM_QUERYENDSESSION:

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -85,14 +85,36 @@ public:
             ppmutexOpenSSL[i] = new CCriticalSection();
         CRYPTO_set_locking_callback(locking_callback);
 
-#ifdef WIN32
-        // Seed OpenSSL PRNG with current contents of the screen
-        RAND_screen();
-#endif
+        // Check whether OpenSSL random number generator is properly seeded. If not, attempt to seed using RAND_poll().
+        // Note that in versions of OpenSSL in the depends in Gridcoin (currently 1.1.1+), and modern Unix distros (using
+        // openSSL 1.1+ or modern Windows operating systems with the equivalent of /dev/urandom, the random number
+        // generator is automatically seeded on init, and periodically reseeded from trusted OS random sources. It is
+        // not necessary to manually reseed the RNG. Here we implement a check via RAND_status() to ensure the RNG
+        // is properly seeded. If not, we try 10 times (probably excessive) to seed the RNG via openSSL's entropy sources,
+        // breaking as soon as the return from RAND_poll() becomes 1 (successfully seeded). A 100 ms sleep is inserted
+        // between each try to ensure we give time for a short term unavailability of the OS entropy source to recover.
+        // If this falls through, we abort the application as we cannot have a non-functioning RNG.
+        bool seed_successful = RAND_status();
+        if (!seed_successful) {
+            for (unsigned int i = 0; i < 10; ++i)
+            {
+                seed_successful = RAND_poll();
 
-        // Seed OpenSSL PRNG with performance counter
-        RandAddSeed();
+                if (seed_successful) break;
+
+                MilliSleep(100);
+            }
+
+            if (!seed_successful) {
+                tfm::format(std::cerr, "ERROR: %s: Unable to initialize the random number generator. Cannot continue. "
+                                       "Please check your operating system to ensure the random number source is "
+                                       "available. (This is /dev/urandom on Linux.)",
+                            __func__);
+                std::abort();
+            }
+        }
     }
+
     ~CInit()
     {
         // Securely erase the memory used by the PRNG
@@ -118,13 +140,15 @@ void RandAddSeedPerfmon()
 {
     RandAddSeed();
 
+    // Only need for OpenSSL < 1.1 and Win32, since 1.1 and greater seed properly from Windows, and on Linux seeds properly
+    // in all cases.
+#if OPENSSL_VERSION_NUMBER < 0x10100000L && defined(WIN32)
     // This can take up to 2 seconds, so only do it every 10 minutes
     static int64_t nLastPerfmon;
     if ( GetAdjustedTime() < nLastPerfmon + 10 * 60)
         return;
     nLastPerfmon =  GetAdjustedTime();
 
-#ifdef WIN32
     // Don't need this on Linux, OpenSSL automatically uses /dev/urandom
     // Seed with the entire set of perfmon data
     unsigned char pdata[250000];


### PR DESCRIPTION
This commit changes CInit to check for proper RNG seeding and use RAND_poll() if necessary. It removes RandAddSeed() RandAddSeedPerfmon() and also the use of RAND_screen. **[Update - RandAddSeed() and RandAddSeedPerfmon() have been retained, but a macro conditional changes what they do.]**

OpenSSL in 1.1.0+ has fixed entropy source issues that obviate the kludges that were in the code to collect additional entropy from Performance Counters/screen etc. In 1.1.0+, OpenSSL automatically seeds (and reseeds) the RNG with entropy from trusted sources without intervention. Obviously the super simple approach to this is something like what I have done in this PR.

There are several big issues remaining however:
1. Some operating systems that are still being supported are using 1.0.2 such as Ubuntu Xenial (16.04), which has problems with the RNG that were fixed in 1.1.0+.
2. The documentation for RAND in OpenSSL states explicity that the status (error return value ) of RAND_bytes() should be checked at each call, because a transient failure of the entropy sources could cause the RNG to not have enough entropy and then degrade into not providing valid random numbers. As far as I can tell this is not done in ANY of the code. RTFM. We should at a minimum put a wrapper around the vanilla RAND_bytes() with a reseed try using RAND_poll() if the call to RAND_bytes() gives an unsuccessful status.
3. A short review of Bitcoin's current RNG code in random.cpp/h shows a far more advanced approach where they essentially largely wrote their own RNG. I am not sure we are ready to drop-ship that in yet.

If people are nervous about removing the RandAddSeed / RandAddSeedPerfmon in places that originally were critical points where more entropy was desired, we could simply call RAND_poll() there, or put RandAddSeed() back in place as a simple wrapper.

Comments?