### PR TITLE
build: Update depends packages (expat, fontconfig, freetype, libXau, libxcb, xcb_proto, xproto)

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,12 +1,12 @@
 package=expat
 GCCFLAGS?=
-$(package)_version=2.2.7
-$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_2_7/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=cbc9102f4a31a8dafd42d642e9a3aa31e79a0aedaa1f6efd2795ebc83174ec18
+$(package)_version=2.4.1
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_4_1/
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-static --without-docbook
+  $(package)_config_opts=--disable-static --without-docbook --without-xmlwf
   $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
   $(package)_cflags_aarch64_linux = $(GCCFLAGS)
@@ -24,4 +24,8 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf share lib/cmake lib/*.la
 endef

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -1,27 +1,25 @@
 package=fontconfig
-$(package)_version=2.12.1
+$(package)_version=2.12.6
 $(package)_download_path=https://www.freedesktop.org/software/fontconfig/release/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
+$(package)_sha256_hash=cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017
 $(package)_dependencies=freetype expat
+$(package)_patches=gperf_header_regen.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
-  $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/gperf_header_regen.patch
 endef
 
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef
 
-# 2.12.1 uses CHAR_WIDTH which is reserved and clashes with some glibc versions, but newer versions of fontconfig
-# have broken makefiles which needlessly attempt to re-generate headers with gperf.
-# Instead, change all uses of CHAR_WIDTH, and disable the rule that forces header re-generation.
-# This can be removed once the upstream build is fixed.
 define $(package)_build_cmds
-  sed -i 's/CHAR_WIDTH/CHARWIDTH/g' fontconfig/fontconfig.h src/fcobjshash.gperf src/fcobjs.h src/fcobjshash.h && \
-  sed -i 's/fcobjshash.h: fcobjshash.gperf/fcobjshash.h:/' src/Makefile && \
   $(MAKE)
 endef
 
@@ -30,5 +28,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/*.la
+  rm -rf var lib/*.la
 endef

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,12 +1,12 @@
 package=freetype
 GCCFLAGS?=
-$(package)_version=2.7.1
+$(package)_version=2.11.0
 $(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
+  $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static --without-brotli
   $(package)_config_opts+=--libdir=$($($(package)_type)_prefix)/lib
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -1,9 +1,9 @@
 package=libXau
 GCCFLAGS?=
-$(package)_version=1.0.8
+$(package)_version=1.0.9
 $(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=fdd477320aeb5cdd67272838722d6b7d544887dfe7de46e1e7cc0c27c2bea4f2
+$(package)_sha256_hash=ccf8cbf0dbf676faa2ea0a6d64bcc3b6746064722b606c8c52917ed00dcb73ec
 $(package)_dependencies=xproto
 
 define $(package)_set_vars

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -1,30 +1,22 @@
 package=libxcb
 GCCFLAGS?=
-$(package)_version=1.10
+$(package)_version=1.14
 $(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c3f2d5b5
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34
 $(package)_dependencies=xcb_proto libXau
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd
-  # Because we pass -qt-xcb to Qt, it will compile in a set of xcb helper libraries and extensions,
-  # so we skip building all of the extensions here.
-  # More info is available from: https://doc.qt.io/qt-5.9/linux-requirements.html
-  $(package)_config_opts += --disable-composite --disable-damage --disable-dpms
-  $(package)_config_opts += --disable-dri2 --disable-dri3 --disable-glx
-  $(package)_config_opts += --disable-present --disable-randr --disable-record
-  $(package)_config_opts += --disable-render --disable-resource --disable-screensaver
-  $(package)_config_opts += --disable-shape --disable-sync
-  $(package)_config_opts += --disable-xevie --disable-xfixes --disable-xfree86-dri
-  $(package)_config_opts += --disable-xinerama --disable-xinput
-  $(package)_config_opts += --disable-xprint --disable-selinux --disable-xtest
-  $(package)_config_opts += --disable-xv --disable-xvmc
-  $(package)_config_opts +=--libdir=$($($(package)_type)_prefix)/lib
-  $(package)_cxxflags_aarch64_linux = $(GCCFLAGS)
-  $(package)_cflags_aarch64_linux = $(GCCFLAGS)
-  $(package)_cxxflags_arm_linux = $(GCCFLAGS)
-  $(package)_cflags_arm_linux = $(GCCFLAGS)
+$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen --without-launchd
+$(package)_config_opts += --disable-dependency-tracking --enable-option-checking
+# Disable unneeded extensions.
+# More info is available from: https://doc.qt.io/qt-5.15/linux-requirements.html
+$(package)_config_opts += --disable-composite --disable-damage --disable-dpms
+$(package)_config_opts += --disable-dri2 --disable-dri3 --disable-glx
+$(package)_config_opts += --disable-present --disable-record --disable-resource
+$(package)_config_opts += --disable-screensaver --disable-xevie --disable-xfree86-dri
+$(package)_config_opts += --disable-xinput --disable-xprint --disable-selinux
+$(package)_config_opts += --disable-xtest --disable-xv --disable-xvmc
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -1,9 +1,9 @@
 package=xcb_proto
 GCCFLAGS?=
-$(package)_version=1.10
-$(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
-$(package)_sha256_hash=7ef40ddd855b750bc597d2a435da21e55e502a0fefa85b274f2c922800baaf05
+$(package)_version=1.14.1
+$(package)_download_path=https://xorg.freedesktop.org/archive/individual/proto
+$(package)_file_name=xcb-proto-$($(package)_version).tar.xz
+$(package)_sha256_hash=f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3
 
 define $(package)_set_vars
   $(package)_config_opts +=--libdir=$($($(package)_type)_prefix)/lib
@@ -26,6 +26,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  find -name "*.pyc" -delete && \
-  find -name "*.pyo" -delete
+  rm -rf lib/python*/site-packages/xcbgen/__pycache__
 endef

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -1,9 +1,9 @@
 package=xproto
 GCCFLAGS?=
