### PR TITLE
gui, voting: Add a one minute timer to check for current poll expiring and update gui

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -839,6 +839,15 @@ void BitcoinGUI::setVotingModel(VotingModel *votingModel)
     overviewPage->setCurrentPollTitle(votingModel->getCurrentPollTitle());
 
     connect(votingModel, &VotingModel::newPollReceived, this, &BitcoinGUI::handleNewPoll);
+
+     QTimer *expiry_check_timer = new QTimer(this);
+
+     // A call to handle new poll on a timer will also update the current polls section of the overview screen
+     // to remove a current poll that expires.
+     connect(expiry_check_timer, &QTimer::timeout, this, &BitcoinGUI::handleNewPoll);
+
+     // Check every minute
+     expiry_check_timer->start(1000 * 60);
 }
 
 void BitcoinGUI::createTrayIcon()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -840,14 +840,14 @@ void BitcoinGUI::setVotingModel(VotingModel *votingModel)
 
     connect(votingModel, &VotingModel::newPollReceived, this, &BitcoinGUI::handleNewPoll);
 
-     QTimer *expiry_check_timer = new QTimer(this);
+    QTimer *expiry_check_timer = new QTimer(this);
 
-     // A call to handle new poll on a timer will also update the current polls section of the overview screen
-     // to remove a current poll that expires.
-     connect(expiry_check_timer, &QTimer::timeout, this, &BitcoinGUI::handleNewPoll);
+    // A call to handle possible expired poll on a timer will update the current polls section of the overview screen
+    // to remove a current poll that has expired.
+    connect(expiry_check_timer, &QTimer::timeout, this, &BitcoinGUI::handleExpiredPoll);
 
-     // Check every minute
-     expiry_check_timer->start(1000 * 60);
+    // Check every minute
+    expiry_check_timer->start(1000 * 60);
 }
 
 void BitcoinGUI::createTrayIcon()
@@ -1860,6 +1860,21 @@ void BitcoinGUI::handleNewPoll()
             Notificator::Information,
             tr("New Poll"),
             tr("A new poll is available. Open Gridcoin to vote."));
+    }
+
+    if (!votingModel) {
+        return;
+    }
+
+    overviewPage->setCurrentPollTitle(votingModel->getCurrentPollTitle());
+}
+
+void BitcoinGUI::handleExpiredPoll()
+{
+    // The only difference between this and handleNewPoll() is no call to the event notifier.
+
+    if (!clientModel || !clientModel->getOptionsModel()) {
+        return;
     }
 
     if (!votingModel) {

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -285,6 +285,7 @@ private slots:
     QString GetEstimatedStakingFrequency(unsigned int nEstimateTime);
 
     void handleNewPoll();
+    void handleExpiredPoll();
 };
 
 //!


### PR DESCRIPTION
This implements a one minute QTimer to call BitcoinGUI::handleNewPoll, which closes #2405.