### PR TITLE
gui: Update copyright year to 2022 for Gridcoin About dialog box

### DIFF
--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -8,7 +8,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui(new Ui::AboutDialog)
 {
     ui->setupUi(this);
-    ui->copyrightLabel->setText("Copyright 2009-2021 The Bitcoin/Peercoin/Black-Coin/Gridcoin developers");
+    ui->copyrightLabel->setText("Copyright 2009-2022 The Bitcoin/Peercoin/Black-Coin/Gridcoin developers");
 
     resize(GRC::ScaleSize(this, width(), height()));
 }


### PR DESCRIPTION
This was missed for Janice.