### PR TITLE
refactor: Replace fprintf with tfm::format

### DIFF
--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -39,7 +39,7 @@ bool AppInit(int argc, char* argv[])
     SetupEnvironment();
     SetupServerArgs();
 
-    // Note every function above the InitLogging() call must use fprintf or similar.
+    // Note every function above the InitLogging() call must use tfm::format or similar.
 
     ThreadHandlerPtr threads = std::make_shared<ThreadHandler>();
     bool fRet = false;
@@ -73,7 +73,7 @@ bool AppInit(int argc, char* argv[])
 
         if (gArgs.IsArgSet("-version"))
         {
-            fprintf(stdout, "%s", VersionMessage().c_str());
+            tfm::format(std::cout, "%s", VersionMessage().c_str());
 
             return false;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -938,7 +938,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         pid_t pid = fork();
         if (pid < 0)
         {
-            fprintf(stderr, "Error: fork() returned %d errno %d\n", pid, errno);
+            tfm::format(std::cerr, "Error: fork() returned %d errno %d\n", pid, errno);
             return false;
         }
         if (pid > 0)
@@ -953,7 +953,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 
         pid_t sid = setsid();
         if (sid < 0)
-            fprintf(stderr, "Error: setsid() returned %d errno %d\n", sid, errno);
+            tfm::format(std::cerr, "Error: setsid() returned %d errno %d\n", sid, errno);
     }
 #endif
 
@@ -980,7 +980,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     if (fDaemon)
-        fprintf(stdout, "Gridcoin server starting\n");
+        tfm::format(std::cout, "Gridcoin server starting\n");
 
     // ********************************************************* Step 5: verify database integrity
 

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -12,7 +12,7 @@
 static int noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style)
 {
     LogPrintf("%s: %s", caption, message);
-    fprintf(stderr, "%s: %s\n", caption.c_str(), message.c_str());
+    tfm::format(std::cerr, "%s: %s\n", caption.c_str(), message.c_str());
     return 4;
 }
 
@@ -26,7 +26,7 @@ static int noui_UpdateMessageBox(const std::string& version, const std::string& 
     std::string caption = _("Gridcoin Update Available");
 
     LogPrintf("%s:\r\n%s", caption, message);
-    fprintf(stderr, "\r\n%s:\r\n%s\r\n%s\r\n", caption.c_str(), version.c_str(), message.c_str());
+    tfm::format(std::cerr, "\r\n%s:\r\n%s\r\n%s\r\n", caption.c_str(), version.c_str(), message.c_str());
 
     return 0;
 }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -118,7 +118,7 @@ static void ThreadSafeMessageBox(const std::string& message, const std::string& 
     else
     {
         LogPrintf("%s: %s", caption, message);
-        fprintf(stderr, "%s: %s\n", caption.c_str(), message.c_str());
+        tfm::format(std::cerr, "%s: %s\n", caption.c_str(), message.c_str());
     }
 }
 
@@ -199,7 +199,7 @@ static void UpdateMessageBox(const std::string& version, const std::string& mess
     else
     {
         LogPrintf("\r\n%s:\r\n%s", caption, message);
-        fprintf(stderr, "\r\n%s:\r\n%s\r\n", caption.c_str(), message.c_str());
+        tfm::format(std::cerr, "\r\n%s:\r\n%s\r\n", caption.c_str(), message.c_str());
     }
 }
 
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
     SetupServerArgs();
     SetupUIArgs(gArgs);
 
-    // Note every function above the InitLogging() call must use fprintf or similar.
+    // Note every function above the InitLogging() call must use tfm::format or similar.
 
     // Command-line options take precedence:
     // Before this would of been done in main then config file loaded.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -705,7 +705,7 @@ void HelpMessageBox::printToConsole()
 {
     // On other operating systems, the expected action is to print the message to the console.
     QString strUsage = header + "\n" + options;
-    fprintf(stdout, "%s", strUsage.toStdString().c_str());
+    tfm::format(std::cout, "%s", strUsage.toStdString().c_str());
 }
 
 void HelpMessageBox::showOrPrint()

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -56,7 +56,7 @@ static bool ipcScanCmd(int argc, char *argv[], bool fRelay)
                 // the first start of the first instance
                 if (ex.get_error_code() != boost::interprocess::not_found_error || !fRelay)
                 {
-                    fprintf(stderr, "main() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
+                    tfm::format(std::cerr, "main() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
                     break;
                 }
             }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -351,7 +351,7 @@ int CommandLineRPC(int argc, char *argv[])
 
     if (strPrint != "")
     {
-        fprintf((nRet == 0 ? stdout : stderr), "%s\n", strPrint.c_str());
+        tfm::format(nRet == 0 ? std::cout : std::cerr, "%s\n", strPrint.c_str());
     }
     return nRet;
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -148,7 +148,7 @@ void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine,
     for (const std::pair<void*, CLockLocation> & i : *lockstack)
         if (i.first == cs)
             return;
-    fprintf(stderr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld().c_str());
+    tfm::format(std::cerr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld().c_str());
     abort();
 }
 

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -415,7 +415,7 @@ bool CTxDB::LoadBlockIndex()
                     _("Blocks Loaded"),
                     (100 * nLoaded / nHighest)));
 
-                fprintf(stdout,"%d ",nLoaded); fflush(stdout);
+                tfm::format(std::cout,"%d ",nLoaded); fflush(stdout);
             }
         }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -284,11 +284,10 @@ bool WildcardMatch(const string& str, const string& mask)
 #ifndef WIN32
 void CreatePidFile(const fs::path &path, pid_t pid)
 {
-    FILE* file = fsbridge::fopen(path, "w");
+    fsbridge::ofstream file{path};
     if (file)
     {
-        fprintf(file, "%d\n", pid);
-        fclose(file);
+        tfm::format(file, "%d\n", pid);
     }
 }
 #endif

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -689,7 +689,7 @@ void PrintException(std::exception* pex, const char* pszThread)
 {
     std::string message = FormatException(pex, pszThread);
     LogPrintf("\n\n************************\n%s", message);
-    fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
+    tfm::format(std::cerr, "\n\n************************\n%s\n", message.c_str());
     strMiscWarning = message;
     throw;
 }
@@ -698,7 +698,7 @@ void PrintExceptionContinue(std::exception* pex, const char* pszThread)
 {
     std::string message = FormatException(pex, pszThread);
     LogPrintf("\n\n************************\n%s", message);
-    fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
+    tfm::format(std::cerr, "\n\n************************\n%s\n", message.c_str());
     strMiscWarning = message;
 }
 


### PR DESCRIPTION
> The locale dependent function fprintf(...) appears to be used...

This should silence 16 lines in the locale dependency linter.  Note that the leveldb, crypto, and univalue folders have been excluded from this PR.

Ref: https://github.com/bitcoin/bitcoin/pull/16205