### PR TITLE
test: Add dead code detection

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -14,6 +14,7 @@ sudo update-alternatives --install /usr/bin/clang-format-diff clang-format-diff 
 ./ci/retry/retry pip3 install flake8==3.8.3
 ./ci/retry/retry pip3 install yq
 ./ci/retry/retry pip3 install mypy==0.781
+./ci/retry/retry pip3 install vulture==2.3
 
 SHELLCHECK_VERSION=v0.7.1
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/

--- a/test/lint/lint-python-dead-code.sh
+++ b/test/lint/lint-python-dead-code.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Find dead Python code.
+
+export LC_ALL=C
+
+if ! command -v vulture > /dev/null; then
+    echo "Skipping Python dead code linting since vulture is not installed. Install by running \"pip3 install vulture\""
+    exit 0
+fi
+
+# --min-confidence 100 will only report code that is guaranteed to be unused within the analyzed files.
+# Any value below 100 introduces the risk of false positives, which would create an unacceptable maintenance burden.
+if ! vulture \
+    --min-confidence 100 \
+    $(git ls-files -- "*.py"); then
+    echo "Python dead code detection found some issues"
+    exit 1
+fi


### PR DESCRIPTION
This adds unreachable code detection for Python based on `vulture`.

Ref: https://github.com/bitcoin/bitcoin/pull/21096

Attempt 2 because Windows has issues with setting the executable bit. Thanks @div72 !