### PR TITLE
util: Fix BN_zero macro in key.cpp for OpenSSL 3.0

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -141,7 +141,12 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     if (!BN_bin2bn(msg, msglen, e)) { ret=-1; goto err; }
     if (8*msglen > n) BN_rshift(e, e, 8-(n & 7));
     zero = BN_CTX_get(ctx);
-    if (!BN_zero(zero)) { ret=-1; goto err; }
+// This is because the header in bn.h for the BN_zero macro has changed the conditional between OpenSSL 1.1 and OpenSSL 3.0.
+#if OPENSSL_API_LEVEL > 908
+    BN_zero_ex(zero);
+#else
+    if (!BN_set_word((zero),0)) { ret=-1; goto err; }
+#endif
     if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
     rr = BN_CTX_get(ctx);
     if (!BN_mod_inverse(rr, pr, order, ctx)) { ret=-1; goto err; }


### PR DESCRIPTION
This is a short term change to get Gridcoin to compile against OpenSSL 3.0. Note that there are many deprecated function warnings during the compilation, but the wallet appears to run perfectly fine in Ubuntu 22.04 with this PR. This should suffice until we get @div72's libsecp256k1 PR's merged.