### PR TITLE
refactor: Scraper thread safety and code cleanup

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -29,6 +29,7 @@
 using namespace GRC;
 
 extern CCriticalSection cs_main;
+extern CCriticalSection cs_ScraperGlobals;
 extern std::string msMiningErrors;
 extern unsigned int nActiveBeforeSB;
 
@@ -1086,6 +1087,8 @@ void Researcher::RunRenewBeaconJob()
     // window begins nActiveBeforeSB seconds before the next superblock.
     // This is four hours by default unless overridden by protocol entry.
     //
+    LOCK(cs_ScraperGlobals);
+
     if (!Quorum::SuperblockNeeded(pindexBest->nTime + nActiveBeforeSB)) {
         TRY_LOCK(pwalletMain->cs_wallet, locked_wallet);
 

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -82,10 +82,10 @@ struct ConvergedManifest
     // the composite convergence by taking parts piecewise in the case of the fallback to bByParts (project) level.
     uint256 nContentHash;
     uint256 ConsensusBlock;
-    int64_t timestamp;
-    bool bByParts;
+    int64_t timestamp = 0;
+    bool bByParts = false;
 
-    CScraperManifest_shared_ptr CScraperConvergedManifest_ptr;
+    CScraperManifest_shared_ptr CScraperConvergedManifest_ptr = nullptr;
 
     mConvergedManifestPart_ptrs ConvergedManifestPartPtrsMap;
 

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -18,6 +18,7 @@
 * Scraper ENUMS      *
 *********************/
 
+/** Defines the object type of the stats entry */
 enum class statsobjecttype
 {
     NetworkWide,
@@ -26,6 +27,7 @@ enum class statsobjecttype
     byCPIDbyProject
 };
 
+/** Defines the event type in the scraper system */
 enum class scrapereventtypes
 {
     OutOfSync,
@@ -37,6 +39,7 @@ enum class scrapereventtypes
     Sleep
 };
 
+/** Defines the validation type of the convergence achieved by the subscriber */
 enum class scraperSBvalidationtype
 {
     Invalid,
@@ -47,86 +50,131 @@ enum class scraperSBvalidationtype
     ProjectLevelConvergence
 };
 
+/** Currently the scraperID is a string. */
 typedef std::string ScraperID;
-// The inner map is sorted in descending order of time. The pair is manifest hash, content hash.
+/** The inner map is sorted in descending order of time. The pair is manifest hash, content hash. */
 typedef std::multimap<int64_t, std::pair<uint256, uint256>, std::greater <int64_t>> mCSManifest;
-// This is sCManifestName, which is the string version of the originating scraper pubkey.
-// See the ScraperID typedef above.
+/** This is sCManifestName, which is the string version of the originating scraper pubkey. */
 typedef std::map<ScraperID, mCSManifest> mmCSManifestsBinnedByScraper;
 
+/** Make the smart shared pointer a little less awkward for CScraperManifest */
 typedef std::shared_ptr<CScraperManifest> CScraperManifest_shared_ptr;
 
-// Note the CParts pointed to by this map are safe to access, because the pointers are guaranteed valid
-// as long as the holding CScraperManifests (both in the CScaperManifest global map, and this cache)
-// still exist. So the safety of these pointers is coincident with the lifespan of CScraperManifests
-// that have reference to them. If you have questions about this, you should review the CSplitBlob abstract
-// class, which is the base class of the CScraperManifest class, and provides the mechanisms for part
-// control. Note that two LOCKS are used to protect the integrity of the underlying global maps,
-// CScraperManifest::cs_mapManifest and CSplitBlob::cs_mapParts.
-// -------------- Project -- Converged Part Pointer
+/** Note the CParts pointed to by this map are safe to access, because the pointers are guaranteed valid
+ * as long as the holding CScraperManifests (both in the CScaperManifest global map, and this cache)
+ * still exist. So the safety of these pointers is coincident with the lifespan of CScraperManifests
+ * that have reference to them. If you have questions about this, you should review the CSplitBlob abstract
+ * class, which is the base class of the CScraperManifest class, and provides the mechanisms for part
+ * control. Note that two LOCKS are used to protect the integrity of the underlying global maps,
+ * CScraperManifest::cs_mapManifest and CSplitBlob::cs_mapParts.
+ * ---------- Project -- Converged Part Pointer
+ * std::map<std::string, CSplitBlob::CPart*> mConvergedManifestPart_ptrs
+ */
 typedef std::map<std::string, CSplitBlob::CPart*> mConvergedManifestPart_ptrs;
 
+/** Used for a "convergence", which is the result of the subscriber comparing published manifests from the scrapers in
+ *  accordance with the rules of convergence, where the rules have been met. The convergence is used as the basis of
+ *  constructing a superblock. */
 struct ConvergedManifest
 {
-    // Empty converged manifest constructor
+    /** Empty converged manifest constructor */
     ConvergedManifest();
 
-    // For constructing a dummy converged manifest from a single manifest
+    /** For constructing a dummy converged manifest from a single manifest */
     ConvergedManifest(CScraperManifest_shared_ptr& in);
 
-    // Call operator to update an already initialized ConvergedManifest with a passed in CScraperManifest
+    /** Call operator to update an already initialized ConvergedManifest with a passed in CScraperManifest */
     bool operator()(const CScraperManifest_shared_ptr& in);
 
-    // IMPORTANT... nContentHash is NOT the hash of part hashes in the order of vParts unlike CScraper::manifest.
-    // It is the hash of the data in the ConvergedManifestPartsMap in the order of the key. It represents
-    // the composite convergence by taking parts piecewise in the case of the fallback to bByParts (project) level.
+    /** IMPORTANT... nContentHash is NOT the hash of part hashes in the order of vParts unlike CScraper::manifest.
+     * It is the hash of the data in the ConvergedManifestPartsMap in the order of the key. It represents
+     * the composite convergence by taking parts piecewise in the case of the fallback to bByParts (project) level.
+     */
     uint256 nContentHash;
+    /** The block on which the convergence was formed. */
     uint256 ConsensusBlock;
+    /** The time of the convergence. */
     int64_t timestamp = 0;
+    /** Flag indicating whether the convergence was formed at the project level. If the rules of convergence cannot
+     * be met at the whole manifest level (which could happen if a project were not available in some manifests, for
+     * example), then in the fallback to put together a convergence from matching at the project (part) level, this flag
+     * will be set if a convergence is formed that way.
+     */
     bool bByParts = false;
 
+    /** The shared pointer to the CScraperManifest that underlies the convergence. If the convergence was at the manifest
+     * level, this will be the manifest selected as the representation of the equivalent manifests used to determine the
+     * convergence. If the convergence is at the parts (project) level, then this will point to a synthesized (non-published)
+     * manifest which only has the vParts vector filled out, and which content is the parts selected to form the byParts
+     * (project) level convergence. Note that this synthesized manifest is LOCAL ONLY and will not be added to mapManifests
+     * or published to other nodes. Convergences in general are the responsibility of the subscriber, not the publisher.
+     */
     CScraperManifest_shared_ptr CScraperConvergedManifest_ptr = nullptr;
 
+    /** A map to the pointers of the parts used to form the convergence. This will be essentially the same as the vParts
+     * vector in the CScraperManifest pointed to by the CScraperConvergedManifest_ptr.
+     */
     mConvergedManifestPart_ptrs ConvergedManifestPartPtrsMap;
 
-    // Used when convergence is at the manifest level (normal)
+    /** A map of the manifests by hash (key) that formed this convergence. This is used when convergence is at the manifest
+     * level (normal).
+     */
     std::map<ScraperID, uint256> mIncludedScraperManifests;
-    // The below is the manifest content hash for the underlying manifests that comprise the convergence. This
-    // will only be populated if the convergence is at the manifest level (bByParts == false). In that case, each
-    // manifest's content in the convergence must be the same. If the convergence is by project, this does not
-    // make sense to populate. See the above comment.
+    /** The below is the manifest content hash for the underlying manifests that comprise the convergence. This
+     * will only be populated if the convergence is at the manifest level (bByParts == false). In that case, each
+     * manifest's content in the convergence must be the same. If the convergence is by project, this does not
+     * make sense to populate.
+     */
     uint256 nUnderlyingManifestContentHash;
 
-    // Used when convergence is at the manifest level (normal) and also at the part (project) level for
-    // scrapers that are not part of any part (project) level convergence.
+    /** The publishing scrapers included in the convergence. If the convergence is at the project level, a scraper in this
+     * vector would have to be included in at least one project level match for the synthesized convergence.
+     */
     std::vector<ScraperID> vIncludedScrapers;
+    /** The publishing scrapers excluded from the convergence. If the convergence is at the project level, a scraper in this
+     *   vector would not have been included in ANY project level match for the synthesized convergence.
+     */
     std::vector<ScraperID> vExcludedScrapers;
+    /** The scrapers not publishing (i.e. no manifests present with the retention period) when the convergence was formed. */
     std::vector<ScraperID> vScrapersNotPublishing;
 
-    // Used when convergence is at the project (bByParts) level (fallback)
-    // ----- Project --------- ScraperID
+    /** Used when convergence is at the project (bByParts) level (fallback)
+     * -------------- Project --- ScraperID
+     * std::multimap<std::string, ScraperID> mIncludedScrapersbyProject
+     */
     std::multimap<std::string, ScraperID> mIncludedScrapersbyProject;
-    // ----- ScraperID ------- Project
+    /** Used when convergence is at the project (bByParts) level (fallback)
+     * ------------- ScraperID --- Project
+     * std::multimap<ScraperID, std::string> mIncludedProjectsbyScraper
+     */
     std::multimap<ScraperID, std::string> mIncludedProjectsbyScraper;
-    // When bByParts (project) level convergence occurs, this records the count of scrapers in the
-    // convergences by project.
+    /** When bByParts (project) level convergence occurs, this records the count of scrapers in the
+     * convergences by project.
+     */
     std::map<std::string, unsigned int> mScraperConvergenceCountbyProject;
 
-    // --------- project
+    /** The projects excluded from the convergence. Since the convergence rules REQUIRE a fallback to project level
+     * convergence if the trial convergence formed at the manifest level excludes a project, this vector should only have
+     * an entry if bByParts is also true.
+     */
     std::vector<std::string> vExcludedProjects;
 
+    /** Populates the part pointers map in the convergence */
     bool PopulateConvergedManifestPartPtrsMap();
 
+    /** Computes the converged content hash */
     void ComputeConvergedContentHash();
 };
 
 
+/** Used for the key of the statistics map(s) in the scraper */
 struct ScraperObjectStatsKey
 {
     statsobjecttype objecttype;
     std::string objectID;
 };
 
+/** Used for the value of the stats entries in the statistics map(s) in the scraper */
 struct ScraperObjectStatsValue
 {
     double dTC;
@@ -136,12 +184,14 @@ struct ScraperObjectStatsValue
     double dMag;
 };
 
+/** Used for the stats entries in the statistics map(s) in the scraper */
 struct ScraperObjectStats
 {
     ScraperObjectStatsKey statskey;
     ScraperObjectStatsValue statsvalue;
 };
 
+/** Comparison for the statistics map entry ordering */
 struct ScraperObjectStatsKeyComp
 {
     bool operator() ( ScraperObjectStatsKey a, ScraperObjectStatsKey b ) const
@@ -150,17 +200,20 @@ struct ScraperObjectStatsKeyComp
     }
 };
 
+/** Definition of the scraper statistics map(s) */
 typedef std::map<ScraperObjectStatsKey, ScraperObjectStats, ScraperObjectStatsKeyComp> ScraperStats;
 
-// This is modeled after AppCacheEntry/Section but named separately.
+/** modeled after AppCacheEntry/Section but named separately. */
 struct ScraperBeaconEntry
 {
     std::string value; //!< Value of entry.
     int64_t timestamp; //!< Timestamp of entry.
 };
 
+/** Definition of the scraper beacon map */
 typedef std::map<std::string, ScraperBeaconEntry> ScraperBeaconMap;
 
+/** Small structure to define the fields and (un)serialization for pending beacon entries */
 struct ScraperPendingBeaconEntry
 {
     std::string cpid;
@@ -184,9 +237,14 @@ struct ScraperPendingBeaconEntry
     }
 };
 
