### PR TITLE
build, lint: Remove x-prefix's from comparisons, Fix some shell script issues the linter complains about, Re-enable boost include checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
     lint:
         name: Lint
         runs-on: ubuntu-latest
-        continue-on-error: true
         steps:
         - name: checkout
           uses: actions/checkout@v2
@@ -94,7 +93,6 @@ jobs:
           with:
             python-version: 3.6
         - name: lint
-          continue-on-error: true
           run: |
             set -o errexit; source ./ci/lint/04_install.sh
             set -o errexit; source ./ci/lint/05_before_script.sh

--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -75,7 +75,7 @@ AC_ARG_WITH([boost-libdir],
 
 BOOST_LDFLAGS=""
 BOOST_CPPFLAGS=""
-AS_IF([test "x$want_boost" = "xyes"],
+AS_IF([test "$want_boost" = "yes"],
       [_AX_BOOST_BASE_RUNDETECT([$1],[$2],[$3])])
 AC_SUBST(BOOST_CPPFLAGS)
 AC_SUBST(BOOST_LDFLAGS)
@@ -84,13 +84,13 @@ AC_SUBST(BOOST_LDFLAGS)
 
 # convert a version string in $2 to numeric and affect to polymorphic var $1
 AC_DEFUN([_AX_BOOST_BASE_TONUMERICVERSION],[
-  AS_IF([test "x$2" = "x"],[_AX_BOOST_BASE_TONUMERICVERSION_req="1.20.0"],[_AX_BOOST_BASE_TONUMERICVERSION_req="$2"])
+  AS_IF([test "$2" = ""],[_AX_BOOST_BASE_TONUMERICVERSION_req="1.20.0"],[_AX_BOOST_BASE_TONUMERICVERSION_req="$2"])
   _AX_BOOST_BASE_TONUMERICVERSION_req_shorten=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\.[[0-9]]*\)'`
   _AX_BOOST_BASE_TONUMERICVERSION_req_major=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\)'`
-  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_major" = "x"],
+  AS_IF([test "$_AX_BOOST_BASE_TONUMERICVERSION_req_major" = ""],
         [AC_MSG_ERROR([You should at least specify libboost major version])])
   _AX_BOOST_BASE_TONUMERICVERSION_req_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.\([[0-9]]*\)'`
-  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_minor" = "x"],
+  AS_IF([test "$_AX_BOOST_BASE_TONUMERICVERSION_req_minor" = ""],
         [_AX_BOOST_BASE_TONUMERICVERSION_req_minor="0"])
   _AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
   AS_IF([test "X$_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor" = "X"],
@@ -130,7 +130,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
-    AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
+    AS_IF([test "$_AX_BOOST_BASE_boost_path" != ""],[
         AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_boost_path/include"])
          AS_IF([test -d "$_AX_BOOST_BASE_boost_path/include" && test -r "$_AX_BOOST_BASE_boost_path/include"],[
            AC_MSG_RESULT([yes])
@@ -165,7 +165,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
 
     dnl overwrite ld flags if we have required special directory with
     dnl --with-boost-libdir parameter
-    AS_IF([test "x$_AX_BOOST_BASE_boost_lib_path" != "x"],
+    AS_IF([test "$_AX_BOOST_BASE_boost_lib_path" != ""],
           [BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_lib_path"])
 
     AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION)])
@@ -191,7 +191,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
 
     dnl if we found no boost with system layout we search for boost libraries
     dnl built and installed without the --layout=system option or for a staged(not installed) version
-    if test "x$succeeded" != "xyes" ; then
+    if test "$succeeded" != "yes" ; then
         CPPFLAGS="$CPPFLAGS_SAVED"
         LDFLAGS="$LDFLAGS_SAVED"
         BOOST_CPPFLAGS=
@@ -204,7 +204,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
                 for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
                     _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
                     V_CHECK=`expr $_version_tmp \> $_version`
-                    if test "x$V_CHECK" = "x1" ; then
+                    if test "$V_CHECK" = "1" ; then
                         _version=$_version_tmp
                     fi
                     VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
@@ -226,13 +226,13 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
                 fi
             fi
         else
-            if test "x$cross_compiling" != "xyes" ; then
+            if test "$cross_compiling" != "yes" ; then
                 for _AX_BOOST_BASE_boost_path in /usr /usr/local /opt /opt/local /opt/homebrew ; do
                     if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path" ; then
                         for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
                             _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
                             V_CHECK=`expr $_version_tmp \> $_version`
-                            if test "x$V_CHECK" = "x1" ; then
+                            if test "$V_CHECK" = "1" ; then
                                 _version=$_version_tmp
                                 best_path=$_AX_BOOST_BASE_boost_path
                             fi
@@ -259,7 +259,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
                     stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
                         stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
                     V_CHECK=`expr $stage_version_shorten \>\= $_version`
-                    if test "x$V_CHECK" = "x1" && test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+                    if test "$V_CHECK" = "1" && test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
                         AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
                         BOOST_CPPFLAGS="-I$BOOST_ROOT"
                         BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
@@ -283,8 +283,8 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
         AC_LANG_POP([C++])
     fi
 
-    if test "x$succeeded" != "xyes" ; then
-        if test "x$_version" = "x0" ; then
+    if test "$succeeded" != "yes" ; then
+        if test "$_version" = "0" ; then
             AC_MSG_NOTICE([[We could not detect the boost libraries (version $1 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
         else
             AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])

--- a/build-aux/m4/ax_boost_filesystem.m4
+++ b/build-aux/m4/ax_boost_filesystem.m4
@@ -53,7 +53,7 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
         [want_boost="yes"]
 	)
 
-	if test "x$want_boost" = "xyes"; then
+	if test "$want_boost" = "yes"; then
         AC_REQUIRE([AC_PROG_CC])
 		CPPFLAGS_SAVED="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
@@ -77,17 +77,17 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 					       ax_cv_boost_filesystem=yes, ax_cv_boost_filesystem=no)
          AC_LANG_POP([C++])
 		])
-		if test "x$ax_cv_boost_filesystem" = "xyes"; then
+		if test "$ax_cv_boost_filesystem" = "yes"; then
 			AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-            if test "x$ax_boost_user_filesystem_lib" = "x"; then
+            if test "$ax_boost_user_filesystem_lib" = ""; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
                                  [link_filesystem="no"])
 				done
-                if test "x$link_filesystem" != "xyes"; then
+                if test "$link_filesystem" != "yes"; then
                 for libextension in `ls -r $BOOSTLIBDIR/boost_filesystem* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -103,10 +103,10 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
+            if test "$ax_lib" = ""; then
                 AC_MSG_ERROR(Could not find a version of the Boost::Filesystem library!)
             fi
-			if test "x$link_filesystem" != "xyes"; then
+			if test "$link_filesystem" != "yes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)
 			fi
 		fi

--- a/build-aux/m4/ax_boost_iostreams.m4
+++ b/build-aux/m4/ax_boost_iostreams.m4
@@ -51,7 +51,7 @@ AC_DEFUN([AX_BOOST_IOSTREAMS],
         [want_boost="yes"]
 	)
 
-	if test "x$want_boost" = "xyes"; then
+	if test "$want_boost" = "yes"; then
         AC_REQUIRE([AC_PROG_CC])
 		CPPFLAGS_SAVED="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
@@ -75,17 +75,17 @@ AC_DEFUN([AX_BOOST_IOSTREAMS],
                              ax_cv_boost_iostreams=yes, ax_cv_boost_iostreams=no)
          AC_LANG_POP([C++])
 		])
-		if test "x$ax_cv_boost_iostreams" = "xyes"; then
+		if test "$ax_cv_boost_iostreams" = "yes"; then
 			AC_DEFINE(HAVE_BOOST_IOSTREAMS,,[define if the Boost::IOStreams library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-            if test "x$ax_boost_user_iostreams_lib" = "x"; then
+            if test "$ax_boost_user_iostreams_lib" = ""; then
                 for libextension in `ls $BOOSTLIBDIR/libboost_iostreams*.so* $BOOSTLIBDIR/libboost_iostream*.dylib* $BOOSTLIBDIR/libboost_iostreams*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_iostreams.*\)\.so.*$;\1;' -e 's;^lib\(boost_iostream.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_iostreams.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_IOSTREAMS_LIB="-l$ax_lib"; AC_SUBST(BOOST_IOSTREAMS_LIB) link_iostreams="yes"; break],
                                  [link_iostreams="no"])
 				done
-                if test "x$link_iostreams" != "xyes"; then
+                if test "$link_iostreams" != "yes"; then
                 for libextension in `ls $BOOSTLIBDIR/boost_iostreams*.dll* $BOOSTLIBDIR/boost_iostreams*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_iostreams.*\)\.dll.*$;\1;' -e 's;^\(boost_iostreams.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -102,10 +102,10 @@ AC_DEFUN([AX_BOOST_IOSTREAMS],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
+            if test "$ax_lib" = ""; then
                 AC_MSG_ERROR(Could not find a version of the Boost::IOStreams library!)
             fi
-			if test "x$link_iostreams" != "xyes"; then
+			if test "$link_iostreams" != "yes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)
 			fi
 		fi

--- a/build-aux/m4/ax_boost_system.m4
+++ b/build-aux/m4/ax_boost_system.m4
@@ -53,7 +53,7 @@ AC_DEFUN([AX_BOOST_SYSTEM],
         [want_boost="yes"]
 	)
 
-	if test "x$want_boost" = "xyes"; then
+	if test "$want_boost" = "yes"; then
         AC_REQUIRE([AC_PROG_CC])
         AC_REQUIRE([AC_CANONICAL_BUILD])
 		CPPFLAGS_SAVED="$CPPFLAGS"
@@ -76,21 +76,21 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
 		])
-		if test "x$ax_cv_boost_system" = "xyes"; then
+		if test "$ax_cv_boost_system" = "yes"; then
 			AC_SUBST(BOOST_CPPFLAGS)
 
 			AC_DEFINE(HAVE_BOOST_SYSTEM,,[define if the Boost::System library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
 			LDFLAGS_SAVE=$LDFLAGS
-            if test "x$ax_boost_user_system_lib" = "x"; then
+            if test "$ax_boost_user_system_lib" = ""; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
 				done
-                if test "x$link_system" != "xyes"; then
+                if test "$link_system" != "yes"; then
                 for libextension in `ls -r $BOOSTLIBDIR/boost_system* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -107,10 +107,10 @@ AC_DEFUN([AX_BOOST_SYSTEM],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
+            if test "$ax_lib" = ""; then
                 AC_MSG_ERROR(Could not find a version of the Boost::System library!)
             fi
-			if test "x$link_system" = "xno"; then
+			if test "$link_system" = "no"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)
 			fi
 		fi

--- a/build-aux/m4/ax_boost_thread.m4
+++ b/build-aux/m4/ax_boost_thread.m4
@@ -51,7 +51,7 @@ AC_DEFUN([AX_BOOST_THREAD],
         [want_boost="yes"]
     )
 
-    if test "x$want_boost" = "xyes"; then
+    if test "$want_boost" = "yes"; then
         AC_REQUIRE([AC_PROG_CC])
         AC_REQUIRE([AC_CANONICAL_BUILD])
         CPPFLAGS_SAVED="$CPPFLAGS"
@@ -94,7 +94,7 @@ AC_DEFUN([AX_BOOST_THREAD],
              CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
         ])
-        if test "x$ax_cv_boost_thread" = "xyes"; then
+        if test "$ax_cv_boost_thread" = "yes"; then
             case "x$host_os" in
                 xsolaris )
                     BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
