### PR TITLE
rpc: Implement -rpcwait and -rpcwaittimeout

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -48,6 +48,10 @@ extern bool fUseFastIndex;
 // Dump addresses to banlist.dat every 5 minutes (300 s)
 static constexpr int DUMP_BANS_INTERVAL = 300;
 
+// RPC client default timeout.
+extern constexpr int DEFAULT_WAIT_CLIENT_TIMEOUT = 0;
+
+
 std::unique_ptr<BanMan> g_banman;
 
 /**
@@ -534,6 +538,11 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections",
                    ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::RPC);
+    argsman.AddArg("-rpcwait", "Wait for RPC server to start.",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    argsman.AddArg("-rpcwaittimeout=<n>", strprintf("Timeout in seconds to wait for the RPC server to start, or 0 for no "
+                                                    "timeout. (default: %d)", DEFAULT_WAIT_CLIENT_TIMEOUT),
+                   ArgsManager::ALLOW_INT, OptionsCategory::RPC);
     argsman.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections",
                    ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::RPC);
     argsman.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u, testnet: %u)",


### PR DESCRIPTION
This is a Bitcoin compatible implementation of -rpcwait and -rpcwaittimeout

Specifying -rpcwait for the rpc client will cause it to wait for the time specified with -rpcwaittimeout (in seconds) with one second attempts to connect. If -rpcwaittimeout is specified as zero or less, the wait is indefinite. Note that the current default value of -rpcwaittimeout is zero.

Note that since we have ported the argsmanager, that ported cleanly. We have the older rpc code, so I did a compatible port of that part. I used the newer `GetTime<T>().` Not sure why the Bitcoin implementation used .count() to get int64_t. It makes more sense to use the chrono durations directly, because otherwise there are effectively two count()s, since GetTime<T> has a count inside of it effectively.

Closes #2346.