### PR TITLE
util: Implement -reindex option, improve -loadblock option

### DIFF
--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -485,9 +485,9 @@ void Upgrade::VerifySHA256SUM()
     }
 }
 
-void Upgrade::CleanupBlockchainData()
+bool Upgrade::GetActualCleanupPath(fs::path& actual_cleanup_path)
 {
-    fs::path CleanupPath = GetDataDir();
+    actual_cleanup_path = GetDataDir();
 
     // This is required because of problems with junction point handling in the boost filesystem library. Please see
     // https://github.com/boostorg/filesystem/issues/125. We are not quite ready to switch over to std::filesystem yet.
@@ -496,16 +496,16 @@ void Upgrade::CleanupBlockchainData()
     //
     // I don't believe it is very common for Windows users to redirect the Gridcoin data directory with a junction point,
     // but it is certainly possible. We should handle it as gracefully as possible.
-    if (fs::is_symlink(CleanupPath))
+    if (fs::is_symlink(actual_cleanup_path))
     {
         LogPrintf("INFO: %s: Data directory is a symlink.",
                   __func__);
 
         try
         {
-            LogPrintf("INFO: %s: True path for the symlink is %s.", __func__, fs::read_symlink(CleanupPath).string());
+            LogPrintf("INFO: %s: True path for the symlink is %s.", __func__, fs::read_symlink(actual_cleanup_path).string());
 
-            CleanupPath = fs::read_symlink(CleanupPath);
+            actual_cleanup_path = fs::read_symlink(actual_cleanup_path);
         }
         catch (fs::filesystem_error &ex)
         {
@@ -515,9 +515,18 @@ void Upgrade::CleanupBlockchainData()
 
             DownloadStatus.SetCleanupBlockchainDataFailed(true);
 
-            return;
+            return false;
         }
     }
+
+    return true;
+}
+
+void Upgrade::CleanupBlockchainData(bool include_blockchain_data_files)
+{
+    fs::path CleanupPath;
+
+    if (!GetActualCleanupPath(CleanupPath)) return;
 
     unsigned int total_items = 0;
     unsigned int items = 0;
@@ -559,7 +568,7 @@ void Upgrade::CleanupBlockchainData()
                 continue;
             }
 
-            else if (fs::is_regular_file(*Iter))
+            else if (fs::is_regular_file(*Iter) && include_blockchain_data_files)
             {
                 size_t FileLoc = Iter->path().filename().string().find("blk");
 
@@ -648,7 +657,7 @@ void Upgrade::CleanupBlockchainData()
                 continue;
             }
 
-            else if (fs::is_regular_file(*Iter))
+            else if (fs::is_regular_file(*Iter) && include_blockchain_data_files)
             {
                 size_t FileLoc = Iter->path().filename().string().find("blk");
 
@@ -875,11 +884,124 @@ void Upgrade::DeleteSnapshot()
     }
 }
 
