### PR TITLE
wallet: remove unused fNoncriticalErrors variable from CWalletDB::FindWalletTx

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -539,7 +539,6 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vector<CWalletTx>& vWtx)
 {
     pwallet->vchDefaultKey = CPubKey();
-    bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
     try {
@@ -595,9 +594,6 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
     catch (...) {
         result = DB_CORRUPT;
     }
-
-    if (fNoncriticalErrors && result == DB_LOAD_OK)
-        result = DB_NONCRITICAL_ERROR;
 
     return result;
 }


### PR DESCRIPTION
> The `CWalletDB::FindWalletTx` method was patterned after `CWalletDB::LoadWallet`, where `fNoncriticalErrors` is used when a tx check fails in `ReadKeyValue`.

> Since `FindWalletTx` is only used by methods which are zapping txs, it makes sense that `ReadKeyValue` is not called and the tx is not checked, so I think that deleting the unused `fNoncriticalErrors` boolean variable and its conditional statement is appropriate.

Ref: https://github.com/bitcoin/bitcoin/pull/11923