### PR TITLE
build: Drop macports support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,16 +462,6 @@ case $host in
      TARGET_OS=darwin
      if  test x$cross_compiling != xyes; then
        BUILD_OS=darwin
-       AC_CHECK_PROG([PORT],port, port)
-       if test x$PORT = xport; then
-         dnl add default macports paths
-         CPPFLAGS="$CPPFLAGS -isystem /opt/local/include"
-         LIBS="$LIBS -L/opt/local/lib"
-         if test -d /opt/local/include/db48; then
-           CPPFLAGS="$CPPFLAGS -I/opt/local/include/db48"
-           LIBS="$LIBS -L/opt/local/lib/db48"
-         fi
-       fi
 
        AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
        AC_CHECK_PROG([BREW],brew, brew)

--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -48,8 +48,6 @@ MacOS
 
 - Download and install the `Qt Mac OS X SDK`_. It is recommended to also install Apple's Xcode with UNIX tools.
 
-- Download and install `MacPorts`_.
-
 - Execute the following commands in a terminal to get the dependencies:
 
 ::
@@ -60,7 +58,6 @@ MacOS
 - Open the .pro file in Qt Creator and build as normal (cmd-B)
 
 .. _`Qt Mac OS X SDK`: https://qt-project.org/downloads
-.. _`MacPorts`: https://www.macports.org/install.php
 
 Alternatively
 -------------
@@ -68,8 +65,6 @@ Alternatively
 - Install Qt Creator and open the makefile.am file for Auto-Tools to build for your OS.
 
 - An executable named gridcoinresearch will be built in the /src/Qt directory.
-
-- If you have used Homebrew to install dependencies earlier, no need to install MacPorts as above.
 
 
 Build configuration options


### PR DESCRIPTION
> It's unmaintained, according to @theuni. https://github.com/bitcoin/bitcoin/pull/14920/files#r246964938
> 
> Alternative is to put it under CI. I don't have a strong opinion on this, opened for separate consideration.

Also https://github.com/bitcoin/bitcoin/pull/4939 for the doc references.