### PR TITLE
gui: Enable masking of cpid in privacy mode

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -340,11 +340,12 @@ void OverviewPage::setPrivacy(bool privacy)
 
     ui->recentTransactionsNoResult->setVisible(m_privacy || !transaction_count);
     ui->listTransactions->setVisible(!m_privacy && transaction_count);
-    if (researcherModel) researcherModel->setMaskAccrualAndMagnitude(m_privacy);
+    if (researcherModel) researcherModel->setMaskCpidMagnitudeAccrual(m_privacy);
 
     LogPrint(BCLog::LogFlags::QT, "INFO: %s: m_privacy = %u", __func__, m_privacy);
 
     updateTransactions();
+    updateResearcherStatus();
     updatePendingAccrual();
 }
 

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -207,7 +207,7 @@ void ResearcherModel::setTheme(const QString& theme_name)
     emit beaconChanged();
 }
 
-void ResearcherModel::setMaskAccrualAndMagnitude(bool privacy)
+void ResearcherModel::setMaskCpidMagnitudeAccrual(bool privacy)
 {
     m_privacy_enabled = privacy;
 
@@ -306,7 +306,13 @@ QString ResearcherModel::email() const
 
 QString ResearcherModel::formatCpid() const
 {
-    return QString::fromStdString(m_researcher->Id().ToString());
+    QString text = QString::fromStdString(m_researcher->Id().ToString());
+
+    if (m_privacy_enabled) {
+        text = "################################";
+    }
+
+    return text;
 }
 
 QString ResearcherModel::formatMagnitude() const
@@ -315,7 +321,7 @@ QString ResearcherModel::formatMagnitude() const
 
     if (outOfSync()) {
         text = "...";
-    } else if (m_privacy_enabled){
+    } else if (m_privacy_enabled) {
         text = "#";
     } else {
         text = QString::fromStdString(m_researcher->Magnitude().ToString());

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -81,7 +81,7 @@ public:
 
     void showWizard(WalletModel* wallet_model);
     void setTheme(const QString& theme_name);
-    void setMaskAccrualAndMagnitude(bool privacy);
+    void setMaskCpidMagnitudeAccrual(bool privacy);
 
     bool configuredForInvestorMode() const;
     bool outOfSync() const;


### PR DESCRIPTION
This small PR enables the masking of the CPID on the overview screen when privacy mode is active. Thanks to @scribblemaniac  for the suggestion. I am leaving the status tooltips out of this. I don't really think they are necessary.