### PR TITLE
build: Bump minimum QT support to 5.9.5, Remove obsolete checks

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -294,6 +294,26 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   AC_SUBST(QT_SELECT, qt5)
   AC_SUBST(MOC_DEFS)
 
+dnl Internal. Check if the included version of Qt meets our minimum of QT 5.9.5
+dnl Requires: INCLUDES must be populated as necessary.
+dnl Output: bitcoin_cv_qt5=yes|no
+AC_DEFUN([_BITCOIN_QT_CHECK_QT5],[
+  AC_CACHE_CHECK(for Qt 5, bitcoin_cv_qt5,[
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <QtCore/qconfig.h>
+      #ifndef QT_VERSION
+      #  include <QtCore/qglobal.h>
+      #endif
+    ]],
+    [[
+      #if QT_VERSION < 0x050905
+      choke
+      #endif
+    ]])],
+    [bitcoin_cv_qt5=yes],
+    [bitcoin_cv_qt5=no])
+])])
+
   dnl Gridcoin: determine whether to disable macOS 10.14+ dark-mode. This feature
   dnl needs Qt 5.12+. If we find an earlier version, the variable substitution in
   dnl share/qt/Info.plist disables macos 10.14 appearance features like dark-mode

--- a/configure.ac
+++ b/configure.ac
@@ -836,7 +836,7 @@ fi
 BITCOIN_QT_INIT
 
 dnl sets $bitcoin_enable_qt, $bitcoin_enable_qt_test, $bitcoin_enable_qt_dbus
-BITCOIN_QT_CONFIGURE([5.5.1])
+BITCOIN_QT_CONFIGURE([5.9.5])
 
 if test x$build_bitcoin_utils$build_gridcoinresearchd$bitcoin_enable_qt$use_tests$use_bench = xnonononono; then
     use_boost=no

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -51,9 +51,6 @@ Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
-#if QT_VERSION < 0x050400
-Q_IMPORT_PLUGIN(AccessibleFactory)
-#endif
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)
@@ -284,9 +281,7 @@ int main(int argc, char *argv[])
 
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#if QT_VERSION >= 0x050600
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
 
     // Initiate the app here to support choosing the data directory.
     Q_INIT_RESOURCE(bitcoin);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -220,16 +220,6 @@ static std::string Translate(const char* psz)
 }
 
 /* qDebug() message handler --> debug.log */
-#if QT_VERSION < 0x050000
-void DebugMessageHandler(QtMsgType type, const char *msg)
-{
-    if (type == QtDebugMsg) {
-        LogPrint(BCLog::LogFlags::QT, "GUI: %s\n", msg);
-    } else {
-        LogPrintf("GUI: %s\n", msg);
-    }
-}
-#else
 void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
 {
     Q_UNUSED(context);
@@ -239,7 +229,6 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, cons
         LogPrintf("GUI: %s\n", msg.toStdString());
     }
 }
-#endif
 
 /* Handle runaway exceptions. Shows a message box with the problem and quits the program.
  */
@@ -350,7 +339,7 @@ int main(int argc, char *argv[])
     // Install global event filter that suppresses help context question mark
     app.installEventFilter(new GUIUtil::WindowContextHelpButtonHintFilter(&app));
 
-#if defined(WIN32) && QT_VERSION >= 0x050000
+#if defined(WIN32)
     // Install global event filter for processing Windows session related Windows messages (WM_QUERYENDSESSION and WM_ENDSESSION)
     app.installNativeEventFilter(new WinShutdownMonitor());
 #endif
@@ -584,13 +573,8 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
 
     std::shared_ptr<ThreadHandler> threads = std::make_shared<ThreadHandler>();
 
-#if QT_VERSION < 0x050000
-    // Install qDebug() message handler to route to debug.log
-    qInstallMsgHandler(DebugMessageHandler);
-#else
     // Install qDebug() message handler to route to debug.log
     qInstallMessageHandler(DebugMessageHandler);
-#endif
 
     // Subscribe to global signals from core
     uiInterface.ThreadSafeMessageBox.connect(ThreadSafeMessageBox);
@@ -680,7 +664,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 // Place this here as guiref has to be defined if we don't want to lose URIs
                 ipcInit(argc, argv);
 
-#if defined(WIN32) && defined(QT_GUI) && QT_VERSION >= 0x050000
+#if defined(WIN32) && defined(QT_GUI)
                 WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("%1 didn't yet exit safely...").arg(QObject::tr(PACKAGE_NAME)), (HWND)window.winId());
 #endif
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -5,12 +5,6 @@
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
-#if QT_VERSION < 0x050000
-Q_IMPORT_PLUGIN(qcncodecs)
-Q_IMPORT_PLUGIN(qjpcodecs)
-Q_IMPORT_PLUGIN(qtwcodecs)
-Q_IMPORT_PLUGIN(qkrcodecs)
-#else
 #if defined(QT_QPA_PLATFORM_MINIMAL)
 Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
 #endif
@@ -20,7 +14,6 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_COCOA)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
-#endif
 #endif
 #endif
 

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -4,7 +4,7 @@
 
 #include <qt/winshutdownmonitor.h>
 
-#if defined(WIN32) && QT_VERSION >= 0x050000
+#if defined(WIN32)
 #include <init.h>
 #include <util.h>
 

--- a/src/qt/winshutdownmonitor.h
+++ b/src/qt/winshutdownmonitor.h
@@ -9,7 +9,6 @@
 #include <QByteArray>
 #include <QString>
 
-#if QT_VERSION >= 0x050000
 #include <windef.h> // for HWND
 
 #include <QAbstractNativeEventFilter>
@@ -23,7 +22,6 @@ public:
     /** Register the reason for blocking shutdown on Windows to allow clean client exit */
     static void registerShutdownBlockReason(const QString& strReason, const HWND& mainWinId);
 };
-#endif
 #endif
 
 #endif // BITCOIN_QT_WINSHUTDOWNMONITOR_H


### PR DESCRIPTION
Ref: https://github.com/bitcoin/bitcoin/pull/21286

Previously, we had a very weak requirement for QT 5.5.1.  When this was implemented, the check in configure was missed, resulting in unexpected behavior and lack of support for features when compiled on systems using QT < 5.5.1.  We now use upstream's method of explicitly checking the QT version at compile time with depends and enforcing the minimum.

This PR also removes old workaround code for handling QT versions as old as <5.  Since we only support 5.9.5 and up going forward, we do not need to handle these cases.

NOTE: DO NOT MERGE UNTIL JANICE.  Debian Stretch goes old stable on August 15th, so we should not enforce this until that date.