### PR TITLE
wallet: Bugfix - Fundrawtransaction: don't terminate when keypool is empty

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1958,7 +1958,13 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
 
                         // Reserve a new key pair from key pool
                         CPubKey vchPubKey;
-                        assert(reservekey.GetReservedKey(vchPubKey)); // should never fail, as we just unlocked
+                        bool ret;
+                        ret = reservekey.GetReservedKey(vchPubKey);
+                        if (!ret)
+                        {
+                            LogPrintf("Keypool ran out, please call keypoolrefill first");
+                            return false;
+                        }
 
                         scriptChange.SetDestination(vchPubKey.GetID());
                     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1958,9 +1958,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
 
                         // Reserve a new key pair from key pool
                         CPubKey vchPubKey;
-                        bool ret;
-                        ret = reservekey.GetReservedKey(vchPubKey);
-                        if (!ret)
+                        if (!reservekey.GetReservedKey(vchPubKey))
                         {
                             LogPrintf("Keypool ran out, please call keypoolrefill first");
                             return false;


### PR DESCRIPTION
~~Previously if the keypool was drained, the wallet would crash here.  Handle the error.~~

See below comment for rationale

Ref: https://github.com/bitcoin/bitcoin/pull/9295