@@ -126,14 +126,14 @@ AC_DEFUN([AX_BOOST_THREAD],
                           break;
                           ;;
                         esac
-            if test "x$ax_boost_user_thread_lib" = "x"; then
+            if test "$ax_boost_user_thread_lib" = ""; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
                     AC_CHECK_LIB($ax_lib, exit,
                                  [link_thread="yes"; break],
                                  [link_thread="no"])
                 done
-                if test "x$link_thread" != "xyes"; then
+                if test "$link_thread" != "yes"; then
                 for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
                     AC_CHECK_LIB($ax_lib, exit,
@@ -150,10 +150,10 @@ AC_DEFUN([AX_BOOST_THREAD],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
+            if test "$ax_lib" = ""; then
                 AC_MSG_ERROR(Could not find a version of the Boost::Thread library!)
             fi
-            if test "x$link_thread" = "xno"; then
+            if test "$link_thread" = "no"; then
                 AC_MSG_ERROR(Could not link against $ax_lib !)
             else
                 BOOST_THREAD_LIB="-l$ax_lib"

--- a/build-aux/m4/ax_boost_unit_test_framework.m4
+++ b/build-aux/m4/ax_boost_unit_test_framework.m4
@@ -51,7 +51,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
         [want_boost="yes"]
 	)
 
-	if test "x$want_boost" = "xyes"; then
+	if test "$want_boost" = "yes"; then
         AC_REQUIRE([AC_PROG_CC])
 		CPPFLAGS_SAVED="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
@@ -70,11 +70,11 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                    ax_cv_boost_unit_test_framework=yes, ax_cv_boost_unit_test_framework=no)
          AC_LANG_POP([C++])
 		])
-		if test "x$ax_cv_boost_unit_test_framework" = "xyes"; then
+		if test "$ax_cv_boost_unit_test_framework" = "yes"; then
 			AC_DEFINE(HAVE_BOOST_UNIT_TEST_FRAMEWORK,,[define if the Boost::Unit_Test_Framework library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
-            if test "x$ax_boost_user_unit_test_framework_lib" = "x"; then
+            if test "$ax_boost_user_unit_test_framework_lib" = ""; then
 			saved_ldflags="${LDFLAGS}"
                 for monitor_library in `ls $BOOSTLIBDIR/libboost_unit_test_framework*.so* $BOOSTLIBDIR/libboost_unit_test_framework*.dylib* $BOOSTLIBDIR/libboost_unit_test_framework*.a* 2>/dev/null` ; do
                     if test -r $monitor_library ; then
@@ -85,13 +85,13 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                        link_unit_test_framework="no"
                     fi
 
-			    if test "x$link_unit_test_framework" = "xyes"; then
+			    if test "$link_unit_test_framework" = "yes"; then
                       BOOST_UNIT_TEST_FRAMEWORK_LIB="-l$ax_lib"
                       AC_SUBST(BOOST_UNIT_TEST_FRAMEWORK_LIB)
 					  break
 				    fi
                 done
-                if test "x$link_unit_test_framework" != "xyes"; then
+                if test "$link_unit_test_framework" != "yes"; then
                 for libextension in `ls $BOOSTLIBDIR/boost_unit_test_framework*.dll* $BOOSTLIBDIR/boost_unit_test_framework*.a* 2>/dev/null  | sed 's,.*/,,' | sed -e 's;^\(boost_unit_test_framework.*\)\.dll.*$;\1;' -e 's;^\(boost_unit_test_framework.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -103,7 +103,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                 link_unit_test_framework="no"
 			saved_ldflags="${LDFLAGS}"
                 for ax_lib in boost_unit_test_framework-$ax_boost_user_unit_test_framework_lib $ax_boost_user_unit_test_framework_lib ; do
-                   if test "x$link_unit_test_framework" = "xyes"; then
+                   if test "$link_unit_test_framework" = "yes"; then
                       break;
                    fi
                    for unittest_library in `ls $BOOSTLIBDIR/lib${ax_lib}.so* $BOOSTLIBDIR/lib${ax_lib}.a* 2>/dev/null` ; do
@@ -115,7 +115,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                        link_unit_test_framework="no"
                     fi
 
-				if test "x$link_unit_test_framework" = "xyes"; then
+				if test "$link_unit_test_framework" = "yes"; then
                         BOOST_UNIT_TEST_FRAMEWORK_LIB="-l$ax_lib"
                         AC_SUBST(BOOST_UNIT_TEST_FRAMEWORK_LIB)
 					    break
@@ -123,10 +123,10 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                   done
                done
             fi
-            if test "x$ax_lib" = "x"; then
+            if test "$ax_lib" = ""; then
                 AC_MSG_ERROR(Could not find a version of the Boost::Unit_Test_Framework library!)
             fi
-			if test "x$link_unit_test_framework" != "xyes"; then
+			if test "$link_unit_test_framework" != "yes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)
 			fi
 		fi

--- a/build-aux/m4/ax_boost_zlib.m4
+++ b/build-aux/m4/ax_boost_zlib.m4
@@ -47,7 +47,7 @@ AC_DEFUN([AX_BOOST_ZLIB],
         [want_boost="yes"]
 	)
 
-	if test "x$want_boost" = "xyes"; then
+	if test "$want_boost" = "yes"; then
         AC_REQUIRE([AC_PROG_CC])
 		CPPFLAGS_SAVED="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
@@ -59,14 +59,14 @@ AC_DEFUN([AX_BOOST_ZLIB],
 
 			AC_DEFINE(HAVE_BOOST_ZLIB,,[define if the Boost::zlib library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-            if test "x$ax_boost_user_zlib_lib" = "x"; then
+            if test "$ax_boost_user_zlib_lib" = ""; then
                 for libextension in `ls $BOOSTLIBDIR/libboost_zlib*.so* $BOOSTLIBDIR/libboost_iostream*.dylib* $BOOSTLIBDIR/libboost_zlib*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_zlib.*\)\.so.*$;\1;' -e 's;^lib\(boost_iostream.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_zlib.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_ZLIB_LIB="-l$ax_lib"; AC_SUBST(BOOST_ZLIB_LIB) link_zlib="yes"; break],
                                  [link_zlib="no"])
 				done
