### PR TITLE
util, qt: Fix snapshot download

### DIFF
--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -25,7 +25,7 @@
 #define progressinterval 1
 #endif
 
-struct_SnapshotStatus DownloadStatus;
+SnapshotStatus DownloadStatus;
 
 enum class logattribute {
     // Can't use ERROR here because it is defined already in windows.h.
@@ -75,7 +75,8 @@ namespace
       CURL *curl;
     };
 
-    static int newerprogress_callback(void *ptr, curl_off_t downtotal, curl_off_t downnow, curl_off_t uptotal, curl_off_t uplnow)
+    static int newerprogress_callback(void *ptr, curl_off_t downtotal, curl_off_t downnow,
+                                      curl_off_t uptotal, curl_off_t uplnow)
     {
         struct progress *pg = (struct progress*)ptr;
         CURL *curl = pg->curl;
@@ -85,8 +86,8 @@ namespace
         {
             boost::this_thread::interruption_point();
             // Set this once.
-            if (DownloadStatus.SnapshotDownloadSize == 0)
-                DownloadStatus.SnapshotDownloadSize = downtotal;
+            if (DownloadStatus.GetSnapshotDownloadSize() == 0)
+                DownloadStatus.SetSnapshotDownloadSize(downtotal);
 
             timetype currenttime = 0;
             curl_easy_getinfo(curl, timeopt, &currenttime);
@@ -107,20 +108,22 @@ namespace
 
 #if LIBCURL_VERSION_NUM >= 0x073700
                     if (speed > 0)
-                        DownloadStatus.SnapshotDownloadSpeed = (int64_t)speed;
-
-                    else {
-                        DownloadStatus.SnapshotDownloadSpeed = 0;
-
+                    {
+                        DownloadStatus.SetSnapshotDownloadSpeed((int64_t) speed);
                     }
+                    else
+                    {
+                        DownloadStatus.SetSnapshotDownloadSpeed(0);
+                    }
+
 #else
                     // Not supported by libcurl
                     DownloadStatus.SnapshotDownloadSpeed = -1;
 #endif
-                    if (DownloadStatus.SnapshotDownloadSize > 0 && (downnow > 0))
+                    if (DownloadStatus.GetSnapshotDownloadSize() > 0 && (downnow > 0))
                     {
-                        DownloadStatus.SnapshotDownloadProgress = ((downnow / (double)DownloadStatus.SnapshotDownloadSize) * 100);
-                        DownloadStatus.SnapshotDownloadAmount = downnow;
+                        DownloadStatus.SetSnapshotDownloadProgress(downnow * 100 / DownloadStatus.GetSnapshotDownloadSize());
+                        DownloadStatus.SetSnapshotDownloadAmount(downnow);
                     }
                 }
             }
@@ -137,7 +140,8 @@ namespace
 #if LIBCURL_VERSION_NUM < 0x072000
     static int olderprogress_callback(void *ptr, double downtotal, double downnow, double uptotal, double upnow)
     {
-        return newerprogress_callback(ptr, (curl_off_t)downtotal, (curl_off_t)downnow, (curl_off_t)uptotal, (curl_off_t)upnow);
+        return newerprogress_callback(ptr, (curl_off_t)downtotal, (curl_off_t)downnow,
+                                      (curl_off_t)uptotal, (curl_off_t)upnow);
     };
 
 #endif
@@ -270,7 +274,8 @@ std::string Http::GetLatestVersionResponse()
 {
     std::string buffer;
     std::string header;
-    std::string url = gArgs.GetArg("-updatecheckurl", "https://api.github.com/repos/gridcoin-community/Gridcoin-Research/releases/latest");
+    std::string url = gArgs.GetArg("-updatecheckurl",
+                                   "https://api.github.com/repos/gridcoin-community/Gridcoin-Research/releases/latest");
 
     struct curl_slist* headers = nullptr;
     headers = curl_slist_append(headers, "Accept: */*");
@@ -286,7 +291,8 @@ std::string Http::GetLatestVersionResponse()
     CURLcode res = curl_easy_perform(curl.get());
 
     if (res > 0)
-        throw std::runtime_error(tfm::format("Failed to get version response from URL %s: %s", url, curl_easy_strerror(res)));
+        throw std::runtime_error(tfm::format("Failed to get version response from URL %s: %s",
+                                             url, curl_easy_strerror(res)));
 
     curl_slist_free_all(headers);
 
@@ -309,10 +315,11 @@ void Http::DownloadSnapshot()
 
     if (!fp)
     {
-        DownloadStatus.SnapshotDownloadFailed = true;
+        DownloadStatus.SetSnapshotDownloadFailed(true);
 
         throw std::runtime_error(
-                tfm::format("Snapshot Downloader: Error opening target %s: %s (%d)", destination.string(), strerror(errno), errno));
+                tfm::format("Snapshot Downloader: Error opening target %s: %s (%d)",
+                            destination.string(), strerror(errno), errno));
     }
 
     std::string buffer;
@@ -363,9 +370,10 @@ void Http::DownloadSnapshot()
 
         else
         {
-            DownloadStatus.SnapshotDownloadFailed = true;
+            DownloadStatus.SetSnapshotDownloadFailed(true);
 
-            throw std::runtime_error(tfm::format("Snapshot Downloader: Failed to download file %s: %s", url, curl_easy_strerror(res)));
+            throw std::runtime_error(tfm::format("Snapshot Downloader: Failed to download file %s: %s",
+                                                 url, curl_easy_strerror(res)));
         }
     }
 
@@ -374,7 +382,7 @@ void Http::DownloadSnapshot()
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
     EvaluateResponse(response_code, url);
 
-    DownloadStatus.SnapshotDownloadComplete = true;
+    DownloadStatus.SetSnapshotDownloadComplete(true);
 
     return;
 }
@@ -402,7 +410,7 @@ std::string Http::GetSnapshotSHA256()
 
     if (res > 0)
     {
-       LogPrintf("Snapshot (GetSnapshotSHA256):  Failed to SHA256SUM of snapshot.zip for URL %s: %s", url, curl_easy_strerror(res));
+       error("%s: Failed to SHA256SUM of snapshot.zip for URL %s: %s", __func__, url, curl_easy_strerror(res));
 
        return "";
     }
@@ -414,7 +422,7 @@ std::string Http::GetSnapshotSHA256()
 
     if (buffer.empty())
     {
-        LogPrintf("Snapshot (GetSnapshotSHA256): Failed to receive SHA256SUM from url: %s", url);
+        error("%s: Failed to receive SHA256SUM from url: %s", __func__, url);
 
         return "";
     }
@@ -423,14 +431,14 @@ std::string Http::GetSnapshotSHA256()
 
     if (loc == std::string::npos)
     {
-        LogPrintf("Snapshot (GetSnapshotSHA256): Malformed SHA256SUM from url: %s", url);
+        error("%s: Malformed SHA256SUM from url: %s", __func__, url);
 
         return "";
     }
 
     else
     {
-        LogPrint(BCLog::LogFlags::VERBOSE, "Snapshot Downloader: Receives SHA256SUM of %s", buffer.substr(0, loc));
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: Receives SHA256SUM of %s", __func__, buffer.substr(0, loc));
 
         return buffer.substr(0, loc);
     }

--- a/src/gridcoin/scraper/http.h
+++ b/src/gridcoin/scraper/http.h
@@ -8,20 +8,218 @@
 
 #include <string>
 #include <stdexcept>
+#include "sync.h"
 
 //!
 //! \brief Struct for snapshot download progress updates.
 //!
