### PR TITLE
test: Add scheduler test coverage

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,35 @@
+name: CD
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release-win:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        script-id: [win32, win64]
+    env:
+      FILE_ENV: ./cd/00_setup_env_${{ matrix.script-id }}.sh
+      OS_NAME: linux
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+              ./depends/built
+              ./ci/scratch/.ccache
+          key: ${{ runner.os }}-${{ matrix.script-id }}
+      - name: build
+        run: |
+          ./cd/run_all.sh
+      - name: release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: '/tmp/release/*'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,12 +6,12 @@ on:
       - '*'
 
 jobs:
-  release-win:
+  release:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        script-id: [win32, win64]
+        script-id: [win32, win64, mac]
     env:
       FILE_ENV: ./cd/00_setup_env_${{ matrix.script-id }}.sh
       OS_NAME: linux
@@ -30,6 +30,6 @@ jobs:
         run: |
           ./cd/run_all.sh
       - name: release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@5e3f23f92c903aac25270f66388fdcb366c5b549
         with:
           files: '/tmp/release/*'

--- a/Makefile.am
+++ b/Makefile.am
@@ -128,7 +128,7 @@ $(OSX_TEMP_ISO): $(APP_DIST_EXTRAS)
 $(OSX_DMG): $(OSX_TEMP_ISO)
 	$(MKDIR_P) $(top_builddir)/release
 	$(DMG) dmg "$<" "$@"
-	@mv $@ $(top_builddir)/release/$@
+	@mv $@ $(top_builddir)/release/$(PACKAGE)-$(PACKAGE_VERSION)-macos.dmg
 
 dpi%.$(OSX_BACKGROUND_IMAGE): contrib/macdeploy/$(OSX_BACKGROUND_SVG)
 	sed 's/PACKAGE_NAME/$(PACKAGE_NAME)/' < "$<" | $(RSVG_CONVERT) -f png -d $* -p $* | $(IMAGEMAGICK_CONVERT) - $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,8 @@ $(BITCOIN_WIN_INSTALLER): all-recursive
 	@test -f $(MAKENSIS) && $(MAKENSIS) -V2 $(top_builddir)/share/setup.nsi || \
 	  echo error: could not build $@
 	@echo built $@
+	@rm release/gridcoinresearch.exe release/gridcoinresearchd.exe
+	@mv $@ $(top_builddir)/release/$@
 
 $(OSX_APP)/Contents/PkgInfo:
 	$(MKDIR_P) $(@D)
@@ -124,7 +126,9 @@ $(OSX_TEMP_ISO): $(APP_DIST_EXTRAS)
 	$(XORRISOFS) -D -l -V "$(OSX_VOLNAME)" -no-pad -r -dir-mode 0755 -o $@ dist -- $(if $(SOURCE_DATE_EPOCH),-volume_date all_file_dates =$(SOURCE_DATE_EPOCH))
 
 $(OSX_DMG): $(OSX_TEMP_ISO)
+	$(MKDIR_P) $(top_builddir)/release
 	$(DMG) dmg "$<" "$@"
+	@mv $@ $(top_builddir)/release/$@
 
 dpi%.$(OSX_BACKGROUND_IMAGE): contrib/macdeploy/$(OSX_BACKGROUND_SVG)
 	sed 's/PACKAGE_NAME/$(PACKAGE_NAME)/' < "$<" | $(RSVG_CONVERT) -f png -d $* -p $* | $(IMAGEMAGICK_CONVERT) - $@

