### PR TITLE
refactor: replace QDateTime::fromTime_t with QDateTime::fromSecsSinceEpoch

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -109,16 +109,16 @@ quint64 ClientModel::getTotalBytesSent() const
 QDateTime ClientModel::getLastBlockDate() const
 {
     if (m_cached_best_block_time != -1) {
-        return QDateTime::fromTime_t(m_cached_best_block_time);
+        return QDateTime::fromSecsSinceEpoch(m_cached_best_block_time);
     }
 
     LOCK(cs_main);
 
     if (pindexBest) {
-        return QDateTime::fromTime_t(pindexBest->GetBlockTime());
+        return QDateTime::fromSecsSinceEpoch(pindexBest->GetBlockTime());
     }
 
-    return QDateTime::fromTime_t(1413033777); // Genesis block's time
+    return QDateTime::fromSecsSinceEpoch(1413033777); // Genesis block's time
 }
 
 void ClientModel::updateTimer()
@@ -258,7 +258,7 @@ QString ClientModel::clientName() const
 
 QString ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::fromTime_t(nClientStartupTime).toString();
+    return QDateTime::fromSecsSinceEpoch(nClientStartupTime).toString();
 }
 
 QString ClientModel::formatBoostVersion()  const

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -907,7 +907,7 @@ void CoinControlDialog::updateView()
             itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.tx->vout[out.i].nValue), 15, " ")); // padding so that sorting works correctly
 
             // date
-            itemOutput->setText(COLUMN_DATE, QDateTime::fromTime_t(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
+            itemOutput->setText(COLUMN_DATE, QDateTime::fromSecsSinceEpoch(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
 
             // immature PoS reward
             {

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -630,7 +630,7 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
             itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.tx->vout[out.i].nValue), 15, " ")); // padding so that sorting works correctly
 
             // date
-            itemOutput->setText(COLUMN_DATE, QDateTime::fromTime_t(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
+            itemOutput->setText(COLUMN_DATE, QDateTime::fromSecsSinceEpoch(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
 
             // immature PoS reward
             {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -43,7 +43,7 @@ QString dateTimeStr(const QDateTime &date)
 
 QString dateTimeStr(qint64 nTime)
 {
-    return dateTimeStr(QDateTime::fromTime_t((qint32)nTime));
+    return dateTimeStr(QDateTime::fromSecsSinceEpoch(nTime));
 }
 
 QString formatPingTime(double dPingTime)

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -9,9 +9,9 @@
 #include <cstdlib>
 
 // Earliest date that can be represented (far in the past)
-const QDateTime TransactionFilterProxy::MIN_DATE = QDateTime::fromTime_t(0);
+const QDateTime TransactionFilterProxy::MIN_DATE = QDateTime::fromSecsSinceEpoch(0);
 // Last date that can be represented (far in the future)
-const QDateTime TransactionFilterProxy::MAX_DATE = QDateTime::fromTime_t(0xFFFFFFFF);
+const QDateTime TransactionFilterProxy::MAX_DATE = QDateTime::fromSecsSinceEpoch(0xFFFFFFFF);
 
 //Halford 1-2-2015 
 TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -655,7 +655,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
     case TypeRole:
         return rec->type;
     case DateRole:
-        return QDateTime::fromTime_t(static_cast<uint>(rec->time));
+        return QDateTime::fromSecsSinceEpoch(rec->time);
     case LongDescriptionRole:
         return priv->describe(rec);
     case AddressRole:


### PR DESCRIPTION
> `QDateTime::fromTime_t` has [been obsoleted](https://doc.qt.io/qt-5.12/qdatetime-obsolete.html#fromTime_t) in favour of [`QDateTime::fromSecsSinceEpoch`](https://doc.qt.io/qt-5.12/qdatetime.html#fromSecsSinceEpoch), which is available from Qt 5.8+.

Ref: https://github.com/bitcoin-core/gui/pull/349

The second commit here for replacing `QDateTime::toTime_t` is not applicable since I cannot find it used in our code.

Tested on Windows 10 cross-compile (depends).