-struct struct_SnapshotStatus{
+class SnapshotStatus
+{
+public:
+    void Reset()
+    {
+        LOCK(cs_lock);
+
+        SnapshotDownloadComplete = false;
+        SnapshotDownloadFailed = false;
+        SnapshotDownloadSpeed = 0;
+        SnapshotDownloadProgress = 0;
+        SnapshotDownloadSize = 0;
+        SnapshotDownloadAmount = 0;
+        SHA256SUMProgress = 0;
+        SHA256SUMComplete = false;
+        SHA256SUMFailed = false;
+        CleanupBlockchainDataProgress = 0;
+        CleanupBlockchainDataComplete = false;
+        CleanupBlockchainDataFailed = false;
+    }
+
+    bool GetSnapshotDownloadComplete()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotDownloadComplete;
+    }
+
+    bool GetSnapshotDownloadFailed()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotDownloadFailed;
+    }
+
+    int64_t GetSnapshotDownloadSpeed()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotDownloadSpeed;
+    }
+
+    int GetSnapshotDownloadProgress()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotDownloadProgress;
+    }
+
+    long long GetSnapshotDownloadSize()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotDownloadSize;
+    }
+
+    long long GetSnapshotDownloadAmount()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotDownloadAmount;
+    }
+
+    int GetSHA256SUMProgress()
+    {
+        LOCK(cs_lock);
+
+        return SHA256SUMProgress;
+    }
+
+    bool GetSHA256SUMComplete()
+    {
+        LOCK(cs_lock);
+
+        return SHA256SUMComplete;
+    }
+
+    bool GetSHA256SUMFailed()
+    {
+        LOCK(cs_lock);
+
+        return SHA256SUMFailed;
+    }
+
+    int GetCleanupBlockchainDataProgress()
+    {
+        LOCK(cs_lock);
+
+        return CleanupBlockchainDataProgress;
+    }
+
+    bool GetCleanupBlockchainDataComplete()
+    {
+        LOCK(cs_lock);
+
+        return CleanupBlockchainDataComplete;
+    }
+
+    bool GetCleanupBlockchainDataFailed()
+    {
+        LOCK(cs_lock);
+
+        return CleanupBlockchainDataFailed;
+    }
+
+    void SetSnapshotDownloadComplete(bool SnapshotDownloadComplete_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotDownloadComplete = SnapshotDownloadComplete_in;
+    }
+
+    void SetSnapshotDownloadFailed(bool SnapshotDownloadFailed_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotDownloadFailed = SnapshotDownloadFailed_in;
+    }
+
+    void SetSnapshotDownloadSpeed(int64_t SnapshotDownloadSpeed_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotDownloadSpeed = SnapshotDownloadSpeed_in;
+    }
+
+    void SetSnapshotDownloadProgress(int SnapshotDownloadProgress_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotDownloadProgress = SnapshotDownloadProgress_in;
+    }
+
+    void SetSnapshotDownloadSize(long long SnapshotDownloadSize_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotDownloadSize = SnapshotDownloadSize_in;
+    }
+
+    void SetSnapshotDownloadAmount(long long SnapshotDownloadAmount_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotDownloadAmount = SnapshotDownloadAmount_in;
+    }
+
+    void SetSHA256SUMProgress(int SHA256SumProgress_in)
+    {
+        LOCK(cs_lock);
+
+        SHA256SUMProgress = SHA256SumProgress_in;
+    }
+
+    void SetSHA256SUMComplete(bool SHA256SUMComplete_in)
+    {
+        LOCK(cs_lock);
+
+        SHA256SUMComplete = SHA256SUMComplete_in;
+    }
+
+    void SetSHA256SUMFailed(bool SHA256SUMFailed_in)
+    {
+        LOCK(cs_lock);
+
+        SHA256SUMFailed = SHA256SUMFailed_in;
+    }
+
+    void SetCleanupBlockchainDataProgress(int CleanupBlockchainDataProgress_in)
+    {
+        LOCK(cs_lock);
+
+        CleanupBlockchainDataProgress = CleanupBlockchainDataProgress_in;
+    }
+
+    void SetCleanupBlockchainDataComplete(bool CleanupBlockchainDataComplete_in)
+    {
+        LOCK(cs_lock);
+
+        CleanupBlockchainDataComplete = CleanupBlockchainDataComplete_in;
+    }
+
+    void SetCleanupBlockchainDataFailed(bool CleanupBlockchainDataFailed_in)
+    {
+        LOCK(cs_lock);
+
+        CleanupBlockchainDataFailed = CleanupBlockchainDataFailed_in;
+    }
+
+private:
+    CCriticalSection cs_lock;
+
     bool SnapshotDownloadComplete = false;
     bool SnapshotDownloadFailed = false;
-    int64_t SnapshotDownloadSpeed;
-    int SnapshotDownloadProgress;
+    int64_t SnapshotDownloadSpeed = 0;
+    int SnapshotDownloadProgress = 0;
     long long SnapshotDownloadSize = 0;
     long long SnapshotDownloadAmount = 0;
+    int SHA256SUMProgress = 0;
+    bool SHA256SUMComplete = false;
+    bool SHA256SUMFailed = false;
+    int CleanupBlockchainDataProgress = 0;
+    bool CleanupBlockchainDataComplete = false;
+    bool CleanupBlockchainDataFailed = false;
 };
 
-extern struct_SnapshotStatus DownloadStatus;
+extern SnapshotStatus DownloadStatus;
 
 //!
 //! \brief HTTP exception.

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -20,22 +20,14 @@
 
 using namespace GRC;
 
-struct_SnapshotExtractStatus GRC::ExtractStatus;
+SnapshotExtractStatus GRC::ExtractStatus;
 
 bool GRC::fCancelOperation = false;
 
 Upgrade::Upgrade()
 {
-    // Clear the structs
-    DownloadStatus.SnapshotDownloadSize = 0;
-    DownloadStatus.SnapshotDownloadSpeed = 0;
-    DownloadStatus.SnapshotDownloadAmount = 0;
-    DownloadStatus.SnapshotDownloadFailed = false;
-    DownloadStatus.SnapshotDownloadComplete = false;
-    DownloadStatus.SnapshotDownloadProgress = 0;
-    ExtractStatus.SnapshotExtractFailed = false;
-    ExtractStatus.SnapshotExtractComplete = false;
-    ExtractStatus.SnapshotExtractProgress = 0;
+    DownloadStatus.Reset();
+    ExtractStatus.Reset();
 }
 
 void Upgrade::ScheduledUpdateCheck()
@@ -47,7 +39,8 @@ void Upgrade::ScheduledUpdateCheck()
 
 bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dialog, bool snapshotrequest)
 {
-    // If testnet skip this || If the user changes this to disable while wallet running just drop out of here now. (need a way to remove items from scheduler)
+    // If testnet skip this || If the user changes this to disable while wallet running just drop out of here now.
+    // (Need a way to remove items from scheduler.)
     if (fTestNet || (gArgs.GetBoolArg("-disableupdatecheck", false) && !snapshotrequest))
         return false;
 
@@ -71,7 +64,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     if (VersionResponse.empty())
     {
-        LogPrintf("%s: No Response from github", __func__);
+        LogPrintf("WARNING %s: No Response from GitHub", __func__);
 
         return false;
     }
@@ -96,7 +89,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     catch (std::exception& ex)
     {
-        LogPrintf("%s: Exception occurred while parsing json response (%s)", __func__, ex.what());
+        error("%s: Exception occurred while parsing json response (%s)", __func__, ex.what());
 
         return false;
     }
@@ -123,7 +116,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     if (GithubVersion.size() != 4)
     {
-        LogPrintf("%s: Got malformed version (%s)", __func__, GithubReleaseData);
+        error("%s: Got malformed version (%s)", __func__, GithubReleaseData);
 
         return false;
     }
@@ -149,7 +142,8 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
     }
     catch (std::exception& ex)
     {
-        LogPrintf("%s: Exception occurred checking client version against github version (%s)", __func__, ToString(ex.what()));
+        error("%s: Exception occurred checking client version against GitHub version (%s)",
+                  __func__, ToString(ex.what()));
 
         return false;
     }
@@ -157,8 +151,9 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
     if (!NewVersion) return NewVersion;
 
     // New version was found
-    client_message_out = _("Local version: ") + strprintf("%d.%d.%d.%d", CLIENT_VERSION_MAJOR, CLIENT_VERSION_MINOR, CLIENT_VERSION_REVISION, CLIENT_VERSION_BUILD) + "\r\n";
-    client_message_out.append(_("Github version: ") + GithubReleaseData + "\r\n");
+    client_message_out = _("Local version: ") + strprintf("%d.%d.%d.%d", CLIENT_VERSION_MAJOR, CLIENT_VERSION_MINOR,
+                                                          CLIENT_VERSION_REVISION, CLIENT_VERSION_BUILD) + "\r\n";
+    client_message_out.append(_("GitHub version: ") + GithubReleaseData + "\r\n");
     client_message_out.append(_("This update is ") + GithubReleaseType + "\r\n\r\n");
 
     // For snapshot requests we will handle things differently after this point
