### PR TITLE
rpc: Change getmininginfo to getstakinginfo

### DIFF
--- a/src/gridcoin/staking/status.cpp
+++ b/src/gridcoin/staking/status.cpp
@@ -316,8 +316,8 @@ void EfficiencyReport::UpdateMetrics(uint64_t weight_sum, int64_t balance_weight
         * (masked_time_intervals_elapsed - prev_masked_time_intervals_elapsed);
 
     // masked_time_intervals_covered / masked_time_intervals_elapsed provides a
-    // measure of the miner loop efficiency.
+    // measure of the staking loop efficiency.
     //
     // actual_cumulative_weight / ideal_cumulative_weight provides a measure of
-    // the overall mining efficiency compared to ideal.
+    // the overall staking efficiency compared to ideal.
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1034,7 +1034,7 @@ bool IsMiningAllowed(CWallet *pwallet)
 }
 
 // This function parses the config file for the directives for side staking. It is used
-// in StakeMiner for the miner loop and also called by rpc getmininginfo.
+// in StakeMiner for the miner loop and also called by rpc getstakinginfo.
 SideStakeAlloc GetSideStakingStatusAndAlloc()
 {
     SideStakeAlloc vSideStakeAlloc;
@@ -1138,7 +1138,7 @@ SideStakeAlloc GetSideStakingStatusAndAlloc()
 }
 
 // This function parses the config file for the directives for stake splitting. It is used
-// in StakeMiner for the miner loop and also called by rpc getmininginfo.
+// in StakeMiner for the miner loop and also called by rpc getstakinginfo.
 bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue)
 {
     // Parse StakeSplit and SideStaking flags.

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -952,7 +952,7 @@ void DiagnosticsDialog::CheckETTS(const double& diff)
         if (ETTS == 0.0)
         {
             QString tooltip = tr("You have no balance and will be unable to retrieve your research rewards when solo "
-                                 "mining. You should acquire GRC to stake so you can retrieve your research rewards. "
+                                 "crunching. You should acquire GRC to stake so you can retrieve your research rewards. "
                                  "Please see https://gridcoin.us/guides/boinc-install.htm.");
 
             UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
@@ -961,7 +961,7 @@ void DiagnosticsDialog::CheckETTS(const double& diff)
         else if (ETTS > 90.0)
         {
             QString tooltip = tr("Your balance is too low given the current network difficulty to stake in a reasonable "
-                                 "period of time to retrieve your research rewards when solo mining. You should acquire "
+                                 "period of time to retrieve your research rewards when solo crunching. You should acquire "
                                  "more GRC to stake more often.");
 
             UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, failed,
@@ -972,7 +972,7 @@ void DiagnosticsDialog::CheckETTS(const double& diff)
         else if (ETTS > 45.0 && ETTS <= 90.0)
         {
             QString tooltip = tr("Your balance is low given the current network difficulty to stake in a reasonable "
-                                 "period of time to retrieve your research rewards when solo mining. You should consider "
+                                 "period of time to retrieve your research rewards when solo crunching. You should consider "
                                  "acquiring more GRC to stake more often.");
 
             UpdateTestStatus(__func__, ui->checkETTSResultLabel, completed, warning,

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -270,7 +270,7 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
     ui->totalLabel->setText(BitcoinUnits::formatWithUnit(unit, balance + stake + unconfirmedBalance + immatureBalance));
 
     // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
-    // for the non-mining users
+    // for the non-staking users
     bool showImmature = immatureBalance != 0;
     ui->immatureLabel->setVisible(showImmature);
     ui->immatureTextLabel->setVisible(showImmature);

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -316,7 +316,7 @@ QString ResearcherModel::formatStatus() const
         return tr("Waiting for sync...");
     }
 
-    // TODO: The getmininginfo RPC shares this global. Refactor to remove it:
+    // TODO: The getstakinginfo RPC shares this global. Refactor to remove it:
     return QString::fromStdString(msMiningErrors);
 }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -185,7 +185,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "walletpassphrase"       , 1 },
     { "walletpassphrase"       , 2 },
 
-    // Mining
+    // Staking
     { "advertisebeacon"        , 0 },
     { "beaconreport"           , 0 },
     { "superblocks"            , 0 },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -20,13 +20,13 @@
 
 using namespace std;
 
-UniValue getmininginfo(const UniValue& params, bool fHelp)
+UniValue getstakinginfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getmininginfo\n"
+            "getstakinginfo\n"
             "\n"
-            "Returns an object containing mining-related information\n");
+            "Returns an object containing staking-related information\n");
 
     UniValue obj(UniValue::VOBJ);
     UniValue diff(UniValue::VOBJ);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -215,7 +215,7 @@ UniValue help(const UniValue& params, bool fHelp)
             "\n"
             "Categories:\n"
             "wallet --------> Returns help for blockchain related commands\n"