-// --- Base58 encoded public key ---- cpid, timestamp
+/** - Base58 encoded public key - {cpid, timestamp, keyid}
+ *  std::map<std::string, ScraperPendingBeaconEntry> ScraperPendingBeaconMap
+ */
 typedef std::map<std::string, ScraperPendingBeaconEntry> ScraperPendingBeaconMap;
 
+/** Used to hold the block hash, scraper beacon map and pending beacon map at the ladder consensus point. This will be used
+ * as appropriate in the convergence formed.
+ */
 struct BeaconConsensus
 {
     uint256 nBlockHash;
@@ -194,6 +252,7 @@ struct BeaconConsensus
     ScraperPendingBeaconMap mPendingMap;
 };
 
+/** Small structure to define the fields for verified beacons and (un)serialization */
 struct ScraperVerifiedBeacons
 {
     // Initialize the timestamp to the current adjusted time.
@@ -217,13 +276,18 @@ struct ScraperVerifiedBeacons
     }
 };
 
+/** A combination of scraper stats and verified beacons. For convenience in the interface between the scraper and the
+ * quorum/superblock code.
+ */
 struct ScraperStatsAndVerifiedBeacons
 {
     ScraperStats mScraperStats;
     ScraperPendingBeaconMap mVerifiedMap;
 };
 
-// Extended AppCache structures similar to those in AppCache.h, except a deleted flag is provided
+/** Extended AppCache structure similar to those in AppCache.h, except a deleted flag is provided. This will be
+ * reimplemented in the future with a custom contract handler since the appcache is being retired.
+ */
 struct AppCacheEntryExt
 {
     std::string value; // Value of entry.
@@ -231,6 +295,9 @@ struct AppCacheEntryExt
     bool deleted; // Deleted flag.
 };
 
+/** Extended AppCache map typedef similar to those in AppCache.h, except a deleted flag is provided. This will be
+ * reimplemented in the future with a custom contract handler since the appcache is being retired.
+ */
 typedef std::unordered_map<std::string, AppCacheEntryExt> AppCacheSectionExt;
 
 #endif // GRIDCOIN_SCRAPER_FWD_H

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -4282,32 +4282,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key) EXCLUS
     return bAddManifestSuccessful;
 }
 
-ConvergedManifest::ConvergedManifest()
-{
-    nContentHash = {};
-    ConsensusBlock = {};
-    timestamp = 0;
-    bByParts = false;
-
-    CScraperConvergedManifest_ptr = nullptr;
-
-    ConvergedManifestPartPtrsMap = {};
-
-    mIncludedScraperManifests = {};
-
-    nUnderlyingManifestContentHash = {};
-
-    vIncludedScrapers = {};
-    vExcludedScrapers = {};
-    vScrapersNotPublishing = {};
-
-    mIncludedScrapersbyProject = {};
-    mIncludedProjectsbyScraper = {};
-
-    mScraperConvergenceCountbyProject = {};
-
-    vExcludedProjects = {};
-}
+ConvergedManifest::ConvergedManifest() { /* Use all defaults */ }
 
 ConvergedManifest::ConvergedManifest(CScraperManifest_shared_ptr& in)
 {
@@ -4316,7 +4291,6 @@ ConvergedManifest::ConvergedManifest(CScraperManifest_shared_ptr& in)
 
     ConsensusBlock = in->ConsensusBlock;
     timestamp = GetAdjustedTime();
-    bByParts = false;
 
     CScraperConvergedManifest_ptr = in;
 
@@ -4333,7 +4307,6 @@ bool ConvergedManifest::operator()(const CScraperManifest_shared_ptr& in)
 
     ConsensusBlock = in->ConsensusBlock;
     timestamp = GetAdjustedTime();
-    bByParts = false;
 
     CScraperConvergedManifest_ptr = in;
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -4268,7 +4268,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key) EXCLUS
 
     LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
 
-    bool bAddManifestSuccessful = CScraperManifest::addManifest(std::move(manifest), Key);
+    bool bAddManifestSuccessful = CScraperManifest::addManifest(manifest, Key);
 
     if (bAddManifestSuccessful)
         _log(logattribute::INFO, "ScraperSendFileManifestContents", "addManifest (send) from this scraper (address "

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -1578,7 +1578,7 @@ void Scraper(bool bSingleShot)
                 _log(logattribute::INFO, "Scraper", "Superblock not needed. age=" + ToString(sbage));
                 _log(logattribute::INFO, "Scraper", "Sleeping for " + ToString(scraper_sleep() / 1000) +" seconds");
 
-                if (!MilliSleep(nScraperSleep)) return;
+                if (!MilliSleep(scraper_sleep())) return;
             }
         }
 
@@ -1695,8 +1695,8 @@ void Scraper(bool bSingleShot)
 
             ScraperHousekeeping();
 
-            _log(logattribute::INFO, "Scraper", "Sleeping for " + ToString(nScraperSleep / 1000) +" seconds");
-            if (!MilliSleep(nScraperSleep)) return;
+            _log(logattribute::INFO, "Scraper", "Sleeping for " + ToString(scraper_sleep() / 1000) +" seconds");
+            if (!MilliSleep(scraper_sleep())) return;
         }
         else
             // This will break from the outer while loop if in singleshot mode and end execution after one pass.
@@ -1765,7 +1765,7 @@ void ScraperSubscriber()
         // Use the same sleep interval configured for the scraper.
         _log(logattribute::INFO, "ScraperSubscriber", "Sleeping for " + ToString(scraper_sleep() / 1000) +" seconds");
 
-        if (!MilliSleep(nScraperSleep)) return;
+        if (!MilliSleep(scraper_sleep())) return;
     }
 }
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -415,7 +415,6 @@ void UpdateVerifiedBeaconsFromConsensus(BeaconConsensus& Consensus)
     unsigned int stale = 0;
 
     LOCK(cs_VerifiedBeacons);
-    _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
     ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -452,8 +451,6 @@ void UpdateVerifiedBeaconsFromConsensus(BeaconConsensus& Consensus)
     {
         _log(logattribute::ERR, "UpdateVerifiedBeaconsFromConsensus", "Verified beacons save to disk failed.");
     }
-
-    _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
 }
 } // anonymous namespace
 
@@ -466,7 +463,6 @@ class ScraperLogger
 {
 
 private:
-
     static CCriticalSection cs_log;
 
     static boost::gregorian::date PrevArchiveCheckDate;
@@ -474,7 +470,6 @@ private:
     fsbridge::ofstream logfile;
 
 public:
-
     ScraperLogger()
     {
         LOCK(cs_log);
@@ -726,11 +721,9 @@ void _log(logattribute eType, const std::string& sCall, const std::string& sMess
 class stringbuilder
 {
 protected:
-
     std::stringstream builtstring;
 
 public:
-
     void append(const std::string &value)
     {
         builtstring << value;
@@ -819,7 +812,6 @@ private:
     fsbridge::ifstream userpassfile;
 
 public:
-
     userpass()
     {
         vuserpass.clear();
@@ -878,7 +870,6 @@ private:
     stringbuilder outdata;
 
 public:
-
     authdata(const std::string& project)
     {
         std::string outfile = project + "_auth.dat";
@@ -1012,7 +1003,6 @@ void ScraperApplyAppCacheEntries()
 {
     {
         LOCK(cs_ScraperGlobals);
-        _log(logattribute::INFO, "LOCK", "cs_ScraperGlobals");
 
         // If there are AppCache entries for the defaults in scraper.h override them. For the first two, this will also
         // override any GetArgs supplied from the command line, which is appropriate as network policy should take precedence.
@@ -1074,8 +1064,6 @@ void ScraperApplyAppCacheEntries()
         _log(logattribute::INFO, "ScraperApplyAppCacheEntries", "REQUIRE_TEAM_WHITELIST_MEMBERSHIP = " + ToString(REQUIRE_TEAM_WHITELIST_MEMBERSHIP));
         _log(logattribute::INFO, "ScraperApplyAppCacheEntries", "TEAM_WHITELIST = " + TEAM_WHITELIST);
         _log(logattribute::INFO, "ScraperApplyAppCacheEntries", "SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD = " + ToString(SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD));
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_ScraperGlobals");
     }
 
     AppCacheSection mScrapers = GetScrapersCache();
@@ -1090,8 +1078,6 @@ void ScraperApplyAppCacheEntries()
 
 AppCacheSection GetScrapersCache()
 {
-    //LOCK(cs_main);
-
     return ReadCacheSection(Section::SCRAPER);
 }
 
@@ -1149,7 +1135,6 @@ AppCacheSectionExt GetExtendedScrapersCache()
 // It can also be called in "single shot" mode.
 void Scraper(bool bSingleShot)
 {
-
     // Initialize these while still single-threaded. They cannot be initialized during declaration because GetDataDir()
     // gives the wrong value that early. If they are already initialized then leave them alone (because this function
     // can be called in singleshot mode.
@@ -1188,7 +1173,6 @@ void Scraper(bool bSingleShot)
         // Also delete any unauthorized CScraperManifests received before the wallet was in sync.
         {
             LOCK(cs_Scraper);
-            _log(logattribute::INFO, "LOCK", "cs_Scraper");
 
             ScraperDirectoryAndConfigSanity();
 
@@ -1196,9 +1180,6 @@ void Scraper(bool bSingleShot)
             // See the comment on the function.
 
             ScraperDeleteUnauthorizedCScraperManifests();
-
-            // End LOCK(cs_Scraper)
-            _log(logattribute::INFO, "ENDLOCK", "cs_Scraper");
         }
 
         int64_t sbage = SuperblockAge();
@@ -1233,14 +1214,10 @@ void Scraper(bool bSingleShot)
                 // Take a lock on the whole scraper for this...
                 {
                     LOCK(cs_Scraper);
-                    _log(logattribute::INFO, "LOCK", "cs_Scraper");
 
                     // The only things we do here while quiescent
                     ScraperDirectoryAndConfigSanity();
                     ScraperCullAndBinCScraperManifests();
-
-                    // End LOCK(cs_Scraper)
-                    _log(logattribute::INFO, "ENDLOCK", "cs_Scraper");
                 }
 
                 // Need the log archive check here, because we don't run housekeeping in this while loop.
@@ -1269,7 +1246,6 @@ void Scraper(bool bSingleShot)
         {
             // Take a lock on cs_Scraper for the main activity portion of the loop.
             LOCK(cs_Scraper);
-            _log(logattribute::INFO, "LOCK", "cs_Scraper");
 
             // Signal stats event to UI.
             uiInterface.NotifyScraperEvent(scrapereventtypes::Stats, CT_UPDATING, {});
@@ -1280,7 +1256,7 @@ void Scraper(bool bSingleShot)
             // Delete manifest entries not on whitelist. Take a lock on cs_StructScraperFileManifest for this.
             {
                 LOCK(cs_StructScraperFileManifest);
-                _log(logattribute::INFO, "LOCK", "download statistics block: cs_StructScraperFileManifest");
+
 
                 ScraperFileManifestMap::iterator entry;
 
@@ -1294,9 +1270,6 @@ void Scraper(bool bSingleShot)
                         DeleteScraperFileManifestEntry(entry_copy->second);
                     }
                 }
-
-                // End LOCK(cs_StructScraperFileManifest)
-                _log(logattribute::INFO, "ENDLOCK", "download statistics block: cs_StructScraperFileManifest");
             }
 
             AuthenticationETagClear();
@@ -1332,9 +1305,6 @@ void Scraper(bool bSingleShot)
 
             // Signal stats event to UI.
             uiInterface.NotifyScraperEvent(scrapereventtypes::Stats, CT_NEW, {});
-
-            // End LOCK(cs_Scraper)
-            _log(logattribute::INFO, "ENDLOCK", "cs_Scraper");
         }
 
         // This is the section to send out manifests. Only do if authorized.
@@ -1350,7 +1320,6 @@ void Scraper(bool bSingleShot)
             // Publish and/or local delete CScraperManifests.
             {
                 LOCK2(cs_StructScraperFileManifest, CScraperManifest::cs_mapManifest);
-                _log(logattribute::INFO, "LOCK2", "manifest send block: cs_StructScraperFileManifest, CScraperManifest::cs_mapManifest");
 
                 // If the hash doesn't match (a new one is available), or there are none, then publish a new one.
                 if (nmScraperFileManifestHash != StructScraperFileManifest.nFileManifestMapHash
@@ -1364,9 +1333,6 @@ void Scraper(bool bSingleShot)
                 }
 
                 nmScraperFileManifestHash = StructScraperFileManifest.nFileManifestMapHash;
-
-                // End LOCK(cs_StructScraperFileManifest)
-                _log(logattribute::INFO, "ENDLOCK2", "manifest send block: cs_StructScraperFileManifest, CScraperManifest::cs_mapManifest");
             }
         }
 
@@ -1435,7 +1401,6 @@ void ScraperSubscriber()
         if (!fScraperActive)
         {
             LOCK(cs_Scraper);
-            _log(logattribute::INFO, "LOCK", "cs_Scraper");
 
             ScraperDirectoryAndConfigSanity();
             // UnauthorizedCScraperManifests should only be seen on the first invocation after getting in sync
@@ -1444,9 +1409,6 @@ void ScraperSubscriber()
             ScraperDeleteUnauthorizedCScraperManifests();
 
             ScraperHousekeeping();
-
-            // END LOCK(cs_Scraper)
-            _log(logattribute::INFO, "ENDLOCK", "cs_Scraper");
         }
 
         // Use the same sleep interval configured for the scraper.
@@ -1539,7 +1501,6 @@ bool ScraperDirectoryAndConfigSanity()
             // Lock the manifest while it is being manipulated.
             {
                 LOCK(cs_StructScraperFileManifest);
-                _log(logattribute::INFO, "LOCK", "align directory with manifest file: cs_StructScraperFileManifest");
 
                 if (StructScraperFileManifest.mScraperFileManifest.empty())
                 {
@@ -1616,9 +1577,6 @@ bool ScraperDirectoryAndConfigSanity()
                         DeleteScraperFileManifestEntry(entry_copy->second);
                     }
                 }
-
-                // End LOCK(cs_StructScraperFileManifest)
-                _log(logattribute::INFO, "ENDLOCK", "align directory with manifest file: cs_StructScraperFileManifest");
             }
 
             // If network policy is set to filter on whitelisted teams, then load team ID map from file. This will prevent the heavyweight
@@ -1626,7 +1584,6 @@ bool ScraperDirectoryAndConfigSanity()
             if (require_team_whitelist_membership())
             {
                 LOCK(cs_TeamIDMap);
-                _log(logattribute::INFO, "LOCK", "cs_TeamIDMap");
 
                 if (TeamIDMap.empty())
                 {
@@ -1651,23 +1608,18 @@ bool ScraperDirectoryAndConfigSanity()
                         }
                     }
                 }
-
-                _log(logattribute::INFO, "ENDLOCK", "cs_TeamIDMap");
             }
 
             // If the verified beacons global has not been loaded from disk, then load it.
             // Log a warning if unsuccessful.
             {
                 LOCK(cs_VerifiedBeacons);
-                _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
                 if (!GetVerifiedBeacons().LoadedFromDisk && !LoadGlobalVerifiedBeacons())
                 {
-                    _log(logattribute::WARNING, "ScraperDirectoryAndConfigSanity", "Initial verified beacon load from file failed. "
-                                                        "This is not necessarily a problem.");
+                    _log(logattribute::WARNING, "ScraperDirectoryAndConfigSanity", "Initial verified beacon load from file "
+                                                                                   "failed. This is not necessarily a problem.");
                 }
-
-                _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
             }
         } // if fScraperActive
     }
@@ -1714,10 +1666,6 @@ bool UserpassPopulated()
 
     return true;
 }
