### PR TITLE
util: Port of Bitcoin upstream base58.h/cpp at a85442f62bf157b07849accd495c55c73535dc73

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -204,6 +204,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     alert.cpp \
     arith_uint256.cpp \
     banman.cpp \
+    base58.cpp \
     chainparams.cpp \
     chainparamsbase.cpp \
     checkpoints.cpp \

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2014-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <base58.h>
+
+#include <hash.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+
+#include <assert.h>
+#include <string.h>
+
+#include <limits>
+
+/** All alphanumeric characters except for "0", "I", "O", and "l" */
+static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+static const int8_t mapBase58[256] = {
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1, 0, 1, 2, 3, 4, 5, 6,  7, 8,-1,-1,-1,-1,-1,-1,
+    -1, 9,10,11,12,13,14,15, 16,-1,17,18,19,20,21,-1,
+    22,23,24,25,26,27,28,29, 30,31,32,-1,-1,-1,-1,-1,
+    -1,33,34,35,36,37,38,39, 40,41,42,43,-1,44,45,46,
+    47,48,49,50,51,52,53,54, 55,56,57,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+};
+
+[[nodiscard]] static bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch, int max_ret_len)
+{
+    // Skip leading spaces.
+    while (*psz && IsSpace(*psz))
+        psz++;
+    // Skip and count leading '1's.
+    int zeroes = 0;
+    int length = 0;
+    while (*psz == '1') {
+        zeroes++;
+        if (zeroes > max_ret_len) return false;
+        psz++;
+    }
+    // Allocate enough space in big-endian base256 representation.
+    int size = strlen(psz) * 733 /1000 + 1; // log(58) / log(256), rounded up.
+    std::vector<unsigned char> b256(size);
+    // Process the characters.
+    static_assert(std::size(mapBase58) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
+    while (*psz && !IsSpace(*psz)) {
+        // Decode base58 character
+        int carry = mapBase58[(uint8_t)*psz];
+        if (carry == -1)  // Invalid b58 character
+            return false;
+        int i = 0;
+        for (std::vector<unsigned char>::reverse_iterator it = b256.rbegin(); (carry != 0 || i < length) && (it != b256.rend()); ++it, ++i) {
+            carry += 58 * (*it);
+            *it = carry % 256;
+            carry /= 256;
+        }
+        assert(carry == 0);
+        length = i;
+        if (length + zeroes > max_ret_len) return false;
+        psz++;
+    }
+    // Skip trailing spaces.
+    while (IsSpace(*psz))
+        psz++;
+    if (*psz != 0)
+        return false;
+    // Skip leading zeroes in b256.
+    std::vector<unsigned char>::iterator it = b256.begin() + (size - length);
+    // Copy result into output vector.
+    vch.reserve(zeroes + (b256.end() - it));
+    vch.assign(zeroes, 0x00);
+    while (it != b256.end())
+        vch.push_back(*(it++));
+    return true;
+}
+
+std::string EncodeBase58(Span<const unsigned char> input)
+{
+    // Skip & count leading zeroes.
+    int zeroes = 0;
+    int length = 0;
+    while (input.size() > 0 && input[0] == 0) {
+        input = input.subspan(1);
+        zeroes++;
+    }
+    // Allocate enough space in big-endian base58 representation.
+    int size = input.size() * 138 / 100 + 1; // log(256) / log(58), rounded up.
+    std::vector<unsigned char> b58(size);
+    // Process the bytes.
+    while (input.size() > 0) {
+        int carry = input[0];
+        int i = 0;
+        // Apply "b58 = b58 * 256 + ch".
+        for (std::vector<unsigned char>::reverse_iterator it = b58.rbegin(); (carry != 0 || i < length) && (it != b58.rend()); it++, i++) {
+            carry += 256 * (*it);
+            *it = carry % 58;
+            carry /= 58;
+        }
+
+        assert(carry == 0);
+        length = i;
+        input = input.subspan(1);
+    }
+    // Skip leading zeroes in base58 result.
+    std::vector<unsigned char>::iterator it = b58.begin() + (size - length);
+    while (it != b58.end() && *it == 0)
+        it++;
+    // Translate the result into a string.
+    std::string str;
+    str.reserve(zeroes + (b58.end() - it));
+    str.assign(zeroes, '1');
+    while (it != b58.end())
+        str += pszBase58[*(it++)];
+    return str;
+}
+
+std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
+{
+    return EncodeBase58(Span<const unsigned char>(pbegin, pend));
+}
+
+bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len)
+{
+    if (!ValidAsCString(str)) {
+        return false;
+    }
+    return DecodeBase58(str.c_str(), vchRet, max_ret_len);
+}
+
+std::string EncodeBase58Check(Span<const unsigned char> input)
+{
+    // add 4-byte hash check to the end
+    std::vector<unsigned char> vch(input.begin(), input.end());
+    // Can't use spans here until we teach hash.h about them.
+    uint256 hash = Hash(vch.begin(), vch.end());
+    vch.insert(vch.end(), (unsigned char*)&hash, (unsigned char*)&hash + 4);
+    return EncodeBase58(vch);
+}
+
+std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn)
+{
+    return EncodeBase58Check(Span<const unsigned char>(vchIn));
+}
+
+[[nodiscard]] static bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet, int max_ret_len)
+{
+    if (!DecodeBase58(psz, vchRet, max_ret_len > std::numeric_limits<int>::max() - 4 ? std::numeric_limits<int>::max() : max_ret_len + 4) ||
+        (vchRet.size() < 4)) {
+        vchRet.clear();
+        return false;
+    }
+    // re-calculate the checksum, ensure it matches the included 4-byte checksum
+    // Can't use spans here until we teach hash.h about them.
+    uint256 hash = Hash(vchRet.begin(), vchRet.end() - 4);
+    if (memcmp(&hash, &vchRet[vchRet.size() - 4], 4) != 0) {
+        vchRet.clear();
+        return false;
+    }
+    vchRet.resize(vchRet.size() - 4);
+    return true;
+}
+
+bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret)
+{
+    if (!ValidAsCString(str)) {
+        return false;
+    }
+    return DecodeBase58Check(str.c_str(), vchRet, max_ret);
+}