--- a/cd/00_setup_env.sh
+++ b/cd/00_setup_env.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+# The root dir.
+# The ci system copies this folder.
+# This is where the depends build is done.
+BASE_ROOT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ >/dev/null 2>&1 && pwd )
+export BASE_ROOT_DIR
+
+echo "Setting specific values in env"
+if [ -n "${FILE_ENV}" ]; then
+  set -o errexit;
+  # shellcheck disable=SC1090
+  source "${FILE_ENV}"
+fi
+
+echo "Fallback to default values in env (if not yet set)"
+# The number of parallel jobs to pass down to make and test_runner.py
+export MAKEJOBS=${MAKEJOBS:--j4}
+# A folder for the ci system to put temporary files (ccache, datadirs for tests, ...)
+# This folder only exists on the ci host.
+export BASE_SCRATCH_DIR=${BASE_SCRATCH_DIR:-$BASE_ROOT_DIR/ci/scratch}
+# What host to compile for. See also ./depends/README.md
+# Tests that need cross-compilation export the appropriate HOST.
+# Tests that run natively guess the host
+export HOST=${HOST:-$("$BASE_ROOT_DIR/depends/config.guess")}
+# Whether to prefer BusyBox over GNU utilities
+export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
+export CONTAINER_NAME=${CONTAINER_NAME:-ci_unnamed}
+export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:18.04}
+# See man 7 debconf
+export DEBIAN_FRONTEND=noninteractive
+export CCACHE_SIZE=${CCACHE_SIZE:-100M}
+export CCACHE_TEMPDIR=${CCACHE_TEMPDIR:-/tmp/.ccache-temp}
+export CCACHE_COMPRESS=${CCACHE_COMPRESS:-1}
+# The cache dir.
+# This folder exists on the ci host and ci guest. Changes are propagated back and forth.
+export CCACHE_DIR=${CCACHE_DIR:-$BASE_SCRATCH_DIR/.ccache}
+# The depends dir.
+# This folder exists on the ci host and ci guest. Changes are propagated back and forth.
+export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}
+# Folder where the build result is put (bin and lib).
+export BASE_OUTDIR=${BASE_OUTDIR:-$BASE_SCRATCH_DIR/out/$HOST}
+# Folder where the build is done (dist and out-of-tree build).
+export BASE_BUILD_DIR=${BASE_BUILD_DIR:-$BASE_SCRATCH_DIR/build}
+export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
+export DOCKER_PACKAGES=${DOCKER_PACKAGES:-build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps bison}
+export PATH=${BASE_ROOT_DIR}/ci/retry:$PATH
+export CI_RETRY_EXE=${CI_RETRY_EXE:-"retry --"}

--- a/cd/00_setup_env_mac.sh
+++ b/cd/00_setup_env_mac.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_macos_cross
+export DOCKER_NAME_TAG=ubuntu:20.04
+export HOST=x86_64-apple-darwin18
+export PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools libtinfo5 python3-dev python3-setuptools xorriso"
+export XCODE_VERSION=12.1
+export XCODE_BUILD_ID=12A7403
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
+export GOAL="deploy"
+export GRIDCOIN_CONFIG="--with-gui --enable-reduce-exports"

--- a/cd/00_setup_env_mac.sh
+++ b/cd/00_setup_env_mac.sh
@@ -12,7 +12,4 @@ export HOST=x86_64-apple-darwin18
 export PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools libtinfo5 python3-dev python3-setuptools xorriso"
 export XCODE_VERSION=12.1
 export XCODE_BUILD_ID=12A7403
-export RUN_UNIT_TESTS=false
-export RUN_FUNCTIONAL_TESTS=false
-export GOAL="deploy"
 export GRIDCOIN_CONFIG="--with-gui --enable-reduce-exports"

--- a/cd/00_setup_env_win32.sh
+++ b/cd/00_setup_env_win32.sh
@@ -10,10 +10,6 @@ export CONTAINER_NAME=ci_win32
 export DOCKER_NAME_TAG=ubuntu:20.04
 export HOST=i686-w64-mingw32
 export PACKAGES="python3 nsis g++-mingw-w64-i686 wine-binfmt wine32"
-export RUN_UNIT_TESTS=false
-export RUN_FUNCTIONAL_TESTS=false
-# export RUN_SECURITY_TESTS="true"
 export GOAL="deploy"
 export GRIDCOIN_CONFIG="--enable-reduce-exports --with-gui=qt5"
 export DPKG_ADD_ARCH="i386"
-export NEED_XVFB="false"

--- a/cd/00_setup_env_win32.sh
+++ b/cd/00_setup_env_win32.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_win32
+export DOCKER_NAME_TAG=ubuntu:20.04
+export HOST=i686-w64-mingw32
+export PACKAGES="python3 nsis g++-mingw-w64-i686 wine-binfmt wine32"
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
+# export RUN_SECURITY_TESTS="true"
+export GOAL="deploy"
+export GRIDCOIN_CONFIG="--enable-reduce-exports --with-gui=qt5"
+export DPKG_ADD_ARCH="i386"
+export NEED_XVFB="false"

--- a/cd/00_setup_env_win64.sh
+++ b/cd/00_setup_env_win64.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_win64
+export DOCKER_NAME_TAG=ubuntu:20.04
+export HOST=x86_64-w64-mingw32
+export PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
+export GOAL="deploy"
+export GRIDCOIN_CONFIG="--enable-reduce-exports --with-gui=qt5"
+export RUN_UNIT_TESTS=false
+export NEED_XVFB="false"

