### PR TITLE
rpc, util, consensus: Implement exception handling framework for MRC and fix ValidateMRC to deal with testnet consensus issue

### DIFF
--- a/src/gridcoin/mrc.h
+++ b/src/gridcoin/mrc.h
@@ -18,6 +18,15 @@
 class CPubKey;
 
 namespace GRC {
+class MRC_error : public std::runtime_error
+{
+public:
+    explicit MRC_error(const std::string& str) : std::runtime_error("ERROR: " + str)
+    {
+        LogPrintf("ERROR: %s", str);
+    }
+};
+
 //!
 //! \brief Contains the reward claim context embedded in each generated block.
 //!
@@ -341,7 +350,7 @@ public:
 //! \param pwallet: The wallet object
 //! \return
 //!
-bool CreateMRC(CBlockIndex* pindex, MRC& mrc, CAmount &nReward, CAmount &fee, CWallet* pwallet);
+void CreateMRC(CBlockIndex* pindex, MRC& mrc, CAmount &nReward, CAmount &fee, CWallet* pwallet);
 
 
 } // namespace GRC

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -392,7 +392,7 @@ bool GRC::ReadStakedInput(
     // Get transaction index for the previous transaction
     if (!txdb.ReadTxIndex(prevout_hash, tx_index)) {
         // Previous transaction not in main chain, may occur during initial download
-        return error("%s: tx index not found", __func__);
+        return error("%s: tx index not found for input tx %s", __func__, prevout_hash.GetHex());
     }
 
     const CDiskTxPos pos = tx_index.pos;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2530,8 +2530,10 @@ UniValue createmrcrequest(const UniValue& params, const bool fHelp) {
     // If the fee is not overridden by the provided fee above (i.e. zero), it will be filled in
     // at the calculated mrc value by CreateMRC. CreateMRC also rechecks the bounds
     // of the provided fee.
-    if (!GRC::CreateMRC(pindex, mrc, reward, fee, pwalletMain)) {
-        throw runtime_error("MRC request creation failed. Please check the log for details.");
+    try {
+        GRC::CreateMRC(pindex, mrc, reward, fee, pwalletMain);
+    } catch (GRC::MRC_error& e) {
+        throw runtime_error(e.what());
     }
 
     if (!dry_run && !force && reward == fee) {

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(createmrc_creates_valid_mrcs)
 {
     account.m_accrual = 72;
     GRC::MRC mrc;
-    CAmount reward, fee{0};
+    CAmount reward{0}, fee{0};
     GRC::CreateMRC(pindex->pprev, mrc, reward, fee, wallet);
 
     BOOST_CHECK_EQUAL(reward, 72);
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(it_accepts_valid_fees)
 {
     account.m_accrual = 72;
     GRC::MRC mrc;
-    CAmount reward, fee{0};
+    CAmount reward{0}, fee{0};
     GRC::CreateMRC(pindex->pprev, mrc, reward, fee, wallet);
 
     mrc.m_fee = 14;
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(it_creates_valid_mrc_claims)
     BOOST_CHECK(CreateRestOfTheBlock(block, pindex->pprev, mrc_map));
 
     GRC::MRC mrc;
-    CAmount reward, fee;
+    CAmount reward{0}, fee{0};
     GRC::CreateMRC(pindex->pprev, mrc, reward, fee, wallet);
     mrc_map[cpid] = {uint256{}, mrc};
 


### PR DESCRIPTION
This implements a simple exception handling class for MRC that is an extension of std::runtime_error. It is similar to the bignum_error class.

The MRC_error initializer issues a LogPrintf to the log with the error, so the throwing function does not have to worry about logging the error separately.

We can get much fancier later, and we need to implement a rigorous exception handling framework across the board IMHO, but this is good enough for the intended purpose here, which is to provide more detailed error feedback to createmrcrequest.