### PR TITLE
net: Small upstream FIXME

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -371,9 +371,8 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
         CNode* pnode = FindNode(static_cast<CService>(addrConnect));
         if (pnode)
         {
-            LogPrintf("Failed to open new connection, already connected FIXME\n");
-            pnode->AddRef();
-            return pnode;
+            LogPrintf("Failed to open new connection, already connected\n");
+            return nullptr;
         }
     }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -47,7 +47,6 @@ UniValue addnode(const UniValue& params, bool fHelp)
         CNode* pnode= ConnectNode(addr, strNode.c_str());
         if(!pnode)
             throw JSONRPCError(-23, "Error: Node connection failed");
-        //FIXME: should not the connection be release()d?
         UniValue result(UniValue::VOBJ);
         result.pushKV("result", "ok");
         return result;


### PR DESCRIPTION
Don't add failed connections to our refcount.  I believe this resolves two "FIXME" statements in the code.

Ref: https://github.com/bitcoin/bitcoin/pull/9626/commits/236618061a445d2cb11e722cfac5fdae5be26abb