### PR TITLE
refactor: Replace local dependent string functions with non-locale versions in strencodings.h/cpp

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -369,12 +369,11 @@ public:
             psz++;
 
         // hex string to bignum
-        static const signed char phexdigit[256] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,1,2,3,4,5,6,7,8,9,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0 };
         *this = 0;
-        while (isxdigit(*psz))
+        while (HexDigit(*psz) >= 0)
         {
             *this <<= 4;
-            int n = phexdigit[(unsigned char)*psz++];
+            int n = HexDigit((unsigned char)*psz++);
             *this += n;
         }
         if (fNegative)

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -552,11 +552,14 @@ public:
     //!
     static uint64_t ParseHeight(const fs::path& snapshot_path)
     {
-        try {
-            return std::stoull(snapshot_path.stem().string());
-        } catch (...) {
-            return 0;
+        uint64_t height = 0;
+
+        if (!ParseUInt64(snapshot_path.stem().string(), &height)) {
+            LogPrint(BCLog::LogFlags::SB, "WARN: %s: Filename in snapshot path does not contain a valid height number.",
+                     __func__);
         }
+
+        return height;
     }
 
     //!

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -799,13 +799,18 @@ MiningProject::MiningProject(std::string name,
 
 MiningProject MiningProject::Parse(const std::string& xml)
 {
+    double rac = 0.0;
+
+    if (!ParseDouble(ExtractXML(xml, "<user_expavg_credit>", "</user_expavg_credit>"), &rac)) {
+        LogPrintf("WARN: %s: Unable to parse user RAC from legacy XML data.", __func__);
+    }
+
     MiningProject project(
         ExtractXML(xml, "<project_name>", "</project_name>"),
         Cpid::Parse(ExtractXML(xml, "<external_cpid>", "</external_cpid>")),
         ExtractXML(xml, "<team_name>", "</team_name>"),
         ExtractXML(xml, "<master_url>", "</master_url>"),
-        std::strtold(ExtractXML(xml, "<user_expavg_credit>",
-                                "</user_expavg_credit>").c_str(), nullptr));
+        rac);
 
     if (IsPoolCpid(project.m_cpid) && !gArgs.GetBoolArg("-pooloperator", false)) {
         project.m_error = MiningProject::Error::POOL;

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -87,7 +87,7 @@ bool UpdateRWSettingsForMode(const ResearcherMode mode, const std::string& email
 //!
 std::string LowerUnderscore(std::string data)
 {
-    boost::to_lower(data);
+    data = ToLower(data);
     boost::replace_all(data, "_", " ");
 
     return data;
@@ -304,7 +304,7 @@ std::set<std::string> GetTeamWhitelist()
             continue;
         }
 
-        boost::to_lower(team_name);
+        team_name = ToLower(team_name);
 
         teams.emplace(std::move(team_name));
     }
@@ -794,7 +794,7 @@ MiningProject::MiningProject(std::string name,
     , m_rac(std::move(rac))
     , m_error(Error::NONE)
 {
-    boost::to_lower(m_team);
+    m_team = ToLower(m_team);
 }
 
 MiningProject MiningProject::Parse(const std::string& xml)
@@ -1106,7 +1106,7 @@ std::string Researcher::Email()
     if (gArgs.GetBoolArg("-investor", false)) return email;
 
     email = gArgs.GetArg("-email", "");
-    boost::to_lower(email);
+    email = ToLower(email);
 
     return email;
 }
@@ -1353,7 +1353,7 @@ GRC::BeaconError Researcher::BeaconError() const
 
 bool Researcher::ChangeMode(const ResearcherMode mode, std::string email)
 {
-    boost::to_lower(email);
+    email = ToLower(email);
 
     if (mode == ResearcherMode::INVESTOR && ConfiguredForInvestorMode()) {
         return true;

--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -171,10 +171,10 @@ namespace
         }
 
         constexpr char expected[] = "etag";
-        constexpr int32_t to_upper = 32;
+        constexpr int32_t shift_to_upper = 32;
 
         for (size_t i = 0; i < 4; ++i) {
-            if (header[i] != expected[i] && header[i] != expected[i] - to_upper) {
+            if (header[i] != expected[i] && header[i] != expected[i] - shift_to_upper) {
                 return std::string();
             }
         }

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -1914,20 +1914,18 @@ bool ProcessProjectTeamFile(const std::string& project, const fs::path& file, co
 
             int64_t nTeamID = 0;
 
-            try
+            if (!ParseInt64(sTeamID, &nTeamID))
             {
-                nTeamID = atoi64(sTeamID);
-            }
-            catch (const std::exception&)
-            {
-                _log(logattribute::ERR, "ProccessProjectTeamFile", tfm::format("Ignoring bad team id for team %s.", sTeamName));
+                _log(logattribute::ERR, __func__, tfm::format("Ignoring bad team id for team %s.", sTeamName));
                 continue;
             }
 
             mTeamIdsForProject[sTeamName] = nTeamID;
         }
         else
+        {
             builder.append(line);
+        }
     }
 
     if (mTeamIdsForProject.empty())
@@ -2319,13 +2317,9 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
                 const std::string& sTeamID = ExtractXML(data, "<teamid>", "</teamid>");
                 int64_t nTeamID = 0;
 
-                try
+                if (!ParseInt64(sTeamID, &nTeamID))
                 {
-                    nTeamID = atoi64(sTeamID);
-                }
-                catch (const std::exception&)
-                {
-                    _log(logattribute::ERR, "ProcessProjectRacFileByCPID", "Bad team id in user stats file data.");
+                    _log(logattribute::ERR, __func__, "Bad team id in user stats file data.");
                     continue;
                 }
 
@@ -2585,13 +2579,9 @@ bool LoadTeamIDList(const fs::path& file)
                 sProject = iter;
             else
             {
-                try
+                if (!ParseInt64(iter, &nTeamID))
                 {
-                    nTeamID = atoi64(iter);
-                }
-                catch (std::exception&)
-                {
-                    _log(logattribute::ERR, "LoadTeamIDList", "Ignoring invalid team id found in team id file.");
+                    _log(logattribute::ERR, __func__, "Ignoring invalid team id found in team id file.");
                     continue;
                 }
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -2921,7 +2921,16 @@ bool LoadScraperFileManifest(const fs::path& file)
         nhash.SetHex(vline[0].c_str());
         LoadEntry.hash = nhash;
 
-        LoadEntry.current = std::stoi(vline[1]);
+        // We will use the ParseUInt from strencodings to avoid the locale specific stoi.
+        unsigned int parsed_current = 0;
+
+        if (!ParseUInt(vline[1], &parsed_current))
+        {
+            _log(logattribute::ERR, __func__, "The \"current\" field not parsed correctly for a manifest entry. Skipping.");
+            continue;
+        }
+
+        LoadEntry.current = parsed_current;
 
         std::istringstream sstimestamp(vline[2]);
         sstimestamp >> ntimestamp;
@@ -2936,7 +2945,17 @@ bool LoadScraperFileManifest(const fs::path& file)
         {
             // Intended for explorer mode, where files not to be included in CScraperManifest
             // are to be maintained, such as team and host files.
-            LoadEntry.excludefromcsmanifest = std::stoi(vline[5]);
+            unsigned int parsed_exclude = 0;
+
+            if (!ParseUInt(vline[5], &parsed_exclude))
+            {
+                // This shouldn't happen given the conditional above, but to be thorough...
+                _log(logattribute::ERR, __func__, "The \"excludefromcsmanifest\" field not parsed correctly for a manifest "
+                                                  "entry. Skipping.");
+                continue;
+            }
+
+            LoadEntry.excludefromcsmanifest = parsed_exclude;
         }
         else
         {

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -886,19 +886,31 @@ void ApplyCache(const std::string& key, T& result)
                 throw std::invalid_argument("Argument is not parseable as a double.");
             }
 
-            // Have to do the copy here, because otherwise the compiler complains about putting &result directly above,
-            // since this is a template.
+            // Have to do the copy here and below, because otherwise the compiler complains about putting &result directly
+            // above, since this is a template.
             result = out;
         }
         else if (std::is_same<T, int64_t>::value)
         {
-            result = atoi64(entry.value);
+            int64_t out = 0;
+
+            if (!ParseInt64(entry.value, &out))
+            {
+                throw std::invalid_argument("Argument is not parseable as an int64_t.");
+            }
+
+            result = out;
         }
         else if (std::is_same<T, unsigned int>::value)
         {
-            // Throw away (zero out) negative integer
-            // This approach limits the range to the non-negative signed int, but that is good enough.
-            result = (unsigned int)std::max(0, stoi(entry.value));
+            unsigned int out = 0;
+
+            if (!ParseUInt(entry.value, &out))
+            {
+                throw std::invalid_argument("Argument is not parseable as an unsigned int.");
+            }
+
+            result = out;
         }
         else if (std::is_same<T, bool>::value)
         {

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -140,7 +140,7 @@ int64_t GetRSAWeightByBlock(const std::string& bb)
     constexpr size_t rsa_weight_offset = 13;
     constexpr size_t magnitude_offset = 15;
 
-    int64_t rsa_weight = 0;
+    int64_t rsa_weight_sum = 0;
 
     // General-purpose deserialization of claim contexts in the hashBoinc field
     // no longer parses out the RSA weight field, so we handle the special case
@@ -154,18 +154,24 @@ int64_t GetRSAWeightByBlock(const std::string& bb)
         if (n == cpid_offset && end - offset != 32) {
             return 0;
         } else if (n == rsa_weight_offset || n == magnitude_offset) {
-            rsa_weight += std::atoi(bb.substr(offset, end - offset).c_str());
+            int64_t rsa_weight = 0;
+
+            if (!ParseInt64(bb.substr(offset, end - offset), &rsa_weight)) {
+                error("%s: Unable to parse rsa weight from hashBoinc.", __func__);
+            }
+
+            rsa_weight_sum += rsa_weight;
         }
 
         offset = end + 3;
         end = bb.find("<|>", offset);
     }
 
-    if (rsa_weight < 0) {
+    if (rsa_weight_sum < 0) {
         return 0;
     }
 
-    return rsa_weight;
+    return rsa_weight_sum;
 }
 } // anonymous namespace
 

--- a/src/gridcoin/staking/reward.cpp
+++ b/src/gridcoin/staking/reward.cpp
@@ -46,7 +46,12 @@ CAmount GRC::GetConstantBlockReward(const CBlockIndex* index)
     //TODO: refactor the expire checking to subroutine
     //Note: time constant is same as GetBeaconPublicKey
     if ((index->nTime - oCBReward.timestamp) <= (60 * 24 * 30 * 6 * 60)) {
-        reward = atoi64(oCBReward.value);
+        // This is a little slippery, because if we ever change CAmount from a int64_t, this will
+        // break. It is unlikely to ever change, however, and avoids an extra copy/implicit cast.
+        if (!ParseInt64(oCBReward.value, &reward)) {
+            error("%s: Cannot parse constant block reward from protocol entry: %s",
+                  __func__, oCBReward.value);
+        }
     }
 
     reward = std::clamp(reward, MIN_CBR, MAX_CBR);

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -350,11 +350,8 @@ public:
         , m_averages(ExtractXML(packed, "<AVERAGES>", "</AVERAGES>"))
         , m_zero_mags(0)
     {
-        try {
-            m_zero_mags = std::stoi(ExtractXML(packed, "<ZERO>", "</ZERO>"));
-        } catch (...) {
-            LogPrint(BCLog::LogFlags::SB,
-                "LegacySuperblock: Failed to parse zero mag CPIDs.\n");
+        if (!ParseInt(ExtractXML(packed, "<ZERO>", "</ZERO>"), &m_zero_mags)) {
+            error("%s: Failed to parse zero mag CPIDs.", __func__);
         }
     }
 
@@ -385,13 +382,43 @@ public:
             }
 
             try {
-                projects.Add(std::move(parts[0]), Superblock::ProjectStats(
-                    std::stoi(parts[1]),                          // average RAC
-                    parts.size() > 2 ? std::stoi(parts[2]) : 0)); // RAC
+                uint64_t average_rac = 0;
+                uint64_t rac = 0;
 
+                if (!ParseUInt64(parts[1], &average_rac)) {
+                    // Note that some of the legacy SBs have project average rac to two decimals, and unlike
+                    // stoi, ParseUInt64 will fail. We will first use ParseDouble and then cast to uint64_t.
+                    // This is only done if necessary.
+                    double d_average_rac = 0.0;
+
+                    if (!ParseDouble(parts[1], &d_average_rac)) {
+                        throw std::invalid_argument("Error in parsing average_rac. Input string is " + parts[1]);
+                    }
+
+                    average_rac = (uint64_t) d_average_rac;
+                }
+
+                if (parts.size() > 2 && !ParseUInt64(parts[2], &rac)) {
+                    // Note that some of the legacy SBs have project rac to two decimals, and unlike
+                    // stoi, ParseUInt64 will fail. We will first use ParseDouble and then cast to uint64_t.
+                    // This is only done if necessary.
+                    double d_rac = 0.0;
+
+                    if (!ParseDouble(parts[2], &d_rac)) {
+                        throw std::invalid_argument("Error in parsing rac. Input string is " + parts[2]);
+                    }
+
+                    rac = (uint64_t) d_rac;
+                }
+
+                projects.Add(std::move(parts[0]), Superblock::ProjectStats(
+                    average_rac,                  // average RAC
+                    parts.size() > 2 ? rac : 0)); // RAC
+
+            } catch (std::exception& e) {
+                error("%s: Failed to parse project RAC: %s", __func__, e.what());
             } catch (...) {
-                LogPrint(BCLog::LogFlags::SB,
-                    "LegacySuperblock: Failed to parse project RAC.\n");
+                error("%s: Failed to parse project RAC.");
             }
         }
 
@@ -459,10 +486,20 @@ private:
 
             if (const CpidOption cpid = MiningId::Parse(parts[0]).TryCpid()) {
                 try {
-                    magnitudes.AddLegacy(*cpid, std::stoi(parts[1]));
+                    uint32_t magnitude = 0;
+
+                    if (!ParseUInt32(parts[1], &magnitude)
+                            || magnitude > static_cast<uint32_t>(std::numeric_limits<uint16_t>::max())) {
+                        throw std::invalid_argument("Error in parsing magnitude. Input string is " + parts[1]);
+                    }
+
+                    // This implicitly casts a 32-bit unsigned integer down to a 16-bit unsigned integer, but this
+                    // is ok because it was bounds-checked above.
+                    magnitudes.AddLegacy(*cpid, magnitude);
+                } catch (std::exception& e) {
+                    error("%s: Failed to parse magnitude: %s", __func__, e.what());
                 } catch(...) {
-                    LogPrint(BCLog::LogFlags::SB,
-                        "LegacySuperblock: Failed to parse magnitude.\n");
+                    error("%s: Failed to parse magnitude.", __func__);
                 }
             }
         }

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -93,7 +93,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
         return false;
     }
 
