### PR TITLE
depends: Port libdmg-hfsplus changes from upstream

### DIFF
--- a/depends/packages/native_libdmg-hfsplus.mk
+++ b/depends/packages/native_libdmg-hfsplus.mk
@@ -1,16 +1,18 @@
 package=native_libdmg-hfsplus
-$(package)_version=0.1
-$(package)_download_path=https://github.com/theuni/libdmg-hfsplus/archive
-$(package)_file_name=libdmg-hfsplus-v$($(package)_version).tar.gz
-$(package)_sha256_hash=6569a02eb31c2827080d7d59001869ea14484c281efab0ae7f2b86af5c3120b3
+$(package)_version=7ac55ec64c96f7800d9818ce64c79670e7f02b67
+$(package)_download_path=https://github.com/planetbeing/libdmg-hfsplus/archive
+$(package)_file_name=$($(package)_version).tar.gz
+$(package)_sha256_hash=56fbdc48ec110966342f0ecddd6f8f89202f4143ed2a3336e42bbf88f940850c
 $(package)_build_subdir=build
+$(package)_patches=remove-libcrypto-dependency.patch
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/remove-libcrypto-dependency.patch && \
   mkdir build
 endef
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)/bin ..
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) ..
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/native_libdmg-hfsplus.mk
+++ b/depends/packages/native_libdmg-hfsplus.mk
@@ -12,7 +12,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) ..
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DCMAKE_C_FLAGS="-Wl,--build-id=none" ..
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/native_libdmg-hfsplus/remove-libcrypto-dependency.patch
+++ b/depends/patches/native_libdmg-hfsplus/remove-libcrypto-dependency.patch
@@ -1,0 +1,45 @@
+From 3e5fd3fb56bc9ff03beb535979e33dcf83fe1f70 Mon Sep 17 00:00:00 2001
+From: Cory Fields <cory-nospam-@coryfields.com>
+Date: Thu, 8 May 2014 12:39:42 -0400
+Subject: [PATCH] dmg: remove libcrypto dependency
+
+---
+ dmg/CMakeLists.txt | 16 ----------------
+ 1 file changed, 16 deletions(-)
+
+diff --git a/dmg/CMakeLists.txt b/dmg/CMakeLists.txt
+index eec62d6..3969f64 100644
+--- a/dmg/CMakeLists.txt
++++ b/dmg/CMakeLists.txt
+@@ -1,12 +1,5 @@
+-INCLUDE(FindOpenSSL)
+ INCLUDE(FindZLIB)
+ 
+-FIND_LIBRARY(CRYPTO_LIBRARIES crypto
+-      PATHS
+-      /usr/lib
+-      /usr/local/lib
+-   )
+-
+ IF(NOT ZLIB_FOUND)
+ 	message(FATAL_ERROR "zlib is required for dmg!")
+ ENDIF(NOT ZLIB_FOUND)
+@@ -18,15 +11,6 @@ link_directories(${PROJECT_BINARY_DIR}/common ${PROJECT_BINARY_DIR}/hfs)
+ 
+ add_library(dmg adc.c base64.c checksum.c dmgfile.c dmglib.c filevault.c io.c partition.c resources.c udif.c)
+ 
+-IF(OPENSSL_FOUND)
+-	add_definitions(-DHAVE_CRYPT)
+-	include_directories(${OPENSSL_INCLUDE_DIR})
+-	target_link_libraries(dmg ${CRYPTO_LIBRARIES})
+-	IF(WIN32)
+-		TARGET_LINK_LIBRARIES(dmg gdi32)
+-	ENDIF(WIN32)
+-ENDIF(OPENSSL_FOUND)
+-
+ target_link_libraries(dmg common hfs z)
+ 
+ add_executable(dmg-bin dmg.c)
+-- 
+2.22.0
+


### PR DESCRIPTION
- build: switch to upstream libdmg-hfsplus
Ref: https://github.com/bitcoin/bitcoin/pull/17057
> Corys PRs (planetbeing/libdmg-hfsplus#7, planetbeing/libdmg-hfsplus#8) have been merged, and the author was active for a little while in 2017/18, so switch back to the upstream libdmg-hfsplus repo. I've added the last of Corys patches into depends.
- build: don't embed a build-id when building libdmg-hfsplus
Ref: https://github.com/bitcoin/bitcoin/pull/18004