### PR TITLE
wallet, contract: Implement contract change option

### DIFF
--- a/src/gridcoin/contract/message.cpp
+++ b/src/gridcoin/contract/message.cpp
@@ -66,12 +66,26 @@ bool CreateContractTx(CWalletTx& wtx_out, CReserveKey reserve_key, CAmount burn_
     CCoinControl coin_control_out;
     CAmount applied_fee_out; // Unused
     bool admin = false;
+    bool contract_change_to_input_address = gArgs.GetBoolArg("-contractchangetoinputaddress", false);
+    CTxDestination out_address {CNoDestination()};
 
     // If the input transaction already selected some inputs, ensure that we
     // pick those inputs again when creating the final transaction:
-    //
     for (auto& txin : wtx_out.vin) {
         coin_control_out.Select(txin.prevout);
+
+        // If contract_change_to_input_address is false or once the first already selected input is encountered
+        // that has a valid address, select that for change and then skip over further address selection for change.
+        if (!contract_change_to_input_address
+                || !std::get_if<CNoDestination>(&out_address)
+                || !ExtractDestination(txin.scriptSig, out_address)) {
+            continue;
+        }
+
+        coin_control_out.destChange = out_address;
+
+        LogPrintf("INFO: %s: Change sent to %s for contract transaction per contractchangetoinputaddress setting.",
+                  __func__, CBitcoinAddress(coin_control_out.destChange).ToString());
     }
 
     for (const auto& contract : wtx_out.vContracts) {
@@ -82,7 +96,6 @@ bool CreateContractTx(CWalletTx& wtx_out, CReserveKey reserve_key, CAmount burn_
     // Nodes validate administrative contracts by checking that the containing
     // transactions include an input signed by the master key, so select coins
     // from the master address and send any change back to it:
-    //
     if (admin && !SelectMasterInputOutput(coin_control_out)) {
         return false;
     }
@@ -100,7 +113,7 @@ bool CreateContractTx(CWalletTx& wtx_out, CReserveKey reserve_key, CAmount burn_
         wtx_out,
         reserve_key,
         applied_fee_out,
-        &coin_control_out);
+        &coin_control_out, contract_change_to_input_address);
 }
 
 //!

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -458,7 +458,9 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-maxsigcachesize=<n>", "Set maximum size for signature cache (default: 50000)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-
+    argsman.AddArg("-contractchangetoinputaddress", "Change from a contract transaction is returned to an input address "
+                                                    "rather than creating a new change address (default: 0)",
+                   ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::WALLET);
 
     // Connections
     argsman.AddArg("-timeout=<n>", "Specify connection timeout in milliseconds (default: 5000)",

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -111,6 +111,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="returnChangeToInputAddressForContracts">
+         <property name="text">
+          <string>Return change to an input address for contract transactions</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Main">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -162,6 +162,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->gridcoinAtStartup, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->gridcoinAtStartupMinimised, OptionsModel::StartMin);
     mapper->addMapping(ui->disableUpdateCheck, OptionsModel::DisableUpdateCheck);
+    mapper->addMapping(ui->returnChangeToInputAddressForContracts, OptionsModel::ContractChangeToInput);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -151,6 +151,9 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case MinStakeSplitValue:
             // This comes from the core and is a read-write setting (see below).
             return QVariant((qint64) gArgs.GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC));
+        case ContractChangeToInput:
+            // This comes from the core and is a read-write setting (see below).
+            return QVariant(gArgs.GetBoolArg("-contractchangetoinputaddress", false));
         default:
             return QVariant();
         }
@@ -303,6 +306,13 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             //config file.
             gArgs.ForceSetArg("-minstakesplitvalue", value.toString().toStdString());
             updateRwSetting("minstakesplitvalue", gArgs.GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC));
+            break;
+        case ContractChangeToInput:
+            // This is a core setting stored in the read-write settings file and once set will override the read-only
+            //config file.
+            gArgs.ForceSetArg("-contractchangetoinputaddress", value.toBool() ? "1" : "0");
+            updateRwSetting("contractchangetoinputaddress", gArgs.GetBoolArg("contractchangetoinputaddress"));
+            break;
         default:
             break;
         }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -43,6 +43,7 @@ public:
         EnableStakeSplit,        // bool
         StakingEfficiency,       // double
         MinStakeSplitValue,      // int
+        ContractChangeToInput,   // bool
         OptionIDRowCount
     };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -270,11 +270,12 @@ public:
     int64_t GetStake() const;
     int64_t GetNewMint() const;
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
-                           int64_t& nFeeRet, const CCoinControl* coinControl = nullptr);
+                           int64_t& nFeeRet, const CCoinControl* coinControl = nullptr, bool change_back_to_input_address = false);
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, std::set<std::pair<const CWalletTx*,unsigned int>>& setCoins,
-                           CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl = nullptr);
+                           CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl = nullptr,
+                           bool change_back_to_input_address = false);
     bool CreateTransaction(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet,
-                           const CCoinControl* coinControl = nullptr);
+                           const CCoinControl* coinControl = nullptr, bool change_back_to_input_address = false);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
     std::string SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false);


### PR DESCRIPTION
This PR introduces a new setting, contractchangetoinputaddress, that defaults to false, and which controls whether the change from a contract transaction goes back to an input address rather than a new address being created.

Setting this new setting to true will cause the wallet to return the change on an input address for the contract transaction, and avoid the creation of a new change address. This reduces anonymity, which is why the default setting is false to retain the original behavior, but addresses #2326, and any other contract type when set to true.

Note that the CreateTransaction function in wallet.h/cpp has been extended to have a default boolean change_back_to_input_address to support this, and also allow this same feature to be done in a general sendtoaddress RPC (not yet implemented).

A checkbox has also been implemented to be able to set the value of contractchangetoinputaddress from the gui. This uses the dynamic settings file to enable this to be shared between the core and the GUI and allow the setting to be immediately active and the state maintained over a wallet restart.

![image](https://user-images.githubusercontent.com/7529186/142773460-d7865207-95f9-462d-88e4-6ca78a2279a7.png)


Closes #2326