### PR TITLE
refactor: Drop noop gcc version checks

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -7,14 +7,6 @@
 
 #include <type_traits>
 
-// GCC 4.8 is missing some C++11 type_traits,
-// https://www.gnu.org/software/gcc/gcc-5/changes.html
-#if defined(__GNUC__) && __GNUC__ < 5
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivial
-#else
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivially_constructible
-#endif
-
 #ifdef WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1


### PR DESCRIPTION
Ref: https://github.com/bitcoin/bitcoin/pull/20491

Our minimum GCC version is 7.  Additionallly, `IS_TRIVIALLY_CONSTRUCTIBLE` does not appear to be in our codebase.