### PR TITLE
researcher: Prefer CPID with active beacon for primary CPID

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1195,6 +1195,12 @@ void Researcher::Reload(MiningProjectMap projects, GRC::BeaconError beacon_error
 
     if (mining_id.Which() != MiningId::Kind::CPID) {
         for (const auto& project_pair : projects) {
+            // Stop searching if the current mining_id already has an active beacon
+            const CpidOption cpid = mining_id.TryCpid();
+            if (cpid && GetBeaconRegistry().ContainsActive(*cpid)) {
+                break;
+            }
+
             TryProjectCpid(mining_id, project_pair.second);
         }
     }


### PR DESCRIPTION
In a situation where multiple CPIDs are detected, Researcher should prefer CPIDs with an active beacon over CPIDs without an active beacon when determining its primary CPID. This change will select the first CPID with an active beacon in the project list, or if there is no such CPID, it will select the last CPID in the project list as before.

The motivation for this change came from my recent experience with finally going solo. I sent my beacon and got everything working very easily. However when I went to add another project, and when to check the projects page of the researcher wizard, it took me back to the beginning of the wizard. I quickly figured out that it had selected the CPID of the new project and just waited for BOINC to resolve the split-CPID before rechecking, but I could see this being a very confusing behavior, especially for someone new to Gridcoin. In this case, there is an obvious choice for the primary CPID. I'm not sure if this is the best way to implement it, but it seems like a reasonable place for the check to me, and in testing it works as I expected it to.