-$(package)_version=7.0.26
+$(package)_version=7.0.31
 $(package)_download_path=https://xorg.freedesktop.org/releases/individual/proto
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=636162c1759805a5a0114a369dffdeccb8af8c859ef6e1445f26a4e6e046514f
+$(package)_sha256_hash=c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747
 
 define $(package)_set_vars
   $(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs

--- a/depends/patches/fontconfig/gperf_header_regen.patch
+++ b/depends/patches/fontconfig/gperf_header_regen.patch
@@ -1,0 +1,23 @@
+commit 7b6eb33ecd88768b28c67ce5d2d68a7eed5936b6
+Author: fanquake <fanquake@gmail.com>
+Date:   Tue Aug 25 14:34:53 2020 +0800
+
+    Remove rule that causes inadvertent header regeneration
+
+    Otherwise the makefile will needlessly attempt to re-generate the
+    headers with gperf. This can be dropped once the upstream build is fixed.
+
+    See #10851.
+
+diff --git a/src/Makefile.in b/src/Makefile.in
+index f4626ad..4ae1b00 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -912,7 +912,7 @@
+ 	' - > $@.tmp && \
+ 	mv -f $@.tmp fcobjshash.gperf && touch $@ || ( $(RM) $@.tmp && false )
+
+-fcobjshash.h: Makefile fcobjshash.gperf
++fcobjshash.h:
+ 	$(AM_V_GEN) $(GPERF) --pic -m 100 fcobjshash.gperf > $@.tmp && \
+ 	mv -f $@.tmp $@ || ( $(RM) $@.tmp && false )


### PR DESCRIPTION
- Expat to 2.4.1
Ref: https://github.com/bitcoin/bitcoin/commit/10ac182f4cfbb7d3494576f68f9aa2e33403f4cb

- Fontconfig to 2.12.6
  - Also use a proper patch format
Ref: https://github.com/bitcoin/bitcoin/pull/23495

- Freetype to 2.11.0
Ref: https://github.com/bitcoin/bitcoin/commit/01544dd78ccc0b0474571da854e27adef97137fb

- libXau to 1.0.9
Ref: https://github.com/bitcoin/bitcoin/commit/fc65127244320500022c3772141850eda28b99af

- libxcb to 1.14
Ref: https://github.com/bitcoin/bitcoin/commit/937b36b5f07f085d25d7f28036e98123837bee13

- xcb_proto to 1.14.1
Ref: https://github.com/bitcoin/bitcoin/commit/d3d547c545021d8339db666d36e48f10ea478f9c

- xproto 7.0.31
Ref: https://github.com/bitcoin/bitcoin/commit/06975573210d9662485f057949829fef8dde7ef1