--- a/cd/00_setup_env_win64.sh
+++ b/cd/00_setup_env_win64.sh
@@ -10,7 +10,4 @@ export CONTAINER_NAME=ci_win64
 export DOCKER_NAME_TAG=ubuntu:20.04
 export HOST=x86_64-w64-mingw32
 export PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
-export GOAL="deploy"
 export GRIDCOIN_CONFIG="--enable-reduce-exports --with-gui=qt5"
-export RUN_UNIT_TESTS=false
-export NEED_XVFB="false"

--- a/cd/03_before_install.sh
+++ b/cd/03_before_install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+BEGIN_FOLD () {
+  echo ""
+  CURRENT_FOLD_NAME=$1
+  echo "::group::${CURRENT_FOLD_NAME}"
+}
+
+END_FOLD () {
+  RET=$?
+    echo "::endgroup::"
+  if [ $RET != 0 ]; then
+    echo "${CURRENT_FOLD_NAME} failed with status code ${RET}"
+  fi
+}
+

--- a/cd/04_install.sh
+++ b/cd/04_install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+if [[ $DOCKER_NAME_TAG == centos* ]]; then
+  export LC_ALL=en_US.utf8
+fi
+if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
+  export LC_ALL=C
+fi
+
+# Create folders that are mounted into the docker
+mkdir -p "${CCACHE_DIR}"
+mkdir -p "/tmp/release"
+
+env | grep -E '^(GRIDCOIN_CONFIG|BASE_|QEMU_|CCACHE_|LC_ALL|BOOST_TEST_RANDOM|DEBIAN_FRONTEND|CONFIG_SHELL|(ASAN|LSAN|TSAN|UBSAN)_OPTIONS|PREVIOUS_RELEASES_DIR)' | tee /tmp/env
+
+export P_CI_DIR="$PWD"
+
+mkdir -p /tmp/release
+
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
+  echo "Creating $DOCKER_NAME_TAG container to run in"
+  ${CI_RETRY_EXE} docker pull "$DOCKER_NAME_TAG"
+
+  DOCKER_ID=$(docker run $DOCKER_ADMIN -idt \
+                  --mount type=bind,src=$BASE_ROOT_DIR,dst=/ro_base,readonly \
+                  --mount type=bind,src=$CCACHE_DIR,dst=$CCACHE_DIR \
+                  --mount type=bind,src=$DEPENDS_DIR,dst=$DEPENDS_DIR \
+                  --mount type=bind,src=/tmp/release,dst=/release \
+                  -w $BASE_ROOT_DIR \
+                  --env-file /tmp/env \
+                  --name $CONTAINER_NAME \
+                  $DOCKER_NAME_TAG)
+  export DOCKER_CI_CMD_PREFIX="docker exec $DOCKER_ID"
+else
+  echo "Running on host system without docker wrapper"
+fi
+
+DOCKER_EXEC () {
+  $DOCKER_CI_CMD_PREFIX bash -c "export PATH=$BASE_SCRATCH_DIR/bins/:\$PATH && cd $P_CI_DIR && $*"
+}
+export -f DOCKER_EXEC
+
+if [ -n "$DPKG_ADD_ARCH" ]; then
+  DOCKER_EXEC dpkg --add-architecture "$DPKG_ADD_ARCH"
+fi
+
+if [[ $DOCKER_NAME_TAG == centos* ]]; then
+  BEGIN_FOLD yum
+  ${CI_RETRY_EXE} DOCKER_EXEC yum -y install epel-release
+  ${CI_RETRY_EXE} DOCKER_EXEC yum -y install $DOCKER_PACKAGES $PACKAGES
+  END_FOLD
+elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
+  BEGIN_FOLD apt
+  ${CI_RETRY_EXE} DOCKER_EXEC apt-get update
+  ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
+  if [ "$NEED_XVFB" == "true" ]; then
+    ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y xvfb
+  fi
+  END_FOLD
+fi
+
+if [ "$OS_NAME" == "macos" ]; then
+  top -l 1 -s 0 | awk ' /PhysMem/ {print}'
+  echo "Number of CPUs: $(sysctl -n hw.logicalcpu)"
+else
+  DOCKER_EXEC free -m -h
+  DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
+  DOCKER_EXEC echo $(lscpu | grep Endian)
+  DOCKER_EXEC echo "Free disk space:"
+  DOCKER_EXEC df -h
+fi
+
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
+  echo "Create $BASE_ROOT_DIR"
+  DOCKER_EXEC rsync -a /ro_base/ $BASE_ROOT_DIR
+fi
+
+if [ "$USE_BUSY_BOX" = "true" ]; then
+  echo "Setup to use BusyBox utils"
+  DOCKER_EXEC mkdir -p $BASE_SCRATCH_DIR/bins/
+  # tar excluded for now because it requires passing in the exact archive type in ./depends (fixed in later BusyBox version)
+  # find excluded for now because it does not recognize the -delete option in ./depends (fixed in later BusyBox version)
+  # ar excluded for now because it does not recognize the -q option in ./depends (unknown if fixed)
+  # shellcheck disable=SC1010
+  DOCKER_EXEC for util in \$\(busybox --list \| grep -v "^ar$" \| grep -v "^tar$" \| grep -v "^find$"\)\; do ln -s \$\(command -v busybox\) $BASE_SCRATCH_DIR/bins/\$util\; done
+  # Print BusyBox version
+  DOCKER_EXEC patch --help
+fi

