### PR TITLE
test: Bump shellcheck, mypy versions

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -13,9 +13,9 @@ sudo update-alternatives --install /usr/bin/clang-format-diff clang-format-diff 
 ./ci/retry/retry pip3 install codespell==2.0.0
 ./ci/retry/retry pip3 install flake8==3.8.3
 ./ci/retry/retry pip3 install yq
-./ci/retry/retry pip3 install mypy==0.781
+./ci/retry/retry pip3 install mypy==0.910
 ./ci/retry/retry pip3 install vulture==2.3
 
-SHELLCHECK_VERSION=v0.7.1
+SHELLCHECK_VERSION=v0.8.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
 export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"


### PR DESCRIPTION
- Shellcheck to 0.8.0
Release notes: https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06
Ref: https://github.com/bitcoin/bitcoin/pull/23635

- mypy to 0.910
Ref: https://github.com/bitcoin/bitcoin/pull/23212/commits/22e652662bb1fb9bd7ae6ab01c20665ad1c57895