### PR TITLE
util: avoid config file load/race

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -22,6 +22,7 @@
 #include <boost/iostreams/filter/newline.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
+#include <openssl/conf.h>
 #include <cstdarg>
 
 using namespace std;
@@ -72,6 +73,13 @@ public:
         for (int i = 0; i < CRYPTO_num_locks(); i++)
             ppmutexOpenSSL[i] = new CCriticalSection();
         CRYPTO_set_locking_callback(locking_callback);
+
+        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
+        // We don't use them so we don't require the config. However some of our libs may call functions
+        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
+        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
+        // that the config appears to have been loaded and there are no modules/engines available.
+        OPENSSL_no_config();
 
         // Check whether OpenSSL random number generator is properly seeded. If not, attempt to seed using RAND_poll().
         // Note that in versions of OpenSSL in the depends in Gridcoin (currently 1.1.1+), and modern Unix distros (using

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -22,6 +22,7 @@
 #include <boost/iostreams/filter/newline.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
+#include <openssl/conf.h>
 #include <cstdarg>
 
 using namespace std;
@@ -72,6 +73,14 @@ public:
         for (int i = 0; i < CRYPTO_num_locks(); i++)
             ppmutexOpenSSL[i] = new CCriticalSection();
         CRYPTO_set_locking_callback(locking_callback);
+
+
+        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
+        // We don't use them so we don't require the config. However some of our libs may call functions
+        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
+        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
+        // that the config appears to have been loaded and there are no modules/engines available.
+        OPENSSL_no_config();
 
         // Check whether OpenSSL random number generator is properly seeded. If not, attempt to seed using RAND_poll().
         // Note that in versions of OpenSSL in the depends in Gridcoin (currently 1.1.1+), and modern Unix distros (using


### PR DESCRIPTION
This fixes a potential issue with loading/unloading openSSL's configuration file (which we do not use)

>
> 
> See [here](https://wiki.openssl.org/index.php/Library_Initialization#OPENSSL_config) for more info. Also [the source](https://github.com/openssl/openssl/blob/OpenSSL_1_0_0-stable/crypto/conf/conf_sap.c) is self-explanatory.
> 
> Since we don't use any loadable functionality, I don't see how this could hurt. Presumably qt tries to load available modules, but the fallbacks should always work.
> 
> One last data point: The depends build is trying to load `/home/ubuntu/build/bitcoin/depends/x86_64-unknown-linux-gnu/etc/openssl/openssl.cnf` which obviously won't be found in the end-user's environment. So this functionality has actually been disabled for a long time anyway.



Ref: https://github.com/bitcoin/bitcoin/pull/6438