### PR TITLE
wallet: Reopen CDBEnv after encryption instead of shutting down

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -109,7 +109,7 @@ void AskPassphraseDialog::accept()
                 if(model->setWalletEncrypted(newpass1)) {
                     QMessageBox::warning(this, tr("Wallet encrypted"),
                                          "<qt>" +
-                                         tr("Gridcoin will close now to finish the encryption process. "
+                                         tr("Your wallet is now encrypted. "
                                          "Remember that encrypting your wallet cannot fully protect "
                                          "your coins from being stolen by malware infecting your computer.") +
                                          "<br><br><b>" +
@@ -118,7 +118,6 @@ void AskPassphraseDialog::accept()
                                          "For security reasons, previous backups of the unencrypted wallet file "
                                          "will become useless as soon as you start using the new, encrypted wallet.") +
                                          "</b></qt>");
-                    QApplication::quit();
                 }
                 else {
                     QMessageBox::critical(this, tr("Wallet encryption failed"),

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -47,6 +47,7 @@ public:
     DbEnv dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
+    std::condition_variable_any m_db_in_use;
 
     CDBEnv();
     ~CDBEnv();
@@ -77,6 +78,7 @@ public:
     void CheckpointLSN(std::string strFile);
     void lsn_reset(const std::string& strFile);
     void CloseDb(const std::string& strFile);
+    void ReloadDbEnv();
     bool RemoveDb(const std::string& strFile);
 
     DbTxn *TxnBegin(int flags=DB_TXN_WRITE_NOSYNC)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2295,11 +2295,7 @@ UniValue encryptwallet(const UniValue& params, bool fHelp)
     if (!pwalletMain->EncryptWallet(strWalletPass))
         throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Error: Failed to encrypt the wallet.");
 
-    // BDB seems to have a bad habit of writing old data into
-    // slack space in .dat files; that is bad if the old data is
-    // unencrypted private keys. So:
-    StartShutdown();
-    return "wallet encrypted; Gridcoin server stopping, restart to run with encrypted wallet.  The keypool has been flushed, you need to make a new backup.";
+    return "wallet encrypted; The keypool has been flushed, you need to make a new backup.";
 }
 
 class DescribeAddressVisitor

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -379,6 +379,11 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         // bits of the unencrypted private key in slack space in the database file.
         CDB::Rewrite(strWalletFile);
 
+        // BDB seems to have a bad habit of writing old data into
+        // slack space in .dat files; that is bad if the old data is
+        // unencrypted private keys. So:
+        CDB::ReloadDbEnv();
+
     }
     NotifyStatusChanged(this);
 


### PR DESCRIPTION
This reloads the database rather than shutting down and forcing the user to restart after encrypting their wallet.

> Shutting down the software was to prevent the BDB environment from writing unencrypted private keys to disk in the database log files, as was noted here. This PR replaces the shutdown behavior with a CDBEnv flush, close, and reopen which achieves the same effect: everything is cleanly flushed and closed, the log files are removed, and then the environment reopened to continue normal operation.

Ref: https://github.com/bitcoin/bitcoin/pull/12493