### PR TITLE
refactor: port upstream ui_interface changes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,7 +174,7 @@ GRIDCOIN_CORE_H = \
     threadsafety.h \
     tinyformat.h \
     txdb.h \
-    ui_interface.h \
+    node/ui_interface.h \
     uint256.h \
     util/check.h \
     util/reverse_iterator.h \
@@ -247,7 +247,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     netbase.cpp \
     net.cpp \
     node/blockstorage.cpp \
-    ui_interface.cpp \
+    node/ui_interface.cpp \
     noui.cpp \
     pbkdf2.cpp \
     policy/policy.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -247,6 +247,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     netbase.cpp \
     net.cpp \
     node/blockstorage.cpp \
+    ui_interface.cpp \
     noui.cpp \
     pbkdf2.cpp \
     policy/policy.cpp \

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -14,7 +14,7 @@
 #include "net.h"
 #include "streams.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "uint256.h"
 
 using namespace std;

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -7,7 +7,7 @@
 
 #include "netbase.h"
 #include "net.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 
 BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time)

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -17,7 +17,7 @@
 #include "txdb.h"
 #include "main.h"
 #include "node/blockstorage.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 #include "validation.h"
 

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -16,7 +16,7 @@
 #include "gridcoin/beacon.h"
 #include "init.h"
 #include "scheduler.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 
 using namespace GRC;
 

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -48,7 +48,7 @@ void ShowChainCorruptedMessage()
             "Your wallet will re-download the blockchain. Your balance may "
             "appear incorrect until the synchronization finishes.\n" ),
         "Gridcoin",
-        CClientUIInterface::OK | CClientUIInterface::MODAL);
+        CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
 }
 
 //!

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -25,6 +25,7 @@
 #include <optional>
 #include <openssl/md5.h>
 #include <set>
+#include <univalue.h>
 
 using namespace GRC;
 

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -15,7 +15,7 @@
 #include "gridcoin/support/xml.h"
 #include "gridcoin/tally.h"
 #include "span.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 
 #include <boost/algorithm/string/case_conv.hpp>

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3,7 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "main.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 
 #include "gridcoin/appcache.h"
 #include "gridcoin/beacon.h"

--- a/src/gridcoin/staking/status.cpp
+++ b/src/gridcoin/staking/status.cpp
@@ -4,7 +4,7 @@
 
 #include "gridcoin/staking/kernel.h"
 #include "gridcoin/staking/status.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 #include "wallet/wallet.h"
 

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "gridcoin/scraper/http.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 
 namespace GRC {
 

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -15,7 +15,7 @@
 #include "gridcoin/voting/payloads.h"
 #include "gridcoin/voting/registry.h"
 #include "node/blockstorage.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "wallet/wallet.h"
 #include <util/string.h>
 

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -6,7 +6,7 @@
 #include "gridcoin/support/xml.h"
 #include "gridcoin/voting/poll.h"
 #include "span.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 
 #include <boost/algorithm/string/join.hpp>

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -15,7 +15,7 @@
 #include "gridcoin/support/block_finder.h"
 #include "node/blockstorage.h"
 #include "txdb.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "validation.h"
 
 using namespace GRC;

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -17,7 +17,7 @@
 #include "init.h"
 #include "rpc/server.h"
 #include "rpc/client.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "gridcoin/upgrade.h"
 
 #include <boost/thread.hpp>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -13,7 +13,7 @@
 #include "banman.h"
 #include "rpc/server.h"
 #include "init.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "scheduler.h"
 #include "gridcoin/gridcoin.h"
 #include "miner.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -36,7 +36,6 @@ extern void ThreadAppInit2(void* parg);
 
 using namespace std;
 CWallet* pwalletMain;
-CClientUIInterface uiInterface;
 extern bool fQtActive;
 extern bool bGridcoinCoreInitComplete;
 extern bool fConfChange;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -188,18 +188,6 @@ static void registerSignalHandler(int signal, void(*handler)(int))
 }
 #endif
 
