### PR TITLE
doc: Fix typo in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,7 +35,7 @@ If you are not on the latest Leisure release please try updating to that and see
 - CPU:
 - RAM:
 - Disk size:
-- Disk Type (HD/SDD):
+- Disk Type (HD/SSD):
 
 **Extra information**
 <!-- This is normally the contents of a `debug.log` file. Raw text or a link to a pastebin type site is preferred. -->


### PR DESCRIPTION
Fix a small typo in the new bug report template.