-bool Upgrade::ResetBlockchainData()
+bool Upgrade::ResetBlockchainData(bool include_blockchain_data_files)
 {
-    CleanupBlockchainData();
+    CleanupBlockchainData(include_blockchain_data_files);
 
     return (DownloadStatus.GetCleanupBlockchainDataComplete() && !DownloadStatus.GetCleanupBlockchainDataFailed());
+}
+
+bool Upgrade::MoveBlockDataFiles(std::set<std::pair<fs::path, uintmax_t>>& block_data_files)
+{
+    fs::path cleanup_path;
+
+    if (!GetActualCleanupPath(cleanup_path)) return false;
+
+    fs::directory_iterator IterEnd;
+
+    try {
+        for (fs::directory_iterator Iter(cleanup_path); Iter != IterEnd; ++Iter) {
+            if (fs::is_regular_file(*Iter)) {
+                size_t FileLoc = Iter->path().filename().string().find("blk");
+
+                if (FileLoc != std::string::npos) {
+                    std::string filetocheck = Iter->path().filename().string();
+
+                    // Check it ends with .dat and starts with blk
+                    if (filetocheck.substr(0, 3) == "blk" && filetocheck.substr(filetocheck.length() - 4, 4) == ".dat") {
+                        fs::path new_name = *Iter;
+                        new_name.replace_extension(".dat.orig");
+
+                        uintmax_t file_size = fs::file_size(Iter->path());
+
+                        // Rename with orig as the extension, because ProcessBlock will load blocks into a new block data
+                        // file.
+                        fs::rename(*Iter, new_name);
+                        block_data_files.insert(std::make_pair(new_name, file_size));
+                    }
+                }
+            }
+        }
+    } catch (fs::filesystem_error &ex) {
+        error("%s: Exception occurred: %s. Failed to rename block data files to blk*.dat.orig in preparation for "
+              "reindexing.", __func__, ex.what());
+
+        return false;
+    }
+
+    return true;
+}
+
+bool Upgrade::ReindexBlockchainData(std::set<std::pair<fs::path, uintmax_t>>& block_data_files)
+{
+    bool successful = true;
+
+    uintmax_t total_size = 0;
+    uintmax_t cumulative_size = 0;
+
+    for (const auto& iter : block_data_files) {
+        total_size += iter.second;
+    }
+
+    if (!total_size) return false;
+
+    try {
+        for (const auto& iter : block_data_files) {
+
+            unsigned int percent_start = cumulative_size * (uintmax_t) 100 / total_size;
+
+            cumulative_size += iter.second;
+
+            unsigned int percent_end = cumulative_size * (uintmax_t) 100 / total_size;
+
+            FILE *block_data_file = fsbridge::fopen(iter.first, "rb");
+
+            LogPrintf("INFO: %s: Loading blocks from %s.", __func__, iter.first.filename().string());
+
+            if (!LoadExternalBlockFile(block_data_file, iter.second, percent_start, percent_end)) {
+                successful = false;
+
+                break;
+            }
+        }
+    } catch (fs::filesystem_error &ex) {
+        error("%s: Exception occurred: %s. Failure occurred during attempt to load blocks from original "
+              "block data file(s).", __func__, ex.what());
+
+        successful = false;
+    }
+
+    if (successful) {
+        try {
+            fs::path cleanup_path;
+
+            if (!GetActualCleanupPath(cleanup_path)) return false;
+
+            for (const auto& iter : block_data_files) {
+                if (!fs::remove(iter.first)) {
+                    LogPrintf("WARN: %s: Reindexing of the blockchain was successful; however, one or more of "
+                              "the original block data files (%s) was not able to be deleted. You "
+                              "will have to delete this file manually.", __func__, iter.first.filename().string());
+                }
+            }
+        }
+        catch (fs::filesystem_error &ex) {
+            LogPrintf("WARN: %s: Exception occurred: %s. This error occurred while attempting to delete the original block "
+                      "data files (blk*.dat.orig). You will have to delete these manually.", __func__, ex.what());
+        }
+    } else {
+        error("%s: A failure occurred during the reindexing of the block data files. The blockchain state is invalid and "
+              "you should restart the wallet with the -resetblockchaindata option to clear out the blockchain database "
+              "and re-sync the blockchain from the network.", __func__);
+
+        DownloadStatus.SetCleanupBlockchainDataFailed(true);
+
+        return false;
+    }
+
+    LogPrintf("INFO: %s: Reindex of the blockchain data was successful.", __func__);
+
+    return true;
 }
 
 std::string Upgrade::ResetBlockchainMessages(ResetBlockchainMsg _msg)

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -932,7 +932,7 @@ bool Upgrade::MoveBlockDataFiles(std::set<std::pair<fs::path, uintmax_t>>& block
     return true;
 }
 