-bool static InitError(const std::string &str)
-{
-    uiInterface.ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::MSG_ERROR);
-    return false;
-}
-
-bool static InitWarning(const std::string &str)
-{
-    uiInterface.ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::MSG_WARNING);
-    return true;
-}
-
 
 bool static Bind(const CService &addr, bool fError = true) {
     if (IsLimited(addr))

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -190,13 +190,13 @@ static void registerSignalHandler(int signal, void(*handler)(int))
 
 bool static InitError(const std::string &str)
 {
-    uiInterface.ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::MODAL);
+    uiInterface.ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::MSG_ERROR);
     return false;
 }
 
 bool static InitWarning(const std::string &str)
 {
-    uiInterface.ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION | CClientUIInterface::MODAL);
+    uiInterface.ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::MSG_WARNING);
     return true;
 }
 
@@ -1052,8 +1052,7 @@ bool AppInit2(ThreadHandlerPtr threads)
                                      " Original wallet.dat saved as wallet.{timestamp}.bak in %s; if"
                                      " your balance or transactions are incorrect you should"
                                      " restore from a backup."), datadir.string());
-            uiInterface.ThreadSafeMessageBox(msg, _("Gridcoin"),
-                CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION | CClientUIInterface::MODAL);
+            InitWarning(msg);
         }
         if (r == CDBEnv::RECOVER_FAIL)
             return InitError(_("wallet.dat corrupt, salvage failed"));
@@ -1250,7 +1249,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         {
             string msg(_("Warning: error reading wallet.dat! All keys read correctly, but transaction data"
                          " or address book entries might be missing or incorrect."));
-            uiInterface.ThreadSafeMessageBox(msg, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION | CClientUIInterface::MODAL);
+            InitWarning(msg);
         }
         else if (nLoadWalletRet == DB_TOO_NEW)
             strErrors << _("Error loading wallet.dat: Wallet requires newer version of Gridcoin") << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2532,7 +2532,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes)
         string strMessage = _("Warning: Disk space is low!");
         strMiscWarning = strMessage;
         LogPrintf("*** %s", strMessage);
-        uiInterface.ThreadSafeMessageBox(strMessage, "Gridcoin", CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION | CClientUIInterface::MODAL);
+        uiInterface.ThreadSafeMessageBox(strMessage, "Gridcoin", CClientUIInterface::MSG_ERROR);
         StartShutdown();
         return false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@
 #include "checkpoints.h"
 #include "txdb.h"
 #include "init.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "gridcoin/beacon.h"
 #include "gridcoin/claim.h"
 #include "gridcoin/contract/contract.h"

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,7 +11,7 @@
 #include "banman.h"
 #include "net.h"
 #include "init.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 #include "util/threadnames.h"
 

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <ui_interface.h>
+#include <node/ui_interface.h>
 
 #include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UI_INTERFACE_H
-#define BITCOIN_UI_INTERFACE_H
+#ifndef BITCOIN_NODE_UI_INTERFACE_H
+#define BITCOIN_NODE_UI_INTERFACE_H
 
 #include <functional>
 #include <memory>

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -34,7 +34,7 @@ static int noui_UpdateMessageBox(const std::string& version, const std::string& 
 void noui_connect()
 {
     // Connect bitcoind signal handlers
-    uiInterface.ThreadSafeMessageBox.connect(noui_ThreadSafeMessageBox);
-    uiInterface.ThreadSafeAskFee.connect(noui_ThreadSafeAskFee);
-    uiInterface.UpdateMessageBox.connect(noui_UpdateMessageBox);
+    uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
+    uiInterface.ThreadSafeAskFee_connect(noui_ThreadSafeAskFee);
+    uiInterface.UpdateMessageBox_connect(noui_UpdateMessageBox);
 }

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "init.h"
 #include "rpc/server.h"
 #include "rpc/client.h"

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -18,7 +18,7 @@
 #include "qt/intro.h"
 #include "guiconstants.h"
 #include "init.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "qtipcserver.h"
 #include "txdb.h"
 #include "util.h"

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -302,7 +302,7 @@ int main(int argc, char *argv[])
     if (command_line_parse_failure) {
         tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error);
         ThreadSafeMessageBox(strprintf("Error reading configuration file.\n"),
-                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::OK | CClientUIInterface::MODAL);
+                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         QMessageBox::critical(nullptr, PACKAGE_NAME, QObject::tr("Error: Cannot parse command line arguments. Please check "
                                                                  "the arguments and ensure they are valid and formatted "
                                                                  "correctly."));
@@ -383,7 +383,7 @@ int main(int argc, char *argv[])
 
     if (!gArgs.ReadConfigFiles(error_msg, true)) {
         ThreadSafeMessageBox(strprintf("Error reading configuration file.\n"),
-                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::OK | CClientUIInterface::MODAL);
+                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         QMessageBox::critical(nullptr, PACKAGE_NAME, QObject::tr("Error: Cannot read configuration file. Please check the "
                                                                  "path and format of the file."));
         return EXIT_FAILURE;
@@ -396,7 +396,7 @@ int main(int argc, char *argv[])
     // Do not call GetDataDir(true) before this step finishes
     if (!CheckDataDirOption()) {
         ThreadSafeMessageBox(strprintf("Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", "")),
-                             "", CClientUIInterface::ICON_ERROR | CClientUIInterface::OK | CClientUIInterface::MODAL);
+                             "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         QMessageBox::critical(nullptr, PACKAGE_NAME,
             QObject::tr("Error: Specified data directory \"%1\" does not exist.")
                               .arg(QString::fromStdString(gArgs.GetArg("-datadir", ""))));
@@ -412,7 +412,7 @@ int main(int argc, char *argv[])
         std::string str = strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running "
                                       "and using that directory."),
                                     dataDir, PACKAGE_NAME);