-
-
-
-
 
 /**********************
 * Project Host Files  *
@@ -1833,10 +1781,6 @@ bool DownloadProjectHostFiles(const WhitelistSnapshot& projectWhitelist)
     return true;
 }
 
-
-
-
-
 /**********************
 * Project Team Files  *
 **********************/
@@ -1865,7 +1809,6 @@ bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist)
     for (const auto& prjs : projectWhitelist)
     {
         LOCK(cs_TeamIDMap);
-        _log(logattribute::INFO, "LOCK", "cs_TeamIDMap");
 
         const auto iter = TeamIDMap.find(prjs.m_name);
         bool fProjTeamIDsMissing = false;
@@ -2010,13 +1953,10 @@ bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist)
         // If require team whitelist is set and bETagChanged is true, then process the file. This also populates/updated the team whitelist TeamIDs
         // in the TeamIDMap and the ETag entries in the ProjTeamETags map.
         if (require_team_whitelist_membership() && bETagChanged) ProcessProjectTeamFile(prjs.m_name, team_file, sTeamETag);
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_TeamIDMap");
     }
 
     return true;
 }
-
 
 // Note this should be called with a lock held on cs_TeamIDMap, which is intended to protect both
 // TeamIDMap and ProjTeamETags.
@@ -2125,7 +2065,6 @@ bool ProcessProjectTeamFile(const std::string& project, const fs::path& file, co
     return true;
 }
 
-
 /**********************
 * Project RAC Files   *
 **********************/
@@ -2171,14 +2110,11 @@ bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
 
     {
         LOCK(cs_VerifiedBeacons);
-        _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
         // This is a copy on purpose. This map is in general
         // very small, and I want to minimize holding the
         // lock.
         GlobalVerifiedBeaconsCopy = GetVerifiedBeacons();
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
     }
 
     // This is a local map scoped to this function for use
@@ -2297,7 +2233,6 @@ bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
     // ProcessProjectRacFileByCPID iterations into the global.
     {
         LOCK(cs_VerifiedBeacons);
-        _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
         ScraperVerifiedBeacons& GlobalVerifiedBeacons = GetVerifiedBeacons();
 
@@ -2317,14 +2252,11 @@ bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
 
             }
         }
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
     }
 
     // After processing, update global structure with the timestamp of the latest file in the manifest.
     {
         LOCK(cs_StructScraperFileManifest);
-        _log(logattribute::INFO, "LOCK", "user (rac) files struct update post process: cs_StructScraperFileManifest");
 
         int64_t nMaxTime = 0;
         for (const auto& entry : StructScraperFileManifest.mScraperFileManifest)
@@ -2334,15 +2266,10 @@ bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
         }
 
         StructScraperFileManifest.timestamp = nMaxTime;
-
-        // End LOCK(cs_StructScraperFileManifest)
-        _log(logattribute::INFO, "ENDLOCK", "user (rac) files struct update post process: cs_StructScraperFileManifest");
     }
+
     return true;
 }
-
-
-
 
 // This version uses a consensus beacon map (and teamid, if team filtering is specified by policy) to filter statistics.
 bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& file, const std::string& etag,
@@ -2389,11 +2316,8 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
     if (require_team_whitelist_membership())
     {
         LOCK(cs_TeamIDMap);
-        _log(logattribute::INFO, "LOCK", "cs_TeamIDMap");
 
         mTeamIDsForProject = TeamIDMap.find(project)->second;
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_TeamIDMap");
     }
 
     std::string line;
@@ -2690,8 +2614,6 @@ bool LoadBeaconList(const fs::path& file, ScraperBeaconMap& mBeaconMap)
     return true;
 }
 
-
-
 bool LoadTeamIDList(const fs::path& file)
 {
     fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
@@ -2762,19 +2684,14 @@ bool LoadTeamIDList(const fs::path& file)
         }
 
         LOCK(cs_TeamIDMap);
-        _log(logattribute::INFO, "LOCK", "cs_TeamIDMap");
 
         // Insert into whitelist team ID map.
         if (!sProject.empty())
             TeamIDMap[sProject] = mTeamIDsForProject;
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_TeamIDMap");
     }
 
     return true;
 }
-
-
 
 bool StoreBeaconList(const fs::path& file)
 {
@@ -2787,12 +2704,8 @@ bool StoreBeaconList(const fs::path& file)
     // Requires a lock.
     {
         LOCK(cs_StructScraperFileManifest);
-        _log(logattribute::INFO, "LOCK", "store beacon list - update consensus block hash: cs_StructScraperFileManifest");
 
         StructScraperFileManifest.nConsensusBlockHash = Consensus.nBlockHash;
-
-        // End LOCK(cs_StructScraperFileManifest)
-        _log(logattribute::INFO, "ENDLOCK", "store beacon list - update consensus block hash: cs_StructScraperFileManifest");
     }
 
     if (fs::exists(file))
@@ -2833,8 +2746,6 @@ bool StoreBeaconList(const fs::path& file)
 
     return true;
 }
-
-
 
 bool StoreTeamIDList(const fs::path& file)
 {
@@ -2913,8 +2824,6 @@ bool StoreTeamIDList(const fs::path& file)
     return true;
 }
 
-
-
 // Insert entry into Manifest. Note that cs_StructScraperFileManifest needs to be taken before calling.
 bool InsertScraperFileManifestEntry(ScraperFileManifestEntry& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest)
 {
@@ -2959,8 +2868,6 @@ unsigned int DeleteScraperFileManifestEntry(ScraperFileManifestEntry& entry) EXC
     return ret;
 }
 
-
-
 // Mark manifest entry non-current. The reason this is encapsulated in a function is
 // to  ensure the rehash is done. Note that cs_StructScraperFileManifest needs to be
 // taken before calling.
@@ -2974,7 +2881,6 @@ bool MarkScraperFileManifestEntryNonCurrent(ScraperFileManifestEntry& entry) EXC
 
     return true;
 }
-
 
 void AlignScraperFileManifestEntries(const fs::path& file, const std::string& filetype, const std::string& sProject, const bool& excludefromcsmanifest)
 {
@@ -2996,15 +2902,6 @@ void AlignScraperFileManifestEntries(const fs::path& file, const std::string& fi
     // Code block to lock StructScraperFileManifest during record insertion and delete because we want this atomic.
     {
         LOCK(cs_StructScraperFileManifest);
-
-        if (excludefromcsmanifest)
-        {
-            _log(logattribute::INFO, "LOCK", "saved manifest for downloaded "+ filetype + " files: AlignScraperFileManifestEntries: cs_StructScraperFileManifest");
-        }
-        else
-        {
-            _log(logattribute::INFO, "LOCK", "saved manifest for processed "+ filetype + " files: AlignScraperFileManifestEntries: cs_StructScraperFileManifest");
-        }
 
         // Iterate mScraperFileManifest to find any prior filetype records for the same project and change current flag to false,
         // or delete if older than SCRAPER_FILE_RETENTION_TIME or non-current and fScraperRetainNonCurrentFiles
@@ -3043,19 +2940,8 @@ void AlignScraperFileManifestEntries(const fs::path& file, const std::string& fi
             _log(logattribute::ERR, "AlignScraperFileManifestEntries", "StoreScraperFileManifest error occurred");
         else
             _log(logattribute::INFO, "AlignScraperFileManifestEntries", "Stored Manifest");
-
-        // End LOCK(cs_StructScraperFileManifest)
-        if (excludefromcsmanifest)
-        {
-            _log(logattribute::INFO, "ENDLOCK", "saved manifest for downloaded "+ filetype + " files: AlignScraperFileManifestEntries: cs_StructScraperFileManifest");
-        }
-        else
-        {
-            _log(logattribute::INFO, "ENDLOCK", "saved manifest for processed "+ filetype + " files: AlignScraperFileManifestEntries: cs_StructScraperFileManifest");
-        }
     }
 }
-
 
 bool LoadScraperFileManifest(const fs::path& file)
 {
@@ -3151,18 +3037,13 @@ bool LoadScraperFileManifest(const fs::path& file)
         // global structure.
         {
             LOCK(cs_StructScraperFileManifest);
-            _log(logattribute::INFO, "LOCK", "load scraper file manifest - update entry: cs_StructScraperFileManifest");
 
             InsertScraperFileManifestEntry(LoadEntry);
-
-            // End LOCK(cs_StructScraperFileManifest
-            _log(logattribute::INFO, "ENDLOCK", "load scraper file manifest - update entry: cs_StructScraperFileManifest");
         }
     }
 
     return true;
 }
-
 
 bool StoreScraperFileManifest(const fs::path& file)
 {
@@ -3187,7 +3068,6 @@ bool StoreScraperFileManifest(const fs::path& file)
     //Lock StructScraperFileManifest during serialize to string.
     {
         LOCK(cs_StructScraperFileManifest);
-        _log(logattribute::INFO, "LOCK", "store scraper file manifest to file: cs_StructScraperFileManifest");
 
         // Header.
         stream << "Hash," << "Current," << "Time," << "Project," << "Filename," << "ExcludeFromCSManifest," << "Filetype" << "\n";
@@ -3205,9 +3085,6 @@ bool StoreScraperFileManifest(const fs::path& file)
                     + entry.second.filetype + "\n";
             stream << sScraperFileManifestEntry;
         }
-
-        // end LOCK(cs_StructScraperFileManifest)
-        _log(logattribute::INFO, "ENDLOCK", "store scraper file manifest to file: cs_StructScraperFileManifest");
     }
 
     _log(logattribute::INFO, "StoreScraperFileManifest", "Finished processing manifest from map.");
@@ -3221,8 +3098,6 @@ bool StoreScraperFileManifest(const fs::path& file)
 
     return true;
 }
