### PR TITLE
build: Misc upstream depends fixes

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -242,4 +242,4 @@ $(foreach package,$(all_packages),$(eval $(call int_config_attach_build_config,$
 $(foreach package,$(all_packages),$(eval $(call int_add_cmds,$(package))))
 
 #special exception: if a toolchain package exists, all non-native packages depend on it
-$(foreach package,$(packages),$(eval $($(package)_unpacked): |$($($(host_arch)_$(host_os)_native_toolchain)_cached) ))
+$(foreach package,$(packages),$(eval $($(package)_extracted): |$($($(host_arch)_$(host_os)_native_toolchain)_cached) ))

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -14,8 +14,9 @@ Each package is required to define at least these variables:
     placeholder such as 1.0 can be used.
 
     $(package)_download_path:
-    Location of the upstream source, without the file-name. Usually http or
-    ftp.
+    Location of the upstream source, without the file-name. Usually http, https
+    or ftp. Secure transmission options like https should be preferred if
+    available.
 
     $(package)_file_name:
     The upstream source filename available at the download path.

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -1,7 +1,7 @@
 package=bdb
 GCCFLAGS?=
 $(package)_version=4.8.30
-$(package)_download_path=http://download.oracle.com/berkeley-db
+$(package)_download_path=https://download.oracle.com/berkeley-db
 $(package)_file_name=db-$($(package)_version).NC.tar.gz
 $(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef
 $(package)_build_subdir=build_unix

--- a/depends/packages/bdb53.mk
+++ b/depends/packages/bdb53.mk
@@ -1,7 +1,7 @@
 package=bdb53
 GCCFLAGS?=
 $(package)_version=5.3.28
-$(package)_download_path=http://download.oracle.com/berkeley-db
+$(package)_download_path=https://download.oracle.com/berkeley-db
 $(package)_file_name=db-$($(package)_version).NC.tar.gz
 $(package)_sha256_hash=76a25560d9e52a198d37a31440fd07632b5f1f8f9f2b6d5438f4bc3e7c9013ef
 $(package)_build_subdir=build_unix

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,7 +1,7 @@
 package=boost
 GCCFLAGS?=
 $(package)_version=1_73_0
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$(subst _,.,$($(package)_version))/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402
 $(package)_dependencies=zlib

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,7 +1,7 @@
 package=freetype
 GCCFLAGS?=
 $(package)_version=2.7.1
-$(package)_download_path=http://download.savannah.gnu.org/releases/$(package)
+$(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
 

--- a/depends/packages/libICE.mk
+++ b/depends/packages/libICE.mk
@@ -1,7 +1,7 @@
 package=libICE
 GCCFLAGS?=
 $(package)_version=1.0.9
-$(package)_download_path=http://xorg.freedesktop.org/releases/individual/lib/
+$(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=8f7032f2c1c64352b5423f6b48a8ebdc339cc63064af34d66a6c9aa79759e202
 $(package)_dependencies=xtrans xproto

--- a/depends/packages/libSM.mk
+++ b/depends/packages/libSM.mk
@@ -1,7 +1,7 @@
 package=libSM
 GCCFLAGS?=
 $(package)_version=1.2.2
-$(package)_download_path=http://xorg.freedesktop.org/releases/individual/lib/
+$(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=0baca8c9f5d934450a70896c4ad38d06475521255ca63b717a6510fdb6e287bd
 $(package)_dependencies=xtrans xproto libICE

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -1,7 +1,7 @@
 package=libXau
 GCCFLAGS?=
 $(package)_version=1.0.8
-$(package)_download_path=http://xorg.freedesktop.org/releases/individual/lib/
+$(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=fdd477320aeb5cdd67272838722d6b7d544887dfe7de46e1e7cc0c27c2bea4f2
 $(package)_dependencies=xproto

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -10,7 +10,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress
+  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -4,10 +4,22 @@ $(package)_version=1.10
 $(package)_download_path=https://xcb.freedesktop.org/dist
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c3f2d5b5
-$(package)_dependencies=xcb_proto libXau xproto
+$(package)_dependencies=xcb_proto libXau
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd
+  # Because we pass -qt-xcb to Qt, it will compile in a set of xcb helper libraries and extensions,
+  # so we skip building all of the extensions here.
+  # More info is available from: https://doc.qt.io/qt-5.9/linux-requirements.html
+  $(package)_config_opts += --disable-composite --disable-damage --disable-dpms
+  $(package)_config_opts += --disable-dri2 --disable-dri3 --disable-glx
+  $(package)_config_opts += --disable-present --disable-randr --disable-record
+  $(package)_config_opts += --disable-render --disable-resource --disable-screensaver
+  $(package)_config_opts += --disable-shape --disable-sync
+  $(package)_config_opts += --disable-xevie --disable-xfixes --disable-xfree86-dri
+  $(package)_config_opts += --disable-xinerama --disable-xinput
+  $(package)_config_opts += --disable-xprint --disable-selinux --disable-xtest
+  $(package)_config_opts += --disable-xv --disable-xvmc
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -1,7 +1,7 @@
 package=libxcb
 GCCFLAGS?=
 $(package)_version=1.10
-$(package)_download_path=http://xcb.freedesktop.org/dist
+$(package)_download_path=https://xcb.freedesktop.org/dist
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c3f2d5b5
 $(package)_dependencies=xcb_proto libXau xproto

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -7,10 +7,9 @@ $(package)_patches=dont_leak_info.patch
 
 define $(package)_set_vars
   $(package)_build_opts=CC="$($(package)_cc)"
-  $(package)_build_opts_darwin=OS=Darwin LIBTOOL="$($(package)_libtool)"
+  $(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
   $(package)_build_opts_mingw32=-f Makefile.mingw
   $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
-  $(package)_build_env+=CFLAGS=-D_DARWIN_C_SOURCE
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -6,8 +6,6 @@ $(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
 $(package)_sha256_hash=7ef40ddd855b750bc597d2a435da21e55e502a0fefa85b274f2c922800baaf05
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared
-  $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -1,7 +1,7 @@
 package=xcb_proto
 GCCFLAGS?=
 $(package)_version=1.10
-$(package)_download_path=http://xcb.freedesktop.org/dist
+$(package)_download_path=https://xcb.freedesktop.org/dist
 $(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
 $(package)_sha256_hash=7ef40ddd855b750bc597d2a435da21e55e502a0fefa85b274f2c922800baaf05
 

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -1,7 +1,7 @@
 package=xproto
 GCCFLAGS?=
 $(package)_version=7.0.26
-$(package)_download_path=http://xorg.freedesktop.org/releases/individual/proto
+$(package)_download_path=https://xorg.freedesktop.org/releases/individual/proto
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=636162c1759805a5a0114a369dffdeccb8af8c859ef6e1445f26a4e6e046514f
 


### PR DESCRIPTION
- Switch to secure download of all dependencies
Ref: https://github.com/bitcoin/bitcoin/pull/16049

- Fix target name
Ref: https://github.com/bitcoin/bitcoin/pull/19868

- boost: Refer to version in URL 
Ref: https://github.com/bitcoin/bitcoin/commit/800655ff3199782b803e671f5baa77ff90a5591d

- Don't build libevent sample code
Ref: https://github.com/bitcoin/bitcoin/pull/11286

- Disable libxcb extensions
Ref: https://github.com/bitcoin/bitcoin/pull/16533

- Only use D_DARWIN_C_SOURCE when building miniupnpc on darwin
Ref: https://github.com/bitcoin/bitcoin/pull/12466

- Don't configure xcb_proto
Ref: https://github.com/bitcoin/bitcoin/pull/17698