### PR TITLE
refactor: Fix advanced compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,12 @@ AC_ARG_ENABLE([glibc-back-compat],
   [use_glibc_compat=$enableval],
   [use_glibc_compat=no])
 
+AC_ARG_ENABLE([threadlocal],
+  [AS_HELP_STRING([--enable-threadlocal],
+  [enable features that depend on the c++ thread_local keyword (currently just thread names in debug logs). (default is to enabled if there is platform support and glibc-back-compat is not enabled)])],
+  [use_thread_local=$enableval],
+  [use_thread_local=auto])
+
 AC_ARG_ENABLE([asm],
   [AS_HELP_STRING([--disable-asm],
   [disable assembly routines (enabled by default)])],
@@ -779,6 +785,48 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
     fi
   ]
 )
+
+dnl thread_local is currently disabled when building with glibc back compat.
+dnl Our minimum supported glibc is 2.17, however support for thread_local
+dnl did not arrive in glibc until 2.18.
+if test "x$use_thread_local" = xyes || { test "x$use_thread_local" = xauto && test "x$use_glibc_compat" = xno; }; then
+  TEMP_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$TEMP_LDFLAGS $PTHREAD_CFLAGS"
+  AC_MSG_CHECKING([for thread_local support])
+  AC_LINK_IFELSE([AC_LANG_SOURCE([
+    #include <thread>
+    static thread_local int foo = 0;
+    static void run_thread() { foo++;}
+    int main(){
+    for(int i = 0; i < 10; i++) { std::thread(run_thread).detach();}
+    return foo;
+    }
+    ])],
+    [
+     case $host in
+       *mingw*)
+          dnl mingw32's implementation of thread_local has also been shown to behave
+          dnl erroneously under concurrent usage; see:
+          dnl https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
+          AC_MSG_RESULT(no)
+          ;;
+        *freebsd*)
+          dnl FreeBSD's implementation of thread_local is also buggy (per
+          dnl https://groups.google.com/d/msg/bsdmailinglist/22ncTZAbDp4/Dii_pII5AwAJ)
+          AC_MSG_RESULT(no)
+          ;;
+        *)
+          AC_DEFINE(HAVE_THREAD_LOCAL,1,[Define if thread_local is supported.])
+          AC_MSG_RESULT(yes)
+          ;;
+      esac
+    ],
+    [
+      AC_MSG_RESULT(no)
+    ]
+  )
+  LDFLAGS="$TEMP_LDFLAGS"
+fi
 
 dnl check for gmtime_r(), fallback to gmtime_s() if that is unavailable
 dnl fail if neither are available.

--- a/configure.ac
+++ b/configure.ac
@@ -229,7 +229,6 @@ if test "x$enable_werror" = "xyes"; then
   if test "x$CXXFLAG_WERROR" = "x"; then
     AC_MSG_ERROR("enable-werror set but -Werror is not usable")
   fi
-  AX_CHECK_COMPILE_FLAG([-Werror=gnu],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=gnu"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=vla],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=vla"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=shadow-field],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=shadow-field"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=switch],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=switch"],,[[$CXXFLAG_WERROR]])
@@ -246,7 +245,6 @@ fi
 if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wall],[CXXFLAGS="$CXXFLAGS -Wall"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wextra],[CXXFLAGS="$CXXFLAGS -Wextra"],,[[$CXXFLAG_WERROR]])
-  AX_CHECK_COMPILE_FLAG([-Wgnu],[CXXFLAGS="$CXXFLAGS -Wgnu"],,[[$CXXFLAG_WERROR]])
   dnl some compilers will ignore -Wformat-security without -Wformat, so just combine the two here.
   AX_CHECK_COMPILE_FLAG([-Wformat -Wformat-security],[CXXFLAGS="$CXXFLAGS -Wformat -Wformat-security"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wvla],[CXXFLAGS="$CXXFLAGS -Wvla"],,[[$CXXFLAG_WERROR]])

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -6,7 +6,7 @@
 
 #include <primitives/transaction.h>
 
-bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
+bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     // Time based nLockTime implemented in 0.1.6

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -132,3 +132,17 @@ bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned
         return false;
     return cKeyCrypter.Decrypt(vchCiphertext, *((CKeyingMaterial*)&vchPlaintext));
 }
+
+bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCryptedSecret, const CPubKey& vchPubKey, CKey& key)
+{
+    CKeyingMaterial vchSecret;
+    if(!DecryptSecret(vMasterKey, vchCryptedSecret, vchPubKey.GetHash(), vchSecret))
+        return false;
+
+    if (vchSecret.size() != 32)
+        return false;
+
+    key.SetPubKey(vchPubKey);
+    key.SetSecret(vchSecret);
+    return (key.GetPubKey() == vchPubKey);
+}

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -121,4 +121,5 @@ public:
 
 bool EncryptSecret(CKeyingMaterial& vMasterKey, const CSecret &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext);
 bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char> &vchCiphertext, const uint256& nIV, CSecret &vchPlaintext);
+bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCryptedSecret, const CPubKey& vchPubKey, CKey& key);
 #endif

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -4,6 +4,7 @@
 
 #include "chainparams.h"
 #include "main.h"
+#include "util/threadnames.h"
 #include "gridcoin/backup.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/gridcoin.h"
