### PR TITLE
util: Change default -dbcache to 100 MB and also implement -txindexdbcache

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -29,7 +29,9 @@ leveldb::DB *txdb; // global pointer for LevelDB object instance
 
 static leveldb::Options GetOptions() {
     leveldb::Options options;
-    int nCacheSizeMB = gArgs.GetArg("-dbcache", 25);
+
+    int nCacheSizeMB = std::clamp<int>(gArgs.GetArg("-txindexdbcache", nDefaultDbCache), nMinDbCache, nMaxTxIndexCache);
+
     options.block_cache = leveldb::NewLRUCache(nCacheSizeMB * 1048576);
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     return options;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -14,6 +14,18 @@
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
 
+// Note in Bitcoin these are in txdb.h, and we will eventually move them there when the db code is refactored.
+//! -dbcache default (MiB). This is for both bdb (the wallet) and leveldb (the transaction db).
+static const int64_t nDefaultDbCache = 100;
+//! max. -dbcache (MiB)
+//! Note that Bitcoin uses sizeof(void*) > 4 ? 16384 : 1024, but this includes the mempool. In Gridcoin it does not,
+//! so we use 1024 as the max.
+static const int64_t nMaxDbCache = 1024;
+//! min. -dbcache (MiB)
+static const int64_t nMinDbCache = 4;
+//! Max memory allocated to block tree DB (leveldb) cache. There is little performance gain over 1024 MB.
+static const int64_t nMaxTxIndexCache = 1024;
+
 // Class that provides access to a LevelDB. Note that this class is frequently
 // instantiated on the stack and then destroyed again, so instantiation has to
 // be very cheap. Unfortunately that means, a CTxDB instance is actually just a

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -298,7 +298,12 @@ void SetupServerArgs()
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-wallet=<dir>", "Specify wallet file (within data directory)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-dbcache=<n>", "Set database cache size in megabytes (default: 25)",
+    argsman.AddArg("-dbcache=<n>", strprintf("Set database cache size in megabytes (%d to %d, default: %d)",
+                                             nMinDbCache, nMaxDbCache, nDefaultDbCache),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-txindexdbcache=<n>", strprintf("Set txindex (leveldb) database cache size in megabytes "
+                                                    "(%d to %d, default: %d)",
+                                                    nMinDbCache, nMaxTxIndexCache, nDefaultDbCache),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-dblogsize=<n>", "Set database disk log size in megabytes (default: 100)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "wallet/db.h"
+#include "dbwrapper.h"
 #include "net.h"
 #include "main.h"
 #include "node/ui_interface.h"
@@ -74,7 +75,7 @@ bool CDBEnv::Open(fs::path pathEnv_)
     if (gArgs.GetBoolArg("-privdb", true))
         nEnvFlags |= DB_PRIVATE;
 
-    int nDbCache = gArgs.GetArg("-dbcache", 25);
+    int nDbCache = std::clamp<int>(gArgs.GetArg("-dbcache", nDefaultDbCache), nMinDbCache, nMaxDbCache);
     dbenv.set_lg_dir(pathLogDir.string().c_str());
     dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
     dbenv.set_lg_bsize(1048576);


### PR DESCRIPTION
This raises the default dbcache to 100 MB from 25 MB. It also clamps the min and max to reasonable values similar to upstream (Bitcoin). It also implements a separate setting for the leveldb cache, -txindexdbcache with the same default, 100 MB.

Closes #2238, closes #2239.