### PR TITLE
refactor: Fix three minor code scanner findings

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import plistlib
 import sys, re, os, shutil, stat, os.path
 from argparse import ArgumentParser
 from ds_store import DSStore

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -259,7 +259,6 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
             return TransactionCreationFailed;
         }
 
-		std::string samt = FormatMoney(wtx.vout[0].nValue);
         if(!uiInterface.ThreadSafeAskFee(nFeeRequired, tr("Sending...").toStdString()))
         {
             return Aborted;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -52,7 +52,7 @@ void CScheduler::serviceQueue()
                     if (newTaskScheduled.wait_until<>(lock, timeToWaitFor) == boost::cv_status::timeout) {
                         break; // Exit loop after timeout, it means we reached the time of the event
                     }
-                } catch (boost::thread_interrupted) {
+                } catch (boost::thread_interrupted&) {
                     // We need to make sure we don't ignore this, or the thread won't end
                     throw;
                 } catch (...) {


### PR DESCRIPTION
- Remove unused import `plistlib` in macdeployqtplus (Ref: https://github.com/bitcoin/bitcoin/pull/22199/commits/dca6c9032993f2bbf8047751d52f2a5c7ebd3ee4)
- Remove unused variable `samt` in walletmodel.  This has never been used.
- Avoid catching by value in scheduler.  I believe this was introduced in https://github.com/gridcoin-community/Gridcoin-Research/pull/1888