### PR TITLE
contract: parse strings for claim and message types

### DIFF
--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -747,12 +747,14 @@ Contract::Type::Type(ContractType type) : EnumByte(type)
 Contract::Type Contract::Type::Parse(std::string input)
 {
     // Ordered by frequency:
+    if (input == "claim")          return ContractType::CLAIM;
     if (input == "beacon")         return ContractType::BEACON;
     if (input == "vote")           return ContractType::VOTE;
     if (input == "poll")           return ContractType::POLL;
     if (input == "project")        return ContractType::PROJECT;
     if (input == "scraper")        return ContractType::SCRAPER;
     if (input == "protocol")       return ContractType::PROTOCOL;
+    if (input == "message")        return ContractType::MESSAGE;
 
     return ContractType::UNKNOWN;
 }


### PR DESCRIPTION
I assume due to the lack of need, message and claim types were not included when `Contract::Type::Parse` function was written. `dumpcontracts` RPC call uses this function to parse the contract type and fails to run with these types. This PR aims to fix that.