### PR TITLE
lint: run mypy over contrib/devtools

### DIFF
--- a/contrib/devtools/circular-dependencies.py
+++ b/contrib/devtools/circular-dependencies.py
@@ -5,6 +5,7 @@
 
 import sys
 import re
+from typing import Dict, List, Set
 
 MAPPING = {
     'core_read.cpp': 'core_io.cpp',
@@ -32,7 +33,7 @@ def module_name(path):
     return None
 
 files = dict()
-deps = dict()
+deps: Dict[str, Set[str]] = dict()
 
 RE = re.compile("^#include [<\"](.*)[\">]")
 
@@ -59,12 +60,12 @@ for arg in sorted(files.keys()):
                     deps[module].add(included_module)
 
 # Loop to find the shortest (remaining) circular dependency
-have_cycle = False
+have_cycle: bool = False
 while True:
     shortest_cycle = None
     for module in sorted(deps.keys()):
         # Build the transitive closure of dependencies of module
-        closure = dict()
+        closure: Dict[str, List[str]] = dict()
         for dep in deps[module]:
             closure[dep] = []
         while True:

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -193,7 +193,7 @@ def elf_read_libraries(filename) -> List[str]:
 
 def check_imported_symbols(filename) -> bool:
     cppfilt = CPPFilt()
-    ok = True
+    ok: bool = True
     for sym, version, arch in read_symbols(filename, True):
         if version and not check_version(MAX_VERSIONS, version, arch):
             print('{}: symbol {} from unsupported version {}'.format(filename, cppfilt(sym), version))
@@ -202,7 +202,7 @@ def check_imported_symbols(filename) -> bool:
 
 def check_exported_symbols(filename) -> bool:
     cppfilt = CPPFilt()
-    ok = True
+    ok: bool = True
     for sym,version,arch in read_symbols(filename, False):
         if arch == 'RISC-V' or sym in IGNORE_EXPORTS:
             continue
@@ -211,7 +211,7 @@ def check_exported_symbols(filename) -> bool:
     return ok
 
 def check_ELF_libraries(filename) -> bool:
-    ok = True
+    ok: bool = True
     for library_name in elf_read_libraries(filename):
         if library_name not in ELF_ALLOWED_LIBRARIES:
             print('{}: NEEDED library {} is not allowed'.format(filename, library_name))
@@ -232,7 +232,7 @@ def macho_read_libraries(filename) -> List[str]:
     return libraries
 
 def check_MACHO_libraries(filename) -> bool:
-    ok = True
+    ok: bool = True
     for dylib in macho_read_libraries(filename):
         if dylib not in MACHO_ALLOWED_LIBRARIES:
             print('{} is not in ALLOWED_LIBRARIES!'.format(dylib))
@@ -252,7 +252,7 @@ def pe_read_libraries(filename) -> List[str]:
     return libraries
 
 def check_PE_libraries(filename) -> bool:
-    ok = True
+    ok: bool = True
     for dylib in pe_read_libraries(filename):
         if dylib not in PE_ALLOWED_LIBRARIES:
             print('{} is not in ALLOWED_LIBRARIES!'.format(dylib))
@@ -285,7 +285,7 @@ def identify_executable(executable) -> Optional[str]:
     return None
 
 if __name__ == '__main__':
-    retval = 0
+    retval: int = 0
     for filename in sys.argv[1:]:
         try:
             etype = identify_executable(filename)
@@ -294,7 +294,7 @@ if __name__ == '__main__':
                 retval = 1
                 continue
 
-            failed = []
+            failed: List[str] = []
             for (name, func) in CHECKS[etype]:
                 if not func(filename):
                     failed.append(name)

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -101,7 +101,7 @@ if ! PYTHONWARNINGS="ignore" flake8 --ignore=B,C,E,F,I,N,W --select=$(IFS=","; e
     EXIT_CODE=1
 fi
 
-if ! mypy --ignore-missing-imports $(git ls-files "test/functional/*.py"); then
+if ! mypy --ignore-missing-imports $(git ls-files "test/functional/*.py" "contrib/devtools/*.py"); then
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
> wumpus mentioned on IRC that we don't currently run `mypy` over the `contrib/devtools` directory, and that it would likely be worthwhile given #20434. This just adds that dir to the linter, as well as some missing annotations to fix existing errors. Note that now we require Python 3.6 we can make use of variable annotations.
> 
> master (patched to check contrib devtools):
> 
> ```shell
> test/lint/lint-python.sh
> contrib/devtools/symbol-check.py:154: error: Incompatible types in assignment (expression has type "List[str]", variable has type "str")
> contrib/devtools/circular-dependencies.py:35: error: Need type annotation for 'deps' (hint: "deps: Dict[<type>, <type>] = ...")
> contrib/devtools/circular-dependencies.py:67: error: Need type annotation for 'closure' (hint: "closure: Dict[<type>, <type>] = ...")
> Found 4 errors in 3 files (checked 187 source files)
> ```
> 
> I haven't quite gone as far as to add annotations like
> 
> ```python
> CHECKS: Dict[str, List[Tuple[str, Callable[[Any], bool]]]] = {...
> ```
> 
> to `symbol-check.py`.

Ref: https://github.com/bitcoin/bitcoin/pull/20451