@@ -166,7 +161,8 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
         return NewVersion;
 
     if (NewMandatory)
-        client_message_out.append(_("WARNING: A mandatory release is available. Please upgrade as soon as possible.") + "\n");
+        client_message_out.append(_("WARNING: A mandatory release is available. Please upgrade as soon as possible.")
+                                  + "\n");
 
     std::string ChangeLog = GithubReleaseBody;
 
@@ -180,7 +176,8 @@ void Upgrade::SnapshotMain()
 {
     std::cout << std::endl;
     std::cout << _("Snapshot Process Has Begun.") << std::endl;
-    std::cout << _("Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.") << std::endl << std::endl;
+    std::cout << _("Warning: Ending this process after Stage 2 will result in syncing from 0 or an "
+                   "incomplete/corrupted blockchain.") << std::endl << std::endl;
 
     // Verify a mandatory release is not available before we continue to snapshot download.
     std::string VersionResponse = "";
@@ -194,86 +191,188 @@ void Upgrade::SnapshotMain()
         throw std::runtime_error(_("Failed to download snapshot as mandatory client is available for download."));
     }
 
-    // Create a thread for snapshot to be downloaded
-    boost::thread SnapshotDownloadThread(std::bind(&Upgrade::DownloadSnapshot, this));
+    Progress progress;
 
-    Progress Prog;
+    progress.SetType(Progress::Type::SnapshotDownload);
 
-    Prog.SetType(0);
+    // Create a worker thread to do all of the heavy lifting. We are going to use a ping-pong workflow state here,
+    // with progress Type as the trigger.
+    boost::thread WorkerMainThread(std::bind(&Upgrade::WorkerMain, boost::ref(progress)));
 
-    while (!DownloadStatus.SnapshotDownloadComplete)
+    while (!DownloadStatus.GetSnapshotDownloadComplete())
     {
-        if (DownloadStatus.SnapshotDownloadFailed)
-            throw std::runtime_error("Failed to download snapshot.zip; See debug.log");
+        LogPrintf("INFO: %s: DownloadStatus.GetSnapshotDownloadComplete() = %i",
+                  __func__,
+                  DownloadStatus.GetSnapshotDownloadComplete());
 
-        if (Prog.Update(DownloadStatus.SnapshotDownloadProgress, DownloadStatus.SnapshotDownloadSpeed, DownloadStatus.SnapshotDownloadAmount, DownloadStatus.SnapshotDownloadSize))
-            std::cout << Prog.Status() << std::flush;
+        if (DownloadStatus.GetSnapshotDownloadFailed())
+        {
+            WorkerMainThread.interrupt();
+            WorkerMainThread.join();
+            throw std::runtime_error("Failed to download snapshot.zip; See debug.log");
+        }
+
+        if (progress.Update(DownloadStatus.GetSnapshotDownloadProgress(), DownloadStatus.GetSnapshotDownloadSpeed(),
+                        DownloadStatus.GetSnapshotDownloadAmount(), DownloadStatus.GetSnapshotDownloadSize()))
+        {
+            std::cout << progress.Status() << std::flush;
+        }
 
         MilliSleep(1000);
     }
 
-    // This is needed in some spots as the download can complete before the next progress update occurs so just 100% here as it was successful
-    if (Prog.Update(100, -1, DownloadStatus.SnapshotDownloadSize, DownloadStatus.SnapshotDownloadSize))
-        std::cout << Prog.Status() << std::flush;
-
-    std::cout << std::endl;
-
-    Prog.SetType(1);
-
-    if (VerifySHA256SUM())
+    // This is needed in some spots as the download can complete before the next progress update occurs so just 100% here
+    // as it was successful
+    if (progress.Update(100, -1, DownloadStatus.GetSnapshotDownloadSize(), DownloadStatus.GetSnapshotDownloadSize()))
     {
-        Prog.Update(100);
-
-        std::cout << Prog.Status() << std::flush;
+        std::cout << progress.Status() << std::flush;
     }
 
-    else
-        throw std::runtime_error("Failed to verify SHA256SUM of snapshot.zip; See debug.log");
-
     std::cout << std::endl;
 
-    Prog.SetType(2);
+    progress.SetType(Progress::Type::SHA256SumVerification);
 
-    if (CleanupBlockchainData())
+    while (!DownloadStatus.GetSHA256SUMComplete())
     {
-        Prog.Update(100);
+        LogPrintf("INFO: %s: DownloadStatus.GetSHA256SUMComplete() = %i",
+                  __func__,
+                  DownloadStatus.GetSHA256SUMComplete());
 
-        std::cout << Prog.Status() << std::flush;
-    }
-
-    else
-        throw std::runtime_error("Failed to Cleanup previous blockchain data; See debug.log");
-
-    std::cout << std::endl;
-
-    Prog.SetType(3);
-
-    // Create a thread for snapshot to be extracted
-    boost::thread SnapshotExtractThread(std::bind(&Upgrade::ExtractSnapshot, this));
-
-    while (!ExtractStatus.SnapshotExtractComplete)
-    {
-        if (ExtractStatus.SnapshotExtractFailed)
+        if (DownloadStatus.GetSHA256SUMFailed())
         {
+            WorkerMainThread.interrupt();
+            WorkerMainThread.join();
+            throw std::runtime_error("Failed to verify SHA256SUM of snapshot.zip; See debug.log");
+        }
+
+        if (progress.Update(DownloadStatus.GetSHA256SUMProgress()))
+        {
+            std::cout << progress.Status() << std::flush;
+        }
+
+        MilliSleep(1000);
+    }
+
+    if (progress.Update(100)) std::cout << progress.Status() << std::flush;
+
+    std::cout << std::endl;
+
+    progress.SetType(Progress::Type::CleanupBlockchainData);
+
+    while (!DownloadStatus.GetCleanupBlockchainDataComplete())
+    {
+        if (DownloadStatus.GetCleanupBlockchainDataFailed())
+        {
+            WorkerMainThread.interrupt();
+            WorkerMainThread.join();
+            throw std::runtime_error("Failed to cleanup previous blockchain data prior to extraction of snapshot.zip; "
+                                     "See debug.log");
+        }
+
+        if (progress.Update(DownloadStatus.GetCleanupBlockchainDataProgress()))
+        {
+            std::cout << progress.Status() << std::flush;
+        }
+
+        MilliSleep(1000);
+    }
+
+    if (progress.Update(100)) std::cout << progress.Status() << std::flush;
+
+    std::cout << std::endl;
+
+    progress.SetType(Progress::Type::SnapshotExtraction);
+
+    while (!ExtractStatus.GetSnapshotExtractComplete())
+    {
+        if (ExtractStatus.GetSnapshotExtractFailed())
+        {
+            WorkerMainThread.interrupt();
+            WorkerMainThread.join();
             // Do this without checking on success, If it passed in stage 3 it will pass here.
             CleanupBlockchainData();
 
             throw std::runtime_error("Failed to extract snapshot.zip; See debug.log");
         }
 
-        if (Prog.Update(ExtractStatus.SnapshotExtractProgress))
-            std::cout << Prog.Status() << std::flush;
+        if (progress.Update(ExtractStatus.GetSnapshotExtractProgress()))
+            std::cout << progress.Status() << std::flush;
 
         MilliSleep(1000);
     }
 
-    if (Prog.Update(100))
-        std::cout << Prog.Status() << std::flush;
+    if (progress.Update(100)) std::cout << progress.Status() << std::flush;
 
     std::cout << std::endl;
+
+    // This interrupt-join needs to be here to ensure the WorkerMain interrupts the while loop and collapses before the
+    // Progress object that was passed to it is destroyed.
+    WorkerMainThread.interrupt();
+    WorkerMainThread.join();
+
     std::cout << _("Snapshot Process Complete!") << std::endl;
 
     return;
