### PR TITLE
build: Disable -fcf-protection for mingw win32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -645,7 +645,15 @@ if test x$use_hardening != xno; then
   AX_CHECK_COMPILE_FLAG([-Wstack-protector],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -Wstack-protector"])
   AX_CHECK_COMPILE_FLAG([-fstack-protector-all],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-protector-all"])
 
-  AX_CHECK_COMPILE_FLAG([-fcf-protection=full],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fcf-protection=full"])
+  case $host in
+    i686-w64-mingw32)
+      dnl Control-Flow Enforcement Technology (CET) does not appear to work for mingw for i686 (32-bit)
+      dnl When it is enabled, unstable executables result. Disable for now.
+      ;;
+    *)
+      AX_CHECK_COMPILE_FLAG([-fcf-protection=full],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fcf-protection=full"])
+      ;;
+  esac
 
   case $host in
     *mingw*)


### PR DESCRIPTION
-fcf-protection does not appear to work properly for mingw in i686 and results in unstable executables being compiled. This disables -fcf-protection for i686-w64-mingw32 hosts only.