### PR TITLE
test: Update util_tests from upstream

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1,13 +1,15 @@
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <vector>
 #include <boost/test/unit_test.hpp>
 
-#include "main.h"
-#include "wallet/wallet.h"
-#include "util.h"
+#include <main.h>
+#include <wallet/wallet.h>
+#include <util.h>
 
 #include <cstdint>
-
-using namespace std;
 
 BOOST_AUTO_TEST_SUITE(util_tests)
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -452,7 +452,6 @@ BOOST_AUTO_TEST_CASE(test_ParseInt32)
     BOOST_CHECK(!ParseInt32("1a", &n));
     BOOST_CHECK(!ParseInt32("aap", &n));
     BOOST_CHECK(!ParseInt32("0x1", &n)); // no hex
-    BOOST_CHECK(!ParseInt32("0x1", &n)); // no hex
     const char test_bytes[] = {'1', 0, '1'};
     std::string teststr(test_bytes, sizeof(test_bytes));
     BOOST_CHECK(!ParseInt32(teststr, &n)); // no embedded NULs
@@ -511,7 +510,6 @@ BOOST_AUTO_TEST_CASE(test_ParseUInt32)
     BOOST_CHECK(!ParseUInt32("1 ", &n));
     BOOST_CHECK(!ParseUInt32("1a", &n));
     BOOST_CHECK(!ParseUInt32("aap", &n));
-    BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
     BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
     const char test_bytes[] = {'1', 0, '1'};
     std::string teststr(test_bytes, sizeof(test_bytes));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
     //BOOST_CHECK(gArgs.ParseParameters(1, (char**)argv_test, error));
     //BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
 
-    BOOST_CHECK(gArgs.ParseParameters(5, (char**)argv_test, error));
+    BOOST_CHECK(gArgs.ParseParameters(7, (char**)argv_test, error));
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -727,5 +727,12 @@ BOOST_AUTO_TEST_CASE(util_mapArgsComparator)
 }
 */
 
+/* Check for mingw/wine issue #3494
+ * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
+ */
+BOOST_AUTO_TEST_CASE(gettime)
+{
+    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Clean up includes, add copyright header, remove declared namespace.
- [tests] util_tests.cpp: actually check ignored args
  Ref: https://github.com/bitcoin/bitcoin/pull/11997
> An array with 7 elements was setup for checking argument parsing, but
was passed to ParseParamaeters with argc=5, meaning the interpretation
of the last two arguments was never actually checked.

- test: remove duplicate assertions in util_tests
  Ref: https://github.com/bitcoin/bitcoin/pull/21491
- Add test for GetTime()
  Ref: https://github.com/bitcoin/bitcoin/pull/3498
> Test for mingw/wine issue #3494, where the upper word of time(NULL) return value gets clobbered.