### PR TITLE
build: don't use deprecated brew package names

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -472,15 +472,15 @@ case $host in
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
-         if $BREW list --versions berkeley-db4 >/dev/null && test "x$BDB_CFLAGS" = "x" && test "x$BDB_LIBS" = "x"; then
-           bdb_prefix=$($BREW --prefix berkeley-db4 2>/dev/null)
+         if $BREW list --versions berkeley-db@4 >/dev/null && test "x$BDB_CFLAGS" = "x" && test "x$BDB_LIBS" = "x"; then
+           bdb_prefix=$($BREW --prefix berkeley-db@4 2>/dev/null)
            dnl This must precede the call to BITCOIN_FIND_BDB48 below.
            BDB_CFLAGS="-I$bdb_prefix/include"
            BDB_LIBS="-L$bdb_prefix/lib -ldb_cxx-4.8"
          fi
 
          openssl_prefix=`$BREW --prefix openssl@1.1 2>/dev/null`
-         qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
+         qt5_prefix=`$BREW --prefix qt@5 2>/dev/null`
          if test x$openssl_prefix != x; then
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH


### PR DESCRIPTION
> Fixes:
> 
> ```shell
> checking for brew... brew
> Warning: Use berkeley-db@4 instead of deprecated berkeley-db4
> ```
> 
> on macOS.

Ref: https://github.com/bitcoin/bitcoin/pull/23564