-bool Upgrade::ReindexBlockchainData(std::set<std::pair<fs::path, uintmax_t>>& block_data_files)
+bool Upgrade::LoadBlockchainData(std::set<std::pair<fs::path, uintmax_t>>& block_data_files)
 {
     bool successful = true;
 

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <iomanip>
 #include <vector>
-#include <set>
 
 #include "gridcoin/scraper/http.h"
 #include "node/ui_interface.h"
@@ -195,17 +194,18 @@ public:
 
     //!
     //! \brief Moves the block data files from .dat to .dat.orig in preparation for reindexing.
-    //! \return
+    //! \return Boolean on success/failure
     //!
-    static bool MoveBlockDataFiles(std::set<std::pair<fs::path, uintmax_t> > &block_data_files);
+    static bool MoveBlockDataFiles(std::vector<std::pair<boost::filesystem::path, uintmax_t>>& block_data_files);
 
     //!
     //! \brief Utility function to support the -reindex startup parameter to rebuild txleveldb and accrual from
     //! existing blockchain data files.
-    //! \return
+    //! \return Boolean on success/failure
     //!
-    static bool LoadBlockchainData(std::set<std::pair<fs::path, uintmax_t> > &block_data_files,
-                                   bool cleanup_imported_files = false);
+    static bool LoadBlockchainData(std::vector<std::pair<boost::filesystem::path, uintmax_t>>& block_data_files,
+                                   bool sort,
+                                   bool cleanup_imported_files);
     //!
     //! \brief Small function to return translated messages.
     //!

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <iomanip>
 #include <vector>
+#include <set>
 
 #include "gridcoin/scraper/http.h"
 #include "node/ui_interface.h"
@@ -141,11 +142,18 @@ public:
     static void DownloadSnapshot();
 
     //!
+    //! \brief Resolves symlinks to the actual path.
+    //! \param actual_cleanup_path is the resolved path
+    //! \return
+    //!
+    static bool GetActualCleanupPath(fs::path& actual_cleanup_path);
+
+    //!
     //! \brief Cleans up previous blockchain data if any is found
     //!
     //! \return Bool on the success of cleanup
     //!
-    static void CleanupBlockchainData();
+    static void CleanupBlockchainData(bool include_blockchain_data_files = true);
 
     //!
     //! \brief This is the worker thread "main" that actually does the brunt of the snapshot download and extraction work.
@@ -183,8 +191,20 @@ public:
     //!
     //! \returns Bool on the success of blockchain cleanup
     //!
-    static bool ResetBlockchainData();
+    static bool ResetBlockchainData(bool include_blockchain_data_files = true);
 
+    //!
+    //! \brief Moves the block data files from .dat to .dat.orig in preparation for reindexing.
+    //! \return
+    //!
+    static bool MoveBlockDataFiles(std::set<std::pair<fs::path, uintmax_t> > &block_data_files);
+
+    //!
+    //! \brief Utility function to support the -reindex startup parameter to rebuild txleveldb and accrual from
+    //! existing blockchain data files.
+    //! \return
+    //!
+    static bool ReindexBlockchainData(std::set<std::pair<fs::path, uintmax_t> > &block_data_files);
     //!
     //! \brief Small function to return translated messages.
     //!

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -204,7 +204,7 @@ public:
     //! existing blockchain data files.
     //! \return
     //!
-    static bool ReindexBlockchainData(std::set<std::pair<fs::path, uintmax_t> > &block_data_files);
+    static bool LoadBlockchainData(std::set<std::pair<fs::path, uintmax_t> > &block_data_files);
     //!
     //! \brief Small function to return translated messages.
     //!

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -204,7 +204,8 @@ public:
     //! existing blockchain data files.
     //! \return
     //!
-    static bool LoadBlockchainData(std::set<std::pair<fs::path, uintmax_t> > &block_data_files);
+    static bool LoadBlockchainData(std::set<std::pair<fs::path, uintmax_t> > &block_data_files,
+                                   bool cleanup_imported_files = false);
     //!
     //! \brief Small function to return translated messages.
     //!

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1182,7 +1182,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     // This is for the second part of the reindex. We need the set to ensure the order is correct.
-    std::set<std::pair<fs::path, uintmax_t>> block_data_files_to_load;
+    std::vector<std::pair<fs::path, uintmax_t>> block_data_files_to_load;
 
     // If -reindex argument passed at startup, then remove existing txleveldb and accrual directories and renaming the
     // exising block data files from blk*.dat to blk*.dat.orig to prepare for reloading index from block data files.
@@ -1381,7 +1381,7 @@ bool AppInit2(ThreadHandlerPtr threads)
             uiInterface.InitMessage(_("Reindexing blockchain from on disk block data files..."));
 
             // The true flag directs LoadBlockchainData to delete the input files after the load is complete.
-            if (!GRC::Upgrade::LoadBlockchainData(block_data_files_to_load, true)) return false;
+            if (!GRC::Upgrade::LoadBlockchainData(block_data_files_to_load, true, true)) return false;
 
             g_timer.GetTimes("reindex complete", "init");
         }
@@ -1413,10 +1413,10 @@ bool AppInit2(ThreadHandlerPtr threads)
                                  "file or directory permissions.", __func__, file.filename().string());
                 }
 
-                block_data_files_to_load.insert(std::make_pair(file, file_size));
+                block_data_files_to_load.push_back(std::make_pair(file, file_size));
             }
 
