### PR TITLE
script: Add More Generated Files to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,13 @@ src/test/test_gridcoin
 src/build.h
 src/obj
 src/qt/forms/*.h
+src/qt/forms/voting/*.h
 src/qt/moc_*.cpp
+src/qt/researcher/moc_*.cpp
+src/qt/voting/moc_*.cpp
 src/qt/moc.*
 src/qt/*.moc
+src/qt/voting/*.moc
 src/qt/test/moc*.cpp
 src/qt/test/test_gridcoin-qt
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
 src/*.exe
 src/gridccoinstake
 src/gridcoinresearchd
+
+#unit test generated files
+src/banlist.dat
 src/test/test_gridcoin
+src/qt/test/test_gridcoin-qt.log
+src/qt/test/test_gridcoin-qt.trs
+src/test-suite.log
+src/test/test_gridcoin.log
+src/test/test_gridcoin.trs
+
 src/build.h
 src/obj
 src/qt/forms/*.h


### PR DESCRIPTION
~50 files are being tracked that are automatically made by Qt builds. It looks like they were moved into subfolders and missed by the existing gitignore. This PR adds those subfolders to the gitignore