### PR TITLE
gui: Add uiInterface.BeaconChanged() call after ActivatePending

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1256,6 +1256,9 @@ bool TryLoadSuperblock(
                     superblock.m_timestamp,
                     block.GetHash(),
                     pindex->nHeight);
+
+        // Notify the GUI if present that beacons have changed.
+        uiInterface.BeaconChanged();
     }
 
     GRC::Quorum::PushSuperblock(std::move(superblock));


### PR DESCRIPTION
In testing the mrc branch I discovered that the GUI change to the beacon status when the beacon activates does not seem to be working. I think this is what was missing. This needs to go into Janice as the failure to update the beacon to activated status without restarting the wallet is not user-friendly.