### PR TITLE
qt: Fix crash during download snapshot on macOS

### DIFF
--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -311,6 +311,8 @@ void Http::DownloadSnapshot()
 
     fs::path destination = GetDataDir() / "snapshot.zip";
 
+    LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: Downloading snapshot to %s.", __func__, destination.string());
+
     ScopedFile fp(fsbridge::fopen(destination, "wb"), &fclose);
 
     if (!fp)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -708,8 +708,6 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
 #ifndef Q_OS_MAC
             qApp->setWindowIcon(QPixmap(":/images/gridcoin_testnet"));
             setWindowIcon(QPixmap(":/images/gridcoin_testnet"));
-#else
-            MacDockIconHandler::instance()->setIcon(QPixmap(":/images/gridcoin_testnet"));
 #endif
             if(trayIcon)
             {
@@ -843,6 +841,14 @@ void BitcoinGUI::createTrayIconMenu()
     // Note: On Mac, the dock icon is used to provide the tray's functionality.
     MacDockIconHandler *dockIconHandler = MacDockIconHandler::instance();
     dockIconHandler->setMainWindow((QMainWindow *)this);
+
+    // We have to set up the icons here late for the macOS
+    if (this->clientModel && this->clientModel->isTestNet()) {
+        dockIconHandler->setIcon(QPixmap(":/images/gridcoin_testnet"));
+    } else {
+    dockIconHandler->setIcon(QPixmap(":/images/gridcoin"));
+    }
+
     trayIconMenu = dockIconHandler->dockMenu();
 #endif
 

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -14,8 +14,13 @@ namespace GRC
 class Progress;
 }
 
+class QAction;
+class QMenuBar;
+class QMenu;
+class QMainWindow;
+class QProgressDialog;
 
-class UpgradeQt
+class UpgradeQt : QObject
 {
 public:
     //!
@@ -69,6 +74,14 @@ public:
     //!
     static bool ResetBlockchain(QApplication& ResetBlockchainApp);
 
+private:
+#ifdef Q_OS_MAC
+    QAction *m_quitAction;
+    QMenuBar *m_appMenuBar;
+    QMenu *trayIconMenu;
+#endif
+
+    QProgressDialog *m_Progress;
 };
 #endif // UPGRADEQT_H
 


### PR DESCRIPTION
This makes further changes to fix a remaining crash on macOS when switching away from Gridcoin during the snapshot download process.

Also addresses #2208.