-        ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::MODAL);
+        ThreadSafeMessageBox(str, _("Gridcoin"), CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         QMessageBox::critical(nullptr, PACKAGE_NAME,
             QObject::tr("Error: Cannot obtain a lock on the specified data directory. "
                         "An instance is probably already using that directory."));
@@ -423,7 +423,7 @@ int main(int argc, char *argv[])
     // Reread config file after correct chain is selected
     if (!gArgs.ReadConfigFiles(error, true)) {
         ThreadSafeMessageBox(strprintf("Error reading configuration file: %s\n", error),
-                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::OK | CClientUIInterface::MODAL);
+                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         QMessageBox::critical(nullptr, PACKAGE_NAME,
             QObject::tr("Error: Cannot parse configuration file: %1.").arg(QString::fromStdString(error)));
         return EXIT_FAILURE;
@@ -431,7 +431,7 @@ int main(int argc, char *argv[])
 
     if (!gArgs.InitSettings(error)) {
         ThreadSafeMessageBox(strprintf("Error initializing settings.\n"),
-                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::OK | CClientUIInterface::MODAL);
+                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         QMessageBox::critical(nullptr, PACKAGE_NAME,
                               QObject::tr("Error initializing settings: %1").arg(QString::fromStdString(error)));
         return EXIT_FAILURE;
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
 
             std::string inftext = resetblockchain.ResetBlockchainMessages(resetblockchain.CleanUp);
 
-            ThreadSafeMessageBox(inftext, _("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::MODAL);
+            ThreadSafeMessageBox(inftext, _("Gridcoin"), CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
             QMessageBox::critical(nullptr, PACKAGE_NAME, QString::fromStdString(inftext));
 
             return EXIT_FAILURE;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -575,16 +575,16 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
     qInstallMessageHandler(DebugMessageHandler);
 
     // Subscribe to global signals from core
-    uiInterface.ThreadSafeMessageBox.connect(ThreadSafeMessageBox);
-    uiInterface.ThreadSafeAskFee.connect(ThreadSafeAskFee);
-    uiInterface.ThreadSafeAskQuestion.connect(ThreadSafeAskQuestion);
+    uiInterface.ThreadSafeMessageBox_connect(ThreadSafeMessageBox);
+    uiInterface.ThreadSafeAskFee_connect(ThreadSafeAskFee);
+    uiInterface.ThreadSafeAskQuestion_connect(ThreadSafeAskQuestion);
 
-    uiInterface.ThreadSafeHandleURI.connect(ThreadSafeHandleURI);
-    uiInterface.InitMessage.connect(InitMessage);
-    uiInterface.QueueShutdown.connect(QueueShutdown);
-    uiInterface.Translate.connect(Translate);
+    uiInterface.ThreadSafeHandleURI_connect(ThreadSafeHandleURI);
+    uiInterface.InitMessage_connect(InitMessage);
+    uiInterface.QueueShutdown_connect(QueueShutdown);
+    uiInterface.Translate_connect(Translate);
 
-    uiInterface.UpdateMessageBox.connect(UpdateMessageBox);
+    uiInterface.UpdateMessageBox_connect(UpdateMessageBox);
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -12,7 +12,7 @@
 #include "gridcoin/staking/difficulty.h"
 #include "gridcoin/staking/status.h"
 #include "gridcoin/superblock.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 
 #include <QDateTime>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -351,34 +351,22 @@ static void MinerStatusChanged(ClientModel *clientmodel, bool staking, double co
 void ClientModel::subscribeToCoreSignals()
 {
     // Connect signals to client
-    uiInterface.NotifyBlocksChanged.connect(boost::bind(NotifyBlocksChanged, this,
-                                                        boost::placeholders::_1, boost::placeholders::_2,
-                                                        boost::placeholders::_3, boost::placeholders::_4));
-    uiInterface.BannedListChanged.connect(boost::bind(BannedListChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this,
-                                                                boost::placeholders::_1));
-    uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this,
-                                                       boost::placeholders::_1, boost::placeholders::_2));
-    uiInterface.NotifyScraperEvent.connect(boost::bind(NotifyScraperEvent, this,
-                                                       boost::placeholders::_1, boost::placeholders::_2,
-                                                       boost::placeholders::_3));
-    uiInterface.MinerStatusChanged.connect(boost::bind(MinerStatusChanged, this,
-                                                       boost::placeholders::_1, boost::placeholders::_2));
+    uiInterface.NotifyBlocksChanged_connect(boost::bind(NotifyBlocksChanged, this,
+                                                      boost::placeholders::_1, boost::placeholders::_2,
+                                                      boost::placeholders::_3, boost::placeholders::_4));
+    uiInterface.BannedListChanged_connect(boost::bind(BannedListChanged, this));
+    uiInterface.NotifyNumConnectionsChanged_connect(boost::bind(NotifyNumConnectionsChanged, this,
+                                                              boost::placeholders::_1));
+    uiInterface.NotifyAlertChanged_connect(boost::bind(NotifyAlertChanged, this,
+                                                     boost::placeholders::_1, boost::placeholders::_2));
+    uiInterface.NotifyScraperEvent_connect(boost::bind(NotifyScraperEvent, this,
+                                                     boost::placeholders::_1, boost::placeholders::_2,
+                                                     boost::placeholders::_3));
+    uiInterface.MinerStatusChanged_connect(boost::bind(MinerStatusChanged, this,
+                                                     boost::placeholders::_1, boost::placeholders::_2));
 }
 
 void ClientModel::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from client
-    uiInterface.NotifyBlocksChanged.disconnect(boost::bind(NotifyBlocksChanged, this,
-                                                           boost::placeholders::_1, boost::placeholders::_2,
-                                                           boost::placeholders::_3, boost::placeholders::_4));
-    uiInterface.BannedListChanged.disconnect(boost::bind(BannedListChanged, this));
-    uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this,
-                                                                   boost::placeholders::_1));
-    uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this,
-                                                          boost::placeholders::_1, boost::placeholders::_2));
-    uiInterface.NotifyScraperEvent.disconnect(boost::bind(NotifyScraperEvent, this,
-                                                          boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
-    uiInterface.MinerStatusChanged.disconnect(boost::bind(MinerStatusChanged, this,
-                                                          boost::placeholders::_1, boost::placeholders::_2));
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -1,13 +1,14 @@
 #include "optionsmodel.h"
-#include "bitcoinunits.h"
-#include "miner.h"
 
 #include <QDebug>
 #include <QSettings>
+#include <univalue.h>
 
-#include "init.h"
-#include "wallet/walletdb.h"
+#include "bitcoinunits.h"
 #include "guiutil.h"
+#include "init.h"
+#include "miner.h"
+#include "wallet/walletdb.h"
 
 OptionsModel::OptionsModel(QObject *parent) :
     QAbstractListModel(parent)

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -4,7 +4,7 @@
 
 #include "qtipcserver.h"
 #include "guiconstants.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 
 #include <boost/algorithm/string/predicate.hpp>

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -606,15 +606,13 @@ void ResearcherModel::onWizardClose()
 void ResearcherModel::subscribeToCoreSignals()
 {
     // Connect signals to client
-    uiInterface.ResearcherChanged.connect(boost::bind(ResearcherChanged, this));
-    uiInterface.BeaconChanged.connect(boost::bind(BeaconChanged, this));
+    uiInterface.ResearcherChanged_connect(std::bind(ResearcherChanged, this));
+    uiInterface.BeaconChanged_connect(std::bind(BeaconChanged, this));
 }
 
 void ResearcherModel::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from client
-    uiInterface.ResearcherChanged.disconnect(boost::bind(ResearcherChanged, this));
-    uiInterface.ResearcherChanged.disconnect(boost::bind(BeaconChanged, this));
 }
 
 void ResearcherModel::commitBeacon(const BeaconStatus beacon_status)

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -10,7 +10,7 @@
 #include "gridcoin/project.h"
 #include "gridcoin/quorum.h"
 #include "gridcoin/researcher.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 
 #include "qt/bitcoinunits.h"
 #include "qt/guiutil.h"

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -6,7 +6,7 @@
 #include "main.h"
 #include "wallet/wallet.h"
 #include "txdb.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "base58.h"
 #include "bitcoingui.h"
 #include "util.h"

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -8,7 +8,7 @@
 #include "addresstablemodel.h"
 #include "bitcoinunits.h"
 #include "wallet/wallet.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 
 #include <QLocale>

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -4,6 +4,7 @@
 
 #include "upgradeqt.h"
 #include "gridcoin/upgrade.h"
+#include "util.h"
 
 #include <QtWidgets>
 #include <QProgressDialog>

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -16,7 +16,7 @@
 #include "qt/voting/votingmodel.h"
 #include "qt/walletmodel.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 
 #include <boost/signals2/signal.hpp>
 

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -11,11 +11,15 @@
 #include "gridcoin/voting/poll.h"
 #include "gridcoin/voting/registry.h"
 #include "gridcoin/voting/result.h"
+#include "logging.h"
 #include "qt/clientmodel.h"
 #include "qt/voting/votingmodel.h"
 #include "qt/walletmodel.h"
 #include "sync.h"
 #include "ui_interface.h"
+
+#include <boost/signals2/signal.hpp>
+
 
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
@@ -301,12 +305,11 @@ VotingResult VotingModel::sendVote(
 
 void VotingModel::subscribeToCoreSignals()
 {
-    uiInterface.NewPollReceived.connect(boost::bind(NewPollReceived, this, boost::placeholders::_1));
+    uiInterface.NewPollReceived_connect(std::bind(NewPollReceived, this, std::placeholders::_1));
 }
 
 void VotingModel::unsubscribeFromCoreSignals()
 {
-    uiInterface.NewPollReceived.disconnect(boost::bind(NewPollReceived, this, boost::placeholders::_1));
 }
 
 void VotingModel::handleNewPoll(int64_t poll_time)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -4,7 +4,7 @@
 #include "addresstablemodel.h"
 #include "transactiontablemodel.h"
 
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "wallet/wallet.h"
 #include "base58.h"
 #include "util.h"

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -5,7 +5,7 @@
 
 #include "init.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "base58.h"
 #include "protocol.h"
 #include "client.h"

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -5,7 +5,7 @@
 
 #include "init.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "protocol.h"
 #include "base58.h"
 #include "wallet/db.h"

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -686,7 +686,7 @@ void StartRPCThreads()
 
     if (!fListening)
     {
-        uiInterface.ThreadSafeMessageBox(strerr, _("Error"), CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+        uiInterface.ThreadSafeMessageBox(strerr, _("Error"), CClientUIInterface::OK | CClientUIInterface::MODAL);
         StartShutdown();
         return;
     }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -602,7 +602,7 @@ void StartRPCThreads()
                                              strWhatAmI,
                                              GetConfigFile().string(),
                                              EncodeBase58(&rand_pwd[0],&rand_pwd[0]+32)),
-                _("Error"), CClientUIInterface::OK | CClientUIInterface::MODAL);
+                _("Error"), CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         StartShutdown();
         return;
     }