-
-
 
 bool StoreStats(const fs::path& file, const ScraperStats& mScraperStats)
 {
@@ -3303,8 +3178,6 @@ bool StoreStats(const fs::path& file, const ScraperStats& mScraperStats)
 * Stats Computations   *
 ************************/
 
-
-
 bool LoadProjectFileToStatsByCPID(const std::string& project, const fs::path& file, const double& projectmag, ScraperStats& mScraperStats)
 {
     fsbridge::ifstream ingzfile(file, std::ios_base::in | std::ios_base::binary);
@@ -3325,8 +3198,6 @@ bool LoadProjectFileToStatsByCPID(const std::string& project, const fs::path& fi
     return bResult;
 }
 
-
-
 bool LoadProjectObjectToStatsByCPID(const std::string& project, const CSerializeData& ProjectData, const double& projectmag, ScraperStats& mScraperStats)
 {
     boostio::basic_array_source<char> input_source(&ProjectData[0], ProjectData.size());
@@ -3340,8 +3211,6 @@ bool LoadProjectObjectToStatsByCPID(const std::string& project, const CSerialize
 
     return bResult;
 }
-
-
 
 bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::filtering_istream& sUncompressedIn,
                                          const double& projectmag, ScraperStats& mScraperStats)
@@ -3469,7 +3338,6 @@ bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::fi
     mScraperStats[ProjectStatsEntry.statskey] = ProjectStatsEntry;
 
     return true;
-
 }
 
 // This function takes the mScraperMap core, which is the byCPIDbyProject
@@ -3587,16 +3455,12 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByCurrentFileManifestState()
     unsigned int nActiveProjects = 0;
     {
         LOCK(cs_StructScraperFileManifest);
-        _log(logattribute::INFO, "LOCK", "GetScraperStatsByCurrentFileManifestState - count active projects: cs_StructScraperFileManifest");
 
         for (auto const& entry : StructScraperFileManifest.mScraperFileManifest)
         {
             //
             if (entry.second.current && !entry.second.excludefromcsmanifest) nActiveProjects++;
         }
-
-        // End LOCK(cs_StructScraperFileManifest)
-        _log(logattribute::INFO, "ENDLOCK", "GetScraperStatsByCurrentFileManifestState - count active projects: cs_StructScraperFileManifest");
     }
     double dMagnitudePerProject = NETWORK_MAGNITUDE / nActiveProjects;
 
@@ -3607,7 +3471,6 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByCurrentFileManifestState()
 
     {
         LOCK(cs_StructScraperFileManifest);
-        _log(logattribute::INFO, "LOCK", "GetScraperStatsByCurrentFileManifestState - load project file to stats: cs_StructScraperFileManifest");
 
         for (auto const& entry : StructScraperFileManifest.mScraperFileManifest)
         {
@@ -3629,11 +3492,7 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByCurrentFileManifestState()
                 }
             }
         }
-
-        // End LOCK(cs_StructScraperFileManifest)
-        _log(logattribute::INFO, "ENDLOCK", "GetScraperStatsByCurrentFileManifestState - load project file to stats: cs_StructScraperFileManifest");
     }
-
 
     // Since this function uses the current project files for statistics, it also makes sense to use the current verified beacons map.
 
@@ -3641,13 +3500,10 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByCurrentFileManifestState()
 
     {
         LOCK(cs_VerifiedBeacons);
-        _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
         ScraperVerifiedBeacons& verified_beacons = GetVerifiedBeacons();
 
         stats_and_verified_beacons.mVerifiedMap = verified_beacons.mVerifiedMap;
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
     }
 
     ProcessNetworkWideFromProjectStats(mScraperStats);
@@ -3658,7 +3514,6 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByCurrentFileManifestState()
 
     return stats_and_verified_beacons;
 }
-
 
 ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest)
 {
@@ -3803,7 +3658,6 @@ bool ScraperSaveCScraperManifestToFiles(uint256 nManifestHash)
 {
     // Check to see if the hash exists in the manifest map, and if not, bail.
     LOCK(CScraperManifest::cs_mapManifest);
-    _log(logattribute::INFO, "LOCK", "CScraperManifest::cs_mapManifest");
 
     // Select manifest based on provided hash.
     auto pair = CScraperManifest::mapManifest.find(nManifestHash);
@@ -3818,12 +3672,8 @@ bool ScraperSaveCScraperManifestToFiles(uint256 nManifestHash)
     // the scraper thread loop, and therefore the directory may not have been set up yet.
     {
         LOCK(cs_Scraper);
-        _log(logattribute::INFO, "LOCK", "cs_Scraper");
 
         ScraperDirectoryAndConfigSanity();
-
-        // End LOCK(cs_Scraper).
-        _log(logattribute::INFO, "ENDLOCK", "cs_Scraper");
     }
 
     fs::path savepath = pathScraper / "manifest_dump";
@@ -3861,7 +3711,6 @@ bool ScraperSaveCScraperManifestToFiles(uint256 nManifestHash)
     const CScraperManifest_shared_ptr manifest = pair->second;
 
     LOCK(manifest->cs_manifest);
-    _log(logattribute::INFO, "LOCK", "cs_manifest");
 
     // Write out to files the parts. Note this assumes one-to-one part to file. Needs to
     // be fixed for more than one part per file.
@@ -3902,9 +3751,6 @@ bool ScraperSaveCScraperManifestToFiles(uint256 nManifestHash)
 
         iPartNum++;
     }
-
-    _log(logattribute::INFO, "ENDLOCK", "cs_manifest");
-    _log(logattribute::INFO, "ENDLOCK", "CScraperManifest::cs_mapManifest");
 
     return true;
 }
@@ -3967,7 +3813,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
 
                 // ... and it exists in the wallet...
                 LOCK(pwalletMain->cs_wallet);
-                _log(logattribute::INFO, "LOCK", "pwalletMain->cs_wallet");
 
                 if (pwalletMain->GetKey(KeyID, KeyOut))
                 {
@@ -3984,7 +3829,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
                          "Found address " + sScraperAddressFromConfig + " in both the wallet and appcache. \n"
                          "This scraper is authorized to publish manifests.");
 
-                    _log(logattribute::INFO, "ENDLOCK", "pwalletMain->cs_wallet");
                     return true;
                 }
                 else
@@ -3993,8 +3837,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
                          "Key not found in the wallet for matching address. Please check that the wallet is unlocked "
                          "(preferably for staking only).");
                 }
-
-                _log(logattribute::INFO, "ENDLOCK", "pwalletMain->cs_wallet");
             }
         }
     }
@@ -4003,7 +3845,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
     else
     {
         LOCK(pwalletMain->cs_wallet);
-        _log(logattribute::INFO, "LOCK", "pwalletMain->cs_wallet");
 
         for (auto const& item : pwalletMain->mapAddressBook)
         {
@@ -4049,7 +3890,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
                                  "Found address " + sScraperAddress + " in both the wallet and appcache. \n"
                                  "This scraper is authorized to publish manifests.");
 
-                            _log(logattribute::INFO, "ENDLOCK", "pwalletMain->cs_wallet");
                             return true;
                         }
                         else
@@ -4062,8 +3902,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
                 }
             }
         }
-
-        _log(logattribute::INFO, "ENDLOCK", "pwalletMain->cs_wallet");
     }
 
     // If we made it here, there is no match or valid key in the wallet
@@ -4072,7 +3910,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
 
     return false;
 }
-
 
 // This function computes the average time between manifests as a function of the last 10 received manifests
 // plus the nTime provided as the argument. This gives ten intervals for sampling between manifests. If the
@@ -4197,7 +4034,6 @@ unsigned int ScraperDeleteUnauthorizedCScraperManifests()
     unsigned int nDeleted = 0;
 
     LOCK(CScraperManifest::cs_mapManifest);
-    _log(logattribute::INFO, "LOCK", "CScraperManifest::cs_mapManifest");
 
     for (auto iter = CScraperManifest::mapManifest.begin(); iter != CScraperManifest::mapManifest.end(); )
     {
@@ -4210,12 +4046,9 @@ unsigned int ScraperDeleteUnauthorizedCScraperManifests()
         CPubKey pubkey;
         {
             LOCK(manifest->cs_manifest);
-            _log(logattribute::INFO, "LOCK", "cs_manifest");
 
             nTime = manifest->nTime;
             pubkey = manifest->pubkey;
-
-            _log(logattribute::INFO, "ENDLOCK", "cs_manifest");
         }
 
         // We are not going to do anything with the banscore here, but it is an out parameter of IsManifestAuthorized.
@@ -4227,30 +4060,21 @@ unsigned int ScraperDeleteUnauthorizedCScraperManifests()
 
             manifest->bCheckedAuthorized = true;
             ++iter;
-
-            _log(logattribute::INFO, "ENDLOCK", "cs_manifest");
         }
         else
         {
             LOCK(manifest->cs_manifest);
-            _log(logattribute::INFO, "LOCK", "cs_manifest");
 
             _log(logattribute::WARNING, "ScraperDeleteUnauthorizedCScraperManifests", "Deleting unauthorized manifest with hash " + iter->first.GetHex());
             // Delete from CScraperManifest map (also advances iter to the next valid element). Immediate flag is set, because there should be
             // no pending delete retention grace for this.
             iter = CScraperManifest::DeleteManifest(iter, true);
             nDeleted++;
-
-            _log(logattribute::INFO, "ENDLOCK", "cs_manifest");
         }
     }
 
-    // End LOCK(CScraperManifest::cs_mapManifest)
-    _log(logattribute::INFO, "ENDLOCK", "CScraperManifest::cs_mapManifest");
-
     return nDeleted;
 }
-
 
 // A lock needs to be taken on cs_StructScraperFileManifest for this function.
 // The sCManifestName is the public key of the scraper in address form.
@@ -4269,7 +4093,6 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key) EXCLUS
 
     {
         LOCK2(CSplitBlob::cs_mapParts, manifest->cs_manifest);
-        _log(logattribute::INFO, "LOCK2", "cs_mapParts, cs_manifest");
 
         // The manifest name is the authorized address of the scraper.
         manifest->sCManifestName = Address.ToString();
@@ -4331,7 +4154,6 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key) EXCLUS
         // because it will never match any whitelisted project. Only include it if it is not empty.
         {
             LOCK(cs_VerifiedBeacons);
-            _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
             ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -4360,8 +4182,6 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key) EXCLUS
 
                 iPartNum++;
             }
-
-            _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
         }
 
         for (auto const& entry : StructScraperFileManifest.mScraperFileManifest)
@@ -4441,8 +4261,6 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key) EXCLUS
 
             iPartNum++;
         }
-
-        _log(logattribute::INFO, "ENDLOCK2", "cs_mapParts, cs_manifest");
     }
 
     // "Sign" and "send".
@@ -4584,15 +4402,6 @@ void ConvergedManifest::ComputeConvergedContentHash()
     nContentHash = Hash(ss.begin(), ss.end());
 }
 
-
-
-
-
-
-
-
-
-
 // ------------------------------------ This an out parameter.
 bool ScraperConstructConvergedManifest(ConvergedManifest& StructConvergedManifest)
 {
@@ -4728,7 +4537,6 @@ bool ScraperConstructConvergedManifest(ConvergedManifest& StructConvergedManifes
     if (bConvergenceSuccessful)
     {
         LOCK(CScraperManifest::cs_mapManifest);
-        _log(logattribute::INFO, "LOCK", "CScraperManifest::cs_mapManifest");
 
         // Select agreed upon (converged) CScraper manifest based on converged hash.
         auto pair = CScraperManifest::mapManifest.find(convergence->second.second);
@@ -4775,8 +4583,6 @@ bool ScraperConstructConvergedManifest(ConvergedManifest& StructConvergedManifes
                 }
             }
         }
-
-        _log(logattribute::INFO, "ENDLOCK", "CScraperManifest::cs_mapManifest");
     }
 
     if (!bConvergenceSuccessful)