-            if (!GRC::Upgrade::LoadBlockchainData(block_data_files_to_load)) return false;
+            if (!GRC::Upgrade::LoadBlockchainData(block_data_files_to_load, false, false)) return false;
 
             g_timer.GetTimes("load blockchain file(s) complete", "init");
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1380,7 +1380,8 @@ bool AppInit2(ThreadHandlerPtr threads)
         if (gArgs.GetBoolArg("-reindex")) {
             uiInterface.InitMessage(_("Reindexing blockchain from on disk block data files..."));
 
-            if (!GRC::Upgrade::LoadBlockchainData(block_data_files_to_load)) return false;
+            // The true flag directs LoadBlockchainData to delete the input files after the load is complete.
+            if (!GRC::Upgrade::LoadBlockchainData(block_data_files_to_load, true)) return false;
 
             g_timer.GetTimes("reindex complete", "init");
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -349,7 +349,10 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-resetblockchaindata", "Reset blockchain data. This argument will remove all previous blockchain data",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-loadblock=<file>", "Imports blocks from external file on startup",
+    argsman.AddArg("-loadblock=<file>", "Imports blocks from external file on startup. The path for the file if specified "
+                                        "is relative to the data directory. Multiple -loadblock parameter instances may "
+                                        "be used to load multiple files. They will be processed in the order specified on "
+                                        "the command line.",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex", "Rebuild chain state and block index from the blk*.dat files on disk",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2846,20 +2846,20 @@ bool LoadExternalBlockFile(FILE* fileIn, size_t file_size, unsigned int percent_
                     CBlock block;
                     blkdat >> block;
                     if (ProcessBlock(nullptr, &block, false)) {
-                        nLoaded++;
+                        ++nLoaded;
+
                         if (display_progress) {
                             unsigned int percent_progress = percent_start + (uint64_t) nPos
                                     * (uint64_t) (percent_end - percent_start) / file_size;
 
-                            LogPrintf("INFO: %s: blocks/s: %f, progress: %u%%", __func__,
-                                      nLoaded / ((GetTimeMillis() - nStart) / 1000.0), percent_progress);
-
                             if (percent_progress != cached_percent_progress) {
                                 uiInterface.InitMessage(_("Block file load progress ") + ToString(percent_progress) + "%");
+                                LogPrintf("INFO: %s: blocks/s: %f, progress: %u%%", __func__,
+                                          nLoaded / ((GetTimeMillis() - nStart) / 1000.0), percent_progress);
 
                                 cached_percent_progress = percent_progress;
                             }
-                        } else {
+                        } else if (nLoaded % 10000 == 0) {
                             LogPrintf("Blocks/s: %f", nLoaded / ((GetTimeMillis() - nStart) / 1000.0));
                         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2788,10 +2788,18 @@ void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     }
 }
 
-bool LoadExternalBlockFile(FILE* fileIn)
+bool LoadExternalBlockFile(FILE* fileIn, size_t file_size, unsigned int percent_start, unsigned int percent_end)
 {
     int64_t nStart = GetTimeMillis();
     int nLoaded = 0;
+
+    bool display_progress = (file_size > 0 && (percent_end - percent_start) > 0) ? true : false;
+    unsigned int cached_percent_progress = 0;
+
+    if (display_progress) {
+        uiInterface.InitMessage(_("Block file load progress ") + ToString(percent_start) + "%");
+    }
+
     {
         LOCK(cs_main);
         try {
@@ -2821,8 +2829,15 @@ bool LoadExternalBlockFile(FILE* fileIn)
                     else
                         nPos += sizeof(pchData) - CMessageHeader::MESSAGE_START_SIZE + 1;
                 } while(!fRequestShutdown);
-                if (nPos == (unsigned int)-1)
+
+                if (nPos == (unsigned int)-1) {
+                    if (display_progress) {
+                        uiInterface.InitMessage(_("Block file load progress ") + ToString(percent_end) + "%");
+                    }
+
                     break;
+                }
+
                 fseek(blkdat.Get(), nPos, SEEK_SET);
                 unsigned int nSize;
                 blkdat >> nSize;
@@ -2832,7 +2847,22 @@ bool LoadExternalBlockFile(FILE* fileIn)
                     blkdat >> block;
                     if (ProcessBlock(nullptr, &block, false)) {
                         nLoaded++;
-                        LogPrintf("Blocks/s: %f", nLoaded / ((GetTimeMillis() - nStart) / 1000.0));
+                        if (display_progress) {
+                            unsigned int percent_progress = percent_start + (uint64_t) nPos
+                                    * (uint64_t) (percent_end - percent_start) / file_size;
+
+                            LogPrintf("INFO: %s: blocks/s: %f, progress: %u%%", __func__,
+                                      nLoaded / ((GetTimeMillis() - nStart) / 1000.0), percent_progress);
+
+                            if (percent_progress != cached_percent_progress) {
+                                uiInterface.InitMessage(_("Block file load progress ") + ToString(percent_progress) + "%");
+
+                                cached_percent_progress = percent_progress;
+                            }
+                        } else {
+                            LogPrintf("Blocks/s: %f", nLoaded / ((GetTimeMillis() - nStart) / 1000.0));
+                        }
+
                         nPos += 4 + nSize;
                     }
                 }

--- a/src/main.h
+++ b/src/main.h
@@ -122,7 +122,8 @@ void PrintBlockTree();
 
 bool ProcessMessages(CNode* pfrom);
 bool SendMessages(CNode* pto, bool fSendTrickle);
-bool LoadExternalBlockFile(FILE* fileIn);
+bool LoadExternalBlockFile(FILE* fileIn, size_t file_size = 0,
+                           unsigned int percent_start = 0, unsigned int percent_end = 100);
 
 GRC::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1001,6 +1001,11 @@ void BitcoinGUI::setNumConnections(int n)
 
 void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
 {
+    // Note: It is a really good question why the GUI uses a different standard than the core for determining whether
+    // the client is in sync.
+    // TODO: Review this and decide whether to converge the sync standards.
+    bool in_sync = false;
+
     // return if we have no connection to the network
     if (!clientModel || clientModel->getNumConnections() == 0)
     {
@@ -1044,6 +1049,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         labelBlocksIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_sync_done_" + sSheet));
 
         overviewPage->showOutOfSyncWarning(false);
+        in_sync = true;
         statusbarAlertsLabel->setText(clientModel->getStatusBarWarnings());
     }
     else
@@ -1052,6 +1058,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         tooltip = tr("Catching up...") + QString("<br>") + tooltip;
 
         overviewPage->showOutOfSyncWarning(true);
+        in_sync = false;
     }
 
     if(!text.isEmpty())
@@ -1064,7 +1071,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
     tooltip = QString("<nobr>") + tooltip + QString("</nobr>");
 
     labelBlocksIcon->setToolTip(tooltip);
-    overviewPage->setHeight(count);
+    overviewPage->setHeight(count, nTotalBlocks, in_sync);
 }
 
 void BitcoinGUI::setDifficulty(double difficulty)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -283,9 +283,20 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
     ui->immatureTextLabel->setVisible(showImmature);
 }
 
-void OverviewPage::setHeight(int height)
+void OverviewPage::setHeight(int height, int height_of_peers, bool in_sync)
 {
-    ui->blocksLabel->setText(QString::number(height));
+    QString text = QString::number(height);
+    unsigned int percent_progress = 0;
+
+    if (!in_sync && height_of_peers > 0 && height < height_of_peers) {
+        percent_progress = height * 100 / height_of_peers;
+
+        text += QString(" of %1 (%2\%)")
+                .arg(QString::number(height_of_peers))
+                .arg(QString::number(percent_progress));
+    }
+
+    ui->blocksLabel->setText(text);
 }
 
 void OverviewPage::setDifficulty(double difficulty, double net_weight)

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -31,7 +31,7 @@ public:
 
 public slots:
     void setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBalance, qint64 immatureBalance);
