### PR TITLE
gui: Implement privacy mode

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -72,6 +72,12 @@ public:
     */
     void setVotingModel(VotingModel *votingModel);
 
+    /**
+     * @brief Queries the state of privacy mode (mask values on overview screen).
+     * @return boolean of the mask values state
+     */
+    bool isPrivacyModeActivated() const;
+
 protected:
     void changeEvent(QEvent *e);
     void closeEvent(QCloseEvent *event);
@@ -140,6 +146,7 @@ private:
     QAction *openRPCConsoleAction;
     QAction *snapshotAction;
     QAction *resetblockchainAction;
+    QAction *m_mask_values_action;
 
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
@@ -244,6 +251,7 @@ private slots:
     void peersClicked();
     void snapshotClicked();
     void resetblockchainClicked();
+    void setPrivacy();
     bool tryQuit();
 
 #ifndef Q_OS_MAC

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -138,8 +138,16 @@ QString BitcoinUnits::formatWithPrivacy(int unit, qint64 amount, bool privacy)
 
 QString BitcoinUnits::formatOverviewRounded(qint64 amount, bool privacy)
 {
+    QString value;
+
     if (amount < factor(BTC)) {
-        return format(BTC, amount);
+        if (privacy) {
+            value = format(BTC, 0, false, false).replace('0', '#');
+        } else {
+            value =  format(BTC, amount, false, false);
+        }
+
+        return value;
     }
 
     qint64 round_scale = 10;
@@ -154,7 +162,6 @@ QString BitcoinUnits::formatOverviewRounded(qint64 amount, bool privacy)
     // Rounds half-down to avoid over-representing the amount:
     const qint64 rounded_amount = static_cast<double>(amount) / round_scale;
 
-    QString value;
     if (privacy) {
         value = format(BTC, 0, false, false).replace('0', '#');
     } else {

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -41,11 +41,13 @@ public:
     //! Number of decimals left
     static int decimals(int unit);
     //! Format as string
-    static QString format(int unit, qint64 amount, bool plussign=false);
+    static QString format(int unit, qint64 amount, bool plussign = false, bool justify = false);
     //! Format as string (with unit)
-    static QString formatWithUnit(int unit, qint64 amount, bool plussign=false);
+    static QString formatWithUnit(int unit, qint64 amount, bool plussign = false);
+    //! Format as string with optional privacy mask
+    static QString formatWithPrivacy(int unit, qint64 amount, bool privacy);
     //! Format as a rounded string approximation for overview presentation
-    static QString formatOverviewRounded(qint64 amount);
+    static QString formatOverviewRounded(qint64 amount, bool privacy = false);
     //! Parse string to coin amount
     static bool parse(int unit, const QString &value, qint64 *val_out);
     ///@}

--- a/src/qt/noresult.cpp
+++ b/src/qt/noresult.cpp
@@ -60,3 +60,8 @@ void NoResult::showDefaultLoadingTitle()
 {
     setTitle(tr("Loading..."));
 }
+
+void NoResult::showPrivacyEnabledTitle()
+{
+    setTitle(tr("Privacy Enabled..."));
+}

--- a/src/qt/noresult.h
+++ b/src/qt/noresult.h
@@ -34,6 +34,7 @@ public slots:
     void showDefaultNothingHereTitle();
     void showDefaultNoResultTitle();
     void showDefaultLoadingTitle();
+    void showPrivacyEnabledTitle();
 
 private:
     Ui::NoResult *ui;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -51,6 +51,7 @@ void OptionsModel::Init()
     fConfirmOnClose = settings.value("fConfirmOnClose", false).toBool();
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
     fLimitTxnDisplay = settings.value("fLimitTxnDisplay", false).toBool();
+    fMaskValues = settings.value("fMaskValues", false).toBool();
     limitTxnDate = settings.value("limitTxnDate", QDate()).toDate();
     nReserveBalance = settings.value("nReserveBalance").toLongLong();
     language = settings.value("language", "").toString();
@@ -133,6 +134,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(fCoinControlFeatures);
         case LimitTxnDisplay:
             return QVariant(fLimitTxnDisplay);
+        case MaskValues:
+            return QVariant(fMaskValues);
         case LimitTxnDate:
             return QVariant(limitTxnDate);
         case DisableUpdateCheck:
@@ -268,6 +271,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("fLimitTxnDisplay", fLimitTxnDisplay);
             emit LimitTxnDisplayChanged(fLimitTxnDisplay);
             break;
+        case MaskValues:
+            fMaskValues = value.toBool();
+            settings.setValue("fMaskValues", fMaskValues);
+            emit MaskValuesChanged(fMaskValues);
+            break;
         case LimitTxnDate:
             limitTxnDate = value.toDate();
             settings.setValue("limitTxnDate", limitTxnDate);
@@ -347,6 +355,11 @@ bool OptionsModel::getLimitTxnDisplay()
     return fLimitTxnDisplay;
 }
 
+bool OptionsModel::getMaskValues()
+{
+    return fMaskValues;
+}
+
 QDate OptionsModel::getLimitTxnDate()
 {
     return limitTxnDate;
@@ -421,6 +434,11 @@ QString OptionsModel::getCurrentStyle()
 void OptionsModel::setCurrentStyle(QString theme)
 {
     setData(QAbstractItemModel::createIndex(WalletStylesheet, 0), theme, Qt::EditRole);
+}
+
+void OptionsModel::setMaskValues(bool privacy_mode)
+{
+    setData(QAbstractItemModel::createIndex(MaskValues, 0), privacy_mode, Qt::EditRole);
 }
 
 QString OptionsModel::getDataDir()

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -44,6 +44,7 @@ public:
         StakingEfficiency,       // double
         MinStakeSplitValue,      // int
         ContractChangeToInput,   // bool
+        MaskValues,              // bool
         OptionIDRowCount
     };
 
@@ -67,6 +68,7 @@ public:
 	bool getDisplayAddresses();
     bool getCoinControlFeatures();
     bool getLimitTxnDisplay();
+    bool getMaskValues();
     QDate getLimitTxnDate();
     int64_t getLimitTxnDateTime();
     QString getLanguage() { return language; }
@@ -75,6 +77,7 @@ public:
 
     /* Explicit setters */
     void setCurrentStyle(QString theme);
+    void setMaskValues(bool privacy_mode);
     void toggleCoinControlFeatures();
 
 private:
@@ -89,6 +92,7 @@ private:
     bool fConfirmOnClose;
     bool fCoinControlFeatures;
     bool fLimitTxnDisplay;
+    bool fMaskValues;
     QDate limitTxnDate;
     QString language;
     QString walletStylesheet;
@@ -99,6 +103,7 @@ signals:
     void reserveBalanceChanged(qint64);
     void coinControlFeaturesChanged(bool);
     void LimitTxnDisplayChanged(bool);
+    void MaskValuesChanged(bool);
     void walletStylesheetChanged(QString);
 };
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -389,7 +389,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         setPrivacy(model->getOptionsModel()->getMaskValues());
 
         // Connect the privacy mode setting to the options dialog.
