### PR TITLE
net: initialize nMessageSize to uint32_t max

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -25,7 +25,6 @@ CMessageHeader::CMessageHeader()
 {
     memcpy(pchMessageStart, Params().MessageStart(), CMessageHeader::MESSAGE_START_SIZE);
     memset(pchCommand, 0, sizeof(pchCommand));
-    nMessageSize = -1;
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -15,6 +15,7 @@
 #include "uint256.h"
 #include "version.h"
 
+#include <limits>
 #include <string>
 
 extern bool fTestNet;
@@ -52,7 +53,7 @@ class CMessageHeader
 
         char pchMessageStart[MESSAGE_START_SIZE];
         char pchCommand[COMMAND_SIZE];
-        uint32_t nMessageSize;
+        uint32_t nMessageSize{std::numeric_limits<uint32_t>::max()};
         uint8_t pchChecksum[CHECKSUM_SIZE];
 };
 


### PR DESCRIPTION
> nMessageSize is uint32_t and is set to -1. This will warn with `-fsanitize=implicit-integer-sign-change` when V1TransportDeserializer calls into the ctor. This pull initializes nMessageSize to `numeric_limits<uint32_t>::max()` instead.

Ref: https://github.com/bitcoin/bitcoin/pull/21905