### PR TITLE
refactor: Use functions guaranteed to be locale independent (ToLower, IsDigit, IsSpace)

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <util/strencodings.h>
 
 static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
@@ -81,7 +82,7 @@ inline bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet)
     CBigNum bn58 = 58;
     CBigNum bn = 0;
     CBigNum bnChar;
-    while (isspace(*psz))
+    while (IsSpace(*psz))
         psz++;
 
     // Convert big endian string to bignum
@@ -89,7 +90,7 @@ inline bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet)
     {
         const char* p1 = strchr(pszBase58, *p);
         if (p1 == nullptr) {
-            while (isspace(*p))
+            while (IsSpace(*p))
                 p++;
             if (*p != '\0')
                 return false;

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_BIGNUM_H
 #define BITCOIN_BIGNUM_H
 
+#include <util/strencodings.h>
 #include "serialize.h"
 #include "uint256.h"
 #include "version.h"
@@ -354,7 +355,7 @@ public:
     {
         // skip 0x
         const char* psz = str.c_str();
-        while (isspace(*psz))
+        while (IsSpace(*psz))
             psz++;
         bool fNegative = false;
         if (*psz == '-')
@@ -362,9 +363,9 @@ public:
             fNegative = true;
             psz++;
         }
-        if (psz[0] == '0' && tolower(psz[1]) == 'x')
+        if (psz[0] == '0' && ToLower((unsigned char)psz[1]) == 'x')
             psz += 2;
-        while (isspace(*psz))
+        while (IsSpace(*psz))
             psz++;
 
         // hex string to bignum

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -134,7 +134,7 @@ WhitelistSnapshot WhitelistSnapshot::Sorted() const
             b.m_name.begin(),
             b.m_name.end(),
             [](const char ac, const char bc) {
-                return std::tolower(ac) < std::tolower(bc);
+                return ToLower(ac) < ToLower(bc);
             });
     };
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -96,7 +96,6 @@ mProjectTeamETags ProjTeamETags;
 std::vector<std::string> GetTeamWhiteList();
 
 std::string urlsanity(const std::string& s, const std::string& type);
-std::string lowercase(std::string s);
 ScraperFileManifest StructScraperFileManifest = {};
 
 // Although scraper_net.h declares these maps, we define them here instead of
@@ -1331,14 +1330,6 @@ bool ScraperHousekeeping()
     return true;
 }
 