-        connect(walletModel->getOptionsModel(), &OptionsModel::MaskValuesChanged, this, & OverviewPage::setPrivacy);
+        connect(walletModel->getOptionsModel(), &OptionsModel::MaskValuesChanged, this, &OverviewPage::setPrivacy);
     }
 
     // update the display unit, to not use the default ("BTC")

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -196,8 +196,16 @@ int OverviewPage::getNumTransactionsForView()
     // Compute the maximum number of transactions the transaction list widget
     // can hold without overflowing.
     const size_t itemHeight = txdelegate->height() + ui->listTransactions->spacing();
-    const size_t contentsHeight = ui->listTransactions->height();
-    const int numItems = contentsHeight / itemHeight;
+
+    // We have to use the frame here because when the listTransactions is hidden, the recentTransactionsNoResult
+    // takes up the space and would cause the calculation to be off.
+    const size_t contentsHeight = std::max(ui->recentTransactionsFrame->height() - ui->recentTransLabel->height(), 0);
+
+    LogPrint(BCLog::LogFlags::QT, "INFO: %s: contentsHeight = %u, itemHeight = %u",
+             __func__, contentsHeight, itemHeight);
+
+    // take one off so that there is not a "half-visible one" there, ensure not below 0.
+    const int numItems = std::max((int) (contentsHeight / itemHeight) - 1, 0);
 
     return numItems;
 }
@@ -213,13 +221,13 @@ void OverviewPage::updateTransactions()
         // for the "nothing here yet" placeholder in the transaction list. It
         // will never appear again:
         //
-        if (numItems > 0)
+        if (!filter->rowCount())
         {
-            delete ui->recentTransactionsNoResult;
-            ui->recentTransactionsNoResult = nullptr;
+            ui->recentTransactionsNoResult->setVisible(true);
         }
 
