### PR TITLE
build: fix -fstack-clash-protection spam for Clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -686,7 +686,7 @@ if test x$use_hardening != xno; then
       dnl See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
       ;;
     *)
-      AX_CHECK_COMPILE_FLAG([-fstack-clash-protection],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-clash-protection"])
+      AX_CHECK_COMPILE_FLAG([-fstack-clash-protection], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-clash-protection"], [], [$CXXFLAG_WERROR])
       ;;
   esac
 


### PR DESCRIPTION
`-fstack-clash-protection` produces a lot of unused argument warnings with clang.