@@ -218,6 +219,9 @@ void InitializeResearcherContext()
 //!
 void ThreadScraper(void* parg)
 {
+    RenameThread("grc-scraper");
+    util::ThreadSetInternalName("grc-scraper");
+
     LogPrint(BCLog::LogFlags::NOISY, "ThreadSraper starting");
 
     try {
@@ -246,6 +250,9 @@ void ThreadScraper(void* parg)
 //!
 void ThreadScraperSubscriber(void* parg)
 {
+    RenameThread("grc-scrapersubscriber");
+    util::ThreadSetInternalName("grc-scrapersubscriber");
+
     LogPrint(BCLog::LogFlags::NOISY, "ThreadScraperSubscriber starting");
 
     try {

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -4,7 +4,8 @@
 
 #pragma once
 
-class CBlockIndex;
+#include "fwd.h"
+
 class CScheduler;
 
 namespace GRC {

--- a/src/gridcoin/magnitude.h
+++ b/src/gridcoin/magnitude.h
@@ -150,7 +150,7 @@ public:
 
     bool operator==(const int64_t other) const
     {
-        return static_cast<int64_t>(m_scaled) == other * SCALE_FACTOR;
+        return static_cast<int64_t>(m_scaled) == other * static_cast<int64_t>(SCALE_FACTOR);
     }
 
     bool operator!=(const int64_t other) const

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -475,7 +475,7 @@ public:
     //!
     //! \param beacons Contains the set of pending beacons to import from.
     //!
-    void ImportRegistry(const BeaconRegistry& beacons)
+    void ImportRegistry(const BeaconRegistry& beacons) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet)
     {
         AssertLockHeld(cs_main);
         AssertLockHeld(pwalletMain->cs_wallet);
@@ -498,7 +498,7 @@ public:
     //!
     //! \return A pointer to the pending beacon if one exists for the CPID.
     //!
-    const PendingBeacon* Try(const Cpid cpid)
+    const PendingBeacon* Try(const Cpid cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         AssertLockHeld(cs_main);
 
@@ -531,7 +531,7 @@ public:
     //! \param cpid   CPID that the beacon was advertised for.
     //! \param result Contains the public key if the transaction succeeded.
     //!
-    void Remember(const Cpid cpid, const AdvertiseBeaconResult& result)
+    void Remember(const Cpid cpid, const AdvertiseBeaconResult& result) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet)
     {
         AssertLockHeld(cs_main);
 

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -22,7 +22,7 @@ extern std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& 
 extern ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
 
 class CBlockIndex;
-class ConvergedScraperStats; // Forward for Superblock
+struct ConvergedScraperStats; // Forward for Superblock
 
 namespace GRC {
 class Superblock; // Forward for QuorumHash

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -10,6 +10,7 @@
 #include "chainparams.h"
 #include "chainparamsbase.h"
 #include "util.h"
+#include "util/threadnames.h"
 #include "net.h"
 #include "txdb.h"
 #include "wallet/walletdb.h"
@@ -37,6 +38,8 @@ bool AppInit(int argc, char* argv[])
 #endif
 
     SetupEnvironment();
+    util::ThreadSetInternalName("gridcoinresearchd-main");
+
     SetupServerArgs();
 
     // Note every function above the InitLogging() call must use tfm::format or similar.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1253,6 +1253,9 @@ bool AppInit2(ThreadHandlerPtr threads)
         // Create new keyUser and set as default key
         RandAddSeedPerfmon();
 
+        // So Clang doesn't complain, even though we are really essentially single-threaded here.
+        LOCK(pwalletMain->cs_wallet);
+
         CPubKey newDefaultKey;
         if (pwalletMain->GetKeyFromPool(newDefaultKey, false)) {
             pwalletMain->SetDefaultKey(newDefaultKey);
@@ -1375,6 +1378,10 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
         LogPrintf("mapBlockIndex.size() = %" PRIszu,   mapBlockIndex.size());
         LogPrintf("nBestHeight = %d",            nBestHeight);
+
+        // So Clang doesn't complian, even though we are essentially single-threaded here.
+        LOCK(pwalletMain->cs_wallet);
+
         LogPrintf("setKeyPool.size() = %" PRIszu,      pwalletMain->setKeyPool.size());
         LogPrintf("mapWallet.size() = %" PRIszu,       pwalletMain->mapWallet.size());
         LogPrintf("mapAddressBook.size() = %" PRIszu,  pwalletMain->mapAddressBook.size());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -6,6 +6,7 @@
 
 #include "chainparams.h"
 #include "util.h"
+#include "util/threadnames.h"
 #include "net.h"
 #include "txdb.h"
 #include "wallet/walletdb.h"
@@ -702,6 +703,7 @@ void ThreadAppInit2(ThreadHandlerPtr th)
 {
     // Make this thread recognisable
     RenameThread("grc-appinit2");
+    util::ThreadSetInternalName("grc-appinit2");
 
     bGridcoinCoreInitComplete = false;
 

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -113,6 +113,8 @@ private:
     // if fUseCrypto is false, vMasterKey must be empty
     bool fUseCrypto;
 
+    bool fDecryptionThoroughlyChecked;
+
 protected:
     bool SetCrypted();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,7 +325,7 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
 //
 
 
-int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
+int CMerkleTx::SetMerkleBranch(const CBlock* pblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -366,7 +366,7 @@ int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
 }
 
 
-bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInputs)
+bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     if (pfMissingInputs)
@@ -604,7 +604,7 @@ void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)
         vtxid.push_back(mi->first);
 }
 
-int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const
+int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (hashBlock.IsNull() || nIndex == -1)
         return 0;
@@ -622,7 +622,7 @@ int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const
     return pindexBest->nHeight - pindex->nHeight + 1;
 }
 
-int CMerkleTx::GetDepthInMainChain(CBlockIndex* &pindexRet) const
+int CMerkleTx::GetDepthInMainChain(CBlockIndex* &pindexRet) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     int nResult = GetDepthInMainChainINTERNAL(pindexRet);
@@ -640,14 +640,14 @@ int CMerkleTx::GetBlocksToMaturity() const
 }
 
 
-bool CMerkleTx::AcceptToMemoryPool()
+bool CMerkleTx::AcceptToMemoryPool() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return ::AcceptToMemoryPool(mempool, *this, nullptr);
 }
 
 
 
-bool CWalletTx::AcceptWalletTransaction(CTxDB& txdb)
+bool CWalletTx::AcceptWalletTransaction(CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
 
     {
@@ -666,7 +666,7 @@ bool CWalletTx::AcceptWalletTransaction(CTxDB& txdb)
     return false;
 }
 
-bool CWalletTx::AcceptWalletTransaction()
+bool CWalletTx::AcceptWalletTransaction() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CTxDB txdb("r");
     return AcceptWalletTransaction(txdb);
@@ -1561,7 +1561,7 @@ bool ForceReorganizeToHash(uint256 NewHash)
     return true;
 }
 
-bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned& cnt_dis, CBlockIndex* pcommon)
+bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned& cnt_dis, CBlockIndex* pcommon) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     set<string> vRereadCPIDs;
     GRC::BeaconRegistry& beacons = GRC::GetBeaconRegistry();
@@ -1676,7 +1676,7 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
     return true;
 }
 
-bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &blockNew, CBlockIndex* pindexNew)
+bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     assert(pindexNew);
     //assert(!pindexNew->pnext);
@@ -1844,7 +1844,7 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
     return true;
 }
 
-bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew)
+bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     unsigned cnt_dis=0;
     unsigned cnt_con=0;
@@ -2116,7 +2116,7 @@ bool CBlock::CheckBlock(int height1, bool fCheckPOW, bool fCheckMerkleRoot, bool
     return true;
 }
 
-bool CBlock::AcceptBlock(bool generated_by_me)
+bool CBlock::AcceptBlock(bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -2384,7 +2384,7 @@ bool AskForOutstandingBlocks(uint256 hashStart)
     return true;
 }
 
-bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me)
+bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -2716,7 +2716,7 @@ bool LoadBlockIndex(bool fAllowNew)
     return true;
 }
 
-void PrintBlockTree()
+void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     // pre-compute tree structure
@@ -4025,7 +4025,7 @@ GRC::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex)
     return block.PullClaim();
 }
 
-GRC::MintSummary CBlock::GetMint() const
+GRC::MintSummary CBlock::GetMint() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -78,7 +78,7 @@ bool TrySignClaim(
     CWallet* pwallet,
     GRC::Claim& claim,
     const CBlock& block,
-    const bool dry_run = false)
+    const bool dry_run = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -142,7 +142,7 @@ bool TrySignClaim(
     CWallet* pwallet,
     const GRC::Claim& claim,
     const CBlock& block,
-    const bool dry_run = false)
+    const bool dry_run = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return TrySignClaim(pwallet, const_cast<GRC::Claim&>(claim), block, dry_run);
 }
@@ -459,7 +459,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev)
 
 bool CreateCoinStake(CBlock &blocknew, CKey &key,
     vector<const CWalletTx*> &StakeInputs,
-    CWallet &wallet, CBlockIndex* pindexPrev)
+    CWallet &wallet, CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     std::string function = __func__;
     function += ": ";
@@ -869,7 +869,7 @@ unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitVal
     return nStakeOutputs;
 }
 
-bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInputs, CWallet *pwallet)
+bool SignStakeBlock(CBlock &block, CKey &key, vector<const CWalletTx*> &StakeInputs, CWallet *pwallet) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     //Sign the coinstake transaction
     unsigned nIn = 0;
@@ -932,7 +932,7 @@ bool CreateGridcoinReward(
     CBlock &blocknew,
     CBlockIndex* pindexPrev,
     int64_t &nReward,
-    CWallet* pwallet)
+    CWallet* pwallet) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Remove fees from coinbase:
     int64_t nFees = blocknew.vtx[0].vout[0].nValue;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -13,6 +13,7 @@
 #include "init.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "util/threadnames.h"
 
 #include <boost/thread.hpp>
 #include <inttypes.h>
