### PR TITLE
build: Port over Bitcoin's translation docs

### DIFF
--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -1,0 +1,101 @@
+Translations
+============
+
+The Gridcoin project has been designed to support multiple localisations. This makes adding new phrases, and completely new languages easily achievable. For managing all application translations, Gridcoin makes use of the Transifex online translation management tool.
+
+### Helping to translate (using Transifex)
+Transifex is setup to monitor the GitHub repo for updates, and when code containing new translations is found, Transifex will process any changes. It may take several hours after a pull-request has been merged, to appear in the Transifex web interface.
+
+Multiple language support is critical in assisting Gridcoin’s global adoption, and growth. One of Gridcoin’s greatest strengths is cross-border money transfers, any help making that easier is greatly appreciated.
+
+See the [Transifex Gridcoin project](https://www.transifex.com/gridcoin/gridcoin/) to assist in translations. You should also join the Slack for announcements - see details below.
+
+### Writing code with translations
+We use automated scripts to help extract translations in both Qt, and non-Qt source files. It is rarely necessary to manually edit the files in `src/qt/locale/`. The translation source files must adhere to the following format:
+`bitcoin_xx_YY.ts or bitcoin_xx.ts`
+
+`src/qt/locale/bitcoin_en.ts` is treated in a special way. It is used as the source for all other translations. Whenever a string in the source code is changed, this file must be updated to reflect those changes. A custom script is used to extract strings from the non-Qt parts. This script makes use of `gettext`, so make sure that utility is installed (ie, `apt-get install gettext` on Ubuntu/Debian). Once this has been updated, `lupdate` (included in the Qt SDK) is used to update `bitcoin_en.ts`.
+
+To automatically regenerate the `bitcoin_en.ts` file, run the following commands:
+```sh
+cd src/
+make translate
+```
+
+**Example Qt translation**
+```cpp
+QToolBar *toolbar = addToolBar(tr("Tabs toolbar"));
+```
+
+### Creating a pull-request
+For general PRs, you shouldn’t include any updates to the translation source files. They will be updated periodically, primarily around pre-releases, allowing time for any new phrases to be translated before public releases. This is also important in avoiding translation related merge conflicts.
+
+When an updated source file is merged into the GitHub repo, Transifex will automatically detect it (although it can take several hours). Once processed, the new strings will show up as "Remaining" in the Transifex web interface and are ready for translators.
+
+To create the pull-request, use the following commands:
+```
+git add src/qt/bitcoinstrings.cpp src/qt/locale/bitcoin_en.ts
+git commit
+```
+
+### Creating a Transifex account
+Visit the [Transifex Signup](https://www.transifex.com/signup/) page to create an account. Take note of your username and password, as they will be required to configure the command-line tool.
+
+You can find the Gridcoin translation project at [https://www.transifex.com/gridcoin/gridcoin/](https://www.transifex.com/gridcoin/gridcoin/).
+
+### Installing the Transifex client command-line tool
+The client is used to fetch updated translations. If you are having problems, or need more details, see [https://docs.transifex.com/client/installing-the-client](https://docs.transifex.com/client/installing-the-client)
+
+`pip install transifex-client`
+
+Setup your Transifex client config as follows. Please *ignore the token field*.
+
+```ini
+nano ~/.transifexrc
+
+[https://www.transifex.com]
+hostname = https://www.transifex.com
+password = PASSWORD
+token =
+username = USERNAME
+```
+
+The Transifex Gridcoin project config file is included as part of the repo. It can be found at `.tx/config`, however you shouldn’t need to change anything.
+
+### Synchronising translations
+
+To assist in updating translations, a helper script is available in the [maintainer-tools repo](https://github.com/bitcoin-core/bitcoin-maintainer-tools). To use it and commit the result, simply do:
+
+```
+python3 ../bitcoin-maintainer-tools/update-translations.py
+git commit -a
+```
+
+**Do not directly download translations** one by one from the Transifex website, as we do a few post-processing steps before committing the translations.
+
+### Handling Plurals (in source files)
+When new plurals are added to the source file, it's important to do the following steps:
+
+1. Open `bitcoin_en.ts` in Qt Linguist (included in the Qt SDK)
+2. Search for `%n`, which will take you to the parts in the translation that use plurals
+3. Look for empty `English Translation (Singular)` and `English Translation (Plural)` fields
+4. Add the appropriate strings for the singular and plural form of the base string
+5. Mark the item as done (via the green arrow symbol in the toolbar)
+6. Repeat from step 2, until all singular and plural forms are in the source file
+7. Save the source file
+
+### Translating a new language
+To create a new language template, you will need to edit the languages manifest file `src/qt/bitcoin_locale.qrc` and add a new entry. Below is an example of the English language entry.
+
+```xml
+<qresource prefix="/translations">
+    <file alias="en">locale/bitcoin_en.qm</file>
+    ...
+</qresource>
+```
+
+**Note:** that the language translation file **must end in `.qm`** (the compiled extension), and not `.ts`.
+
+### Questions and general assistance
+
+If you are a translator, you should also join the Slack, the invite link is available on the [README](https://github.com/gridcoin-community/Gridcoin-Research#community). Announcements will be posted during application pre-releases to notify translators to check for updates.

--- a/doc/translation_strings_policy.md
+++ b/doc/translation_strings_policy.md
@@ -1,0 +1,100 @@
+Translation Strings Policy
+===========================
+
+This document provides guidelines for internationalization of the Gridcoin software.
+
+How to translate?
+------------------
+
+To mark a message as translatable
+
+- In GUI source code (under `src/qt`): use `tr("...")`
+
+- In non-GUI source code (under `src`): use `_("...")`
+
+No internationalization is used for e.g. developer scripts outside `src`.
+
+Strings to be translated
+-------------------------
+
+On a high level, these strings are to be translated:
+
+- GUI strings, anything that appears in a dialog or window
+
+### GUI strings
+
+Do not translate technical or extremely rare errors.
+Anything else that appears to the user in the GUI is to be translated. This includes labels, menu items, button texts, tooltips and window titles.
+This includes messages passed to the GUI through the UI interface through `InitMessage`, `ThreadSafeMessageBox` or `ShowProgress`.
+
+General recommendations
+------------------------
+
+### Avoid unnecessary translation strings
+
+Try not to burden translators with translating messages that are e.g. slight variations of other messages.
+In the GUI, avoid the use of text where an icon or symbol will do.
+Make sure that placeholder texts in forms do not end up in the list of strings to be translated (use `<string notr="true">`).
+
+### Make translated strings understandable
+
+Try to write translation strings in an understandable way, for both the user and the translator. Avoid overly technical or detailed messages.
+
+### Do not translate internal errors
+
+Do not translate internal errors, log messages, or messages that appear on the RPC interface. If an error is to be shown to the user,
+use a translatable generic message, then log the detailed message to the log. E.g., "A fatal internal error occurred, see debug.log for details".
+This helps troubleshooting; if the error is the same for everyone, the likelihood is increased that it can be found using a search engine.
+
+### Avoid fragments
+
+Avoid dividing up a message into fragments. Translators see every string separately, so they may misunderstand the context if the messages are not self-contained.
+
+### Avoid HTML in translation strings
+
+There have been difficulties with the use of HTML in translation strings; translators should not be able to accidentally affect the formatting of messages.
+This may sometimes be at conflict with the recommendation in the previous section.
+
+### Plurals
+
+Plurals can be complex in some languages. A quote from the gettext documentation:
+
+    In Polish we use e.g. plik (file) this way:
+    1 plik,
+    2,3,4 pliki,
+    5-21 pliko'w,
+    22-24 pliki,
+    25-31 pliko'w
+    and so on
+
+In Qt code, use tr's third argument for optional plurality. For example:
+
+    tr("%n hour(s)","",secs/HOUR_IN_SECONDS);
+    tr("%n day(s)","",secs/DAY_IN_SECONDS);
+    tr("%n week(s)","",secs/WEEK_IN_SECONDS);
+
+This adds `<numerusform>`s to the respective `.ts` file, which can be translated separately depending on the language. In English, this is simply:
+
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network</source>
+        <translation>
+            <numerusform>%n active connection to Bitcoin network</numerusform>
+            <numerusform>%n active connections to Bitcoin network</numerusform>
+        </translation>
+    </message>
+
+Where possible, try to avoid embedding numbers into the flow of the string at all. E.g.,
+
+    WARNING: check your network connection, %d blocks received in the last %d hours (%d expected)
+
+versus
+
+    WARNING: check your network connection, less blocks (%d) were received in the last %n hours than expected (%d).
+
+The second example reduces the number of pluralized words that translators have to handle from three to one, at no cost to comprehensibility of the sentence.
+
+### String freezes
+
+During a string freeze (often before a major release), no translation strings are to be added, modified or removed.
+
+This can be checked by executing `make translate` in the `src` directory, then verifying that `bitcoin_en.ts` remains unchanged.


### PR DESCRIPTION
This is a port of Bitcoin's translation docs now that we are using the Transifex system. @cyrossignol some of the instructions need to be changed for this. Please put up a PR against my source branch for this PR and I will flow it through.

I think we also need to bring over a modified .tx/config file.