### PR TITLE
qt: Replace deprecated Qt functions

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -288,7 +288,7 @@ QVariant AddressTableModel::headerData(int section, Qt::Orientation orientation,
 Qt::ItemFlags AddressTableModel::flags(const QModelIndex &index) const
 {
     if(!index.isValid())
-        return nullptr;
+        Qt::NoItemFlags;
     AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -288,7 +288,7 @@ QVariant AddressTableModel::headerData(int section, Qt::Orientation orientation,
 Qt::ItemFlags AddressTableModel::flags(const QModelIndex &index) const
 {
     if(!index.isValid())
-        Qt::NoItemFlags;
+        return Qt::NoItemFlags;
     AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -37,8 +37,13 @@ BitcoinAmountField::BitcoinAmountField(QWidget* parent) : QWidget(parent), amoun
     setFocusProxy(amount);
 
     // If one of the widgets changes, the combined content changes as well
-    connect(amount, static_cast<void (QDoubleSpinBox::*)(const QString&)>(&QDoubleSpinBox::valueChanged),
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        connect(amount, static_cast<void (QDoubleSpinBox::*)(const QString&)>(&QDoubleSpinBox::textChanged),
             this, &BitcoinAmountField::textChanged);
+    #else
+        connect(amount, static_cast<void (QDoubleSpinBox::*)(const QString&)>(&QDoubleSpinBox::valueChanged),
+            this, &BitcoinAmountField::textChanged);
+    #endif
     connect(unit, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &BitcoinAmountField::unitChanged);
 
 

--- a/src/qt/researcher/researcherwizardmodedetailpage.cpp
+++ b/src/qt/researcher/researcherwizardmodedetailpage.cpp
@@ -42,8 +42,13 @@ void ResearcherWizardModeDetailPage::initializePage()
     ui->modeButtonGroup->setId(ui->poolRadioButton, ResearcherWizard::ModePool);
     ui->modeButtonGroup->setId(ui->investorRadioButton, ResearcherWizard::ModeInvestor);
 
-    connect(ui->modeButtonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked),
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+        connect(ui->modeButtonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::idClicked),
             this, &ResearcherWizardModeDetailPage::onModeChange);
+    #else
+        connect(ui->modeButtonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked),
+            this, &ResearcherWizardModeDetailPage::onModeChange);
+    #endif
 
     if (m_researcher_model->configuredForInvestorMode()) {
         ui->investorRadioButton->setChecked(true);

--- a/src/qt/voting/pollwizardtypepage.cpp
+++ b/src/qt/voting/pollwizardtypepage.cpp
@@ -34,9 +34,14 @@ PollWizardTypePage::PollWizardTypePage(QWidget* parent)
     registerField("pollType*", type_proxy);
     setField("pollType", PollTypes::PollTypeUnknown);
 
-    connect(
-        m_type_buttons, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
-        [=](QAbstractButton*) { type_proxy->setValue(m_type_buttons->checkedId()); });
+    #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+        connect(
+            m_type_buttons, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
+            [=](QAbstractButton*) { type_proxy->setValue(m_type_buttons->checkedId()); });
+    #else
+        connect(m_type_buttons, &QButtonGroup::idClicked,
+            this, [=] { type_proxy->setValue(m_type_buttons->checkedId()); });
+    #endif
 }
 
 PollWizardTypePage::~PollWizardTypePage()

--- a/src/qt/voting/votewizardballotpage.cpp
+++ b/src/qt/voting/votewizardballotpage.cpp
@@ -39,9 +39,13 @@ VoteWizardBallotPage::VoteWizardBallotPage(QWidget *parent)
     registerField("txid", new DummyField(this), "", "");
     registerField("responseLabels", new DummyField(this));
 
-    connect(
-        m_choice_buttons.get(), QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
-        [this](QAbstractButton*) { emit completeChanged(); });
+    #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+        connect(
+            m_choice_buttons.get(), QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
+            [this](QAbstractButton*) { emit completeChanged(); });
+    #else
+        connect(m_choice_buttons.get(), &QButtonGroup::idClicked, this, [=] { emit completeChanged(); });
+    #endif
 }
 
 VoteWizardBallotPage::~VoteWizardBallotPage()


### PR DESCRIPTION
- `QSpinBox::valueChanged` was deprecated in QT 5.15.  Replace with `QSpinBox::textChanged`, introduced in 5.14. (https://doc.qt.io/qt-5/qspinbox-obsolete.html)
- `QFlags::QFlags(QFlags::Zero)` was deprecated in QT 5.15.  Replace with upstream solution `Qt::NoItemFlags`.  (https://doc.qt.io/qt-5/qflags-obsolete.html)
- `QButtonGroup::buttonClicked` was deprecated in QT 5.15.  Replace with `QButtonGroup::idClicked`. (https://doc.qt.io/qt-5/qbuttongroup-obsolete.html)