### PR TITLE
staking, gui: Fixes a missing miner search interval update for no coins corner case

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -489,6 +489,16 @@ bool CreateCoinStake(CBlock &blocknew, CKey &key,
 
     if (!wallet.SelectCoinsForStaking(txnew.nTime, CoinsToStake, error_flag, balance, true))
     {
+        g_miner_status.UpdateLastSearch(
+            kernel_found,
+            txnew.nTime,
+            blocknew.nVersion,
+            StakeWeightSum,
+            StakeValueSum,
+            0, // This should be set to zero for an unsuccessful iteration due to no stakeable coins.
+            StakeWeightMax,
+            GRC::CalculateStakeWeightV8(balance));
+
         g_miner_status.UpdateCurrentErrors(error_flag);
 
         LogPrint(BCLog::LogFlags::VERBOSE, "%s: %s", __func__, g_miner_status.FormatErrors());


### PR DESCRIPTION
In the special case where there are no coins available to stake, the CreateCoinStake loop ends early and never calls the update
search at the bottom. This puts the call inside the if statement that executes if there are no coins to ensure the miner status
properly updates to no staking if all of the UTXOs are on cooldown. This can cause getstakingstatus and the coinweight and staking icon to not reflect the proper status in the case where a wallet has one UTXO that was eligible to stake, then stakes and goes on cooldown and there are no other coins left to stake. This must go in Janice. I don't need a review on this but I am putting up a PR for documentation purposes.