### PR TITLE
rpc: ParseHash: Fail when length is not 64

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -130,6 +130,8 @@ uint256 ParseHashV(const UniValue& v, string strName)
         strHex = v.get_str();
     if (!IsHex(strHex)) // Note: IsHex("") is false
         throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be hexadecimal string (not '"+strHex+"')");
+    if (64 != strHex.length())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s must be of length %d (not %d)", strName, 64, strHex.length()));
     uint256 result;
     result.SetHex(strHex);
     return result;


### PR DESCRIPTION
SHA256 hashes should always be 64 characters.

Ref: https://github.com/bitcoin/bitcoin/pull/9042