### PR TITLE
gui: Fix address book selected model record when editing

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -185,8 +185,11 @@ void AddressBookPage::onEditAction()
             tab == SendingTab ?
             EditAddressDialog::EditSendingAddress :
             EditAddressDialog::EditReceivingAddress);
+
+    QModelIndex origIndex = filterProxyModel->mapToSource(indexes.at(0));
+    origIndex = proxyModel->mapToSource(origIndex);
+
     dlg.setModel(model);
-    QModelIndex origIndex = proxyModel->mapToSource(indexes.at(0));
     dlg.loadRow(origIndex.row());
     dlg.exec();
 }


### PR DESCRIPTION
This is a small fix for a regression described by the comment in #2252: 

> There also seems to be a label related problem when right clicking on an address and then edit in the Receive tab the dialog does not show the address and changes will not save. (nothing happens when I click OK, dialog remains open)

The addition of an address/label filter to the "receive" and "favorites" pages in #2138 created a need for an extra indirection to map a selected table row to a model record for an address when using the "edit" action in the context menu.

Note: this does not address the unwanted insertion of a "(no label)" label described also by #2252. I may have time to knock that one out later if someone doesn't beat me to it.