### PR TITLE
rpc: add additional ban time fields to listbanned

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -260,6 +260,7 @@ UniValue listbanned(const UniValue& params, bool fHelp)
 
     banmap_t banMap;
     g_banman->GetBanned(banMap);
+    const int64_t current_time{GetTime()};
 
     UniValue bannedAddresses(UniValue::VARR);
     for (const auto& entry : banMap)
@@ -267,8 +268,10 @@ UniValue listbanned(const UniValue& params, bool fHelp)
         const CBanEntry& banEntry = entry.second;
         UniValue rec(UniValue::VOBJ);
         rec.pushKV("address", entry.first.ToString());
-        rec.pushKV("banned_until", banEntry.nBanUntil);
         rec.pushKV("ban_created", banEntry.nCreateTime);
+        rec.pushKV("banned_until", banEntry.nBanUntil);
+        rec.pushKV("ban_duration", (banEntry.nBanUntil - banEntry.nCreateTime));
+        rec.pushKV("time_remaining", (banEntry.nBanUntil - current_time));
         rec.pushKV("ban_reason", banEntry.banReasonToString());
 
         bannedAddresses.push_back(rec);


### PR DESCRIPTION
> This PR adds a `ban_duration` and `time_remaining` field to the `listbanned` RPC command.

Ref: https://github.com/bitcoin/bitcoin/pull/21602