@@ -747,6 +748,7 @@ void ThreadSocketHandler(void* parg)
 {
     // Make this thread recognisable as the networking thread
     RenameThread("grc-net");
+    util::ThreadSetInternalName("grc-net");
 
     try
     {
@@ -1119,6 +1121,7 @@ void ThreadMapPort(void* parg)
 {
     // Make this thread recognisable as the UPnP thread
     RenameThread("grc-UPnP");
+    util::ThreadSetInternalName("grc-UPnP");
 
     try
     {
@@ -1269,6 +1272,7 @@ void ThreadDNSAddressSeed(void* parg)
 {
     // Make this thread recognisable as the DNS seeding thread
     RenameThread("grc-dnsseed");
+    util::ThreadSetInternalName("grc-dnsseed");
 
     try
     {
@@ -1366,6 +1370,7 @@ void ThreadDumpAddress(void* parg)
 {
     // Make this thread recognisable as the address dumping thread
     RenameThread("grc-adrdump");
+    util::ThreadSetInternalName("grc-adrdump");
 
     try
     {
@@ -1391,6 +1396,7 @@ void ThreadOpenConnections(void* parg)
 {
     // Make this thread recognisable as the connection opening thread
     RenameThread("grc-opencon");
+    util::ThreadSetInternalName("grc-opencon");
 
     try
     {
@@ -1432,6 +1438,8 @@ void static ProcessOneShot()
 
 void static ThreadStakeMiner(void* parg)
 {
+    RenameThread("grc-stakeminer");
+    util::ThreadSetInternalName("grc-stakeminer");
 
     LogPrint(BCLog::LogFlags::NET, "ThreadStakeMiner started");
     CWallet* pwallet = (CWallet*)parg;
@@ -1595,7 +1603,8 @@ void ThreadOpenConnections2(void* parg)
 void ThreadOpenAddedConnections(void* parg)
 {
     // Make this thread recognisable as the connection opening thread
-    RenameThread("grc-opencon");
+    RenameThread("grc-openaddedcon");
+    util::ThreadSetInternalName("grc-openaddedcon");
 
     try
     {
@@ -1720,6 +1729,7 @@ void ThreadMessageHandler(void* parg)
 {
     // Make this thread recognisable as the message handling thread
     RenameThread("grc-msghand");
+    util::ThreadSetInternalName("grc-msghand");
 
     try
     {
@@ -1983,7 +1993,9 @@ void static Discover()
 void StartNode(void* parg)
 {
     // Make this thread recognisable as the startup thread
-    RenameThread("grc-start");
+    RenameThread("grc-nodestart");
+    util::ThreadSetInternalName("grc-nodestart");
+
     fShutdown = false;
     MAX_OUTBOUND_CONNECTIONS = (int)gArgs.GetArg("-maxoutboundconnections", 8);
     int nMaxOutbound = 0;

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -8,6 +8,7 @@
 
 #include "amount.h"
 #include "primitives/transaction.h"
+#include "consensus/consensus.h"
 
 enum GetMinFee_mode
 {
@@ -19,7 +20,19 @@ enum GetMinFee_mode
 inline CAmount GetBaseFee(const CTransaction& tx, enum GetMinFee_mode mode = GMF_BLOCK)
 {
     // Base fee is either MIN_TX_FEE or MIN_RELAY_TX_FEE
-    CAmount nBaseFee = (mode == GMF_RELAY) ? MIN_RELAY_TX_FEE : MIN_TX_FEE;
+
+    CAmount nBaseFee = 0;
+
+    // Written this way to silence the duplicate branch warning on advanced compilers while MIN_RELAY_TX_FEE
+    // and MIN_TX_FEE are equal.
+    if (mode != GMF_RELAY)
+    {
+        nBaseFee = MIN_TX_FEE;
+    }
+    else if (mode == GMF_RELAY)
+    {
+        nBaseFee = MIN_RELAY_TX_FEE;
+    }
 
     // For block version 11 onwards, which corresponds to CTransaction::CURRENT_VERSION 2,
     // a multiplier is used on top of MIN_TX_FEE and MIN_RELAY_TX_FEE

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -153,13 +153,13 @@ private:
         struct {
             size_type capacity;
             char* indirect;
-        };
-    } _union = {};
+        } indirect_contents;
+    } _union;
 
     T* direct_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.direct) + pos; }
     const T* direct_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.direct) + pos; }
-    T* indirect_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.indirect) + pos; }
-    const T* indirect_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.indirect) + pos; }
+    T* indirect_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.indirect_contents.indirect) + pos; }
+    const T* indirect_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.indirect_contents.indirect) + pos; }
     bool is_direct() const { return _size <= N; }
 
     void change_capacity(size_type new_capacity) {
@@ -177,17 +177,17 @@ private:
                 /* FIXME: Because malloc/realloc here won't call new_handler if allocation fails, assert
                     success. These should instead use an allocator or new/delete so that handlers
                     are called as necessary, but performance would be slightly degraded by doing so. */
-                _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
-                assert(_union.indirect);
-                _union.capacity = new_capacity;
+                _union.indirect_contents.indirect = static_cast<char*>(realloc(_union.indirect_contents.indirect, ((size_t)sizeof(T)) * new_capacity));
+                assert(_union.indirect_contents.indirect);
+                _union.indirect_contents.capacity = new_capacity;
             } else {
                 char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
                 assert(new_indirect);
                 T* src = direct_ptr(0);
                 T* dst = reinterpret_cast<T*>(new_indirect);
                 memcpy(dst, src, size() * sizeof(T));
-                _union.indirect = new_indirect;
-                _union.capacity = new_capacity;
+                _union.indirect_contents.indirect = new_indirect;
+                _union.indirect_contents.capacity = new_capacity;
                 _size += N + 1;
             }
         }
@@ -296,7 +296,7 @@ public:
         if (is_direct()) {
             return N;
         } else {
-            return _union.capacity;
+            return _union.indirect_contents.capacity;
         }
     }
 
@@ -458,8 +458,8 @@ public:
             clear();
         }
         if (!is_direct()) {
-            free(_union.indirect);
-            _union.indirect = nullptr;
+            free(_union.indirect_contents.indirect);
+            _union.indirect_contents.indirect = nullptr;
         }
     }
 
@@ -511,7 +511,7 @@ public:
         if (is_direct()) {
             return 0;
         } else {
-            return ((size_t)(sizeof(T))) * _union.capacity;
+            return ((size_t)(sizeof(T))) * _union.indirect_contents.capacity;
         }
     }
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -222,7 +222,13 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
 
     editStatus = OK;
 
-    if(role == Qt::EditRole)
+    auto address_count = [this](const QVariant &value) {
+        LOCK(wallet->cs_wallet);
+
+        return wallet->mapAddressBook.count(CBitcoinAddress(value.toString().toStdString()).Get());
+    };
+
+    if (role == Qt::EditRole)
     {
         switch(index.column())
         {
@@ -250,7 +256,7 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
             }
             // Check for duplicate addresses to prevent accidental deletion of addresses, if you try
             // to paste an existing address over another address (with a different label)
-            else if(wallet->mapAddressBook.count(CBitcoinAddress(value.toString().toStdString()).Get()))
+            else if(address_count(value))
             {
                 editStatus = DUPLICATE_ADDRESS;
                 return false;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -22,6 +22,7 @@
 #include "qtipcserver.h"
 #include "txdb.h"
 #include "util.h"
+#include "util/threadnames.h"
 #include "winshutdownmonitor.h"
 #include "gridcoin/upgrade.h"
 #include "gridcoin/gridcoin.h"
@@ -248,6 +249,8 @@ int main(int argc, char *argv[])
     g_timer.InitTimer("default", false);
 
     SetupEnvironment();
+    util::ThreadSetInternalName("gridcoinresearch-main");
+
     SetupServerArgs();
     SetupUIArgs(gArgs);
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -348,50 +348,37 @@ static void MinerStatusChanged(ClientModel *clientmodel, bool staking, double co
                               Q_ARG(double, coin_weight));
 }
 
-// This is ugly but is the easiest way to support the wide range of boost versions and deal with the
-// boost placeholders global namespace pollution fix for later versions (>= 1.73) without breaking earlier ones.
-#if BOOST_VERSION >= 107300
 void ClientModel::subscribeToCoreSignals()
 {
     // Connect signals to client
-    uiInterface.NotifyBlocksChanged.connect(boost::bind(NotifyBlocksChanged, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
+    uiInterface.NotifyBlocksChanged.connect(boost::bind(NotifyBlocksChanged, this,
+                                                        boost::placeholders::_1, boost::placeholders::_2,
+                                                        boost::placeholders::_3, boost::placeholders::_4));
     uiInterface.BannedListChanged.connect(boost::bind(BannedListChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this, boost::placeholders::_1));
-    uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this, boost::placeholders::_1, boost::placeholders::_2));
-    uiInterface.NotifyScraperEvent.connect(boost::bind(NotifyScraperEvent, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
-    uiInterface.MinerStatusChanged.connect(boost::bind(MinerStatusChanged, this, boost::placeholders::_1, boost::placeholders::_2));
+    uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this,
+                                                                boost::placeholders::_1));
+    uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this,
+                                                       boost::placeholders::_1, boost::placeholders::_2));
+    uiInterface.NotifyScraperEvent.connect(boost::bind(NotifyScraperEvent, this,
+                                                       boost::placeholders::_1, boost::placeholders::_2,
+                                                       boost::placeholders::_3));
+    uiInterface.MinerStatusChanged.connect(boost::bind(MinerStatusChanged, this,
+                                                       boost::placeholders::_1, boost::placeholders::_2));
 }
 
 void ClientModel::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from client
