### PR TITLE
depends: Bump ccache and curl

### DIFF
--- a/depends/packages/curl.mk
+++ b/depends/packages/curl.mk
@@ -1,9 +1,9 @@
 package=curl
 GCCFLAGS?=
-$(package)_version=7.77.0
+$(package)_version=7.78.0
 $(package)_download_path=https://curl.haxx.se/download/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=b0a3428acb60fa59044c4d0baae4e4fc09ae9af1d8a3aa84b2e3fbcd99841f77
+$(package)_sha256_hash=ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7
 $(package)_dependencies=openssl
 
 define $(package)_set_vars

--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,8 +1,8 @@
 package=native_ccache
-$(package)_version=3.4.3
-$(package)_download_path=https://samba.org/ftp/ccache
-$(package)_file_name=ccache-$($(package)_version).tar.bz2
-$(package)_sha256_hash=38decec3eed6524a002ffae52b25781843553c28e2d840e7e55e6831c40264d2
+$(package)_version=3.7.12
+$(package)_download_path=https://github.com/ccache/ccache/releases/download/v$($(package)_version)
+$(package)_file_name=ccache-$($(package)_version).tar.gz
+$(package)_sha256_hash=d2abe88d4c283ce960e233583061127b156ffb027c6da3cf10770fc0c7244194
 
 define $(package)_set_vars
   $(package)_config_opts=


### PR DESCRIPTION
- ccache from 3.4.3 to 3.7.12.  Updating to 4.0 and beyond will lead to backwards-incompatible changes. (https://ccache.dev/releasenotes.html#_ccache_3_7_12)
- curl from 7.77.0 to 7.78.0.  Fixes 5 CVEs. (https://curl.se/news.html)