@@ -686,7 +686,7 @@ void StartRPCThreads()
 
     if (!fListening)
     {
-        uiInterface.ThreadSafeMessageBox(strerr, _("Error"), CClientUIInterface::OK | CClientUIInterface::MODAL);
+        uiInterface.ThreadSafeMessageBox(strerr, _("Error"), CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         StartShutdown();
         return;
     }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -6,7 +6,7 @@
 #include "amount.h"
 #include "init.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "base58.h"
 #include "server.h"
 #include "client.h"
@@ -686,7 +686,7 @@ void StartRPCThreads()
 
     if (!fListening)
     {
-        uiInterface.ThreadSafeMessageBox(strerr, _("Error"), CClientUIInterface::OK | CClientUIInterface::MODAL);
+        uiInterface.ThreadSafeMessageBox(strerr, _("Error"), CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         StartShutdown();
         return;
     }

--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -4,6 +4,76 @@
 
 #include <ui_interface.h>
 
+#include <boost/signals2/optional_last_value.hpp>
+#include <boost/signals2/signal.hpp>
+
+
+CClientUIInterface uiInterface;
+
+
+struct UISignals {
+    boost::signals2::signal<CClientUIInterface::ThreadSafeMessageBoxSig> ThreadSafeMessageBox;
+    boost::signals2::signal<CClientUIInterface::ThreadSafeAskQuestionSig> ThreadSafeAskQuestion;
+    boost::signals2::signal<CClientUIInterface::InitMessageSig> InitMessage;
+    boost::signals2::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
+    boost::signals2::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
+    boost::signals2::signal<CClientUIInterface::BannedListChangedSig> BannedListChanged;
+    boost::signals2::signal<CClientUIInterface::MinerStatusChangedSig> MinerStatusChanged;
+    boost::signals2::signal<CClientUIInterface::ResearcherChangedSig> ResearcherChanged;
+    boost::signals2::signal<CClientUIInterface::BeaconChangedSig> BeaconChanged;
+    boost::signals2::signal<CClientUIInterface::NewPollReceivedSig> NewPollReceived;
+    boost::signals2::signal<CClientUIInterface::NotifyScraperEventSig> NotifyScraperEvent;
+    boost::signals2::signal<CClientUIInterface::ThreadSafeAskFeeSig> ThreadSafeAskFee;
+    boost::signals2::signal<CClientUIInterface::ThreadSafeHandleURISig> ThreadSafeHandleURI;
+    boost::signals2::signal<CClientUIInterface::QueueShutdownSig> QueueShutdown;
+    boost::signals2::signal<CClientUIInterface::TranslateSig> Translate;
+    boost::signals2::signal<CClientUIInterface::NotifyBlocksChangedSig> NotifyBlocksChanged;
+    boost::signals2::signal<CClientUIInterface::UpdateMessageBoxSig> UpdateMessageBox;
+};
+static UISignals g_ui_signals;
+
+#define ADD_SIGNALS_IMPL_WRAPPER(signal_name)                                                                 \
+    boost::signals2::connection CClientUIInterface::signal_name##_connect(std::function<signal_name##Sig> fn) \
+    {                                                                                                         \
+        return g_ui_signals.signal_name.connect(fn);                                                          \
+    }
+
+ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeMessageBox);
+ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeAskQuestion);
+ADD_SIGNALS_IMPL_WRAPPER(InitMessage);
+ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
+ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
+ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
+ADD_SIGNALS_IMPL_WRAPPER(MinerStatusChanged);
+ADD_SIGNALS_IMPL_WRAPPER(ResearcherChanged);
+ADD_SIGNALS_IMPL_WRAPPER(BeaconChanged);
+ADD_SIGNALS_IMPL_WRAPPER(NewPollReceived);
+ADD_SIGNALS_IMPL_WRAPPER(NotifyScraperEvent);
+ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeAskFee);
+ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeHandleURI);
+ADD_SIGNALS_IMPL_WRAPPER(QueueShutdown);
+ADD_SIGNALS_IMPL_WRAPPER(Translate);
+ADD_SIGNALS_IMPL_WRAPPER(NotifyBlocksChanged);
+ADD_SIGNALS_IMPL_WRAPPER(UpdateMessageBox);
+
+void CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
+void CClientUIInterface::UpdateMessageBox(const std::string& version, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, message); }
+bool CClientUIInterface::ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption) { return g_ui_signals.ThreadSafeAskFee(nFeeRequired, strCaption).value_or(false); }
+bool CClientUIInterface::ThreadSafeAskQuestion(std::string caption, std::string body) { return g_ui_signals.ThreadSafeAskQuestion(caption, body).value_or(false); }
+void CClientUIInterface::ThreadSafeHandleURI(const std::string& strURI) { return g_ui_signals.ThreadSafeHandleURI(strURI); }
+void CClientUIInterface::InitMessage(const std::string &message) { return g_ui_signals.InitMessage(message); }
+void CClientUIInterface::QueueShutdown() { return g_ui_signals.QueueShutdown(); }
+std::string CClientUIInterface::Translate(const char* psz) { return g_ui_signals.Translate(psz).value_or(std::string(psz)); }
+void CClientUIInterface::NotifyBlocksChanged(bool syncing, int height, int64_t best_time, uint32_t target_bits) { return g_ui_signals.NotifyBlocksChanged(syncing, height, best_time, target_bits); }
+void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
+void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListChanged(); }
+void CClientUIInterface::MinerStatusChanged(bool staking, double coin_weight) { return g_ui_signals.MinerStatusChanged(staking, coin_weight); }
+void CClientUIInterface::ResearcherChanged() { return g_ui_signals.ResearcherChanged(); }
+void CClientUIInterface::BeaconChanged() { return g_ui_signals.BeaconChanged(); }
+void CClientUIInterface::NewPollReceived(int64_t poll_time) { return g_ui_signals.NewPollReceived(poll_time); }
+void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }
+void CClientUIInterface::NotifyScraperEvent(const scrapereventtypes& ScraperEventtype, ChangeType status, const std::string& message) { return g_ui_signals.NotifyScraperEvent(ScraperEventtype, status, message); }
+
 
 bool InitError(const std::string &str)
 {

--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2010-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <ui_interface.h>
+
+
+bool InitError(const std::string &str)
+{
+    uiInterface.ThreadSafeMessageBox(str, "Gridcoin", CClientUIInterface::MSG_ERROR);
+    return false;
+}
+
+void InitWarning(const std::string &str)
+{
+    uiInterface.ThreadSafeMessageBox(str, "Gridcoin", CClientUIInterface::MSG_WARNING);
+}

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -135,6 +135,13 @@ public:
     boost::signals2::signal<void (const scrapereventtypes& ScraperEventtype, ChangeType status, const std::string& message)> NotifyScraperEvent;
 };
 
