### PR TITLE
refactor, build: Upstream fixes for the /crypto files.  Implement Keccak and SHA3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -702,7 +702,21 @@ AC_CHECK_DECLS([bswap_16, bswap_32, bswap_64],,,
                  #include <byteswap.h>
                  #endif])
 
-AC_CHECK_DECLS([__builtin_clz, __builtin_clzl, __builtin_clzll])
+AC_MSG_CHECKING(for __builtin_clzl)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[
+ (void) __builtin_clzl(0);
+  ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_BUILTIN_CLZL, 1, [Define this symbol if you have __builtin_clzl])],
+ [ AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING(for __builtin_clzll)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[
+  (void) __builtin_clzll(0);
+  ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_BUILTIN_CLZLL, 1, [Define this symbol if you have __builtin_clzll])],
+ [ AC_MSG_RESULT(no)]
+)
 
 dnl Check for MSG_NOSIGNAL
 AC_MSG_CHECKING(for MSG_NOSIGNAL)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ GRIDCOIN_CORE_H = \
     compat.h \
     compat/assumptions.h \
     compat/byteswap.h \
+    compat/cpuid.h \
     compat/endian.h \
     consensus/consensus.h \
     consensus/merkle.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -321,6 +321,8 @@ crypto_libgridcoin_crypto_base_a_SOURCES = \
     crypto/common.h \
     crypto/hmac_sha256.cpp \
     crypto/hmac_sha256.h \
+    crypto/sha3.cpp \
+    crypto/sha3.h \
     crypto/hmac_sha512.cpp \
     crypto/hmac_sha512.h \
     crypto/poly1305.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -323,6 +323,8 @@ crypto_libgridcoin_crypto_base_a_SOURCES = \
     crypto/hmac_sha256.h \
     crypto/hmac_sha512.cpp \
     crypto/hmac_sha512.h \
+    crypto/poly1305.h \
+    crypto/poly1305.cpp \
     crypto/ripemd160.cpp \
     crypto/ripemd160.h \
     crypto/sha1.cpp \
@@ -330,7 +332,9 @@ crypto_libgridcoin_crypto_base_a_SOURCES = \
     crypto/sha256.cpp \
     crypto/sha256.h \
     crypto/sha512.cpp \
-    crypto/sha512.h
+    crypto/sha512.h \
+    crypto/siphash.cpp \
+    crypto/siphash.h
 
 if USE_ASM
 crypto_libgridcoin_crypto_base_a_SOURCES += crypto/sha256_sse4.cpp

--- a/src/compat/cpuid.h
+++ b/src/compat/cpuid.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMPAT_CPUID_H
+#define BITCOIN_COMPAT_CPUID_H
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#define HAVE_GETCPUID
+
+#include <cpuid.h>
+
+// We can't use cpuid.h's __get_cpuid as it does not support subleafs.
+void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
+{
+#ifdef __GNUC__
+    __cpuid_count(leaf, subleaf, a, b, c, d);
+#else
+  __asm__ ("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "0"(leaf), "2"(subleaf));
+#endif
+}
+
+#endif // defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#endif // BITCOIN_COMPAT_CPUID_H

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Bitcoin Core developers
+// Copyright (c) 2017-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -71,7 +71,7 @@ void ChaCha20::Seek(uint64_t pos)
     input[13] = pos >> 32;
 }
 
-void ChaCha20::Output(unsigned char* c, size_t bytes)
+void ChaCha20::Keystream(unsigned char* c, size_t bytes)
 {
     uint32_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
     uint32_t j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
@@ -176,5 +176,135 @@ void ChaCha20::Output(unsigned char* c, size_t bytes)
         }
         bytes -= 64;
         c += 64;
