### PR TITLE
qt: Notificator class refactoring.  Notificator always takes 3 args.  Remove Growl support.

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -836,7 +836,7 @@ void BitcoinGUI::createTrayIcon()
     trayIcon->show();
 #endif
 
-    notificator = new Notificator(qApp->applicationName(), trayIcon);
+    notificator = new Notificator(qApp->applicationName(), trayIcon, this);
 }
 
 void BitcoinGUI::createTrayIconMenu()

--- a/src/qt/macnotificationhandler.h
+++ b/src/qt/macnotificationhandler.h
@@ -3,19 +3,16 @@
 
 #include <QObject>
 
-/** Macintosh-specific notification handler (supports UserNotificationCenter and Growl).
+/** Macintosh-specific notification handler (supports UserNotificationCenter).
  */
 class MacNotificationHandler : public QObject
 {
     Q_OBJECT
 
 public:
-    /** shows a 10.8+ UserNotification in the UserNotificationCenter
+    /** shows a macOS 10.8+ UserNotification in the UserNotificationCenter
      */
     void showNotification(const QString &title, const QString &text);
-
-    /** executes AppleScript */
-    void sendAppleScript(const QString &script);
 
     /** check if OS can handle UserNotifications */
     bool hasUserNotificationCenterSupport(void);

--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -30,20 +30,6 @@ void MacNotificationHandler::showNotification(const QString &title, const QStrin
     }
 }
 
-// sendAppleScript just take a QString and executes it as apple script
-void MacNotificationHandler::sendAppleScript(const QString &script)
-{
-    QByteArray utf8 = script.toUtf8();
-    char* cString = (char *)utf8.constData();
-    NSString *scriptApple = [[NSString alloc] initWithUTF8String:cString];
-
-    NSAppleScript *as = [[NSAppleScript alloc] initWithSource:scriptApple];
-    NSDictionary *err = nil;
-    [as executeAndReturnError:&err];
-    [as release];
-    [scriptApple release];
-}
-
 bool MacNotificationHandler::hasUserNotificationCenterSupport(void)
 {
     Class possibleClass = NSClassFromString(@"NSUserNotificationCenter");

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -39,7 +39,7 @@ programName(_programName),
 mode(None),
 trayIcon(_trayIcon)
 #ifdef USE_DBUS
-,interface(0)
+    ,interface(nullptr)
 #endif
 {
     if(_trayIcon && _trayIcon->supportsMessages())
@@ -154,14 +154,14 @@ QVariant FreedesktopImage::toVariant(const QImage &img)
 
 void Notificator::notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
 {
-    Q_UNUSED(cls);
-    // Arguments for DBus call:
+    // https://developer.gnome.org/notification-spec/
+    // Arguments for DBus "Notify" call:
     QList<QVariant> args;
     
     // Program Name:
     args.append(programName);
     
-    // Unique ID of this notification type:
+    // Replaces ID; A value of 0 means that this notification won't replace any existing notifications:
     args.append(0U);
     
     // Application Icon, empty string
@@ -209,9 +209,8 @@ void Notificator::notifyDBus(Class cls, const QString &title, const QString &tex
 }
 #endif
 
-void Notificator::notifySystray(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
+void Notificator::notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout)
 {
-    Q_UNUSED(icon);
     QSystemTrayIcon::MessageIcon sicon = QSystemTrayIcon::NoIcon;
     switch(cls) // Set icon based on class
     {
@@ -224,7 +223,7 @@ void Notificator::notifySystray(Class cls, const QString &title, const QString &
 
 // Based on Qt's tray icon implementation
 #ifdef Q_OS_MAC
-void Notificator::notifyMacUserNotificationCenter(Class cls, const QString &title, const QString &text, const QIcon &icon) {
+void Notificator::notifyMacUserNotificationCenter(const QString &title, const QString &text) {
     // icon is not supported by the user notification center yet. OSX will use the app icon.
     MacNotificationHandler::instance()->showNotification(title, text);
 }
@@ -241,11 +240,11 @@ void Notificator::notify(Class cls, const QString &title, const QString &text, c
             break;
 #endif
         case QSystemTray:
-            notifySystray(cls, title, text, icon, millisTimeout);
+            notifySystray(cls, title, text, millisTimeout);
             break;
 #ifdef Q_OS_MAC
         case UserNotificationCenter:
-            notifyMacUserNotificationCenter(cls, title, text, icon);
+            notifyMacUserNotificationCenter(title, text);
             break;
 #endif
         default:

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -49,8 +49,6 @@ private:
         None,                       /**< Ignore informational notifications, and show a modal pop-up dialog for Critical notifications. */
         Freedesktop,                /**< Use DBus org.freedesktop.Notifications */
         QSystemTray,                /**< Use QSystemTrayIcon::showMessage() */
-        Growl12,                    /**< Use the Growl 1.2 notification system (Mac only) */
-        Growl13,                    /**< Use the Growl 1.3 notification system (Mac only) */
         UserNotificationCenter      /**< Use the 10.8+ User Notification Center (Mac only) */
     };
     QString programName;
@@ -63,7 +61,6 @@ private:
 #endif
     void notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout);
 #ifdef Q_OS_MAC
-    void notifyGrowl(Class cls, const QString &title, const QString &text, const QIcon &icon);
     void notifyMacUserNotificationCenter(const QString &title, const QString &text);
 #endif
 };

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -19,7 +19,7 @@ public:
     /** Create a new notificator.
        @note Ownership of trayIcon is not transferred to this object.
     */
-    Notificator(const QString &programName=QString(), QSystemTrayIcon *trayIcon=0, QWidget *parent=0);
+    Notificator(const QString &programName, QSystemTrayIcon *trayIcon, QWidget *parent);
     ~Notificator();
 
     // Message class
@@ -48,7 +48,7 @@ private:
     enum Mode {
         None,                       /**< Ignore informational notifications, and show a modal pop-up dialog for Critical notifications. */
         Freedesktop,                /**< Use DBus org.freedesktop.Notifications */
-        QSystemTray,                /**< Use QSystemTray::showMessage */
+        QSystemTray,                /**< Use QSystemTrayIcon::showMessage() */
         Growl12,                    /**< Use the Growl 1.2 notification system (Mac only) */
         Growl13,                    /**< Use the Growl 1.3 notification system (Mac only) */
         UserNotificationCenter      /**< Use the 10.8+ User Notification Center (Mac only) */
@@ -61,10 +61,10 @@ private:
 
     void notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
 #endif
-    void notifySystray(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
+    void notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout);
 #ifdef Q_OS_MAC
     void notifyGrowl(Class cls, const QString &title, const QString &text, const QIcon &icon);
-    void notifyMacUserNotificationCenter(Class cls, const QString &title, const QString &text, const QIcon &icon);
+    void notifyMacUserNotificationCenter(const QString &title, const QString &text);
 #endif
 };
 


### PR DESCRIPTION
>     * removes misplaced `Q_UNUSED(cls)`; `cls` is actually used:
>       https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/qt/notificator.cpp#L188
> 
>     * removes unused parameters in functions `notifySystray()` and `notifyMacUserNotificationCenter()`
> 
>     * improves comments

  - Ref: https://github.com/bitcoin/bitcoin/pull/15007

Notificator should take 3 arguments
 - Ref: https://github.com/bitcoin/bitcoin/pull/3348


Remove Growl support, remove unused code

  > There is no longer a reason to support Growl.
  > A) It went to pay-ware since a couple of years
  > B) Since OSX 10.8, the operating system has its own modal notification options (Notification Center).

 - Ref: https://github.com/bitcoin/bitcoin/pull/11268