-        LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(): numItems = %d, getLimit() = %d", numItems, filter->getLimit());
+        LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(): numItems = %d, getLimit() = %d",
+                 numItems, filter->getLimit());
 
         // This is a "stairstep" approach, using x3 to x6 factors to size the setLimit.
         // Based on testing with a wallet with a large number of transactions (40k+)
@@ -262,12 +270,13 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
     currentStake = stake;
     currentUnconfirmedBalance = unconfirmedBalance;
     currentImmatureBalance = immatureBalance;
-    ui->headerBalanceLabel->setText(BitcoinUnits::formatOverviewRounded(balance));
-    ui->balanceLabel->setText(BitcoinUnits::formatWithUnit(unit, balance));
-    ui->stakeLabel->setText(BitcoinUnits::formatWithUnit(unit, stake));
-    ui->unconfirmedLabel->setText(BitcoinUnits::formatWithUnit(unit, unconfirmedBalance));
-    ui->immatureLabel->setText(BitcoinUnits::formatWithUnit(unit, immatureBalance));
-    ui->totalLabel->setText(BitcoinUnits::formatWithUnit(unit, balance + stake + unconfirmedBalance + immatureBalance));
+    ui->headerBalanceLabel->setText(BitcoinUnits::formatOverviewRounded(balance, m_privacy));
+    ui->balanceLabel->setText(BitcoinUnits::formatWithPrivacy(unit, balance, m_privacy));
+    ui->stakeLabel->setText(BitcoinUnits::formatWithPrivacy(unit, stake, m_privacy));
+    ui->unconfirmedLabel->setText(BitcoinUnits::formatWithPrivacy(unit, unconfirmedBalance, m_privacy));
+    ui->immatureLabel->setText(BitcoinUnits::formatWithPrivacy(unit, immatureBalance, m_privacy));
+    ui->totalLabel->setText(BitcoinUnits::formatWithPrivacy(unit, balance + stake + unconfirmedBalance + immatureBalance,
+                                                            m_privacy));
 
     // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
     // for the non-mining users
@@ -289,12 +298,44 @@ void OverviewPage::setDifficulty(double difficulty, double net_weight)
 
 void OverviewPage::setCoinWeight(double coin_weight)
 {
-    ui->coinWeightLabel->setText(QString::number(coin_weight, 'f', 2));
+    QString text;
+
+    if (m_privacy) {
+        text = QString("#.##");
+    } else {
+        text = QString::number(coin_weight, 'f', 2);
+    }
+
+    ui->coinWeightLabel->setText(text);
 }
 
 void OverviewPage::setCurrentPollTitle(const QString& title)
 {
     ui->currentPollsTitleLabel->setText(title);
+}
+
+void OverviewPage::setPrivacy(bool privacy)
+{
+    m_privacy = privacy;
+    int transaction_count = filter->rowCount();
+
+    if (currentBalance != -1) {
+        setBalance(currentBalance, currentStake, currentUnconfirmedBalance, currentImmatureBalance);
+    }
+
+    if (m_privacy) {
+        ui->recentTransactionsNoResult->showPrivacyEnabledTitle();
+    } else {
+        ui->recentTransactionsNoResult->showDefaultNothingHereTitle();
+    }
+    ui->recentTransactionsNoResult->setVisible(m_privacy || !transaction_count);
+    ui->listTransactions->setVisible(!m_privacy && transaction_count);
+    if (researcherModel) researcherModel->setMaskAccrualAndMagnitude(m_privacy);
+
+    LogPrint(BCLog::LogFlags::QT, "INFO: %s: m_privacy = %u", __func__, m_privacy);
+
+    updateTransactions();
+    updatePendingAccrual();
 }
 
 void OverviewPage::setResearcherModel(ResearcherModel *researcherModel)
@@ -324,7 +365,13 @@ void OverviewPage::setWalletModel(WalletModel *model)
         filter->setDynamicSortFilter(true);
         filter->setSortRole(Qt::EditRole);
         filter->setShowInactive(false);
-        filter->setLimit(getNumTransactionsForView());
+
+        int num_transactions_for_view = getNumTransactionsForView();
+        filter->setLimit(num_transactions_for_view);
+
+        LogPrint(BCLog::LogFlags::QT, "INFO: %s: num_transactions_for_view = %i, getLimit() = %i",
+                 __func__, num_transactions_for_view, filter->getLimit());
+
         filter->sort(TransactionTableModel::Status, Qt::DescendingOrder);
         ui->listTransactions->setModel(filter.get());
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
@@ -337,6 +384,12 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         connect(model->getOptionsModel(), &OptionsModel::LimitTxnDisplayChanged, this, &OverviewPage::updateTransactions);
         connect(model, &WalletModel::transactionUpdated, this, &OverviewPage::updateTransactions);
