### PR TITLE
net: Do not add random inbound peers to addrman

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3081,14 +3081,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->fGetAddr = true;
             addrman.Good(pfrom->addr);
         }
-        else
-        {
-            if (((CNetAddr)pfrom->addr) == (CNetAddr)addrFrom)
-            {
-                addrman.Add(addrFrom, addrFrom);
-                addrman.Good(addrFrom);
-            }
-        }
 
 
         // Ask the first connected node for block updates


### PR DESCRIPTION
This ports a very old Bitcoin netcode change. We will be rebasing our entire netcode in the future, but let's get this change in for Kermit.

> We should learn about new peers via address messages.
> 
> An inbound peer connecting to us tells us nothing about
its ability to accept incoming connections from us, so
we shouldn't assume that we can connect to it based on
this.
> 
> The vast majority of nodes on the network do not accept
incoming connections, adding them will only slow down
the process of making a successful connection in the
future.
> 
> Nodes which have configured themselves to not announce would prefer we
not violate their privacy by announcing them in GETADDR responses.


Ref: https://github.com/bitcoin/bitcoin/pull/8594