+/** Show warning message **/
+void InitWarning(const std::string& str);
+
+/** Show error message **/
+bool InitError(const std::string& str);
+constexpr auto AbortError = InitError;
+
 extern CClientUIInterface uiInterface;
 
 /**

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -36,34 +36,45 @@ public:
     /** Flags for CClientUIInterface::ThreadSafeMessageBox */
     enum MessageBoxFlags
     {
-        YES                   = 0x00000002,
-        OK                    = 0x00000004,
-        NO                    = 0x00000008,
-        YES_NO                = (YES|NO),
-        CANCEL                = 0x00000010,
-        APPLY                 = 0x00000020,
-        CLOSE                 = 0x00000040,
-        OK_DEFAULT            = 0x00000000,
-        YES_DEFAULT           = 0x00000000,
-        NO_DEFAULT            = 0x00000080,
-        CANCEL_DEFAULT        = 0x80000000,
-        ICON_EXCLAMATION      = 0x00000100,
-        ICON_HAND             = 0x00000200,
-        ICON_WARNING          = ICON_EXCLAMATION,
-        ICON_ERROR            = ICON_HAND,
-        ICON_QUESTION         = 0x00000400,
-        ICON_INFORMATION      = 0x00000800,
-        ICON_STOP             = ICON_HAND,
-        ICON_ASTERISK         = ICON_INFORMATION,
-        ICON_MASK             = (0x00000100|0x00000200|0x00000400|0x00000800),
-        FORWARD               = 0x00001000,
-        BACKWARD              = 0x00002000,
-        RESET                 = 0x00004000,
-        HELP                  = 0x00008000,
-        MORE                  = 0x00010000,
-        SETUP                 = 0x00020000,
-        // Force blocking, modal message box dialog (not just OS notification)
-        MODAL                 = 0x00040000
+        ICON_INFORMATION    = 0,
+        ICON_WARNING        = (1U << 0),
+        ICON_ERROR          = (1U << 1),
+        /**
+         * Mask of all available icons in CClientUIInterface::MessageBoxFlags
+         * This needs to be updated, when icons are changed there!
+         */
+        ICON_MASK = (ICON_INFORMATION | ICON_WARNING | ICON_ERROR),
+
+        /** These values are taken from qmessagebox.h "enum StandardButton" to be directly usable */
+        BTN_OK      = 0x00000400U, // QMessageBox::Ok
+        BTN_YES     = 0x00004000U, // QMessageBox::Yes
+        BTN_NO      = 0x00010000U, // QMessageBox::No
+        BTN_ABORT   = 0x00040000U, // QMessageBox::Abort
+        BTN_RETRY   = 0x00080000U, // QMessageBox::Retry
+        BTN_IGNORE  = 0x00100000U, // QMessageBox::Ignore
+        BTN_CLOSE   = 0x00200000U, // QMessageBox::Close
+        BTN_CANCEL  = 0x00400000U, // QMessageBox::Cancel
+        BTN_DISCARD = 0x00800000U, // QMessageBox::Discard
+        BTN_HELP    = 0x01000000U, // QMessageBox::Help
+        BTN_APPLY   = 0x02000000U, // QMessageBox::Apply
+        BTN_RESET   = 0x04000000U, // QMessageBox::Reset
+        /**
+         * Mask of all available buttons in CClientUIInterface::MessageBoxFlags
+         * This needs to be updated, when buttons are changed there!
+         */
+        BTN_MASK = (BTN_OK | BTN_YES | BTN_NO | BTN_ABORT | BTN_RETRY | BTN_IGNORE |
+                    BTN_CLOSE | BTN_CANCEL | BTN_DISCARD | BTN_HELP | BTN_APPLY | BTN_RESET),
+
+        /** Force blocking, modal message box dialog (not just OS notification) */
+        MODAL               = 0x10000000U,
+
+        /** Do not print contents of message to debug log */
+        SECURE              = 0x40000000U,
+
+        /** Predefined combinations for certain default usage cases */
+        MSG_INFORMATION = ICON_INFORMATION,
+        MSG_WARNING = (ICON_WARNING | BTN_OK | MODAL),
+        MSG_ERROR = (ICON_ERROR | BTN_OK | MODAL)
     };
 
     /** Show message box. */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,7 +8,7 @@
 #include "support/cleanse.h"
 #include "sync.h"
 #include "version.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,6 +5,7 @@
 
 #include "amount.h"
 #include "netbase.h" // for AddTimeData