+    }
+}
+
+void ChaCha20::Crypt(const unsigned char* m, unsigned char* c, size_t bytes)
+{
+    uint32_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
+    uint32_t j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
+    unsigned char *ctarget = nullptr;
+    unsigned char tmp[64];
+    unsigned int i;
+
+    if (!bytes) return;
+
+    j0 = input[0];
+    j1 = input[1];
+    j2 = input[2];
+    j3 = input[3];
+    j4 = input[4];
+    j5 = input[5];
+    j6 = input[6];
+    j7 = input[7];
+    j8 = input[8];
+    j9 = input[9];
+    j10 = input[10];
+    j11 = input[11];
+    j12 = input[12];
+    j13 = input[13];
+    j14 = input[14];
+    j15 = input[15];
+
+    for (;;) {
+        if (bytes < 64) {
+            // if m has fewer than 64 bytes available, copy m to tmp and
+            // read from tmp instead
+            for (i = 0;i < bytes;++i) tmp[i] = m[i];
+            m = tmp;
+            ctarget = c;
+            c = tmp;
+        }
+        x0 = j0;
+        x1 = j1;
+        x2 = j2;
+        x3 = j3;
+        x4 = j4;
+        x5 = j5;
+        x6 = j6;
+        x7 = j7;
+        x8 = j8;
+        x9 = j9;
+        x10 = j10;
+        x11 = j11;
+        x12 = j12;
+        x13 = j13;
+        x14 = j14;
+        x15 = j15;
+        for (i = 20;i > 0;i -= 2) {
+            QUARTERROUND( x0, x4, x8,x12)
+            QUARTERROUND( x1, x5, x9,x13)
+            QUARTERROUND( x2, x6,x10,x14)
+            QUARTERROUND( x3, x7,x11,x15)
+            QUARTERROUND( x0, x5,x10,x15)
+            QUARTERROUND( x1, x6,x11,x12)
+            QUARTERROUND( x2, x7, x8,x13)
+            QUARTERROUND( x3, x4, x9,x14)
+        }
+        x0 += j0;
+        x1 += j1;
+        x2 += j2;
+        x3 += j3;
+        x4 += j4;
+        x5 += j5;
+        x6 += j6;
+        x7 += j7;
+        x8 += j8;
+        x9 += j9;
+        x10 += j10;
+        x11 += j11;
+        x12 += j12;
+        x13 += j13;
+        x14 += j14;
+        x15 += j15;
+
+        x0 ^= ReadLE32(m + 0);
+        x1 ^= ReadLE32(m + 4);
+        x2 ^= ReadLE32(m + 8);
+        x3 ^= ReadLE32(m + 12);
+        x4 ^= ReadLE32(m + 16);
+        x5 ^= ReadLE32(m + 20);
+        x6 ^= ReadLE32(m + 24);
+        x7 ^= ReadLE32(m + 28);
+        x8 ^= ReadLE32(m + 32);
+        x9 ^= ReadLE32(m + 36);
+        x10 ^= ReadLE32(m + 40);
+        x11 ^= ReadLE32(m + 44);
+        x12 ^= ReadLE32(m + 48);
+        x13 ^= ReadLE32(m + 52);
+        x14 ^= ReadLE32(m + 56);
+        x15 ^= ReadLE32(m + 60);
+
+        ++j12;
+        if (!j12) ++j13;
+
+        WriteLE32(c + 0, x0);
+        WriteLE32(c + 4, x1);
+        WriteLE32(c + 8, x2);
+        WriteLE32(c + 12, x3);
+        WriteLE32(c + 16, x4);
+        WriteLE32(c + 20, x5);
+        WriteLE32(c + 24, x6);
+        WriteLE32(c + 28, x7);
+        WriteLE32(c + 32, x8);
+        WriteLE32(c + 36, x9);
+        WriteLE32(c + 40, x10);
+        WriteLE32(c + 44, x11);
+        WriteLE32(c + 48, x12);
+        WriteLE32(c + 52, x13);
+        WriteLE32(c + 56, x14);
+        WriteLE32(c + 60, x15);
+
+        if (bytes <= 64) {
+            if (bytes < 64) {
+                for (i = 0;i < bytes;++i) ctarget[i] = c[i];
+            }
+            input[12] = j12;
+            input[13] = j13;
+            return;
+        }
+        bytes -= 64;
+        c += 64;
+        m += 64;
     }
 }

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Bitcoin Core developers
+// Copyright (c) 2017-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -8,7 +8,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-/** A PRNG class for ChaCha20. */
+/** A class for ChaCha20 256-bit stream cipher developed by Daniel J. Bernstein
+    https://cr.yp.to/chacha/chacha-20080128.pdf */
 class ChaCha20
 {
 private:
@@ -17,10 +18,17 @@ private:
 public:
     ChaCha20();
     ChaCha20(const unsigned char* key, size_t keylen);
-    void SetKey(const unsigned char* key, size_t keylen);
-    void SetIV(uint64_t iv);
-    void Seek(uint64_t pos);
-    void Output(unsigned char* output, size_t bytes);
+    void SetKey(const unsigned char* key, size_t keylen); //!< set key with flexible keylength; 256bit recommended */
+    void SetIV(uint64_t iv); // set the 64bit nonce
+    void Seek(uint64_t pos); // set the 64bit block counter
+
+    /** outputs the keystream of size <bytes> into <c> */
+    void Keystream(unsigned char* c, size_t bytes);
+
+    /** enciphers the message <input> of length <bytes> and write the enciphered representation into <output>
+     *  Used for encryption and decryption (XOR)
+     */
+    void Crypt(const unsigned char* input, unsigned char* output, size_t bytes);
 };
 
 #endif // BITCOIN_CRYPTO_CHACHA20_H

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Copyright (c) 2014-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -82,12 +82,12 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
 uint64_t static inline CountBits(uint64_t x)
 {
-#if HAVE_DECL___BUILTIN_CLZL
+#if HAVE_BUILTIN_CLZL
     if (sizeof(unsigned long) >= sizeof(uint64_t)) {
         return x ? 8 * sizeof(unsigned long) - __builtin_clzl(x) : 0;
     }
 #endif
-#if HAVE_DECL___BUILTIN_CLZLL
+#if HAVE_BUILTIN_CLZLL
     if (sizeof(unsigned long long) >= sizeof(uint64_t)) {
         return x ? 8 * sizeof(unsigned long long) - __builtin_clzll(x) : 0;
     }

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Copyright (c) 2014-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -256,7 +256,7 @@ CRIPEMD160& CRIPEMD160::Write(const unsigned char* data, size_t len)
         ripemd160::Transform(s, buf);
         bufsize = 0;
     }