--- a/src/base58.h
+++ b/src/base58.h
@@ -1,182 +1,64 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2012 The Bitcoin Developers
-// Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or https://opensource.org/licenses/mit-license.php.
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-
-//
-// Why base-58 instead of standard base-64 encoding?
-// - Don't want 0OIl characters that look the same in some fonts and
-//      could be used to create visually identical looking account numbers.
-// - A string with non-alphanumeric characters is not as easily accepted as an account number.
-// - E-mail usually won't line-break if there's no punctuation to break at.
-// - Double-clicking selects the whole number as one word if it's all alphanumeric.
-//
+/**
+ * Why base-58 instead of standard base-64 encoding?
+ * - Don't want 0OIl characters that look the same in some fonts and
+ *      could be used to create visually identical looking data.
+ * - A string with non-alphanumeric characters is not as easily accepted as input.
+ * - E-mail usually won't line-break if there's no punctuation to break at.
+ * - Double-clicking selects the whole string as one word if it's all alphanumeric.
+ */
 #ifndef BITCOIN_BASE58_H
 #define BITCOIN_BASE58_H
 
-#include "bignum.h"
+#include <attributes.h>
+#include <span.h>
+
+#include <string>
+#include <vector>
+
 #include "key.h"
 #include "script.h"
 
-#include <string>
-#include <variant>
-#include <vector>
-#include <util/strencodings.h>
-#include <util/string.h>
+/**
+ * Encode a byte span as a base58-encoded string
+ */
+std::string EncodeBase58(Span<const unsigned char> input);
 
-static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+/**
+ * Encode a byte sequence as a base58-encoded string. (Retained for compatibility until other code is
+ * converted to use spans.)
+ */
+std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend);
 
-// Encode a byte sequence as a base58-encoded string
-inline std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
-{
-    CAutoBN_CTX pctx;
-    CBigNum bn58 = 58;
-    CBigNum bn0 = 0;
+/**
+ * Decode a base58-encoded string (str) into a byte vector (vchRet).
+ * return true if decoding is successful.
+ */
+[[nodiscard]] bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet,
+                                int max_ret_len = std::numeric_limits<int>::max());
 
-    // Convert big endian data to little endian
-    // Extra zero at the end make sure bignum will interpret as a positive number
-    std::vector<unsigned char> vchTmp(pend-pbegin+1, 0);
-    reverse_copy(pbegin, pend, vchTmp.begin());
+/**
+ * Encode a byte span into a base58-encoded string, including checksum
+ */
+std::string EncodeBase58Check(Span<const unsigned char> input);
 
-    // Convert little endian data to bignum
-    CBigNum bn;
-    bn.setvch(vchTmp);
+/**
+ * Encode a byte vector to a base58-encoded string, including checksum. (Retained for compatibility until other code
+ * is converted to use spans.)
+ */
+std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn);
 