-    uiInterface.NotifyBlocksChanged.disconnect(boost::bind(NotifyBlocksChanged, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
+    uiInterface.NotifyBlocksChanged.disconnect(boost::bind(NotifyBlocksChanged, this,
+                                                           boost::placeholders::_1, boost::placeholders::_2,
+                                                           boost::placeholders::_3, boost::placeholders::_4));
     uiInterface.BannedListChanged.disconnect(boost::bind(BannedListChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this, boost::placeholders::_1));
-    uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this, boost::placeholders::_1, boost::placeholders::_2));
-    uiInterface.NotifyScraperEvent.disconnect(boost::bind(NotifyScraperEvent, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
-    uiInterface.MinerStatusChanged.disconnect(boost::bind(MinerStatusChanged, this, boost::placeholders::_1, boost::placeholders::_2));
+    uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this,
+                                                                   boost::placeholders::_1));
+    uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this,
+                                                          boost::placeholders::_1, boost::placeholders::_2));
+    uiInterface.NotifyScraperEvent.disconnect(boost::bind(NotifyScraperEvent, this,
+                                                          boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+    uiInterface.MinerStatusChanged.disconnect(boost::bind(MinerStatusChanged, this,
+                                                          boost::placeholders::_1, boost::placeholders::_2));
 }
-#else
-void ClientModel::subscribeToCoreSignals()
-{
-    // Connect signals to client
-    uiInterface.NotifyBlocksChanged.connect(boost::bind(NotifyBlocksChanged, this, _1, _2, _3, _4));
-    uiInterface.BannedListChanged.connect(boost::bind(BannedListChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this, _1));
-    uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this, _1, _2));
-    uiInterface.NotifyScraperEvent.connect(boost::bind(NotifyScraperEvent, this, _1, _2, _3));
-    uiInterface.MinerStatusChanged.connect(boost::bind(MinerStatusChanged, this, _1, _2));
-}
-
-void ClientModel::unsubscribeFromCoreSignals()
-{
-    // Disconnect signals from client
-    uiInterface.NotifyBlocksChanged.disconnect(boost::bind(NotifyBlocksChanged, this, _1, _2, _3, _4));
-    uiInterface.BannedListChanged.disconnect(boost::bind(BannedListChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this, _1));
-    uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this, _1, _2));
-    uiInterface.NotifyScraperEvent.disconnect(boost::bind(NotifyScraperEvent, this, _1, _2, _3));
-    uiInterface.MinerStatusChanged.disconnect(boost::bind(MinerStatusChanged, this, _1, _2));
-}
-#endif

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -11,7 +11,7 @@ class TransactionTableModel;
 class BanTableModel;
 class PeerTableModel;
 
-class ConvergedScraperStats;
+struct ConvergedScraperStats;
 class CWallet;
 
 QT_BEGIN_NAMESPACE

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -26,7 +26,7 @@ QString ToQString(std::string s)
     return str1;
 }
 
-QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
+QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -347,7 +347,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     return parts;
 }
 
-void TransactionRecord::updateStatus(const CWalletTx &wtx)
+void TransactionRecord::updateStatus(const CWalletTx &wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     // Determine transaction status
@@ -434,7 +434,7 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
     }
 }
 
-bool TransactionRecord::statusUpdateNeeded()
+bool TransactionRecord::statusUpdateNeeded() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     return status.cur_num_blocks != nBestHeight;

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -112,7 +112,7 @@ VotingModel::VotingModel(
     {
         LOCK(cs_main);
 
-        for (const auto iter : m_registry.Polls().OnlyActive()) {
+        for (const auto& iter : m_registry.Polls().OnlyActive()) {
             m_last_poll_time = std::max(m_last_poll_time, iter->Ref().Time());
         }
     }

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -202,7 +202,7 @@ std::vector<PollItem> VotingModel::buildPollTable(const PollFilterFlag flags) co
 
     LOCK(cs_main);
 
-    for (const auto iter : m_registry.Polls().Where(flags)) {
+    for (const auto& iter : m_registry.Polls().Where(flags)) {
         if (std::optional<PollItem> item = BuildPollItem(iter)) {
             items.push_back(std::move(*item));
         }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -378,41 +378,33 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
                               Q_ARG(int, status));
 }
 
-// This is ugly but is the easiest way to support the wide range of boost versions and deal with the
-// boost placeholders global namespace pollution fix for later versions (>= 1.73) without breaking earlier ones.
-#if BOOST_VERSION >= 107300
 void WalletModel::subscribeToCoreSignals()
 {
     // Connect signals to wallet
-    wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this, boost::placeholders::_1));
-    wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5));
-    wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+    wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this,
+                                                    boost::placeholders::_1));
+    wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this,
+                                                         boost::placeholders::_1, boost::placeholders::_2,
+                                                         boost::placeholders::_3, boost::placeholders::_4,
+                                                         boost::placeholders::_5));
+    wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this,
+                                                         boost::placeholders::_1, boost::placeholders::_2,
+                                                         boost::placeholders::_3));
 }
 
 void WalletModel::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from wallet
-    wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this, boost::placeholders::_1));
-    wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5));
-    wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+    wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this,
+                                                       boost::placeholders::_1));
+    wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this,
+                                                            boost::placeholders::_1, boost::placeholders::_2,
+                                                            boost::placeholders::_3, boost::placeholders::_4,
+                                                            boost::placeholders::_5));
+    wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this,
+                                                            boost::placeholders::_1, boost::placeholders::_2,
+                                                            boost::placeholders::_3));
 }
