### PR TITLE
rpc: Remove readconfig

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1940,30 +1940,6 @@ UniValue projects(const UniValue& params, bool fHelp)
     return res;
 }
 
-UniValue readconfig(const UniValue& params, bool fHelp)
-{
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "readconfig\n"
-                "\n"
-                "Re-reads config file; Does not overwrite pre-existing loaded values\n");
-
-    UniValue res(UniValue::VOBJ);
-
-    LOCK(cs_main);
-
-    std::string error_msg;
-
-    if (!gArgs.ReadConfigFiles(error_msg, true))
-    {
-        throw JSONRPCError(RPC_MISC_ERROR, error_msg);
-    }
-
-    res.pushKV("readconfig", 1);
-
-    return res;
-}
-
 UniValue readdata(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -384,7 +384,6 @@ static const CRPCCommand vRPCCommands[] =
     { "parseaccrualsnapshotfile",&parseaccrualsnapshotfile,cat_developer     },
     { "parselegacysb",           &parselegacysb,           cat_developer     },
     { "projects",                &projects,                cat_developer     },
-    { "readconfig",              &readconfig,              cat_developer     },
     { "readdata",                &readdata,                cat_developer     },
     { "reorganize",              &rpc_reorganize,          cat_developer     },
     { "sendalert",               &sendalert,               cat_developer     },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -197,7 +197,6 @@ extern UniValue network(const UniValue& params, bool fHelp);
 extern UniValue parseaccrualsnapshotfile(const UniValue& params, bool fHelp);
 extern UniValue parselegacysb(const UniValue& params, bool fHelp);
 extern UniValue projects(const UniValue& params, bool fHelp);
-extern UniValue readconfig(const UniValue& params, bool fHelp);
 extern UniValue readdata(const UniValue& params, bool fHelp);
 extern UniValue rpc_reorganize(const UniValue& params, bool fHelp);
 extern UniValue sendalert(const UniValue& params, bool fHelp);


### PR DESCRIPTION
The removal of readconfig should have been in the ArgsManager port but was overlooked. The read-only config file under the new ArgsManager following Bitcoin is supposed to be read-only by the node. Writeable changes go in the json settings file, and currently are done by changesettings, not by modifying the underlying file while the wallet is running.