### PR TITLE
qt: Follow Qt docs when implementing rowCount and columnCount

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -157,13 +157,17 @@ AddressTableModel::~AddressTableModel()
 
 int AddressTableModel::rowCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return priv->size();
 }
 
 int AddressTableModel::columnCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return columns.length();
 }
 

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -101,13 +101,17 @@ BanTableModel::~BanTableModel()
 
 int BanTableModel::rowCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return priv->size();
 }
 
 int BanTableModel::columnCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return columns.length();
 }
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -137,13 +137,17 @@ void PeerTableModel::stopAutoRefresh()
 
 int PeerTableModel::rowCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return priv->size();
 }
 
 int PeerTableModel::columnCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return columns.length();
 }
 

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -135,13 +135,17 @@ ProjectTableModel::~ProjectTableModel()
 
 int ProjectTableModel::rowCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return m_data->size();
 }
 
 int ProjectTableModel::columnCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return m_columns.size();
 }
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -302,13 +302,17 @@ void TransactionTableModel::updateConfirmations()
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return priv->size();
 }
 
 int TransactionTableModel::columnCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    if (parent.isValid()) {
+        return 0;
+    }
     return columns.length();
 }
 

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -33,13 +33,17 @@ public:
 
     int rowCount(const QModelIndex &parent) const override
     {
-        Q_UNUSED(parent);
+        if (parent.isValid()) {
+            return 0;
+        }
         return m_rows.size();
     }
 
     int columnCount(const QModelIndex &parent) const override
     {
-        Q_UNUSED(parent);
+        if (parent.isValid()) {
+            return 0;
+        }
         return m_columns.size();
     }
 


### PR DESCRIPTION
> [`QAbstractItemModel::rowCount`](https://doc.qt.io/qt-5/qabstractitemmodel.html#rowCount):
> 
> > **Note:** When implementing a table based model, `rowCount()` should return 0 when the parent is valid.
> 
> [`QAbstractItemModel::columnCount`](https://doc.qt.io/qt-5/qabstractitemmodel.html#columnCount):
> 
> > **Note:** When implementing a table based model, `columnCount()` should return 0 when the parent is valid.



Ref: https://github.com/bitcoin-core/gui/pull/173