### PR TITLE
refactor, qt: Drop redundant setEditTriggers(NoEditTriggers) calls, Fix typo in QtInputSupport check

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -395,7 +395,7 @@ AC_DEFUN([_BITCOIN_QT_CHECK_STATIC_LIBS], [
   dnl Gridcoin uses SVG:
   PKG_CHECK_MODULES([QT_SVG], [${qt_lib_prefix}Svg${qt_lib_suffix}], [QT_LIBS="$QT_SVG_LIBS $QT_LIBS"])
   if test "x$TARGET_OS" = xlinux; then
-    PKG_CHECK_MODULES([QT_INPUT], [${qt_lib_prefix}XcbQpa], [QT_LIBS="$QT_INPUT_LIBS $QT_LIBS"])
+    PKG_CHECK_MODULES([QT_INPUT], [${qt_lib_prefix}InputSupport], [QT_LIBS="$QT_INPUT_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_SERVICE], [${qt_lib_prefix}ServiceSupport], [QT_LIBS="$QT_SERVICE_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_XCBQPA], [${qt_lib_prefix}XcbQpa], [QT_LIBS="$QT_XCBQPA_LIBS $QT_LIBS"])
   elif test "x$TARGET_OS" = xdarwin; then

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -310,7 +310,6 @@ void RPCConsole::setClientModel(ClientModel *model)
         // set up peer table
         ui->peerWidget->setModel(model->getPeerTableModel());
         ui->peerWidget->verticalHeader()->hide();
-        ui->peerWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
         ui->peerWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
         ui->peerWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
         ui->peerWidget->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -361,7 +360,6 @@ void RPCConsole::setClientModel(ClientModel *model)
         // set up ban table
         ui->banlistWidget->setModel(model->getBanTableModel());
         ui->banlistWidget->verticalHeader()->hide();
-        ui->banlistWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
         ui->banlistWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
         ui->banlistWidget->setSelectionMode(QAbstractItemView::SingleSelection);
         ui->banlistWidget->setContextMenuPolicy(Qt::CustomContextMenu);


### PR DESCRIPTION
> 
> 
> The models of the both views have no `Qt::ItemIsEditable` flag:
> 
> https://github.com/bitcoin-core/gui/blob/3c87dbe95c925274f80234ad4a88beb5a05fdfff/src/qt/peertablemodel.cpp#L218-L224
> 
> https://github.com/bitcoin-core/gui/blob/3c87dbe95c925274f80234ad4a88beb5a05fdfff/src/qt/bantablemodel.cpp#L148-L154


Ref: https://github.com/bitcoin-core/gui/pull/254

Also fix a typo introduced upstream.

Ref: https://github.com/bitcoin/bitcoin/pull/22820