### PR TITLE
rpc, contract: Adjust ValidateMRC, CreateMRC, and createmrcrequest to correct provided fee handling

### DIFF
--- a/src/gridcoin/mrc.cpp
+++ b/src/gridcoin/mrc.cpp
@@ -209,54 +209,8 @@ uint256 MRC::GetHash() const
 
 bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransaction& tx) const
 {
-    // The MRC transaction should only have one contract on it, and the contract type should be MRC (which we already
-    // know to arrive at this virtual method implementation).
-    if (tx.GetContracts().size() != 1) return false;
-
-    // Check that the burn in the contract is equal or greater than the required burn.
-    CAmount burn_amount = 0;
-
-    for (const auto& output : tx.vout) {
-        if (output.scriptPubKey == (CScript() << OP_RETURN)) {
-            burn_amount += output.nValue;
-        }
-    }
-
-    GRC::MRC mrc = contract.CopyPayloadAs<GRC::MRC>();
-
-    LogPrintf("INFO: %s: mrc m_client_version = %s, m_fee = %s, m_last_block_hash = %s, m_magnitude = %u, "
-              "m_magnitude_unit = %f, m_mining_id = %s, m_organization = %s, m_research_subsidy = %s, "
-              "m_version = %s",
-              __func__,
-              mrc.m_client_version,
-              FormatMoney(mrc.m_fee),
-              mrc.m_last_block_hash.GetHex(),
-              mrc.m_magnitude,
-              mrc.m_magnitude_unit,
-              mrc.m_mining_id.ToString(),
-              mrc.m_organization,
-              FormatMoney(mrc.m_research_subsidy),
-              mrc.m_version);
-
-    if (burn_amount < mrc.RequiredBurnAmount()) {
-        return error("%s: Burn amount of %s in mrc contract is less than the required %s.",
-                     __func__,
-                     FormatMoney(mrc.m_fee),
-                     FormatMoney(mrc.RequiredBurnAmount())
-                     );
-    }
-
-    // We cannot fully validate incoming mrc transactions to the mempool. During testing under stress, a node can send an
-    // mrc transaction right before the receipt of a block staked by another node, which then results in the just submitted
-    // transaction being invalid on nodes that receive it after the staked block, but valid on the sending node (because
-    // the order is reversed). To avoid this we will relieve the strict requirement here and do a partial validation which
-    // checks the burn fee and the MRC contract signature to ensure the MRC contract is validly signed by an active beacon
-    // holder. The block level validations handle the full MRC validation. This completes the concept of a "bad" or "stale"
-    // mrc transaction being accepted into the memory pool. They will also be bound into the block, but they will be
-    // "absorbed," meaning they will not result in a coinstake payout to the mrc requester. The deterrent to prevent someone
-    // from flooding the mempool with invalid mrc transactions that pass this level of checking is the loss of the burn fees
-    // AND the trouble to create the valid beacon context and signature for each MRC request transaction.
-    return ValidateMRC(tx, mrc);
+    // Fully validate the incoming MRC txn.
+    return ValidateMRC(contract, tx);
 }
 
 namespace {

--- a/src/gridcoin/mrc.h
+++ b/src/gridcoin/mrc.h
@@ -337,7 +337,7 @@ public:
 //! \param pindexPrev: The index for the last block (head of the chain) when the MRC was created.
 //! \param mrc: The MRC contract object itself (out parameter)
 //! \param nReward: The research reward (out parameter)
-//! \param fee: The MRC fees to be taken out of the research reward (out parameter)
+//! \param fee: The MRC fees to be taken out of the research reward (in/out parameter)
 //! \param pwallet: The wallet object
 //! \return
 //!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4645,7 +4645,7 @@ bool ValidateMRC(const GRC::Contract& contract, const CTransaction& tx)
     // The MRC transaction should only have one contract on it, and the contract type should be MRC (which we already
     // know to arrive at this virtual method implementation).
     if (tx.GetContracts().size() != 1) {
-        return error("%s: Validation failed: The transaction, hash %s, that contains the MRC has more than contract.",
+        return error("%s: Validation failed: The transaction, hash %s, that contains the MRC has more than one contract.",
                      __func__,
                      tx.GetHash().GetHex());
     }

--- a/src/main.h
+++ b/src/main.h
@@ -131,7 +131,7 @@ unsigned int GetCoinstakeOutputLimit(const int& block_version);
 Fraction FoundationSideStakeAllocation();
 CBitcoinAddress FoundationSideStakeAddress();
 unsigned int GetMRCOutputLimit(const int& block_version, bool include_foundation_sidestake);
-bool ValidateMRC(const CTransaction& tx, const GRC::MRC& mrc);
+bool ValidateMRC(const GRC::Contract &contract, const CTransaction& tx);
 bool ValidateMRC(const CBlockIndex* mrc_last_pindex, const GRC::MRC& mrc);
 
 int GetNumBlocksOfPeers();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1048,11 +1048,11 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
     // [MRC 1], ..., [MRC p].
     //
     // Currently according to the output limit rules encoded in CreateMRC and here:
-    // For block version 10:
+    // For block version 10-11:
     // one empty, m <= 6, m + n <= 7, and p = 0.
     //
-    // For block version 11 and above:
-    // one empty, m <= 6, m + n <= 7, and p <= 5.
+    // For block version 12:
+    // one empty, m <= 6, m + n <= 10, and p <= 10.
 
     // The total generated GRC is the total of the reward splits - the fees (the original GridcoinReward which is the
     // research reward + CBR), plus the total of the MRC outputs 2 to p (these outputs already have the fees subtracted)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2522,22 +2522,16 @@ UniValue createmrcrequest(const UniValue& params, const bool fHelp) {
         throw runtime_error("MRC requests require version 12 blocks to be active.");
     }
 
-    if (!GRC::CreateMRC(pindex, mrc, reward, fee, pwalletMain)) {
-        throw runtime_error("MRC request creation failed.");
+    // If the fee is provided, set the fee for the CreateMRC to this value to override the calculated fee.
+    if (provided_fee != 0) {
+        fee = provided_fee;
     }
 
-    if (provided_fee != 0) {
-        if (!force) {
-            if (provided_fee < fee) {
-                throw runtime_error("Provided fee lower than required.");
-            }
-
-            if (provided_fee > mrc.m_research_subsidy) {
-                throw runtime_error("Provided fee higher than subsidy.");
-            }
-        }
-
-        mrc.m_fee = provided_fee;
+    // If the fee is not overridden by the provided fee above (i.e. zero), it will be filled in
+    // at the calculated mrc value by CreateMRC. CreateMRC also rechecks the bounds
+    // of the provided fee.
+    if (!GRC::CreateMRC(pindex, mrc, reward, fee, pwalletMain)) {
+        throw runtime_error("MRC request creation failed. Please check the log for details.");
     }
 
     if (!dry_run && !force && reward == fee) {

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(createmrc_creates_valid_mrcs)
 {
     account.m_accrual = 72;
     GRC::MRC mrc;
-    CAmount reward, fee;
+    CAmount reward, fee{0};
     GRC::CreateMRC(pindex->pprev, mrc, reward, fee, wallet);
 
     BOOST_CHECK_EQUAL(reward, 72);
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(it_accepts_valid_fees)
 {
     account.m_accrual = 72;
     GRC::MRC mrc;
-    CAmount reward, fee;
+    CAmount reward, fee{0};
     GRC::CreateMRC(pindex->pprev, mrc, reward, fee, wallet);
 
     mrc.m_fee = 14;


### PR DESCRIPTION
This PR makes adjustments to ValidateMRC, CreateMRC, and the associated createmrcrequest to properly accommodate provided fees other than the (minimum) calculated value. Without this PR, specifying a provided fee resulted in an error if it was not exactly equal to the calculated minimum fee.