### PR TITLE
Fix breakage introduced by use of FormatISO8601DateTime

### DIFF
--- a/src/gridcoin/backup.cpp
+++ b/src/gridcoin/backup.cpp
@@ -25,7 +25,7 @@ std::string GRC::GetBackupFilename(const std::string& basename, const std::strin
 {
     std::string sBackupFilename;
     fs::path rpath;
-    sBackupFilename = basename + "-" + std::string(FormatISO8601DateTime(GetTime()));
+    sBackupFilename = basename + "-" + std::string(FormatISO8601DateTimeDashSep(GetTime()));
     if (!suffix.empty())
         sBackupFilename = sBackupFilename + "-" + suffix;
     rpath = GetBackupPath() / sBackupFilename;

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -151,6 +151,19 @@ std::string FormatISO8601DateTime(int64_t nTime) {
     return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
 
+std::string FormatISO8601DateTimeDashSep(int64_t nTime) {
+    struct tm ts;
+    time_t time_val = nTime;
+#ifdef HAVE_GMTIME_R
+    if (gmtime_r(&time_val, &ts) == nullptr) {
+#else
+    if (gmtime_s(&ts, &time_val) != 0) {
+#endif
+        return {};
+    }
+    return strprintf("%04i-%02i-%02iT%02i-%02i-%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
+}
+
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -90,6 +90,7 @@ T GetTime();
  * helper functions if possible.
  */
 std::string FormatISO8601DateTime(int64_t nTime);
+std::string FormatISO8601DateTimeDashSep(int64_t nTime);
 std::string FormatISO8601Date(int64_t nTime);
 int64_t ParseISO8601DateTime(const std::string& str);
 


### PR DESCRIPTION
This fixes the breakage caused by use of FormatISO8601DateTime in backup functions. Operating systems do not like colons in
filenames. This introduces a function called FormatISO8601DateTimeDashSep which is also ISO8601 compliant but uses no separators. This provides backup filenames consistent with the past.

This PR has been tested by exercising backupwallet and maintainbackups, which both appear to work correctly now.