### PR TITLE
LibreSSL doesn't define OPENSSL_VERSION, use LIBRESSL_VERSION_TEXT instead

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -959,8 +959,10 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
         LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
-    #else
+    #elif defined OPENSSL_VERSION
         LogPrintf("Using OpenSSL version %s\n", OpenSSL_version(OPENSSL_VERSION));
+    #elif defined LIBRESSL_VERSION_TEXT
+        LogPrintf("Using %s\n", LIBRESSL_VERSION_TEXT);
     #endif
 
     std::ostringstream strErrors;


### PR DESCRIPTION
> OpenBSD is using LibreSSL by default instead of openssl.
> 
> This change adds LIBRESSL_VERSION_TEXT macrocheck and adds conditionals before these macros. If none is defined, nothing is printed at all.

Ref: https://github.com/bitcoin/bitcoin/pull/7520

Not sure how to tag this