+}
+
+void Upgrade::WorkerMain(Progress& progress)
+{
+    // The "steps" are triggered in SnapshotMain but processed here in this switch statement.
+    bool finished = false;
+
+    while (!finished)
+    {
+        boost::this_thread::interruption_point();
+
+        switch (progress.GetType())
+        {
+        case Progress::Type::SnapshotDownload:
+            if (DownloadStatus.GetSnapshotDownloadFailed())
+            {
+                finished = true;
+                return;
+            }
+            else if (!DownloadStatus.GetSnapshotDownloadComplete())
+            {
+                DownloadSnapshot();
+            }
+            break;
+        case Progress::Type::SHA256SumVerification:
+            if (DownloadStatus.GetSHA256SUMFailed())
+            {
+                finished = true;
+                return;
+            }
+            else if (!DownloadStatus.GetSHA256SUMComplete())
+            {
+                 VerifySHA256SUM();
+            }
+            break;
+        case Progress::Type::CleanupBlockchainData:
+            if (DownloadStatus.GetCleanupBlockchainDataFailed())
+            {
+                finished = true;
+                return;
+            }
+            else if (!DownloadStatus.GetCleanupBlockchainDataComplete())
+            {
+                CleanupBlockchainData();
+            }
+            break;
+        case Progress::Type::SnapshotExtraction:
+            if (ExtractStatus.GetSnapshotExtractFailed())
+            {
+                finished = true;
+                return;
+            }
+            else if (!ExtractStatus.GetSnapshotExtractComplete())
+            {
+                ExtractSnapshot();
+            }
+        }
+
+        MilliSleep(1000);
+    }
 }
 
 void Upgrade::DownloadSnapshot()
@@ -285,18 +384,22 @@ void Upgrade::DownloadSnapshot()
     {
         HTTPHandler.DownloadSnapshot();
     }
-
     catch(std::runtime_error& e)
     {
         LogPrintf("Snapshot Downloader: Exception occurred while attempting to download snapshot (%s)", e.what());
 
-        DownloadStatus.SnapshotDownloadFailed = true;
+        DownloadStatus.SetSnapshotDownloadFailed(true);
     }
+
+    LogPrintf("INFO %s: Snapshot download complete: DownloadStatus.GetSnapshotDownloadComplete() = %i",
+              __func__, DownloadStatus.GetSnapshotDownloadComplete());
+
+    DownloadStatus.SetSnapshotDownloadComplete(true);
 
     return;
 }
 
-bool Upgrade::VerifySHA256SUM()
+void Upgrade::VerifySHA256SUM()
 {
     Http HTTPHandler;
 
@@ -306,17 +409,19 @@ bool Upgrade::VerifySHA256SUM()
     {
         ServerSHA256SUM = HTTPHandler.GetSnapshotSHA256();
     }
-
     catch (std::runtime_error& e)
     {
-        LogPrintf("Snapshot (VerifySHA256SUM): Exception occurred while attempting to retrieve snapshot SHA256SUM (%s)", e.what());
+        LogPrintf("Snapshot (VerifySHA256SUM): Exception occurred while attempting to retrieve snapshot SHA256SUM (%s)",
+                  e.what());
     }
 
     if (ServerSHA256SUM.empty())
     {
         LogPrintf("Snapshot (VerifySHA256SUM): Empty sha256sum returned from server");
 
-        return false;
+        DownloadStatus.SetSHA256SUMFailed(true);
+
+        return;
     }
 
     unsigned char digest[SHA256_DIGEST_LENGTH];
@@ -334,11 +439,21 @@ bool Upgrade::VerifySHA256SUM()
     {
         LogPrintf("Snapshot (VerifySHA256SUM): Failed to open snapshot.zip");
 
-        return false;
+        DownloadStatus.SetSHA256SUMFailed(true);
+
+        return;
     }
 
+    unsigned int total_reads = fs::file_size(fileloc) / sizeof(buffer) + 1;
+
+    unsigned int read_count = 0;
     while ((bytesread = fread(buffer, 1, sizeof(buffer), file)))
+    {
         SHA256_Update(&ctx, buffer, bytesread);
+        ++read_count;
+
+        DownloadStatus.SetSHA256SUMProgress(read_count * 100 / total_reads);
+    }
 
     SHA256_Final(digest, &ctx);
 
@@ -352,48 +467,62 @@ bool Upgrade::VerifySHA256SUM()
     fclose(file);
 
     if (ServerSHA256SUM == FileSHA256SUM)
-        return true;
+    {
+        DownloadStatus.SetSHA256SUMComplete(true);
 
+        return;
+    }
     else
     {
-        LogPrintf("Snapshot (VerifySHA256SUM): Mismatch of sha256sum of snapshot.zip (Server = %s / File = %s)", ServerSHA256SUM, FileSHA256SUM);
+        LogPrintf("Snapshot (VerifySHA256SUM): Mismatch of sha256sum of snapshot.zip (Server = %s / File = %s)",
+                  ServerSHA256SUM, FileSHA256SUM);
 
-        return false;
+        DownloadStatus.SetSHA256SUMFailed(true);
+
+        return;
     }
 }
 
-bool Upgrade::CleanupBlockchainData()
+void Upgrade::CleanupBlockchainData()
 {
     fs::path CleanupPath = GetDataDir();
+
+    unsigned int total_items = 0;
+    unsigned int items = 0;
 
     // We must delete previous blockchain data
     // txleveldb
     // blk*.dat
     fs::directory_iterator IterEnd;
 
+    // Count for progress bar first
     try
     {
-        // Remove the files. We iterate as we know blk* will exist more and more in future as well
         for (fs::directory_iterator Iter(CleanupPath); Iter != IterEnd; ++Iter)
         {
             if (fs::is_directory(Iter->path()))
             {
-                for (const auto& path_segment : Iter->path())
+                if (fs::relative(Iter->path(), CleanupPath) == (fs::path) "txleveldb")
                 {
-                    if (path_segment.string() == "txleveldb")
+                    for (fs::recursive_directory_iterator it(Iter->path());
+                         it != fs::recursive_directory_iterator();
+                         ++it)
                     {
-                        if (!fs::remove_all(*Iter)) return false;
+                        ++total_items;
                     }
                 }
 
-                for (const auto& path_segment : Iter->path())
+                if (fs::relative(Iter->path(), CleanupPath) == (fs::path) "accrual")
                 {
-                    if (path_segment.string() == "accrual")
+                    for (fs::recursive_directory_iterator it(Iter->path());
+                         it != fs::recursive_directory_iterator();
+                         ++it)
                     {
-                        if (!fs::remove_all(*Iter)) return false;
+                        ++total_items;
                     }
                 }
 
+                // If it was a directory no need to check if a regular file below.
                 continue;
             }
 
@@ -404,13 +533,110 @@ bool Upgrade::CleanupBlockchainData()
                 if (FileLoc != std::string::npos)
                 {
                     std::string filetocheck = Iter->path().filename().string();
+
                     // Check it ends with .dat and starts with blk
                     if (filetocheck.substr(0, 3) == "blk" && filetocheck.substr(filetocheck.length() - 4, 4) == ".dat")
-                        if (!fs::remove(*Iter))
-                            return false;
+                    {
+                        ++total_items;
+                    }
+                }
+            }
+        }
+    }
+    catch (fs::filesystem_error &ex)
+    {
+        LogPrintf("%s: Exception occurred: %s", __func__, ex.what());
+
+        DownloadStatus.SetCleanupBlockchainDataFailed(true);
+
+        return;
+    }
+
+    if (!total_items)
+    {
+        DownloadStatus.SetCleanupBlockchainDataComplete(true);
+
+        return;
+    }
+
+    // Now try the cleanup.
+    try
+    {
+        // Remove the files. We iterate as we know blk* will exist more and more in future as well
+        for (fs::directory_iterator Iter(CleanupPath); Iter != IterEnd; ++Iter)
+        {
+            if (fs::is_directory(Iter->path()))
+            {
+                if (fs::relative(Iter->path(), CleanupPath) == (fs::path) "txleveldb")
+                {
+                    for (fs::recursive_directory_iterator it(Iter->path());
+                         it != fs::recursive_directory_iterator();)
+                    {
+                        fs::path filepath = *it++;
+
+                        if (fs::remove(filepath))
+                        {
+                            ++items;
+                            DownloadStatus.SetCleanupBlockchainDataProgress(items * 100 / total_items);
+                        }
+                        else
+                        {
+                            DownloadStatus.SetCleanupBlockchainDataFailed(true);
+
+                            return;
+                        }
+                    }
                 }
 
+                if (fs::relative(Iter->path(), CleanupPath) == (fs::path) "accrual")
+                {
+                    for (fs::recursive_directory_iterator it(Iter->path());
+                         it != fs::recursive_directory_iterator();)
+                    {
+                        fs::path filepath = *it++;
+
+                        if (fs::remove(filepath))
+                        {
+                            ++items;
+                            DownloadStatus.SetCleanupBlockchainDataProgress(items * 100 / total_items);
+                        }
+                        else
+                        {
+                            DownloadStatus.SetCleanupBlockchainDataFailed(true);
+
+                            return;
+                        }
+                    }
+                }
+
+                // If it was a directory no need to check if a regular file below.
                 continue;
+            }
+
+            else if (fs::is_regular_file(*Iter))
+            {
+                size_t FileLoc = Iter->path().filename().string().find("blk");
+
+                if (FileLoc != std::string::npos)
+                {
+                    std::string filetocheck = Iter->path().filename().string();
+
+                    // Check it ends with .dat and starts with blk
+                    if (filetocheck.substr(0, 3) == "blk" && filetocheck.substr(filetocheck.length() - 4, 4) == ".dat")
+                    {
+                        if (fs::remove(*Iter))
+                        {
+                            ++items;
+                            DownloadStatus.SetCleanupBlockchainDataProgress(items * 100 / total_items);
+                        }
+                        else
+                        {
+                            DownloadStatus.SetCleanupBlockchainDataFailed(true);
+
+                            return;
+                        }
+                    }
+                }
             }
         }
     }