--- a/cd/04_install.sh
+++ b/cd/04_install.sh
@@ -59,9 +59,6 @@ elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
   BEGIN_FOLD apt
   ${CI_RETRY_EXE} DOCKER_EXEC apt-get update
   ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
-  if [ "$NEED_XVFB" == "true" ]; then
-    ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y xvfb
-  fi
   END_FOLD
 fi
 

--- a/cd/05_before_script.sh
+++ b/cd/05_before_script.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+DOCKER_EXEC mkdir -p ${DEPENDS_DIR}/SDKs ${DEPENDS_DIR}/sdk-sources
+
+OSX_SDK_BASENAME="Xcode-${XCODE_VERSION}-${XCODE_BUILD_ID}-extracted-SDK-with-libcxx-headers.tar.gz"
+OSX_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OSX_SDK_BASENAME}"
+
+if [ -n "$XCODE_VERSION" ] && [ ! -f "$OSX_SDK_PATH" ]; then
+  sudo curl --location --fail "${SDK_URL}/${OSX_SDK_BASENAME}" -o "$OSX_SDK_PATH"
+fi
+
+if [ -n "$XCODE_VERSION" ] && [ -f "$OSX_SDK_PATH" ]; then
+  DOCKER_EXEC tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
+fi
+if [[ $HOST = *-mingw32 ]]; then
+  DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
+fi
+if [ -z "$NO_DEPENDS" ]; then
+  if [[ $DOCKER_NAME_TAG == centos* ]]; then
+    # CentOS has problems building the depends if the config shell is not explicitly set
+    # (i.e. for libevent a Makefile with an empty SHELL variable is generated, leading to
+    #  an error as the first command is executed)
+    SHELL_OPTS="CONFIG_SHELL=/bin/bash"
+  else
+    SHELL_OPTS="CONFIG_SHELL="
+  fi
+  DOCKER_EXEC $SHELL_OPTS make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+fi
+if [[ $HOST = x86_64-apple-darwin* ]]; then
+  DOCKER_EXEC "cd src/ && ../contrib/nomacro.pl"
+fi

--- a/cd/06_script_a.sh
+++ b/cd/06_script_a.sh
@@ -9,33 +9,23 @@ export LC_ALL=C.UTF-8
 GRIDCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$DEPENDS_DIR/$HOST --bindir=$BASE_OUTDIR/bin --libdir=$BASE_OUTDIR/lib"
 DOCKER_EXEC "ccache --zero-stats --max-size=$CCACHE_SIZE"
 
+DOCKER_EXEC mkdir -p "${BASE_BUILD_DIR}/gridcoin-$HOST"
+export P_CI_DIR="${BASE_BUILD_DIR}/gridcoin-$HOST"
+
 BEGIN_FOLD autogen
 if [ -n "$CONFIG_SHELL" ]; then
-  DOCKER_EXEC "$CONFIG_SHELL" -c "./autogen.sh"
+  DOCKER_EXEC "$CONFIG_SHELL" -c "{BASE_ROOT_DIR}/autogen.sh"
 else
-  DOCKER_EXEC ./autogen.sh
+  DOCKER_EXEC ${BASE_ROOT_DIR}/autogen.sh
 fi
 END_FOLD
 
-DOCKER_EXEC mkdir -p "${BASE_BUILD_DIR}"
-export P_CI_DIR="${BASE_BUILD_DIR}"
-
 BEGIN_FOLD configure
-DOCKER_EXEC "${BASE_ROOT_DIR}/configure" --cache-file=config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
-END_FOLD
-
-BEGIN_FOLD distdir
-DOCKER_EXEC make distdir VERSION=$HOST
-END_FOLD
-
-export P_CI_DIR="${BASE_BUILD_DIR}/gridcoin-$HOST"
-
-BEGIN_FOLD configure
-DOCKER_EXEC ./configure --cache-file=../config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
+DOCKER_EXEC ${BASE_ROOT_DIR}/configure $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
 END_FOLD
 
 BEGIN_FOLD build
