### PR TITLE
test: Add sanity_tests from upstream

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -57,6 +57,7 @@ GRIDCOIN_TESTS =\
 	test/multisig_tests.cpp \
 	test/netbase_tests.cpp \
 	test/rpc_tests.cpp \
+	test/sanity_tests.cpp \
 	test/scheduler_tests.cpp \
 	test/script_p2sh_tests.cpp \
 	test/script_tests.cpp \

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2012-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <key.h>
+#include <util/time.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(sanity_tests)
+
+BOOST_AUTO_TEST_CASE(basic_sanity)
+{
+  BOOST_CHECK_MESSAGE(ECC_InitSanityCheck() == true, "openssl ECC test");
+  BOOST_CHECK_MESSAGE(ChronoSanityCheck() == true, "chrono epoch test");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds two sanity checks that already exist in our codebase:
- `ECC_InitSanityCheck()` from key.cpp
- `ChronoSanityCheck()` from time.cpp

Ref: https://github.com/bitcoin/bitcoin/pull/5604