### PR TITLE
qt, refactor: Use enum type as switch argument in *TableModel

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -178,42 +178,35 @@ QVariant AddressTableModel::data(const QModelIndex &index, int role) const
 
     AddressTableEntry *rec = static_cast<AddressTableEntry*>(index.internalPointer());
 
-    if(role == Qt::DisplayRole || role == Qt::EditRole)
-    {
-        switch(index.column())
-        {
+    const auto column = static_cast<ColumnIndex>(index.column());
+    if (role == Qt::DisplayRole || role == Qt::EditRole) {
+        switch (column) {
         case Label:
-            if(rec->label.isEmpty() && role == Qt::DisplayRole)
-            {
+            if (rec->label.isEmpty() && role == Qt::DisplayRole) {
                 return tr("(no label)");
-            }
-            else
-            {
+            } else {
                 return rec->label;
             }
         case Address:
             return rec->address;
-        }
-    }
-    else if (role == Qt::FontRole)
-    {
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
+    } else if (role == Qt::FontRole) {
         QFont font;
         if(index.column() == Address)
         {
             font = GUIUtil::bitcoinAddressFont();
         }
         return font;
-    }
-    else if (role == TypeRole)
-    {
+    } else if (role == TypeRole) {
         switch(rec->type)
         {
         case AddressTableEntry::Sending:
             return Send;
         case AddressTableEntry::Receiving:
             return Receive;
-        default: break;
-        }
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     }
     return QVariant();
 }

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -25,15 +25,13 @@ bool BannedNodeLessThan::operator()(const CCombinedBan& left, const CCombinedBan
     if (order == Qt::DescendingOrder)
         std::swap(pLeft, pRight);
 
-    switch(column)
-    {
+    switch (static_cast<BanTableModel::ColumnIndex>(column)) {
     case BanTableModel::Address:
         return pLeft->subnet.ToString().compare(pRight->subnet.ToString()) < 0;
     case BanTableModel::Bantime:
         return pLeft->banEntry.nBanUntil < pRight->banEntry.nBanUntil;
-    }
-
-    return false;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
 }
 
 // private implementation
@@ -122,16 +120,17 @@ QVariant BanTableModel::data(const QModelIndex &index, int role) const
 
     CCombinedBan *rec = static_cast<CCombinedBan*>(index.internalPointer());
 
+    const auto column = static_cast<ColumnIndex>(index.column());
     if (role == Qt::DisplayRole) {
-        switch(index.column())
-        {
+        switch (column) {
         case Address:
             return QString::fromStdString(rec->subnet.ToString());
         case Bantime:
             QDateTime date = QDateTime::fromMSecsSinceEpoch(0);
             date = date.addSecs(rec->banEntry.nBanUntil);
             return QLocale::system().toString(date, QLocale::LongFormat);
-        }
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     }
 
     return QVariant();

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -23,8 +23,7 @@ bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombine
     if (order == Qt::DescendingOrder)
         std::swap(pLeft, pRight);
 
-    switch(column)
-    {
+    switch (static_cast<PeerTableModel::ColumnIndex>(column)) {
     case PeerTableModel::NetNodeId:
         return pLeft->id < pRight->id;
     case PeerTableModel::Address:
@@ -37,9 +36,8 @@ bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombine
         return pLeft->nSendBytes < pRight->nSendBytes;
     case PeerTableModel::Received:
         return pLeft->nRecvBytes < pRight->nRecvBytes;
-    }
-
-    return false;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
 }
 
 // private implementation
@@ -158,9 +156,9 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
 
     CNodeCombinedStats *rec = static_cast<CNodeCombinedStats*>(index.internalPointer());
 
+    const auto column = static_cast<ColumnIndex>(index.column());
     if (role == Qt::DisplayRole) {
-        switch(index.column())
-        {
+        switch (column) {
         case NetNodeId:
             return (qint64)rec->nodeStats.id;
         case Address:
@@ -179,16 +177,18 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
             return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
         case Received:
             return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
-        }
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     } else if (role == Qt::TextAlignmentRole) {
-        switch (index.column()) {
+        switch (column) {
             case Ping:
             case Sent:
             case Received:
                 return QVariant(Qt::AlignRight | Qt::AlignVCenter);
             default:
                 return QVariant();
-        }
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     }
 
     return QVariant();

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -605,20 +605,22 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return QVariant();
     TransactionRecord *rec = static_cast<TransactionRecord*>(index.internalPointer());
 
-    switch(role)
-    {
+    const auto column = static_cast<ColumnIndex>(index.column());
+    switch (role) {
     case Qt::DecorationRole:
-        switch(index.column())
-        {
+        switch (column) {
         case Status:
             return txStatusDecoration(rec);
+        case Date: return {};
+        case Type: return {};
         case ToAddress:
             return txAddressDecoration(rec);
-        }
-        break;
+        case Amount: return {};
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     case Qt::DisplayRole:
-        switch(index.column())
-        {
+        switch (column) {
+        case Status: return {};
         case Date:
             return formatTxDate(rec);
         case Type:
@@ -627,12 +629,11 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return formatTxToAddress(rec, false);
         case Amount:
             return formatTxAmount(rec);
-        }
-        break;
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     case Qt::EditRole:
         // Edit role is used for sorting, so return the unformatted values
-        switch(index.column())
-        {
+        switch (column) {
         case Status:
             return QString::fromStdString(rec->status.sortKey);
         case Date:
@@ -643,8 +644,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return formatTxToAddress(rec, true);
         case Amount:
             return rec->credit + rec->debit;
-        }
-        break;
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     case Qt::ToolTipRole:
         return formatTooltip(rec);
     case Qt::TextAlignmentRole:

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -72,8 +72,8 @@ public:
                         return QString::number(row->m_vote_percent_AVW, 'f', 4);
                     case PollTableModel::TopAnswer:
                         return row->m_top_answer;
-                }
-                break;
+                } // no default case, so the compiler can warn about missing cases
+                assert(false);
 
             case Qt::TextAlignmentRole:
                 switch (index.column()) {
@@ -102,8 +102,8 @@ public:
                         return QVariant::fromValue(row->m_vote_percent_AVW);
                     case PollTableModel::TopAnswer:
                         return row->m_top_answer;
-                }
-                break;
+                } // no default case, so the compiler can warn about missing cases
+                assert(false);
         }
 
         return QVariant();


### PR DESCRIPTION
> This PR makes code more maintainable by leveraging `-Wswitch` compiler warnings.
> 
> Only the `RecentRequestsTableModel` is not refactored, because its `enum ColumnIndex` contains additional `NUMBER_OF_COLUMNS` value.
> 
> No behavior change.

Ref: https://github.com/bitcoin-core/gui/pull/166

This also adds Gridcoin-specific PollTableModel