@@ -4802,7 +4608,6 @@ bool ScraperConstructConvergedManifest(ConvergedManifest& StructConvergedManifes
         uiInterface.NotifyScraperEvent(scrapereventtypes::Convergence, CT_DELETED, {});
 
     return bConvergenceSuccessful;
-
 }
 
 // Subordinate function to ScraperConstructConvergedManifest to try to find a convergence at the Project (part) level
@@ -4821,7 +4626,6 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
     StructConvergedManifest.CScraperConvergedManifest_ptr = std::shared_ptr<CScraperManifest>(new CScraperManifest);
 
     LOCK(StructConvergedManifest.CScraperConvergedManifest_ptr->cs_manifest);
-    _log(logattribute::INFO, "LOCK", "cs_manifest");
 
     // We are going to do this for each project in the whitelist.
     unsigned int iCountSuccessfulConvergedProjects = 0;
@@ -4844,7 +4648,6 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
 
         {
             LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
-            _log(logattribute::INFO, "LOCK2", "CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts");
 
             // For the selected project in the whitelist, walk each scraper.
             for (const auto& iter : mMapCSManifestsBinnedByScraper)
@@ -4860,7 +4663,6 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
                     CScraperManifest_shared_ptr manifest = pair->second;
 
                     LOCK(manifest->cs_manifest);
-                    _log(logattribute::INFO, "LOCK", "manifest->cs_manifest");
 
                     // Find the part number in the manifest that corresponds to the whitelisted project.
                     // Once we find a part that corresponds to the selected project in the given manifest, then break,
@@ -4916,12 +4718,8 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
 
                         }
                     }
-
-                    _log(logattribute::INFO, "ENDLOCK", "manifest->cs_manifest");
                 }
             }
-
-            _log(logattribute::INFO, "ENDLOCK2", "CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts");
         }
 
         // Walk the time map (backwards in time because the sort order is descending), and select the first
@@ -4948,10 +4746,8 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
                 std::map<uint256, CSplitBlob::CPart>::iterator iPart;
                 {
                     LOCK(CSplitBlob::cs_mapParts);
-                    _log(logattribute::INFO, "LOCK", "CSplitBlob::cs_mapParts");
 
                     iPart = CSplitBlob::mapParts.find(std::get<0>(iter.second));
-                    _log(logattribute::INFO, "ENDLOCK", "CSplitBlob::cs_mapParts");
                 }
 
                 uint256 nContentHashCheck = Hash(iPart->second.data.begin(), iPart->second.data.end());
@@ -5015,14 +4811,12 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
         // with a manifest that has the newest part associated with a successful part (project) level convergence.
 
         LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
-        _log(logattribute::INFO, "LOCK2", "CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts");
 
         // Select manifest based on provided hash.
         auto pair = CScraperManifest::mapManifest.find(nManifestHashForConvergedBeaconList);
         CScraperManifest_shared_ptr manifest = pair->second;
 
         LOCK(manifest->cs_manifest);
-        _log(logattribute::INFO, "LOCK", "manifest->cs_manifest");
 
         // Bail if BeaconList is not found or empty.
         if (pair == CScraperManifest::mapManifest.end() || manifest->vParts[0]->data.size() == 0)
@@ -5030,7 +4824,6 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
             _log(logattribute::WARNING, "ScraperConstructConvergedManifestByProject", "BeaconList was not found in the converged manifests from the scrapers.");
 
             bConvergenceSuccessful = false;
-            _log(logattribute::INFO, "ENDLOCK", "cs_manifest");
         }
         else
         {
@@ -5161,9 +4954,6 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
                     }
                 }
             }
-
-            _log(logattribute::INFO, "ENDLOCK", "manifest->cs_manifest");
-            _log(logattribute::INFO, "ENDLOCK2", "CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts");
         }
     }
 
@@ -5176,10 +4966,7 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
     }
 
     return bConvergenceSuccessful;
-
-    _log(logattribute::INFO, "ENDLOCK", "cs_manifest");
 }
-
 
 mmCSManifestsBinnedByScraper BinCScraperManifestsByScraper() EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest)
 {
@@ -5196,7 +4983,6 @@ mmCSManifestsBinnedByScraper BinCScraperManifestsByScraper() EXCLUSIVE_LOCKS_REQ
         uint256 nContentHash;
         {
             LOCK(manifest->cs_manifest);
-            _log(logattribute::INFO, "LOCK", "CScraperManifest::cs_mapManifest");
 
             // Do not consider manifests that do not have all of their parts.
             if (!manifest->isComplete()) continue;
@@ -5228,7 +5014,6 @@ mmCSManifestsBinnedByScraper BinCScraperManifestsByScraper() EXCLUSIVE_LOCKS_REQ
     return mMapCSManifestsBinnedByScraper;
 }
 
-
 mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests()
 {
     // Apply the SCRAPER_CMANIFEST_RETAIN_NONCURRENT bool and if false delete any existing
@@ -5248,7 +5033,6 @@ mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests()
     }
 
     LOCK(CScraperManifest::cs_mapManifest);
-    _log(logattribute::INFO, "LOCK", "CScraperManifest::cs_mapManifest");
 
     // Bin by scraper and order by manifest time within scraper bin.
     mmCSManifestsBinnedByScraper mMapCSManifestsBinnedByScraper = BinCScraperManifestsByScraper();
@@ -5300,11 +5084,8 @@ mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests()
     // SCRAPER_CMANIFEST_RETENTION_TIME as well.
     {
         LOCK(cs_ConvergedScraperStatsCache);
-        _log(logattribute::INFO, "LOCK", "cs_ConvergedScraperStatsCache");
 
         ConvergedScraperStatsCache.DeleteOldConvergenceFromPastConvergencesMap();
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_ConvergedScraperStatsCache");
     }
 
     unsigned int nPendingDeleted = 0;
@@ -5322,12 +5103,8 @@ mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests()
     // that large. (The lock on CScraperManifest::cs_mapManifest is still held from above.)
     mMapCSManifestsBinnedByScraper = BinCScraperManifestsByScraper();
 
-    _log(logattribute::INFO, "ENDLOCK", "CScraperManifest::cs_mapManifest");
-
     return mMapCSManifestsBinnedByScraper;
 }
-
-
 
 // ---------------------------------------------- In ---------------------------------------- Out
 bool LoadBeaconListFromConvergedManifest(const ConvergedManifest& StructConvergedManifest, ScraperBeaconMap& mBeaconMap)
@@ -5429,7 +5206,6 @@ std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& Verifie
     return result;
 }
 
-
 ScraperStatsAndVerifiedBeacons GetScraperStatsAndVerifiedBeacons(const ConvergedScraperStats &stats)
 {
     ScraperStatsAndVerifiedBeacons stats_and_verified_beacons;
@@ -5467,28 +5243,20 @@ ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global)
     if (from_global)
     {
         LOCK(cs_VerifiedBeacons);
-        _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
         // An intentional copy.
         VerifiedBeacons = GetVerifiedBeacons().mVerifiedMap;
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
-
     }
     else
     {
         LOCK(cs_ConvergedScraperStatsCache);
-        _log(logattribute::INFO, "LOCK", "cs_ConvergedScraperStatsCache");
 
         // An intentional copy.
         VerifiedBeacons = GetScraperStatsAndVerifiedBeacons(ConvergedScraperStatsCache).mVerifiedMap;
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_ConvergedScraperStatsCache");
     }
 
     return VerifiedBeacons;
 }
-
 
 /***********************
 *      Subscriber      *
@@ -5509,7 +5277,6 @@ Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bContrac
     bool bConvergenceUpdateNeeded = true;
     {
         LOCK(cs_ConvergedScraperStatsCache);
-        _log(logattribute::INFO, "LOCK", "cs_ConvergedScraperStatsCache");
 
         // If the cache is less than nScraperSleep in minutes old OR not dirty...
         if (GetAdjustedTime() - ConvergedScraperStatsCache.nTime < (scraper_sleep() / 1000) || ConvergedScraperStatsCache.bClean)
@@ -5517,9 +5284,6 @@ Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bContrac
             bConvergenceUpdateNeeded = false;
             _log(logattribute::INFO, __func__, "Cached convergence is fresh, convergence update not needed.");
         }
-
-        // End LOCK(cs_ConvergedScraperStatsCache)
-        _log(logattribute::INFO, "ENDLOCK", "cs_ConvergedScraperStatsCache");
     }
 
     ConvergedManifest StructConvergedManifest;
@@ -5604,11 +5368,7 @@ Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bContrac
                         if (superblock_Prev.WellFormed())
                             // If the current is empty and the previous was not empty, then the contract has been deleted.
                             uiInterface.NotifyScraperEvent(scrapereventtypes::SBContract, CT_DELETED, {});
-
-                    // End LOCK(cs_ConvergedScraperStatsCache)
-                    _log(logattribute::INFO, "ENDLOCK", "cs_ConvergedScraperStatsCache");
                 }
-
 
                 _log(logattribute::INFO, "ScraperGetSuperblockContract", "Superblock object generated from convergence");
 
@@ -5645,7 +5405,6 @@ Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bContrac
         // If we are here, we are using cached information.
 
         LOCK(cs_ConvergedScraperStatsCache);
-        _log(logattribute::INFO, "LOCK", "cs_ConvergedScraperStatsCache");
 
         superblock = ConvergedScraperStatsCache.NewFormatSuperblock;
 
@@ -5655,10 +5414,6 @@ Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bContrac
         uiInterface.NotifyScraperEvent(scrapereventtypes::SBContract, CT_UPDATED, {});
 
         _log(logattribute::INFO, "ScraperGetSuperblockContract", "Superblock object from cached converged stats");
-
-        // End LOCK(cs_ConvergedScraperStatsCache)
-        _log(logattribute::INFO, "ENDLOCK", "cs_ConvergedScraperStatsCache");
-
     }
 
     return superblock;
@@ -5682,20 +5437,15 @@ UniValue sendscraperfilemanifest(const UniValue& params, bool fHelp)
     if (IsScraperAuthorizedToBroadcastManifests(AddressOut, KeyOut))
     {
         LOCK(cs_StructScraperFileManifest);
-        _log(logattribute::INFO, "LOCK", "cs_StructScraperFileManifest");
 
         ret = ScraperSendFileManifestContents(AddressOut, KeyOut);
         uiInterface.NotifyScraperEvent(scrapereventtypes::Manifest, CT_NEW, {});
-
-        _log(logattribute::INFO, "ENDLOCK", "cs_StructScraperFileManifest");
     }
     else
         ret = false;
 
     return UniValue(ret);
 }
-
-
 
 UniValue savescraperfilemanifest(const UniValue& params, bool fHelp)
 {
@@ -5710,7 +5460,6 @@ UniValue savescraperfilemanifest(const UniValue& params, bool fHelp)
     return UniValue(ret);
 }
 
-
 UniValue deletecscrapermanifest(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1 )
@@ -5720,15 +5469,11 @@ UniValue deletecscrapermanifest(const UniValue& params, bool fHelp)
                 );
 
     LOCK(CScraperManifest::cs_mapManifest);
-    _log(logattribute::INFO, "LOCK", "CScraperManifest::cs_mapManifest");
 
     bool ret = CScraperManifest::DeleteManifest(uint256S(params[0].get_str()), true);
 
-    _log(logattribute::INFO, "ENDLOCK", "CScraperManifest::cs_mapManifest");
-
     return UniValue(ret);
 }
-
 
 UniValue archivelog(const UniValue& params, bool fHelp)
 {
@@ -5802,7 +5547,6 @@ UniValue ConvergedScraperStatsToJson(ConvergedScraperStats& ConvergedScraperStat
 
     return ret;
 }
-
 
 UniValue convergencereport(const UniValue& params, bool fHelp)
 {
@@ -6027,7 +5771,6 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
 
             bPastConvergencesEmpty = false;
         }
-
     }
 
     if (!bPastConvergencesEmpty)
@@ -6244,4 +5987,3 @@ UniValue scraperreport(const UniValue& params, bool fHelp)
 
     return ret;
 }
-

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -139,9 +139,9 @@ struct ScraperFileManifestEntry
     std::string filename; // Filename
     std::string project;
     uint256 hash; // hash of file
-    int64_t timestamp;
-    bool current;
-    bool excludefromcsmanifest;
+    int64_t timestamp = 0;
+    bool current = true;
+    bool excludefromcsmanifest = true;
     std::string filetype;
 };
 
@@ -152,7 +152,7 @@ struct ScraperFileManifest
     ScraperFileManifestMap mScraperFileManifest;
     uint256 nFileManifestMapHash;
     uint256 nConsensusBlockHash;
-    int64_t timestamp;
+    int64_t timestamp = 0;
 };
 
 // Both TeamIDMap and ProjTeamETags are protected by cs_TeamIDMap.
@@ -1321,9 +1321,10 @@ void Scraper(bool bSingleShot)
             {
                 LOCK2(cs_StructScraperFileManifest, CScraperManifest::cs_mapManifest);
 
-                // If the hash doesn't match (a new one is available), or there are none, then publish a new one.
-                if (nmScraperFileManifestHash != StructScraperFileManifest.nFileManifestMapHash
-                        || !CScraperManifest::mapManifest.size())
+                // If the hash is valid and doesn't match (a new one is available), or there are none, then publish a new one.
+                if (!StructScraperFileManifest.nFileManifestMapHash.IsNull()
+                        && (nmScraperFileManifestHash != StructScraperFileManifest.nFileManifestMapHash
+                            || !CScraperManifest::mapManifest.size()))
                 {
                     _log(logattribute::INFO, "Scraper", "Publishing new CScraperManifest.");
 

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2014-2021 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
-
 #ifndef GRIDCOIN_SCRAPER_SCRAPER_H
 #define GRIDCOIN_SCRAPER_SCRAPER_H
 
@@ -49,8 +48,8 @@ extern bool SCRAPER_CMANIFEST_RETAIN_NONCURRENT;
 extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME;
 extern bool SCRAPER_CMANIFEST_INCLUDE_NONCURRENT_PROJ_FILES;
 extern std::atomic<double> MAG_ROUND;
-extern std::atomic<double>  NETWORK_MAGNITUDE;
-extern std::atomic<double>  CPID_MAG_LIMIT;
+extern std::atomic<double> NETWORK_MAGNITUDE;
+extern std::atomic<double> CPID_MAG_LIMIT;
 extern unsigned int SCRAPER_CONVERGENCE_MINIMUM;
 extern double SCRAPER_CONVERGENCE_RATIO;
 extern double CONVERGENCE_BY_PROJECT_RATIO;

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -24,7 +24,7 @@
 #include "gridcoin/scraper/fwd.h"
 #include "gridcoin/superblock.h"
 
-// Thread safety
+// Thread safety. See scraper.cpp for documentation.
 extern CCriticalSection cs_Scraper;
 extern CCriticalSection cs_ScraperGlobals;
 extern CCriticalSection cs_mScrapersExt;
@@ -68,22 +68,114 @@ extern AppCacheSectionExt mScrapersExt;
 * Functions          *
 *********************/
 
