### PR TITLE
refactor: small python cleanup

### DIFF
--- a/contrib/wallettools/walletchangepass.py
+++ b/contrib/wallettools/walletchangepass.py
@@ -1,5 +1,6 @@
 from jsonrpc import ServiceProxy
+import getpass
 access = ServiceProxy("http://127.0.0.1:8332")
-pwd = raw_input("Enter old wallet passphrase: ")
-pwd2 = raw_input("Enter new wallet passphrase: ")
+pwd = getpass.getpass(prompt="Enter old wallet passphrase: ")
+pwd2 = getpass.getpass(prompt="Enter new wallet passphrase: ")
 access.walletpassphrasechange(pwd, pwd2)

--- a/contrib/wallettools/walletunlock.py
+++ b/contrib/wallettools/walletunlock.py
@@ -1,4 +1,5 @@
 from jsonrpc import ServiceProxy
+import getpass
 access = ServiceProxy("http://127.0.0.1:8332")
-pwd = raw_input("Enter wallet passphrase: ")
+pwd = getpass.getpass(prompt="Enter wallet passphrase: ")
 access.walletpassphrase(pwd, 60)

--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -58,7 +58,7 @@ XGETTEXT=os.getenv('XGETTEXT', 'xgettext')
 if not XGETTEXT:
     print('Cannot extract strings: xgettext utility is not installed or not configured.',file=sys.stderr)
     print('Please install package "gettext" and re-run \'./configure\'.',file=sys.stderr)
-    exit(1)
+    sys.exit(1)
 child = Popen([XGETTEXT,'--output=-','-n','--keyword=_'] + files, stdout=PIPE)
 (out, err) = child.communicate()
 


### PR DESCRIPTION
- Use sys.exit(...) instead of exit(...)
  - Ref: https://github.com/bitcoin/bitcoin/pull/10781
- Changed bitrpc.py's raw_input to getpass for passwords to conceal characters during command line input.
  - Ref: https://github.com/bitcoin/bitcoin/pull/4035