-
-std::string lowercase(std::string s)
-{
-    std::transform(s.begin(), s.end(), s.begin(), ToLower);
-
-    return s;
-}
-
 // A lock on cs_Scraper should be taken before calling this function.
 bool ScraperDirectoryAndConfigSanity()
 {
@@ -1613,7 +1604,7 @@ bool DownloadProjectHostFiles(const WhitelistSnapshot& projectWhitelist)
 
         if (buserpass)
         {
-            authdata ad(lowercase(prjs.m_name));
+            authdata ad(ToLower(prjs.m_name));
 
             ad.setoutputdata("host", prjs.m_name, sHostETag);
 
@@ -1739,7 +1730,7 @@ bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist)
 
         if (buserpass)
         {
-            authdata ad(lowercase(prjs.m_name));
+            authdata ad(ToLower(prjs.m_name));
 
             ad.setoutputdata("team", prjs.m_name, sTeamETag);
 
@@ -2044,7 +2035,7 @@ bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
 
         if (buserpass)
         {
-            authdata ad(lowercase(prjs.m_name));
+            authdata ad(ToLower(prjs.m_name));
 
             ad.setoutputdata("user", prjs.m_name, sRacETag);
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -31,6 +31,7 @@
 #include <boost/date_time.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/gregorian/greg_date.hpp>
+#include <util/strencodings.h>
 #include <random>
 
 using namespace GRC;
@@ -1333,7 +1334,7 @@ bool ScraperHousekeeping()
 
 std::string lowercase(std::string s)
 {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    std::transform(s.begin(), s.end(), s.begin(), ToLower);
 
     return s;
 }

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -49,15 +49,7 @@ std::string HTTPPost(const std::string& strMsg, const std::map<std::string,std::
 
 std::string rfc1123Time()
 {
-    char buffer[64];
-    time_t now;
-    time(&now);
-    struct tm* now_gmt = gmtime(&now);
-    std::string locale(setlocale(LC_TIME, nullptr));
-    setlocale(LC_TIME, "C"); // we want POSIX (aka "C") weekday/month strings
-    strftime(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S +0000", now_gmt);
-    setlocale(LC_TIME, locale.c_str());
-    return std::string(buffer);
+    return DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", GetTime());
 }
 
 std::string HTTPReply(int nStatus, const std::string& strMsg, bool keepalive)

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -1,3 +1,4 @@
+#include <util/strencodings.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -8,7 +9,7 @@ BOOST_AUTO_TEST_SUITE(getarg_tests)
 static void AddArgs(const std::string& strArg)
 {
     std::vector<std::string> vecArg;
-    boost::split(vecArg, strArg, boost::is_space(), boost::token_compress_on);
+    boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
 
     for (const auto& arg : vecArg)
     {
@@ -24,7 +25,7 @@ static bool ResetArgs(const std::string& strAddArg, const std::string& strArgIn 
     std::string strArg = strArgIn.empty() ? strAddArg : strArgIn;
 
     std::vector<std::string> vecArg;
-    boost::split(vecArg, strArg, boost::is_space(), boost::token_compress_on);
+    boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
 
 
     // Insert dummy executable name:

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <sstream>
+#include <util/strencodings.h>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -53,8 +54,8 @@ ParseScript(string s)
         {
             // Empty string, ignore. (boost::split given '' will return one word)
         }
-        else if (all(w, is_digit()) ||
-            (starts_with(w, "-") && all(string(w.begin()+1, w.end()), is_digit())))
+        else if (all(w, ::IsDigit) ||
+            (starts_with(w, "-") && all(string(w.begin()+1, w.end()), ::IsDigit)))
         {
             // Number
             int64_t n = atoi64(w);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -139,6 +139,7 @@ BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
     // Formats used within Bitcoin
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M:%S", 1317425777), "09/30/11 23:36:17");
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M", 1317425777), "09/30/11 23:36");
+    BOOST_CHECK_EQUAL(DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", 1317425777), "Fri, 30 Sep 2011 23:36:17 +0000");
 */
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -9,6 +9,7 @@
 #include "version.h"
 #include "ui_interface.h"
 #include "util.h"
+#include <util/strencodings.h>
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/join.hpp>
@@ -195,7 +196,7 @@ string FormatMoney(int64_t n, bool fPlus)
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
-    for (int i = str.size()-1; (str[i] == '0' && isdigit(str[i-2])); --i)
+    for (int i = str.size()-1; (str[i] == '0' && IsDigit(str[i-2])); --i)
         ++nTrim;
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);
@@ -217,7 +218,7 @@ bool ParseMoney(const char* pszIn, int64_t& nRet)
     string strWhole;
     int64_t nUnits = 0;
     const char* p = pszIn;
-    while (isspace(*p))
+    while (IsSpace(*p))
         p++;
     for (; *p; p++)
     {
@@ -225,21 +226,21 @@ bool ParseMoney(const char* pszIn, int64_t& nRet)
         {
             p++;
             int64_t nMult = CENT*10;
-            while (isdigit(*p) && (nMult > 0))
+            while (IsDigit(*p) && (nMult > 0))
             {
                 nUnits += nMult * (*p++ - '0');
                 nMult /= 10;
             }
             break;
         }
-        if (isspace(*p))
+        if (IsSpace(*p))
             break;
-        if (!isdigit(*p))
+        if (!IsDigit(*p))
             return false;
         strWhole.insert(strWhole.end(), *p);
     }
     for (; *p; p++)
-        if (!isspace(*p))
+        if (!IsSpace(*p))
             return false;
     if (strWhole.size() > 10) // guard against 63 bit overflow
         return false;


### PR DESCRIPTION
- Use `ToLower(...)` instead of `std::tolower`. `std::tolower` is locale dependent.
    - For the scraper we can use the utility function that already exists to convert to lowercase.
    
- Use `IsDigit(...)` instead of `std::isdigit`. Some implementations (e.g. Microsoft in 1252 codepage) may classify single-byte characters other than [0-9] as digits.

- Use `IsSpace(...)` instead of `boost::is_space`

- Change the `rfc1123Time()` method to use a simpler format


Ref: https://github.com/bitcoin/bitcoin/pull/14599

Linter output is reduced by 27 lines