-    while (end >= data + 64) {
+    while (end - data >= 64) {
         // Process full chunks directly from the source.
         ripemd160::Transform(s, data);
         bytes += 64;

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Copyright (c) 2014-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -163,7 +163,7 @@ CSHA1& CSHA1::Write(const unsigned char* data, size_t len)
         sha1::Transform(s, buf);
         bufsize = 0;
     }
-    while (end >= data + 64) {
+    while (end - data >= 64) {
         // Process full chunks directly from the source.
         sha1::Transform(s, data);
         bytes += 64;

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -9,9 +9,10 @@
 #include <string.h>
 #include <atomic>
 
+#include <compat/cpuid.h>
+
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #if defined(USE_ASM)
-#include <cpuid.h>
 namespace sha256_sse4
 {
 void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks);
@@ -547,18 +548,7 @@ bool SelfTest() {
     return true;
 }
 
-
 #if defined(USE_ASM) && (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
-// We can't use cpuid.h's __get_cpuid as it does not support subleafs.
-void inline cpuid(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
-{
-#ifdef __GNUC__
-    __cpuid_count(leaf, subleaf, a, b, c, d);
-#else
-  __asm__ ("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "0"(leaf), "2"(subleaf));
-#endif
-}
-
 /** Check whether the OS has enabled AVX registers. */
 bool AVXEnabled()
 {
@@ -573,7 +563,7 @@ bool AVXEnabled()
 std::string SHA256AutoDetect()
 {
     std::string ret = "standard";
-#if defined(USE_ASM) && (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
+#if defined(USE_ASM) && defined(HAVE_GETCPUID)
     bool have_sse4 = false;
     bool have_xsave = false;
     bool have_avx = false;
@@ -590,7 +580,7 @@ std::string SHA256AutoDetect()
     (void)enabled_avx;
 
     uint32_t eax, ebx, ecx, edx;
-    cpuid(1, 0, eax, ebx, ecx, edx);
+    GetCPUID(1, 0, eax, ebx, ecx, edx);
     have_sse4 = (ecx >> 19) & 1;
     have_xsave = (ecx >> 27) & 1;
     have_avx = (ecx >> 28) & 1;
@@ -598,7 +588,7 @@ std::string SHA256AutoDetect()
         enabled_avx = AVXEnabled();
     }
     if (have_sse4) {
-        cpuid(7, 0, eax, ebx, ecx, edx);
+        GetCPUID(7, 0, eax, ebx, ecx, edx);
         have_avx2 = (ebx >> 5) & 1;
         have_shani = (ebx >> 29) & 1;
     }

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Copyright (c) 2014-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -24,6 +24,7 @@ public:
     CSHA256& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CSHA256& Reset();
+    uint64_t Size() const { return bytes; }
 };
 
 /** Autodetect the best available SHA256 implementation.

--- a/src/crypto/sha3.cpp
+++ b/src/crypto/sha3.cpp
@@ -1,0 +1,161 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Based on https://github.com/mjosaarinen/tiny_sha3/blob/master/sha3.c
+// by Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#include <crypto/sha3.h>
+#include <crypto/common.h>
+#include <span.h>
+
+#include <algorithm>
+#include <array> // For std::begin and std::end.
+
+#include <stdint.h>
+
+// Internal implementation code.
+namespace
+{
+uint64_t Rotl(uint64_t x, int n) { return (x << n) | (x >> (64 - n)); }
+} // namespace
+
+void KeccakF(uint64_t (&st)[25])
+{
+    static constexpr uint64_t RNDC[24] = {
+        0x0000000000000001, 0x0000000000008082, 0x800000000000808a, 0x8000000080008000,
+        0x000000000000808b, 0x0000000080000001, 0x8000000080008081, 0x8000000000008009,
+        0x000000000000008a, 0x0000000000000088, 0x0000000080008009, 0x000000008000000a,
+        0x000000008000808b, 0x800000000000008b, 0x8000000000008089, 0x8000000000008003,
+        0x8000000000008002, 0x8000000000000080, 0x000000000000800a, 0x800000008000000a,
+        0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008
+    };
+    static constexpr int ROUNDS = 24;
+
+    for (int round = 0; round < ROUNDS; ++round) {
+        uint64_t bc0, bc1, bc2, bc3, bc4, t;
+
+        // Theta
+        bc0 = st[0] ^ st[5] ^ st[10] ^ st[15] ^ st[20];
+        bc1 = st[1] ^ st[6] ^ st[11] ^ st[16] ^ st[21];
+        bc2 = st[2] ^ st[7] ^ st[12] ^ st[17] ^ st[22];
+        bc3 = st[3] ^ st[8] ^ st[13] ^ st[18] ^ st[23];
+        bc4 = st[4] ^ st[9] ^ st[14] ^ st[19] ^ st[24];
+        t = bc4 ^ Rotl(bc1, 1); st[0] ^= t; st[5] ^= t; st[10] ^= t; st[15] ^= t; st[20] ^= t;
+        t = bc0 ^ Rotl(bc2, 1); st[1] ^= t; st[6] ^= t; st[11] ^= t; st[16] ^= t; st[21] ^= t;
+        t = bc1 ^ Rotl(bc3, 1); st[2] ^= t; st[7] ^= t; st[12] ^= t; st[17] ^= t; st[22] ^= t;
+        t = bc2 ^ Rotl(bc4, 1); st[3] ^= t; st[8] ^= t; st[13] ^= t; st[18] ^= t; st[23] ^= t;
+        t = bc3 ^ Rotl(bc0, 1); st[4] ^= t; st[9] ^= t; st[14] ^= t; st[19] ^= t; st[24] ^= t;
+
+        // Rho Pi
+        t = st[1];
+        bc0 = st[10]; st[10] = Rotl(t, 1); t = bc0;
+        bc0 = st[7]; st[7] = Rotl(t, 3); t = bc0;
+        bc0 = st[11]; st[11] = Rotl(t, 6); t = bc0;
+        bc0 = st[17]; st[17] = Rotl(t, 10); t = bc0;
+        bc0 = st[18]; st[18] = Rotl(t, 15); t = bc0;
+        bc0 = st[3]; st[3] = Rotl(t, 21); t = bc0;
+        bc0 = st[5]; st[5] = Rotl(t, 28); t = bc0;
+        bc0 = st[16]; st[16] = Rotl(t, 36); t = bc0;
+        bc0 = st[8]; st[8] = Rotl(t, 45); t = bc0;
+        bc0 = st[21]; st[21] = Rotl(t, 55); t = bc0;
+        bc0 = st[24]; st[24] = Rotl(t, 2); t = bc0;
+        bc0 = st[4]; st[4] = Rotl(t, 14); t = bc0;
+        bc0 = st[15]; st[15] = Rotl(t, 27); t = bc0;
+        bc0 = st[23]; st[23] = Rotl(t, 41); t = bc0;
+        bc0 = st[19]; st[19] = Rotl(t, 56); t = bc0;
+        bc0 = st[13]; st[13] = Rotl(t, 8); t = bc0;
+        bc0 = st[12]; st[12] = Rotl(t, 25); t = bc0;
+        bc0 = st[2]; st[2] = Rotl(t, 43); t = bc0;
+        bc0 = st[20]; st[20] = Rotl(t, 62); t = bc0;
+        bc0 = st[14]; st[14] = Rotl(t, 18); t = bc0;
+        bc0 = st[22]; st[22] = Rotl(t, 39); t = bc0;
+        bc0 = st[9]; st[9] = Rotl(t, 61); t = bc0;
+        bc0 = st[6]; st[6] = Rotl(t, 20); t = bc0;
+        st[1] = Rotl(t, 44);
+
+        // Chi Iota
+        bc0 = st[0]; bc1 = st[1]; bc2 = st[2]; bc3 = st[3]; bc4 = st[4];
+        st[0] = bc0 ^ (~bc1 & bc2) ^ RNDC[round];
+        st[1] = bc1 ^ (~bc2 & bc3);
+        st[2] = bc2 ^ (~bc3 & bc4);
+        st[3] = bc3 ^ (~bc4 & bc0);
+        st[4] = bc4 ^ (~bc0 & bc1);
+        bc0 = st[5]; bc1 = st[6]; bc2 = st[7]; bc3 = st[8]; bc4 = st[9];
+        st[5] = bc0 ^ (~bc1 & bc2);
+        st[6] = bc1 ^ (~bc2 & bc3);
+        st[7] = bc2 ^ (~bc3 & bc4);
+        st[8] = bc3 ^ (~bc4 & bc0);
+        st[9] = bc4 ^ (~bc0 & bc1);
+        bc0 = st[10]; bc1 = st[11]; bc2 = st[12]; bc3 = st[13]; bc4 = st[14];
+        st[10] = bc0 ^ (~bc1 & bc2);
+        st[11] = bc1 ^ (~bc2 & bc3);
+        st[12] = bc2 ^ (~bc3 & bc4);
+        st[13] = bc3 ^ (~bc4 & bc0);
+        st[14] = bc4 ^ (~bc0 & bc1);
+        bc0 = st[15]; bc1 = st[16]; bc2 = st[17]; bc3 = st[18]; bc4 = st[19];
+        st[15] = bc0 ^ (~bc1 & bc2);
+        st[16] = bc1 ^ (~bc2 & bc3);
+        st[17] = bc2 ^ (~bc3 & bc4);
+        st[18] = bc3 ^ (~bc4 & bc0);
+        st[19] = bc4 ^ (~bc0 & bc1);
+        bc0 = st[20]; bc1 = st[21]; bc2 = st[22]; bc3 = st[23]; bc4 = st[24];
+        st[20] = bc0 ^ (~bc1 & bc2);
+        st[21] = bc1 ^ (~bc2 & bc3);
+        st[22] = bc2 ^ (~bc3 & bc4);
+        st[23] = bc3 ^ (~bc4 & bc0);
+        st[24] = bc4 ^ (~bc0 & bc1);
+    }
+}
+
+SHA3_256& SHA3_256::Write(Span<const unsigned char> data)
+{
+    if (m_bufsize && m_bufsize + data.size() >= sizeof(m_buffer)) {
+        // Fill the buffer and process it.
+        std::copy(data.begin(), data.begin() + sizeof(m_buffer) - m_bufsize, m_buffer + m_bufsize);
+        data = data.subspan(sizeof(m_buffer) - m_bufsize);
+        m_state[m_pos++] ^= ReadLE64(m_buffer);
+        m_bufsize = 0;
+        if (m_pos == RATE_BUFFERS) {
+            KeccakF(m_state);
+            m_pos = 0;
+        }
+    }
+    while (data.size() >= sizeof(m_buffer)) {
+        // Process chunks directly from the buffer.
+        m_state[m_pos++] ^= ReadLE64(data.data());
+        data = data.subspan(8);
+        if (m_pos == RATE_BUFFERS) {
+            KeccakF(m_state);
+            m_pos = 0;
+        }
+    }
+    if (data.size()) {
+        // Keep the remainder in the buffer.
+        std::copy(data.begin(), data.end(), m_buffer + m_bufsize);
+        m_bufsize += data.size();
+    }
+    return *this;
+}
+
+SHA3_256& SHA3_256::Finalize(Span<unsigned char> output)
+{
+    assert(output.size() == OUTPUT_SIZE);
+    std::fill(m_buffer + m_bufsize, m_buffer + sizeof(m_buffer), 0);
+    m_buffer[m_bufsize] ^= 0x06;
+    m_state[m_pos] ^= ReadLE64(m_buffer);
+    m_state[RATE_BUFFERS - 1] ^= 0x8000000000000000;
+    KeccakF(m_state);
+    for (unsigned i = 0; i < 4; ++i) {
+        WriteLE64(output.data() + 8 * i, m_state[i]);
+    }
+    return *this;
+}
+
+SHA3_256& SHA3_256::Reset()
+{
+    m_bufsize = 0;
+    m_pos = 0;
+    std::fill(std::begin(m_state), std::end(m_state), 0);
+    return *this;
+}

--- a/src/crypto/sha3.h
+++ b/src/crypto/sha3.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_SHA3_H
+#define BITCOIN_CRYPTO_SHA3_H
+
+#include <span.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+//! The Keccak-f[1600] transform.
+void KeccakF(uint64_t (&st)[25]);
+
+class SHA3_256
+{
+private:
+    uint64_t m_state[25] = {0};
+    unsigned char m_buffer[8];
+    unsigned m_bufsize = 0;
+    unsigned m_pos = 0;
+
+    //! Sponge rate in bits.
+    static constexpr unsigned RATE_BITS = 1088;
+
+    //! Sponge rate expressed as a multiple of the buffer size.
+    static constexpr unsigned RATE_BUFFERS = RATE_BITS / (8 * sizeof(m_buffer));
+
+    static_assert(RATE_BITS % (8 * sizeof(m_buffer)) == 0, "Rate must be a multiple of 8 bytes");
+
+public:
+    static constexpr size_t OUTPUT_SIZE = 32;
+
+    SHA3_256() {}
+    SHA3_256& Write(Span<const unsigned char> data);
+    SHA3_256& Finalize(Span<unsigned char> output);
+    SHA3_256& Reset();
+};
+
+#endif // BITCOIN_CRYPTO_SHA3_H

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Copyright (c) 2014-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -168,7 +168,7 @@ CSHA512& CSHA512::Write(const unsigned char* data, size_t len)
         sha512::Transform(s, buf);
         bufsize = 0;
     }
-    while (end >= data + 128) {
+    while (end - data >= 128) {
         // Process full chunks directly from the source.
         sha512::Transform(s, data);
         data += 128;

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 The Bitcoin Core developers
+// Copyright (c) 2016-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -49,7 +49,7 @@ CSipHasher& CSipHasher::Write(const unsigned char* data, size_t size)
 {
     uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
     uint64_t t = tmp;
-    int c = count;
+    uint8_t c = count;
 
     while (size--) {
         t |= ((uint64_t)(*(data++))) << (8 * (c % 8));

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2018 The Bitcoin Core developers
+// Copyright (c) 2016-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -15,7 +15,7 @@ class CSipHasher
 private:
     uint64_t v[4];
     uint64_t tmp;
-    int count;
+    uint8_t count; // Only the low 8 bits of the input size matter.
 
 public:
     /** Construct a SipHash calculator initialized with 128-bit key (k0, k1) */


### PR DESCRIPTION
- Change CSipHasher's count variable to uint8_t
  Ref: https://github.com/bitcoin/bitcoin/pull/19931
> SipHash technically supports arbitrarily long inputs (at least, I couldn't find a limit in the paper), but only the low 8 bits of the length matter. Because of that we should use an unsigned type to track the length (as any signed type could overflow, which is UB). uint8_t is sufficient, however.
- Do not construct out-of-bound pointers in SHA2 code
  Ref: https://github.com/bitcoin/bitcoin/pull/15950
> This looks like an issue in the current SHA256/512 code, where a pointer outside of the area pointed to may be constructed (this is UB in theory, though in practice every supported platform treats pointers as integers).
- build: improve __builtin_clz* detection
  Ref: https://github.com/bitcoin/bitcoin/pull/19403
> The way we currently test for __builtin_clz* support with AC_CHECK_DECLS does not work with Clang
- Implement Keccak and SHA3_256
  Ref: https://github.com/bitcoin/bitcoin/pull/19841
> Add a simple (and initially unoptimized) Keccak/SHA3 implementation, as one will be needed for TORv3 support (the conversion from BIP155 encoding to .onion notation uses a SHA3-based checksum).

- Actually enable crypto libraries added in https://github.com/gridcoin-community/Gridcoin-Research/pull/1453

- compat: move cpuid 
- crypto: port some upstream changes 