### PR TITLE
util, test: Don't allow Base32/64-decoding or ParseMoney(…) on strings with embedded NUL characters. Add tests.  Add negative test case.

### DIFF
--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -1,6 +1,13 @@
-#include <boost/test/unit_test.hpp>
+// Copyright (c) 2012-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace std::literals;
 
 BOOST_AUTO_TEST_SUITE(base32_tests)
 
@@ -8,13 +15,24 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
 {
     static const std::string vstrIn[]  = {"","f","fo","foo","foob","fooba","foobar"};
     static const std::string vstrOut[] = {"","my======","mzxq====","mzxw6===","mzxw6yq=","mzxw6ytb","mzxw6ytboi======"};
-    for (unsigned int i = 0; i < std::size(vstrIn); i++)
+    for (unsigned int i=0; i<std::size(vstrIn); i++)
     {
         std::string strEnc = EncodeBase32(vstrIn[i]);
         BOOST_CHECK(strEnc == vstrOut[i]);
         std::string strDec = DecodeBase32(vstrOut[i]);
         BOOST_CHECK(strDec == vstrIn[i]);
     }
+
+    // Decoding strings with embedded NUL characters should fail
+    bool failure;
+    (void)DecodeBase32("invalid\0"s, &failure); // correct size, invalid due to \0
+    BOOST_CHECK(failure);
+    (void)DecodeBase32("AWSX3VPP"s, &failure); // valid
+    BOOST_CHECK(!failure);
+    (void)DecodeBase32("AWSX3VPP\0invalid"s, &failure); // correct size, invalid due to \0
+    BOOST_CHECK(failure);
+    (void)DecodeBase32("AWSX3VPPinvalid"s, &failure); // invalid size
+    BOOST_CHECK(failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
 {
     static const std::string vstrIn[]  = {"","f","fo","foo","foob","fooba","foobar"};
     static const std::string vstrOut[] = {"","my======","mzxq====","mzxw6===","mzxw6yq=","mzxw6ytb","mzxw6ytboi======"};
-    for (unsigned int i=0; i<std::size(vstrIn); i++)
+    for (unsigned int i = 0; i < std::size(vstrIn); i++)
     {
         std::string strEnc = EncodeBase32(vstrIn[i]);
         BOOST_CHECK(strEnc == vstrOut[i]);

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -1,8 +1,13 @@
-#include <boost/test/unit_test.hpp>
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "main.h"
-#include "wallet/wallet.h"
-#include "util.h"
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace std::literals;
 
 BOOST_AUTO_TEST_SUITE(base64_tests)
 
@@ -17,6 +22,17 @@ BOOST_AUTO_TEST_CASE(base64_testvectors)
         std::string strDec = DecodeBase64(strEnc);
         BOOST_CHECK(strDec == vstrIn[i]);
     }
+
+    // Decoding strings with embedded NUL characters should fail
+    bool failure;
+    (void)DecodeBase64("invalid\0"s, &failure);
+    BOOST_CHECK(failure);
+    (void)DecodeBase64("nQB/pZw="s, &failure);
+    BOOST_CHECK(!failure);
+    (void)DecodeBase64("nQB/pZw=\0invalid"s, &failure);
+    BOOST_CHECK(failure);
+    (void)DecodeBase64("nQB/pZw=invalid\0"s, &failure);
+    BOOST_CHECK(failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -277,6 +277,8 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
     BOOST_CHECK_EQUAL(ret, COIN*10);
     BOOST_CHECK(ParseMoney("1.00", ret));
     BOOST_CHECK_EQUAL(ret, COIN);
+    BOOST_CHECK(ParseMoney("1", ret));
+    BOOST_CHECK_EQUAL(ret, COIN);
     BOOST_CHECK(ParseMoney("0.1", ret));
     BOOST_CHECK_EQUAL(ret, COIN/10);
     BOOST_CHECK(ParseMoney("0.01", ret));
@@ -296,6 +298,14 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
 
     // Attempted 63 bit overflow should fail
     BOOST_CHECK(!ParseMoney("92233720368.54775808", ret));
+
+    // Parsing negative amounts must fail
+    BOOST_CHECK(!ParseMoney("-1", ret));
+
+    // Parsing strings with embedded NUL characters should fail
+    BOOST_CHECK(!ParseMoney(std::string("\0-1", 3), ret));
+    BOOST_CHECK(!ParseMoney(std::string("\01", 2), ret));
+    BOOST_CHECK(!ParseMoney(std::string("1\0", 2), ret));
 }
 
 BOOST_AUTO_TEST_CASE(util_IsHex)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -10,6 +10,7 @@
 #include "ui_interface.h"
 #include "util.h"
 #include <util/strencodings.h>
+#include <util/string.h>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
@@ -221,6 +222,9 @@ string FormatMoney(int64_t n, bool fPlus)
 
 bool ParseMoney(const string& str, int64_t& nRet)
 {
+    if (!ValidAsCString(str)) {
+        return false;
+    }
     return ParseMoney(str.c_str(), nRet);
 }
 

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <util/strencodings.h>
+#include <util/string.h>
 
 #include <tinyformat.h>
 
@@ -190,6 +191,12 @@ std::vector<unsigned char> DecodeBase64(const char* p, bool* pf_invalid)
 
 std::string DecodeBase64(const std::string& str, bool* pf_invalid)
 {
+    if (!ValidAsCString(str)) {
+        if (pf_invalid) {
+            *pf_invalid = true;
+        }
+        return {};
+    }
     std::vector<unsigned char> vchRet = DecodeBase64(str.c_str(), pf_invalid);
     return std::string((const char*)vchRet.data(), vchRet.size());
 }
@@ -259,6 +266,12 @@ std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)
 
 std::string DecodeBase32(const std::string& str, bool* pf_invalid)
 {
+    if (!ValidAsCString(str)) {
+        if (pf_invalid) {
+            *pf_invalid = true;
+        }
+        return {};
+    }
     std::vector<unsigned char> vchRet = DecodeBase32(str.c_str(), pf_invalid);
     return std::string((const char*)vchRet.data(), vchRet.size());
 }


### PR DESCRIPTION
> Don't allow Base32/64-decoding or `ParseMoney(…)` on strings with embedded `NUL` characters.

Also test these cases

Ref: https://github.com/bitcoin/bitcoin/pull/17753


Add test case to ensure negative amounts fail `ParseMoney`

Ref: https://github.com/practicalswift/bitcoin/commit/fa3a81af18347a1d3fed41aa89ee643cbf0e7abc

Also adds copyright headers