### PR TITLE
consensus: Move DoS into contract validators to allow variability of DoS based on context and further fixes to ValidateMRC

### DIFF
--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -613,10 +613,11 @@ public:
     //!
     //! \param contract Contains the beacon data to validate.
     //! \param tx       Transaction that contains the contract.
+    //! \param DoS      Misbehavior out.
     //!
     //! \return \c true if the contract contains a valid beacon.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int &DoS) const override;
 
     //!
     //! \brief Register a beacon from contract data.

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -158,7 +158,7 @@ public:
         ClearCache(Section::SCRAPER);
     }
 
-    bool Validate(const Contract& contract, const CTransaction& tx) const override
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override
     {
         return true; // No contextual validation needed yet
     }
@@ -195,7 +195,7 @@ public:
         // Nothing to do.
     }
 
-    bool Validate(const Contract& contract, const CTransaction& tx) const override
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override
     {
         return true; // No contextual validation needed yet
     }
@@ -279,12 +279,13 @@ public:
     //!
     //! \param contract Contract to validate.
     //! \param tx       Transaction that contains the contract.
+    //! \param DoS      Misbehavior score out.
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx)
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS)
     {
-        return GetHandler(contract.m_type.Value()).Validate(contract, tx);
+        return GetHandler(contract.m_type.Value()).Validate(contract, tx, DoS);
     }
 
     //!
@@ -595,10 +596,10 @@ void GRC::ApplyContracts(
     }
 }
 
-bool GRC::ValidateContracts(const CTransaction& tx)
+bool GRC::ValidateContracts(const CTransaction& tx, int& DoS)
 {
     for (const auto& contract : tx.GetContracts()) {
-        if (!g_dispatcher.Validate(contract, tx)) {
+        if (!g_dispatcher.Validate(contract, tx, DoS)) {
             return false;
         }
     }

--- a/src/gridcoin/contract/contract.h
+++ b/src/gridcoin/contract/contract.h
@@ -514,10 +514,11 @@ void ApplyContracts(
 //! \brief Perform contextual validation for the contracts in a transaction.
 //!
 //! \param tx Transaction to validate contracts for.
+//! \param DoS Misbehavior score out parameter
 //!
 //! \return \c false When a contract in the transaction fails validation.
 //!
-bool ValidateContracts(const CTransaction& tx);
+bool ValidateContracts(const CTransaction& tx, int& DoS);
 
 //!
 //! \brief Revert previously-applied contracts from a transaction by passing

--- a/src/gridcoin/contract/handler.h
+++ b/src/gridcoin/contract/handler.h
@@ -77,10 +77,11 @@ struct IContractHandler
     //!
     //! \param contract Contract to validate.
     //! \param tx       Transaction that contains the contract.
+    //! \param DoS      Misbehavior score out.
     //!
     //! \return \c false If the contract fails validation.
     //!
-    virtual bool Validate(const Contract& contract, const CTransaction& tx) const = 0;
+    virtual bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const = 0;
 
     //!
     //! \brief Destroy the contract handler state to prepare for historical

--- a/src/gridcoin/mrc.cpp
+++ b/src/gridcoin/mrc.cpp
@@ -207,10 +207,10 @@ uint256 MRC::GetHash() const
     return hasher.GetHash();
 }
 
-bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransaction& tx) const
+bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const
 {
     // Fully validate the incoming MRC txn.
-    return ValidateMRC(contract, tx);
+    return ValidateMRC(contract, tx, DoS);
 }
 
 namespace {

--- a/src/gridcoin/mrc.h
+++ b/src/gridcoin/mrc.h
@@ -322,7 +322,7 @@ public:
     // Reset is a noop for MRC's here.
     void Reset() override {}
 
-    bool Validate(const Contract& contract, const CTransaction& tx) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
 
     // Add is a noop here, because this is handled at the block level by the staker (in the miner) as with the claim.
     void Add(const ContractContext& ctx) override {}

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -297,10 +297,11 @@ public:
     //!
     //! \param contract Contract to validate.
     //! \param tx       Transaction that contains the contract.
+    //! \param DoS      Misbehavior score out
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx) const override
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override
     {
         return true; // No contextual validation needed yet
     }

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -357,10 +357,11 @@ public:
     //!
     //! \param contract Contract to validate.
     //! \param tx       Transaction that contains the contract.
+    //! \param DoS      Misbehavior score out.
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
 
     //!
     //! \brief Register a poll or vote from contract data.

--- a/src/main.h
+++ b/src/main.h
@@ -131,7 +131,7 @@ unsigned int GetCoinstakeOutputLimit(const int& block_version);
 Fraction FoundationSideStakeAllocation();
 CBitcoinAddress FoundationSideStakeAddress();
 unsigned int GetMRCOutputLimit(const int& block_version, bool include_foundation_sidestake);
-bool ValidateMRC(const GRC::Contract &contract, const CTransaction& tx);
+bool ValidateMRC(const GRC::Contract &contract, const CTransaction& tx, int& DoS);
 bool ValidateMRC(const CBlockIndex* mrc_last_pindex, const GRC::MRC& mrc);
 
 int GetNumBlocksOfPeers();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -374,7 +374,8 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev,
             // that we don't include a transaction that disrupts validation of
             // the block:
             //
-            if (!tx.GetContracts().empty() && !GRC::ValidateContracts(tx)) {
+            int DoS = 0; // Unused here.
+            if (!tx.GetContracts().empty() && !GRC::ValidateContracts(tx, DoS)) {
                 LogPrint(BCLog::LogFlags::MINER,
                     "%s: contract failed contextual validation. Skipped tx %s",
                     __func__,


### PR DESCRIPTION
This PR moves the assignment of DoS into the contract validation methods to allow different DoS's to be assigned based on different context/error conditions. This is used in ValidateMRC because different validation failures have different severities.

ValidateMRC was also refactored to implement the DoS scoring, and several other problems corrected.

Note the conditions used for the testnet and mainnet for the exertion of the reject_payment_interval validation have been refined. They are compatible with all current blocks containing MRC on testnet.