-    void setHeight(int height);
+    void setHeight(int height, int height_of_peers, bool in_sync);
     void setDifficulty(double difficulty, double net_weight);
     void setCoinWeight(double coin_weight);
     void setCurrentPollTitle(const QString& title);


### PR DESCRIPTION
This PR adds to the GRC::Upgrade utility class and implements the wallet -reindex startup parameter.

The way this PR works is to call ResetBlockchainData with include_blockchain_data_files set to false, which erases the txleveldb and accrual directories, but leaves intact the blk*.dat files. Then MoveBlockDataFiles is called which moves the block data files from blk*.dat to blk*.dat.orig and returns a set with the files moved, which then is retained to pass to the second part of the reindex operation.

Then LoadBlockIndex() is called, which recreates the blockchain database. Then in the import blocks area (Step 9), the GRC code is initialized, so that GRC structures will be loaded correctly during reindex and ReindexBlockchainData is called with the set of files to reindex as its argument. If ReindexBlockchainData is successful, then it deletes the .orig files

This effectively is an automatically managed version of -loadblock or -bootstrap.

I added a % progress indicator.

I also added a % progress indicator for the blocks field on the overview screen when not in sync. Closes #841.

Supports investigation of #2238.

Tested on Linux and Windows. Note that snapshot download and blockchain reset functionality was also regression tested.