+/**
+ * @brief Returns the hash of the provided input file path. If the file path cannot be resolved or an exception occurs
+ * in processing the file, a null hash is returned.
+ * @param inputfile
+ * @return uint256 hash
+ */
 uint256 GetFileHash(const fs::path& inputfile);
+/**
+ * @brief Provides the computed scraper stats and verified beacons from the input converged manifest
+ * @param StructConvergedManifest
+ * @return ScraperStatsAndVerifiedBeacons
+ */
 ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
+/**
+ * @brief Gets a copy of the extended scrapers cache global. This global is an extension of the appcache in that it
+ * retains deleted entries with a deleted flag.
+ * @return AppCacheSectionExt
+ */
 AppCacheSectionExt GetExtendedScrapersCache();
+/**
+ * @brief Returns whether this node is authorized to download statistics.
+ * @return bool
+ */
 bool IsScraperAuthorized();
+/**
+ * @brief Returns whether this node is authorized to broadcast statistics manifests to the network as a scraper.
+ * @param AddressOut
+ * @param KeyOut
+ * @return bool
+ *
+ * The idea here is that there are two levels of authorization. The first level is whether any
+ * node can operate as a "scraper", in other words, download the stats files themselves.
+ * The second level, which is the IsScraperAuthorizedToBroadcastManifests() function,
+ * is to authorize a particular node to actually be able to publish manifests.
+ * The second function is intended to override the first, with the first being a network wide
+ * policy. So to be clear, if the network wide policy has IsScraperAuthorized() set to false
+ * then ONLY nodes that have IsScraperAuthorizedToBroadcastManifests() can download stats at all.
+ * If IsScraperAuthorized() is set to true, then you have two levels of operation allowed.
+ * Nodes can run -scraper and download stats for themselves. They will only be able to publish
+ * manifests if for that node IsScraperAuthorizedToBroadcastManifests() evaluates to true.
+ * This allows flexibility in network policy, and will allow us to convert from a scraper based
+ * approach to convergence back to individual node stats download and convergence without a lot of
+ * headaches.
+ *
+ * This function checks to see if the local node is authorized to publish manifests. Note that this code could be
+ * modified to bypass this check, so messages sent will also be validated on receipt by the complement
+ * to this function, IsManifestAuthorized(CKey& Key) in the CScraperManifest class.
+ */
 bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& KeyOut);
+/**
+ * @brief Returns whether the scraper with the input public key at the input time has exceeded the maximum allowable
+ * manifest publishing rate. This is a DoS function and is used to issue misbehavior points, which could result in banning
+ * the node that has exceeded the max publishing rate.
+ * @param nTime
+ * @param PubKey
+ * @return bool
+ *
+ * This function computes the average time between manifests as a function of the last 10 received manifests
+ * plus the nTime provided as the argument. This gives ten intervals for sampling between manifests. If the
+ * average time between manifests is less than 50% of the nScraperSleep interval, or the most recent manifest
+ * for a scraper is more than five minutes in the future (accounts for clock skew) then the publishing rate
+ * of the scraper is deemed too high. This is actually used in CScraperManifest::IsManifestAuthorized to ban
+ * a scraper that is abusing the network by sending too many manifests over a very short period of time.
+ */
 bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
-GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false, bool bFromHousekeeping = false);
-scraperSBvalidationtype ValidateSuperblock(const GRC::Superblock& NewFormatSuperblock, bool bUseCache = true, unsigned int nReducedCacheBits = 32);
+/**
+ * @brief Generates a superblock (contract) from the current convergence. It will construct/update the convergence if needed.
+ * @param bStoreConvergedStats
+ * @param bContractDirectFromStatsUpdate
+ * @param bFromHousekeeping
+ * @return GRC::Superblock
+ */
+GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false,
+                                             bool bFromHousekeeping = false);
+/**
+ * @brief Gets the verified beacon ID's from the input converged manifest (overloaded)
+ * @param StructConvergedManifest
+ * @return std::vector<uint160> of beacon ID's
+ */
 std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
+/**
+ * @brief Gets the verified beacon ID's from the input VerifiedBeaconMap (overloaded)
+ * @param VerifiedBeaconMap
+ * @return std::vector<uint160> of beacon ID's
+ */
 std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& VerifiedBeaconMap);
+/**
+ * @brief Returns the scraper stats and verified beacons in one structure from the input ConvergedScraperStats
+ * @param stats
+ * @return ScraperStatsAndVerifiedBeacons
+ */
 ScraperStatsAndVerifiedBeacons GetScraperStatsAndVerifiedBeacons(const ConvergedScraperStats &stats);
+/**
+ * @brief Returns a map of pending beacons
+ * @return ScraperPendingBeaconMap of pending beacons
+ */
 ScraperPendingBeaconMap GetPendingBeaconsForReport();
+/**
+ * @brief Returns a map of verified beacons
+ * @param from_global
+ * @return ScraperPendingBeaconMap of verified beacons
+ */
 ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = false);
 
+/** Vector of strings that correspond with the statsobjecttype ENUM class */
 static std::vector<std::string> vstatsobjecttypestrings = { "NetWorkWide", "byCPID", "byProject", "byCPIDbyProject" };
 
+/** Vector of strings that correspond with the scraperSBvalidationtype ENUM class */
 static std::vector<std::string> scraperSBvalidationtypestrings = {
     "Invalid",
     "Unknown",
@@ -93,43 +185,50 @@ static std::vector<std::string> scraperSBvalidationtypestrings = {
     "ProjectLevelConvergence"
 };
 
-
+/**
+ * @brief Returns text that corresponds to the input statsobjecttype
+ * @param StatsObjType
+ * @return std::string
+ */
 const std::string GetTextForstatsobjecttype(statsobjecttype StatsObjType)
 {
     return vstatsobjecttypestrings[static_cast<int>(StatsObjType)];
 }
 
+/**
+ * @brief Returns text that corresponds to the input scraperSBvalidationtype
+ * @param ScraperSBValidationType
+ * @return std::string
+ */
 const std::string GetTextForscraperSBvalidationtype(scraperSBvalidationtype ScraperSBValidationType)
 {
     return scraperSBvalidationtypestrings[static_cast<int>(ScraperSBValidationType)];
 }
 
-
+/**
+ * @brief Rounds the double floating point magnitude according to the global parameter MAG_ROUND.
+ * @param dMag
+ * @return double
+ */
 double MagRound(double dMag)
 {
     return round(dMag / MAG_ROUND) * MAG_ROUND;
 }
 
+/**
+ * @brief Returns the number of scrapers required for a supermajority when determining a convergence. This is a CONSENSUS
+ * critical function
+ * @param nScraperCount
+ * @return unsigned int
+ */
 unsigned int NumScrapersForSupermajority(unsigned int nScraperCount)
 {
     LOCK(cs_ScraperGlobals);
 
-    unsigned int nRequired = std::max(SCRAPER_CONVERGENCE_MINIMUM, (unsigned int)std::ceil(SCRAPER_CONVERGENCE_RATIO * nScraperCount));
+    unsigned int nRequired = std::max(SCRAPER_CONVERGENCE_MINIMUM,
+                                      (unsigned int)std::ceil(SCRAPER_CONVERGENCE_RATIO * nScraperCount));
 
     return nRequired;
 }
-
-/*********************
-* Scraper            *
-*********************/
-
-// For version 2 of the scraper we will restructure into a class. For now this is a placeholder.
-/*
- * class scraper
-{
-public:
-    scraper();
-};
-*/
 
 #endif // GRIDCOIN_SCRAPER_SCRAPER_H

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -677,8 +677,10 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
     // hash the object
     uint256 hash(Hash(vRecv.begin(), vRecv.end()));
 
+    LOCK(cs_mapManifest);
+
     // see if we do not already have it
-    if (WITH_LOCK(cs_mapManifest, return AlreadyHave(pfrom, CInv(MSG_SCRAPERINDEX, hash))))
+    if (AlreadyHave(pfrom, CInv(MSG_SCRAPERINDEX, hash)))
     {
         LogPrint(BCLog::LogFlags::SCRAPER, "INFO: ScraperManifest::RecvManifest: Already have CScraperManifest %s from "
                                            "node %s.", hash.GetHex(), pfrom->addrName);
@@ -687,7 +689,7 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
 
     CScraperManifest_shared_ptr manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
 
-    LOCK2(cs_mapManifest, cs_mapParts);
+    LOCK(cs_mapParts);
 
     const auto it = mapManifest.emplace(hash, manifest);
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -423,7 +423,7 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest)
     }
 }
 
-bool CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_out)
+[[nodiscard]] bool CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_out)
 EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manifest)
 {
     const auto pbegin = ss.begin();

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -756,7 +756,7 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
     return true;
 }
 
