### PR TITLE
test, refactor: Use FastRandomContext for all tests. Add a header for test_gridcoin

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -66,6 +66,7 @@ GRIDCOIN_TESTS =\
 	test/serialize_tests.cpp \
 	test/sigopcount_tests.cpp \
 	test/test_gridcoin.cpp \
+	test/test_gridcoin.h \
 	test/transaction_tests.cpp \
 	test/uint256_tests.cpp \
 	test/util_tests.cpp \

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -17,13 +17,13 @@
 #include <streams.h>
 #include <util/strencodings.h>
 
+#include <test/test_gridcoin.h>
+
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(crypto_tests)
-
-FastRandomContext ctx;
 
 template<typename Hasher, typename In, typename Out>
 static void TestVector(const Hasher &h, const In &in, const Out &out) {
@@ -40,7 +40,7 @@ static void TestVector(const Hasher &h, const In &in, const Out &out) {
         Hasher hasher(h);
         size_t pos = 0;
         while (pos < in.size()) {
-            size_t len = ctx.randrange((in.size() - pos + 1) / 2 + 1);
+            size_t len = InsecureRandRange((in.size() - pos + 1) / 2 + 1);
             hasher.Write((const uint8_t*)in.data() + pos, len);
             pos += len;
             if (pos > 0 && pos + 2 * out.size() > in.size() && pos < in.size()) {
@@ -555,6 +555,7 @@ BOOST_AUTO_TEST_CASE(poly1305_testvector)
 
 BOOST_AUTO_TEST_CASE(countbits_tests)
 {
+    FastRandomContext ctx;
     for (unsigned int i = 0; i <= 64; ++i) {
         if (i == 0) {
             // Check handling of zero.
@@ -580,7 +581,7 @@ BOOST_AUTO_TEST_CASE(sha256d64)
         unsigned char in[64 * 32];
         unsigned char out1[32 * 32], out2[32 * 32];
         for (int j = 0; j < 64 * i; ++j) {
-            in[j] = ctx.randbits(8);
+            in[j] = InsecureRandBits(8);
         }
         for (int j = 0; j < i; ++j) {
             CHash256().Write(in + 64 * j, 64).Finalize(out1 + 32 * j);
@@ -604,8 +605,8 @@ static void TestSHA3_256(const std::string& input, const std::string& output)
 
     // Reset and split randomly in 3
     sha.Reset();
-    int s1 = ctx.randrange(in_bytes.size() + 1);
-    int s2 = ctx.randrange(in_bytes.size() + 1 - s1);
+    int s1 = InsecureRandRange(in_bytes.size() + 1);
+    int s2 = InsecureRandRange(in_bytes.size() + 1 - s1);
     int s3 = in_bytes.size() - s1 - s2;
     sha.Write(MakeSpan(in_bytes).first(s1)).Write(MakeSpan(in_bytes).subspan(s1, s2));
     sha.Write(MakeSpan(in_bytes).last(s3)).Finalize(out);

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -555,7 +555,6 @@ BOOST_AUTO_TEST_CASE(poly1305_testvector)
 
 BOOST_AUTO_TEST_CASE(countbits_tests)
 {
-    FastRandomContext ctx;
     for (unsigned int i = 0; i <= 64; ++i) {
         if (i == 0) {
             // Check handling of zero.
@@ -568,7 +567,7 @@ BOOST_AUTO_TEST_CASE(countbits_tests)
         } else {
             for (int k = 0; k < 1000; k++) {
                 // Randomly test 1000 samples of each length above 10 bits.
-                uint64_t j = ((uint64_t)1) << (i - 1) | ctx.randbits(i - 1);
+                uint64_t j = ((uint64_t)1) << (i - 1) | InsecureRandBits(i - 1);
                 BOOST_CHECK_EQUAL(CountBits(j), i);
             }
         }

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -13,6 +13,8 @@
 #include "random.h"
 #include "banman.h"
 
+#include <test/test_gridcoin.h>
+
 #include <stdint.h>
 
 // Tests this internal-to-main.cpp method:

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(DoS_misbehavior_decay)
 
 CTransaction RandomOrphan()
 {
-    auto it = mapOrphanTransactions.lower_bound(GetRandHash());
+    auto it = mapOrphanTransactions.lower_bound(InsecureRand256());
     if (it == mapOrphanTransactions.end())
         it = mapOrphanTransactions.begin();
     return it->second;
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         CTransaction tx;
         tx.vin.resize(1);
         tx.vin[0].prevout.n = 0;
-        tx.vin[0].prevout.hash = GetRandHash();
+        tx.vin[0].prevout.hash = InsecureRand256();
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(DoS_checkSig)
         CTransaction& tx = orphans[i];
         tx.vin.resize(1);
         tx.vin[0].prevout.n = 0;
-        tx.vin[0].prevout.hash = GetRandHash();
+        tx.vin[0].prevout.hash = InsecureRand256();
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;

--- a/src/test/mruset_tests.cpp
+++ b/src/test/mruset_tests.cpp
@@ -5,6 +5,8 @@ using namespace std;
 #include "mruset.h"
 #include "random.h"
 
+#include <test/test_gridcoin.h>
+
 #define NUM_TESTS 16
 #define MAX_SIZE 100
 
@@ -31,12 +33,11 @@ BOOST_AUTO_TEST_SUITE(mruset_tests)
 // Test that an mruset behaves like a set, as long as no more than MAX_SIZE elements are in it
 BOOST_AUTO_TEST_CASE(mruset_like_set)
 {
-    FastRandomContext ctx;
     for (int nTest=0; nTest<NUM_TESTS; nTest++)
     {
         mrutester tester;
         while (tester.size() < MAX_SIZE)
-            tester.insert(ctx.randrange(2 * MAX_SIZE));
+            tester.insert(InsecureRandRange(2 * MAX_SIZE));
     }
 
 }
@@ -44,13 +45,12 @@ BOOST_AUTO_TEST_CASE(mruset_like_set)
 // Test that an mruset's size never exceeds its max_size
 BOOST_AUTO_TEST_CASE(mruset_limited_size)
 {
-    FastRandomContext ctx;
     for (int nTest=0; nTest<NUM_TESTS; nTest++)
     {
         mruset<int> mru(MAX_SIZE);
         for (int nAction=0; nAction<3*MAX_SIZE; nAction++)
         {
-            mru.insert(ctx.randrange(2 * MAX_SIZE));
+            mru.insert(InsecureRandRange(2 * MAX_SIZE));
             BOOST_CHECK(mru.size() <= MAX_SIZE);
         }
     }

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -1,6 +1,8 @@
 #define BOOST_TEST_MODULE Gridcoin Test Suite
 #include <boost/test/unit_test.hpp>
 
+#include <test/test_gridcoin.h>
+
 #include <leveldb/env.h>
 #include <leveldb/helpers/memenv/memenv.h>
 
@@ -20,14 +22,18 @@ extern CClientUIInterface uiInterface;
  */
 extern bool g_mock_deterministic_tests;
 
+FastRandomContext g_insecure_rand_ctx;
+
+uint256 insecure_rand_seed = GetRandHash();
+FastRandomContext insecure_rand_ctx(insecure_rand_seed);
+
 extern void noui_connect();
 extern leveldb::Options GetOptions();
 extern void InitLogging();
 
-
 struct TestingSetup {
     TestingSetup() {
-        fs::path m_path_root = fs::temp_directory_path() / "test_common_" PACKAGE_NAME / GetRandHash().ToString();
+        fs::path m_path_root = fs::temp_directory_path() / "test_common_" PACKAGE_NAME / InsecureRand256().ToString();
         fUseFastIndex = true; // Don't verify block hashes when loading
         gArgs.ForceSetArg("-datadir", m_path_root.string());
         gArgs.ClearPathCache();

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -24,9 +24,6 @@ extern bool g_mock_deterministic_tests;
 
 FastRandomContext g_insecure_rand_ctx;
 
-uint256 insecure_rand_seed = GetRandHash();
-FastRandomContext insecure_rand_ctx(insecure_rand_seed);
-
 extern void noui_connect();
 extern leveldb::Options GetOptions();
 extern void InitLogging();

--- a/src/test/test_gridcoin.h
+++ b/src/test/test_gridcoin.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_TEST_TEST_GRIDCOIN_H
+#define GRIDCOIN_TEST_TEST_GRIDCOIN_H
+
+#include <main.h>
+#include <random.h>
+#include <wallet/wallet.h>
+
+extern uint256 insecure_rand_seed;
+extern FastRandomContext insecure_rand_ctx;
+
+static inline void SeedInsecureRand(bool fDeterministic = false)
+{
+    if (fDeterministic) {
+        insecure_rand_seed = uint256();
+    } else {
+        insecure_rand_seed = GetRandHash();
+    }
+    insecure_rand_ctx = FastRandomContext(insecure_rand_seed);
+}
+
+static inline uint32_t InsecureRand32() { return insecure_rand_ctx.rand32(); }
+static inline uint256 InsecureRand256() { return insecure_rand_ctx.rand256(); }
+static inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.randbits(bits); }
+static inline uint64_t InsecureRandRange(uint64_t range) { return insecure_rand_ctx.randrange(range); }
+static inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
+static inline std::vector<unsigned char> InsecureRandBytes(size_t len) { return insecure_rand_ctx.randbytes(len); }
+
+#endif

--- a/src/test/test_gridcoin.h
+++ b/src/test/test_gridcoin.h
@@ -9,18 +9,7 @@
 #include <random.h>
 #include <wallet/wallet.h>
 
-extern uint256 insecure_rand_seed;
-extern FastRandomContext insecure_rand_ctx;
-
-static inline void SeedInsecureRand(bool fDeterministic = false)
-{
-    if (fDeterministic) {
-        insecure_rand_seed = uint256();
-    } else {
-        insecure_rand_seed = GetRandHash();
-    }
-    insecure_rand_ctx = FastRandomContext(insecure_rand_seed);
-}
+extern FastRandomContext g_insecure_rand_ctx;
 
 static inline uint32_t InsecureRand32() { return insecure_rand_ctx.rand32(); }
 static inline uint256 InsecureRand256() { return insecure_rand_ctx.rand256(); }

--- a/src/test/test_gridcoin.h
+++ b/src/test/test_gridcoin.h
@@ -11,11 +11,11 @@
 
 extern FastRandomContext g_insecure_rand_ctx;
 
-static inline uint32_t InsecureRand32() { return insecure_rand_ctx.rand32(); }
-static inline uint256 InsecureRand256() { return insecure_rand_ctx.rand256(); }
-static inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.randbits(bits); }
-static inline uint64_t InsecureRandRange(uint64_t range) { return insecure_rand_ctx.randrange(range); }
-static inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
-static inline std::vector<unsigned char> InsecureRandBytes(size_t len) { return insecure_rand_ctx.randbytes(len); }
+static inline uint32_t InsecureRand32() { return g_insecure_rand_ctx.rand32(); }
+static inline uint256 InsecureRand256() { return g_insecure_rand_ctx.rand256(); }
+static inline uint64_t InsecureRandBits(int bits) { return g_insecure_rand_ctx.randbits(bits); }
+static inline uint64_t InsecureRandRange(uint64_t range) { return g_insecure_rand_ctx.randrange(range); }
+static inline bool InsecureRandBool() { return g_insecure_rand_ctx.randbool(); }
+static inline std::vector<unsigned char> InsecureRandBytes(size_t len) { return g_insecure_rand_ctx.randbytes(len); }
 
 #endif


### PR DESCRIPTION
- > Currently, the unit tests rely on a mix of an encapsulated FastRandomContext, and some of the Rand*() functions for randomness. This is inefficient, and will become more inefficient when the Rand* functions are changed to always provide strong randomness.

  Ref: https://github.com/bitcoin/bitcoin/pull/10321

- Split out a header file for test_gridcoin so we can include the FastRandomContext functions

Note - this header file may be incomplete or just incorrect.  I am not very experienced with C++ headers at all