### PR TITLE
refactor: Pass values by reference

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -331,7 +331,7 @@ CNode* FindNode(const CNetAddr& ip)
     return nullptr;
 }
 
-CNode* FindNode(std::string addrName)
+CNode* FindNode(const std::string& addrName)
 {
     LOCK(cs_vNodes);
     for (auto const& pnode : vNodes) {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -380,7 +380,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
     return true;
 }
 
-bool SetProxy(enum Network net, CService addrProxy) {
+bool SetProxy(enum Network net, const CService &addrProxy) {
     assert(net >= 0 && net < NET_MAX);
     if (!addrProxy.IsValid())
         return false;
@@ -398,7 +398,7 @@ bool GetProxy(enum Network net, proxyType &proxyInfoOut) {
     return true;
 }
 
-bool SetNameProxy(CService addrProxy) {
+bool SetNameProxy(const CService &addrProxy) {
     if (!addrProxy.IsValid())
         return false;
     LOCK(cs_proxyInfos);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -177,10 +177,10 @@ class CService : public CNetAddr
 typedef CService proxyType;
 
 enum Network ParseNetwork(std::string net);
-bool SetProxy(enum Network net, CService addrProxy);
-bool GetProxy(enum Network net, proxyType &proxyInfoOut);
-bool IsProxy(const CNetAddr &addr);
-bool SetNameProxy(CService addrProxy);
+bool SetProxy(enum Network net, const CService& addrProxy);
+bool GetProxy(enum Network net, proxyType& proxyInfoOut);
+bool IsProxy(const CNetAddr& addr);
+bool SetNameProxy(const CService& addrProxy);
 bool HaveNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);


### PR DESCRIPTION
I have noticed that the arguments of the functions
* `SetProxy`
* `SetNameProxy`
* `FindNode`

are not passed by reference.

Upstream this seems to be different: https://github.com/bitcoin/bitcoin/blob/master/src/netbase.cpp#L608-L632 and this PR adjusts this. I compiled the wallet and ran it successfully on Linux. I have not done any other tests.