### PR TITLE
gui, util: Add AccrualChangedFromStakeOrMRC core signal

### DIFF
--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -9,12 +9,14 @@
 #include "gridcoin/accrual/null.h"
 #include "gridcoin/accrual/research_age.h"
 #include "gridcoin/accrual/snapshot.h"
+#include "gridcoin/researcher.h"
 #include "gridcoin/claim.h"
 #include "gridcoin/cpid.h"
 #include "gridcoin/quorum.h"
 #include "gridcoin/superblock.h"
 #include "gridcoin/tally.h"
 #include "util.h"
+#include "node/ui_interface.h"
 
 #include <unordered_map>
 
@@ -293,6 +295,14 @@ public:
             assert(pindex->nHeight > account.m_last_block_ptr->nHeight);
             account.m_last_block_ptr = pindex;
         }
+
+        const GRC::CpidOption walletholder_cpid = GRC::Researcher::Get()->Id().TryCpid();
+
+        // Signal that the stake results in an accrual change for the walletholder's cpid. This drastically reduces
+        // the signal frequency.
+        if (walletholder_cpid && *walletholder_cpid == cpid) {
+            uiInterface.AccrualChangedFromStakeOrMRC();
+        }
     }
 
     //!
@@ -340,6 +350,14 @@ public:
                       pindex->nHeight,
                       account.m_last_block_ptr->nHeight
                       );
+
+            const GRC::CpidOption walletholder_cpid = GRC::Researcher::Get()->Id().TryCpid();
+
+            // Signal that the stake results in an accrual change for the walletholder's cpid. This drastically reduces
+            // the signal frequency.
+            if (walletholder_cpid && *walletholder_cpid == cpid) {
+                uiInterface.AccrualChangedFromStakeOrMRC();
+            }
         }
     }
 

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2010-2020 The Bitcoin Core developers
+// Copyright (c) 2014-2022 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <node/ui_interface.h>
 
@@ -20,6 +21,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::BannedListChangedSig> BannedListChanged;
     boost::signals2::signal<CClientUIInterface::MinerStatusChangedSig> MinerStatusChanged;
     boost::signals2::signal<CClientUIInterface::ResearcherChangedSig> ResearcherChanged;
+    boost::signals2::signal<CClientUIInterface::AccrualChangedFromStakeOrMRCSig> AccrualChangedFromStakeOrMRC;
     boost::signals2::signal<CClientUIInterface::BeaconChangedSig> BeaconChanged;
     boost::signals2::signal<CClientUIInterface::NewPollReceivedSig> NewPollReceived;
     boost::signals2::signal<CClientUIInterface::NotifyScraperEventSig> NotifyScraperEvent;
@@ -46,6 +48,7 @@ ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 ADD_SIGNALS_IMPL_WRAPPER(MinerStatusChanged);
 ADD_SIGNALS_IMPL_WRAPPER(ResearcherChanged);
+ADD_SIGNALS_IMPL_WRAPPER(AccrualChangedFromStakeOrMRC);
 ADD_SIGNALS_IMPL_WRAPPER(BeaconChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NewPollReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyScraperEvent);
@@ -69,6 +72,7 @@ void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { re
 void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListChanged(); }
 void CClientUIInterface::MinerStatusChanged(bool staking, double coin_weight) { return g_ui_signals.MinerStatusChanged(staking, coin_weight); }
 void CClientUIInterface::ResearcherChanged() { return g_ui_signals.ResearcherChanged(); }
+void CClientUIInterface::AccrualChangedFromStakeOrMRC() { return g_ui_signals.AccrualChangedFromStakeOrMRC(); }
 void CClientUIInterface::BeaconChanged() { return g_ui_signals.BeaconChanged(); }
 void CClientUIInterface::NewPollReceived(int64_t poll_time) { return g_ui_signals.NewPollReceived(poll_time); }
 void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -123,7 +123,7 @@ public:
     /** Researcher context changed */
     ADD_SIGNALS_DECL_WRAPPER(ResearcherChanged, void);
 
-    /** Researcher context changed */
+    /** Walletholder accrual changed as a result of stake or MRC to the walletholder */
     ADD_SIGNALS_DECL_WRAPPER(AccrualChangedFromStakeOrMRC, void);
 
     /** Beacon changed */

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2012-2020 The Bitcoin developers
+// Copyright (c) 2014-2022 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -121,6 +122,9 @@ public:
 
     /** Researcher context changed */
     ADD_SIGNALS_DECL_WRAPPER(ResearcherChanged, void);
+
+    /** Researcher context changed */
+    ADD_SIGNALS_DECL_WRAPPER(AccrualChangedFromStakeOrMRC, void);
 
     /** Beacon changed */
     ADD_SIGNALS_DECL_WRAPPER(BeaconChanged, void);

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -45,6 +45,16 @@ void ResearcherChanged(ResearcherModel* model)
 }
 
 //!
+//! \brief Model callback bound to the \c AccrualChangedFromStakeOrMRC core signal.
+//!
+void AccrualChangedFromStakeOrMRC(ResearcherModel* model)
+{
+    LogPrint(LogFlags::QT, "GUI: received ResearcherChanged() core signal");
+
+    QMetaObject::invokeMethod(model, "accrualChanged", Qt::QueuedConnection);
+}
+
+//!
 //! \brief Model callback bound to the \c BeaconChanged core signal.
 //!
 void BeaconChanged(ResearcherModel* model)
@@ -645,6 +655,7 @@ void ResearcherModel::subscribeToCoreSignals()
 {
     // Connect signals to client
     uiInterface.ResearcherChanged_connect(std::bind(ResearcherChanged, this));
+    uiInterface.AccrualChangedFromStakeOrMRC_connect(std::bind(AccrualChangedFromStakeOrMRC, this));
     uiInterface.BeaconChanged_connect(std::bind(BeaconChanged, this));
 }
 


### PR DESCRIPTION
This adds a core UI signal that is activated when a stake or MRC payment occurs to the cpid that matches the walletholder. This ensures that the pending accrual will be immediately updated when a stake or MRC payment occurs that changes the accrual for the walletholder.