### PR TITLE
test: Add explicit references to related CVE's in comments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1376,7 +1376,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
         // If such overwrites are allowed, coinbases and transactions depending upon those
         // can be duplicated to remove the ability to spend the first instance -- even after
         // being sent to another address.
-        // See BIP30 and http://r6.ca/blog/20120206T005236Z.html for more information.
+        // See BIP30, CVE-2012-1909, and http://r6.ca/blog/20120206T005236Z.html for more information.
         // This logic is not necessary for memory pool transactions, as AcceptToMemoryPool
         // already refuses previously-known transaction ids entirely.
         // This rule was originally applied all blocks whose timestamp was after March 15, 2012, 0:00 UTC.
@@ -3528,7 +3528,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             AddOrphanTx(tx);
 
-            // DoS prevention: do not allow mapOrphanTransactions to grow unbounded
+            // DoS prevention: do not allow mapOrphanTransactions to grow unbounded (see CVE-2012-3789)
             unsigned int nEvicted = LimitOrphanTxSize(MAX_ORPHAN_TRANSACTIONS);
             if (nEvicted > 0)
                 LogPrintf("mapOrphan overflow, removed %u tx", nEvicted);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -84,7 +84,7 @@ bool CheckTransaction(const CTransaction& tx)
     if (GetSerializeSize(tx, (SER_NETWORK & SER_SKIPSUPERBLOCK), PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
         return tx.DoS(100, error("CheckTransaction() : size limits failed"));
 
-    // Check for negative or overflow output values
+    // Check for negative or overflow output values (see CVE-2010-5139)
     CAmount nValueOut = 0;
     for (unsigned int i = 0; i < tx.vout.size(); i++)
     {


### PR DESCRIPTION
> This functional test includes two scenarios that test for regressions of vulnerabilities, but they are only briefly described. There are freely available documents explaining in detail the issues, but without explicit mentions, the developer trying to maintain the code needs an additional step of digging in commit history and PR conversations to figure it out.
...
This improves developer experience by making understanding the tests easier.

Ref: https://github.com/bitcoin/bitcoin/pull/14696