-            "mining --------> Returns help for staking/cpid/beacon related commands\n"
+            "staking -------> Returns help for staking/cpid/beacon related commands\n"
             "developer -----> Returns help for developer commands\n"
             "network -------> Returns help for network related commands\n"
             "voting --------> Returns help for voting related commands\n"
@@ -236,8 +236,8 @@ UniValue help(const UniValue& params, bool fHelp)
     if (strCommand == "wallet")
         category = cat_wallet;
 
-    else if (strCommand == "mining")
-        category = cat_mining;
+    else if (strCommand == "staking" || strCommand == "mining")
+        category = cat_staking;
 
     else if (strCommand == "developer")
         category = cat_developer;
@@ -347,21 +347,22 @@ static const CRPCCommand vRPCCommands[] =
     { "walletpassphrase",        &walletpassphrase,        cat_wallet        },
     { "walletpassphrasechange",  &walletpassphrasechange,  cat_wallet        },
 
-  // Mining commands
-    { "advertisebeacon",         &advertisebeacon,         cat_mining        },
-    { "beaconconvergence",       &beaconconvergence,       cat_mining        },
-    { "beaconreport",            &beaconreport,            cat_mining        },
-    { "beaconstatus",            &beaconstatus,            cat_mining        },
-    { "explainmagnitude",        &explainmagnitude,        cat_mining        },
-    { "getlaststake",            &getlaststake,            cat_mining        },
-    { "getmininginfo",           &getmininginfo,           cat_mining        },
-    { "lifetime",                &lifetime,                cat_mining        },
-    { "magnitude",               &magnitude,               cat_mining        },
-    { "pendingbeaconreport",     &pendingbeaconreport,     cat_mining        },
-    { "resetcpids",              &resetcpids,              cat_mining        },
-    { "revokebeacon",            &revokebeacon,            cat_mining        },
-    { "superblockage",           &superblockage,           cat_mining        },
-    { "superblocks",             &superblocks,             cat_mining        },
+  // Staking commands
+    { "advertisebeacon",         &advertisebeacon,         cat_staking        },
+    { "beaconconvergence",       &beaconconvergence,       cat_staking        },
+    { "beaconreport",            &beaconreport,            cat_staking        },
+    { "beaconstatus",            &beaconstatus,            cat_staking        },
+    { "explainmagnitude",        &explainmagnitude,        cat_staking        },
+    { "getlaststake",            &getlaststake,            cat_staking        },
+    { "getstakinginfo",          &getstakinginfo,          cat_staking        },
+    { "getmininginfo",           &getstakinginfo,          cat_staking        }, //alias for getstakinginfo (compatibility)
+    { "lifetime",                &lifetime,                cat_staking        },
+    { "magnitude",               &magnitude,               cat_staking        },
+    { "pendingbeaconreport",     &pendingbeaconreport,     cat_staking        },
+    { "resetcpids",              &resetcpids,              cat_staking        },
+    { "revokebeacon",            &revokebeacon,            cat_staking        },
+    { "superblockage",           &superblockage,           cat_staking        },
+    { "superblocks",             &superblocks,             cat_staking        },
 
   // Developer commands
     { "auditsnapshotaccrual",    &auditsnapshotaccrual,    cat_developer     },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -39,7 +39,7 @@ enum rpccategory
 {
     cat_null,
     cat_wallet,
-    cat_mining,
+    cat_staking,
     cat_developer,
     cat_network,
     cat_voting,
@@ -163,14 +163,14 @@ extern UniValue walletlock(const UniValue& params, bool fHelp);
 extern UniValue walletpassphrase(const UniValue& params, bool fHelp);
 extern UniValue walletpassphrasechange(const UniValue& params, bool fHelp);
 
-//Mining
+// Staking
 extern UniValue advertisebeacon(const UniValue& params, bool fHelp);
 extern UniValue beaconreport(const UniValue& params, bool fHelp);
 extern UniValue beaconconvergence(const UniValue& params, bool fHelp);
 extern UniValue beaconstatus(const UniValue& params, bool fHelp);
 extern UniValue explainmagnitude(const UniValue& params, bool fHelp);
 extern UniValue getlaststake(const UniValue& params, bool fHelp);
-extern UniValue getmininginfo(const UniValue& params, bool fHelp);
+extern UniValue getstakinginfo(const UniValue& params, bool fHelp);
 extern UniValue lifetime(const UniValue& params, bool fHelp);
 extern UniValue magnitude(const UniValue& params, bool fHelp);
 extern UniValue pendingbeaconreport(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Retain getmininginfo and the mining help category as an alias for backwards compatibility. Closes #2392.