### PR TITLE
rpc: Print OpenSSL version fix

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -957,7 +957,11 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 #endif
 
-    LogPrintf("Using OpenSSL version %s", SSLeay_version(SSLEAY_VERSION));
+    #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+        LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
+    #else
+        LogPrintf("Using OpenSSL version %s\n", OpenSSL_version(OPENSSL_VERSION));
+    #endif
 
     std::ostringstream strErrors;
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -234,7 +234,11 @@ RPCConsole::RPCConsole(QWidget *parent) :
     connect(ui->clearButton, &QPushButton::clicked, this, &RPCConsole::clear);
 
     // set OpenSSL version label
-    ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
+    #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+        ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
+    #else
+        ui->openSSLVersion->setText(OpenSSL_version(OPENSSL_VERSION));
+    #endif
 
     // set Qt version label
     ui->qtVersion->setText("Qt " + QString::fromLocal8Bit(qVersion()) + " (built against " + QString::fromStdString(QT_VERSION_STR) + ")");


### PR DESCRIPTION
> `SSLeay_version(SSLEAY_VERSION)` was replaced with `OpenSSL_version(OPENSSL_VERSION)` in openssl/openssl@b0700d2.

Without this code older versions of openSSL will error on compile.

Ref: https://github.com/bitcoin/bitcoin/pull/7083