### PR TITLE
test: Avoid copies of CTransaction

### DIFF
--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -26,7 +26,7 @@ extern bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, 
 BOOST_AUTO_TEST_SUITE(multisig_tests)
 
 CScript
-sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)
+sign_multisig(const CScript& scriptPubKey, const std::vector<CKey>& keys, const CTransaction& transaction, int whichIn)
 {
     uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL);
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(script_PushData)
 }
 
 CScript
-sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transaction)
+sign_multisig(const CScript& scriptPubKey, const std::vector<CKey>& keys, const CTransaction& transaction)
 {
     uint256 hash = SignatureHash(scriptPubKey, transaction, 0, SIGHASH_ALL);
 
@@ -204,7 +204,7 @@ sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transac
     return result;
 }
 CScript
-sign_multisig(CScript scriptPubKey, CKey key, CTransaction transaction)
+sign_multisig(const CScript& scriptPubKey, const CKey& key, const CTransaction& transaction)
 {
     std::vector<CKey> keys;
     keys.push_back(key);


### PR DESCRIPTION
> Avoid the copy (or move) constructor of `CTransaction` in test code, wherever a simple reference can be used instead.

Ref: https://github.com/bitcoin/bitcoin/pull/12949