-    boost::to_lower(GithubReleaseTypeData);
+    GithubReleaseTypeData = ToLower(GithubReleaseTypeData);
     if (GithubReleaseTypeData.find("leisure") != std::string::npos)
         GithubReleaseType = _("leisure");
 

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -128,7 +128,14 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
         // 3 numbers to check for production.
         for (unsigned int x = 0; x < 3; x++)
         {
-            if (std::stoi(GithubVersion[x]) > LocalVersion[x])
+            int github_version = 0;
+
+            if (!ParseInt(GithubVersion[x], &github_version))
+            {
+                throw std::invalid_argument("Failed to parse GitHub version from official GitHub project repo.");
+            }
+
+            if (github_version > LocalVersion[x])
             {
                 NewVersion = true;
                 if (x < 2)

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -974,7 +974,7 @@ PollBuilder PollBuilder::SetDuration(const uint32_t days)
 
 PollBuilder PollBuilder::SetTitle(std::string title)
 {
-    boost::trim(title);
+    title = TrimString(title);
 
     if (title.empty()) {
         throw VotingError(_("Please enter a poll title."));
@@ -1039,7 +1039,7 @@ PollBuilder PollBuilder::AddChoices(std::vector<std::string> labels)
 
 PollBuilder PollBuilder::AddChoice(std::string label)
 {
-    boost::trim(label);
+    label = TrimString(label);
 
     if (label.empty()) {
         throw VotingError(_("A poll choice cannot be empty."));

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -17,8 +17,6 @@
 #include "wallet/wallet.h"
 #include <util/string.h>
 
-#include <boost/algorithm/string/trim.hpp>
-
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
 

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -25,17 +25,13 @@ namespace {
 //!
 PollWeightType ParseWeightType(const std::string& value)
 {
-    try {
-        const uint32_t parsed = std::stoul(value);
+        uint32_t parsed = 0;
 
-        if (parsed > Poll::WeightType::MAX) {
+        if (!ParseUInt32(value, &parsed) || parsed > Poll::WeightType::MAX) {
             return PollWeightType::UNKNOWN;
         }
 
         return static_cast<PollWeightType>(parsed);
-    } catch (...) {
-        return PollWeightType::UNKNOWN;
-    }
 }
 
 //!
@@ -48,11 +44,14 @@ PollWeightType ParseWeightType(const std::string& value)
 //!
 uint32_t ParseDurationDays(const std::string& value)
 {
-    try {
-        return std::stoul(value);
-    } catch (...) {
-        return 0;
+    uint32_t duration = 0;
+
+    if (!ParseUInt32(value, &duration)) {
+        error("%s: Unable to parse poll duration from legacy poll contract. Input string is %s.",
+              __func__, value);
     }
+
+    return duration;
 }
 
 //!

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -34,7 +34,7 @@ namespace {
 std::string ParseLegacyVoteTitle(const std::string& key)
 {
     std::string title = key.substr(0, key.find(';'));
-    boost::to_lower(title);
+    title = ToLower(title);
 
     return title;
 }
@@ -801,7 +801,7 @@ void PollRegistry::AddPoll(const ContractContext& ctx)
     // The title used as the key for the m_poll map keyed by title, and also checked for duplicates, should
     // not be case-sensitive, regardless of whether v1 or v2+. We should not be allowing the insertion of two v2 polls
     // with the same title except for a difference in case.
-    boost::to_lower(poll_title);
+    poll_title = ToLower(poll_title);
 
     auto result_pair = m_polls.emplace(std::move(poll_title), PollReference());
 

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -635,7 +635,7 @@ public:
         if (m_legacy_choices_cache.empty()) {
             for (uint8_t i = 0; i < m_poll.Choices().size(); ++i) {
                 std::string label = m_poll.Choices().At(i)->m_label;
-                boost::to_lower(label);
+                label = ToLower(label);
 
                 m_legacy_choices_cache.emplace(std::move(label), i);
             }

--- a/src/gridcoin/voting/vote.cpp
+++ b/src/gridcoin/voting/vote.cpp
@@ -54,7 +54,15 @@ LegacyVote LegacyVote::Parse(const std::string& key, const std::string& value)
 {
     const auto parse_double = [](const std::string& value, const double places) {
         const double scale = std::pow(10, places);
-        return std::nearbyint(strtod(value.c_str(), nullptr) * scale) / scale;
+
+        double parsed_value = 0.0;
+
+        if (!ParseDouble(value, &parsed_value)) {
+            LogPrintf("WARN: %s: Error parsing legacy vote with value = %s",
+                      __func__, value);
+        }
+
+        return std::nearbyint(parsed_value * scale) / scale;
     };
 
     return LegacyVote(

--- a/src/gridcoin/voting/vote.cpp
+++ b/src/gridcoin/voting/vote.cpp
@@ -80,7 +80,7 @@ LegacyVote::ParseResponses(const std::map<std::string, uint8_t>& choice_map) con
     std::vector<std::pair<uint8_t, uint64_t>> responses;
 
     for (auto& answer : answers) {
-        boost::to_lower(answer);
+        answer = ToLower(answer);
 
         auto iter = choice_map.find(answer);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -20,7 +20,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <openssl/crypto.h>
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 
 static boost::thread_group threadGroup;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1099,15 +1099,13 @@ SideStakeAlloc GetSideStakingStatusAndAlloc()
             continue;
         }
 
-        try
+        if (!ParseDouble(entry.second, &dAllocation))
         {
-            dAllocation = stof(entry.second) / 100.0;
-        }
-        catch (...)
-        {
-            LogPrintf("WARN: %s: Invalid allocation provided. Skipping allocation.", __func__);
+            LogPrintf("WARN: %s: Invalid allocation %s provided. Skipping allocation.", __func__, entry.second);
             continue;
         }
+
+        dAllocation /= 100.0;
 
         if (dAllocation <= 0)
         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -14,7 +14,6 @@
 #include "ui_interface.h"
 #include "util.h"
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/thread.hpp>
 #include <inttypes.h>
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -30,7 +30,7 @@ bool fNameLookup = false;
 static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
 
 enum Network ParseNetwork(std::string net) {
-    boost::to_lower(net);
+    net = ToLower(net);
     if (net == "ipv4") return NET_IPV4;
     if (net == "ipv6") return NET_IPV6;
     if (net == "tor")  return NET_TOR;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -15,7 +15,6 @@
 #include <fcntl.h>
 #endif
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 
 using namespace std;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -85,7 +85,6 @@
 #include "gridcoin/staking/difficulty.h"
 #include "gridcoin/superblock.h"
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/join.hpp>
 #include "util.h"
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -27,8 +27,6 @@
 
 #include <memory>
 
-#define printf OutputDebugStringF
-
 using namespace std;
 using namespace boost;
 using namespace boost::asio;

--- a/src/rpc/dataacq.cpp
+++ b/src/rpc/dataacq.cpp
@@ -15,7 +15,6 @@
 #include "util.h"
 #include <util/string.h>
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string.hpp>
 #include <algorithm>
 

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -110,7 +110,7 @@ int ReadHTTPHeaders(std::basic_istream<char>& stream, std::map<std::string, std:
         {
             std::string strHeader = str.substr(0, nColon);
             boost::trim(strHeader);
-            boost::to_lower(strHeader);
+            strHeader = ToLower(strHeader);
             std::string strValue = str.substr(nColon+1);
             boost::trim(strValue);
             mapHeadersRet[strHeader] = strValue;

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -109,10 +109,10 @@ int ReadHTTPHeaders(std::basic_istream<char>& stream, std::map<std::string, std:
         if (nColon != std::string::npos)
         {
             std::string strHeader = str.substr(0, nColon);
-            boost::trim(strHeader);
+            strHeader = TrimString(strHeader);
             strHeader = ToLower(strHeader);
             std::string strValue = str.substr(nColon+1);
-            boost::trim(strValue);
+            strValue = TrimString(strValue);
             mapHeadersRet[strHeader] = strValue;
             if (strHeader == "content-length" && !ParseInt(strValue, &nLen)) {
                 throw std::invalid_argument("Unable to parse content-length value.");

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -92,7 +92,8 @@ bool HTTPAuthorized(map<string, string>& mapHeaders)
     string strAuth = mapHeaders["authorization"];
     if (strAuth.substr(0,6) != "Basic ")
         return false;
-    string strUserPass64 = strAuth.substr(6); boost::trim(strUserPass64);
+    string strUserPass64 = strAuth.substr(6);
+    strUserPass64 = TrimString(strUserPass64);
     string strUserPass = DecodeBase64(strUserPass64);
     return TimingResistantEqual(strUserPass, strRPCUserColonPass);
 }

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -110,7 +110,12 @@ struct Legacy
             std::copy_n(binary_cpid.begin(), researcher.cpid.size(), researcher.cpid.begin());
 
             // Ensure we do not blow out the binary space (technically we can handle 0-65535)
-            double magnitude_d = strtod(ExtractValue(entry, ",", 1).c_str(), nullptr);
+            double magnitude_d = 0.0;
+
+            if (!ParseDouble(ExtractValue(entry, ",", 1), &magnitude_d)) {
+                error("%s: Unable to parse magnitude for entry = %s.", __func__, entry);
+            }
+
             // Changed to 65535 for the new NN. This will still be able to be successfully unpacked by any node.
             magnitude_d = std::clamp(magnitude_d, 0.0, 65535.0);
             researcher.magnitude = htobe16(roundint(magnitude_d));

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -78,7 +78,11 @@ struct Legacy
         }
 
         // Append zero magnitude researchers so the beacon count matches
-        int num_zero_mag = atoi(ExtractXML(sBlock,"<ZERO>","</ZERO>"));
+        int num_zero_mag = 0;
+        if (!ParseInt(ExtractXML(sBlock,"<ZERO>","</ZERO>"), &num_zero_mag)) {
+            error("%s: Unable to parse number of zero magnitude researchers from legary binary superblock data.",
+                  __func__);
+        };
         const std::string zero_entry("0,15;");
         for(int i=0; i<num_zero_mag; ++i)
             stream << zero_entry;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -245,7 +245,12 @@ bool ParseMoney(const char* pszIn, int64_t& nRet)
         return false;
     if (nUnits < 0 || nUnits > COIN)
         return false;
-    int64_t nWhole = atoi64(strWhole);
+
+    int64_t nWhole = 0;
+
+    // Because of the protection above, this assert should never fail.
+    assert(ParseInt64(strWhole, &nWhole));
+
     int64_t nValue = nWhole*COIN + nUnits;
 
     nRet = nValue;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -11,7 +11,6 @@
 #include "util.h"
 #include <util/strencodings.h>
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 #include <boost/date_time/posix_time/posix_time.hpp>  //For day of year

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -274,6 +274,22 @@ std::string DecodeBase32(const std::string& str, bool* pf_invalid)
     return true;
 }
 
+bool ParseInt(const std::string& str, int *out)
+{
+    if (!ParsePrechecks(str))
+        return false;
+    char *endp = nullptr;
+    errno = 0; // strtol will not set errno if valid
+    long int n = strtol(str.c_str(), &endp, 10);
+    if(out) *out = (int)n;
+    // Note that strtol returns a *long int*, so even if strtol doesn't report an over/underflow
+    // we still have to check that the returned value is within the range of an *int*. On 64-bit
+    // platforms the size of these types may be different.
+    return endp && *endp == 0 && !errno &&
+        n >= std::numeric_limits<int>::min() &&
+        n <= std::numeric_limits<int>::max();
+}
+
 bool ParseInt32(const std::string& str, int32_t *out)
 {
     if (!ParsePrechecks(str))
@@ -303,6 +319,23 @@ bool ParseInt64(const std::string& str, int64_t *out)
     return endp && *endp == 0 && !errno &&
         n >= std::numeric_limits<int64_t>::min() &&
         n <= std::numeric_limits<int64_t>::max();
+}
+
+bool ParseUInt(const std::string& str, unsigned int *out)
+{
+    if (!ParsePrechecks(str))
+        return false;
+    if (str.size() >= 1 && str[0] == '-') // Reject negative values, unfortunately strtoul accepts these by default if they fit in the range
+        return false;
+    char *endp = nullptr;
+    errno = 0; // strtoul will not set errno if valid
+    unsigned long int n = strtoul(str.c_str(), &endp, 10);
+    if(out) *out = (unsigned int)n;
+    // Note that strtoul returns a *unsigned long int*, so even if it doesn't report an over/underflow
+    // we still have to check that the returned value is within the range of an *unsigned int*. On 64-bit
+    // platforms the size of these types may be different.
+    return endp && *endp == 0 && !errno &&
+        n <= std::numeric_limits<unsigned int>::max();
 }
 
 bool ParseUInt32(const std::string& str, uint32_t *out)

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -86,6 +86,13 @@ constexpr inline bool IsSpace(char c) noexcept {
 }
 
 /**
+ * Convert string to signed integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseInt(const std::string& str, int *out);
+
+/**
  * Convert string to signed 32-bit integer with strict parse error feedback.
  * @returns true if the entire string could be parsed as valid integer,
  *   false if not the entire string could be parsed or when overflow or underflow occurred.
@@ -98,6 +105,13 @@ constexpr inline bool IsSpace(char c) noexcept {
  *   false if not the entire string could be parsed or when overflow or underflow occurred.
  */
 [[nodiscard]] bool ParseInt64(const std::string& str, int64_t *out);
+
+/**
+ * Convert decimal string to unsigned integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseUInt(const std::string& str, unsigned int *out);
 
 /**
  * Convert decimal string to unsigned 32-bit integer with strict parse error feedback.

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -72,7 +72,15 @@ static bool InterpretBool(const std::string& strValue)
 {
     if (strValue.empty())
         return true;
-    return (atoi(strValue) != 0);
+
+    // Maintaining the behavior as described above, but replacing the atoi with ParseInt.
+    int value = 0;
+    if (!ParseInt(strValue, &value)) {
+        // Do nothing. The value will remain at zero if not parseable. This is to prevent
+        // a warning on [[nodiscard]]
+    }
+
+    return (value);
 }
 
 static std::string SettingName(const std::string& arg)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -496,7 +496,24 @@ std::string ArgsManager::GetArg(const std::string& strArg, const std::string& st
 int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const
 {
     const util::SettingsValue value = GetSetting(strArg);
-    return value.isNull() ? nDefault : value.isFalse() ? 0 : value.isTrue() ? 1 : value.isNum() ? value.get_int64() : atoi64(value.get_str());
+
+    int64_t arg_value = 0;
+
+    if (value.isNull()) {
+        arg_value = nDefault;
+    } else if (value.isFalse()) {
+        arg_value = 0;
+    } else if (value.isTrue()) {
+        arg_value = 1;
+    } else if (value.isNum()) {
+        arg_value = value.get_int64();
+    } else {
+        if (!ParseInt64(value.get_str(), &arg_value)) {
+            // Do nothing. If we get here and the string cannot be parsed, it should return zero, just like atoi64.
+        }
+    }
+
+    return arg_value;
 }
 
 bool ArgsManager::GetBoolArg(const std::string& strArg, bool fDefault) const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -451,7 +451,12 @@ static void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
         nOrderPos = -1; // TODO : calculate elsewhere
         return;
     }
-    nOrderPos = atoi64(mapValue["n"].c_str());
+
+    nOrderPos = 0;
+    if (!ParseInt64(mapValue["n"], &nOrderPos))
+    {
+        error("%s: nOrderPos cannot be parsed: %s.", __func__, mapValue["n"]);
+    }
 }
 
 
@@ -601,9 +606,9 @@ public:
 
             ReadOrderPos(nOrderPos, mapValue);
 
-            nTimeSmart = mapValue.count("timesmart")
-                ? (unsigned int)atoi64(mapValue["timesmart"])
-                : 0;
+            if (!mapValue.count("timesmart") || !ParseUInt(mapValue["timesmart"], &nTimeSmart)) {
+                nTimeSmart = 0;
+            }
         }
 
         mapValue.erase("fromaccount");


### PR DESCRIPTION
This PR changes stod, stof, stoul, stoull, strtold, strtod, isxdigit, stoi, boost_to_lower, atoi, boost::trim, and atoi64 to their non-locale specific equivalents in strencodings.h/cpp. It also removes an unnecessary printf define not covered in #2269.

There is a separate commit for each different type of replacement for ease of review.

Quite frankly some of this is downright silly, but I went ahead and did the replacements anyway, even though the replacements are likely to be slightly slower.

This closes #2268.