-bool CScraperManifest::addManifest(std::shared_ptr<CScraperManifest>&& m, CKey& keySign)
+bool CScraperManifest::addManifest(std::shared_ptr<CScraperManifest> m, CKey& keySign)
 EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, cs_mapParts)
 {
     uint256 hash;

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -18,21 +18,26 @@
 
 #include <univalue.h>
 
-
-/** Abstract class for blobs that are split into parts. */
+/** Abstract class for blobs that are split into parts. This more complex approach using a parent vanilla parts class will
+ *  allow the parts system to be used for other purposes besides the scrapers if needed in the future.
+ * polymorphism.
+ */
 class CSplitBlob
 {
 public:
-    /** Parts of the Split object */
+    /** Parts of the Split object. For right now in the current implementation for the scraper system, all objects are
+     *  represented by one part. This provides the future capability to have large objects greater than the message size
+     *  limit (currently 32 MiB), but this is not necessary now.
+     */
     struct CPart {
-        std::set<std::pair<CSplitBlob*,unsigned>> refs;
+        std::set<std::pair<CSplitBlob*, unsigned int>> refs;
         CSerializeData data;
         uint256 hash;
         CPart(const uint256& ihash)
             :hash(ihash)
         {}
         CDataStream getReader() const { return CDataStream(data.begin(), data.end(), SER_NETWORK, PROTOCOL_VERSION); }
-        bool present() const {return !this->data.empty();}
+        bool present() const { return !this->data.empty(); }
     };
 
     // static methods
@@ -47,7 +52,7 @@ public:
     static bool SendPartTo(CNode* pto, const uint256& hash);
 
     // public methods
-    /** Boolean that returns whether all parts for the split object have been received. **/
+    /** Boolean that returns whether all parts for the split object have been received. */
     bool isComplete() const;
 
     /** Notification that this Split object is fully received. */
@@ -66,10 +71,9 @@ public:
     virtual ~CSplitBlob();
 
     // static variables
-    /** Mutex for mapParts **/
+    /** Mutex for mapParts */
     static CCriticalSection cs_mapParts;
 
-    /* We could store the parts in mapRelay and have getdata service for free. */
     /** map from part hash to scraper Index, so we can attach incoming Part in Index */
     static std::map<uint256, CPart> mapParts GUARDED_BY(cs_mapParts);
 
@@ -77,7 +81,7 @@ public:
     /** Guards vParts and other manifest fields of the manifest (derived) class.
      * Note that this needs to be mutable so that a lock can be taken internally on cs_manifest on an
      * otherwise const qualified member function.
-     **/
+     */
     mutable CCriticalSection cs_manifest;
 
     std::vector<CPart*> vParts GUARDED_BY(cs_manifest);
@@ -94,7 +98,7 @@ public: /* constructors */
     CScraperManifest(CScraperManifest& manifest);
 
 public: /* static methods */
-    /** Mutex protects both mapManifest and MapPendingDeletedManifest **/
+    /** Mutex protects both mapManifest and MapPendingDeletedManifest */
     static CCriticalSection cs_mapManifest;
 
     /** map from index hash to scraper Index, so we can process Inv messages */
@@ -123,7 +127,7 @@ public: /* static methods */
     /** Send a manifest of requested hash to node (from mapManifest).
      * @returns whether something was sent
      */
-     static bool SendManifestTo(CNode* pfrom, const uint256& hash);
+    static bool SendManifestTo(CNode* pfrom, const uint256& hash);
 
     /** Add new manifest object into list of known manifests */
     static bool addManifest(std::shared_ptr<CScraperManifest> m, CKey& keySign);
@@ -131,25 +135,29 @@ public: /* static methods */
     /** Validate whether received manifest is authorized */
     static bool IsManifestAuthorized(int64_t& nTime, CPubKey& PubKey, unsigned int& banscore_out);
 
-    /** Delete Manifest (key version) **/
+    /** Delete Manifest (key version) */
     static bool DeleteManifest(const uint256& nHash, const bool& fImmediate = false);
 
-    /** Delete Manifest (iterator version) **/
+    /** Delete Manifest (iterator version) */
     static std::map<uint256, std::shared_ptr<CScraperManifest>>::iterator
         DeleteManifest(std::map<uint256, std::shared_ptr<CScraperManifest>>::iterator& iter, const bool& fImmediate = false);
 
-    /** Delete PendingDeletedManifests **/
+    /** Delete PendingDeletedManifests */
     static unsigned int DeletePendingDeletedManifests();
 
 
 public: /*==== fields ====*/
-    /** Local only (not serialized) pointer to hash (index) field of mapManifest **/
+    /** LOCAL only (not serialized) pointer to hash (index) field of mapManifest */
     const uint256* phash GUARDED_BY(cs_manifest) = nullptr;
 
+    /** By convention the string version of the public key on the scraper used to publish the manifest */
     std::string sCManifestName GUARDED_BY(cs_manifest);
+    /** The public key of the private key used by the publishing scraper to sign the manifest */
     CPubKey pubkey GUARDED_BY(cs_manifest);
+    /** The signature on the manifest from the publishing scraper */
     std::vector<unsigned char> signature GUARDED_BY(cs_manifest);
 
+    /** Project "directory" entry in the manifest. The GridcoinTeamID is not used. */
     struct dentry {
         std::string project;
         std::string ETag;
@@ -162,22 +170,30 @@ public: /*==== fields ====*/
 
         void Serialize(CDataStream& s) const;
         void Unserialize(CDataStream& s);
+
+        /** Outputs content of dentry in JSON format. Helper function to CScraperManifest::ToJson(). */
         UniValue ToJson() const;
     };
 
+    /** Vector of project entries */
     std::vector<dentry> projects GUARDED_BY(cs_manifest);
 
+    /** Part index in the vParts vector for the BeaconList. This should always be zero once populated (the first element). */
     int BeaconList GUARDED_BY(cs_manifest) = -1 ;
     unsigned BeaconList_c GUARDED_BY(cs_manifest) = 0;
+    /** The block on which the convergence will be formed if this manifest is part of a convergence. */
     uint256 ConsensusBlock GUARDED_BY(cs_manifest);
+    /** The time the manifest was published */
     int64_t nTime GUARDED_BY(cs_manifest) = 0;
 
+    /** The hash of the manifest's contents (the vparts vector). This hash is used for matching purposes in a convergence. */
     uint256 nContentHash GUARDED_BY(cs_manifest);
 
-    // The bCheckedAuthorized flag is LOCAL only. It is not serialized/deserialized. This
-    // is set during Unserializecheck to false if wallet not in sync, and true if in sync
-    // and scraper ID matches authorized list (i.e. IsManifestAuthorized is true.
-    // The node will walk the mapManifest from
+    /** The bCheckedAuthorized flag is LOCAL only. It is not serialized/deserialized. This
+     * is set during Unserializecheck to false if wallet not in sync, and true if in sync
+     * and scraper ID matches authorized list (i.e. IsManifestAuthorized is true.
+     * The node will walk the mapManifest from
+     */
     bool bCheckedAuthorized GUARDED_BY(cs_manifest);
 
 public: /* public methods */
@@ -185,14 +201,23 @@ public: /* public methods */
     /** Hook called when all parts are available */
     void Complete() override;
 
-    /** Serialize this object for seding over the network. */
+    /** Serialize this object for sending over the network. This includes the signature as well as the payload. */
     void Serialize(CDataStream& s) const;
+    /** Serialize without the signature. We need this to generate the (inner) content for the hash to sign with the key. */
     void SerializeWithoutSignature(CDataStream& s) const;
+    /** Serialize the contents (vParts vector) for purposes of content comparison. This is used to fill out the nContentHash,
+     *  which is then included in SerializeWithoutSignature.
+     */
     void SerializeForManifestCompare(CDataStream& ss) const;
+    /** A combination of unserialization and integrity checking, which includes hash checks, authorization checks, and
+     *  signature checks.
+     */
     void UnserializeCheck(CDataStream& s, unsigned int& banscore_out);
 
+    /** Checks to see whether manifest age is current according to the SCRAPER_CMANIFEST_RETENTION_TIME network setting. */
     bool IsManifestCurrent() const;
 
+    /** Outputs manifest in JSON format. */
     UniValue ToJson() const;
 };
 

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -124,10 +124,10 @@ public: /* static methods */
      */
     static void PushInvTo(CNode* pto);
 
-    /** Send a manifest of requested hash to node (from mapManifest).
+    /** Send manifest pointed to by the provided smart pointer to node.
      * @returns whether something was sent
      */
-    static bool SendManifestTo(CNode* pfrom, const uint256& hash);
+    static bool SendManifestTo(CNode* pfrom, std::shared_ptr<CScraperManifest> manifest);
 
     /** Add new manifest object into list of known manifests */
     static bool addManifest(std::shared_ptr<CScraperManifest> m, CKey& keySign);

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -71,7 +71,7 @@ public:
 
     /* We could store the parts in mapRelay and have getdata service for free. */
     /** map from part hash to scraper Index, so we can attach incoming Part in Index */
-    static std::map<uint256,CPart> mapParts GUARDED_BY(cs_mapParts);
+    static std::map<uint256, CPart> mapParts GUARDED_BY(cs_mapParts);
 
     // member variables
     /** Guards vParts and other manifest fields of the manifest (derived) class.
@@ -143,7 +143,9 @@ public: /* static methods */
 
 
 public: /*==== fields ====*/
+    /** Local only (not serialized) pointer to hash (index) field of mapManifest **/
     const uint256* phash GUARDED_BY(cs_manifest) = nullptr;
+
     std::string sCManifestName GUARDED_BY(cs_manifest);
     CPubKey pubkey GUARDED_BY(cs_manifest);
     std::vector<unsigned char> signature GUARDED_BY(cs_manifest);

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -143,7 +143,7 @@ public: /* static methods */
 
 
 public: /*==== fields ====*/
-    const uint256* phash GUARDED_BY(cs_manifest);
+    const uint256* phash GUARDED_BY(cs_manifest) = nullptr;
     std::string sCManifestName GUARDED_BY(cs_manifest);
     CPubKey pubkey GUARDED_BY(cs_manifest);
     std::vector<unsigned char> signature GUARDED_BY(cs_manifest);

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -212,7 +212,7 @@ public: /* public methods */
     /** A combination of unserialization and integrity checking, which includes hash checks, authorization checks, and
      *  signature checks.
      */
-    void UnserializeCheck(CDataStream& s, unsigned int& banscore_out);
+    [[nodiscard]] bool UnserializeCheck(CDataStream& s, unsigned int& banscore_out);
 
     /** Checks to see whether manifest age is current according to the SCRAPER_CMANIFEST_RETENTION_TIME network setting. */
     bool IsManifestCurrent() const;

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -126,7 +126,7 @@ public: /* static methods */
      static bool SendManifestTo(CNode* pfrom, const uint256& hash);
 
     /** Add new manifest object into list of known manifests */
-    static bool addManifest(std::shared_ptr<CScraperManifest>&& m, CKey& keySign);
+    static bool addManifest(std::shared_ptr<CScraperManifest> m, CKey& keySign);
 
     /** Validate whether received manifest is authorized */
     static bool IsManifestAuthorized(int64_t& nTime, CPubKey& PubKey, unsigned int& banscore_out);

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -17,6 +17,7 @@
 #include <string>
 
 extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME;
+extern CCriticalSection cs_ScraperGlobals;
 
 extern std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
 extern std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& VerifiedBeaconMap);
