### PR TITLE
Fix build with Boost 1.77.0

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -235,7 +235,11 @@ void ofstream::close()
 }
 #else // __GLIBCXX__
 
+#if BOOST_VERSION >= 107700
+static_assert(sizeof(*BOOST_FILESYSTEM_C_STR(fs::path())) == sizeof(wchar_t),
+#else
 static_assert(sizeof(*fs::path().BOOST_FILESYSTEM_C_STR) == sizeof(wchar_t),
+#endif // BOOST_VERSION >= 107700
     "Warning: This build is using boost::filesystem ofstream and ifstream "
     "implementations which will fail to open paths containing multibyte "
     "characters. You should delete this static_assert to ignore this warning, "


### PR DESCRIPTION
> BOOST_FILESYSTEM_C_STR changed to accept the path as an argument.

Ref: https://github.com/bitcoin/bitcoin/pull/22713