+#include "support/cleanse.h"
 #include "sync.h"
 #include "version.h"
 #include "ui_interface.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -446,7 +446,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                     string strMessage = _("Warning: Please check that your computer's date and time are correct! If your clock is wrong Gridcoin will not work properly.");
                     strMiscWarning = strMessage;
                     LogPrintf("*** %s", strMessage);
-                    uiInterface.ThreadSafeMessageBox(strMessage+" ", string("Gridcoin"), CClientUIInterface::OK | CClientUIInterface::ICON_EXCLAMATION);
+                    uiInterface.ThreadSafeMessageBox(strMessage+" ", string("Gridcoin"), CClientUIInterface::MSG_WARNING);
                 }
             }
         }

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -6,7 +6,7 @@
 #include "wallet/db.h"
 #include "net.h"
 #include "main.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "util.h"
 
 #include <stdint.h>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -6,7 +6,7 @@
 #include "init.h" // for pwalletMain
 #include "rpc/server.h"
 #include "rpc/protocol.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "base58.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -8,7 +8,7 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #include "crypter.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include "base58.h"
 #include "wallet/coincontrol.h"
 #include <boost/algorithm/string/replace.hpp>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -19,7 +19,7 @@
 #include "keystore.h"
 #include "script.h"
 #include "streams.h"
-#include "ui_interface.h"
+#include "node/ui_interface.h"
 #include <util/string.h>
 #include "wallet/generated_type.h"
 #include "wallet/walletdb.h"


### PR DESCRIPTION
This PR is related to my work on `src/main.*`. The chain I am currently following is:
`Port of ui_interface changes* -> Port of PaymentServer -> Port of other src/qt/bitcoin.cpp changes -> Port of BitcoinApplication/InitExecutor -> Removal of bGridcoinCoreInitComplete`

There are no changes that affect performance or consensus contained but this will ease future code porting from upstream.
