### PR TITLE
util, test: Don't allow Base58 decoding of non-Base58 strings. Add Base58 tests. Add whitespace tests.

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -23,6 +23,7 @@
 #include <variant>
 #include <vector>
 #include <util/strencodings.h>
+#include <util/string.h>
 
 static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
@@ -124,6 +125,9 @@ inline bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet)
 // returns true if decoding is successful
 inline bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet)
 {
+    if (!ValidAsCString(str)) {
+        return false;
+    }
     return DecodeBase58(str.c_str(), vchRet);
 }
 
@@ -165,6 +169,9 @@ inline bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRe
 // returns true if decoding is successful
 inline bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet)
 {
+    if (!ValidAsCString(str)) {
+        return false;
+    }
     return DecodeBase58Check(str.c_str(), vchRet);
 }
 

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -55,6 +55,12 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
     }
 
     BOOST_CHECK(!DecodeBase58("invalid", result));
+
+    // check that DecodeBase58 skips whitespace, but still fails with unexpected non-whitespace at the end.
+    BOOST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result));
+    BOOST_CHECK( DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t ", result));
+    std::vector<unsigned char> expected = ParseHex("971a55");
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
 }
 
 // Visitor to check address type

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -1,10 +1,15 @@
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <boost/test/unit_test.hpp>
 
-#include "base58.h"
-#include "util.h"
-#include "test/data/base58_encode_decode.json.h"
-#include "test/data/base58_keys_valid.json.h"
-#include "test/data/base58_keys_invalid.json.h"
+#include <base58.h>
+#include <util.h>
+#include <util/strencodings.h>
+#include <test/data/base58_encode_decode.json.h>
+#include <test/data/base58_keys_valid.json.h>
+#include <test/data/base58_keys_invalid.json.h>
 
 #include <univalue.h>
 
@@ -55,12 +60,24 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
     }
 
     BOOST_CHECK(!DecodeBase58("invalid", result));
+    BOOST_CHECK(!DecodeBase58(std::string("invalid"), result));
+    BOOST_CHECK(!DecodeBase58(std::string("\0invalid", 8), result));
+
+    BOOST_CHECK(DecodeBase58(std::string("good", 4), result));
+    BOOST_CHECK(!DecodeBase58(std::string("bad0IOl", 7), result));
+    BOOST_CHECK(!DecodeBase58(std::string("goodbad0IOl", 11), result));
+    BOOST_CHECK(!DecodeBase58(std::string("good\0bad0IOl", 12), result));
 
     // check that DecodeBase58 skips whitespace, but still fails with unexpected non-whitespace at the end.
     BOOST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result));
     BOOST_CHECK( DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t ", result));
     std::vector<unsigned char> expected = ParseHex("971a55");
     BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+
+    BOOST_CHECK(DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh", 21), result));
+    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oi", 21), result));
+    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh0IOl", 25), result));
+    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh\00IOl", 26), result));
 }
 
 // Visitor to check address type

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <util/strencodings.h>
+#include <util/string.h>
 
 #include <tinyformat.h>
 
@@ -269,7 +270,7 @@ std::string DecodeBase32(const std::string& str, bool* pf_invalid)
         return false;
     if (str.size() >= 1 && (IsSpace(str[0]) || IsSpace(str[str.size()-1]))) // No padding allowed
         return false;
-    if (str.size() != strlen(str.c_str())) // No embedded NUL characters allowed
+    if (!ValidAsCString(str)) // No embedded NUL characters allowed
         return false;
     return true;
 }


### PR DESCRIPTION
> Don't allow Base58 decoding of non-Base58 strings. Add Base58 tests.

Ref: https://github.com/bitcoin/bitcoin/pull/17721

Add tests to ensure whitespace is skipped.
Ref: https://github.com/bitcoin/bitcoin/pull/3712

Also adds copyright headers