-    // Convert bignum to std::string
-    std::string str;
-    // Expected size increase from base58 conversion is approximately 137%
-    // use 138% to be safe
-    str.reserve((pend - pbegin) * 138 / 100 + 1);
-    CBigNum dv;
-    CBigNum rem;
-    while (bn > bn0)
-    {
-        if (!BN_div(&dv, &rem, &bn, &bn58, pctx))
-            throw bignum_error("EncodeBase58 : BN_div failed");
-        bn = dv;
-        unsigned int c = rem.getulong();
-        str += pszBase58[c];
-    }
-
-    // Leading zeroes encoded as base58 zeros
-    for (const unsigned char* p = pbegin; p < pend && *p == 0; p++)
-        str += pszBase58[0];
-
-    // Convert little endian std::string to big endian
-    reverse(str.begin(), str.end());
-    return str;
-}
-
-// Encode a byte vector as a base58-encoded string
-inline std::string EncodeBase58(const std::vector<unsigned char>& vch)
-{
-    return EncodeBase58(&vch[0], &vch[0] + vch.size());
-}
-
-// Decode a base58-encoded string psz into byte vector vchRet
-// returns true if decoding is successful
-inline bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet)
-{
-    CAutoBN_CTX pctx;
-    vchRet.clear();
-    CBigNum bn58 = 58;
-    CBigNum bn = 0;
-    CBigNum bnChar;
-    while (IsSpace(*psz))
-        psz++;
-
-    // Convert big endian string to bignum
-    for (const char* p = psz; *p; p++)
-    {
-        const char* p1 = strchr(pszBase58, *p);
-        if (p1 == nullptr) {
-            while (IsSpace(*p))
-                p++;
-            if (*p != '\0')
-                return false;
-            break;
-        }
-        bnChar.setulong(p1 - pszBase58);
-        if (!BN_mul(&bn, &bn, &bn58, pctx))
-            throw bignum_error("DecodeBase58 : BN_mul failed");
-        bn += bnChar;
-    }
-
-    // Get bignum as little endian data
-    std::vector<unsigned char> vchTmp = bn.getvch();
-
-    // Trim off sign byte if present
-    if (vchTmp.size() >= 2 && vchTmp.end()[-1] == 0 && vchTmp.end()[-2] >= 0x80)
-        vchTmp.erase(vchTmp.end()-1);
-
-    // Restore leading zeros
-    int nLeadingZeros = 0;
-    for (const char* p = psz; *p == pszBase58[0]; p++)
-        nLeadingZeros++;
-    vchRet.assign(nLeadingZeros + vchTmp.size(), 0);
-
-    // Convert little endian data to big endian
-    reverse_copy(vchTmp.begin(), vchTmp.end(), vchRet.end() - vchTmp.size());
-    return true;
-}
-
-// Decode a base58-encoded string str into byte vector vchRet
-// returns true if decoding is successful
-inline bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet)
-{
-    if (!ValidAsCString(str)) {
-        return false;
-    }
-    return DecodeBase58(str.c_str(), vchRet);
-}
-
-
-
-
-// Encode a byte vector to a base58-encoded string, including checksum
-inline std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn)
-{
-    // add 4-byte hash check to the end
-    std::vector<unsigned char> vch(vchIn);
-    uint256 hash = Hash(vch.begin(), vch.end());
-    vch.insert(vch.end(), (unsigned char*)&hash, (unsigned char*)&hash + 4);
-    return EncodeBase58(vch);
-}
-
-// Decode a base58-encoded string psz that includes a checksum, into byte vector vchRet
-// returns true if decoding is successful
-inline bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet)
-{
-    if (!DecodeBase58(psz, vchRet))
-        return false;
-    if (vchRet.size() < 4)
-    {
-        vchRet.clear();
-        return false;
-    }
-    uint256 hash = Hash(vchRet.begin(), vchRet.end()-4);
-    if (memcmp(&hash, &vchRet.end()[-4], 4) != 0)
-    {
-        vchRet.clear();
-        return false;
-    }
-    vchRet.resize(vchRet.size()-4);
-    return true;
-}
-
-// Decode a base58-encoded string str that includes a checksum, into byte vector vchRet
-// returns true if decoding is successful
-inline bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet)
-{
-    if (!ValidAsCString(str)) {
-        return false;
-    }
-    return DecodeBase58Check(str.c_str(), vchRet);
-}
-
-
-
+/**
+ * Decode a base58-encoded string (str) that includes a checksum into a byte
+ * vector (vchRet), return true if decoding is successful. The max_ret_len is not used yet and defaulted
+ * to the integer numeric limit max - 4. This is reserved for more Bitcoin upstream porting.
+ */
+[[nodiscard]] bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet,
+                                     int max_ret_len = std::numeric_limits<int>::max() - 4);
 
 
 /** Base class for all base58-encoded data */
@@ -219,8 +101,7 @@ public:
     bool SetString(const char* psz)
     {
         std::vector<unsigned char> vchTemp;
-        DecodeBase58Check(psz, vchTemp);
-        if (vchTemp.empty())
+        if (!DecodeBase58Check(psz, vchTemp))
         {
             vchData.clear();
             nVersion = 0;


### PR DESCRIPTION
This port involves a fairly straightforward port of the upstream base58 code. Note that a couple of overloads and minor changes were necessary because we do not have spans implemented in a number of places yet.

This closes #2300.