-#else
-void WalletModel::subscribeToCoreSignals()
-{
-    // Connect signals to wallet
-    wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
-    wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5));
-    wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
-}
-
-void WalletModel::unsubscribeFromCoreSignals()
-{
-    // Disconnect signals from wallet
-    wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
-    wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5));
-    wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
-}
-#endif
 
 // WalletModel::UnlockContext implementation
 WalletModel::UnlockContext WalletModel::requestUnlock()

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -917,7 +917,7 @@ std::vector<std::string> CRPCTable::listCommands() const
 
     std::transform( mapCommands.begin(), mapCommands.end(),
                     std::back_inserter(commandList),
-                    boost::bind(&commandMap::value_type::first,_1) );
+                    boost::bind(&commandMap::value_type::first,boost::placeholders::_1) );
     // remove deprecated commands from autocomplete
     for(auto &command: DEPRECATED_RPCS) {
         std::remove(commandList.begin(), commandList.end(), command);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -347,7 +347,7 @@ UniValue listpolls(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    for (const auto iter : GetPollRegistry().Polls().OnlyActive(active)) {
+    for (const auto& iter : GetPollRegistry().Polls().OnlyActive(active)) {
         if (const PollOption poll = iter->TryPollFromDisk()) {
             json.push_back(PollToJson(*poll, iter.Ref()));
         }

--- a/src/script.h
+++ b/src/script.h
@@ -452,7 +452,7 @@ public:
         // Immediate operand
         if (opcode <= OP_PUSHDATA4)
         {
-            unsigned int nSize;
+            unsigned int nSize = 0;
             if (opcode < OP_PUSHDATA1)
             {
                 nSize = opcode;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -1,19 +1,23 @@
-// Copyright (c) 2011-2016 The Bitcoin Core developers
+// Copyright (c) 2011-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "sync.h"
 #include "util.h"
+#include <util/threadnames.h>
 
 #include <stdio.h>
 #include <set>
 #include <memory>
 
 #ifdef DEBUG_LOCKCONTENTION
+#if !defined(HAVE_THREAD_LOCAL)
+static_assert(false, "thread_local is not supported");
+#endif
 void PrintLockContention(const char* pszName, const char* pszFile, int nLine)
 {
-    LogPrintf("LOCKCONTENTION: %s", pszName);
-    LogPrintf("Locker: %s:%d", pszFile, nLine);
+    LogPrintf("LOCKCONTENTION: %s\n", pszName);
+    LogPrintf("Locker: %s:%d\n", pszFile, nLine);
 }
 #endif /* DEBUG_LOCKCONTENTION */
 
@@ -30,104 +34,164 @@ void PrintLockContention(const char* pszName, const char* pszFile, int nLine)
 //
 
 struct CLockLocation {
-    CLockLocation(const char* pszName, const char* pszFile, int nLine, bool fTryIn)
-    {
-        mutexName = pszName;
-        sourceFile = pszFile;
-        sourceLine = nLine;
-        fTry = fTryIn;
-    }
+    CLockLocation(
+        const char* pszName,
+        const char* pszFile,
+        int nLine,
+        bool fTryIn,
+        const std::string& thread_name
+        )
+        : fTry(fTryIn),
+          mutexName(pszName),
+          sourceFile(pszFile),
+          m_thread_name(thread_name),
+          sourceLine(nLine) {}
 
     std::string ToString() const
     {
-        return mutexName + "  " + sourceFile + ":" + ::ToString(sourceLine) + (fTry ? " (TRY)" : "");
+        return strprintf(
+            "'%s' in %s:%s%s (in thread '%s')",
+            mutexName, sourceFile, sourceLine, (fTry ? " (TRY)" : "") , m_thread_name);
+    }
+
+    std::string Name() const
+    {
+        return mutexName;
     }
 
 private:
     bool fTry;
     std::string mutexName;
     std::string sourceFile;
+    const std::string& m_thread_name;
     int sourceLine;
 };
 
-typedef std::vector<std::pair<void*, CLockLocation> > LockStack;
-typedef std::map<std::pair<void*, void*>, LockStack> LockOrders;
-typedef std::set<std::pair<void*, void*> > InvLockOrders;
+using LockStackItem = std::pair<void*, CLockLocation>;
+using LockStack = std::vector<LockStackItem>;
+using LockStacks = std::unordered_map<std::thread::id, LockStack>;
+
+using LockPair = std::pair<void*, void*>;
+using LockOrders = std::map<LockPair, LockStack>;
+using InvLockOrders = std::set<LockPair>;
 
 struct LockData {
-    // Very ugly hack: as the global constructs and destructors run single
-    // threaded, we use this boolean to know whether LockData still exists,
-    // as DeleteLock can get called by global CCriticalSection destructors
-    // after LockData disappears.
-    bool available;
-    LockData() : available(true) {}
-    ~LockData() { available = false; }
-
+    LockStacks m_lock_stacks;
     LockOrders lockorders;
     InvLockOrders invlockorders;
     std::mutex dd_mutex;
-} static lockdata;
+};
 
-static thread_local std::unique_ptr<LockStack> lockstack;
+LockData& GetLockData() {
+    // This approach guarantees that the object is not destroyed until after its last use.
+    // The operating system automatically reclaims all the memory in a program's heap when that program exits.
+    // Since the ~LockData() destructor is never called, the LockData class and all
+    // its subclasses must have implicitly-defined destructors.
+    static LockData& lock_data = *new LockData();
+    return lock_data;
+}
 
-static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch, const LockStack& s1, const LockStack& s2)
+static void potential_deadlock_detected(const LockPair& mismatch, const LockStack& s1, const LockStack& s2)
 {
-    LogPrintf("POTENTIAL DEADLOCK DETECTED");
-    LogPrintf("Previous lock order was:");
-    for (const std::pair<void*, CLockLocation> & i : s2) {
+    LogPrintf("POTENTIAL DEADLOCK DETECTED\n");
+    LogPrintf("Previous lock order was:\n");
+    for (const LockStackItem& i : s1) {
         if (i.first == mismatch.first) {
-            LogPrintf(" (1)");
+            LogPrintf(" (1)"); /* Continued */
         }
         if (i.first == mismatch.second) {
-            LogPrintf(" (2)");
+            LogPrintf(" (2)"); /* Continued */
         }
-        LogPrintf(" %s", i.second.ToString());
+        LogPrintf(" %s\n", i.second.ToString());
     }
-    LogPrintf("Current lock order is:");
-    for (const std::pair<void*, CLockLocation> & i : s1) {
+
+    std::string mutex_a, mutex_b;
+    LogPrintf("Current lock order is:\n");
+    for (const LockStackItem& i : s2) {
         if (i.first == mismatch.first) {
-            LogPrintf(" (1)");
+            LogPrintf(" (1)"); /* Continued */
+            mutex_a = i.second.Name();
         }
         if (i.first == mismatch.second) {
-            LogPrintf(" (2)");
+            LogPrintf(" (2)"); /* Continued */
+            mutex_b = i.second.Name();
         }
-        LogPrintf(" %s", i.second.ToString());
+        LogPrintf(" %s\n", i.second.ToString());
+    }
+    if (g_debug_lockorder_abort) {
+        tfm::format(std::cerr, "Assertion failed: detected inconsistent lock order for %s, details in debug log.\n", s2.back().second.ToString());
+        abort();
+    }
+
+    if (g_debug_lockorder_throw_exception) {
+        throw std::logic_error(strprintf("potential deadlock detected: %s -> %s -> %s", mutex_b, mutex_a, mutex_b));
+    } else {
+        LogPrintf("potential deadlock detected: %s -> %s -> %s", mutex_b, mutex_a, mutex_b);
     }
 }
 
-static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
+static void push_lock(void* c, const CLockLocation& locklocation)
 {
-    if (!lockstack)
-        lockstack.reset(new LockStack);
-
+    LockData& lockdata = GetLockData();
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
 
-    lockstack->push_back(std::make_pair(c, locklocation));
-
-    for (const std::pair<void*, CLockLocation> & i : (*lockstack)) {
+    LockStack& lock_stack = lockdata.m_lock_stacks[std::this_thread::get_id()];
+    lock_stack.emplace_back(c, locklocation);
+    for (const LockStackItem& i : lock_stack) {
         if (i.first == c)
             break;
 
-        std::pair<void*, void*> p1 = std::make_pair(i.first, c);
+        const LockPair p1 = std::make_pair(i.first, c);
         if (lockdata.lockorders.count(p1))
             continue;
-        lockdata.lockorders[p1] = (*lockstack);
 
-        std::pair<void*, void*> p2 = std::make_pair(c, i.first);
+        const LockPair p2 = std::make_pair(c, i.first);
+        if (lockdata.lockorders.count(p2)) {
+            auto lock_stack_copy = lock_stack;
+            lock_stack.pop_back();
+            potential_deadlock_detected(p1, lockdata.lockorders[p2], lock_stack_copy);
+            // potential_deadlock_detected() does not return unless both g_debug_lockorder_abort and
+            // g_debug_lockorder_throw_exception are false.
+        }
+
+        lockdata.lockorders.emplace(p1, lock_stack);
         lockdata.invlockorders.insert(p2);
-        if (lockdata.lockorders.count(p2))
-            potential_deadlock_detected(p1, lockdata.lockorders[p2], lockdata.lockorders[p1]);
     }
 }
 
 static void pop_lock()
 {
-    lockstack->pop_back();
+    LockData& lockdata = GetLockData();
+    std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
+
+    LockStack& lock_stack = lockdata.m_lock_stacks[std::this_thread::get_id()];
+    lock_stack.pop_back();
+    if (lock_stack.empty()) {
+        lockdata.m_lock_stacks.erase(std::this_thread::get_id());
+    }
 }
 
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry)
 {
-    push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry), fTry);
+    push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry, util::ThreadGetInternalName()));
+}
+
+void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line)
+{
+    {
+        LockData& lockdata = GetLockData();
+        std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
+
+        const LockStack& lock_stack = lockdata.m_lock_stacks[std::this_thread::get_id()];
+        if (!lock_stack.empty()) {
+            const auto& lastlock = lock_stack.back();
+            if (lastlock.first == cs) {
+                lockname = lastlock.second.Name();
+                return;
+            }
+        }
+    }
+    throw std::system_error(EPERM, std::generic_category(), strprintf("%s:%s %s was not most recent critical section locked", file, line, guardname));
 }
 
 void LeaveCritical()
@@ -137,41 +201,80 @@ void LeaveCritical()
 
 std::string LocksHeld()
 {
+    LockData& lockdata = GetLockData();
+    std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
+
+    const LockStack& lock_stack = lockdata.m_lock_stacks[std::this_thread::get_id()];
     std::string result;
-    for (const std::pair<void*, CLockLocation> & i : *lockstack)
+    for (const LockStackItem& i : lock_stack)
         result += i.second.ToString() + std::string("\n");
     return result;
 }
 
-void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs)
+static bool LockHeld(void* mutex)
 {
-    for (const std::pair<void*, CLockLocation> & i : *lockstack)
-        if (i.first == cs)
-            return;
-    tfm::format(std::cerr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld().c_str());
+    LockData& lockdata = GetLockData();
+    std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
+
+    const LockStack& lock_stack = lockdata.m_lock_stacks[std::this_thread::get_id()];
+    for (const LockStackItem& i : lock_stack) {
+        if (i.first == mutex) return true;
+    }
+
+    return false;
+}
+
+template <typename MutexType>
+void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs)
+{
+    if (LockHeld(cs)) return;
+    tfm::format(std::cerr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld());
     abort();
 }
