### PR TITLE
Improve upon scanforunspent rpc

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1269,7 +1269,7 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Gridcoin Address");
 
     // Store as: TXID, VOUT, nValue, nHeight
-    std::deque<std::tuple<uint256, unsigned int, int64_t, int>> Multisig;
+    std::vector<std::pair<std::pair<uint256, unsigned int>, std::pair<int64_t, int>>> Multisig;
 
     {
         LOCK(cs_main);
@@ -1324,8 +1324,8 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
                         if (!txindex.vSpent[dummy.n].IsNull())
                             continue;
 
-                        // Add to deque
-                        Multisig.emplace_back(std::make_tuple(tx.GetHash(), j, txout.nValue, pblkindex->nHeight));
+                        // Add to vector
+                        Multisig.push_back(std::make_pair(std::make_pair(tx.GetHash(), j), std::make_pair(txout.nValue, pblkindex->nHeight)));
                     }
                 }
             }
@@ -1365,14 +1365,14 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
         {
             nCount++;
 
-            nValue += std::get<2>(data);
+            nValue += data.second.first;
 
             UniValue txdata(UniValue::VOBJ);
 
-            txdata.pushKV("txid", std::get<0>(data).ToString());
-            txdata.pushKV("vout", (int)std::get<1>(data));
-            txdata.pushKV("value", ValueFromAmount(std::get<2>(data)));
-            txdata.pushKV("height", std::get<3>(data));
+            txdata.pushKV("txid", data.first.first.ToString());
+            txdata.pushKV("vout", (int)data.first.second);
+            txdata.pushKV("value", ValueFromAmount(data.second.first));
+            txdata.pushKV("height", data.second.second);
 
             txres.push_back(txdata);
             // Parse into type file here
@@ -1382,15 +1382,15 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
                 if (nType == 0)
                 {
                     exportoutput << spacing << "<tx id=\"" << nCount << "\">\n";
-                    exportoutput << spacing << spacing << "<txid>" << std::get<0>(data).ToString() << "</txid>\n";
-                    exportoutput << spacing << spacing << "<vout>" << std::get<1>(data) << "</vout>\n";
-                    exportoutput << spacing << spacing << "<value>" << std::fixed << setprecision(8) << std::get<2>(data) / (double)COIN << "</value>\n";
-                    exportoutput << spacing << spacing << "<height>" << std::get<3>(data) << "</height>\n";
+                    exportoutput << spacing << spacing << "<txid>" << data.first.first.ToString() << "</txid>\n";
+                    exportoutput << spacing << spacing << "<vout>" << data.first.second << "</vout>\n";
+                    exportoutput << spacing << spacing << "<value>" << std::fixed << setprecision(8) << data.second.first / (double)COIN << "</value>\n";
+                    exportoutput << spacing << spacing << "<height>" << data.second.second << "</height>\n";
                     exportoutput << spacing << "</tx>\n";
                 }
 
                 else if (nType == 1)
-                    exportoutput << std::get<0>(data).ToString() << " / " << std::get<1>(data) << " / " << std::fixed << setprecision(8) << std::get<2>(data) / (double)COIN << " / " << std::get<3>(data) << "\n";
+                    exportoutput << data.first.first.ToString() << " / " << data.first.second << " / " << std::fixed << setprecision(8) << data.second.first / (double)COIN << " / " << data.second.second << "\n";
             }
         }
 


### PR DESCRIPTION
After the daunting process of consolidating the gridcoin.world mutli-signature address, I determined that there was room for improvement on the function. This is a small improvement.

What could be improved?

* Add a block number to be included in the data to allow a end-user to utilize the consolidatemsunspent function without having to manually pull up the block number as alternate to script based creation of raw transaction
* Store data in a way that makes sense (beginning to end of scan)

Changes:
* Change from std::unordered_multimap to std::vector
* Add a fourth variable to include a block number in the results 
* Use a std::vector to store those variables instead of std::unordered_multimap std::pair(s)
* Store the results consistently 