### PR TITLE
ci: Update KNOWN_VIOLATIONS list for the linter for functions we don't care are locale-dependent

### DIFF
--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -5,22 +5,10 @@
 
 export LC_ALL=C
 KNOWN_VIOLATIONS=(
-    "src/bitcoin-tx.cpp.*stoul"
-    "src/bitcoin-tx.cpp.*trim_right"
-    "src/dbwrapper.cpp.*stoul"
-    "src/dbwrapper.cpp:.*vsnprintf"
-    "src/httprpc.cpp.*trim"
-    "src/init.cpp:.*atoi"
-    "src/qt/rpcconsole.cpp:.*atoi"
-    "src/rest.cpp:.*strtol"
-    "src/test/dbwrapper_tests.cpp:.*snprintf"
-    "src/torcontrol.cpp:.*atoi"
-    "src/torcontrol.cpp:.*strtol"
     "src/util/strencodings.cpp:.*atoi"
     "src/util/strencodings.cpp:.*strtol"
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
-    "src/util/system.cpp:.*atoi"
     "src/logging.h:.*strftime"
     "src/gridcoin/backup.cpp:.*strftime"
     "src/rpc/protocol.cpp:.*strftime"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -14,8 +14,6 @@ KNOWN_VIOLATIONS=(
     "src/qt/rpcconsole.cpp:.*atoi"
     "src/rest.cpp:.*strtol"
     "src/test/dbwrapper_tests.cpp:.*snprintf"
-    "src/test/fuzz/locale.cpp"
-    "src/test/fuzz/parse_numbers.cpp:.*atoi"
     "src/torcontrol.cpp:.*atoi"
     "src/torcontrol.cpp:.*strtol"
     "src/util/strencodings.cpp:.*atoi"
@@ -23,6 +21,10 @@ KNOWN_VIOLATIONS=(
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
     "src/util/system.cpp:.*atoi"
+    "src/logging.h:.*strftime"
+    "src/gridcoin/backup.cpp:.*strftime"
+    "src/rpc/protocol.cpp:.*strftime"
+    "src/rpc/rawtransaction.cpp:.*strftime"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"


### PR DESCRIPTION
- Add exceptions for `strftime`
- Remove violations fixed in #2270 