-                if test "x$link_zlib" != "xyes"; then
+                if test "$link_zlib" != "yes"; then
                 for libextension in `ls $BOOSTLIBDIR/boost_zlib*.dll* $BOOSTLIBDIR/boost_zlib*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_zlib.*\)\.dll.*$;\1;' -e 's;^\(boost_zlib.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,

--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -69,12 +69,12 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
       [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
         [ax_cv_cxx_compile_cxx$1=yes],
         [ax_cv_cxx_compile_cxx$1=no])])
-    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+    if test "$ax_cv_cxx_compile_cxx$1" = "yes"; then
       ac_success=yes
     fi])
 
   m4_if([$2], [noext], [], [dnl
-  if test x$ac_success = xno; then
+  if test "$ac_success" = "no"; then
     for alternative in ${ax_cxx_compile_alternatives}; do
       switch="-std=gnu++${alternative}"
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
@@ -98,7 +98,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   fi])
 
   m4_if([$2], [ext], [], [dnl
-  if test x$ac_success = xno; then
+  if test "$ac_success" = "no"; then
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
     dnl Cray's crayCC needs "-h std=c++11"
@@ -122,18 +122,18 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
           break
         fi
       done
-      if test x$ac_success = xyes; then
+      if test "$ac_success" = "yes"; then
         break
       fi
     done
   fi])
   AC_LANG_POP([C++])
-  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
-    if test x$ac_success = xno; then
+  if test "$ax_cxx_compile_cxx$1_required" = "true"; then
+    if test "$ac_success" = "no"; then
       AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
     fi
   fi
-  if test x$ac_success = xno; then
+  if test "$ac_success" = "no"; then
     HAVE_CXX$1=0
     AC_MSG_NOTICE([No compiler with C++$1 support was found])
   else

--- a/build-aux/m4/ax_pthread.m4
+++ b/build-aux/m4/ax_pthread.m4
@@ -104,18 +104,18 @@ ax_pthread_ok=no
 # First of all, check if the user has set any of the PTHREAD_LIBS,
 # etcetera environment variables, and if threads linking works using
 # them:
-if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
+if test "$PTHREAD_CFLAGS$PTHREAD_LIBS" != ""; then
         ax_pthread_save_CC="$CC"
         ax_pthread_save_CFLAGS="$CFLAGS"
         ax_pthread_save_LIBS="$LIBS"
-        AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
-        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
+        AS_IF([test "$PTHREAD_CC" != ""], [CC="$PTHREAD_CC"])
+        AS_IF([test "$PTHREAD_CXX" != ""], [CXX="$PTHREAD_CXX"])
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
         LIBS="$PTHREAD_LIBS $LIBS"
         AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
         AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
         AC_MSG_RESULT([$ax_pthread_ok])
-        if test "x$ax_pthread_ok" = "xno"; then
+        if test "$ax_pthread_ok" = "no"; then
                 PTHREAD_LIBS=""
                 PTHREAD_CFLAGS=""
         fi
@@ -212,7 +212,7 @@ AC_CACHE_CHECK([whether $CC is Clang],
     [ax_cv_PTHREAD_CLANG],
     [ax_cv_PTHREAD_CLANG=no
      # Note that Autoconf sets GCC=yes for Clang as well as GCC
-     if test "x$GCC" = "xyes"; then
+     if test "$GCC" = "yes"; then
         AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
             [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
 #            if defined(__clang__) && defined(__llvm__)
@@ -235,12 +235,12 @@ ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
 # [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
 # To solve this, first try -pthread together with -lpthread for GCC
 
-AS_IF([test "x$GCC" = "xyes"],
+AS_IF([test "$GCC" = "yes"],
       [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
 
 # Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
 
-AS_IF([test "x$ax_pthread_clang" = "xyes"],
+AS_IF([test "$ax_pthread_clang" = "yes"],
       [ax_pthread_flags="-pthread,-lpthread -pthread"])
 
 
@@ -261,12 +261,12 @@ case $host_os in
         ax_pthread_check_macro="--"
         ;;
 esac
-AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+AS_IF([test "$ax_pthread_check_macro" = "--"],
       [ax_pthread_check_cond=0],
       [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
 
 
-if test "x$ax_pthread_ok" = "xno"; then
+if test "$ax_pthread_ok" = "no"; then
 for ax_pthread_try_flag in $ax_pthread_flags; do
 
         case $ax_pthread_try_flag in
@@ -287,7 +287,7 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
 
                 pthread-config)
                 AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
-                AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
+                AS_IF([test "$ax_pthread_config" = "no"], [continue])
                 PTHREAD_CFLAGS="`pthread-config --cflags`"
                 PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
                 ;;
@@ -338,7 +338,7 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
         LIBS="$ax_pthread_save_LIBS"
 
         AC_MSG_RESULT([$ax_pthread_ok])
-        AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
+        AS_IF([test "$ax_pthread_ok" = "yes"], [break])
 
         PTHREAD_LIBS=""
         PTHREAD_CFLAGS=""
@@ -349,7 +349,7 @@ fi
 # Clang needs special handling, because older versions handle the -pthread
 # option in a rather... idiosyncratic way
 
-if test "x$ax_pthread_clang" = "xyes"; then
+if test "$ax_pthread_clang" = "yes"; then
 
         # Clang takes -pthread; it has never supported any other flag
 
@@ -395,7 +395,7 @@ if test "x$ax_pthread_clang" = "xyes"; then
              ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
              ax_pthread_save_CFLAGS="$CFLAGS"
              for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
-                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                AS_IF([test "$ax_pthread_try" = "unknown"], [break])
                 CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
                 ac_link="$ax_pthread_save_ac_link"
                 AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
@@ -406,7 +406,7 @@ if test "x$ax_pthread_clang" = "xyes"; then
              done
              ac_link="$ax_pthread_save_ac_link"
              CFLAGS="$ax_pthread_save_CFLAGS"
-             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             AS_IF([test "$ax_pthread_try" = ""], [ax_pthread_try=no])
              ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
             ])
 
@@ -420,7 +420,7 @@ fi # $ax_pthread_clang = yes
 
 
 # Various other checks:
-if test "x$ax_pthread_ok" = "xyes"; then
+if test "$ax_pthread_ok" = "yes"; then
         ax_pthread_save_CFLAGS="$CFLAGS"
         ax_pthread_save_LIBS="$LIBS"
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
@@ -437,9 +437,9 @@ if test "x$ax_pthread_ok" = "xyes"; then
                                 [])
              done
             ])
-        AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
-               test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
-               test "x$ax_pthread_joinable_attr_defined" != "xyes"],
+        AS_IF([test "$ax_cv_PTHREAD_JOINABLE_ATTR" != "unknown" && \
+               test "$ax_cv_PTHREAD_JOINABLE_ATTR" != "PTHREAD_CREATE_JOINABLE" && \
+               test "$ax_pthread_joinable_attr_defined" != "yes"],
               [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
                                   [$ax_cv_PTHREAD_JOINABLE_ATTR],
                                   [Define to necessary symbol if this constant
@@ -456,8 +456,8 @@ if test "x$ax_pthread_ok" = "xyes"; then
              ;;
              esac
             ])
-        AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
-               test "x$ax_pthread_special_flags_added" != "xyes"],
+        AS_IF([test "$ax_cv_PTHREAD_SPECIAL_FLAGS" != "no" && \
+               test "$ax_pthread_special_flags_added" != "yes"],
               [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
                ax_pthread_special_flags_added=yes])
 
@@ -469,8 +469,8 @@ if test "x$ax_pthread_ok" = "xyes"; then
                             [ax_cv_PTHREAD_PRIO_INHERIT=yes],
                             [ax_cv_PTHREAD_PRIO_INHERIT=no])
             ])
-        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
-               test "x$ax_pthread_prio_inherit_defined" != "xyes"],
+        AS_IF([test "$ax_cv_PTHREAD_PRIO_INHERIT" = "yes" && \
+               test "$ax_pthread_prio_inherit_defined" != "yes"],
               [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
                ax_pthread_prio_inherit_defined=yes
               ])
@@ -479,7 +479,7 @@ if test "x$ax_pthread_ok" = "xyes"; then
         LIBS="$ax_pthread_save_LIBS"
 
         # More AIX lossage: compile with *_r variant
-        if test "x$GCC" != "xyes"; then
+        if test "$GCC" != "yes"; then
             case $host_os in
                 aix*)
                 AS_CASE(["x/$CC"],
@@ -489,11 +489,11 @@ if test "x$ax_pthread_ok" = "xyes"; then
                          [x/*],
                          [
 			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
-			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			   AS_IF([test "${CXX}" != ""], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
 			 ],
                          [
 			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
-			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			   AS_IF([test "${CXX}" != ""], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
 			 ]
                      )
                     ])
@@ -511,7 +511,7 @@ AC_SUBST([PTHREAD_CC])
 AC_SUBST([PTHREAD_CXX])
 
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
-if test "x$ax_pthread_ok" = "xyes"; then
+if test "$ax_pthread_ok" = "yes"; then
         ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
         :
 else

--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -6,7 +6,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
   AC_ARG_VAR(BDB_CFLAGS, [C compiler flags for BerkeleyDB, bypasses autodetection])
   AC_ARG_VAR(BDB_LIBS, [Linker flags for BerkeleyDB, bypasses autodetection])
 
-  if test "x$BDB_CFLAGS" = "x"; then
+  if test "$BDB_CFLAGS" = ""; then
     AC_MSG_CHECKING([for Berkeley DB C++ headers])
     BDB_CPPFLAGS=
     bdbpath=X
@@ -26,7 +26,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
           #error "failed to find bdb 4.8+"
         #endif
       ]])],[
-        if test "x$bdbpath" = "xX"; then
+        if test "$bdbpath" = "X"; then
           bdbpath="${searchpath}"
         fi
       ],[
@@ -43,10 +43,10 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
         break
       ],[])
     done
-    if test "x$bdbpath" = "xX"; then
+    if test "$bdbpath" = "X"; then
       AC_MSG_RESULT([no])
       AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
-    elif test "x$bdb48path" = "xX"; then
+    elif test "$bdb48path" = "X"; then
       BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
       AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
         AC_MSG_WARN([Found Berkeley DB other than 4.8; wallets opened by this build will not be portable!])
@@ -62,7 +62,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
   fi
   AC_SUBST(BDB_CPPFLAGS)
   
-  if test "x$BDB_LIBS" = "x"; then
+  if test "$BDB_LIBS" = ""; then
     # TODO: Ideally this could find the library version and make sure it matches the headers being used
     for searchlib in db_cxx-4.8 db_cxx; do
       AC_CHECK_LIB([$searchlib],[main],[
@@ -70,7 +70,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
         break
       ])
     done
-    if test "x$BDB_LIBS" = "x"; then
+    if test "$BDB_LIBS" = ""; then
         AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
     fi
   fi

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -5,8 +5,8 @@ dnl file COPYING or https://opensource.org/licenses/mit-license.php.
 dnl Helper for cases where a qt dependency is not met.
 dnl Output: If qt version is auto, set bitcoin_enable_qt to false. Else, exit.
 AC_DEFUN([BITCOIN_QT_FAIL],[
-  if test "x$bitcoin_qt_want_version" = xauto && test "x$bitcoin_qt_force" != xyes; then
-    if test "x$bitcoin_enable_qt" != xno; then
+  if test "$bitcoin_qt_want_version" = "auto" && test "$bitcoin_qt_force" != "yes"; then
+    if test "$bitcoin_enable_qt" != "no"; then
       AC_MSG_WARN([$1; bitcoin-qt frontend will not be built])
     fi
     bitcoin_enable_qt=no
@@ -17,7 +17,7 @@ AC_DEFUN([BITCOIN_QT_FAIL],[
 ])
 
 AC_DEFUN([BITCOIN_QT_CHECK],[
-  if test "x$bitcoin_enable_qt" != xno && test "x$bitcoin_qt_want_version" != xno; then
+  if test "$bitcoin_enable_qt" != "no" && test "$bitcoin_qt_want_version" != "no"; then
     true
     $1
   else
@@ -35,12 +35,12 @@ dnl Inputs: $4: If "yes", don't fail if $2 is not found.
 dnl Output: $1 is set to the path of $2 if found. $2 are searched in order.
 AC_DEFUN([BITCOIN_QT_PATH_PROGS],[
   BITCOIN_QT_CHECK([
-    if test "x$3" != x; then
+    if test "$3" != ""; then
       AC_PATH_PROGS($1,$2,,$3)
     else
       AC_PATH_PROGS($1,$2)
     fi
-    if test "x$$1" = x && test "x$4" != xyes; then
+    if test "$$1" = "" && test "$4" != "yes"; then
       BITCOIN_QT_FAIL([$1 not found])
     fi
   ])
@@ -57,14 +57,14 @@ AC_DEFUN([BITCOIN_QT_INIT],[
     [build bitcoin-qt GUI (default=auto)])],
     [
      bitcoin_qt_want_version=$withval
-     if test "x$bitcoin_qt_want_version" = xyes; then
+     if test "$bitcoin_qt_want_version" = "yes"; then
        bitcoin_qt_force=yes
        bitcoin_qt_want_version=auto
      fi
     ],
     [bitcoin_qt_want_version=auto])
 
-  AS_IF([test "x$with_gui" = xqt5_debug],
+  AS_IF([test "$with_gui" = "qt5_debug"],
         [AS_CASE([$host],
                  [*darwin*], [qt_lib_suffix=_debug],
                  [*mingw*], [qt_lib_suffix=d],
@@ -86,7 +86,7 @@ AC_DEFUN([BITCOIN_QT_INIT],[
   dnl Android doesn't support D-Bus and certainly doesn't use it for notifications
   case $host in
     *android*)
-      if test "x$use_dbus" != xyes; then
+      if test "$use_dbus" != "yes"; then
         use_dbus=no
       fi
     ;;
@@ -118,10 +118,10 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   CPPFLAGS="$QT_INCLUDES $CPPFLAGS"
   CXXFLAGS="$PIC_FLAGS $CXXFLAGS"
   _BITCOIN_QT_IS_STATIC
-  if test "x$bitcoin_cv_static_qt" = xyes; then
+  if test "$bitcoin_cv_static_qt" = "yes"; then
     _BITCOIN_QT_CHECK_STATIC_LIBS
 
-    if test "x$qt_plugin_path" != x; then
+    if test "$qt_plugin_path" != ""; then
       if test -d "$qt_plugin_path/platforms"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/platforms"
       fi
@@ -144,22 +144,22 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     fi
 
     AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-    if test "x$TARGET_OS" != xandroid; then
+    if test "$TARGET_OS" != "android"; then
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QMinimalIntegrationPlugin], [-lqminimal])
       AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
     fi
-    if test "x$TARGET_OS" = xwindows; then
+    if test "$TARGET_OS" = "windows"; then
       dnl Linking against wtsapi32 is required. See bitcoin/bitcoin#17749 and
       dnl https://bugreports.qt.io/browse/QTBUG-27097.
       AX_CHECK_LINK_FLAG([-lwtsapi32], [QT_LIBS="$QT_LIBS -lwtsapi32"], [AC_MSG_ERROR([could not link against -lwtsapi32])])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWindowsIntegrationPlugin], [-lqwindows])
       AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
-    elif test "x$TARGET_OS" = xlinux; then
+    elif test "$TARGET_OS" = "linux"; then
       dnl workaround for https://bugreports.qt.io/browse/QTBUG-74874
       AX_CHECK_LINK_FLAG([-lxcb-shm], [QT_LIBS="-lxcb-shm $QT_LIBS"], [AC_MSG_ERROR([could not link against -lxcb-shm])])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QXcbIntegrationPlugin], [-lqxcb])
       AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
-    elif test "x$TARGET_OS" = xdarwin; then
+    elif test "$TARGET_OS" = "darwin"; then
       AX_CHECK_LINK_FLAG([[-framework Carbon]],[QT_LIBS="$QT_LIBS -framework Carbon"],[AC_MSG_ERROR(could not link against Carbon framework)])
       AX_CHECK_LINK_FLAG([[-framework IOSurface]],[QT_LIBS="$QT_LIBS -framework IOSurface"],[AC_MSG_ERROR(could not link against IOSurface framework)])
       AX_CHECK_LINK_FLAG([[-framework Metal]],[QT_LIBS="$QT_LIBS -framework Metal"],[AC_MSG_ERROR(could not link against Metal framework)])
@@ -167,7 +167,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QCocoaIntegrationPlugin], [-lqcocoa])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QMacStylePlugin], [-lqmacstyle])
       AC_DEFINE(QT_QPA_PLATFORM_COCOA, 1, [Define this symbol if the qt platform is cocoa])
-    elif test "x$TARGET_OS" = xandroid; then
+    elif test "$TARGET_OS" = "android"; then
       QT_LIBS="-Wl,--export-dynamic,--undefined=JNI_OnLoad -lqtforandroid -ljnigraphics -landroid -lqtfreetype $QT_LIBS"
       AC_DEFINE(QT_QPA_PLATFORM_ANDROID, 1, [Define this symbol if the qt platform is android])
     fi
@@ -179,11 +179,11 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   CXXFLAGS=$TEMP_CXXFLAGS
   ])
 
-  if test "x$qt_bin_path" = x; then
+  if test "$qt_bin_path" = ""; then
     qt_bin_path="`$PKG_CONFIG --variable=host_bins ${qt_lib_prefix}Core 2>/dev/null`"
   fi
 
-  if test "x$use_hardening" != xno; then
+  if test "$use_hardening" != "no"; then
     BITCOIN_QT_CHECK([
     AC_MSG_CHECKING(whether -fPIE can be used with this Qt config)
     TEMP_CPPFLAGS=$CPPFLAGS
@@ -258,26 +258,26 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   BITCOIN_QT_CHECK([
     bitcoin_enable_qt=yes
     bitcoin_enable_qt_test=yes
-    if test "x$have_qt_test" = xno; then
+    if test "$have_qt_test" = "no"; then
       bitcoin_enable_qt_test=no
     fi
     bitcoin_enable_qt_dbus=no
-    if test "x$use_dbus" != xno && test "x$have_qt_dbus" = xyes; then
+    if test "$use_dbus" != "no" && test "$have_qt_dbus" = "yes"; then
       bitcoin_enable_qt_dbus=yes
     fi
-    if test "x$use_dbus" = xyes && test "x$have_qt_dbus" = xno; then
+    if test "$use_dbus" = "yes" && test "$have_qt_dbus" = "no"; then
       AC_MSG_ERROR([libQtDBus not found. Install libQtDBus or remove --with-qtdbus.])
     fi
-    if test "x$LUPDATE" = x; then
+    if test "$LUPDATE" = ""; then
       AC_MSG_WARN([lupdate tool is required to update Qt translations.])
     fi
-    if test "x$LCONVERT" = x; then
+    if test "$LCONVERT" = ""; then
       AC_MSG_WARN([lconvert tool is required to update Qt translations.])
     fi
   ],[
     bitcoin_enable_qt=no
   ])
-  if test x$bitcoin_enable_qt = xyes; then
+  if test "$bitcoin_enable_qt" = "yes"; then
     AC_MSG_RESULT([$bitcoin_enable_qt ($qt_lib_prefix)])
   else
     AC_MSG_RESULT([$bitcoin_enable_qt])
@@ -318,7 +318,7 @@ AC_DEFUN([_BITCOIN_QT_CHECK_QT5],[
   dnl needs Qt 5.12+. If we find an earlier version, the variable substitution in
   dnl share/qt/Info.plist disables macos 10.14 appearance features like dark-mode
   dnl and accent colors.
-  if test "x$TARGET_OS" = xdarwin; then
+  if test "$TARGET_OS" = "darwin"; then
     BITCOIN_QT_CHECK([
       PKG_CHECK_MODULES([QT_MACOS_DARK_MODE_DUMMY], [${qt_lib_prefix}Gui${qt_lib_suffix} >= 5.12],
                         [AC_SUBST(QT_MACOS_DISABLE_DARK_MODE, False)],
@@ -394,17 +394,17 @@ AC_DEFUN([_BITCOIN_QT_CHECK_STATIC_LIBS], [
   PKG_CHECK_MODULES([QT_CONCURRENT], [${qt_lib_prefix}Concurrent${qt_lib_suffix}], [QT_LIBS="$QT_CONCURRENT_LIBS $QT_LIBS"])
   dnl Gridcoin uses SVG:
   PKG_CHECK_MODULES([QT_SVG], [${qt_lib_prefix}Svg${qt_lib_suffix}], [QT_LIBS="$QT_SVG_LIBS $QT_LIBS"])
-  if test "x$TARGET_OS" = xlinux; then
+  if test "$TARGET_OS" = "linux"; then
     PKG_CHECK_MODULES([QT_INPUT], [${qt_lib_prefix}InputSupport], [QT_LIBS="$QT_INPUT_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_SERVICE], [${qt_lib_prefix}ServiceSupport], [QT_LIBS="$QT_SERVICE_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_XCBQPA], [${qt_lib_prefix}XcbQpa], [QT_LIBS="$QT_XCBQPA_LIBS $QT_LIBS"])
-  elif test "x$TARGET_OS" = xdarwin; then
+  elif test "$TARGET_OS" = "darwin"; then
     PKG_CHECK_MODULES([QT_CLIPBOARD], [${qt_lib_prefix}ClipboardSupport${qt_lib_suffix}], [QT_LIBS="$QT_CLIPBOARD_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_GRAPHICS], [${qt_lib_prefix}GraphicsSupport${qt_lib_suffix}], [QT_LIBS="$QT_GRAPHICS_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_SERVICE], [${qt_lib_prefix}ServiceSupport${qt_lib_suffix}], [QT_LIBS="$QT_SERVICE_LIBS $QT_LIBS"])
-  elif test "x$TARGET_OS" = xwindows; then
+  elif test "$TARGET_OS" = "windows"; then
     PKG_CHECK_MODULES([QT_WINDOWSUIAUTOMATION], [${qt_lib_prefix}WindowsUIAutomationSupport${qt_lib_suffix}], [QT_LIBS="$QT_WINDOWSUIAUTOMATION_LIBS $QT_LIBS"])
-  elif test "x$TARGET_OS" = xandroid; then
+  elif test "$TARGET_OS" = "android"; then
     PKG_CHECK_MODULES([QT_EGL], [${qt_lib_prefix}EglSupport], [QT_LIBS="$QT_EGL_LIBS $QT_LIBS"])
   fi
 ])
@@ -441,7 +441,7 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS],[
 
   BITCOIN_QT_CHECK([
     PKG_CHECK_MODULES([QT_TEST], [${qt_lib_prefix}Test${qt_lib_suffix} $qt_version], [QT_TEST_INCLUDES="$QT_TEST_CFLAGS"; have_qt_test=yes], [have_qt_test=no])
-    if test "x$use_dbus" != xno; then
+    if test "$use_dbus" != "no"; then
       PKG_CHECK_MODULES([QT_DBUS], [${qt_lib_prefix}DBus $qt_version], [QT_DBUS_INCLUDES="$QT_DBUS_CFLAGS"; have_qt_dbus=yes], [have_qt_dbus=no])
     fi
   ])

--- a/build-aux/m4/bitcoin_subdir_to_include.m4
+++ b/build-aux/m4/bitcoin_subdir_to_include.m4
@@ -5,13 +5,13 @@ dnl file COPYING or https://opensource.org/licenses/mit-license.php.
 dnl BITCOIN_SUBDIR_TO_INCLUDE([CPPFLAGS-VARIABLE-NAME],[SUBDIRECTORY-NAME],[HEADER-FILE])
 dnl SUBDIRECTORY-NAME must end with a path separator
 AC_DEFUN([BITCOIN_SUBDIR_TO_INCLUDE],[
-  if test "x$2" = "x"; then
+  if test "$2" = ""; then
     AC_MSG_RESULT([default])
   else
     echo "#include <$2$3.h>" >conftest.cpp
     newinclpath=`${CXXCPP} ${CPPFLAGS} -M conftest.cpp 2>/dev/null | [ tr -d '\\n\\r\\\\' | sed -e 's/^.*[[:space:]:]\(\/[^[:space:]]*\)]$3[\.h[[:space:]].*$/\1/' -e t -e d`]
     AC_MSG_RESULT([${newinclpath}])
-    if test "x${newinclpath}" != "x"; then
+    if test "${newinclpath}" != ""; then
       eval "$1=\"\$$1\"' -I${newinclpath}'"
     fi
   fi

--- a/build-aux/m4/m4_ax_boost_iostreams.m4
+++ b/build-aux/m4/m4_ax_boost_iostreams.m4
@@ -51,7 +51,7 @@ AC_DEFUN([AX_BOOST_IOSTREAMS],
         [want_boost="yes"]
 	)
 
-	if test "x$want_boost" = "xyes"; then
+	if test "$want_boost" = "yes"; then
         AC_REQUIRE([AC_PROG_CC])
 		CPPFLAGS_SAVED="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
@@ -75,17 +75,17 @@ AC_DEFUN([AX_BOOST_IOSTREAMS],
                              ax_cv_boost_iostreams=yes, ax_cv_boost_iostreams=no)
          AC_LANG_POP([C++])
 		])
-		if test "x$ax_cv_boost_iostreams" = "xyes"; then
+		if test "$ax_cv_boost_iostreams" = "yes"; then
 			AC_DEFINE(HAVE_BOOST_IOSTREAMS,,[define if the Boost::IOStreams library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-            if test "x$ax_boost_user_iostreams_lib" = "x"; then
+            if test "$ax_boost_user_iostreams_lib" = ""; then
                 for libextension in `ls $BOOSTLIBDIR/libboost_iostreams*.so* $BOOSTLIBDIR/libboost_iostream*.dylib* $BOOSTLIBDIR/libboost_iostreams*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_iostreams.*\)\.so.*$;\1;' -e 's;^lib\(boost_iostream.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_iostreams.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_IOSTREAMS_LIB="-l$ax_lib"; AC_SUBST(BOOST_IOSTREAMS_LIB) link_iostreams="yes"; break],
                                  [link_iostreams="no"])
 				done
