### PR TITLE
util: fix FormatVersion

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -46,7 +46,10 @@ const std::string CLIENT_NAME("Halford");
 
 static std::string FormatVersion(int nVersion)
 {
-    return strprintf("%d.%d.%d", nVersion / 10000, (nVersion / 100) % 100, nVersion % 100);
+    if (nVersion % 100 == 0) {
+        return strprintf("%d.%d.%d", nVersion / 1000000, (nVersion / 10000) % 100, (nVersion / 100) % 100);
+    }
+    return strprintf("%d.%d.%d.%d", nVersion / 1000000, (nVersion / 10000) % 100, (nVersion / 100) % 100, nVersion % 100);
 }
 
 std::string FormatFullVersion()

--- a/src/util.h
+++ b/src/util.h
@@ -118,8 +118,6 @@ std::string GetFileContents(const fs::path filepath);
 
 int64_t GetTimeOffset();
 int64_t GetAdjustedTime();
-std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample);
 void runCommand(std::string strCommand);
 


### PR DESCRIPTION
Accidental changes introduced in #2367 seems to have broken FormatVersion(or somehow I managed to skip 498 major releases) resulting in version 5.3.2.2 being formatted as 503.2.2. This affects user agent generation and the alert system. This PR changes the function to act like pre-#2367.

I've verified that user agent is returned correctly after this PR with a special tool.