### PR TITLE
refactor: Remove sprintf and printf

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -620,7 +620,7 @@ void _log(logattribute eType, const std::string& sCall, const std::string& sMess
 
     catch (std::exception& ex)
     {
-        printf("Logger : exception occurred in _log function (%s)\n", ex.what());
+        tfm::format(std::cerr, "Logger : exception occurred in _log function (%s)\n", ex.what());
 
         return;
     }

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -453,16 +453,14 @@ void Upgrade::VerifySHA256SUM()
 
     SHA256_Final(digest, &ctx);
 
-    char mdString[SHA256_DIGEST_LENGTH*2+1];
+    const std::vector<unsigned char> digest_vector(digest, digest + SHA256_DIGEST_LENGTH);
 
-    for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
-        sprintf(&mdString[i*2], "%02x", (unsigned int)digest[i]);
-
-    std::string FileSHA256SUM = {mdString};
+    std::string FileSHA256SUM = HexStr(digest_vector);
 
     if (ServerSHA256SUM == FileSHA256SUM)
     {
-        LogPrint(BCLog::LogFlags::VERBOSE, "INFO %s: SHA256SUM verification successful.", __func__);
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO %s: SHA256SUM verification successful (Server = %s, File = %s).",
+                 __func__, ServerSHA256SUM, FileSHA256SUM);
 
         DownloadStatus.SetSHA256SUMProgress(100);
         DownloadStatus.SetSHA256SUMComplete(true);

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -41,7 +41,7 @@ static bool ResetArgs(const std::string& strAddArg, const std::string& strArgIn 
 
     bool status = gArgs.ParseParameters(vecChar.size(), &vecChar[0], error);
 
-    if (!status) printf("ERROR: %s: %s", __func__, error.c_str());
+    if (!status) tfm::format(std::cerr, "ERROR: %s: %s\n", __func__, error);
 
     return status;
 }

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -133,12 +133,10 @@ struct Legacy
             const char* chIn = s1.c_str();
             unsigned char digest2[16];
             MD5((unsigned char*)chIn, strlen(chIn), (unsigned char*)&digest2);
-            char mdString2[33];
-            for(int i = 0; i < 16; i++) {
-                sprintf(&mdString2[i*2], "%02x", (unsigned int)digest2[i]);
-            }
-            std::string xmd5(mdString2);
-            return xmd5;
+
+            const std::vector<unsigned char> digest_vector(digest2, digest2 + sizeof(digest2));
+
+            return HexStr(digest_vector);
         }
         catch (std::exception &e)
         {


### PR DESCRIPTION
This replaces the sprintf with HexStr(). Closes #2264.
This also replaces printf with tfm::format.

Partially addresses #2268.