-DOCKER_EXEC make $MAKEJOBS deploy || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false )
+DOCKER_EXEC make $MAKEJOBS deploy || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make deploy V=1 ; false )
 END_FOLD
 
 BEGIN_FOLD cache_stats

--- a/cd/06_script_a.sh
+++ b/cd/06_script_a.sh
@@ -41,5 +41,4 @@ END_FOLD
 BEGIN_FOLD cache_stats
 DOCKER_EXEC "ccache --version | head -n 1 && ccache --show-stats"
 DOCKER_EXEC du -sh "${DEPENDS_DIR}"/*/
-DOCKER_EXEC du -sh "${PREVIOUS_RELEASES_DIR}"
 END_FOLD

--- a/cd/06_script_a.sh
+++ b/cd/06_script_a.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+GRIDCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$DEPENDS_DIR/$HOST --bindir=$BASE_OUTDIR/bin --libdir=$BASE_OUTDIR/lib"
+DOCKER_EXEC "ccache --zero-stats --max-size=$CCACHE_SIZE"
+
+BEGIN_FOLD autogen
+if [ -n "$CONFIG_SHELL" ]; then
+  DOCKER_EXEC "$CONFIG_SHELL" -c "./autogen.sh"
+else
+  DOCKER_EXEC ./autogen.sh
+fi
+END_FOLD
+
+DOCKER_EXEC mkdir -p "${BASE_BUILD_DIR}"
+export P_CI_DIR="${BASE_BUILD_DIR}"
+
+BEGIN_FOLD configure
+DOCKER_EXEC "${BASE_ROOT_DIR}/configure" --cache-file=config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
+END_FOLD
+
+BEGIN_FOLD distdir
+DOCKER_EXEC make distdir VERSION=$HOST
+END_FOLD
+
+export P_CI_DIR="${BASE_BUILD_DIR}/gridcoin-$HOST"
+
+BEGIN_FOLD configure
+DOCKER_EXEC ./configure --cache-file=../config.cache $GRIDCOIN_CONFIG_ALL $GRIDCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
+END_FOLD
+
+BEGIN_FOLD build
+DOCKER_EXEC make $MAKEJOBS deploy || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false )
+END_FOLD
+
+BEGIN_FOLD cache_stats
+DOCKER_EXEC "ccache --version | head -n 1 && ccache --show-stats"
+DOCKER_EXEC du -sh "${DEPENDS_DIR}"/*/
+DOCKER_EXEC du -sh "${PREVIOUS_RELEASES_DIR}"
+END_FOLD

