### PR TITLE
gui: Modify VerifyTCPPort to use the status of CheckOutboundConnectionCount

### DIFF
--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -142,6 +142,8 @@ void DiagnosticsDialog::UpdateTestResult(std::string test_name, DiagnosticResult
 
 DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetTestResult(std::string test_name)
 {
+    LOCK(cs_diagnostictests);
+
     DiagnosticResult result;
 
     auto iter = m_test_result_map.find(test_name);

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -126,17 +126,41 @@ unsigned int DiagnosticsDialog::UpdateTestStatus(std::string test_name, QLabel *
 
     SetResultLabel(label, test_status, test_result, override_text, tooltip_text);
 
+    UpdateTestResult(test_name, test_result);
+
     UpdateOverallDiagnosticResult(test_result);
 
     return m_test_status_map.size();
 }
 
+void DiagnosticsDialog::UpdateTestResult(std::string test_name, DiagnosticResult test_result)
+{
+    LOCK(cs_diagnostictests);
+
+    m_test_result_map[test_name] = test_result;
+}
+
+DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetTestResult(std::string test_name)
+{
+    DiagnosticResult result;
+
+    auto iter = m_test_result_map.find(test_name);
+
+    if (iter == m_test_result_map.end()) {
+        result = NA;
+    } else {
+        result = iter->second;
+    }
+
+    return result;
+}
 
 void DiagnosticsDialog::ResetOverallDiagnosticResult()
 {
     LOCK(cs_diagnostictests);
 
     m_test_status_map.clear();
+    m_test_result_map.clear();
 
     m_overall_diagnostic_result_status = pending;
 
@@ -541,6 +565,17 @@ void DiagnosticsDialog::clkReportResults(const int64_t& time_offset, const bool&
 void DiagnosticsDialog::VerifyTCPPort()
 {
     UpdateTestStatus(__func__, ui->verifyTCPPortResultLabel, pending, NA);
+
+    // Note that if the CheckConnectionCount test has been run already (which it must given the order the tests are
+    // run above), then the test result cannot be NA. So if it did not fail, it must be either warning or passed,
+    // which is sufficient in and of itself to mark VerifyTCPPort() successful without further testing, since
+    // to get valid outbound connections, the port must be working.
+    if (GetTestStatus("CheckConnectionCount") == completed
+            && GetTestResult("CheckConnectionCount") != failed) {
+        UpdateTestStatus("VerifyTCPPort", ui->verifyTCPPortResultLabel, completed, passed);
+
+        return;
+    }
 
     m_tcpSocket = new QTcpSocket(this);
 

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -75,9 +75,11 @@ private:
     // Boolean to indicate researcher mode.
     bool m_researcher_mode = true;
 
-    // Holds the test status entries
+    // Holds the test status and result entries
     typedef std::unordered_map<std::string, DiagnosticTestStatus> DiagnosticTestStatus_map;
+    typedef std::unordered_map<std::string, DiagnosticResult> DiagnosticTestResult_map;
     DiagnosticTestStatus_map m_test_status_map;
+    DiagnosticTestResult_map m_test_result_map;
 
     ResearcherModel *m_researcher_model;
 
@@ -91,8 +93,10 @@ public:
                                   DiagnosticTestStatus test_status, DiagnosticResult test_result,
                                   QString override_text = QString(), QString tooltip_text = QString());
     DiagnosticTestStatus GetTestStatus(std::string test_name);
+    void UpdateTestResult(std::string test_name, DiagnosticResult test_result);
     void ResetOverallDiagnosticResult();
     void UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in);
+    DiagnosticResult GetTestResult(std::string test_name);
     DiagnosticResult GetOverallDiagnosticResult();
     DiagnosticTestStatus GetOverallDiagnosticStatus();
     void DisplayOverallDiagnosticResult();


### PR DESCRIPTION
Note that the VerifyTCPPort test has historically used the port testing service portquiz.net. This service has gone down in the past. Since we are checking outbound and the CheckOutboundConnection test is done first, if that check did not fail, simply mark the VerifyTCPPort test successful, since the port must be working properly if successful outbound connections have been made. This makes it much less likely to get an inaccurate Port test, since BOTH no connections would have to be occurring AND portquiz.net would have to be down.

Obviously using more than one port verification service as a fallback would eliminate this possibility entirely, but this is reserved for consideration when the diagnostics get refactored to address #2477. (The diagnostics really need to be refactored anyway. I did a refactoring a while back to clean up some of the mess, but it still is ugly.)

This PR is sufficient to close #2445.