### PR TITLE
lint: Fix linter warning, fix typo

### DIFF
--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -64,7 +64,7 @@ child = Popen([XGETTEXT,'--output=-','-n','--keyword=_'] + files, stdout=PIPE)
 
 messages = parse_po(out.decode('utf-8'))
 
-f = open(OUT_CPP, 'w')
+f = open(OUT_CPP, 'w', encoding="utf-8")
 f.write("""
 
 #include <QtGlobal>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -504,7 +504,7 @@ void SendCoinsDialog::selectedConsolidationRecipient(SendCoinsRecipient consolid
     }
 
     // The AddressTableModel substitutes the translated "(no label)" when the label is empty. If we use
-    // that here, we will end up pasting a literal lable of "(no label)". Because the translation (tr) should
+    // that here, we will end up pasting a literal label of "(no label)". Because the translation (tr) should
     // be consistent between here and the AddressTableModel::data, it should match the conditional and be put
     // back to the desired empty QString.
     if (consolidationRecipient.label == tr("(no label)")) consolidationRecipient.label = QString();

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -28,7 +28,7 @@ fi
 
 SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced)
 EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
-if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|univalue)/'); then
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|univalue)/|contrib/rpcstresstest/'); then
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
Always specify encoding when opening files with `open(...)` in Python.

Remove newly introduced typo.