--- a/cd/06_script_b.sh
+++ b/cd/06_script_b.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+DOCKER_EXEC mv release/* /release
+
+for f in /tmp/release/*; do
+    sha256sum $f > $f.SHA256
+done

--- a/cd/06_script_b.sh
+++ b/cd/06_script_b.sh
@@ -8,6 +8,15 @@ export LC_ALL=C.UTF-8
 
 DOCKER_EXEC mv release/* /release
 
-for f in /tmp/release/*; do
+if [[ $HOST = *-apple-* ]]; then
+	KV=$(cat $BASE_ROOT_DIR/depends/hosts/darwin.mk | grep "OSX_MIN_VERSION=")
+	VER=${KV#OSX_MIN_VERSION=}
+	for f in /tmp/release/*.dmg; do
+		mv $f ${f%.dmg}-min-$VER.dmg
+	done
+fi
+
+cd /tmp/release/
+for f in *; do
     sha256sum $f > $f.SHA256
 done

--- a/cd/run_all.sh
+++ b/cd/run_all.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+set -o errexit; source ./cd/00_setup_env.sh
+set -o errexit; source ./cd/03_before_install.sh
+set -o errexit; source ./cd/04_install.sh
+set -o errexit; source ./cd/05_before_script.sh
+set -o errexit; source ./cd/06_script_a.sh
+set -o errexit; source ./cd/06_script_b.sh

--- a/configure.ac
+++ b/configure.ac
@@ -887,7 +887,7 @@ fi
 if test x$use_boost = xyes; then
 
 dnl Minimum required Boost version
-define(MINIMUM_REQUIRED_BOOST, 1.58.0)
+define(MINIMUM_REQUIRED_BOOST, 1.60.0)
 
 dnl Check for Boost libs
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
@@ -957,11 +957,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   #include <boost/thread/thread.hpp>
   #include <boost/version.hpp>
   ]],[[
-  #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
-      boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
-  #else
-   choke me
-  #endif
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
   ]])],
   [boost_sleep=yes;
      AC_DEFINE(HAVE_WORKING_BOOST_SLEEP_FOR, 1, [Define this symbol if boost sleep_for works])],

--- a/configure.ac
+++ b/configure.ac
@@ -1193,7 +1193,6 @@ AC_SUBST(QR_LIBS)
 AC_CONFIG_FILES([Makefile src/Makefile share/setup.nsi share/qt/Info.plist])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])
-AC_CONFIG_LINKS([CHANGELOG.md:CHANGELOG.md COPYING:COPYING])
 
 dnl boost's m4 checks do something really nasty: they export these vars. As a
 dnl result, they leak into secp256k1's configure and crazy things happen.

--- a/configure.ac
+++ b/configure.ac
@@ -1193,6 +1193,7 @@ AC_SUBST(QR_LIBS)
 AC_CONFIG_FILES([Makefile src/Makefile share/setup.nsi share/qt/Info.plist])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])
+AC_CONFIG_LINKS([CHANGELOG.md:CHANGELOG.md COPYING:COPYING])
 
 dnl boost's m4 checks do something really nasty: they export these vars. As a
 dnl result, they leak into secp256k1's configure and crazy things happen.

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import plistlib
 import sys, re, os, shutil, stat, os.path
 from argparse import ArgumentParser
 from ds_store import DSStore

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -51,7 +51,7 @@ Var StartMenuGroup
 !insertmacro MUI_LANGUAGE English
 
 # Installer attributes
-OutFile @abs_top_srcdir@/@PACKAGE_TARNAME@-${VERSION}-win@WINDOWS_BITS@-setup.exe
+OutFile @abs_top_builddir@/@PACKAGE_TARNAME@-${VERSION}-win@WINDOWS_BITS@-setup.exe
 !if "@WINDOWS_BITS@" == "64"
 InstallDir $PROGRAMFILES64\GridcoinResearch
 !else
@@ -76,9 +76,9 @@ ShowUninstDetails show
 Section -Main SEC0000
     SetOutPath $INSTDIR
     SetOverwrite on
-    File @abs_top_srcdir@/release/@GRIDCOIN_GUI_NAME@@EXEEXT@
+    File @abs_top_builddir@/release/@GRIDCOIN_GUI_NAME@@EXEEXT@
     SetOutPath $INSTDIR\daemon
-    File @abs_top_srcdir@/release/@GRIDCOIN_DAEMON_NAME@@EXEEXT@
+    File @abs_top_builddir@/release/@GRIDCOIN_DAEMON_NAME@@EXEEXT@
     SetOutPath $INSTDIR\doc
     File /oname=COPYING.txt @abs_top_srcdir@/COPYING
     File /oname=CHANGELOG.md @abs_top_srcdir@/CHANGELOG.md

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -57,6 +57,7 @@ GRIDCOIN_TESTS =\
 	test/multisig_tests.cpp \
 	test/netbase_tests.cpp \
 	test/rpc_tests.cpp \
+	test/scheduler_tests.cpp \
 	test/script_p2sh_tests.cpp \
 	test/script_tests.cpp \
 	test/serialize_tests.cpp \

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -288,7 +288,7 @@ QVariant AddressTableModel::headerData(int section, Qt::Orientation orientation,
 Qt::ItemFlags AddressTableModel::flags(const QModelIndex &index) const
 {
     if(!index.isValid())
-        return nullptr;
+        Qt::NoItemFlags;
     AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -288,7 +288,7 @@ QVariant AddressTableModel::headerData(int section, Qt::Orientation orientation,
 Qt::ItemFlags AddressTableModel::flags(const QModelIndex &index) const
 {
     if(!index.isValid())
-        Qt::NoItemFlags;
+        return Qt::NoItemFlags;
     AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -37,8 +37,13 @@ BitcoinAmountField::BitcoinAmountField(QWidget* parent) : QWidget(parent), amoun
     setFocusProxy(amount);
 
     // If one of the widgets changes, the combined content changes as well
-    connect(amount, static_cast<void (QDoubleSpinBox::*)(const QString&)>(&QDoubleSpinBox::valueChanged),
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        connect(amount, static_cast<void (QDoubleSpinBox::*)(const QString&)>(&QDoubleSpinBox::textChanged),
             this, &BitcoinAmountField::textChanged);
+    #else
+        connect(amount, static_cast<void (QDoubleSpinBox::*)(const QString&)>(&QDoubleSpinBox::valueChanged),
+            this, &BitcoinAmountField::textChanged);
+    #endif
     connect(unit, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &BitcoinAmountField::unitChanged);
 
 

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -2,11 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#if defined(WIN32) && BOOST_VERSION == 104900
-#define BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME
-#define BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME
-#endif
-
 #include "qtipcserver.h"
 #include "guiconstants.h"
 #include "ui_interface.h"
@@ -17,8 +12,8 @@
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/version.hpp>
 
-#if defined(WIN32) && (!defined(BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME) || !defined(BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME) || BOOST_VERSION < 104900)
-#warning Compiling without BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME and BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME uncommented in boost/interprocess/detail/tmp_dir_helpers.hpp or using a boost version before 1.49 may have unintended results see svn.boost.org/trac/boost/ticket/5392
+#if defined(WIN32) && (!defined(BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME) || !defined(BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME))
+#warning Compiling without BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME and BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME uncommented in boost/interprocess/detail/tmp_dir_helpers.hpp may have unintended results see svn.boost.org/trac/boost/ticket/5392
 #endif
 
 using namespace boost;

--- a/src/qt/researcher/researcherwizardmodedetailpage.cpp
+++ b/src/qt/researcher/researcherwizardmodedetailpage.cpp
@@ -42,8 +42,13 @@ void ResearcherWizardModeDetailPage::initializePage()
     ui->modeButtonGroup->setId(ui->poolRadioButton, ResearcherWizard::ModePool);
     ui->modeButtonGroup->setId(ui->investorRadioButton, ResearcherWizard::ModeInvestor);
 
-    connect(ui->modeButtonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked),
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+        connect(ui->modeButtonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::idClicked),
             this, &ResearcherWizardModeDetailPage::onModeChange);
+    #else
+        connect(ui->modeButtonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked),
+            this, &ResearcherWizardModeDetailPage::onModeChange);
+    #endif
 
     if (m_researcher_model->configuredForInvestorMode()) {
         ui->investorRadioButton->setChecked(true);

--- a/src/qt/researcher/researcherwizardmodepage.cpp
+++ b/src/qt/researcher/researcherwizardmodepage.cpp
@@ -47,7 +47,7 @@ void ResearcherWizardModePage::initializePage()
     connect(ui->poolIconLabel, &ClickLabel::clicked, this, static_cast<void (ResearcherWizardModePage::*)()>(&ResearcherWizardModePage::selectPool));
     connect(ui->poolRadioButton, &QRadioButton::toggled, this, static_cast<void (ResearcherWizardModePage::*)(bool)>(&ResearcherWizardModePage::selectPool));
     connect(ui->investorIconLabel, &ClickLabel::clicked, this, static_cast<void (ResearcherWizardModePage::*)()>(&ResearcherWizardModePage::selectInvestor));
-    connect(ui->investorRadioButton, &QRadioButton::toggled, this, static_cast<void (ResearcherWizardModePage::*)()>(&ResearcherWizardModePage::selectInvestor));
+    connect(ui->investorRadioButton, &QRadioButton::toggled, this, static_cast<void (ResearcherWizardModePage::*)(bool)>(&ResearcherWizardModePage::selectInvestor));
 
     if (m_researcher_model->configuredForInvestorMode()) {
         selectInvestor();

--- a/src/qt/voting/pollwizardtypepage.cpp
+++ b/src/qt/voting/pollwizardtypepage.cpp
@@ -34,9 +34,14 @@ PollWizardTypePage::PollWizardTypePage(QWidget* parent)
     registerField("pollType*", type_proxy);
     setField("pollType", PollTypes::PollTypeUnknown);
 
-    connect(
-        m_type_buttons, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
-        [=](QAbstractButton*) { type_proxy->setValue(m_type_buttons->checkedId()); });
+    #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+        connect(
+            m_type_buttons, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
+            [=](QAbstractButton*) { type_proxy->setValue(m_type_buttons->checkedId()); });
+    #else
+        connect(m_type_buttons, &QButtonGroup::idClicked,
+            this, [=] { type_proxy->setValue(m_type_buttons->checkedId()); });
+    #endif
 }
 
 PollWizardTypePage::~PollWizardTypePage()

--- a/src/qt/voting/votewizardballotpage.cpp
+++ b/src/qt/voting/votewizardballotpage.cpp
@@ -39,9 +39,13 @@ VoteWizardBallotPage::VoteWizardBallotPage(QWidget *parent)
     registerField("txid", new DummyField(this), "", "");
     registerField("responseLabels", new DummyField(this));
 
-    connect(
-        m_choice_buttons.get(), QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
-        [this](QAbstractButton*) { emit completeChanged(); });
+    #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+        connect(
+            m_choice_buttons.get(), QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
+            [this](QAbstractButton*) { emit completeChanged(); });
+    #else
+        connect(m_choice_buttons.get(), &QButtonGroup::idClicked, this, [=] { emit completeChanged(); });
+    #endif
 }
 
 VoteWizardBallotPage::~VoteWizardBallotPage()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -259,7 +259,6 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
             return TransactionCreationFailed;
         }
 
-		std::string samt = FormatMoney(wtx.vout[0].nValue);
         if(!uiInterface.ThreadSafeAskFee(nFeeRequired, tr("Sending...").toStdString()))
         {
             return Aborted;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -52,7 +52,7 @@ void CScheduler::serviceQueue()
                     if (newTaskScheduled.wait_until<>(lock, timeToWaitFor) == boost::cv_status::timeout) {
                         break; // Exit loop after timeout, it means we reached the time of the event
                     }
-                } catch (boost::thread_interrupted) {
+                } catch (boost::thread_interrupted&) {
                     // We need to make sure we don't ignore this, or the thread won't end
                     throw;
                 } catch (...) {

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2012-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <scheduler.h>
+
+#include <boost/chrono/chrono.hpp>
+#include <boost/thread.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(scheduler_tests)
+
+static void microTask(CScheduler& s, boost::mutex& mutex, int& counter, int delta, boost::chrono::system_clock::time_point rescheduleTime)
+{
+    {
+        boost::unique_lock<boost::mutex> lock(mutex);
+        counter += delta;
+    }
+    boost::chrono::system_clock::time_point noTime = boost::chrono::system_clock::time_point::min();
+    if (rescheduleTime != noTime) {
+        CScheduler::Function f = std::bind(&microTask, std::ref(s), std::ref(mutex), std::ref(counter), -delta + 1, noTime);
+        s.schedule(f, rescheduleTime);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(wait_until_past)
+{
+    boost::condition_variable condvar;
+    boost::mutex mtx;
+    boost::unique_lock<boost::mutex> lock{mtx};
+
+    const auto wait_until = [&](const boost::chrono::seconds& d) {
+        return condvar.wait_until<>(lock, boost::chrono::system_clock::now() - d);
+    };
+
+    BOOST_CHECK(boost::cv_status::timeout == wait_until(boost::chrono::seconds{1}));
+    BOOST_CHECK(boost::cv_status::timeout == wait_until(boost::chrono::minutes{1}));
+    BOOST_CHECK(boost::cv_status::timeout == wait_until(boost::chrono::hours{1}));
+    BOOST_CHECK(boost::cv_status::timeout == wait_until(boost::chrono::hours{10}));
+    BOOST_CHECK(boost::cv_status::timeout == wait_until(boost::chrono::hours{100}));
+    BOOST_CHECK(boost::cv_status::timeout == wait_until(boost::chrono::hours{1000}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a test case for the scheduler from upstream. The goal of this PR was initially to port https://github.com/bitcoin/bitcoin/pull/18285, which adds a test case to catch bugs like this one https://github.com/gridcoin-community/Gridcoin-Research/issues/1887.  While working I discovered we didn't test the scheduler at all, so let's get more coverage.

Ref: https://github.com/bitcoin/bitcoin/pull/18232/commits/fa6bad251d6d11cfacc34effac304d3553855895

Optional other tests include:
```
BOOST_AUTO_TEST_CASE(manythreads)

    // Stress test: hundreds of microsecond-scheduled tasks,
    // serviced by 10 threads.
    //
    // So... ten shared counters, which if all the tasks execute
    // properly will sum to the number of tasks done.
    // Each task adds or subtracts a random amount from one of the
    // counters, and then schedules another task 0-1000
    // microseconds in the future to subtract or add from
    // the counter -random_amount+1, so in the end the shared
    // counters should sum to the number of initial tasks performed.
...


 BOOST_AUTO_TEST_CASE(singlethreadedscheduler_ordered)

    // each queue should be well ordered with respect to itself but not other queues
    SingleThreadedSchedulerClient queue1(&scheduler);
    SingleThreadedSchedulerClient queue2(&scheduler);

    // create more threads than queues
    // if the queues only permit execution of one task at once then
    // the extra threads should effectively be doing nothing
    // if they don't we'll get out of order behaviour
...