-                if test "x$link_iostreams" != "xyes"; then
+                if test "$link_iostreams" != "yes"; then
                 for libextension in `ls $BOOSTLIBDIR/boost_iostreams*.dll* $BOOSTLIBDIR/boost_iostreams*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_iostreams.*\)\.dll.*$;\1;' -e 's;^\(boost_iostreams.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -102,10 +102,10 @@ AC_DEFUN([AX_BOOST_IOSTREAMS],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
+            if test "$ax_lib" = ""; then
                 AC_MSG_ERROR(Could not find a version of the library!)
             fi
-			if test "x$link_iostreams" != "xyes"; then
+			if test "$link_iostreams" != "yes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)
 			fi
 		fi

--- a/cd/06_script_b.sh
+++ b/cd/06_script_b.sh
@@ -16,7 +16,7 @@ if [[ $HOST = *-apple-* ]]; then
 	done
 fi
 
-cd /tmp/release/
+cd /tmp/release/ || { echo "Failure"; exit 1; }
 for f in *; do
     sha256sum $f > $f.SHA256
 done

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_CONFIG_MACRO_DIR([build-aux/m4])
 
 m4_ifndef([PKG_PROG_PKG_CONFIG], [m4_fatal([PKG_PROG_PKG_CONFIG macro not found. Please install pkg-config and re-run autogen.sh])])
 PKG_PROG_PKG_CONFIG
-if test "x$PKG_CONFIG" = x; then
+if test "$PKG_CONFIG" = ""; then
   AC_MSG_ERROR([pkg-config not found])
 fi
 
@@ -43,7 +43,7 @@ dnl make the compilation flags quiet unless V=1 is used
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 dnl Compiler checks (here before libtool).
-if test "x${CXXFLAGS+set}" = "xset"; then
+if test "${CXXFLAGS+set}" = "set"; then
   CXXFLAGS_overridden=yes
 else
   CXXFLAGS_overridden=no
@@ -68,7 +68,7 @@ CHECK_ATOMIC
 dnl Unless the user specified OBJCXX, force it to be the same as CXX. This ensures
 dnl that we get the same -std flags for both.
 m4_ifdef([AC_PROG_OBJCXX],[
-if test "x${OBJCXX+set}" = "x"; then
+if test "${OBJCXX+set}" = ""; then
   OBJCXX="${CXX}"
 fi
 AC_PROG_OBJCXX
@@ -185,7 +185,7 @@ AC_ARG_ENABLE([asm],
   [use_asm=$enableval],
   [use_asm=yes])
 
-if test "x$use_asm" = xyes; then
+if test "$use_asm" = "yes"; then
   AC_DEFINE(USE_ASM, 1, [Define this symbol to build in assembly routines])
 fi
 
@@ -213,20 +213,20 @@ AC_ARG_ENABLE([werror],
 AC_LANG_PUSH([C++])
 AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
-if test "x$enable_debug" = xyes; then
+if test "$enable_debug" = "yes"; then
     CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER"
-    if test "x$GCC" = xyes; then
+    if test "$GCC" = "yes"; then
         CFLAGS="$CFLAGS -g3 -O0"
     fi
 
-    if test "x$GXX" = xyes; then
+    if test "$GXX" = "yes"; then
         CXXFLAGS="$CXXFLAGS -g3 -O0"
     fi
 fi
 
 ERROR_CXXFLAGS=
-if test "x$enable_werror" = "xyes"; then
-  if test "x$CXXFLAG_WERROR" = "x"; then
+if test "$enable_werror" = "yes"; then
+  if test "$CXXFLAG_WERROR" = ""; then
     AC_MSG_ERROR("enable-werror set but -Werror is not usable")
   fi
   AX_CHECK_COMPILE_FLAG([-Werror=vla],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=vla"],,[[$CXXFLAG_WERROR]])
@@ -242,7 +242,7 @@ if test "x$enable_werror" = "xyes"; then
   AX_CHECK_COMPILE_FLAG([-Werror=mismatched-tags], [ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=mismatched-tags"], [], [$CXXFLAG_WERROR])
 fi
 
-if test "x$CXXFLAGS_overridden" = "xno"; then
+if test "$CXXFLAGS_overridden" = "no"; then
   AX_CHECK_COMPILE_FLAG([-Wall],[CXXFLAGS="$CXXFLAGS -Wall"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wextra],[CXXFLAGS="$CXXFLAGS -Wextra"],,[[$CXXFLAG_WERROR]])
   dnl some compilers will ignore -Wformat-security without -Wformat, so just combine the two here.
@@ -281,7 +281,7 @@ enable_sse41=no
 enable_avx2=no
 enable_shani=no
 
-if test "x$use_asm" = "xyes"; then
+if test "$use_asm" = "yes"; then
 
 dnl Check for optional instruction set support. Enabling these does _not_ imply that all code will
 dnl be compiled with them, rather that specific objects/libs may use them after checking for runtime
@@ -430,12 +430,12 @@ case $host in
      AX_CHECK_LINK_FLAG([[-static]],[LIBTOOL_APP_LDFLAGS="$LIBTOOL_APP_LDFLAGS -all-static"])
 
      AC_PATH_PROG([MAKENSIS], [makensis], none)
-     if test x$MAKENSIS = xnone; then
+     if test "$MAKENSIS" = "none"; then
        AC_MSG_WARN("makensis not found. Cannot create installer.")
      fi
 
      AC_PATH_TOOL(WINDRES, windres, none)
-     if test x$WINDRES = xnone; then
+     if test "$WINDRES" = "none"; then
        AC_MSG_ERROR("windres not found")
      fi
 
@@ -460,19 +460,19 @@ case $host in
      ;;
   *darwin*)
      TARGET_OS=darwin
-     if  test x$cross_compiling != xyes; then
+     if  test "$cross_compiling" != "yes"; then
        BUILD_OS=darwin
 
        AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
        AC_CHECK_PROG([BREW],brew, brew)
-       if test x$BREW = xbrew; then
+       if test "$BREW" = "brew"; then
          dnl These Homebrew packages may be keg-only, meaning that they won't be found
          dnl in expected paths because they may conflict with system files. Ask
          dnl Homebrew where each one is located, then adjust paths accordingly.
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
-         if $BREW list --versions berkeley-db@4 >/dev/null && test "x$BDB_CFLAGS" = "x" && test "x$BDB_LIBS" = "x"; then
+         if $BREW list --versions berkeley-db@4 >/dev/null && test "$BDB_CFLAGS" = "" && test "$BDB_LIBS" = ""; then
            bdb_prefix=$($BREW --prefix berkeley-db@4 2>/dev/null)
            dnl This must precede the call to BITCOIN_FIND_BDB48 below.
            BDB_CFLAGS="-I$bdb_prefix/include"
@@ -481,12 +481,12 @@ case $host in
 
          openssl_prefix=`$BREW --prefix openssl@1.1 2>/dev/null`
          qt5_prefix=`$BREW --prefix qt@5 2>/dev/null`
-         if test x$openssl_prefix != x; then
+         if test "$openssl_prefix" != ""; then
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
          fi
 
-         if test x$qt5_prefix != x; then
+         if test "$qt5_prefix" != ""; then
            PKG_CONFIG_PATH="$qt5_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
          fi
@@ -546,34 +546,34 @@ case "$host" in arm-*)
     CXXFLAGS="$CXXFLAGS -Wno-psabi"
 esac
 
-if test "x$enable_debug" = xyes; then
-    if test "x$GCC" = xyes; then
-        if test x$TARGET_OS = xwindows; then
+if test "$enable_debug" = "yes"; then
+    if test "$GCC" = "yes"; then
+        if test "$TARGET_OS" = "windows"; then
           CFLAGS="$CFLAGS -O1"
         fi
     fi
-    if test "x$GXX" = xyes; then
-        if test x$TARGET_OS = xwindows; then
+    if test "$GXX" = "yes"; then
+        if test "$TARGET_OS" = "windows"; then
           CXXFLAGS="$CXXFLAGS -O1"
         fi
     fi
 fi
 
-if test x$use_extended_functional_tests != xno; then
+if test "$use_extended_functional_tests" != "no"; then
   AC_SUBST(EXTENDED_FUNCTIONAL_TESTS, --extended)
 fi
 
-if test x$use_lcov = xyes; then
-  if test x$LCOV = x; then
+if test "$use_lcov" = "yes"; then
+  if test "$LCOV" = ""; then
     AC_MSG_ERROR("lcov testing requested but lcov not found")
   fi
-  if test x$GCOV = x; then
+  if test "$GCOV" = ""; then
     AC_MSG_ERROR("lcov testing requested but gcov not found")
   fi
-  if test x$PYTHON = x; then
+  if test "$PYTHON" = ""; then
     AC_MSG_ERROR("lcov testing requested but python not found")
   fi
-  if test x$GENHTML = x; then
+  if test "$GENHTML" = ""; then
     AC_MSG_ERROR("lcov testing requested but genhtml not found")
   fi
   LCOV="$LCOV --gcov-tool=$GCOV"
@@ -585,7 +585,7 @@ if test x$use_lcov = xyes; then
   CXXFLAGS="$CXXFLAGS -Og"
 fi
 
-if test x$use_lcov_branch != xno; then
+if test "$use_lcov_branch" != "no"; then
   AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
 fi
 
@@ -602,15 +602,15 @@ AC_SYS_LARGEFILE
 # detect POSIX or GNU variant of strerror_r
 AC_FUNC_STRERROR_R
 
-if test x$ac_cv_sys_file_offset_bits != x &&
-   test x$ac_cv_sys_file_offset_bits != xno &&
-   test x$ac_cv_sys_file_offset_bits != xunknown; then
+if test "$ac_cv_sys_file_offset_bits" != "" &&
+   test "$ac_cv_sys_file_offset_bits" != "no" &&
+   test "$ac_cv_sys_file_offset_bits" != "unknown"; then
   CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
 fi
 
-if test x$ac_cv_sys_large_files != x &&
-   test x$ac_cv_sys_large_files != xno &&
-   test x$ac_cv_sys_large_files != xunknown; then
+if test "$ac_cv_sys_large_files" != "" &&
+   test "$ac_cv_sys_large_files" != "no" &&
+   test "$ac_cv_sys_large_files" != "unknown"; then
   CPPFLAGS="$CPPFLAGS -D_LARGE_FILES=$ac_cv_sys_large_files"
 fi
 
@@ -622,7 +622,7 @@ AX_GCC_FUNC_ATTRIBUTE([dllimport])
 
 AC_SEARCH_LIBS([clock_gettime],[rt])
 
-if test x$TARGET_OS != xwindows; then
+if test "$TARGET_OS" != "windows"; then
   # All windows code is PIC, forcing it on just adds useless compile warnings
   AX_CHECK_COMPILE_FLAG([-fPIC],[PIC_FLAGS="-fPIC"])
 fi
@@ -631,7 +631,7 @@ fi
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348. To work around that, set
 # -fstack-reuse=none for all gcc builds. (Only gcc understands this flag)
 AX_CHECK_COMPILE_FLAG([-fstack-reuse=none],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-reuse=none"])
-if test x$use_hardening != xno; then
+if test "$use_hardening" != "no"; then
   AX_CHECK_COMPILE_FLAG([-Wstack-protector],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -Wstack-protector"])
   AX_CHECK_COMPILE_FLAG([-fstack-protector-all],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-protector-all"])
 
@@ -677,7 +677,7 @@ if test x$use_hardening != xno; then
 fi
 
 dnl this flag screws up non-darwin gcc even when the check fails. special-case it.
-if test x$TARGET_OS = xdarwin; then
+if test "$TARGET_OS" = "darwin"; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
 fi
 
@@ -759,7 +759,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ],
   [
     AC_MSG_RESULT(no)
-    if test x$use_reduce_exports = xyes; then
+    if test "$use_reduce_exports" = "yes"; then
       AC_MSG_ERROR([Cannot find a working visibility attribute. Use --disable-reduce-exports.])
     fi
   ]
@@ -767,7 +767,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
 
 dnl Our minimum supported glibc is 2.17, however support for thread_local
 dnl did not arrive in glibc until 2.18.
-if test "x$use_thread_local" = xyes || test "x$use_thread_local" = xauto; then
+if test "$use_thread_local" = "yes" || test "$use_thread_local" = "auto"; then
   TEMP_LDFLAGS="$LDFLAGS"
   LDFLAGS="$TEMP_LDFLAGS $PTHREAD_CFLAGS"
   AC_MSG_CHECKING([for thread_local support])
@@ -915,7 +915,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 )
 
 # Check for reduced exports
-if test x$use_reduce_exports = xyes; then
+if test "$use_reduce_exports" = "yes"; then
   AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],[RE_CXXFLAGS="-fvisibility=hidden"],
   [AC_MSG_ERROR([Cannot set default symbol visibility. Use --disable-reduce-exports.])])
 fi
@@ -928,13 +928,13 @@ AC_SUBST(LEVELDB_CPPFLAGS)
 AC_SUBST(LIBLEVELDB)
 AC_SUBST(LIBMEMENV)
 
-if test x$enable_wallet != xno; then
+if test "$enable_wallet" != "no"; then
     dnl Check for libdb_cxx only if wallet enabled
     BITCOIN_FIND_BDB48
 fi
 
 dnl Check for libminiupnpc (optional)
-if test x$use_upnp != xno; then
+if test "$use_upnp" != "no"; then
   AC_CHECK_HEADERS(
     [miniupnpc/miniwget.h miniupnpc/miniupnpc.h miniupnpc/upnpcommands.h miniupnpc/upnperrors.h],
     [AC_CHECK_LIB([miniupnpc], [main],[MINIUPNPC_LIBS=-lminiupnpc], [have_miniupnpc=no])],
@@ -942,7 +942,7 @@ if test x$use_upnp != xno; then
   )
 dnl The minimum supported miniUPnPc API version is set to 10. This keeps compatibility
 dnl with Ubuntu 16.04 LTS and Debian 8 libminiupnpc-dev packages.
-if test x$have_miniupnpc != xno; then
+if test "$have_miniupnpc" != "no"; then
   AC_MSG_CHECKING([whether miniUPnPc API version is supported])
   AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
       @%:@include <miniupnpc/miniupnpc.h>
@@ -968,13 +968,13 @@ BITCOIN_QT_INIT
 dnl sets $bitcoin_enable_qt, $bitcoin_enable_qt_test, $bitcoin_enable_qt_dbus
 BITCOIN_QT_CONFIGURE([5.9.5])
 
-if test x$build_bitcoin_utils$build_gridcoinresearchd$bitcoin_enable_qt$use_tests$use_bench = xnonononono; then
+if test "$build_bitcoin_utils$build_gridcoinresearchd$bitcoin_enable_qt$use_tests$use_bench" = "nonononono"; then
     use_boost=no
 else
     use_boost=yes
 fi
 
-if test x$use_boost = xyes; then
+if test "$use_boost" = "yes"; then
 
 dnl Minimum required Boost version
 define(MINIMUM_REQUIRED_BOOST, 1.60.0)
@@ -995,19 +995,19 @@ BOOST_CPPFLAGS="-DBOOST_SP_USE_STD_ATOMIC -DBOOST_AC_USE_STD_ATOMIC $BOOST_CPPFL
 BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_IOSTREAMS_LIB $BOOST_THREAD_LIB $BOOST_ZLIB_LIB"
 fi
 
-if test x$use_reduce_exports = xyes; then
+if test "$use_reduce_exports" = "yes"; then
     CXXFLAGS="$CXXFLAGS $RE_CXXFLAGS"
     AX_CHECK_LINK_FLAG([[-Wl,--exclude-libs,ALL]], [RELDFLAGS="-Wl,--exclude-libs,ALL"])
 fi
 
-if test x$use_tests = xyes; then
+if test "$use_tests" = "yes"; then
 
-  if test x$HEXDUMP = x; then
+  if test "$HEXDUMP" = ""; then
     AC_MSG_ERROR(hexdump is required for tests)
   fi
 
 
-  if test x$use_boost = xyes; then
+  if test "$use_boost" = "yes"; then
 
   AX_BOOST_UNIT_TEST_FRAMEWORK
 
@@ -1037,7 +1037,7 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto not found.)])
 PKG_CHECK_MODULES([LIBZIP], [libzip],,[AC_MSG_ERROR(libzip not found.)])
 PKG_CHECK_MODULES([CURL], [libcurl],,[AC_MSG_ERROR(libcurl not found.)])
 
-if test x$use_qr != xno; then
+if test "$use_qr" != "no"; then
   BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
 fi
 
@@ -1047,7 +1047,7 @@ need_bundled_univalue=yes
 UNIVALUE_CFLAGS='-I$(srcdir)/univalue/include'
 UNIVALUE_LIBS='univalue/libunivalue.la'
 
-AM_CONDITIONAL([EMBEDDED_UNIVALUE],[test x$need_bundled_univalue = xyes])
+AM_CONDITIONAL([EMBEDDED_UNIVALUE],[test "$need_bundled_univalue" = "yes"])
 AC_SUBST(UNIVALUE_CFLAGS)
 AC_SUBST(UNIVALUE_LIBS)
 
@@ -1060,19 +1060,19 @@ AC_CHECK_DECLS([EVP_MD_CTX_new],,,[AC_INCLUDES_DEFAULT
 CXXFLAGS="${save_CXXFLAGS}"
 
 AC_MSG_CHECKING([whether to build gridcoinresearchd])
-AM_CONDITIONAL([BUILD_GRIDCOINRESEARCHD], [test x$build_gridcoinresearchd = xyes])
+AM_CONDITIONAL([BUILD_GRIDCOINRESEARCHD], [test "$build_gridcoinresearchd" = "yes"])
 AC_MSG_RESULT($build_gridcoinresearchd)
 
 AC_MSG_CHECKING([whether to build utils (bitcoin-cli bitcoin-tx)])
-AM_CONDITIONAL([BUILD_BITCOIN_UTILS], [test x$build_bitcoin_utils = xyes])
+AM_CONDITIONAL([BUILD_BITCOIN_UTILS], [test "$build_bitcoin_utils" = "yes"])
 AC_MSG_RESULT($build_bitcoin_utils)
 
 AC_LANG_POP
 
-if test "x$use_ccache" != "xno"; then
+if test "$use_ccache" != "no"; then
   AC_MSG_CHECKING(if ccache should be used)
-  if test x$CCACHE = x; then
-    if test "x$use_ccache" = "xyes"; then
+  if test "$CCACHE" = ""; then
+    if test "$use_ccache" = "yes"; then
       AC_MSG_ERROR([ccache not found.]);
     else
       use_ccache=no
@@ -1084,13 +1084,13 @@ if test "x$use_ccache" != "xno"; then
   fi
   AC_MSG_RESULT($use_ccache)
 fi
-if test "x$use_ccache" = "xyes"; then
+if test "$use_ccache" = "yes"; then
     AX_CHECK_PREPROC_FLAG([-Qunused-arguments],[CPPFLAGS="-Qunused-arguments $CPPFLAGS"])
 fi
 
 dnl enable wallet
 AC_MSG_CHECKING([if wallet should be enabled])
-if test x$enable_wallet != xno; then
+if test "$enable_wallet" != "no"; then
   AC_MSG_RESULT(yes)
   AC_DEFINE_UNQUOTED([ENABLE_WALLET],[1],[Define to 1 to enable wallet functions])
 
@@ -1100,24 +1100,24 @@ fi
 
 dnl enable upnp support
 AC_MSG_CHECKING([whether to build with support for UPnP])
-if test x$have_miniupnpc = xno; then
-  if test x$use_upnp = xyes; then
+if test "$have_miniupnpc" = "no"; then
+  if test "$use_upnp" = "yes"; then
      AC_MSG_ERROR("UPnP requested but cannot be built. Use --without-miniupnpc.")
   fi
   AC_MSG_RESULT(no)
 else
-  if test x$use_upnp != xno; then
+  if test "$use_upnp" != "no"; then
     AC_MSG_RESULT(yes)
     AC_MSG_CHECKING([whether to build with UPnP enabled by default])
     use_upnp=yes
     upnp_setting=0
-    if test x$use_upnp_default != xno; then
+    if test "$use_upnp_default" != "no"; then
       use_upnp_default=yes
       upnp_setting=1
     fi
     AC_MSG_RESULT($use_upnp_default)
     AC_DEFINE_UNQUOTED([USE_UPNP],[$upnp_setting],[UPnP support not compiled if undefined, otherwise value (0 or 1) determines default state])
-    if test x$TARGET_OS = xwindows; then
+    if test "$TARGET_OS" = "windows"; then
       MINIUPNPC_CPPFLAGS="-DSTATICLIB -DMINIUPNP_STATICLIB"
     fi
   else
@@ -1127,25 +1127,25 @@ fi
 
 dnl these are only used when qt is enabled
 BUILD_TEST_QT=""
-if test x$bitcoin_enable_qt != xno; then
+if test "$bitcoin_enable_qt" != "no"; then
   CPPFLAGS="$CPPFLAGS -DQT_GUI"
 
   dnl enable dbus support
   AC_MSG_CHECKING([whether to build GUI with support for D-Bus])
-  if test x$bitcoin_enable_qt_dbus != xno; then
+  if test "$bitcoin_enable_qt_dbus" != "no"; then
     AC_DEFINE([USE_DBUS],[1],[Define if dbus support should be compiled in])
   fi
   AC_MSG_RESULT($bitcoin_enable_qt_dbus)
 
   dnl enable qr support
   AC_MSG_CHECKING([whether to build GUI with support for QR codes])
-  if test x$have_qrencode = xno; then
-    if test x$use_qr = xyes; then
+  if test "$have_qrencode" = "no"; then
+    if test "$use_qr" = "yes"; then
      AC_MSG_ERROR("QR support requested but cannot be built. use --without-qrencode")
     fi
     AC_MSG_RESULT(no)
   else
-    if test x$use_qr != xno; then
+    if test "$use_qr" != "no"; then
       AC_MSG_RESULT(yes)
       AC_DEFINE([USE_QRCODE],[1],[Define if QR support should be compiled in])
       use_qr=yes
@@ -1155,12 +1155,12 @@ if test x$bitcoin_enable_qt != xno; then
     fi
   fi
 
-  if test x$XGETTEXT = x; then
+  if test "$XGETTEXT" = ""; then
     AC_MSG_WARN("xgettext is required to update qt translations")
   fi
 
   AC_MSG_CHECKING([whether to build test_bitcoin-qt])
-  if test x$use_gui_tests$bitcoin_enable_qt_test = xyesyes; then
+  if test "$use_gui_tests$bitcoin_enable_qt_test" = "yesyes"; then
     AC_MSG_RESULT([yes])
     BUILD_TEST_QT="yes"
   else
@@ -1168,10 +1168,10 @@ if test x$bitcoin_enable_qt != xno; then
   fi
 fi
 
-AM_CONDITIONAL([ENABLE_ZMQ], [test "x$use_zmq" = "xyes"])
+AM_CONDITIONAL([ENABLE_ZMQ], [test "$use_zmq" = "yes"])
 
 AC_MSG_CHECKING([whether to build test_bitcoin])
-if test x$use_tests = xyes; then
+if test "$use_tests" = "yes"; then
   AC_MSG_RESULT([yes])
   BUILD_TEST="yes"
 else
@@ -1180,37 +1180,37 @@ else
 fi
 
 AC_MSG_CHECKING([whether to reduce exports])
-if test x$use_reduce_exports = xyes; then
+if test "$use_reduce_exports" = "yes"; then
   AC_MSG_RESULT([yes])
 else
   AC_MSG_RESULT([no])
 fi
 
-if test x$build_bitcoin_utils$build_bitcoin_libs$build_gridcoinresearchd$bitcoin_enable_qt$use_bench$use_tests = xnononononono; then
+if test "$build_bitcoin_utils$build_bitcoin_libs$build_gridcoinresearchd$bitcoin_enable_qt$use_bench$use_tests" = "nononononono"; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
 
-AM_CONDITIONAL([TARGET_DARWIN], [test x$TARGET_OS = xdarwin])
-AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
-AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
-AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
-AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
-AM_CONDITIONAL([ENABLE_QT],[test x$bitcoin_enable_qt = xyes])
-AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$BUILD_TEST_QT = xyes])
-AM_CONDITIONAL([ENABLE_BENCH],[test x$use_bench = xyes])
-AM_CONDITIONAL([USE_QRCODE], [test x$use_qr = xyes])
-AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
-AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
-AM_CONDITIONAL([ENABLE_SSE42],[test x$enable_sse42 = xyes])
-AM_CONDITIONAL([ENABLE_SSE41],[test x$enable_sse41 = xyes])
-AM_CONDITIONAL([ENABLE_AVX2],[test x$enable_avx2 = xyes])
-AM_CONDITIONAL([ENABLE_SHANI],[test x$enable_shani = xyes])
-AM_CONDITIONAL([ENABLE_ARM_CRC],[test x$enable_arm_crc = xyes])
-AM_CONDITIONAL([USE_ASM],[test x$use_asm = xyes])
-AM_CONDITIONAL([WORDS_BIGENDIAN],[test x$ac_cv_c_bigendian = xyes])
-AM_CONDITIONAL([ARCH_x86], [test x$have_x86 = xtrue])
-AM_CONDITIONAL([ARCH_x86_64], [test x$have_x86_64 = xtrue])
-AM_CONDITIONAL([ARCH_ARM], [test x$have_arm = xtrue])
+AM_CONDITIONAL([TARGET_DARWIN], [test "$TARGET_OS" = "darwin"])
+AM_CONDITIONAL([BUILD_DARWIN], [test "$BUILD_OS" = "darwin"])
+AM_CONDITIONAL([TARGET_WINDOWS], [test "$TARGET_OS" = "windows"])
+AM_CONDITIONAL([ENABLE_WALLET],[test "$enable_wallet" = "yes"])
+AM_CONDITIONAL([ENABLE_TESTS],[test "$BUILD_TEST" = "yes"])
+AM_CONDITIONAL([ENABLE_QT],[test "$bitcoin_enable_qt" = "yes"])
+AM_CONDITIONAL([ENABLE_QT_TESTS],[test "$BUILD_TEST_QT" = "yes"])
+AM_CONDITIONAL([ENABLE_BENCH],[test "$use_bench" = "yes"])
+AM_CONDITIONAL([USE_QRCODE], [test "$use_qr" = "yes"])
+AM_CONDITIONAL([USE_LCOV],[test "$use_lcov" = "yes"])
+AM_CONDITIONAL([HARDEN],[test "$use_hardening" = "yes"])
+AM_CONDITIONAL([ENABLE_SSE42],[test "$enable_sse42" = "yes"])
+AM_CONDITIONAL([ENABLE_SSE41],[test "$enable_sse41" = "yes"])
+AM_CONDITIONAL([ENABLE_AVX2],[test "$enable_avx2" = "yes"])
+AM_CONDITIONAL([ENABLE_SHANI],[test "$enable_shani" = "yes"])
+AM_CONDITIONAL([ENABLE_ARM_CRC],[test "$enable_arm_crc" = "yes"])
+AM_CONDITIONAL([USE_ASM],[test "$use_asm" = "yes"])
+AM_CONDITIONAL([WORDS_BIGENDIAN],[test "$ac_cv_c_bigendian" = "yes"])
+AM_CONDITIONAL([ARCH_x86], [test "$have_x86" = "true"])
+AM_CONDITIONAL([ARCH_x86_64], [test "$have_x86_64" = "true"])
+AM_CONDITIONAL([ARCH_ARM], [test "$have_arm" = "true"])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])
@@ -1325,7 +1325,7 @@ echo
 echo "Options used to compile and link:"
 echo "  with wallet   = $enable_wallet"
 echo "  with gui / qt = $bitcoin_enable_qt"
-if test x$bitcoin_enable_qt != xno; then
+if test "$bitcoin_enable_qt" != "no"; then
     echo "    with qr     = $use_qr"
 fi
 echo "  with zmq      = $use_zmq"

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -33,7 +33,7 @@ if test -z $with_gui && test -n "@no_qt@"; then
   with_gui=no
 fi
 
-if test x@host_os@ = xdarwin; then
+if test "@host_os@" = darwin; then
   BREW=no
   PORT=no
 fi

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -38,7 +38,7 @@ if test "@host_os@" = darwin; then
   PORT=no
 fi
 
-if test x@host_os@ = xmingw32; then
+if test "@host_os@" = "mingw32"; then
   if test -z $with_qt_incdir; then
     with_qt_incdir=$depends_prefix/include
   fi

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -12,7 +12,7 @@
 # one. Any remaining diff signals an error.
 
 export LC_ALL=C
-if test "x$1" = "x"; then
+if test -z $1; then
     echo "Usage: $0 <commit>..."
     exit 1
 fi
@@ -24,7 +24,7 @@ for commit in $(git rev-list --reverse $1); do
     if git rev-list -n 1 --pretty="%s" $commit | grep -q "^scripted-diff:"; then
         git checkout --quiet $commit^ || exit
         SCRIPT="$(git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
-        if test "x$SCRIPT" = "x"; then
+        if test -z "$SCRIPT"; then
             echo "Error: missing script for: $commit"
             echo "Failed"
             RET=1

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -21,11 +21,8 @@ EXIT_CODE=0
 IGNORE_EXIT=(
   "lint-assertions.sh"
   "lint-circular-dependencies.sh"
-  "lint-format-strings.sh"
-  "lint-includes.sh"
   "lint-python-dead-code.sh"
   "lint-python.sh"
-  "lint-tests.sh"
 )
 
 for f in "${SCRIPTDIR}"/lint-*.sh; do

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -18,11 +18,23 @@ LINTALL=$(basename "${BASH_SOURCE[0]}")
 
 EXIT_CODE=0
 
+IGNORE_EXIT=(
+  "lint-assertions.sh"
+  "lint-circular-dependencies.sh"
+  "lint-format-strings.sh"
+  "lint-includes.sh"
+  "lint-python-dead-code.sh"
+  "lint-python.sh"
+  "lint-tests.sh"
+)
+
 for f in "${SCRIPTDIR}"/lint-*.sh; do
   if [ "$(basename "$f")" != "$LINTALL" ]; then
     if ! "$f"; then
       echo "^---- failure generated from $f"
-      EXIT_CODE=1
+      if ! python -c "import sys; sys.exit(int(sys.argv[1] not in sys.argv[2:]))" $(basename "$f") "${IGNORE_EXIT[@]}"; then
+        EXIT_CODE=1
+      fi
     fi
   fi
 done

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -71,30 +71,30 @@ EXPECTED_BOOST_INCLUDES=(
     boost/thread/thread.hpp
 )
 
-#for BOOST_INCLUDE in $(git grep '^#include <boost/' -- "*.cpp" "*.h" | cut -f2 -d: | cut -f2 -d'<' | cut -f1 -d'>' | sort -u); do
-#    IS_EXPECTED_INCLUDE=0
-#    for EXPECTED_BOOST_INCLUDE in "${EXPECTED_BOOST_INCLUDES[@]}"; do
-#        if [[ "${BOOST_INCLUDE}" == "${EXPECTED_BOOST_INCLUDE}" ]]; then
-#            IS_EXPECTED_INCLUDE=1
-#            break
-#        fi
-#    done
-#    if [[ ${IS_EXPECTED_INCLUDE} == 0 ]]; then
-#        EXIT_CODE=1
-#        echo "A new Boost dependency in the form of \"${BOOST_INCLUDE}\" appears to have been introduced:"
-#        git grep "${BOOST_INCLUDE}" -- "*.cpp" "*.h"
-#        echo
-#    fi
-#done
+for BOOST_INCLUDE in $(git grep '^#include <boost/' -- "*.cpp" "*.h" | cut -f2 -d: | cut -f2 -d'<' | cut -f1 -d'>' | sort -u); do
+    IS_EXPECTED_INCLUDE=0
+    for EXPECTED_BOOST_INCLUDE in "${EXPECTED_BOOST_INCLUDES[@]}"; do
+        if [[ "${BOOST_INCLUDE}" == "${EXPECTED_BOOST_INCLUDE}" ]]; then
+            IS_EXPECTED_INCLUDE=1
+            break
+        fi
+    done
+    if [[ ${IS_EXPECTED_INCLUDE} == 0 ]]; then
+        EXIT_CODE=1
+        echo "A new Boost dependency in the form of \"${BOOST_INCLUDE}\" appears to have been introduced:"
+        git grep "${BOOST_INCLUDE}" -- "*.cpp" "*.h"
+        echo
+    fi
+done
 
-#for EXPECTED_BOOST_INCLUDE in "${EXPECTED_BOOST_INCLUDES[@]}"; do
-#    if ! git grep -q "^#include <${EXPECTED_BOOST_INCLUDE}>" -- "*.cpp" "*.h"; then
-#        echo "Good job! The Boost dependency \"${EXPECTED_BOOST_INCLUDE}\" is no longer used."
-#        echo "Please remove it from EXPECTED_BOOST_INCLUDES in $0"
-#        echo "to make sure this dependency is not accidentally reintroduced."
-#        echo
-#        EXIT_CODE=1
-#    fi
-#done
+for EXPECTED_BOOST_INCLUDE in "${EXPECTED_BOOST_INCLUDES[@]}"; do
+    if ! git grep -q "^#include <${EXPECTED_BOOST_INCLUDE}>" -- "*.cpp" "*.h"; then
+        echo "Good job! The Boost dependency \"${EXPECTED_BOOST_INCLUDE}\" is no longer used."
+        echo "Please remove it from EXPECTED_BOOST_INCLUDES in $0"
+        echo "to make sure this dependency is not accidentally reintroduced."
+        echo
+        EXIT_CODE=1
+    fi
+done
 
 exit ${EXIT_CODE}

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -49,26 +49,51 @@ if [[ ${INCLUDED_CPP_FILES} != "" ]]; then
 fi
 
 EXPECTED_BOOST_INCLUDES=(
+    boost/algorithm/hex.hpp
     boost/algorithm/string.hpp
+    boost/algorithm/string/case_conv.hpp
     boost/algorithm/string/classification.hpp
+    boost/algorithm/string/join.hpp
+    boost/algorithm/string/predicate.hpp
     boost/algorithm/string/replace.hpp
     boost/algorithm/string/split.hpp
+    boost/asio.hpp
+    boost/asio/ip/v6_only.hpp
+    boost/asio/ssl.hpp
+    boost/assert.hpp
+    boost/assign/list_inserter.hpp
+    boost/assign/list_of.hpp
+    boost/assign/std/vector.hpp
+    boost/bind/bind.hpp
+    boost/date_time.hpp
+    boost/date_time/gregorian/greg_date.hpp
+    boost/date_time/gregorian/gregorian.hpp
+    boost/date_time/gregorian/gregorian_types.hpp
     boost/date_time/posix_time/posix_time.hpp
+    boost/date_time/posix_time/posix_time_types.hpp
+    boost/exception/diagnostic_information.hpp
+    boost/exception/exception.hpp
     boost/filesystem.hpp
     boost/filesystem/fstream.hpp
-    boost/multi_index/hashed_index.hpp
-    boost/multi_index/ordered_index.hpp
-    boost/multi_index/sequenced_index.hpp
-    boost/multi_index_container.hpp
-    boost/process.hpp
-    boost/signals2/connection.hpp
+    boost/interprocess/ipc/message_queue.hpp
+    boost/iostreams/copy.hpp
+    boost/iostreams/concepts.hpp
+    boost/iostreams/device/array.hpp
+    boost/iostreams/filter/gzip.hpp
+    boost/iostreams/filter/newline.hpp
+    boost/iostreams/filtering_stream.hpp
+    boost/iostreams/stream.hpp
+    boost/lexical_cast.hpp
+    boost/range/adaptor/reversed.hpp
+    boost/serialization/binary_object.hpp
+    boost/shared_ptr.hpp
     boost/signals2/optional_last_value.hpp
     boost/signals2/signal.hpp
     boost/test/unit_test.hpp
+    boost/thread.hpp
     boost/thread/condition_variable.hpp
-    boost/thread/mutex.hpp
-    boost/thread/shared_mutex.hpp
-    boost/thread/thread.hpp
+    boost/tuple/tuple.hpp
+    boost/version.hpp
 )
 
 for BOOST_INCLUDE in $(git grep '^#include <boost/' -- "*.cpp" "*.h" | cut -f2 -d: | cut -f2 -d'<' | cut -f1 -d'>' | sort -u); do


### PR DESCRIPTION
Addresses:
- build: remove x-prefix's from comparisons
> Very old shells suffered from bugs which meant that prefixing variables with an "x" to ensure that the lefthand side of a comparison always started with an alphanumeric character was needed. Modern shells don't suffer from this issue (i.e Bash was fixed in 1996).
> 
> In any case, we've already got unprefixed checks used in our codebase, i.e
> 
> https://github.com/bitcoin/bitcoin/blob/681b25e3cd7d084f642693152322ed9a40f33ba0/configure.ac#L292
> 
> and have libs (in depends) that also use unprefixed comparisons in their
> configure scripts.
> 
> I think it's time that we consolidate on not using the x-prefix workaround. At best it's mostly just confusing. Could simplify some of these checks further in future.
> 
> More info: https://github.com/koalaman/shellcheck/wiki/SC2268 https://www.vidarholen.net/contents/blog/?p=1035


  - Ref: https://github.com/bitcoin/bitcoin/pull/23593
- SC2268 - Avoid x-prefix in comparisons as it no longer serves a purpose.
  - https://github.com/koalaman/shellcheck/wiki/SC2268
- SC2164 - Use `cd ... || exit` in case `cd` fails.
  - https://github.com/koalaman/shellcheck/wiki/SC2164
- Revert https://github.com/gridcoin-community/Gridcoin-Research/pull/2474/commits/49aa91180816bbe8183486db51dd341ea0999614
- Update `EXPECTED_BOOST_INCLUDES`