### PR TITLE
util: clean obsolete config keys

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -527,6 +527,7 @@ bool GRC::CleanConfig() {
         new_config_lines.push_back(line);
 skip:;
     }
+    orig_config.close();
 
     if (commit) {
         if (!BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"))) {
@@ -540,6 +541,7 @@ skip:;
             std::ostream_iterator<std::string> out(new_config_file, "\n");
             std::copy(new_config_lines.begin(), new_config_lines.end(), out);
 
+            new_config_file.close();
             fs::rename(new_config_path, GetConfigFile());
         } catch (const fs::filesystem_error& e) {
             return error("%s: Error saving config: %s", __func__, e.what());

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -510,8 +510,9 @@ bool GRC::CleanConfig() {
     bool commit{false};
     std::vector<std::string> new_config_lines;
 
-    std::string obsolete_keys[] = {"privatekey", "publickey", "PrimaryCPID", "NEURAL_", "enablespeech",
-                                   "suppressupgrade", "UpdatingLeaderboard"};
+    std::string obsolete_keys[] = {"privatekey", "AutoUpgrade", "cpumining", "enablespeech",
+                                   "NEURAL_", "PrimaryCPID", "publickey", "SessionGuid",
+                                   "suppressupgrade", "tickers", "UpdatingLeaderboard"};
 
     std::string line;
     while (std::getline(orig_config, line)) {

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -500,3 +500,52 @@ void GRC::ScheduleBackgroundJobs(CScheduler& scheduler)
     ScheduleUpdateChecks(scheduler);
     ScheduleBeaconDBPassivation(scheduler);
 }
+
+bool GRC::CleanConfig() {
+    fsbridge::ifstream orig_config(GetConfigFile());
+    if (!orig_config.good()) {
+        return false;
+    }
+
+    bool commit{false};
+    std::vector<std::string> new_config_lines;
+
+    std::string obsolete_keys[] = {"privatekey", "publickey", "PrimaryCPID", "NEURAL_", "enablespeech",
+                                   "suppressupgrade", "UpdatingLeaderboard"};
+
+    std::string line;
+    while (std::getline(orig_config, line)) {
+        if (!commit) {
+            commit |= line.rfind(obsolete_keys[0], 0) != std::string::npos;
+        }
+
+        for (const auto& key : obsolete_keys) {
+            if (line.rfind(key, 0) != std::string::npos) {
+                goto skip;
+            }
+        }
+        new_config_lines.push_back(line);
+skip:;
+    }
+
+    if (commit) {
+        if (!BackupConfigFile(GetBackupFilename("gridcoinresearch.conf"))) {
+            return error("%s: Config backup failed.", __func__);
+        }
+
+        try {
+            fs::path new_config_path(GetConfigFile().replace_extension("conf~"));
+            fsbridge::ofstream new_config_file(new_config_path);
+
+            std::ostream_iterator<std::string> out(new_config_file, "\n");
+            std::copy(new_config_lines.begin(), new_config_lines.end(), out);
+
+            fs::rename(new_config_path, GetConfigFile());
+        } catch (const fs::filesystem_error& e) {
+            return error("%s: Error saving config: %s", __func__, e.what());
+        }
+    }
+
+    return true;
+}
+

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -32,6 +32,14 @@ void CloseResearcherRegistryFile();
 //! \param scheduler Scheduler instance to register jobs with.
 //!
 void ScheduleBackgroundJobs(CScheduler& scheduler);
+
+//!
+//! \brief Cleans the config file of obsolete config keys. Might not make changes
+//! if a specific key is not present.
+//!
+//! \return \c true if no errors occurred.
+//!
+bool CleanConfig();
 } // namespace GRC
 
 #endif // GRIDCOIN_GRIDCOIN_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -804,6 +804,10 @@ bool AppInit2(ThreadHandlerPtr threads)
         {
             LogPrintf("WARNING: failed to create configuration file: %s", e.what());
         }
+    } else {
+        if (!GRC::CleanConfig()) {
+            InitWarning("Failed to clean obsolete config keys.");
+        }
     }
 
     //6-10-2014: R Halford: Updating Boost version to 1.5.5 to prevent sync issues; print the boost version to verify:


### PR DESCRIPTION
Removes obsolete config keys if a beacon private key is detected in the config file.

Fixes #2423 