### PR TITLE
depends: cleanup package configure flags

### DIFF
--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -7,7 +7,7 @@ $(package)_sha256_hash=fdd477320aeb5cdd67272838722d6b7d544887dfe7de46e1e7cc0c27c
 $(package)_dependencies=xproto
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared
+  $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -7,7 +7,7 @@ $(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c
 $(package)_dependencies=xcb_proto libXau xproto
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-static
+  $(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -6,7 +6,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared -without-tools --disable-sdltest --libdir="$($($(package)_type)_prefix)/lib"
+  $(package)_config_opts=--disable-shared --without-tools --without-tests --disable-sdltest --libdir="$($($(package)_type)_prefix)/lib"
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -6,7 +6,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=636162c1759805a5a0114a369dffdeccb8af8c859ef6e1445f26a4e6e046514f
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared
+  $(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)


### PR DESCRIPTION
This PR adds additional configure flags to packages in depends to explicitly disable features we aren't using.

Ref: https://github.com/bitcoin/bitcoin/pull/16370