### PR TITLE
build: fix unoptimized libraries in depends

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -12,7 +12,7 @@ define $(package)_set_vars
   $(package)_config_opts_mingw32=--enable-mingw
   $(package)_config_opts_linux=--with-pic
   $(package)_cflags+=-Wno-error=implicit-function-declaration
-  $(package)_cxxflags=-std=c++17
+  $(package)_cxxflags+=-std=c++17
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/bdb53.mk
+++ b/depends/packages/bdb53.mk
@@ -12,7 +12,7 @@ define $(package)_set_vars
   $(package)_config_opts_mingw32=--enable-mingw
   $(package)_config_opts_linux=--with-pic
   $(package)_cflags+=-Wno-error=implicit-function-declaration
-  $(package)_cxxflags=-std=c++17
+  $(package)_cxxflags+=-std=c++17
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cxxflags_arm_linux = $(GCCFLAGS)

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -28,7 +28,7 @@ ifneq (,$(findstring clang,$($(package)_cxx)))
 endif
 $(package)_archiver_$(host_os)=$($(package)_ar)
 $(package)_config_libraries=filesystem,system,thread,test,iostreams
-$(package)_cxxflags=-std=c++17 -fvisibility=hidden
+$(package)_cxxflags+=-std=c++17 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_android=-fPIC
 endef


### PR DESCRIPTION
> We need to append-to rather than set CXXFLAGS, otherwise we loose -O2 & -pipe from our defaults.
> ...
> Bdb is the same, for the CXX portion of its code. C code has been built with -O2. Boost has actually been unaffected because it receives -O3 from it's own build flags.

Ref: https://github.com/bitcoin/bitcoin/pull/22840