### PR TITLE
gui: Add back in accidentally deleted condition for UnlockStaking and Unlock cases in AskPassphraseDialog::textChanged()

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -181,6 +181,8 @@ void AskPassphraseDialog::textChanged()
         break;
     case UnlockStaking:
     case Unlock: // Old passphrase x1
+        acceptable = !ui->oldPassphraseEdit->text().isEmpty();
+        break;
     case ChangePass: // Old passphrase x1, new passphrase x2
         acceptable = !ui->oldPassphraseEdit->text().isEmpty() && !ui->newPassphraseEdit->text().isEmpty() && !ui->repeatNewPassphraseEdit->text().isEmpty();
         break;


### PR DESCRIPTION
This corrects a regression introduced by #2299.