+template void AssertLockHeldInternal(const char*, const char*, int, Mutex*);
+template void AssertLockHeldInternal(const char*, const char*, int, RecursiveMutex*);
+
+template <typename MutexType>
+void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs)
+{
+    if (!LockHeld(cs)) return;
+    tfm::format(std::cerr, "Assertion failed: lock %s held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld());
+    abort();
+}
+template void AssertLockNotHeldInternal(const char*, const char*, int, Mutex*);
+template void AssertLockNotHeldInternal(const char*, const char*, int, RecursiveMutex*);
 
 void DeleteLock(void* cs)
 {
-    if (!lockdata.available) {
-        // We're already shutting down.
-        return;
-    }
+    LockData& lockdata = GetLockData();
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
-    std::pair<void*, void*> item = std::make_pair(cs, (void*)0);
+    const LockPair item = std::make_pair(cs, nullptr);
     LockOrders::iterator it = lockdata.lockorders.lower_bound(item);
     while (it != lockdata.lockorders.end() && it->first.first == cs) {
-        std::pair<void*, void*> invitem = std::make_pair(it->first.second, it->first.first);
+        const LockPair invitem = std::make_pair(it->first.second, it->first.first);
         lockdata.invlockorders.erase(invitem);
         lockdata.lockorders.erase(it++);
     }
     InvLockOrders::iterator invit = lockdata.invlockorders.lower_bound(item);
     while (invit != lockdata.invlockorders.end() && invit->first == cs) {
-        std::pair<void*, void*> invinvitem = std::make_pair(invit->second, invit->first);
+        const LockPair invinvitem = std::make_pair(invit->second, invit->first);
         lockdata.lockorders.erase(invinvitem);
         lockdata.invlockorders.erase(invit++);
     }
 }
+
+bool LockStackEmpty()
+{
+    LockData& lockdata = GetLockData();
+    std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
+    const auto it = lockdata.m_lock_stacks.find(std::this_thread::get_id());
+    if (it == lockdata.m_lock_stacks.end()) {
+        return true;
+    }
+    return it->second.empty();
+}
+
+bool g_debug_lockorder_abort = false;
+bool g_debug_lockorder_throw_exception = false;
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -148,7 +148,8 @@ static void push_lock(void* c, const CLockLocation& locklocation)
         const LockPair p2 = std::make_pair(c, i.first);
         if (lockdata.lockorders.count(p2)) {
             auto lock_stack_copy = lock_stack;
-            lock_stack.pop_back();
+            // Only pop_back if not continuing program operation
+            if (g_debug_lockorder_abort || g_debug_lockorder_throw_exception) lock_stack.pop_back();
             potential_deadlock_detected(p1, lockdata.lockorders[p2], lock_stack_copy);
             // potential_deadlock_detected() does not return unless both g_debug_lockorder_abort and
             // g_debug_lockorder_throw_exception are false.

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -38,6 +38,9 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     walletdb.WriteAccountingEntry(ae);
 
     wtx.mapValue["comment"] = "z";
+
+    LOCK(pwalletMain->cs_wallet);
+
     pwalletMain->AddToWallet(wtx, &walletdb);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[0]->nTimeReceived = (unsigned int)1333333335;

--- a/src/test/gridcoin/beacon_tests.cpp
+++ b/src/test/gridcoin/beacon_tests.cpp
@@ -919,7 +919,7 @@ BOOST_AUTO_TEST_CASE(it_parses_a_payload_from_a_legacy_contract_key_and_value)
     const GRC::BeaconPayload payload = GRC::BeaconPayload::Parse(key, value);
 
     // Legacy beacon payloads always parse to version 1:
-    BOOST_CHECK_EQUAL(payload.m_version, 1);
+    BOOST_CHECK_EQUAL(payload.m_version, (uint32_t) 1);
     BOOST_CHECK(payload.m_cpid == cpid);
     BOOST_CHECK(payload.m_beacon.m_public_key == TestKey::Public());
     BOOST_CHECK_EQUAL(payload.m_beacon.m_timestamp, 0);

--- a/src/test/gridcoin/cpid_tests.cpp
+++ b/src/test/gridcoin/cpid_tests.cpp
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(it_is_hashable_to_key_a_lookup_map)
     std::hash<GRC::Cpid> hasher;
 
     // CPID halves, little endian
-    const size_t expected = 0x0706050403020100ull + 0x1514131211100908ull;
+    const size_t expected = static_cast<size_t>(0x0706050403020100ull + 0x1514131211100908ull);
 
     BOOST_CHECK_EQUAL(hasher(cpid), expected);
 }

--- a/src/test/gridcoin/magnitude_tests.cpp
+++ b/src/test/gridcoin/magnitude_tests.cpp
@@ -18,49 +18,49 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_zero_magnitude)
 {
     const GRC::Magnitude mag = GRC::Magnitude::Zero();
 
-    BOOST_CHECK_EQUAL(mag.Scaled(), 0);
+    BOOST_CHECK_EQUAL(mag.Scaled(), (uint32_t) 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_to_zero_when_rounding_invalid_magnitudes)
 {
     // Negative
     const GRC::Magnitude negative = GRC::Magnitude::RoundFrom(-1.234);
-    BOOST_CHECK_EQUAL(negative.Scaled(), 0);
+    BOOST_CHECK_EQUAL(negative.Scaled(), (uint32_t) 0);
 
     // Rounds-down to zero
     const GRC::Magnitude effectively_zero = GRC::Magnitude::RoundFrom(0.005);
-    BOOST_CHECK_EQUAL(effectively_zero.Scaled(), 0);
+    BOOST_CHECK_EQUAL(effectively_zero.Scaled(), (uint32_t) 0);
 
     // Exceeded maximum
     const GRC::Magnitude overflow = GRC::Magnitude::RoundFrom(32767.123);
-    BOOST_CHECK_EQUAL(overflow.Scaled(), 0);
+    BOOST_CHECK_EQUAL(overflow.Scaled(), (uint32_t) 0);
 }
 
 BOOST_AUTO_TEST_CASE(it_rounds_a_small_magnitude_to_two_places)
 {
     const GRC::Magnitude min = GRC::Magnitude::RoundFrom(0.0051);
-    BOOST_CHECK_EQUAL(min.Scaled(), 1);
+    BOOST_CHECK_EQUAL(min.Scaled(), (uint32_t) 1);
 
     const GRC::Magnitude max = GRC::Magnitude::RoundFrom(0.994);
-    BOOST_CHECK_EQUAL(max.Scaled(), 99);
+    BOOST_CHECK_EQUAL(max.Scaled(), (uint32_t) 99);
 }
 
 BOOST_AUTO_TEST_CASE(it_rounds_a_medium_magnitude_to_one_place)
 {
     const GRC::Magnitude min = GRC::Magnitude::RoundFrom(0.995);
-    BOOST_CHECK_EQUAL(min.Scaled(), 100);
+    BOOST_CHECK_EQUAL(min.Scaled(), (uint32_t) 100);
 
     const GRC::Magnitude max = GRC::Magnitude::RoundFrom(9.94);
-    BOOST_CHECK_EQUAL(max.Scaled(), 990);
+    BOOST_CHECK_EQUAL(max.Scaled(), (uint32_t) 990);
 }
 
 BOOST_AUTO_TEST_CASE(it_rounds_a_large_magnitude_to_a_whole)
 {
     const GRC::Magnitude min = GRC::Magnitude::RoundFrom(9.95);
-    BOOST_CHECK_EQUAL(min.Scaled(), 1000);
+    BOOST_CHECK_EQUAL(min.Scaled(), (uint32_t) 1000);
 
     const GRC::Magnitude max = GRC::Magnitude::RoundFrom(32767.0);
-    BOOST_CHECK_EQUAL(max.Scaled(), 3276700);
+    BOOST_CHECK_EQUAL(max.Scaled(), (uint32_t) 3276700);
 }
 
 BOOST_AUTO_TEST_CASE(it_compares_another_magnitude_for_equality)
@@ -124,25 +124,25 @@ BOOST_AUTO_TEST_CASE(it_reports_its_size_category)
 BOOST_AUTO_TEST_CASE(it_presents_the_scaled_magnitude_representation)
 {
     const GRC::Magnitude small = GRC::Magnitude::RoundFrom(0.11);
-    BOOST_CHECK_EQUAL(small.Scaled(), 11);
+    BOOST_CHECK_EQUAL(small.Scaled(), (uint32_t) 11);
 
     const GRC::Magnitude medium = GRC::Magnitude::RoundFrom(1.1);
-    BOOST_CHECK_EQUAL(medium.Scaled(), 110);
+    BOOST_CHECK_EQUAL(medium.Scaled(), (uint32_t) 110);
 
     const GRC::Magnitude large = GRC::Magnitude::RoundFrom(11.0);
-    BOOST_CHECK_EQUAL(large.Scaled(), 1100);
+    BOOST_CHECK_EQUAL(large.Scaled(), (uint32_t) 1100);
 }
 
 BOOST_AUTO_TEST_CASE(it_presents_the_compact_magnitude_representation)
 {
     const GRC::Magnitude small = GRC::Magnitude::RoundFrom(0.11);
-    BOOST_CHECK_EQUAL(small.Compact(), 11);
+    BOOST_CHECK_EQUAL(small.Compact(), (uint16_t) 11);
 
     const GRC::Magnitude medium = GRC::Magnitude::RoundFrom(1.1);
-    BOOST_CHECK_EQUAL(medium.Compact(), 11);
+    BOOST_CHECK_EQUAL(medium.Compact(), (uint16_t) 11);
 
     const GRC::Magnitude large = GRC::Magnitude::RoundFrom(11.0);
-    BOOST_CHECK_EQUAL(large.Compact(), 11);
+    BOOST_CHECK_EQUAL(large.Compact(), (uint16_t) 11);
 }
 
 BOOST_AUTO_TEST_CASE(it_presents_the_floating_point_magnitude_representation)

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -1087,7 +1087,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     }
 
     const auto& beacon_ids = superblock.m_verified_beacons;