@@ -419,47 +645,52 @@ bool Upgrade::CleanupBlockchainData()
     {
         LogPrintf("%s: Exception occurred: %s", __func__, ex.what());
 
-        return false;
+        DownloadStatus.SetCleanupBlockchainDataFailed(true);
+
+        return;
     }
 
-    return true;
+    DownloadStatus.SetCleanupBlockchainDataProgress(100);
+    DownloadStatus.SetCleanupBlockchainDataComplete(true);
+
+    return;
 }
 
-bool Upgrade::ExtractSnapshot()
+void Upgrade::ExtractSnapshot()
 {
-    std::string ArchiveFileString = GetDataDir().string() +  "/snapshot.zip";
-    const char* ArchiveFile = ArchiveFileString.c_str();
-    fs::path ExtractPath = GetDataDir();
-    struct zip* ZipArchive;
-    struct zip_file* ZipFile;
-    struct zip_stat ZipStat;
-    char Buf[1024*1024];
-    int err;
-    uint64_t i, j;
-    int64_t entries, len, sum;
-    long long totaluncompressedsize = 0;
-    long long currentuncompressedsize = 0;
-    int64_t lastupdated = GetAdjustedTime();
-
     try
     {
-        ZipArchive = zip_open(ArchiveFile, 0, &err);
+        fs::path archive_path = GetDataDir() / "snapshot.zip";
+        FILE* archive_file = fsbridge::fopen(archive_path, "rb");
+
+        fs::path ExtractPath = GetDataDir();
+
+        zip_error_t* err = new zip_error_t;
+        zip_error_init(err);
+
+        struct zip* ZipArchive;
+        struct zip_stat ZipStat;
+        long long totaluncompressedsize = 0;
+        long long currentuncompressedsize = 0;
+        int64_t lastupdated = GetAdjustedTime();
+
+        zip_source_t* zip_source = zip_source_filep_create(archive_file, 0, -1, err);
+
+        ZipArchive = zip_open_from_source(zip_source, 0, err);
 
         if (ZipArchive == nullptr)
         {
-            zip_error_to_str(Buf, sizeof(Buf), err, errno);
+            ExtractStatus.SetSnapshotExtractFailed(true);
 
-            ExtractStatus.SnapshotExtractFailed = true;
+            LogPrintf("Snapshot (ExtractSnapshot): Error opening snapshot.zip: %s", zip_error_strerror(err));
 
-            LogPrintf("Snapshot (ExtractSnapshot): Error opening snapshot.zip: %s", Buf);
-
-            return false;
+            return;
         }
 
-        entries = zip_get_num_entries(ZipArchive, 0);
+        uint64_t entries = (uint64_t) zip_get_num_entries(ZipArchive, 0);
 
         // Let's scan for total size uncompressed so we can do a detailed progress for the watching user
-        for (j = 0; j < (uint64_t)entries; j++)
+        for (u_int64_t j = 0; j < entries; ++j)
         {
             if (zip_stat_index(ZipArchive, j, 0, &ZipStat) == 0)
             {
@@ -472,34 +703,38 @@ bool Upgrade::ExtractSnapshot()
         // if the zip file has no entries.
         if (!totaluncompressedsize)
         {
-            ExtractStatus.SnapshotZipInvalid = true;
+            ExtractStatus.SetSnapshotZipInvalid(true);
 
             LogPrintf("Snapshot (ExtractSnapshot): Error - snapshot.zip has no entries");
 
-            return false;
+            return;
         }
 
         // Now extract
-        for (i = 0; i < (uint64_t)entries; i++)
+        for (u_int64_t i = 0; i < entries; ++i)
         {
             if (zip_stat_index(ZipArchive, i, 0, &ZipStat) == 0)
             {
                 // Does this require a directory
                 if (ZipStat.name[strlen(ZipStat.name) - 1] == '/')
+                {
                     fs::create_directory(ExtractPath / ZipStat.name);
-
+                }
                 else
                 {
+                    struct zip_file* ZipFile;
+
                     ZipFile = zip_fopen_index(ZipArchive, i, 0);
 
                     if (!ZipFile)
                     {
-                        ExtractStatus.SnapshotExtractFailed = true;
+                        ExtractStatus.SetSnapshotExtractFailed(true);
 
                         LogPrintf("Snapshot (ExtractSnapshot): Error opening file %s within snapshot.zip", ZipStat.name);
 
-                        return false;
+                        return;
                     }
+
 
                     fs::path ExtractFileString = ExtractPath / ZipStat.name;
 
@@ -507,31 +742,34 @@ bool Upgrade::ExtractSnapshot()
 
                     if (!ExtractFile)
                     {
-                        ExtractStatus.SnapshotExtractFailed = true;
+                        ExtractStatus.SetSnapshotExtractFailed(true);
 
                         LogPrintf("Snapshot (ExtractSnapshot): Error opening file %s on filesystem", ZipStat.name);
 
-                        return false;
+                        return;
                     }
 
-                    sum = 0;
+                    int64_t sum = 0;
 
-                    while ((uint64_t)sum != ZipStat.size)
+                    while ((uint64_t) sum < ZipStat.size)
                     {
+                        int64_t len = 0;
+                        char Buf[256*1024];
+
                         boost::this_thread::interruption_point();
 
-                        len = zip_fread(ZipFile, Buf, 1024*1024);
+                        len = zip_fread(ZipFile, &Buf, 256*1024);
 
                         if (len < 0)
                         {
-                            ExtractStatus.SnapshotExtractFailed = true;
+                            ExtractStatus.SetSnapshotExtractFailed(true);
 
                             LogPrintf("Snapshot (ExtractSnapshot): Failed to read zip buffer");
 
-                            return false;
+                            return;
                         }
 
-                        fwrite(Buf, 1, (uint64_t)len, ExtractFile);
+                        fwrite(Buf, 1, (uint64_t) len, ExtractFile);
 
                         sum += len;
                         currentuncompressedsize += len;
@@ -541,7 +779,8 @@ bool Upgrade::ExtractSnapshot()
                         {
                             lastupdated = GetAdjustedTime();
 
-                            ExtractStatus.SnapshotExtractProgress = ((currentuncompressedsize / (double)totaluncompressedsize) * 100);
+                            ExtractStatus.SetSnapshotExtractProgress(currentuncompressedsize * 100
+                                                                     / totaluncompressedsize);
                         }
                     }
 
@@ -553,22 +792,33 @@ bool Upgrade::ExtractSnapshot()
 
         if (zip_close(ZipArchive) == -1)
         {
-            ExtractStatus.SnapshotExtractFailed = true;
+            ExtractStatus.SetSnapshotExtractFailed(true);
 
             LogPrintf("Snapshot (ExtractSnapshot): Failed to close snapshot.zip");
 
-            return false;
+            return;
         }
-
-        ExtractStatus.SnapshotExtractComplete = true;
     }
 
     catch (boost::thread_interrupted&)
     {
-        return false;
+        ExtractStatus.SetSnapshotExtractFailed(true);
+
+        return;
     }
 
-    return true;
+    catch (std::exception& e)
+    {
+        error("%s: Error occurred during snapshot zip file extraction: %s", __func__, e.what());
+
+        ExtractStatus.SetSnapshotExtractFailed(true);
+
+        return;
+    }
+
+    ExtractStatus.SetSnapshotExtractProgress(100);
+    ExtractStatus.SetSnapshotExtractComplete(true);
+    return;
 }
 
 void Upgrade::DeleteSnapshot()
@@ -591,7 +841,9 @@ void Upgrade::DeleteSnapshot()
 
 bool Upgrade::ResetBlockchainData()
 {
-    return CleanupBlockchainData();
+    CleanupBlockchainData();
+
+    return (DownloadStatus.GetCleanupBlockchainDataComplete() && !DownloadStatus.GetCleanupBlockchainDataFailed());
 }
 
 std::string Upgrade::ResetBlockchainMessages(ResetBlockchainMsg _msg)
@@ -604,7 +856,8 @@ std::string Upgrade::ResetBlockchainMessages(ResetBlockchainMsg _msg)
             stream << _("Datadir: ");
             stream << GetDataDir().string();
             stream << "\r\n\r\n";
-            stream << _("Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.");
+            stream << _("Due to the failure to delete the blockchain data you will be required to manually delete the data "
+                        "before starting your wallet.");
             stream << "\r\n";
             stream << _("Failure to do so will result in undefined behaviour or failure to start wallet.");
             stream << "\r\n\r\n";
@@ -623,8 +876,10 @@ std::string Upgrade::ResetBlockchainMessages(ResetBlockchainMsg _msg)
             break;
         }
 
-        case UpdateAvailable: stream << _("Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied."); break;
-        case GithubResponse: stream << _("Latest Version github data response:"); break;
+        case UpdateAvailable: stream << _("Unable to download a snapshot, as the wallet has detected that a new mandatory "
+                                          "version is available for install. The mandatory upgrade must be installed before "
+                                          "the snapshot can be downloaded and applied."); break;
+        case GithubResponse: stream << _("Latest Version GitHub data response:"); break;
     }
 
     const std::string& output = stream.str();

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -15,17 +15,89 @@
 
 namespace GRC {
 
-/** Snapshot Extraction Status struct **/
-struct struct_SnapshotExtractStatus{
+/** Snapshot Extraction Status **/
+class SnapshotExtractStatus
+{
+
+public:
+    void Reset()
+    {
+        SnapshotZipInvalid = false;
+        SnapshotExtractComplete = false;
+        SnapshotExtractFailed = false;
+        SnapshotExtractProgress = 0;
+    }
+
+    bool GetSnapshotZipInvalid()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotZipInvalid;
+    }
+
+    bool GetSnapshotExtractComplete()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotExtractComplete;
+    }
+
+    bool GetSnapshotExtractFailed()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotExtractFailed;
+    }
+
+    int GetSnapshotExtractProgress()
+    {
+        LOCK(cs_lock);
+
+        return SnapshotExtractProgress;
+    }
+
+    void SetSnapshotZipInvalid(bool SnapshotZipInvalid_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotZipInvalid = SnapshotZipInvalid_in;
+    }
+
+    void SetSnapshotExtractComplete(bool SnapshotExtractComplete_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotExtractComplete = SnapshotExtractComplete_in;
+    }
+
+    void SetSnapshotExtractFailed(bool SnapshotExtractFailed_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotExtractFailed = SnapshotExtractFailed_in;
+    }
+
+    void SetSnapshotExtractProgress(int SnapshotExtractProgress_in)
+    {
+        LOCK(cs_lock);
+
+        SnapshotExtractProgress = SnapshotExtractProgress_in;
+    }
+
+private:
+    CCriticalSection cs_lock;
+
     bool SnapshotZipInvalid = false;
     bool SnapshotExtractComplete = false;
     bool SnapshotExtractFailed = false;
-    int SnapshotExtractProgress;
+    int SnapshotExtractProgress = 0;
 };
 
-extern struct_SnapshotExtractStatus ExtractStatus;
+extern SnapshotExtractStatus ExtractStatus;
 /** Qt Side **/
 extern bool fCancelOperation;
+
+class Progress;
 
 /** A Class to support update checks and allow easy application of the latest snapshot **/
 //!
@@ -57,7 +129,7 @@ public:
     static void ScheduledUpdateCheck();
 
     //!
-    //! \brief Check for latest updates on github.
+    //! \brief Check for latest updates on GitHub.
     //!
     static bool CheckForLatestUpdate(std::string& client_message_out, bool ui_dialog = true, bool snapshotrequest = false);
 
@@ -65,21 +137,26 @@ public:
     //! \brief Function that will be threaded to download snapshot
     //! and provide realtime updates on the progress.
     //!
-    void DownloadSnapshot();
+    static void DownloadSnapshot();
 
     //!
     //! \brief Cleans up previous blockchain data if any is found
     //!
     //! \return Bool on the success of cleanup
     //!
-    static bool CleanupBlockchainData();
+    static void CleanupBlockchainData();
+
+    //!
+    //! \brief This is the worker thread "main" that actually does the brunt of the snapshot download and extraction work.
+    //!
+    static void WorkerMain(Progress &progress);
 
     //!
     //! \brief Extracts the snapshot zip file
     //!
     //! \return Bool on the success of extraction
     //!
-    bool ExtractSnapshot();
+    static void ExtractSnapshot();
 
     //!
     //! \brief Snapshot main function that runs the full snapshot task
@@ -93,7 +170,7 @@ public:
     //!
     //! \return Bool on the success of matching SHA256SUM
     //!
-    static bool VerifySHA256SUM();
+    static void VerifySHA256SUM();
 
     //!
     //! \brief Small function to delete the snapshot.zip file
@@ -123,9 +200,22 @@ public:
 //!
 class Progress
 {
-private:
+public:
+    // The order of this enum must be correlated with the StartStrings below.
+    enum Type
+    {
+        SnapshotDownload,
+        SHA256SumVerification,
+        CleanupBlockchainData,
+        SnapshotExtraction,
+    };
 
-    int Type;
+private:
+    // To enforce thread safety on type enum.
+    CCriticalSection cs_lock;
+
+    Type type;
+
     int CurrentProgress;
 
     const char *StartBar = "[";
@@ -133,7 +223,7 @@ private:
     const char *Filler = "*";
     /** Keep this even for simplicity **/
     const int LengthBar = 50;
-    /** Keep spaced for cleaning look thou this may not be perfect when translated **/
+    /** Keep spaced for cleaner look though this may not be perfect when translated **/
     const std::string StartStrings[4] = { _("Stage (1/4): Downloading snapshot.zip:         "),
                                           _("Stage (2/4): Verify SHA256SUM of snapshot.zip: "),
                                           _("Stage (3/4): Cleanup blockchain data:          "),
@@ -158,11 +248,20 @@ public:
     //! \brief Function to set what stage of the snapshot process we are at.
     //! Also resets fully when needed.
     //!
-    void SetType(int Typein)
+    void SetType(Type type_in)
     {
-        Type = Typein;
+        LOCK(cs_lock);
+
+        type = type_in;
 
         Reset(true);
+    }
+
+    Type GetType()
+    {
+        LOCK(cs_lock);
+
+        return type;
     }
 
     //!
@@ -197,21 +296,42 @@ public:
 
             ProgressString << " (" << CurrentProgress << "%)";
 
-            if (Type == 0)
+            if (type == 0)
             {
                 if (ProgressBytes < 1000000 && ProgressBytes > 0)
-                    ProgressString << " " << std::fixed << std::setprecision(1) << (ProgressBytes / (double)1000) << " " << _("KB/s");
-
+                {
+                    ProgressString << " "
+                                   << std::fixed
+                                   << std::setprecision(1)
+                                   << (ProgressBytes / (double)1000)
+                                   << " "
+                                   << _("KB/s");
+                }
                 else if (ProgressBytes >= 1000000)
-                    ProgressString << " " << std::fixed << std::setprecision(1) << (ProgressBytes / (double)1000000) << " " << _("MB/s");
+                {
+                    ProgressString << " "
+                                   << std::fixed
+                                   << std::setprecision(1)
+                                   << (ProgressBytes / (double)1000000)
+                                   << " "
+                                   << _("MB/s");
+                }
 
                 // Unsupported progress
                 else
+                {
                     ProgressString << " " << _("N/A");
+                }
 
-                ProgressString << " (" << std::fixed << std::setprecision(2) << (ProgressNow / (double)(1024 * 1024 * 1024)) << _("GB/");
-                ProgressString << std::fixed << std::setprecision(2) << (ProgressTotal / (double)(1024 * 1024 * 1024)) << _("GB)");
-
+                ProgressString << " ("
+                               << std::fixed
+                               << std::setprecision(2)
+                               << (ProgressNow / (double)(1024 * 1024 * 1024))
+                               << _("GB/")
+                               << std::fixed
+                               << std::setprecision(2)
+                               << (ProgressTotal / (double)(1024 * 1024 * 1024))
+                               << _("GB)");
             }
         }
 
@@ -242,12 +362,15 @@ private:
         ProgressString.str(std::string());
 
         if (!fullreset)
+        {
             ProgressString << "\r";
-
+        }
         else
+        {
             CurrentProgress = 0;
+        }
 
-        ProgressString << StartStrings[Type] << StartBar;
+        ProgressString << StartStrings[type] << StartBar;
     }
 };
 } // namespace GRC

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -27,6 +27,8 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
     SnapshotApp.processEvents();
     SnapshotApp.setWindowIcon(QPixmap(":/images/gridcoin"));
 
