### PR TITLE
net: Hard Coded Seed Node Cleanup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -210,7 +210,7 @@ static void CreateNewConfigFile()
     myConfig
         << "addnode=addnode-us-central.cycy.me\n"
         << "addnode=ec2-3-81-39-58.compute-1.amazonaws.com\n"
-        << "addnode=gridcoin.ddns.net\n"
+        << "addnode=gridcoin.network\n"
         << "addnode=seeds.gridcoin.ifoggz-network.xyz\n"
         << "addnode=seed.gridcoin.pl\n"
         << "addnode=www.grcpool.com\n";

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1267,6 +1267,7 @@ static const char *strDNSSeed[][2] = {
     {"ec2-3-81-39-58.compute-1.amazonaws.com", "ec2-3-81-39-58.compute-1.amazonaws.com"},
     {"node.grcpool.com", "node.grcpool.com"},
     {"seeds.gridcoin.ifoggz-network.xyz", "seeds.gridcoin.ifoggz-network.xyz"},
+    {"node.gridcoin.network", "node.gridcoin.network"},
     {"", ""},
 };
 


### PR DESCRIPTION
See https://github.com/gridcoin-community/Gridcoin-Research/pull/783 for the last time this was done.

For 2022 we are adding [gridcoin.network ](https://gridcoin.network/) as a seed node. For the config writer I replaced gridcoin.ddns.net as @G-UK has stated his site is no longer actively maintained.

All existing seed nodes were checked against https://addnode.cycy.me/ and my local wallet to ensure they were working. 

As I posted in Slack I am open to adding more.