### PR TITLE
refactor: convert C-style (void) parameter lists to C++ style ()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -597,7 +597,7 @@ std::string VersionMessage()
  *  Ensure that Bitcoin is running in a usable environment with all
  *  necessary library support.
  */
-bool InitSanityCheck(void)
+bool InitSanityCheck()
 {
     // The below sanity check is still required for OpenSSL via key.cpp until Bitcoin's secp256k1 is ported over. For now we have
     // only ported the accelerated hashing.

--- a/src/key.h
+++ b/src/key.h
@@ -182,6 +182,6 @@ public:
 };
 
 /** Check that required EC support is available at runtime */
-bool ECC_InitSanityCheck(void);
+bool ECC_InitSanityCheck();
 
 #endif

--- a/src/qt/macnotificationhandler.h
+++ b/src/qt/macnotificationhandler.h
@@ -15,7 +15,7 @@ public:
     void showNotification(const QString &title, const QString &text);
 
     /** check if OS can handle UserNotifications */
-    bool hasUserNotificationCenterSupport(void);
+    bool hasUserNotificationCenterSupport();
     static MacNotificationHandler *instance();
 };
 

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -41,7 +41,7 @@ static void add_coin(int64_t nValue, int nAge = 6*24, bool fIsFromMe = false, in
     vCoins.push_back(output);
 }
 
-static void empty_wallet(void)
+static void empty_wallet()
 {
     for(COutput& output : vCoins)
         delete output.tx;


### PR DESCRIPTION
Tested on Windows 10 cross-compile (depends).

Ref: https://github.com/bitcoin/bitcoin/pull/14214

> In C, an empty parameter list, (), means the function takes any arguments, and (void) means the function does not take any parameters.
> In C++, an empty parameter list means the function does not take any parameters.
>
> So, C++ still supports (void) parameter lists with the same semantics, why change to ()?
> 
>    removing the redundant void improves signal-to-noise ratio of the code
>    using (void) exposes a rare inconsistency in that a template taking a template (T) parameter list, cannot be instantiated with T=void