+    // We use the functions from the core-side Upgrade class for the worker thread and heavy lifting, but the "main" for
+    // the Qt side is here rather than the SnapshotMain().
     Upgrade UpgradeMain;
 
     // Verify a mandatory release is not available before we continue to snapshot download.
@@ -34,7 +36,8 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
     if (UpgradeMain.CheckForLatestUpdate(VersionResponse, false, true))
     {
-        ErrorMsg(UpgradeMain.ResetBlockchainMessages(Upgrade::UpdateAvailable), UpgradeMain.ResetBlockchainMessages(Upgrade::GithubResponse) + "\r\n" + VersionResponse);
+        ErrorMsg(UpgradeMain.ResetBlockchainMessages(Upgrade::UpdateAvailable),
+                 UpgradeMain.ResetBlockchainMessages(Upgrade::GithubResponse) + "\r\n" + VersionResponse);
 
         return false;
     }
@@ -48,40 +51,45 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
     Progress.setValue(0);
     Progress.show();
 
+    // When doing this for the Qt side, we are only going to use this for the SetType to drive the workflow.
+    GRC::Progress worker_progress;
+
     SnapshotApp.processEvents();
 
     // Create a thread for snapshot to be downloaded
-    boost::thread SnapshotDownloadThread(std::bind(&UpgradeQt::DownloadSnapshot, this)); // thread runs free
-
-    std::string BaseProgressString = _("Stage (1/4): Downloading snapshot.zip: Speed ");
+    boost::thread WorkerMainThread(Upgrade::WorkerMain, boost::ref(worker_progress)); // thread runs free
 
     QString OutputText;
 
