### PR TITLE
poll: Fix the possible infinite loop warning on GetChoices() in result.cpp

### DIFF
--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -633,7 +633,21 @@ public:
     const LegacyChoiceMap& GetChoices()
     {
         if (m_legacy_choices_cache.empty()) {
-            for (uint8_t i = 0; i < m_poll.Choices().size(); ++i) {
+            uint8_t m_poll_choices_size = 0;
+
+            // This silences the code scan warning of a possible infinite loop due to the overflow of the uint8_t i counter
+            // against the comparison to m_poll.Choices.size(). Note it is the logged equivalent to std::min<uint8_t>. Since
+            // this is legacy polls only and those are no longer issued, and this condition does not actually exist in the
+            // chain, this is purely for formality's sake.
+            if (m_poll.Choices().size() > (size_t) std::numeric_limits<uint8_t>::max()) {
+                LogPrintf("WARN: %s: Number of legacy poll choices exceeds bins available in m_legacy_choices_cache map. "
+                          "Limiting to %u.", __func__, std::numeric_limits<uint8_t>::max());
+                m_poll_choices_size = std::numeric_limits<uint8_t>::max();
+            } else {
+                m_poll_choices_size = m_poll.Choices().size();
+            }
+
+            for (uint8_t i = 0; i < m_poll_choices_size; ++i) {
                 std::string label = m_poll.Choices().At(i)->m_label;
                 label = ToLower(label);
 


### PR DESCRIPTION
This is a bit silly change to silence the code scanner warning of a possible infinite loop condition in GetChoices() due to the loop counter being a uint8_t and the right hand size of the comparison condition being size_t. It is on legacy only polls anyway, of which no more are being issued, and this condition is not known to exist in the chain, so this PR is purely formality.