-    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), 2);
+    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), (size_t) 2);
     BOOST_CHECK(beacon_ids.m_verified[0] == meta.beacon_id_1);
     BOOST_CHECK(beacon_ids.m_verified[1] == meta.beacon_id_2);
 }
@@ -1232,7 +1232,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_fallback_convergence)
     }
 
     const auto& beacon_ids = superblock.m_verified_beacons;
-    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), 2);
+    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), (size_t) 2);
     BOOST_CHECK(beacon_ids.m_verified[0] == meta.beacon_id_1);
     BOOST_CHECK(beacon_ids.m_verified[1] == meta.beacon_id_2);
 }
@@ -1954,7 +1954,7 @@ BOOST_AUTO_TEST_CASE(it_replaces_the_collection_from_scraper_statistics)
 
     beacon_ids.Reset(stats_and_verified_beacons.mVerifiedMap);
 
-    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), 2);
+    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), (size_t) 2);
     BOOST_CHECK(beacon_ids.m_verified[0] == meta.beacon_id_1);
     BOOST_CHECK(beacon_ids.m_verified[1] == meta.beacon_id_2);
 }
@@ -1997,7 +1997,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     GRC::Superblock::VerifiedBeacons beacon_ids;
     stream >> beacon_ids;
 
-    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), 2);
+    BOOST_CHECK_EQUAL(beacon_ids.m_verified.size(), (size_t) 2);
     BOOST_CHECK(beacon_ids.m_verified[0] == meta.beacon_id_1);
     BOOST_CHECK(beacon_ids.m_verified[1] == meta.beacon_id_2);
 }

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -2363,7 +2363,7 @@ BOOST_AUTO_TEST_CASE(it_is_hashable_to_key_a_lookup_map)
     });
 
     // MD5 halves, little endian
-    const size_t expected = 0x0706050403020100ull + 0x1514131211100908ull;
+    const size_t expected = static_cast<size_t>(0x0706050403020100ull + 0x1514131211100908ull);
 
     BOOST_CHECK_EQUAL(hasher(hash_md5), expected);
 }

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         CScript s;
         s << key[0].GetPubKey() << OP_CHECKSIG;
         BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 1);
+        BOOST_CHECK(solutions.size() == (size_t) 1);
         CTxDestination addr;
         BOOST_CHECK(ExtractDestination(s, addr));
         BOOST_CHECK(addr == keyaddr[0]);
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         CScript s;
         s << OP_DUP << OP_HASH160 << key[0].GetPubKey().GetID() << OP_EQUALVERIFY << OP_CHECKSIG;
         BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 1);
+        BOOST_CHECK(solutions.size() == (size_t) 1);
         CTxDestination addr;
         BOOST_CHECK(ExtractDestination(s, addr));
         BOOST_CHECK(addr == keyaddr[0]);
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         CScript s;
         s << OP_2 << key[0].GetPubKey() << key[1].GetPubKey() << OP_2 << OP_CHECKMULTISIG;
         BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK_EQUAL(solutions.size(), 4);
+        BOOST_CHECK_EQUAL(solutions.size(), (size_t) 4);
         CTxDestination addr;
         BOOST_CHECK(!ExtractDestination(s, addr));
         BOOST_CHECK(IsMine(keystore, s) != ISMINE_NO);
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         CScript s;
         s << OP_1 << key[0].GetPubKey() << key[1].GetPubKey() << OP_2 << OP_CHECKMULTISIG;
         BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK_EQUAL(solutions.size(), 4);
+        BOOST_CHECK_EQUAL(solutions.size(), (size_t) 4);
         vector<CTxDestination> addrs;
         int nRequired;
         BOOST_CHECK(ExtractDestinations(s, whichType, addrs, nRequired));
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         CScript s;
         s << OP_2 << key[0].GetPubKey() << key[1].GetPubKey() << key[2].GetPubKey() << OP_3 << OP_CHECKMULTISIG;
         BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 5);
+        BOOST_CHECK(solutions.size() == (size_t) 5);
     }
 }
 

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 2));
 
     BOOST_CHECK(::AreInputsStandard(txTo, mapInputs));
-    BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txTo, mapInputs), 1);
+    BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txTo, mapInputs), (unsigned int) 1);
 
     // Make sure adding crap to the scriptSigs makes them non-standard:
     for (int i = 0; i < 3; i++)
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd.vin[1].scriptSig << OP_0 << Serialize(oneOfEleven);
 
     BOOST_CHECK(!::AreInputsStandard(txToNonStd, mapInputs));
-    BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd, mapInputs), 11);
+    BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd, mapInputs), (unsigned int) 11);
 
     txToNonStd.vin[0].scriptSig.clear();
     BOOST_CHECK(!::AreInputsStandard(txToNonStd, mapInputs));

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -20,21 +20,21 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
 {
     // Test CScript::GetSigOpCount()
     CScript s1;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 0);
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 0);
+    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), (unsigned int) 0);
+    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), (unsigned int) 0);
 
     uint160 dummy;
     s1 << OP_1 << dummy << dummy << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 2);
+    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), (unsigned int) 2);
     s1 << OP_IF << OP_CHECKSIG << OP_ENDIF;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 3);
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 21);
+    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), (unsigned int) 3);
+    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), (unsigned int) 21);
 
     CScript p2sh;
     p2sh.SetDestination(s1.GetID());
     CScript scriptSig;
     scriptSig << OP_0 << Serialize(s1);
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig), 3);
+    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig), (unsigned int) 3);
 
     std::vector<CKey> keys;
     for (int i = 0; i < 3; i++)
@@ -45,15 +45,15 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     }
     CScript s2;
     s2.SetMultisig(1, keys);
-    BOOST_CHECK_EQUAL(s2.GetSigOpCount(true), 3);
-    BOOST_CHECK_EQUAL(s2.GetSigOpCount(false), 20);
+    BOOST_CHECK_EQUAL(s2.GetSigOpCount(true), (unsigned int) 3);
+    BOOST_CHECK_EQUAL(s2.GetSigOpCount(false), (unsigned int) 20);
 
     p2sh.SetDestination(s2.GetID());
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(true), 0);
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(false), 0);
+    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(true), (unsigned int) 0);
+    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(false), (unsigned int) 0);
     CScript scriptSig2;
     scriptSig2 << OP_1 << dummy << dummy << Serialize(s2);
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig2), 3);
+    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig2), (unsigned int) 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -124,22 +124,22 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // try making 34 cents from 1,2,5,10,20 - we can't do it exactly
         BOOST_CHECK( wallet.SelectCoinsMinConf(34 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_GT(nValueRet, 34 * CENT);         // but should get more than 34 cents
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);     // the best should be 20+10+5.  it's incredibly unlikely the 1 or 2 got included (but possible)
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 3);     // the best should be 20+10+5.  it's incredibly unlikely the 1 or 2 got included (but possible)
 
         // when we try making 7 cents, the smaller coins (1,2,5) are enough.  We should see just 2+5
         BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 7 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 2);
 
         // when we try making 8 cents, the smaller coins (1,2,5) are exactly enough.
         BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK(nValueRet == 8 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 3);
 
         // when we try making 9 cents, no subset of smaller coins is enough, and we get the next bigger coin (10)
         BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 10 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 1);
 
         // now clear out the wallet and start again to test choosing between subsets of smaller coins and the next biggest coin
         empty_wallet();
@@ -157,26 +157,26 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // now try making 16 cents.  the best smaller coins can do is 6+7+8 = 21; not as good at the next biggest coin, 20
         BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 20 * CENT); // we should get 20 in one coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 1);
 
         add_coin( 5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
 
         // now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, better than the next biggest coin, 20
         BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 18 * CENT); // we should get 18 in 3 coins
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 3);
 
         add_coin( 18*CENT); // now we have 5+6+7+8+18+20+30
 
         // and now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, the same as the next biggest coin, 18
         BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 18 * CENT);  // we should get 18 in 1 coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1); // because in the event of a tie, the biggest coin wins
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 1); // because in the event of a tie, the biggest coin wins
 
         // now try making 11 cents.  we should get 5+6
         BOOST_CHECK( wallet.SelectCoinsMinConf(11 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 11 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 2);
 
         // check that the smallest bigger coin is used
         add_coin( 1*COIN);
@@ -185,11 +185,11 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin( 4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
         BOOST_CHECK( wallet.SelectCoinsMinConf(95 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);  // we should get 1 BTC in 1 coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 1);
 
         BOOST_CHECK( wallet.SelectCoinsMinConf(195 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 2 * COIN);  // we should get 2 BTC in 1 coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 1);
 
         // empty the wallet and start again, now with fractions of a cent, to test sub-cent change avoidance
         empty_wallet();
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         BOOST_CHECK( wallet.SelectCoinsMinConf(500000 * COIN, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // we should get the exact amount
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 10); // in ten coins
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 10); // in ten coins
 
         // if there's not enough in the smaller coins to make at least 1 cent change (0.5+0.6+0.7 < 1.0+1.0),
         // we need to try finding an exact subset anyway
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(1111 * CENT);
         BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1111 * CENT); // we get the bigger coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 1);
 
         // but sometimes it's possible, and we use an exact subset (0.4 + 0.6 = 1.0)
         empty_wallet();
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(1111 * CENT);
         BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);   // we should get the exact amount
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2); // in two coins 0.4+0.6
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 2); // in two coins 0.4+0.6
 
         // test avoiding sub-cent change
         empty_wallet();
