### PR TITLE
util: Fix crash when parsing command line with -noincludeconf=0, Properly handle -noincludeconf on command line

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -494,6 +494,11 @@ std::string ArgsManager::GetArg(const std::string& strArg, const std::string& st
     return value.isNull() ? strDefault : value.isFalse() ? "0" : value.isTrue() ? "1" : value.get_str();
 }
 
+int64_t ArgsManager::GetIntArg(const std::string& strArg, int64_t nDefault) const
+{
+    return GetArg(strArg, nDefault);
+}
+
 int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const
 {
     const util::SettingsValue value = GetSetting(strArg);

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -272,11 +272,14 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
         m_settings.command_line_options[key].push_back(value);
     }
 
-    // we do not allow -includeconf from command line
+    // we do not allow -includeconf from command line, only -noincludeconf
     if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
-            const auto& include{*util::SettingsSpan(*includes).begin()}; // pick first value as example
-            error = "-includeconf cannot be used from commandline; -includeconf=" + include.write();
-            return false;
+        const util::SettingsSpan values{*includes};
+        // Range may be empty if -noincludeconf was passed
+        if (!values.empty()) {
+            error = "-includeconf cannot be used from commandline; -includeconf=" + values.begin()->write();
+            return false; // pick first value as example
+        }
     }
     return true;
 }

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -273,14 +273,12 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     }
 
     // we do not allow -includeconf from command line
-    bool success = true;
     if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
-        for (const auto& include : util::SettingsSpan(*includes)) {
-            error += "-includeconf cannot be used from commandline; -includeconf=" + include.get_str() + "\n";
-            success = false;
-        }
+            const auto& include{*util::SettingsSpan(*includes).begin()}; // pick first value as example
+            error = "-includeconf cannot be used from commandline; -includeconf=" + include.write();
+            return false;
     }
-    return success;
+    return true;
 }
 
 std::optional<unsigned int> ArgsManager::GetArgFlags(const std::string& name) const

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -270,6 +270,15 @@ public:
     int64_t GetArg(const std::string& strArg, int64_t nDefault) const;
 
     /**
+     * Return integer argument or default value (alias for GetArg used in newer Bitcoin code)
+     *
+     * @param strArg Argument to get (e.g. "-foo")
+     * @param nDefault (e.g. 1)
+     * @return command-line argument (0 if invalid number) or default value
+     */
+    int64_t GetIntArg(const std::string& strArg, int64_t nDefault) const;
+
+    /**
      * Return boolean argument or default value
      *
      * @param strArg Argument to get (e.g. "-foo")


### PR DESCRIPTION
> The error message has several issues:
> 
>     * It may crash instead of cleanly shutting down, when `-noincludeconf=0` is passed
> 
>     * It doesn't quote the value
> 
>     * It includes an erroneous trailing `\n`
> 
>     * It is redundantly mentioning `"-includeconf cannot be used from commandline;"` several times, when once should be more than sufficient
> 
> 
> Fix all issues by:
> 
>     * Replacing `get_str()` with `write()` to fix the crash and quoting issue
> 
>     * Remove the `\n` and only print the first value to fix the other issues
> 
> 
> Before:
> 
> ```
> $ ./src/bitcoind -noincludeconf=0
> terminate called after throwing an instance of 'std::runtime_error'
>   what():  JSON value is not a string as expected
> Aborted (core dumped)
> 
> $ ./src/bitcoind -includeconf='a b' -includeconf=c
> Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=a b
> -includeconf cannot be used from commandline; -includeconf=c
> ```
> 
> After:
> 
> ```
> $ ./src/bitcoind -noincludeconf=0
> Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=true
> 
> $ ./src/bitcoind -includeconf='a b' -includeconf=c
> Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf="a b"
> ```
> 
> Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34493
> 
> Testcase: https://github.com/bitcoin/bitcoin/files/6515429/clusterfuzz-testcase-minimized-system-6328535926046720.log
> 
> ```
> FUZZ=system ./src/test/fuzz/fuzz ./clusterfuzz-testcase-minimized-system-6328535926046720.log
> ```
> 
> See https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md

Ref: https://github.com/bitcoin/bitcoin/pull/22002

---------------------------------------------------

> Before:
> 
> ```
> $ ./src/qt/bitcoin-qt -noincludeconf
> (memory violation, can be observed with valgrind or similar)
> ```
> 
> After:
> 
> ```
> $ ./src/qt/bitcoin-qt -noincludeconf
> (passes startup)
> ```
> 
> Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34884



> Before:
> 
> ```
> $ ./src/qt/bitcoin-qt -noincludeconf
> (memory violation, can be observed with valgrind or similar)
> ```
> 
> After:
> 
> ```
> $ ./src/qt/bitcoin-qt -noincludeconf
> (passes startup)
> ```
> 
> Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34884

Ref: https://github.com/bitcoin/bitcoin/pull/22137