### PR TITLE
build: Try posix-specific CXX first for mingw32 host, Fix Windows cross-compiling with Qt 5.15

### DIFF
--- a/cd/05_before_script.sh
+++ b/cd/05_before_script.sh
@@ -18,9 +18,7 @@ fi
 if [ -n "$XCODE_VERSION" ] && [ -f "$OSX_SDK_PATH" ]; then
   DOCKER_EXEC tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
-if [[ $HOST = *-mingw32 ]]; then
-  DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
-fi
+
 if [ -z "$NO_DEPENDS" ]; then
   if [[ $DOCKER_NAME_TAG == centos* ]]; then
     # CentOS has problems building the depends if the config shell is not explicitly set

--- a/cd/05_before_script.sh
+++ b/cd/05_before_script.sh
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2018-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C.UTF-8
 

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -25,9 +25,7 @@ fi
 if [ -n "$XCODE_VERSION" ] && [ -f "$OSX_SDK_PATH" ]; then
   DOCKER_EXEC tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
-if [[ $HOST = *-mingw32 ]]; then
-  DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
-fi
+
 if [ -z "$NO_DEPENDS" ]; then
   if [[ $DOCKER_NAME_TAG == centos* ]]; then
     # CentOS has problems building the depends if the config shell is not explicitly set

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -1,3 +1,7 @@
+ifneq ($(shell which $(host)-g++-posix),)
+mingw32_CXX := $(host)-g++-posix
+endif
+
 mingw32_CFLAGS=-pipe
 mingw32_CXXFLAGS=$(mingw32_CFLAGS)
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -164,6 +164,7 @@ $(package)_config_opts_mingw32 += -no-dbus
 $(package)_config_opts_mingw32 += -no-freetype
 $(package)_config_opts_mingw32 += -xplatform win32-g++
 $(package)_config_opts_mingw32 += "QMAKE_CFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"
+$(package)_config_opts_mingw32 += "QMAKE_CXX = '$($(package)_cxx)'"
 $(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -49,25 +49,6 @@ The first step is to install the mingw-w64 cross-compilation tool chain:
 
     sudo apt install g++-mingw-w64-x86-64
 
-Next, set the default `mingw32 g++` compiler option to POSIX:
-
-```
-sudo update-alternatives --config x86_64-w64-mingw32-g++
-```
-
-After running the above command, you should see output similar to that below.
-Choose the option that ends with `posix`.
-
-```
-There are 2 choices for the alternative x86_64-w64-mingw32-g++ (providing /usr/bin/x86_64-w64-mingw32-g++).
-  Selection    Path                                   Priority   Status
-------------------------------------------------------------
-  0            /usr/bin/x86_64-w64-mingw32-g++-win32   60        auto mode
-* 1            /usr/bin/x86_64-w64-mingw32-g++-posix   30        manual mode
-  2            /usr/bin/x86_64-w64-mingw32-g++-win32   60        manual mode
-Press <enter> to keep the current choice[*], or type selection number:
-```
-
 Once the toolchain is installed the build steps are common:
 
 Note that for WSL the Gridcoin source path MUST be somewhere in the default mount file system, for

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -46,8 +46,17 @@ Acquire the source in the usual way:
 ## Building for 64-bit Windows
 
 The first step is to install the mingw-w64 cross-compilation tool chain:
+  - on modern systems (Ubuntu 21.04 Hirsute Hippo or newer, Debian 11 Bullseye or newer):
 
-    sudo apt install g++-mingw-w64-x86-64
+```sh
+sudo apt install g++-mingw-w64-x86-64-posix
+```
+
+  - on older systems:
+
+```sh
+sudo apt install g++-mingw-w64-x86-64
+```
 
 Once the toolchain is installed the build steps are common:
 


### PR DESCRIPTION
> On master, when cross-compiling for Windows using our depends build system, we must manually choose the POSIX thread model for the `x86_64-w64-mingw32-g++` compiler.
> 
> This PR improves the build system to make this choice automagically.

Ref: https://github.com/bitcoin/bitcoin/pull/22093

> While changes introduced in #22093 worked fine with Qt 5.12, after bumping Qt up to 5.15 the cross-compiling of `qt` package for Windows fails with `error: ‘mutex’ in namespace ‘std’ does not name a type`.

Ref: https://github.com/bitcoin/bitcoin/pull/24131