@@ -261,12 +261,12 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // trying to make 1.0001 from these three coins
         BOOST_CHECK( wallet.SelectCoinsMinConf(1.0001 * COIN, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1.0105 * COIN);   // we should get all coins
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 3);
 
         // but if we try to make 0.999, we should take the bigger of the two small coins to avoid sub-cent change
         BOOST_CHECK( wallet.SelectCoinsMinConf(0.999 * COIN, spendTime, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1.01 * COIN);   // we should get 1 + 0.01
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), (size_t) 2);
 
         // test randomness
         {

--- a/src/util.h
+++ b/src/util.h
@@ -289,7 +289,7 @@ public:
     void removeByName(const std::string tname);
 private:
     boost::thread_group threadGroup;
-    std::map<std::string,boost::thread*> threadMap;
+    std::map<std::string, boost::thread*> threadMap;
 };
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -226,7 +226,7 @@ UniValue getnewaddress(const UniValue& params, bool fHelp)
 }
 
 
-CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
+CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false) EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
 {
     CWalletDB walletdb(pwalletMain->strWalletFile);
 
@@ -566,7 +566,7 @@ UniValue getreceivedbyaddress(const UniValue& params, bool fHelp)
 }
 
 
-void GetAccountAddresses(string strAccount, set<CTxDestination>& setAddress)
+void GetAccountAddresses(string strAccount, set<CTxDestination>& setAddress) EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
 {
     for (auto const& item : pwalletMain->mapAddressBook)
     {
@@ -622,7 +622,7 @@ UniValue getreceivedbyaccount(const UniValue& params, bool fHelp)
     return ValueFromAmount(nAmount);
 }
 
-int64_t GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMinDepth, const isminefilter& filter = ISMINE_SPENDABLE)
+int64_t GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMinDepth, const isminefilter& filter = ISMINE_SPENDABLE) EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
 {
     int64_t nBalance = 0;
 
@@ -648,7 +648,7 @@ int64_t GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     return nBalance;
 }
 
-int64_t GetAccountBalance(const string& strAccount, int nMinDepth, const isminefilter& filter = ISMINE_SPENDABLE)
+int64_t GetAccountBalance(const string& strAccount, int nMinDepth, const isminefilter& filter = ISMINE_SPENDABLE) EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
 {
     CWalletDB walletdb(pwalletMain->strWalletFile);
     return GetAccountBalance(walletdb, strAccount, nMinDepth, filter);
@@ -1212,7 +1212,7 @@ struct tallyitem
     }
 };
 
-UniValue ListReceived(const UniValue& params, bool fByAccounts)
+UniValue ListReceived(const UniValue& params, bool fByAccounts) EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
 {
     // Minimum confirmations
     int nMinDepth = 1;
@@ -1387,7 +1387,7 @@ UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
 
  void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDepth,
                        bool fLong, UniValue& ret, const isminefilter& filter = ISMINE_SPENDABLE,
-                       bool stakes_only = false)
+                       bool stakes_only = false) EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
  {
     int64_t nFee;
     string strSentAccount;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -86,13 +86,13 @@ private:
                      std::set<std::pair<const CWalletTx*, unsigned int>>& setCoinsRet, int64_t& nValueRet,
                      const CCoinControl* coinControl = nullptr, bool contract = false) const;
 
-    CWalletDB *pwalletdbEncryption;
+    CWalletDB *pwalletdbEncryption GUARDED_BY(cs_wallet);
 
     // the current wallet version: clients below this version are not able to load the wallet
-    int nWalletVersion;
+    int nWalletVersion GUARDED_BY(cs_wallet);
 
     // the maximum wallet format version: memory-only variable that specifies to what version this wallet may be upgraded
-    int nWalletMaxVersion;
+    int nWalletMaxVersion GUARDED_BY(cs_wallet);
 
 public:
     /// Main wallet lock.
@@ -105,21 +105,25 @@ public:
     bool fFileBacked;
     std::string strWalletFile;
 
-    std::set<int64_t> setKeyPool;
-    std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
+    std::set<int64_t> setKeyPool GUARDED_BY(cs_wallet);
+    std::map<CKeyID, CKeyMetadata> mapKeyMetadata GUARDED_BY(cs_wallet);
 
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
-    MasterKeyMap mapMasterKeys;
-    unsigned int nMasterKeyMaxID;
+    MasterKeyMap mapMasterKeys GUARDED_BY(cs_wallet);
+    unsigned int nMasterKeyMaxID GUARDED_BY(cs_wallet);
 
     CWallet()
     {
+        LOCK(cs_wallet);
+
         SetNull();
     }
 
     CWallet(std::string strWalletFileIn)
     {
+        LOCK(cs_wallet);
+
         SetNull();
 
         strWalletFile = strWalletFileIn;
@@ -168,7 +172,7 @@ public:
     //!
     CKey MasterPrivateKey() const;
 
-    void SetNull()
+    void SetNull() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     {
         nWalletVersion = FEATURE_BASE;
         nWalletMaxVersion = FEATURE_BASE;
@@ -179,17 +183,21 @@ public:
         nTimeFirstKey = 0;
     }
 
-    std::map<uint256, CWalletTx> mapWallet;
-    int64_t nOrderPosNext;
-    std::map<uint256, int> mapRequestCount;
+    std::map<uint256, CWalletTx> mapWallet GUARDED_BY(cs_wallet);
+    int64_t nOrderPosNext GUARDED_BY(cs_wallet);
+    std::map<uint256, int> mapRequestCount GUARDED_BY(cs_wallet);
 
-    std::map<CTxDestination, std::string> mapAddressBook;
+    std::map<CTxDestination, std::string> mapAddressBook GUARDED_BY(cs_wallet);
 
-    CPubKey vchDefaultKey;
-    int64_t nTimeFirstKey;
+    CPubKey vchDefaultKey GUARDED_BY(cs_wallet);
+    int64_t nTimeFirstKey GUARDED_BY(cs_wallet);
 
     // check whether we are allowed to upgrade (or already support) to the named feature
-    bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
+    bool CanSupportFeature(enum WalletFeature wf) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+    {
+        AssertLockHeld(cs_wallet);
+        return nWalletMaxVersion >= wf;
+    }
 
     void AvailableCoinsForStaking(std::vector<COutput>& vCoins, unsigned int nSpendTime, int64_t& nBalanceOut) const;
     bool SelectCoinsForStaking(unsigned int nSpendTime, std::vector<std::pair<const CWalletTx*,unsigned int> >& vCoinsRet,
@@ -211,7 +219,13 @@ public:
     // Load metadata (used by LoadWallet)
     bool LoadKeyMetadata(const CPubKey &pubkey, const CKeyMetadata &metadata);
 
-    bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
+    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+    {
+        AssertLockHeld(cs_wallet);
+        nWalletVersion = nVersion;
+        nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion);
+        return true;
+    }
 
     // Adds an encrypted key to the store, and saves it to disk.
     bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
@@ -368,7 +382,7 @@ public:
         }
     }
 
-    unsigned int GetKeyPoolSize()
+    unsigned int GetKeyPoolSize() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     {
         AssertLockHeld(cs_wallet); // setKeyPool
         return setKeyPool.size();


### PR DESCRIPTION
This PR is an assortment of fixes in relatively fine-grained commits that clear up many of the warnings produced by compiling the Gridcoin code with advanced Clang compilers. Note that the first three commits are important, because the debug lock stack was not working correctly , so I ported the rest of the Bitcoin sync.h/cpp code (with a few necessary include tweaks). The last commit is also very important as #2270 broke RPC because ParseInt fails if lines have \r's.

The only thread safety work done here is the bare minimum required to stop Clang from complaining with AssertLockHeld.

Implementation of additional thread safety work, starting with the scraper, will be in separate PR's. In general the thread safety of Gridcoin has been good and wallet stability is very good, but Clang is quite exacting with the static thread analyzer, and this will require a significant amount of work to fully implement the GUARDED_BY and EXCLUSIVE_LOCKS_REQUIRED, etc.