@@ -1623,6 +1624,8 @@ struct ConvergedScraperStats
         std::map<uint32_t, std::pair<GRC::QuorumHash, ConvergedManifest>>::iterator iter;
         for (iter = PastConvergences.begin(); iter != PastConvergences.end(); )
         {
+            LOCK(cs_ScraperGlobals);
+
             // If the convergence entry is older than CManifest retention time, then delete the past convergence
             // entry, because the underlying CManifest will be deleted by the housekeeping loop using the same
             // aging. The erase advances the iterator in C++11.

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -1556,21 +1556,10 @@ struct hash<GRC::QuorumHash>
 // This is part of the scraper but is put here, because it needs the complete NN:Superblock class.
 struct ConvergedScraperStats
 {
-    ConvergedScraperStats() : Convergence(), NewFormatSuperblock()
-    {
-        bClean = false;
-        bMinHousekeepingComplete = false;
-
-        nTime = 0;
-        mScraperConvergedStats = {};
-        PastConvergences = {};
-    }
+    ConvergedScraperStats() : Convergence(), NewFormatSuperblock() { /* All defaults */ }
 
     ConvergedScraperStats(const int64_t nTime_in, const ConvergedManifest& Convergence) : Convergence(Convergence)
     {
-        bClean = false;
-        bMinHousekeepingComplete = false;
-
         nTime = nTime_in;
 
         mScraperConvergedStats = GetScraperStatsByConvergedManifest(Convergence).mScraperStats;
@@ -1579,7 +1568,7 @@ struct ConvergedScraperStats
     // Flag to indicate cache is clean or dirty (i.e. state change of underlying statistics has occurred.
     // This flag is marked true in ScraperGetSuperblockContract() and false on receipt or deletion of
     // statistics objects.
-    bool bClean;
+    bool bClean = false;
 
     // This flag tracks the completion of at least one iteration of the housekeeping loop. The purpose of this flag
     // is to ensure enough time has gone by after a (re)start of the wallet that a complete set of manifests/parts
@@ -1590,9 +1579,9 @@ struct ConvergedScraperStats
     // before the superblock is received. This has the effect of allowing a grace period of nScraperSleep after the
     // wallet start where an incoming superblock will allowed with Result::UNKNOWN, rather than rejected with
     // Result::INVALID.
-    bool bMinHousekeepingComplete;
+    bool bMinHousekeepingComplete = false;
 
-    int64_t nTime;
+    int64_t nTime = 0;
     ScraperStats mScraperConvergedStats;
     ConvergedManifest Convergence;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3337,9 +3337,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                             // but it is an out parameter of IsManifestAuthorized.
                             unsigned int banscore_out = 0;
 
-                            // We have to copy out the nTime and pubkey from the selected manifest, because the IsManifestAuthorized call
-                            // chain traverses the map and locks the cs_manifests in turn, which creats a deadlock potential if the cs_manifest
-                            // lock is already held on one of the manifests.
+                            // We have to copy out the nTime and pubkey from the selected manifest, because the
+                            // IsManifestAuthorized call chain traverses the map and locks the cs_manifests in turn,
+                            // which creates a deadlock potential if the cs_manifest lock is already held on one of
+                            // the manifests.
                             int64_t nTime = 0;
                             CPubKey pubkey;
                             {
@@ -3347,7 +3348,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
                                 nTime = manifest->nTime;
                                 pubkey = manifest->pubkey;
-
                             }
 
                             // Also don't send a manifest that is not current.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3078,7 +3078,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         /* Notify the peer about statsscraper blobs we have */
-        LOCK(CScraperManifest::cs_mapManifest);
+        LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
 
         CScraperManifest::PushInvTo(pfrom);
 
@@ -3186,17 +3186,25 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
         }
 
-        LOCK(cs_main);
-        CTxDB txdb("r");
         for (unsigned int nInv = 0; nInv < vInv.size(); nInv++)
         {
             const CInv &inv = vInv[nInv];
 
-            if (fShutdown)
-                return true;
-            pfrom->AddInventoryKnown(inv);
+            if (fShutdown) return true;
 
-            bool fAlreadyHave = AlreadyHave(txdb, inv);
+            // cs_main lock here must be tightly scoped and not be concatenated outside the cs_mapManifest lock, because
+            // that will lead to a deadlock. In the original position above the for loop, cs_main is taken first here, then
+            // cs_mapManifest below, while in the scraper thread, ScraperCullAndBinCScraperManifests() first locks
+            // cs_mapManifest, then calls ScraperDeleteUnauthorizedCScraperManifests(), which calls IsManifestAuthorized(),
+            // which locks cs_main to read the AppCacheSection for authorized scrapers.
+            bool fAlreadyHave;
+            {
+                LOCK(cs_main);
+                CTxDB txdb("r");
+
+                pfrom->AddInventoryKnown(inv);
+                fAlreadyHave = AlreadyHave(txdb, inv);
+            }
 
             // Check also the scraper data propagation system to see if it needs
             // this inventory object:
@@ -3208,20 +3216,26 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
             LogPrint(BCLog::LogFlags::NOISY, " got inventory: %s  %s", inv.ToString(), fAlreadyHave ? "have" : "new");
 
-            if (!fAlreadyHave)
-                pfrom->AskFor(inv);
-            else if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
-                pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(mapOrphanBlocks[inv.hash])->GetHash(true));
-            } else if (nInv == nLastBlock) {
-                // In case we are on a very long side-chain, it is possible that we already have
-                // the last block in an inv bundle sent in response to getblocks. Try to detect
-                // this situation and push another getblocks to continue.
-                pfrom->PushGetBlocks(mapBlockIndex[inv.hash], uint256());
-                LogPrint(BCLog::LogFlags::NOISY, "force getblock request: %s", inv.ToString());
-            }
+            // Relock cs_main after getting done with the CScraperManifest::AlreadyHave.
+            {
+                LOCK(cs_main);
 
-            // Track requests for our stuff
-            Inventory(inv.hash);
+                if (!fAlreadyHave)
+                    pfrom->AskFor(inv);
+                else if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
+                    pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(mapOrphanBlocks[inv.hash])->GetHash(true));
+                } else if (nInv == nLastBlock) {
+                    // In case we are on a very long side-chain, it is possible that we already have
+                    // the last block in an inv bundle sent in response to getblocks. Try to detect
+                    // this situation and push another getblocks to continue.
+                    pfrom->PushGetBlocks(mapBlockIndex[inv.hash], uint256());
+                    LogPrint(BCLog::LogFlags::NOISY, "force getblock request: %s", inv.ToString());
+                }
+
+                // Track requests for our stuff
+                Inventory(inv.hash);
+
+            }
         }
     }
 
@@ -3303,7 +3317,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 }
                 else if(!pushed &&  inv.type == MSG_SCRAPERINDEX)
                 {
-                    LOCK(CScraperManifest::cs_mapManifest);
+                    LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
 
                     // Do not send manifests while out of sync.
                     if (!OutOfSyncByAge())
@@ -3323,8 +3337,22 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                             // but it is an out parameter of IsManifestAuthorized.
                             unsigned int banscore_out = 0;
 
+                            // We have to copy out the nTime and pubkey from the selected manifest, because the IsManifestAuthorized call
+                            // chain traverses the map and locks the cs_manifests in turn, which creats a deadlock potential if the cs_manifest
+                            // lock is already held on one of the manifests.
+                            int64_t nTime = 0;
+                            CPubKey pubkey;
+                            {
+                                LOCK(manifest->cs_manifest);
+
+                                nTime = manifest->nTime;
+                                pubkey = manifest->pubkey;
+
+                            }
+
                             // Also don't send a manifest that is not current.
-                            if (CScraperManifest::IsManifestAuthorized(manifest->nTime, manifest->pubkey, banscore_out) && manifest->IsManifestCurrent())
+                            if (CScraperManifest::IsManifestAuthorized(nTime, pubkey, banscore_out)
+                                    && WITH_LOCK(manifest->cs_manifest, return manifest->IsManifestCurrent()))
                             {
                                 CScraperManifest::SendManifestTo(pfrom, inv.hash);
                             }
@@ -3662,15 +3690,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
     else if (strCommand == "scraperindex")
     {
-        LOCK(CScraperManifest::cs_mapManifest);
-
-        CScraperManifest::RecvManifest(pfrom,vRecv);
+        CScraperManifest::RecvManifest(pfrom, vRecv);
     }
     else if (strCommand == "part")
     {
-        LOCK(CSplitBlob::cs_mapParts);
-
-        CSplitBlob::RecvPart(pfrom,vRecv);
+        CSplitBlob::RecvPart(pfrom, vRecv);
     }
 
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -275,7 +275,7 @@ bool LockStackEmpty()
     return it->second.empty();
 }
 
-bool g_debug_lockorder_abort = false;
-bool g_debug_lockorder_throw_exception = false;
+bool g_debug_lockorder_abort = true;
+bool g_debug_lockorder_throw_exception = true;
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -275,7 +275,7 @@ bool LockStackEmpty()
     return it->second.empty();
 }
 
-bool g_debug_lockorder_abort = true;
-bool g_debug_lockorder_throw_exception = true;
+bool g_debug_lockorder_abort = false;
+bool g_debug_lockorder_throw_exception = false;
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -436,6 +436,8 @@ ConvergedScraperStats GetTestConvergence(
 
     auto CScraperConvergedManifest_ptr = std::shared_ptr<CScraperManifest>(new CScraperManifest());
 
+    LOCK(CScraperConvergedManifest_ptr->cs_manifest);
+
     convergence.mScraperConvergedStats = stats.mScraperStats;
 
     convergence.Convergence.bByParts = by_parts;
@@ -512,11 +514,10 @@ ConvergedScraperStats GetTestConvergence(
     uint256 manifest_hash(Hash(ss.begin(), ss.end()));
 
     // insert into the global map
-    const auto it = CScraperManifest::mapManifest.emplace(manifest_hash, std::move(CScraperConvergedManifest_ptr));
+    const auto it = CScraperManifest::mapManifest.emplace(manifest_hash, CScraperConvergedManifest_ptr);
 
-    CScraperManifest& manifest = *it.first->second;
     /* set the hash pointer inside */
-    manifest.phash= &it.first->first;
+    CScraperConvergedManifest_ptr->phash= &it.first->first;
 
     return convergence;
 }


### PR DESCRIPTION
This is a detailed PR that fully implements the appropriate keywords/qualifiers in the scraper system for the Clang thread safety static analysis. This allows advanced compilers to detect thread safety problems such as access to functions/variables without prior locks held. One thing the static analysis does NOT do is analyze for potential deadlocks due to lock order conflicts. In particular that caused a lot of headaches with this PR. The scraper is quite complex and uses a fine grained locking scheme to ensure that it can run relatively unimpeded with multiple threads accessing it. Unfortunately the by product of that is that extremely careful attention to locking order needs to be adhered to avoid deadlocks. The deadlock detection after many adjustments was done using manual code review of the call chains and the debug mode deadlock detection built into the wallet already in sync.h/cpp in debug mode. Note that this is difficult, because our old net code has an existing potential deadlock between cs_main and the cs_vnodes, which prevents running the wallet a long time to drain out all potential deadlocks.

Note: Once @div72 helped me get the Bitcoin sync.h/cpp port running the way I wanted where we could continue to run the wallet while logging potential deadlocks. I did a few more adjustments which are in the thread safety II commit. The remaining entries are all related to variations of the above mentioned potential deadlock and do not need to be fixed. We will cover those in the net code port.

~~I probably will squash some of these commits as this PR gets closer to completion, as they are too fine grained right now.~~ [Done] Also, I am going to be ripping out the scraper lock logging, as that has proven not to be terribly useful, and eats up log file space and also stresses out the core to GUI signaling to update the scraper tab.

I have also taken the time to improve the documentation of the scraper, including replacing the // style comments with Doxygen compliant commenting where appropriate.

I removed the move(s) for the CScraperManifests, because once I converted those to be accessed via smart shared pointers earlier, "moving" the ownership of the pointer during a call is downright silly, given the control block of the shared pointer keeps track of the references and the reference of the calling function will fall away as soon as it is out of scope.

I have also more fully encapsulated the scraper appcache/extended appcache in anticipation of ripping the appcache out and replacing it with a native contract handler for the scraper section.

~~Note that this is built on top of #2292, so includes those commits at the moment. They will disappear once #2292 is merged and this PR is rebased.~~ [Done]

Final note on testing: I have been running this on two different testnet scraper nodes, one of those in explorer mode, and it is running perfectly, with no problems and the two nodes participating in the convergences properly. I think this is ready to go.

There is one thread safety log entry remaining, and it is on PushMessages, but I believe it is a false positive. The PushMessages template appears to make copies of all of the Args... and I think that may be generating the false positive, because the custom serialization of the CScraperManifest appropriately does NOT copy the mutex.

A future improvement to the scraper would be to convert the custom reference system in the parts area to use smart shared pointers like the CScraperManifests, but that belongs in a separate PR, and the existing system is working perfectly, as demonstrated by running the scraperreport, which shows every object/reference fully accounted for.

Another future improvement would be to change the fallback rule to project level to be no more than 24 hours earlier than the present, as the existing algorithm will use the entire inventory of CScraperManifests to attempt a convergence at the manifest level before falling back to the project level if a project is not available. The effect of this the scraper to end up retaining the same statistics for two superblocks if a project has gone offline for < 48 hours. This change will correct that, but will have to be done at the next mandatory.

Finally, the scraper uses string fields rather than the newer native fields in the Fern+ code, and this is primarily because the scraper was written first, before the Fern code, before all of that refactoring was available. It would be good to retrofit the native fields and the more efficient storage/processing that goes along with it, but that is a significant amount of work for a dubious benefit at the current time.