### PR TITLE
net: Do not propagate obviously poor addresses onto the network

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -491,17 +491,23 @@ int CAddrMan::Check_()
 
 void CAddrMan::GetAddr_(std::vector<CAddress> &vAddr)
 {
-    int nNodes = ADDRMAN_GETADDR_MAX_PCT*vRandom.size()/100;
+    unsigned int nNodes = ADDRMAN_GETADDR_MAX_PCT * vRandom.size() / 100;
     if (nNodes > ADDRMAN_GETADDR_MAX)
         nNodes = ADDRMAN_GETADDR_MAX;
 
-    // perform a random shuffle over the first nNodes elements of vRandom (selecting from all)
-    for (int n = 0; n<nNodes; n++)
+    // gather a list of random nodes, skipping those of low quality
+    for (unsigned int n = 0; n < vRandom.size(); n++)
     {
+        if (vAddr.size() >= nNodes)
+            break;
+
         int nRndPos = GetRandInt(vRandom.size() - n) + n;
         SwapRandom(n, nRndPos);
         assert(mapInfo.count(vRandom[n]) == 1);
-        vAddr.push_back(mapInfo[vRandom[n]]);
+        
+        const CAddrInfo& ai = mapInfo[vRandom[n]];
+        if(!ai.IsTerrible())
+            vAddr.push_back(ai);
     }
 }
 


### PR DESCRIPTION
This is a simple backport of https://github.com/bitcoin/bitcoin/pull/4632. When we port the new net code it will be obsolete, but until then it probably makes sense to use the commit anyway.


> This is a first pass at filtering bad addresses.
> 
> ETA: Although this might not be a perfect solution, we need to stop the practice of returning long dead garbage addresses to other peers. This addresses one of the longstanding Things That Bug Me About Bitcoin.