-    while (!DownloadStatus.SnapshotDownloadComplete)
+    worker_progress.SetType(Progress::Type::SnapshotDownload);
+
+    std::string BaseProgressString = _("Stage (1/4): Downloading snapshot.zip: Speed ");
+
+    while (!DownloadStatus.GetSnapshotDownloadComplete())
     {
-        if (DownloadStatus.SnapshotDownloadFailed)
+        if (DownloadStatus.GetSnapshotDownloadFailed())
         {
             ErrorMsg(_("Failed to download snapshot.zip; See debug.log"), _("The wallet will now shutdown."));
 
             return false;
         }
 
-        if (DownloadStatus.SnapshotDownloadSpeed < 1000000 && DownloadStatus.SnapshotDownloadSpeed > 0)
-            OutputText = ToQString(BaseProgressString + RoundToString((DownloadStatus.SnapshotDownloadSpeed / (double)1000), 1) + " " + _("KB/s")
-                                   + " (" + RoundToString(DownloadStatus.SnapshotDownloadAmount / (double)(1024 * 1024 * 1024), 2) + _("GB/")
-                                   + RoundToString(DownloadStatus.SnapshotDownloadSize / (double)(1024 * 1024 * 1024), 2) + _("GB)"));
+        if (DownloadStatus.GetSnapshotDownloadSpeed() < 1000000 && DownloadStatus.GetSnapshotDownloadSpeed() > 0)
+            OutputText = ToQString(BaseProgressString + RoundToString((DownloadStatus.GetSnapshotDownloadSpeed() / (double)1000), 1) + " " + _("KB/s")
+                                   + " (" + RoundToString(DownloadStatus.GetSnapshotDownloadAmount() / (double)(1024 * 1024 * 1024), 2) + _("GB/")
+                                   + RoundToString(DownloadStatus.GetSnapshotDownloadSize() / (double)(1024 * 1024 * 1024), 2) + _("GB)"));
 
-        else if (DownloadStatus.SnapshotDownloadSpeed > 1000000)
-            OutputText = ToQString(BaseProgressString + RoundToString((DownloadStatus.SnapshotDownloadSpeed / (double)1000000), 1) + " " + _("MB/s")
-                                   + " (" + RoundToString(DownloadStatus.SnapshotDownloadAmount / (double)(1024 * 1024 * 1024), 2) + _("GB/")
-                                   + RoundToString(DownloadStatus.SnapshotDownloadSize / (double)(1024 * 1024 * 1024), 2) + _("GB)"));
+        else if (DownloadStatus.GetSnapshotDownloadSpeed() > 1000000)
+            OutputText = ToQString(BaseProgressString + RoundToString((DownloadStatus.GetSnapshotDownloadSpeed() / (double)1000000), 1) + " " + _("MB/s")
+                                   + " (" + RoundToString(DownloadStatus.GetSnapshotDownloadAmount() / (double)(1024 * 1024 * 1024), 2) + _("GB/")
+                                   + RoundToString(DownloadStatus.GetSnapshotDownloadSize() / (double)(1024 * 1024 * 1024), 2) + _("GB)"));
 
         // Not supported
         else
             OutputText = ToQString(BaseProgressString + " " + _("N/A"));
 
         Progress.setLabelText(OutputText);
-        Progress.setValue(DownloadStatus.SnapshotDownloadProgress);
+        Progress.setValue(DownloadStatus.GetSnapshotDownloadProgress());
 
         SnapshotApp.processEvents();
 
@@ -91,14 +99,13 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
             {
                 fCancelOperation = true;
 
-                SnapshotDownloadThread.interrupt();
-                SnapshotDownloadThread.join();
+                WorkerMainThread.interrupt();
+                WorkerMainThread.join();
 
                 Msg(_("Snapshot operation canceled."), _("The wallet will now shutdown."));
 
                 return false;
             }
-
             // Avoid the window disappearing for 1 second after a reset
             else
             {
@@ -117,35 +124,45 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
     SnapshotApp.processEvents();
 
-    // Get the snapshot.zip Sha256sum from webserver
-    if (UpgradeMain.VerifySHA256SUM())
+    worker_progress.SetType(Progress::Type::SHA256SumVerification);
+
+    while (!DownloadStatus.GetSHA256SUMComplete())
     {
-        Progress.setValue(100);
-
-        SnapshotApp.processEvents();
-    }
-
-    else
-    {
-        ErrorMsg(_("SHA256SUM of snapshot.zip does not match the server's SHA256SUM."), _("The wallet will now shutdown."));
-
-        return false;
-    }
-
-    if (Progress.wasCanceled())
-    {
-        if (CancelOperation())
+        if (DownloadStatus.GetSHA256SUMFailed())
         {
-            fCancelOperation = true;
-
-            Msg(_("Snapshot operation canceled."), _("The wallet will now shutdown."));
+            ErrorMsg(_("Failed to download snapshot.zip; See debug.log"), _("The wallet will now shutdown."));
 
             return false;
         }
-    }
 
-    // Make it seen
-    MilliSleep(3000);
+        Progress.setValue(DownloadStatus.GetSHA256SUMProgress());
+
+        SnapshotApp.processEvents();
+
+        if (Progress.wasCanceled())
+        {
+            if (CancelOperation())
+            {
+                fCancelOperation = true;
+
+                WorkerMainThread.interrupt();
+                WorkerMainThread.join();
+
+                Msg(_("Snapshot operation canceled."), _("The wallet will now shutdown."));
+
+                return false;
+            }
+            // Avoid the window disappearing for 1 second after a reset
+            else
+            {
+                Progress.reset();
+
+                continue;
+            }
+        }
+
+        MilliSleep(1000);
+    }
 
     Progress.reset();
     Progress.setValue(0);
@@ -153,48 +170,55 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
     SnapshotApp.processEvents();
 
-    // Clean up the blockchain data
-    if (UpgradeMain.CleanupBlockchainData())
+    worker_progress.SetType(Progress::Type::CleanupBlockchainData);
+
+    while (!DownloadStatus.GetCleanupBlockchainDataComplete())
     {
-        Progress.setValue(100);
-
-        SnapshotApp.processEvents();
-    }
-
-    else
-    {
-        ErrorMsg(_("Could not clean up previous blockchain data."), _("The wallet will now shutdown."));
-
-        return false;
-    }
-
-    if (Progress.wasCanceled())
-    {
-        if (CancelOperation())
+        if (DownloadStatus.GetCleanupBlockchainDataFailed())
         {
-            fCancelOperation = true;
-
-            Msg(_("Snapshot operation canceled."), _("The wallet will now shutdown."));
+            ErrorMsg(_("Failed to download snapshot.zip; See debug.log"), _("The wallet will now shutdown."));
 
             return false;
         }
-    }
 
-    // Make it seen
-    MilliSleep(3000);
+        Progress.setValue(DownloadStatus.GetCleanupBlockchainDataProgress());
+
+        SnapshotApp.processEvents();
+
+        if (Progress.wasCanceled())
+        {
+            if (CancelOperation())
+            {
+                fCancelOperation = true;
+
+                WorkerMainThread.interrupt();
+                WorkerMainThread.join();
+
+                Msg(_("Snapshot operation canceled."), _("The wallet will now shutdown."));
+
+                return false;
+            }
+            // Avoid the window disappearing for 1 second after a reset
+            else
+            {
+                Progress.reset();
+
+                continue;
+            }
+        }
+
+        MilliSleep(1000);
+    }
 
     Progress.reset();
     Progress.setValue(0);
