### PR TITLE
net: No longer send local address in addrMe

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3048,7 +3048,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         // record my external IP reported by peer
-        if (addrFrom.IsRoutable() && addrMe.IsRoutable())
+        if (addrMe.IsRoutable())
             addrSeenByPeer = addrMe;
 
         // Be shy and don't send version until we hear

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -485,7 +485,7 @@ void CNode::PushVersion()
 {
     int64_t nTime = GetAdjustedTime();
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0",0)));
-    CAddress addrMe = GetLocalAddress(&addr);
+    CAddress addrMe = CAddress(CService(), nLocalServices);
     GetRandBytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
     LogPrint(BCLog::LogFlags::NET, "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s",
         PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), addr.ToString());


### PR DESCRIPTION
Since the following PR https://github.com/gridcoin-community/Gridcoin-Research/pull/2451 was recently merged, it also makes sense to include the Bitcoin commit based on it in our code as well. For reference, see https://github.com/bitcoin/bitcoin/pull/8740

> After https://github.com/bitcoin/bitcoin/pull/8594 the addrFrom sent by a node is not used anymore at all, so don't bother sending it (it was already not used if it is an invalid address so this doesn't disadvantage older versions either).
> 
> Also mitigates the privacy issue in (https://github.com/bitcoin/bitcoin/issues/8616). It doesn't completely solve the issue as GetLocalAddress is also called in AdvertiseLocal, but at least when advertising addresses it stands out less as our address.