### PR TITLE
lockedpool: When possible, use madvise to avoid including sensitive information in core dumps

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -249,6 +249,9 @@ void *PosixLockedPageAllocator::AllocateLocked(size_t len, bool *lockingSuccess)
     }
     if (addr) {
         *lockingSuccess = mlock(addr, len) == 0;
+#ifdef MADV_DONTDUMP
+        madvise(addr, len, MADV_DONTDUMP);
+#endif
     }
     return addr;
 }

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -249,8 +249,10 @@ void *PosixLockedPageAllocator::AllocateLocked(size_t len, bool *lockingSuccess)
     }
     if (addr) {
         *lockingSuccess = mlock(addr, len) == 0;
-#ifdef MADV_DONTDUMP
+#if defined(MADV_DONTDUMP) // Linux
         madvise(addr, len, MADV_DONTDUMP);
+#elif defined(MADV_NOCORE) // FreeBSD
+        madvise(addr, len, MADV_NOCORE);
 #endif
     }
     return addr;


### PR DESCRIPTION
> If we're mlocking something, it's because it's sensitive information. Therefore, don't include it in core dump files
> 
> The return value is not checked because the madvise calls might fail on older kernels as a rule (unsure).

Ref: https://github.com/bitcoin/bitcoin/pull/15600

Fixes CVE-2019-15947 - https://github.com/bitcoin/bitcoin/issues/16824

Also FreeBSD

https://github.com/bitcoin/bitcoin/pull/18443