-
     Progress.setLabelText(ToQString(_("Stage (4/4): Extracting snapshot.zip")));
 
     SnapshotApp.processEvents();
 
-    // Extract Snapshot
-    // Create a thread for snapshot to be extracted
-    boost::thread SnapshotExtractThread(std::bind(&UpgradeQt::ExtractSnapshot, this));
+    worker_progress.SetType(Progress::Type::SnapshotExtraction);
 
-    while (!ExtractStatus.SnapshotExtractComplete)
+    while (!ExtractStatus.GetSnapshotExtractComplete())
     {
         if (Progress.wasCanceled())
         {
@@ -202,14 +226,13 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
             {
                 fCancelOperation = true;
 
-                SnapshotDownloadThread.interrupt();
-                SnapshotDownloadThread.join();
+                WorkerMainThread.interrupt();
+                WorkerMainThread.join();
 
                 Msg(_("Snapshot operation canceled."), _("The wallet will now shutdown."));
 
                 return false;
             }
-
             // Avoid the window disappearing for 1 second after a reset
             else
             {
@@ -220,20 +243,23 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
         }
 
-        if (ExtractStatus.SnapshotZipInvalid)
+        if (ExtractStatus.GetSnapshotZipInvalid())
         {
             fCancelOperation = true;
 
-            SnapshotDownloadThread.interrupt();
-            SnapshotDownloadThread.join();
+            WorkerMainThread.interrupt();
+            WorkerMainThread.join();
 
             Msg(_("Snapshot operation canceled due to an invalid snapshot zip."), _("The wallet will now shutdown."));
 
             return false;
         }
 
-        if (ExtractStatus.SnapshotExtractFailed)
+        if (ExtractStatus.GetSnapshotExtractFailed())
         {
+            WorkerMainThread.interrupt();
+            WorkerMainThread.join();
+
             ErrorMsg(_("Snapshot extraction failed! Cleaning up any extracted data"), _("The wallet will now shutdown."));
 
             // Do this without checking on success, If it passed in stage 3 it will pass here.
@@ -242,7 +268,7 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
             return false;
         }
 
-        Progress.setValue(ExtractStatus.SnapshotExtractProgress);
+        Progress.setValue(ExtractStatus.GetSnapshotExtractProgress());
 
         SnapshotApp.processEvents();
 
@@ -251,29 +277,14 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
     Progress.setValue(100);
 
+    WorkerMainThread.interrupt();
+    WorkerMainThread.join();
+
     SnapshotApp.processEvents();
 
     Msg(_("Snapshot operation successful!"), _("The wallet is now shutting down. Please restart your wallet."));
 
     return true;
-}
-
-void UpgradeQt::DownloadSnapshot()
-{
-   RenameThread("grc-snapshotdl");
-
-   Upgrade upgrade;
-
-   upgrade.DownloadSnapshot();
-}
-
-void UpgradeQt::ExtractSnapshot()
-{
-    RenameThread("grc-snapshotex");
-
-    Upgrade upgrade;
-
-    upgrade.ExtractSnapshot();
 }
 
 void UpgradeQt::ErrorMsg(const std::string& text, const std::string& informativetext)
@@ -331,7 +342,8 @@ void UpgradeQt::DeleteSnapshot()
 {
     // File is out of scope now check if it exists and if so delete it.
     // This covers partial downloaded files or a http response downloaded into file.
-    std::string snapshotfile = gArgs.GetArg("-snapshoturl", "https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip");
+    std::string snapshotfile = gArgs.GetArg("-snapshoturl",
+                                            "https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip");
 
     size_t pos = snapshotfile.find_last_of("/");
 
@@ -359,16 +371,19 @@ bool UpgradeQt::ResetBlockchain(QApplication& ResetBlockchainApp)
 
     Upgrade resetblockchain;
 
-    bool fSuccess = resetblockchain.CleanupBlockchainData();
+    resetblockchain.CleanupBlockchainData();
+
+    bool fSuccess = (DownloadStatus.GetCleanupBlockchainDataComplete() && !DownloadStatus.GetCleanupBlockchainDataFailed());
 
     if (fSuccess)
-        Msg(_("Reset Blockchain Data: Blockchain data removal was a success"), _("The wallet will now shutdown. Please start your wallet to begin sync from zero"), false);
+        Msg(_("Reset Blockchain Data: Blockchain data removal was a success"),
+            _("The wallet will now shutdown. Please start your wallet to begin sync from zero"), false);
 
     else
     {
         std::string inftext = resetblockchain.ResetBlockchainMessages(Upgrade::CleanUp);
 
-        ErrorMsg(_("Reset Blockchain Data: Blockchain data removal was a failure"), inftext);
+        ErrorMsg(_("Reset Blockchain Data: Blockchain data removal failed."), inftext);
     }
 
     return fSuccess;

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -9,6 +9,12 @@
 #include <QString>
 #include <QApplication>
 
+namespace GRC
+{
+class Progress;
+}
+
+
 class UpgradeQt
 {
 public:
@@ -22,16 +28,6 @@ public:
     //! \return Returns success of snapshot task.
     //!
     bool SnapshotMain(QApplication& SnapshotApp);
-    //!
-    //! \brief Function called via thread to download snapshot and provide realtime updates of progress.
-    //!
-    //! \return Success of function.
-    //!
-    void DownloadSnapshot();
-    //!
-    //! \brief Function called via thread to extract snapshot and provide realtime updates of progress.
-    //!
-    void ExtractSnapshot();
     //!
     //! \brief ErrorMsg box for displaying errors that have occurred during snapshot process.
     //!


### PR DESCRIPTION
This fixes the snapshot download for macOS and also makes other cleanups and adjustments.

Note that this draft PR uses a single additional worker thread for the heavyweight download/verification/unpack functions, with a "ping-pong" triggered workflow. Given that the actual cause of the crash was not due to the threading, I may revert back to the simpler workflow, invoking a separate worker thread in each step. -- Update nope. What I did is working very well, so I am going to leave it.

I went ahead and did progress updating for both the SHA256SUM verification and the blockchain data cleanup function, since they are pretty heavyweight and take a pretty long time on slower machines, so it is good to see actual progress, instead of going from 0 to 100 instantaneously.

I also changed the SnapshotStatus and SnapshotExtractStatus structs into thread safe classes with getters and setters because they are accessed by multiple threads.

This has been tested on macOS Catalina (10.15) and works well.

Closes #2208.