### PR TITLE
build: Only Show Testnet Shortcut on Testnet Builds

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -93,7 +93,13 @@ Section -post SEC0001
     !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
     CreateDirectory $SMPROGRAMS\$StartMenuGroup
     CreateShortcut "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk" $INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@
-    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\@PACKAGE_NAME@ (testnet, @WINDOWS_BITS@-bit).lnk" "$INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@" "-testnet" "$INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@" 1
+    !if @CLIENT_VERSION_IS_RELEASE@ == false
+        CreateShortcut "$SMPROGRAMS\$StartMenuGroup\@PACKAGE_NAME@ (testnet, @WINDOWS_BITS@-bit).lnk" "$INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@" "-testnet" "$INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@" 1
+    !else
+        #delete any existing testnet shortcuts
+        Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\@PACKAGE_NAME@ (testnet, @WINDOWS_BITS@-bit).lnk"
+        Delete /REBOOTOK "$SMSTARTUP\Gridcoin-testnet.lnk"
+    !endif
     CreateShortcut "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk" $INSTDIR\uninstall.exe
     !insertmacro MUI_STARTMENU_WRITE_END
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayName "$(^Name)"


### PR DESCRIPTION
Make it so releases don't show a testnet shortcut but it will be there for testnet builds. I've seen an increasing number of users accidentally run the testnet shortcut without knowing that it's a different network, so this should help stop that issue

<br>

Tested with cross-compilation from Ubuntu 20 and running the builds on Windows 10. 

<br>

<sup>As an aside about the style of the if statement here: you have to compare a boolean value with `==` for NSIS since `!if true` and `!if false` will always run since it only checks if the boolean exists</sup>