### PR TITLE
net: only adjust time with data from outbound nodes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3057,7 +3057,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // Moved the below from AddTimeData to here to follow bitcoin's approach.
         int64_t nOffsetSample = nTime - GetTime();
         pfrom->nTimeOffset = nOffsetSample;
-        if (gArgs.GetBoolArg("-synctime", true))
+        if (!pfrom->fInbound && gArgs.GetBoolArg("-synctime", true))
             AddTimeData(pfrom->addr, nOffsetSample);
 
         // Change version


### PR DESCRIPTION
See upstream PR 23631 for the rationale.