### PR TITLE
net: Implement an upper limit of 950 for max network connections

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -479,7 +479,7 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-port=<port>", "Listen for connections on <port> (default: 32749 or testnet: 32748)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
-    argsman.AddArg("-maxconnections=<n>", "Maintain at most <n> connections to peers (default: 125)",
+    argsman.AddArg("-maxconnections=<n>", "Maintain at most <n> connections to peers (default: 125, upper limit of 950)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-maxoutboundconnections=<n>", "Maximum number of outbound connections (default: 8)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -949,9 +949,8 @@ void ThreadSocketHandler2(void* parg)
             else if (nInbound >= max_connections - MAX_OUTBOUND_CONNECTIONS)
             {
                 LogPrint(BCLog::LogFlags::NET,
-                         "Surpassed max inbound connections maxconnections:%" PRId64 " minus max_outbound:%i",
-                         max_connections,
-                         MAX_OUTBOUND_CONNECTIONS);
+                         "Surpassed max inbound connections of %i",
+                         std::max<int>(max_connections - MAX_OUTBOUND_CONNECTIONS, 0));
 
                 closesocket(hSocket);
             }
@@ -2008,7 +2007,7 @@ void StartNode(void* parg)
     }
 
     LogPrintf("Using %i OutboundConnections with a MaxConnections of %" PRId64,
-              MAX_OUTBOUND_CONNECTIONS, max_connections);
+              nMaxOutbound, max_connections);
 
     if (pnodeLocalHost == nullptr)
         pnodeLocalHost = new CNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -927,6 +927,8 @@ void ThreadSocketHandler2(void* parg)
             CAddress addr;
             int nInbound = 0;
 
+            int max_connections = std::min<int>(gArgs.GetArg("-maxconnections", 125), 950);
+
             if (hSocket != INVALID_SOCKET)
                 if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))
                     LogPrintf("Warning: Unknown socket family");
@@ -944,11 +946,11 @@ void ThreadSocketHandler2(void* parg)
                 if (nErr != WSAEWOULDBLOCK)
                     LogPrintf("socket error accept INVALID_SOCKET: %d", nErr);
             }
-            else if (nInbound >= gArgs.GetArg("-maxconnections", 125) - MAX_OUTBOUND_CONNECTIONS)
+            else if (nInbound >= max_connections - MAX_OUTBOUND_CONNECTIONS)
             {
                 LogPrint(BCLog::LogFlags::NET,
                          "Surpassed max inbound connections maxconnections:%" PRId64 " minus max_outbound:%i",
-                         gArgs.GetArg("-maxconnections", 125),
+                         max_connections,
                          MAX_OUTBOUND_CONNECTIONS);
 
                 closesocket(hSocket);
@@ -1996,15 +1998,17 @@ void StartNode(void* parg)
     util::ThreadSetInternalName("grc-nodestart");
 
     fShutdown = false;
-    MAX_OUTBOUND_CONNECTIONS = (int)gArgs.GetArg("-maxoutboundconnections", 8);
+    MAX_OUTBOUND_CONNECTIONS = (int) gArgs.GetArg("-maxoutboundconnections", 8);
+    int max_connections = std::min<int>(gArgs.GetArg("-maxconnections", 125), 950);
     int nMaxOutbound = 0;
     if (semOutbound == nullptr) {
         // initialize semaphore
-        nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS, (int)gArgs.GetArg("-maxconnections", 125));
+        nMaxOutbound = std::min<int>(MAX_OUTBOUND_CONNECTIONS, max_connections);
         semOutbound = new CSemaphore(nMaxOutbound);
     }
 
-    LogPrintf("Using %i OutboundConnections with a MaxConnections of %" PRId64, MAX_OUTBOUND_CONNECTIONS, gArgs.GetArg("-maxconnections", 125));
+    LogPrintf("Using %i OutboundConnections with a MaxConnections of %" PRId64,
+              MAX_OUTBOUND_CONNECTIONS, max_connections);
 
     if (pnodeLocalHost == nullptr)
         pnodeLocalHost = new CNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices));


### PR DESCRIPTION
This is a small PR that implements a maximum limit of 950 network connections until the network code is upgraded and the file descriptor limit can be changed. This will be the only thing merged after RC2 for Janice.