+
+        // Set the privacy state for the overview screen from the optionsModel for init.
+        setPrivacy(model->getOptionsModel()->getMaskValues());
+
+        // Connect the privacy mode setting to the options dialog.
+        connect(walletModel->getOptionsModel(), &OptionsModel::MaskValuesChanged, this, & OverviewPage::setPrivacy);
     }
 
     // update the display unit, to not use the default ("BTC")

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -35,6 +35,7 @@ public slots:
     void setDifficulty(double difficulty, double net_weight);
     void setCoinWeight(double coin_weight);
     void setCurrentPollTitle(const QString& title);
+    void setPrivacy(bool privacy);
 
 signals:
     void transactionClicked(const QModelIndex &index);
@@ -55,6 +56,7 @@ private:
     qint64 currentUnconfirmedBalance;
     qint64 currentImmatureBalance;
     int scaledDecorationSize;
+    bool m_privacy = false;
 
     TxViewDelegate *txdelegate;
     std::unique_ptr<TransactionFilterProxy> filter;

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -202,6 +202,13 @@ void ResearcherModel::setTheme(const QString& theme_name)
     emit beaconChanged();
 }
 
+void ResearcherModel::setMaskAccrualAndMagnitude(bool privacy)
+{
+    m_privacy_enabled = privacy;
+
+    refresh();
+}
+
 bool ResearcherModel::configuredForInvestorMode() const
 {
     return m_configured_for_investor_mode;
@@ -294,20 +301,30 @@ QString ResearcherModel::formatCpid() const
 
 QString ResearcherModel::formatMagnitude() const
 {
+    QString text;
+
     if (outOfSync()) {
-        return "...";
+        text = "...";
+    } else if (m_privacy_enabled){
+        text = "#";
+    } else {
+        text = QString::fromStdString(m_researcher->Magnitude().ToString());
     }
 
-    return QString::fromStdString(m_researcher->Magnitude().ToString());
+    return text;
 }
 
 QString ResearcherModel::formatAccrual(const int display_unit) const
 {
+    QString text;
+
     if (outOfSync()) {
-        return "...";
+        text = "...";
+    } else {
+        text = BitcoinUnits::formatWithPrivacy(display_unit, m_researcher->Accrual(), m_privacy_enabled);
     }
 
-    return BitcoinUnits::formatWithUnit(display_unit, m_researcher->Accrual());
+    return text;
 }
 
 QString ResearcherModel::formatStatus() const

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -81,6 +81,7 @@ public:
 
     void showWizard(WalletModel* wallet_model);
     void setTheme(const QString& theme_name);
+    void setMaskAccrualAndMagnitude(bool privacy);
 
     bool configuredForInvestorMode() const;
     bool outOfSync() const;
@@ -120,6 +121,7 @@ private:
     bool m_configured_for_investor_mode;
     bool m_wizard_open;
     bool m_out_of_sync;
+    bool m_privacy_enabled;
     QString m_theme_suffix;
 
     void subscribeToCoreSignals();


### PR DESCRIPTION
This PR is based on https://github.com/bitcoin/bitcoin/pull/16432 and implements value masking (privacy mode) for the Gridcoin overview screen.

While the PR generally follows the Bitcoin approach, the reviewers that made the comments on the Bitcoin PR that the state of privacy should be stored in the optionsModel are correct. On restart, the GUI should remember the privacy setting to avoid actually revealing balances to the people around the workstation if a wallet restart is necessary.

Note that in addition to the state maintenance in the optionsModel, I wanted to retain the hotkey approach that Bitcoin adopted. This necessitated connecting the Settings -> Mask values entry, which has a hotkey of [Shift][Ctrl][M] to the optionsModel state.

When the hotkey sequenced is pressed, the Settings->Mask values toggle is selected or the Settings->Options->Display->Mask values in the Overview screen checkbox is checked, the overview screen is masked to look like this:

![image](https://user-images.githubusercontent.com/7529186/144265790-51e4f44b-297a-4a70-9e84-546c4f90237d.png)
 
The GRC values and the coin weight, magnitude, and pending reward fields are masked to #.## or # and the recent transactions are hidden.

Closes #1550.