### PR TITLE
qt: Prevent pasting (no label) as label in consolidation transaction

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -490,8 +490,6 @@ void SendCoinsDialog::coinControlConsolidateWizardButtonClicked()
 
 void SendCoinsDialog::selectedConsolidationRecipient(SendCoinsRecipient consolidationRecipient)
 {
-    LogPrintf("INFO: %s: SLOT called.", __func__);
-
     ui->coinControlChangeCheckBox->setChecked(true);
     ui->coinControlChangeEdit->setText(consolidationRecipient.address);
 
@@ -504,6 +502,12 @@ void SendCoinsDialog::selectedConsolidationRecipient(SendCoinsRecipient consolid
             removeEntry(entry);
         }
     }
+
+    // The AddressTableModel substitutes the translated "(no label)" when the label is empty. If we use
+    // that here, we will end up pasting a literal lable of "(no label)". Because the translation (tr) should
+    // be consistent between here and the AddressTableModel::data, it should match the conditional and be put
+    // back to the desired empty QString.
+    if (consolidationRecipient.label == tr("(no label)")) consolidationRecipient.label = QString();
 
     pasteEntry(consolidationRecipient);
 }


### PR DESCRIPTION
QVariant AddressTableModel::data substitutes tr("(no label)") for an empty QString label for display prettification. Unfortunately since the model values are used in the void SendCoinsDialog::selectedConsolidationRecipient, without filtering this substitution back out, it results in pasting a literal translation of "(no label)" as the label for the consolidation transaction. This label is then saved for that address. This one-liner filters that out and restores the intended behavior.

Together with #2253 closes #2252.