### PR TITLE
build: Adjust depends packages to successfully compile on OpenSUSE

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -6,7 +6,8 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=cbc9102f4a31a8dafd42d642e9a3aa31e79a0aedaa1f6efd2795ebc83174ec18
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-static
+  $(package)_config_opts=--disable-static --without-docbook
+  $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -8,6 +8,7 @@ $(package)_dependencies=freetype expat
 define $(package)_set_vars
   $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
+  $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -7,6 +7,7 @@ $(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4
 
 define $(package)_set_vars
   $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
+  $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -8,6 +8,7 @@ $(package)_dependencies=xproto
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
+  $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -20,6 +20,7 @@ define $(package)_set_vars
   $(package)_config_opts += --disable-xinerama --disable-xinput
   $(package)_config_opts += --disable-xprint --disable-selinux --disable-xtest
   $(package)_config_opts += --disable-xv --disable-xvmc
+  $(package)_config_opts +=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -8,6 +8,7 @@ $(package)_dependencies=libxcb
 define $(package)_set_vars
 $(package)_config_opts = --enable-option-checking --disable-dependency-tracking
 $(package)_config_opts += --disable-static --disable-docs
+$(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -6,6 +6,7 @@ $(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
 $(package)_sha256_hash=7ef40ddd855b750bc597d2a435da21e55e502a0fefa85b274f2c922800baaf05
 
 define $(package)_set_vars
+  $(package)_config_opts +=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -7,6 +7,7 @@ $(package)_sha256_hash=636162c1759805a5a0114a369dffdeccb8af8c859ef6e1445f26a4e6e
 
 define $(package)_set_vars
   $(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs
+  $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/patches/bzip2/Makefile.patch
+++ b/depends/patches/bzip2/Makefile.patch
@@ -1,17 +1,21 @@
 --- Makefile	2019-07-13 13:50:05.000000000 -0400
 +++ Makefile	2019-10-28 13:31:36.918640240 -0400
-@@ -15,10 +15,10 @@
+@@ -15,13 +15,13 @@
  SHELL=/bin/sh
-
+ 
  # To assist in cross-compiling
 -CC=gcc
 -AR=ar
 -RANLIB=ranlib
 -LDFLAGS=
-+# CC=gcc
-+# AR=ar
-+# RANLIB=ranlib
-+# LDFLAGS=
-
++#CC=gcc
++#AR=ar
++#RANLIB=ranlib
++#LDFLAGS=
+ 
  BIGFILES=-D_FILE_OFFSET_BITS=64
- CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
+-CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
++CFLAGS=-Wall -Winline -O2 -g $(BIGFILES) -fPIC
+ 
+ # Where you want it installed when you do 'make install'
+ PREFIX=/usr/local


### PR DESCRIPTION
OpenSUSE uses /usr/lib64 rather than lib and this confuses the depends system. These changes ensure all packages here install to the lib folder in the depends build root. Other Linux distros that use /usr/lib64 will also benefit from this, and it is idempotent for distributions that use /usr/lib.