### PR TITLE
gui: Initial implementation of GUI MRC submission form

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -146,6 +146,7 @@ QT_MOC_CPP = \
   qt/moc_guiutil.cpp \
   qt/moc_intro.cpp \
   qt/moc_mrcmodel.cpp \
+  qt/moc_mrcrequestpage.cpp \
   qt/moc_monitoreddatamapper.cpp \
   qt/moc_noresult.cpp \
   qt/moc_notificator.cpp \
@@ -254,6 +255,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/macos_appnap.h \
   qt/monitoreddatamapper.h \
   qt/mrcmodel.h \
+  qt/mrcrequestpage.h \
   qt/noresult.h \
   qt/notificator.h \
   qt/optionsdialog.h \
@@ -338,6 +340,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/intro.cpp \
   qt/monitoreddatamapper.cpp \
   qt/mrcmodel.cpp \
+  qt/mrcrequestpage.cpp \
   qt/noresult.cpp \
   qt/notificator.cpp \
   qt/optionsdialog.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -85,6 +85,7 @@ QT_FORMS_UI = \
   qt/forms/editaddressdialog.ui \
   qt/forms/favoritespage.ui \
   qt/forms/intro.ui \
+  qt/forms/mrcrequestpage.ui \
   qt/forms/noresult.ui \
   qt/forms/optionsdialog.ui \
   qt/forms/overviewpage.ui \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -145,6 +145,7 @@ QT_MOC_CPP = \
   qt/moc_favoritespage.cpp \
   qt/moc_guiutil.cpp \
   qt/moc_intro.cpp \
+  qt/moc_mrcmodel.cpp \
   qt/moc_monitoreddatamapper.cpp \
   qt/moc_noresult.cpp \
   qt/moc_notificator.cpp \
@@ -252,6 +253,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/macnotificationhandler.h \
   qt/macos_appnap.h \
   qt/monitoreddatamapper.h \
+  qt/mrcmodel.h \
   qt/noresult.h \
   qt/notificator.h \
   qt/optionsdialog.h \
@@ -335,6 +337,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/guiutil.cpp \
   qt/intro.cpp \
   qt/monitoreddatamapper.cpp \
+  qt/mrcmodel.cpp \
   qt/noresult.cpp \
   qt/notificator.cpp \
   qt/optionsdialog.cpp \

--- a/src/gridcoin/mrc.cpp
+++ b/src/gridcoin/mrc.cpp
@@ -283,7 +283,7 @@ void GRC::CreateMRC(CBlockIndex* pindex,
                     MRC& mrc,
                     CAmount &nReward,
                     CAmount &fee,
-                    CWallet* pwallet) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+                    CWallet* pwallet, bool no_sign) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const GRC::ResearcherPtr researcher = GRC::Researcher::Get();
 
@@ -356,16 +356,14 @@ void GRC::CreateMRC(CBlockIndex* pindex,
         }
     }
 
-    if (!TrySignMRC(pwallet, pindex, mrc)) {
+    if (!no_sign && !TrySignMRC(pwallet, pindex, mrc)) {
         throw MRC_error(strprintf("%s: Failed to sign mrc.", __func__));
     }
 
-    LogPrintf(
-        "INFO: %s: for %s mrc %s magnitude %d Research %s",
-        __func__,
-        mrc.m_mining_id.ToString(),
-        FormatMoney(nReward),
-        mrc.m_magnitude,
-        FormatMoney(mrc.m_research_subsidy));
+    LogPrintf("INFO: %s: for %s mrc request created: magnitude %d, research rewards %s, mrc fee %s.",
+                __func__,
+                mrc.m_mining_id.ToString(),
+                mrc.m_magnitude,
+                FormatMoney(mrc.m_research_subsidy),
+                FormatMoney(mrc.m_fee));
 }
-

--- a/src/gridcoin/mrc.h
+++ b/src/gridcoin/mrc.h
@@ -348,9 +348,10 @@ public:
 //! \param nReward: The research reward (out parameter)
 //! \param fee: The MRC fees to be taken out of the research reward (in/out parameter)
 //! \param pwallet: The wallet object
+//! \param no_sign: If true, don't sign the MRC (trail run).
 //! \return
 //!
-void CreateMRC(CBlockIndex* pindex, MRC& mrc, CAmount &nReward, CAmount &fee, CWallet* pwallet);
+void CreateMRC(CBlockIndex* pindex, MRC& mrc, CAmount &nReward, CAmount &fee, CWallet* pwallet, bool no_sign = false);
 
 
 } // namespace GRC

--- a/src/gridcoin/mrc.h
+++ b/src/gridcoin/mrc.h
@@ -348,7 +348,7 @@ public:
 //! \param nReward: The research reward (out parameter)
 //! \param fee: The MRC fees to be taken out of the research reward (in/out parameter)
 //! \param pwallet: The wallet object
-//! \param no_sign: If true, don't sign the MRC (trail run).
+//! \param no_sign: If true, don't sign the MRC (trial run).
 //! \return
 //!
 void CreateMRC(CBlockIndex* pindex, MRC& mrc, CAmount &nReward, CAmount &fee, CWallet* pwallet, bool no_sign = false);

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -22,6 +22,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::MinerStatusChangedSig> MinerStatusChanged;
     boost::signals2::signal<CClientUIInterface::ResearcherChangedSig> ResearcherChanged;
     boost::signals2::signal<CClientUIInterface::AccrualChangedFromStakeOrMRCSig> AccrualChangedFromStakeOrMRC;
+    boost::signals2::signal<CClientUIInterface::MRCChangedSig> MRCChanged;
     boost::signals2::signal<CClientUIInterface::BeaconChangedSig> BeaconChanged;
     boost::signals2::signal<CClientUIInterface::NewPollReceivedSig> NewPollReceived;
     boost::signals2::signal<CClientUIInterface::NotifyScraperEventSig> NotifyScraperEvent;
@@ -49,6 +50,7 @@ ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 ADD_SIGNALS_IMPL_WRAPPER(MinerStatusChanged);
 ADD_SIGNALS_IMPL_WRAPPER(ResearcherChanged);
 ADD_SIGNALS_IMPL_WRAPPER(AccrualChangedFromStakeOrMRC);
+ADD_SIGNALS_IMPL_WRAPPER(MRCChanged);
 ADD_SIGNALS_IMPL_WRAPPER(BeaconChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NewPollReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyScraperEvent);
@@ -73,6 +75,7 @@ void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListCha
 void CClientUIInterface::MinerStatusChanged(bool staking, double coin_weight) { return g_ui_signals.MinerStatusChanged(staking, coin_weight); }
 void CClientUIInterface::ResearcherChanged() { return g_ui_signals.ResearcherChanged(); }
 void CClientUIInterface::AccrualChangedFromStakeOrMRC() { return g_ui_signals.AccrualChangedFromStakeOrMRC(); }
+void CClientUIInterface::MRCChanged() { return g_ui_signals.MRCChanged(); }
 void CClientUIInterface::BeaconChanged() { return g_ui_signals.BeaconChanged(); }
 void CClientUIInterface::NewPollReceived(int64_t poll_time) { return g_ui_signals.NewPollReceived(poll_time); }
 void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -126,6 +126,9 @@ public:
     /** Walletholder accrual changed as a result of stake or MRC to the walletholder */
     ADD_SIGNALS_DECL_WRAPPER(AccrualChangedFromStakeOrMRC, void);
 
+    /** MRC state changed */
+    ADD_SIGNALS_DECL_WRAPPER(MRCChanged, void);
+
     /** Beacon changed */
     ADD_SIGNALS_DECL_WRAPPER(BeaconChanged, void);
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -12,6 +12,7 @@
 #include "clientmodel.h"
 #include "walletmodel.h"
 #include "researcher/researchermodel.h"
+#include "mrcmodel.h"
 #include "voting/votingmodel.h"
 #include "optionsmodel.h"
 #include "guiutil.h"
@@ -663,11 +664,13 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 ClientModel clientModel(&optionsModel);
                 WalletModel walletModel(pwalletMain, &optionsModel);
                 ResearcherModel researcherModel;
+                MRCModel mrcModel(&walletModel, &clientModel);
                 VotingModel votingModel(clientModel, optionsModel, walletModel);
 
                 window.setResearcherModel(&researcherModel);
                 window.setClientModel(&clientModel);
                 window.setWalletModel(&walletModel);
+                window.setMRCModel(&mrcModel);
                 window.setVotingModel(&votingModel);
 
                 // If -min option passed, start window minimized.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -664,7 +664,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 ClientModel clientModel(&optionsModel);
                 WalletModel walletModel(pwalletMain, &optionsModel);
                 ResearcherModel researcherModel;
-                MRCModel mrcModel(&walletModel, &clientModel);
+                MRCModel mrcModel(&walletModel, &clientModel, &researcherModel);
                 VotingModel votingModel(clientModel, optionsModel, walletModel);
 
                 window.setResearcherModel(&researcherModel);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -830,6 +830,17 @@ void BitcoinGUI::setResearcherModel(ResearcherModel *researcherModel)
     connect(researcherModel, &ResearcherModel::beaconChanged, this, &BitcoinGUI::updateBeaconIcon);
 }
 
+void BitcoinGUI::setMRCModel(MRCModel *mrcModel)
+{
+    m_mrc_model = mrcModel;
+
+    if (!mrcModel) {
+        return;
+    }
+
+    overviewPage->setMRCModel(mrcModel);
+}
+
 void BitcoinGUI::setVotingModel(VotingModel *votingModel)
 {
     this->votingModel = votingModel;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -18,6 +18,7 @@ class TransactionTableModel;
 class ClientModel;
 class WalletModel;
 class ResearcherModel;
+class MRCModel;
 class VotingModel;
 class TransactionView;
 class OverviewPage;
@@ -69,6 +70,11 @@ public:
     */
     void setResearcherModel(ResearcherModel *researcherModel);
 
+    /** Set the MRC model.
+        The MRC model provides the model for MRC payment requests.
+    */
+    void setMRCModel(MRCModel *mrcModel);
+
     /** Set the voting model.
         The voting model facilitates presentation of and interaction with network polls and votes.
     */
@@ -91,6 +97,7 @@ private:
     ClientModel *clientModel;
     WalletModel *walletModel;
     ResearcherModel *researcherModel;
+    MRCModel *m_mrc_model;
     VotingModel *votingModel;
 
     QStackedWidget *centralWidget;
@@ -239,6 +246,8 @@ private slots:
     void themeToggled();
     /** Show researcher/beacon configuration dialog */
     void researcherClicked();
+    /** Show MRC payment request dialog */
+    //void mrcPaymentClicked();
     /** Show about dialog */
     void aboutClicked();
     /** Open config file */

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -246,8 +246,6 @@ private slots:
     void themeToggled();
     /** Show researcher/beacon configuration dialog */
     void researcherClicked();
-    /** Show MRC payment request dialog */
-    //void mrcPaymentClicked();
     /** Show about dialog */
     void aboutClicked();
     /** Open config file */

--- a/src/qt/forms/mrcrequestpage.ui
+++ b/src/qt/forms/mrcrequestpage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>687</width>
-    <height>500</height>
+    <width>694</width>
+    <height>580</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,213 +19,275 @@
   <property name="windowTitle">
    <string>MRC Requests</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="800,50,100,100">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
    <item>
-    <layout class="QGridLayout" name="gridLayout" columnstretch="300,100">
-     <item row="2" column="0">
-      <widget class="QLabel" name="mrcQueueHeadFeeLabel">
-       <property name="text">
-        <string>MRC Fee @ Head of Queue</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="mrcQueueLimitLabel">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>MRC Request Pay Limit per Block</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="mrcQueuePositionLabel">
-       <property name="text">
-        <string>Your Projected MRC Request Position in Queue</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="mrcQueueLimit">
-       <property name="toolTip">
-        <string>The maximum number of MRCs that can be paid per block</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="mrcQueueHeadFee">
-       <property name="toolTip">
-        <string>The highest MRC fee being paid of MRCs in the memory pool</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QLabel" name="mrcMinimumSubmitFee">
-       <property name="toolTip">
-        <string>The calculated minimum fee for the MRC. This may not be sufficient to submit the MRC if the queue is already full. In that case, you need to use the MRC fee boost to raise the fee to get your MRC in the queue.</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="mrcQueueTailFeeLabel">
-       <property name="text">
-        <string>MRC Fee @ Tail of Queue</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="mrcQueueTailFee">
-       <property name="toolTip">
-        <string>The lowest MRC fee being paid of MRCs in the memory pool</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="numMRCInQueueLabel">
-       <property name="text">
-        <string>Number of All MRC Requests in Queue</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="mrcQueuePosition">
-       <property name="toolTip">
-        <string>Your projected or actual position among MRCs in the memory pool ordered by MRC fee in descending order</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="numMRCInQueue">
-       <property name="toolTip">
-        <string>The number of MRCs in the memory pool</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="mrcMinimumSubmitFeeLabel">
-       <property name="text">
-        <string>Your MRC Calculated Minimum Fee</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="mrcQueuePayLimitFeeLabel">
-       <property name="text">
-        <string>MRC Fee @ Pay Limit Position in Queue</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="mrcQueuePayLimitFee">
-       <property name="toolTip">
-        <string>The MRC fee being paid by the MRC in the last position within the pay limit in the memory pool</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QFrame" name="waitForNextBlockUpdateFrame">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="waitForBlockUpdateLabel">
+          <property name="text">
+           <string>Please wait.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="waitForBlockUpdate">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="pixmap">
+           <pixmap resource="../bitcoin.qrc">:/icons/no_result</pixmap>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="mrcFeeHorizontalLayout" stretch="300,100">
-     <item>
-      <widget class="QLabel" name="mrcFeeBoostLabel">
-       <property name="text">
-        <string>MRC Fee Boost</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="BitcoinAmountField" name="mrcFeeBoostSpinBox"/>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="ButtonHorizontalLayout" stretch="0,0,0,0,0">
-     <item>
-      <widget class="QPushButton" name="mrcUpdateButton">
-       <property name="text">
-        <string>Update</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mrcSubmitButton">
-       <property name="text">
-        <string>Submit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="SubmittedIconLabel">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../bitcoin.qrc">:/icons/transaction_confirmed</pixmap>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="ErrorIconLabel">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="mrcRequestButtonBox">
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QFrame" name="mrcStatusSubmitFrame">
+     <layout class="QVBoxLayout" name="verticalLayout_6" stretch="8,0,2,2">
+      <item>
+       <layout class="QGridLayout" name="gridLayout" columnstretch="300,100">
+        <item row="3" column="0">
+         <widget class="QLabel" name="mrcQueuePayLimitFeeLabel">
+          <property name="text">
+           <string>MRC Fee @ Pay Limit Position in Queue</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="mrcQueueTailFeeLabel">
+          <property name="text">
+           <string>MRC Fee @ Tail of Queue</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLabel" name="mrcQueuePosition">
+          <property name="toolTip">
+           <string>Your projected or actual position among MRCs in the memory pool ordered by MRC fee in descending order</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="numMRCInQueueLabel">
+          <property name="text">
+           <string>Number of All MRC Requests in Queue</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="numMRCInQueue">
+          <property name="toolTip">
+           <string>The number of MRCs in the memory pool</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="mrcQueuePositionLabel">
+          <property name="text">
+           <string>Your Projected MRC Request Position in Queue</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLabel" name="mrcQueuePayLimitFee">
+          <property name="toolTip">
+           <string>The MRC fee being paid by the MRC in the last position within the pay limit in the memory pool</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="mrcQueueLimitLabel">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="text">
+           <string>MRC Request Pay Limit per Block</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="mrcMinimumSubmitFeeLabel">
+          <property name="text">
+           <string>Your MRC Calculated Minimum Fee</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QLabel" name="mrcMinimumSubmitFee">
+          <property name="toolTip">
+           <string>The calculated minimum fee for the MRC. This may not be sufficient to submit the MRC if the queue is already full. In that case, you need to use the MRC fee boost to raise the fee to get your MRC in the queue.</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLabel" name="mrcQueueTailFee">
+          <property name="toolTip">
+           <string>The lowest MRC fee being paid of MRCs in the memory pool</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="mrcQueueLimit">
+          <property name="toolTip">
+           <string>The maximum number of MRCs that can be paid per block</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="mrcQueueHeadFee">
+          <property name="toolTip">
+           <string>The highest MRC fee being paid of MRCs in the memory pool</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="mrcQueueHeadFeeLabel">
+          <property name="text">
+           <string>MRC Fee @ Head of Queue</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="mrcFeeHorizontalLayout" stretch="300,100">
+        <item>
+         <widget class="QLabel" name="mrcFeeBoostLabel">
+          <property name="text">
+           <string>MRC Fee Boost</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="BitcoinAmountField" name="mrcFeeBoostSpinBox"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="ButtonHorizontalLayout" stretch="0,0,0,0,0">
+        <item>
+         <widget class="QPushButton" name="mrcUpdateButton">
+          <property name="text">
+           <string>Update</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="mrcSubmitButton">
+          <property name="text">
+           <string>Submit</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="SubmittedIconLabel">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="pixmap">
+           <pixmap resource="../bitcoin.qrc">:/icons/transaction_confirmed</pixmap>
+          </property>
+          <property name="scaledContents">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="ErrorIconLabel">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="pixmap">
+           <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
+          </property>
+          <property name="scaledContents">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDialogButtonBox" name="mrcRequestButtonBox">
+          <property name="standardButtons">
+           <set>QDialogButtonBox::Ok</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/qt/forms/mrcrequestpage.ui
+++ b/src/qt/forms/mrcrequestpage.ui
@@ -219,7 +219,7 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="mrcFeeHorizontalLayout" stretch="300,100">
+       <layout class="QHBoxLayout" name="mrcFeeHorizontalLayout" stretch="300,0,100">
         <item>
          <widget class="QLabel" name="mrcFeeBoostLabel">
           <property name="text">
@@ -227,6 +227,13 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="mrcFeeBoostRaiseToMinimumButton">
+          <property name="text">
+           <string>Raise to Minimum For Submit</string>
           </property>
          </widget>
         </item>

--- a/src/qt/forms/mrcrequestpage.ui
+++ b/src/qt/forms/mrcrequestpage.ui
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MRCRequestPage</class>
+ <widget class="QWidget" name="MRCRequestPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QLabel" name="placeholderLabel">
+   <property name="geometry">
+    <rect>
+     <x>70</x>
+     <y>80</y>
+     <width>58</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>TextLabel</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/mrcrequestpage.ui
+++ b/src/qt/forms/mrcrequestpage.ui
@@ -1,32 +1,244 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MRCRequestPage</class>
- <widget class="QWidget" name="MRCRequestPage">
+ <widget class="QDialog" name="MRCRequestPage">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>687</width>
+    <height>500</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
-  <widget class="QLabel" name="placeholderLabel">
-   <property name="geometry">
-    <rect>
-     <x>70</x>
-     <y>80</y>
-     <width>58</width>
-     <height>18</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
+  <property name="windowTitle">
+   <string>MRC Requests</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="800,50,100,100">
+   <item>
+    <layout class="QGridLayout" name="gridLayout" columnstretch="300,100">
+     <item row="2" column="0">
+      <widget class="QLabel" name="mrcQueueHeadFeeLabel">
+       <property name="text">
+        <string>MRC Fee @ Head of Queue</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="mrcQueueLimitLabel">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>MRC Request Pay Limit per Block</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="mrcQueuePositionLabel">
+       <property name="text">
+        <string>Your Projected MRC Request Position in Queue</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="mrcQueueLimit">
+       <property name="toolTip">
+        <string>The maximum number of MRCs that can be paid per block</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="mrcQueueHeadFee">
+       <property name="toolTip">
+        <string>The highest MRC fee being paid of MRCs in the memory pool</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLabel" name="mrcMinimumSubmitFee">
+       <property name="toolTip">
+        <string>The calculated minimum fee for the MRC. This may not be sufficient to submit the MRC if the queue is already full. In that case, you need to use the MRC fee boost to raise the fee to get your MRC in the queue.</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="mrcQueueTailFeeLabel">
+       <property name="text">
+        <string>MRC Fee @ Tail of Queue</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="mrcQueueTailFee">
+       <property name="toolTip">
+        <string>The lowest MRC fee being paid of MRCs in the memory pool</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="numMRCInQueueLabel">
+       <property name="text">
+        <string>Number of All MRC Requests in Queue</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="mrcQueuePosition">
+       <property name="toolTip">
+        <string>Your projected or actual position among MRCs in the memory pool ordered by MRC fee in descending order</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="numMRCInQueue">
+       <property name="toolTip">
+        <string>The number of MRCs in the memory pool</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="mrcMinimumSubmitFeeLabel">
+       <property name="text">
+        <string>Your MRC Calculated Minimum Fee</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="mrcQueuePayLimitFeeLabel">
+       <property name="text">
+        <string>MRC Fee @ Pay Limit Position in Queue</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="mrcQueuePayLimitFee">
+       <property name="toolTip">
+        <string>The MRC fee being paid by the MRC in the last position within the pay limit in the memory pool</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="mrcFeeHorizontalLayout" stretch="300,100">
+     <item>
+      <widget class="QLabel" name="mrcFeeBoostLabel">
+       <property name="text">
+        <string>MRC Fee Boost</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="BitcoinAmountField" name="mrcFeeBoostSpinBox"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="ButtonHorizontalLayout" stretch="0,0,0,0,0">
+     <item>
+      <widget class="QPushButton" name="mrcUpdateButton">
+       <property name="text">
+        <string>Update</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="mrcSubmitButton">
+       <property name="text">
+        <string>Submit</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="SubmittedIconLabel">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../bitcoin.qrc">:/icons/transaction_confirmed</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="ErrorIconLabel">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="mrcRequestButtonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
- <resources/>
+ <customwidgets>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QSpinBox</extends>
+   <header>bitcoinamountfield.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -747,6 +747,16 @@
                   </property>
                  </spacer>
                 </item>
+                <item>
+                 <widget class="QToolButton" name="mrcRequestToolButton">
+                  <property name="toolTip">
+                   <string>Open the Manual Reward Claim (MRC) request page</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
                 <item alignment="Qt::AlignVCenter">
                  <widget class="QLabel" name="researcherAlertLabel">
                   <property name="text">

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -92,8 +92,6 @@ void MRCModel::showMRCDialog()
         m_mrc_request = new MRCRequestPage(nullptr, this);
     }
 
-    //MRCRequestPage *mrc_request = new MRCRequestPage(nullptr, this);
-
     m_mrc_request->show();
 }
 
@@ -250,7 +248,7 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         return;
     }
 
-    // This is similar to createmrcrequest
+    // This is similar to createmrcrequest in many ways, but the state tracking is more complicated.
 
     AssertLockHeld(cs_main);
 
@@ -266,26 +264,10 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         return;
     }
 
-    if (m_submitted_mrc) {
-        LogPrintf("INFO: %s: Before clearing statement: m_submitted_mrc optional is present.",
-                  __func__);
-    } else {
-        LogPrintf("INFO: %s: Before clearing statement: m_submitted_mrc optional is null.",
-                  __func__);
-    }
-
     // Clear the submitted mrc once the block advances again after the stake (which is one more than the submission block).
     if (m_submitted_mrc && m_block_height >= m_submitted_height + 2) {
         m_submitted_mrc = {};
         m_submitted_height = 0;
-    }
-
-    if (m_submitted_mrc) {
-        LogPrintf("INFO: %s: After clearing statement: m_submitted_mrc optional is present.",
-                  __func__);
-    } else {
-        LogPrintf("INFO: %s: After clearing statement: m_submitted_mrc optional is null.",
-                  __func__);
     }
 
     m_mrc_min_fee = 0;
@@ -392,16 +374,6 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     // 2. The block height has advanced from the original submission height, and 3. The accrual is equal or higher than
     // the research subsidy in the submitted MRC, which means the MRC has not been paid by the staker. This method avoids
     // more expensive lookups against the block/transactions.
-    CAmount submitted_research_subsidy = m_submitted_mrc ? m_submitted_mrc->m_research_subsidy : 0;
-
-    LogPrintf("INFO: %s: m_block_height = %i, m_submitted_height = %i, m_submitted_mrc->m_research_subsidy = %s, "
-              "m_researcher_model->getAccrual() = %s",
-              __func__,
-              m_block_height,
-              m_submitted_height,
-              FormatMoney(submitted_research_subsidy),
-              FormatMoney(m_researcher_model->getAccrual()));
-
     if (m_submitted_mrc
             && m_block_height > m_submitted_height
             && m_submitted_mrc->m_research_subsidy <= m_researcher_model->getAccrual()) {

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -252,7 +252,7 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         m_mrc_error_desc = e.what();
     }
 
-    // If the (mininum) fee comes back equal to the reward we are in the zero payout interval (i.e. too soon).
+    // If the (minimum) fee comes back equal to the reward we are in the zero payout interval (i.e. too soon).
     if (m_mrc_min_fee == m_reward) {
         m_mrc_error |= true;
         m_mrc_status = MRCRequestStatus::ZERO_PAYOUT;

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -33,6 +33,7 @@ MRCModel::MRCModel(WalletModel* wallet_model, ClientModel *client_model, Researc
     , m_wallet_model(wallet_model)
     , m_client_model(client_model)
     , m_researcher_model(researcher_model)
+    , m_mrc_request(nullptr)
     , m_submitted_mrc({})
     , m_mrc_status(MRCRequestStatus::NONE)
     , m_reward(0)
@@ -73,6 +74,10 @@ MRCModel::MRCModel(WalletModel* wallet_model, ClientModel *client_model, Researc
 
 MRCModel::~MRCModel()
 {
+    if (m_mrc_request) {
+        m_mrc_request->done(QDialog::Accepted);
+    }
+
     unsubscribeFromCoreSignals();
 }
 
@@ -83,9 +88,13 @@ WalletModel* MRCModel::getWalletModel()
 
 void MRCModel::showMRCDialog()
 {
-    MRCRequestPage *mrc_request = new MRCRequestPage(nullptr, this);
+    if (!m_mrc_request) {
+        m_mrc_request = new MRCRequestPage(nullptr, this);
+    }
 
-    mrc_request->show();
+    //MRCRequestPage *mrc_request = new MRCRequestPage(nullptr, this);
+
+    m_mrc_request->show();
 }
 
 void MRCModel::setMRCFeeBoost(CAmount& fee_boost)

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) 2014-2022 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/mrcmodel.h"

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -188,11 +188,10 @@ bool MRCModel::submitMRC(MRCRequestStatus& s, QString& e) EXCLUSIVE_LOCKS_REQUIR
     std::string e_str;
 
     std::tie(wtx, e_str) = GRC::SendContract(GRC::MakeContract<GRC::MRC>(GRC::ContractAction::ADD, m_mrc));
-    if (!QString::fromStdString(e_str).isEmpty()) {
+    if (!e_str.empty()) {
         m_mrc_error = true;
-        m_mrc_status = MRCRequestStatus::SUBMIT_ERROR;
-        m_mrc_error_desc = e;
-        s = m_mrc_status;
+        s = m_mrc_status = MRCRequestStatus::SUBMIT_ERROR;
+        e = m_mrc_error_desc = QString::fromStdString(e_str);
         return false;
     } else {
         m_submitted_mrc = m_mrc;

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -329,16 +329,23 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
               m_mrc_pos,
               m_mrc_output_limit - 1);
 
-    if (found) {
+    if (found && m_mrc_pos <= m_mrc_output_limit - 1) {
         m_mrc_error |= true;
         m_mrc_status = MRCRequestStatus::PENDING;
         m_mrc_error_desc = tr("You have a pending MRC request.").toStdString();
+    } else if (found && m_mrc_pos > m_mrc_output_limit - 1) {
+        m_mrc_error |= true;
+        m_mrc_status = MRCRequestStatus::QUEUE_FULL;
+        m_mrc_error_desc = tr("Your MRC was successfully submitted, but other MRCs with higher fees have pushed your MRC "
+                              "down in the queue past the pay limit, and your MRC will be canceled. Wait until the next "
+                              "block is received and the queue clears and try again. Your fee for the canceled MRC will "
+                              "be refunded.").toStdString();
     } else if (m_mrc_pos > m_mrc_output_limit - 1) {
         m_mrc_error |= true;
         m_mrc_status = MRCRequestStatus::QUEUE_FULL;
-        m_mrc_error_desc = tr("The MRC queue is full. You can try inputting a provided fee high enough to put your MRC "
-                           "request in the queue and displace another MRC request.").toStdString();
-    } else if (m_wallet_locked) {
+        m_mrc_error_desc = tr("The MRC queue is full. You can try boosting your fee to put your MRC request in the queue "
+                              "and displace another MRC request.").toStdString();
+    } else if (m_wallet_locked && !found) {
         m_mrc_error |= true;
         m_mrc_status = MRCRequestStatus::WALLET_LOCKED;
         m_mrc_error_desc = tr("The wallet is locked.").toStdString();

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -147,6 +147,7 @@ MRCModel::ModelStatus MRCModel::getMRCModelStatus()
     } else if (!IsV12Enabled(m_block_height)) {
         return MRCModel::ModelStatus::INVALID_BLOCK_VERSION;
     } else if (OutOfSyncByAge()) {
+        // Note that m_mrc_status == MRCRequestStatus::NONE if OutOfSyncByAge() is true.
         return MRCModel::ModelStatus::OUT_OF_SYNC;
     } else if (m_block_height <= m_init_block_height) {
         return MRCModel::ModelStatus::NO_BLOCK_UPDATE_FROM_INIT;
@@ -221,6 +222,11 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     m_mrc_status = MRCRequestStatus::NONE;
     m_mrc_error_desc = QString{};
 
+    // Stop here if out of sync.
+    if (OutOfSyncByAge()) {
+        return;
+    }
+
     if (!m_researcher_model) {
         m_mrc_error |= true;
         m_mrc_status = MRCRequestStatus::NOT_VALID_RESEARCHER;
@@ -234,9 +240,6 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         m_mrc_status = MRCRequestStatus::NOT_VALID_RESEARCHER;
         return;
     }
-
-    // Stop here if out of sync.
-    if (OutOfSyncByAge()) return;
 
     // This is similar to createmrcrequest
 

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -2,4 +2,338 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include "qt/mrcmodel.h"
+#include "main.h"
+#include "wallet/wallet.h"
+#include "gridcoin/contract/contract.h"
+#include "gridcoin/contract/message.h"
+#include "mrcmodel.h"
+#include "walletmodel.h"
+#include "clientmodel.h"
+#include "qt/mrcrequestpage.h"
+#include "node/ui_interface.h"
+
+extern CWallet* pwalletMain;
+
+namespace {
+//!
+//! \brief Model callback bound to the \c MRCChanged core signal.
+//!
+void MRCChanged(MRCModel* model)
+{
+    LogPrint(BCLog::LogFlags::QT, "GUI: received MRCChanged() core signal");
+
+    QMetaObject::invokeMethod(model, "mrcChanged", Qt::QueuedConnection);
+
+}
+} // anonymous namespace
+
+MRCModel::MRCModel(WalletModel* wallet_model, ClientModel *client_model, QObject *parent)
+    : QObject(parent)
+    , m_wallet_model(wallet_model)
+    , m_client_model(client_model)
+    , m_mrc_status(MRCRequestStatus::NONE)
+    , m_reward(0)
+    , m_mrc_min_fee(0)
+    , m_mrc_fee(0)
+    , m_mrc_fee_boost(0)
+    , m_mrc_queue_length(0)
+    , m_mrc_pos(0)
+    , m_mrc_queue_tail_fee(std::numeric_limits<CAmount>::max())
+    , m_mrc_queue_pay_limit_fee(std::numeric_limits<CAmount>::max())
+    , m_mrc_queue_head_fee(0)
+    , m_mrc_output_limit(0)
+    , m_mrc_error(false)
+    , m_mrc_error_desc(std::string{})
+    , m_wallet_locked(false)
+{
+    subscribeToCoreSignals();
+
+    // Here instead of the core signal for number of blocks changed, we take it from the client model, because
+    // there is a rate limiter there if the wallet is not in sync. This is necessary, because a new block can be
+    // received with no MRC contract, and therefore an m_mrc already generated here will then be stale. So
+    // to force a generation of an updated m_mrc against the new block, we need to connect the mrcChanged slot
+    // to this as well as the core MRCChanged signal.
+    connect(m_client_model, &ClientModel::numBlocksChanged, this, &MRCModel::mrcChanged);
+
+    // Detects whether the wallet has been locked or unlocked.
+    connect(m_wallet_model, &WalletModel::encryptionStatusChanged, this, &MRCModel::walletStatusChanged);
+
+    WalletModel::EncryptionStatus encryption_status = m_wallet_model->getEncryptionStatus();
+
+    walletStatusChanged(encryption_status);
+
+    refresh();
+}
+
+MRCModel::~MRCModel()
+{
+    unsubscribeFromCoreSignals();
+}
+
+WalletModel* MRCModel::getWalletModel()
+{
+    return m_wallet_model;
+}
+
+void MRCModel::showMRCDialog()
+{
+    MRCRequestPage *mrc_request = new MRCRequestPage(nullptr, this);
+
+    mrc_request->show();
+}
+
+void MRCModel::setMRCFeeBoost(CAmount& fee_boost)
+{
+    m_mrc_fee_boost = fee_boost;
+
+    refresh();
+}
+
+int MRCModel::getMRCFeeBoost()
+{
+    return m_mrc_fee_boost;
+}
+
+int MRCModel::getMRCQueueLength()
+{
+    return m_mrc_queue_length;
+}
+
+int MRCModel::getMRCPos()
+{
+    return m_mrc_pos;
+}
+
+CAmount MRCModel::getMRCQueueTailFee()
+{
+    return m_mrc_queue_tail_fee;
+}
+
+CAmount MRCModel::getMRCQueuePayLimitFee()
+{
+    return m_mrc_queue_pay_limit_fee;
+}
+
+CAmount MRCModel::getMRCQueueHeadFee()
+{
+    return m_mrc_queue_head_fee;
+}
+
+CAmount MRCModel::getMRCMinimumSubmitFee()
+{
+    return m_mrc_min_fee;
+}
+
+int MRCModel::getMRCOutputLimit()
+{
+    return m_mrc_output_limit;
+}
+
+bool MRCModel::isMRCError(MRCRequestStatus &s, std::string& e)
+{
+    if (m_mrc_error) {
+        e = m_mrc_error_desc;
+        s = m_mrc_status;
+        return true;
+    }
+
+    return false;
+}
+
+bool MRCModel::submitMRC(MRCRequestStatus& s, std::string& e) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    if (m_mrc_status != MRCRequestStatus::ELIGIBLE) {
+        return error("%s: submitMRC called while m_mrc_status, %i, is not ELIGIBLE.",
+                     __func__,
+                     static_cast<int>(m_mrc_status));
+    }
+
+    LOCK(pwalletMain->cs_wallet);
+
+    CWalletTx wtx;
+
+    std::tie(wtx, e) = GRC::SendContract(GRC::MakeContract<GRC::MRC>(GRC::ContractAction::ADD, m_mrc));
+    if (!e.empty()) {
+        m_mrc_error = true;
+        m_mrc_status = MRCRequestStatus::SUBMIT_ERROR;
+        m_mrc_error_desc = e;
+        s = m_mrc_status;
+        return false;
+    } else {
+        m_mrc_error = false;
+        m_mrc_status = MRCRequestStatus::PENDING;
+        m_mrc_error_desc = std::string{};
+        s = m_mrc_status;
+    }
+
+    return true;
+}
+
+bool MRCModel::isWalletLocked()
+{
+    return m_wallet_locked;
+}
+
+void MRCModel::subscribeToCoreSignals()
+{
+    uiInterface.MRCChanged_connect(std::bind(MRCChanged, this));
+}
+
+void MRCModel::unsubscribeFromCoreSignals()
+{
+    // Disconnect signals from client (no-op currently)
+}
+
+void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    // This is similar to createmrcrequest
+
+    AssertLockHeld(cs_main);
+
+    CBlockIndex* pindex = mapBlockIndex[hashBestChain];
+
+    if (!IsV12Enabled(pindex->nHeight)) {
+        return;
+    }
+
+    m_mrc_error = false;
+    m_mrc_error_desc = std::string{};
+    m_mrc_min_fee = 0;
+    m_mrc_fee = 0;
+
+    m_mrc_output_limit = static_cast<int>(GetMRCOutputLimit(pindex->nVersion, false));
+
+    // Do a first run with m_mrc_min_fee = 0 to compute the mrc min fee required.
+    try {
+        GRC::CreateMRC(pindex, m_mrc, m_reward, m_mrc_min_fee, pwalletMain, m_wallet_locked);
+    } catch (GRC::MRC_error& e) {
+        m_mrc_error |= true;
+        m_mrc_status = MRCRequestStatus::CREATE_ERROR;
+        m_mrc_error_desc = e.what();
+    }
+
+    // If the (mininum) fee comes back equal to the reward we are in the zero payout interval (i.e. too soon).
+    if (m_mrc_min_fee == m_reward) {
+        m_mrc_error |= true;
+        m_mrc_status = MRCRequestStatus::ZERO_PAYOUT;
+        m_mrc_error_desc = "Too soon since your last research rewards payment.";
+    }
+
+    // If there is a fee boost, add the boost to the fee from the initial run above.
+    if (m_mrc_fee_boost != 0) {
+        m_mrc_fee = m_mrc_min_fee + m_mrc_fee_boost;
+    }
+
+    // If the total mrc free which is the min fee + boost is greater than the reward, then the fee is excessive.
+    if (m_mrc_fee > m_reward) {
+        m_mrc_error |= true;
+        m_mrc_status = MRCRequestStatus::EXCESSIVE_FEE;
+        m_mrc_error_desc = "The total fee (the minimum fee + fee boost) is greater than the rewards due.";
+    }
+
+    // Rerun CreateMRC with that new total fee
+    if (m_mrc_fee_boost != 0) {
+        try {
+            GRC::CreateMRC(pindex, m_mrc, m_reward, m_mrc_fee, pwalletMain, m_wallet_locked);
+        } catch (GRC::MRC_error& e) {
+            m_mrc_error |= true;
+            m_mrc_status = MRCRequestStatus::CREATE_ERROR;
+            m_mrc_error_desc = e.what();
+        }
+    }
+
+    LogPrintf("INFO: %s: After stage 1: m_mrc_error = %u, m_mrc_status = %i, m_mrc_error_desc = %s",
+              __func__,
+              m_mrc_error,
+              static_cast<int>(m_mrc_status),
+              m_mrc_error_desc);
+
+    // We do the mempool loop here regardless of whether there is an error condition or not.
+    m_mrc_queue_length = 0;
+    m_mrc_pos = 0;
+    m_mrc_queue_tail_fee = std::numeric_limits<CAmount>::max();
+    m_mrc_queue_head_fee = 0;
+
+    bool found{false};
+
+    // This will allow sorting the fees in descending order to help determine the payout limit fee.
+    std::vector<CAmount> mrc_fee_vector;
+
+    for (const auto& [_, tx] : mempool.mapTx) {
+        if (!tx.GetContracts().empty()) {
+            // By protocol the MRC contract MUST be the only one in the transaction.
+            const GRC::Contract& contract = tx.GetContracts()[0];
+
+            if (contract.m_type == GRC::ContractType::MRC) {
+                GRC::MRC mempool_mrc = contract.CopyPayloadAs<GRC::MRC>();
+
+                found |= m_mrc.m_mining_id == mempool_mrc.m_mining_id;
+
+                if (!found && mempool_mrc.m_fee >= m_mrc.m_fee) ++m_mrc_pos;
+                m_mrc_queue_head_fee = std::max(m_mrc_queue_head_fee, mempool_mrc.m_fee);
+                m_mrc_queue_tail_fee = std::min(m_mrc_queue_tail_fee, mempool_mrc.m_fee);
+
+                mrc_fee_vector.push_back(mempool_mrc.m_fee);
+
+                ++m_mrc_queue_length;
+            } // match to mrc contract type
+        } // contract present in transaction?
+    } // mempool transaction iterator
+
+    // The tail fee converges from the max numeric limit of CAmount; however, when the above loop is done
+    // it cannot end up with a number higher than the head fee. This can happen if there are no MRC transactions
+    // in the loop.
+    m_mrc_queue_tail_fee = std::min(m_mrc_queue_head_fee, m_mrc_queue_tail_fee);
+
+    // Sort the fees in descending order for the pay limit calculation.
+    std::sort(mrc_fee_vector.begin(), mrc_fee_vector.end(), std::greater<CAmount>());
+
+    // Here we select the minimum of the mrc_fee_vector.size() - 1 in the case where the sorted vector does not reach the
+    // m_mrc_output_limit - 1, or the m_mrc_output_limit - 1 if the sorted vector indicates the queue is (over)full,
+    // i.e. the number of MRC's in the queue exceeds the m_mrc_output_limit for paying in a block.
+    int pay_limit_fee_pos = std::min<int>(mrc_fee_vector.size(), m_mrc_output_limit) - 1;
+
+    if (pay_limit_fee_pos >= 0) {
+        m_mrc_queue_pay_limit_fee = mrc_fee_vector[pay_limit_fee_pos];
+    }
+
+    m_mrc_queue_pay_limit_fee = std::min(m_mrc_queue_head_fee, m_mrc_queue_pay_limit_fee);
+
+    LogPrintf("INFO: %s: Post mempool loop: m_mrc_pos = %i, m_mrc_output_limit - 1 = %i",
+              __func__,
+              m_mrc_pos,
+              m_mrc_output_limit - 1);
+
+    if (found) {
+        m_mrc_error |= true;
+        m_mrc_status = MRCRequestStatus::PENDING;
+        m_mrc_error_desc = "You have a pending MRC request.";
+    } else if (m_mrc_pos > m_mrc_output_limit - 1) {
+        m_mrc_error |= true;
+        m_mrc_status = MRCRequestStatus::QUEUE_FULL;
+        m_mrc_error_desc = "The MRC queue is full. You can try inputting a provided fee high enough to put your MRC "
+                           "request in the queue and displace another MRC request.";
+    } else if (m_wallet_locked) {
+        m_mrc_error |= true;
+        m_mrc_status = MRCRequestStatus::WALLET_LOCKED;
+        m_mrc_error_desc = "The wallet is locked.";
+    } else if (!m_mrc_error) {
+        m_mrc_status = MRCRequestStatus::ELIGIBLE;
+        m_mrc_error_desc = std::string{};
+    }
+
+    LogPrintf("INFO: %s: After stage 2: m_mrc_error = %u, m_mrc_status = %i, m_mrc_error_desc = %s",
+              __func__,
+              m_mrc_error,
+              static_cast<int>(m_mrc_status),
+              m_mrc_error_desc);
+}
+
+void MRCModel::walletStatusChanged(int encryption_status) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    m_wallet_locked = (encryption_status == static_cast<int>(WalletModel::EncryptionStatus::Locked));
+
+    refresh();
+
+    emit walletStatusChangedSignal();
+}

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -12,6 +12,7 @@
 class WalletModel;
 class ClientModel;
 class ResearcherModel;
+class MRCRequestPage;
 
 //!
 //! \brief The MRCRequestStatus enum describes the status of the MRC request
@@ -86,6 +87,7 @@ private:
     WalletModel* m_wallet_model;
     ClientModel* m_client_model;
     ResearcherModel* m_researcher_model;
+    MRCRequestPage* m_mrc_request;
 
     GRC::MRC m_mrc;
     std::optional<GRC::MRC> m_submitted_mrc;

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -25,6 +25,7 @@ enum class MRCRequestStatus
     PENDING,
     QUEUE_FULL,
     PENDING_CANCEL,
+    STALE_CANCEL,
     ZERO_PAYOUT,
     EXCESSIVE_FEE,
     WALLET_LOCKED,
@@ -87,6 +88,7 @@ private:
     ResearcherModel* m_researcher_model;
 
     GRC::MRC m_mrc;
+    std::optional<GRC::MRC> m_submitted_mrc;
     MRCRequestStatus m_mrc_status;
     CAmount m_reward;
     CAmount m_mrc_min_fee;
@@ -105,6 +107,7 @@ private:
 
     int m_init_block_height;
     int m_block_height;
+    int m_submitted_height;
 
 signals:
     void mrcChanged();

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -13,6 +13,9 @@ class WalletModel;
 class ClientModel;
 class ResearcherModel;
 
+//!
+//! \brief The MRCRequestStatus enum describes the status of the MRC request
+//!
 enum class MRCRequestStatus
 {
     NONE,
@@ -27,6 +30,11 @@ enum class MRCRequestStatus
     SUBMIT_ERROR
 };
 
+//!
+//! \brief The MRCModel class provides a GUI model of the state of the MRC queue and the researcher's MRC status
+//!
+//! Note that the MRC queue is "synthetic". It is filtered from the transactions in the memory pool and consists
+//! of the transactions that have a valid MRC contract.
 class MRCModel : public QObject
 {
     Q_OBJECT
@@ -38,6 +46,11 @@ public:
                       QObject* parent = nullptr);
     ~MRCModel();
 
+    //!
+    //! \brief The ModelStatus enum describes the overall status of the MRC model.
+    //!
+    //! The MRC request widgets are only shown in the MRCRequestPage if the model is VALID.
+    //!
     enum ModelStatus {
         VALID,
         NOT_VALID_RESEARCHER,
@@ -96,6 +109,14 @@ signals:
     void walletStatusChangedSignal();
 
 public slots:
+    //!
+    //! \brief refresh does the brunt of the work in the MRCModel.
+    //!
+    //! It runs trial CreateMRCs and loops through the memory pool to construct the synthetic MRC queue and
+    //! provides the necessary information for the MRCRequestPage to control the MRC submission by the user.
+    //!
+    //! It provides structured status and error states of the MRC request(s).
+    //!
     void refresh();
     void walletStatusChanged(int encryption_status);
 };

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -6,13 +6,23 @@
 #define GRIDCOIN_QT_MRCMODEL_H
 
 #include <QObject>
+#include "amount.h"
+#include "gridcoin/mrc.h"
+
+class WalletModel;
+class ClientModel;
 
 enum class MRCRequestStatus
 {
+    NONE,
+    CREATE_ERROR,
+    ELIGIBLE,
     PENDING,
-    REJECTED_QUEUE_FULL,
-    STALE,
-    DELETED
+    QUEUE_FULL,
+    ZERO_PAYOUT,
+    EXCESSIVE_FEE,
+    WALLET_LOCKED,
+    SUBMIT_ERROR
 };
 
 class MRCModel : public QObject
@@ -20,10 +30,56 @@ class MRCModel : public QObject
     Q_OBJECT
 
 public:
-    MRCModel();
+    explicit MRCModel(WalletModel* wallet_model, ClientModel* client_model, QObject* parent = nullptr);
     ~MRCModel();
 
-};
+    WalletModel* getWalletModel();
 
+    void showMRCDialog();
+    void setMRCFeeBoost(CAmount& fee);
+    int getMRCFeeBoost();
+    int getMRCQueueLength();
+    int getMRCPos();
+    CAmount getMRCQueueTailFee();
+    CAmount getMRCQueuePayLimitFee();
+    CAmount getMRCQueueHeadFee();
+    CAmount getMRCMinimumSubmitFee();
+    int getMRCOutputLimit();
+    bool isMRCError(MRCRequestStatus& s, std::string& e);
+    bool submitMRC(MRCRequestStatus& s, std::string& e);
+    bool isWalletLocked();
+
+private:
+    void subscribeToCoreSignals();
+    void unsubscribeFromCoreSignals();
+
+    WalletModel* m_wallet_model;
+    ClientModel* m_client_model;
+
+    GRC::MRC m_mrc;
+    MRCRequestStatus m_mrc_status;
+    CAmount m_reward;
+    CAmount m_mrc_min_fee;
+    CAmount m_mrc_fee;
+    CAmount m_mrc_fee_boost;
+    int m_mrc_queue_length;
+    int m_mrc_pos;
+    CAmount m_mrc_queue_tail_fee;
+    CAmount m_mrc_queue_pay_limit_fee;
+    CAmount m_mrc_queue_head_fee;
+    int m_mrc_output_limit;
+
+    bool m_mrc_error;
+    std::string m_mrc_error_desc;
+    bool m_wallet_locked;
+
+signals:
+    void mrcChanged();
+    void walletStatusChangedSignal();
+
+public slots:
+    void refresh();
+    void walletStatusChanged(int encryption_status);
+};
 
 #endif // GRIDCOIN_QT_MRCMODEL_H

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -24,6 +24,7 @@ enum class MRCRequestStatus
     CREATE_ERROR,
     PENDING,
     QUEUE_FULL,
+    PENDING_CANCEL,
     ZERO_PAYOUT,
     EXCESSIVE_FEE,
     WALLET_LOCKED,
@@ -70,10 +71,11 @@ public:
     CAmount getMRCQueuePayLimitFee();
     CAmount getMRCQueueHeadFee();
     CAmount getMRCMinimumSubmitFee();
+    CAmount getMRCReward();
     int getMRCOutputLimit();
     ModelStatus getMRCModelStatus();
-    bool isMRCError(MRCRequestStatus& s, std::string& e);
-    bool submitMRC(MRCRequestStatus& s, std::string& e);
+    bool isMRCError(MRCRequestStatus& s, QString& e);
+    bool submitMRC(MRCRequestStatus& s, QString& e);
     bool isWalletLocked();
 
 private:
@@ -98,7 +100,7 @@ private:
     int m_mrc_output_limit;
 
     bool m_mrc_error;
-    std::string m_mrc_error_desc;
+    QString m_mrc_error_desc;
     bool m_wallet_locked;
 
     int m_init_block_height;

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2014-2022 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_MRCMODEL_H
+#define GRIDCOIN_QT_MRCMODEL_H
+
+
+enum class MRCRequestStatus
+{
+    PENDING,
+    REJECTED_QUEUE_FULL,
+    STALE,
+    DELETED
+};
+
+
+#endif // GRIDCOIN_QT_MRCMODEL_H

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -11,12 +11,14 @@
 
 class WalletModel;
 class ClientModel;
+class ResearcherModel;
 
 enum class MRCRequestStatus
 {
     NONE,
-    CREATE_ERROR,
     ELIGIBLE,
+    NOT_VALID_RESEARCHER,
+    CREATE_ERROR,
     PENDING,
     QUEUE_FULL,
     ZERO_PAYOUT,
@@ -30,11 +32,15 @@ class MRCModel : public QObject
     Q_OBJECT
 
 public:
-    explicit MRCModel(WalletModel* wallet_model, ClientModel* client_model, QObject* parent = nullptr);
+    explicit MRCModel(WalletModel* wallet_model,
+                      ClientModel* client_model,
+                      ResearcherModel* researcher_model,
+                      QObject* parent = nullptr);
     ~MRCModel();
 
     enum ModelStatus {
         VALID,
+        NOT_VALID_RESEARCHER,
         INVALID_BLOCK_VERSION,
         OUT_OF_SYNC,
         NO_BLOCK_UPDATE_FROM_INIT
@@ -63,6 +69,7 @@ private:
 
     WalletModel* m_wallet_model;
     ClientModel* m_client_model;
+    ResearcherModel* m_researcher_model;
 
     GRC::MRC m_mrc;
     MRCRequestStatus m_mrc_status;

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -5,6 +5,7 @@
 #ifndef GRIDCOIN_QT_MRCMODEL_H
 #define GRIDCOIN_QT_MRCMODEL_H
 
+#include <QObject>
 
 enum class MRCRequestStatus
 {
@@ -12,6 +13,16 @@ enum class MRCRequestStatus
     REJECTED_QUEUE_FULL,
     STALE,
     DELETED
+};
+
+class MRCModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    MRCModel();
+    ~MRCModel();
+
 };
 
 

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -33,6 +33,13 @@ public:
     explicit MRCModel(WalletModel* wallet_model, ClientModel* client_model, QObject* parent = nullptr);
     ~MRCModel();
 
+    enum ModelStatus {
+        VALID,
+        INVALID_BLOCK_VERSION,
+        OUT_OF_SYNC,
+        NO_BLOCK_UPDATE_FROM_INIT
+    };
+
     WalletModel* getWalletModel();
 
     void showMRCDialog();
@@ -45,6 +52,7 @@ public:
     CAmount getMRCQueueHeadFee();
     CAmount getMRCMinimumSubmitFee();
     int getMRCOutputLimit();
+    ModelStatus getMRCModelStatus();
     bool isMRCError(MRCRequestStatus& s, std::string& e);
     bool submitMRC(MRCRequestStatus& s, std::string& e);
     bool isWalletLocked();
@@ -72,6 +80,9 @@ private:
     bool m_mrc_error;
     std::string m_mrc_error_desc;
     bool m_wallet_locked;
+
+    int m_init_block_height;
+    int m_block_height;
 
 signals:
     void mrcChanged();

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -7,9 +7,17 @@
 #include "mrcmodel.h"
 #include "qt/decoration.h"
 
-MRCRequestPage::MRCRequestPage(QWidget *parent) :
-    QWidget(parent),
-    ui(new Ui::MRCRequestPage)
+MRCRequestPage::MRCRequestPage(
+    QWidget *parent,
+    MRCModel* mrc_model)
+    : QWidget(parent)
+    , ui(new Ui::MRCRequestPage)
+    , m_mrc_model(mrc_model)
 {
     ui->setupUi(this);
+}
+
+MRCRequestPage::~MRCRequestPage()
+{
+    delete ui;
 }

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -264,7 +264,8 @@ void MRCRequestPage::showMRCStatus(const MRCModel::ModelStatus& status) {
         ui->mrcStatusSubmitFrame->hide();
         return;
     case MRCModel::ModelStatus::NO_BLOCK_UPDATE_FROM_INIT:
-        ui->waitForBlockUpdateLabel->setText(tr("A block update must have occurred since the wallet start to submit MRCs."));
+        ui->waitForBlockUpdateLabel->setText(tr("A block update must have occurred after wallet start or sync to submit "
+                                                "MRCs."));
         ui->waitForNextBlockUpdateFrame->show();
         ui->mrcStatusSubmitFrame->hide();
         return;

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) 2014-2022 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/mrcrequestpage.h"

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -2,22 +2,171 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "main.h"
+#include "qspinbox.h"
+#include "sync.h"
 #include "mrcrequestpage.h"
 #include "ui_mrcrequestpage.h"
 #include "mrcmodel.h"
+#include "walletmodel.h"
+#include "optionsmodel.h"
 #include "qt/decoration.h"
+#include "bitcoinunits.h"
 
 MRCRequestPage::MRCRequestPage(
     QWidget *parent,
     MRCModel* mrc_model)
-    : QWidget(parent)
+    : QDialog(parent)
     , ui(new Ui::MRCRequestPage)
     , m_mrc_model(mrc_model)
 {
+    if (m_mrc_model) {
+        m_wallet_model = m_mrc_model->getWalletModel();
+    }
+
     ui->setupUi(this);
+
+    m_orig_geometry = this->geometry();
+    m_gridLayout_orig_geometry = ui->gridLayout->geometry();
+
+    m_scaled_size = GRC::ScaleSize(this, width(), height());
+
+    resize(m_scaled_size);
+
+    ui->SubmittedIconLabel->setPixmap(GRC::ScaleIcon(this, ":/icons/round_green_check", 32));
+    ui->ErrorIconLabel->setPixmap(GRC::ScaleIcon(this, ":/icons/warning", 32));
+
+    connect(m_mrc_model, &MRCModel::mrcChanged, this, &MRCRequestPage::updateMRCStatus);
+    connect(m_mrc_model, &MRCModel::walletStatusChangedSignal, this, &MRCRequestPage::updateMRCStatus);
+
+    connect(ui->mrcRequestButtonBox, &QDialogButtonBox::clicked, this, &MRCRequestPage::buttonBoxClicked);
+    connect(ui->mrcUpdateButton, &QAbstractButton::clicked, this, &MRCRequestPage::updateMRCStatus);
+    connect(ui->mrcFeeBoostSpinBox, &BitcoinAmountField::textChanged, this, &MRCRequestPage::setMRCProvidedFee);
+    connect(ui->mrcSubmitButton, &QAbstractButton::clicked, this, &MRCRequestPage::submitMRC);
+
+    ui->mrcFeeBoostSpinBox->setValue(m_mrc_model->getMRCFeeBoost());
+
+    ui->ErrorIconLabel->hide();
+    ui->SubmittedIconLabel->hide();
+
+    updateMRCStatus();
 }
 
 MRCRequestPage::~MRCRequestPage()
 {
     delete ui;
+}
+
+void MRCRequestPage::updateMRCModel()
+{
+    if (!m_mrc_model) return;
+
+    m_mrc_model->refresh();
+}
+
+void MRCRequestPage::setMRCProvidedFee()
+{
+    if (!m_mrc_model) return;
+
+    CAmount fee_boost = ui->mrcFeeBoostSpinBox->value();
+
+    m_mrc_model->setMRCFeeBoost(fee_boost);
+
+    updateMRCStatus();
+}
+
+void MRCRequestPage::buttonBoxClicked(QAbstractButton* button)
+{
+    if (ui->mrcRequestButtonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
+        done(QDialog::Accepted);
+    } else {
+        done(QDialog::Rejected);
+    }
+}
+
+void MRCRequestPage::updateMRCStatus()
+{
+    if (!m_mrc_model) return;
+
+    updateMRCModel();
+
+    int display_unit = BitcoinUnits::BTC;
+    if (m_wallet_model && m_wallet_model->getOptionsModel()) {
+        display_unit = m_wallet_model->getOptionsModel()->getDisplayUnit();
+    }
+
+    ui->mrcQueueLimit->setText(QString::number(m_mrc_model->getMRCOutputLimit()));
+    ui->numMRCInQueue->setText(QString::number(m_mrc_model->getMRCQueueLength()));
+    ui->mrcQueueHeadFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueueHeadFee()));
+    ui->mrcQueuePayLimitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueuePayLimitFee()));
+    ui->mrcQueueTailFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueueTailFee()));
+
+    MRCRequestStatus s;
+    std::string e;
+    QString message;
+
+    // Note MRCError treats the PENDING status as an error from a handling point of view, because it blocks the
+    // submission of a new MRC while there is one already in progress.
+    if (m_mrc_model->isMRCError(s, e)) {
+        message = QString::fromStdString(e) + " MRC request cannot be submitted.";
+
+        ui->mrcSubmitButton->setEnabled(false);
+        ui->mrcSubmitButton->setToolTip(message);
+
+        if (s == MRCRequestStatus::PENDING) {
+            ui->mrcQueuePosition->setText(QString::number(m_mrc_model->getMRCPos() + 1));
+            ui->mrcQueuePositionLabel->setText("Your Submitted MRC Request Position in Queue");
+
+            ui->mrcMinimumSubmitFee->setText("N/A");
+
+            ui->SubmittedIconLabel->show();
+            ui->ErrorIconLabel->hide();
+            ui->ErrorIconLabel->setToolTip("");
+        } else if (s == MRCRequestStatus::QUEUE_FULL) {
+            ui->mrcQueuePosition->setText("N/A");
+            ui->mrcQueuePositionLabel->setText("Your Projected MRC Request Position in Queue");
+
+            ui->mrcMinimumSubmitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCMinimumSubmitFee()));
+
+            ui->ErrorIconLabel->show();
+            ui->ErrorIconLabel->setToolTip(message);
+        } else {
+            ui->mrcQueuePosition->setText("N/A");
+            ui->mrcQueuePositionLabel->setText("Your Projected MRC Request Position in Queue");
+
+            ui->mrcMinimumSubmitFee->setText("N/A");
+
+            ui->SubmittedIconLabel->hide();
+            ui->ErrorIconLabel->show();
+            ui->ErrorIconLabel->setToolTip(message);
+        }
+    } else {
+        message = "Submits the MRC request.";
+
+        ui->mrcQueuePosition->setText(QString::number(m_mrc_model->getMRCPos() + 1));
+        ui->mrcQueuePositionLabel->setText("Your Projected MRC Request Position in Queue");
+
+        ui->mrcMinimumSubmitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCMinimumSubmitFee()));
+
+        ui->mrcSubmitButton->setEnabled(true);
+        ui->mrcSubmitButton->setToolTip(message);
+        ui->SubmittedIconLabel->hide();
+        ui->ErrorIconLabel->hide();
+        ui->ErrorIconLabel->setToolTip("");
+    }
+}
+
+void MRCRequestPage::submitMRC()
+{
+    MRCRequestStatus s;
+    std::string e;
+    QString message;
+
+    if (!m_mrc_model) return;
+
+    if (!m_mrc_model->submitMRC(s, e)) {
+        message = QString::fromStdString(e) + " MRC request cannot be submitted.";
+
+        ui->mrcSubmitButton->setToolTip(message);
+    }
 }

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -143,6 +143,7 @@ void MRCRequestPage::updateMRCStatus()
 
             ui->mrcMinimumSubmitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCMinimumSubmitFee()));
 
+            ui->SubmittedIconLabel->hide();
             ui->ErrorIconLabel->show();
             ui->ErrorIconLabel->setToolTip(message);
         } else {
@@ -215,5 +216,11 @@ void MRCRequestPage::submitMRC()
         message = QString::fromStdString(e) + " MRC request cannot be submitted.";
 
         ui->mrcSubmitButton->setToolTip(message);
+    } else {
+        // Since MRC was successfully submitted, reset the fee boost to zero.
+        CAmount fee_boost = 0;
+
+        ui->mrcFeeBoostSpinBox->clear();
+        m_mrc_model->setMRCFeeBoost(fee_boost);
     }
 }

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -180,6 +180,12 @@ void MRCRequestPage::updateMRCStatus()
 
 void MRCRequestPage::showMRCStatus(MRCModel::ModelStatus status) {
     switch (status) {
+    case MRCModel::ModelStatus::NOT_VALID_RESEARCHER:
+        ui->waitForBlockUpdateLabel->setText(tr("You must have an active beacon and the wallet must be in solo mode to "
+                                                "submit MRCs."));
+        ui->waitForNextBlockUpdateFrame->show();
+        ui->mrcStatusSubmitFrame->hide();
+        return;
     case MRCModel::ModelStatus::INVALID_BLOCK_VERSION:
         ui->waitForBlockUpdateLabel->setText(tr("The block version must be v12 or higher to submit MRCs."));
         ui->waitForNextBlockUpdateFrame->show();

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -2,4 +2,14 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include "qt/mrcrequestpage.h"
+#include "mrcrequestpage.h"
+#include "ui_mrcrequestpage.h"
+#include "mrcmodel.h"
+#include "qt/decoration.h"
+
+MRCRequestPage::MRCRequestPage(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::MRCRequestPage)
+{
+    ui->setupUi(this);
+}

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -138,12 +138,12 @@ void MRCRequestPage::updateMRCStatus()
     // Note MRCError treats the PENDING status as an error from a handling point of view, because it blocks the
     // submission of a new MRC while there is one already in progress.
     if (m_mrc_model->isMRCError(s, e)) {
-        message = e + " MRC request cannot be submitted.";
-
         ui->mrcSubmitButton->setEnabled(false);
-        ui->mrcSubmitButton->setToolTip(message);
 
-        if (s == MRCRequestStatus::PENDING) {
+        switch (s) {
+        case MRCRequestStatus::PENDING:
+            message = e + " MRC request cannot be submitted.";
+
             ui->mrcQueuePosition->setText(QString::number(m_mrc_model->getMRCPos() + 1));
             ui->mrcQueuePositionLabel->setText(tr("Your Submitted MRC Request Position in Queue"));
 
@@ -155,7 +155,11 @@ void MRCRequestPage::updateMRCStatus()
             ui->SubmittedIconLabel->show();
             ui->ErrorIconLabel->hide();
             ui->ErrorIconLabel->setToolTip("");
-        } else if (s == MRCRequestStatus::PENDING_CANCEL){
+
+            break;
+        case MRCRequestStatus::PENDING_CANCEL:
+            message = e;
+
             ui->mrcQueuePosition->setText(QString::number(m_mrc_model->getMRCPos() + 1));
             ui->mrcQueuePositionLabel->setText(tr("Your Submitted MRC Request Position in Queue"));
 
@@ -167,7 +171,27 @@ void MRCRequestPage::updateMRCStatus()
             ui->SubmittedIconLabel->hide();
             ui->ErrorIconLabel->show();
             ui->ErrorIconLabel->setToolTip(message);
-        } else if (s == MRCRequestStatus::QUEUE_FULL) {
+
+            break;
+        case MRCRequestStatus::STALE_CANCEL:
+            message = e;
+
+            ui->mrcQueuePosition->setText(QString::number(m_mrc_model->getMRCPos() + 1));
+            ui->mrcQueuePositionLabel->setText(tr("Your Submitted MRC Request Position in Queue"));
+
+            ui->mrcMinimumSubmitFee->setText(tr("N/A"));
+
+            ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(false);
+            ui->mrcFeeBoostRaiseToMinimumButton->hide();
+
+            ui->SubmittedIconLabel->hide();
+            ui->ErrorIconLabel->show();
+            ui->ErrorIconLabel->setToolTip(message);
+
+            break;
+        case MRCRequestStatus::QUEUE_FULL:
+            message = e + " MRC request cannot be submitted.";
+
             ui->mrcQueuePosition->setText(tr("N/A"));
             ui->mrcQueuePositionLabel->setText(tr("Your Projected MRC Request Position in Queue"));
 
@@ -184,7 +208,11 @@ void MRCRequestPage::updateMRCStatus()
             ui->SubmittedIconLabel->hide();
             ui->ErrorIconLabel->show();
             ui->ErrorIconLabel->setToolTip(message);
-        } else {
+
+            break;
+        default:
+            message = e + " MRC request cannot be submitted.";
+
             ui->mrcQueuePosition->setText(tr("N/A"));
             ui->mrcQueuePositionLabel->setText(tr("Your Projected MRC Request Position in Queue"));
 
@@ -193,7 +221,9 @@ void MRCRequestPage::updateMRCStatus()
             ui->SubmittedIconLabel->hide();
             ui->ErrorIconLabel->show();
             ui->ErrorIconLabel->setToolTip(message);
-        }
+        } // switch for error conditions
+
+        ui->mrcSubmitButton->setToolTip(message);
     } else {
         message = "Submits the MRC request.";
 

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -97,9 +97,24 @@ void MRCRequestPage::updateMRCStatus()
 
     ui->mrcQueueLimit->setText(QString::number(m_mrc_model->getMRCOutputLimit()));
     ui->numMRCInQueue->setText(QString::number(m_mrc_model->getMRCQueueLength()));
-    ui->mrcQueueHeadFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueueHeadFee()));
-    ui->mrcQueuePayLimitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueuePayLimitFee()));
-    ui->mrcQueueTailFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueueTailFee()));
+
+    if (m_mrc_model->getMRCQueueLength() > 0) {
+        ui->mrcQueueHeadFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueueHeadFee()));
+    } else {
+        ui->mrcQueueHeadFee->setText("N/A");
+    }
+
+    if (m_mrc_model->getMRCQueueLength() >= m_mrc_model->getMRCOutputLimit()) {
+        ui->mrcQueuePayLimitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueuePayLimitFee()));
+    } else {
+        ui->mrcQueuePayLimitFee->setText("N/A");
+    }
+
+    if (m_mrc_model->getMRCQueueLength() > 0) {
+        ui->mrcQueueTailFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCQueueTailFee()));
+    } else {
+        ui->mrcQueueTailFee->setText("N/A");
+    }
 
     MRCRequestStatus s;
     std::string e;

--- a/src/qt/mrcrequestpage.h
+++ b/src/qt/mrcrequestpage.h
@@ -9,8 +9,8 @@
 #include <QDialog>
 
 #include "bitcoinamountfield.h"
+#include "mrcmodel.h"
 
-class MRCModel;
 class WalletModel;
 
 namespace Ui {
@@ -35,6 +35,7 @@ private:
     QSize m_scaled_size;
 
     void updateMRCModel();
+    void showMRCStatus(MRCModel::ModelStatus status);
 
 private slots:
     void buttonBoxClicked(QAbstractButton* button);

--- a/src/qt/mrcrequestpage.h
+++ b/src/qt/mrcrequestpage.h
@@ -33,11 +33,8 @@ private:
     MRCModel *m_mrc_model;
     WalletModel *m_wallet_model;
 
-    QRect m_orig_geometry;
-    QRect m_gridLayout_orig_geometry;
-    QSize m_scaled_size;
-
     void updateMRCModel();
+
     //!
     //! \brief showMRCStatus shows or hides the MRC status and submission widgets.
     //! \param status
@@ -45,12 +42,13 @@ private:
     //! showMRCStatus shows or hides the MRC status and submission widgets based on the value of the status parameter.
     //! If the status is VALID, then the widgets allowing the view of the queue state and the submission are shown.
     //! In any other state, a customized blank form with a specialized message is shown based on the status value.
-    void showMRCStatus(MRCModel::ModelStatus status);
+    void showMRCStatus(const MRCModel::ModelStatus& status);
 
 private slots:
     void buttonBoxClicked(QAbstractButton* button);
     void updateMRCStatus();
-    void setMRCProvidedFee();
+    void setMRCFeeBoost();
+    void setMRCFeeBoostToSubmitMinimum();
     void submitMRC();
 };
 

--- a/src/qt/mrcrequestpage.h
+++ b/src/qt/mrcrequestpage.h
@@ -5,15 +5,19 @@
 #ifndef GRIDCOIN_QT_MRCREQUESTPAGE_H
 #define GRIDCOIN_QT_MRCREQUESTPAGE_H
 
-#include <QWidget>
+#include <QAbstractButton>
+#include <QDialog>
+
+#include "bitcoinamountfield.h"
 
 class MRCModel;
+class WalletModel;
 
 namespace Ui {
     class MRCRequestPage;
 }
 
-class MRCRequestPage : public QWidget
+class MRCRequestPage : public QDialog
 {
     Q_OBJECT
 
@@ -24,7 +28,19 @@ public:
 private:
     Ui::MRCRequestPage *ui;
     MRCModel *m_mrc_model;
+    WalletModel *m_wallet_model;
 
+    QRect m_orig_geometry;
+    QRect m_gridLayout_orig_geometry;
+    QSize m_scaled_size;
+
+    void updateMRCModel();
+
+private slots:
+    void buttonBoxClicked(QAbstractButton* button);
+    void updateMRCStatus();
+    void setMRCProvidedFee();
+    void submitMRC();
 };
 
 #endif // GRIDCOIN_QT_MRCREQUESTPAGE_H

--- a/src/qt/mrcrequestpage.h
+++ b/src/qt/mrcrequestpage.h
@@ -5,6 +5,23 @@
 #ifndef GRIDCOIN_QT_MRCREQUESTPAGE_H
 #define GRIDCOIN_QT_MRCREQUESTPAGE_H
 
+#include <QWidget>
 
+namespace Ui {
+    class MRCRequestPage;
+}
+
+class MRCRequestPage : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit MRCRequestPage(QWidget* parent = nullptr);
+    ~MRCRequestPage();
+
+private:
+    Ui::MRCRequestPage *ui;
+
+};
 
 #endif // GRIDCOIN_QT_MRCREQUESTPAGE_H

--- a/src/qt/mrcrequestpage.h
+++ b/src/qt/mrcrequestpage.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2014-2022 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_MRCREQUESTPAGE_H
+#define GRIDCOIN_QT_MRCREQUESTPAGE_H
+
+
+
+#endif // GRIDCOIN_QT_MRCREQUESTPAGE_H

--- a/src/qt/mrcrequestpage.h
+++ b/src/qt/mrcrequestpage.h
@@ -17,6 +17,9 @@ namespace Ui {
     class MRCRequestPage;
 }
 
+//!
+//! \brief The MRCRequestPage class implements the GUI MRC request form as a non-model dialog
+//!
 class MRCRequestPage : public QDialog
 {
     Q_OBJECT
@@ -35,6 +38,13 @@ private:
     QSize m_scaled_size;
 
     void updateMRCModel();
+    //!
+    //! \brief showMRCStatus shows or hides the MRC status and submission widgets.
+    //! \param status
+    //!
+    //! showMRCStatus shows or hides the MRC status and submission widgets based on the value of the status parameter.
+    //! If the status is VALID, then the widgets allowing the view of the queue state and the submission are shown.
+    //! In any other state, a customized blank form with a specialized message is shown based on the status value.
     void showMRCStatus(MRCModel::ModelStatus status);
 
 private slots:

--- a/src/qt/mrcrequestpage.h
+++ b/src/qt/mrcrequestpage.h
@@ -7,6 +7,8 @@
 
 #include <QWidget>
 
+class MRCModel;
+
 namespace Ui {
     class MRCRequestPage;
 }
@@ -16,11 +18,12 @@ class MRCRequestPage : public QWidget
     Q_OBJECT
 
 public:
-    explicit MRCRequestPage(QWidget* parent = nullptr);
+    explicit MRCRequestPage(QWidget* parent = nullptr, MRCModel *mrc_model = nullptr);
     ~MRCRequestPage();
 
 private:
     Ui::MRCRequestPage *ui;
+    MRCModel *m_mrc_model;
 
 };
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -167,6 +167,8 @@ OverviewPage::OverviewPage(QWidget *parent) :
 
     // start with displaying the "out of sync" warnings
     showOutOfSyncWarning(true);
+
+    showHideMRCToolButton();
 }
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)
@@ -359,11 +361,20 @@ void OverviewPage::setResearcherModel(ResearcherModel *researcherModel)
         return;
     }
 
+
     updateResearcherStatus();
+    showHideMRCToolButton();
+
     connect(researcherModel, &ResearcherModel::researcherChanged, this, &OverviewPage::updateResearcherStatus);
     connect(researcherModel, &ResearcherModel::magnitudeChanged, this, &OverviewPage::updateMagnitude);
     connect(researcherModel, &ResearcherModel::accrualChanged, this, &OverviewPage::updatePendingAccrual);
     connect(researcherModel, &ResearcherModel::beaconChanged, this, &OverviewPage::updateResearcherAlert);
+
+    // Show or hide the MRC request tool button based on the researcher and beacon status.
+    connect(researcherModel, &ResearcherModel::researcherChanged, this, &OverviewPage::showHideMRCToolButton);
+    connect(researcherModel, &ResearcherModel::beaconChanged, this, &OverviewPage::showHideMRCToolButton);
+
+
     connect(ui->researcherConfigToolButton, &QAbstractButton::clicked, this, &OverviewPage::onBeaconButtonClicked);
 }
 
@@ -523,6 +534,23 @@ void OverviewPage::onMRCRequestClicked()
     }
 
     m_mrc_model->showMRCDialog();
+}
+
+void OverviewPage::showHideMRCToolButton()
+{
+    if (!researcherModel) {
+        ui->mrcRequestToolButton->hide();
+        return;
+    }
+
+    if (!researcherModel->hasActiveBeacon()
+            || researcherModel->configuredForInvestorMode()
+            || researcherModel->detectedPoolMode()) {
+        ui->mrcRequestToolButton->hide();
+        return;
+    }
+
+    ui->mrcRequestToolButton->show();
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -9,6 +9,7 @@
 #include "main.h"
 #endif
 #include "researcher/researchermodel.h"
+#include "mrcmodel.h"
 #include "walletmodel.h"
 #include "bitcoinunits.h"
 #include "optionsmodel.h"
@@ -120,6 +121,7 @@ OverviewPage::OverviewPage(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::OverviewPage),
     researcherModel(nullptr),
+    m_mrc_model(nullptr),
     walletModel(nullptr),
     currentBalance(-1),
     currentStake(0),
@@ -365,6 +367,17 @@ void OverviewPage::setResearcherModel(ResearcherModel *researcherModel)
     connect(ui->researcherConfigToolButton, &QAbstractButton::clicked, this, &OverviewPage::onBeaconButtonClicked);
 }
 
+void OverviewPage::setMRCModel(MRCModel *mrcModel)
+{
+    m_mrc_model = mrcModel;
+
+    if (!mrcModel) {
+        return;
+    }
+
+    connect(ui->mrcRequestToolButton, &QAbstractButton::clicked, this, &OverviewPage::onMRCRequestClicked);
+}
+
 void OverviewPage::setWalletModel(WalletModel *model)
 {
     this->walletModel = model;
@@ -501,6 +514,15 @@ void OverviewPage::onBeaconButtonClicked()
     }
 
     researcherModel->showWizard(walletModel);
+}
+
+void OverviewPage::onMRCRequestClicked()
+{
+    if (!m_mrc_model) {
+        return;
+    }
+
+    m_mrc_model->showMRCDialog();
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -38,6 +38,7 @@ public slots:
     void setCoinWeight(double coin_weight);
     void setCurrentPollTitle(const QString& title);
     void setPrivacy(bool privacy);
+    void showHideMRCToolButton();
 
 signals:
     void transactionClicked(const QModelIndex &index);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -12,6 +12,7 @@ namespace Ui {
     class OverviewPage;
 }
 class ResearcherModel;
+class MRCModel;
 class WalletModel;
 class TxViewDelegate;
 class TransactionFilterProxy;
@@ -26,6 +27,7 @@ public:
     ~OverviewPage();
 
     void setResearcherModel(ResearcherModel *model);
+    void setMRCModel(MRCModel *model);
     void setWalletModel(WalletModel *model);
     void showOutOfSyncWarning(bool fShow);
 
@@ -50,6 +52,7 @@ private:
 
     Ui::OverviewPage *ui;
     ResearcherModel *researcherModel;
+    MRCModel *m_mrc_model;
     WalletModel *walletModel;
     qint64 currentBalance;
     qint64 currentStake;
@@ -69,6 +72,7 @@ private slots:
     void updatePendingAccrual();
     void updateResearcherAlert();
     void onBeaconButtonClicked();
+    void onMRCRequestClicked();
     void handleTransactionClicked(const QModelIndex &index);
     void handlePollLabelClicked();
 };

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -798,6 +798,10 @@ NoResult #titleLabel {
     image: url(:/icons/dark_settings_action_needed);
 }
 
+#mrcRequestToolButton {
+    image: url(:/icons/tx_contract_mrc)
+}
+
 #listTransactions {
     background: none;
     border: none;

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -778,6 +778,10 @@ NoResult #titleLabel {
     image: url(:/icons/light_settings_action_needed);
 }
 
+#mrcRequestToolButton {
+    image: url(:/icons/tx_contract_mrc)
+}
+
 #listTransactions {
     background: none;
     border: none;

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -314,6 +314,11 @@ bool ResearcherModel::needsBeaconAuth() const
     return m_beacon->m_public_key != m_pending_beacon->m_public_key;
 }
 
+CAmount ResearcherModel::getAccrual() const
+{
+    return m_researcher->Accrual();
+}
+
 QString ResearcherModel::email() const
 {
     return QString::fromStdString(Researcher::Email());

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -6,6 +6,7 @@
 #define GRIDCOIN_QT_RESEARCHER_RESEARCHERMODEL_H
 
 #include <memory>
+#include "amount.h"
 #include <QObject>
 
 QT_BEGIN_NAMESPACE
@@ -97,6 +98,8 @@ public:
     bool hasRAC() const;
     bool hasSplitCpid() const;
     bool needsBeaconAuth() const;
+
+    CAmount getAccrual() const;
 
     QString email() const;
     QString formatCpid() const;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -79,6 +79,8 @@ void WalletModel::updateStatus()
 {
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
 
+    LogPrintf("INFO: %s called.", __func__);
+
     if(cachedEncryptionStatus != newEncryptionStatus)
         emit encryptionStatusChanged(newEncryptionStatus);
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -79,8 +79,6 @@ void WalletModel::updateStatus()
 {
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
 
-    LogPrintf("INFO: %s called.", __func__);
-
     if(cachedEncryptionStatus != newEncryptionStatus)
         emit encryptionStatusChanged(newEncryptionStatus);
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2596,7 +2596,6 @@ UniValue createmrcrequest(const UniValue& params, const bool fHelp) {
 
     pay_limit_fee = std::min(head_fee, pay_limit_fee);
 
-
     if (!dry_run && !force) {
         if (found) {
             throw runtime_error("Outstanding MRC request already present in the mempool for CPID.");


### PR DESCRIPTION
This is the initial implementation of the GUI submission form, implemented mainly in mrcmodel.h/cpp and mrcrequestpage.h/cpp/ui. Note that it is from my mrc_wizard branch, which in turn is based on the mrc branch, so this PR will show the mrc branch commits until the latest mrc PR is merged and the mrc_wizard branch is rebased [done].

As of 5/16/2022 this is a fully functional MRC submission screen. It is currently accessed by a tool button next to the researcher "gear" button on the main screen that is visible ONLY if the wallet is in solo mode, the researcher has a valid beacon, and the wallet is in sync.

The screen looks like this:
![image](https://user-images.githubusercontent.com/7529186/167949518-fe9bfa41-a266-40e6-849b-f01ecc0a2e9a.png)
(This picture shows the screen in the state where an error is displayed that it is too soon since the last payment, as a tooltip.)

The PR touches several other areas to provide minor extensions, and in the case of the rpc function createmrcrequests, bug fixes on the queue head/tail calculation, and implementation of the pay limit fee calculation, which in the case of where the queue is oversubscribed (i.e. the number of MRCs in the memory pool exceeds the maximum that can be paid out in a block), provides the fee paid by the last MRC in the queue sorted by fee (which is the last one that will be paid by the miner). This is the minimum hurdle to get over when fee boosting to displace the last entry in the pay limit and take over the last slot.

The model and page have implemented full signaling from the core of state changes that affect MRC status to allow automatic updating of the screen without having to push the "update" button. (In fact, the update button may be removed soon, as it is probably not necessary anymore.) Note this also has the advantage that the MRC request page responds correctly to actions taken by the local node core (or other nodes) as they come across the network. For example if the local node owner has the MRC request screen open and decides to submit an MRC via the debug console or rpc createmrcrequest, if the request is successful, the MRC request screen will reflect the submission in real time as if the MRC submit screen were used.

If an MRC cannot be submitted, the triangular error icon will be displayed (with an appropriate tooltip) and the submit button will be disabled. The error conditions can be seen very easily by looking at MRCModel::refresh() and MRCModel::submitMRC().

See in MRCModel.h

enum class MRCRequestStatus
{
    NONE,
    ELIGIBLE,
    NOT_VALID_RESEARCHER,
    CREATE_ERROR,
    PENDING,
    QUEUE_FULL,
    PENDING_CANCEL,
    STALE_CANCEL,
    ZERO_PAYOUT,
    EXCESSIVE_FEE,
    WALLET_LOCKED,
    SUBMIT_ERROR
};

also see

    enum ModelStatus {
        VALID,
        NOT_VALID_RESEARCHER,
        INVALID_BLOCK_VERSION,
        OUT_OF_SYNC,
        NO_BLOCK_UPDATE_FROM_INIT
    };


So everything except for NONE and ELIGIBLE in MRCRequestStatus is considered an error state. The handling of "PENDING", however, is specialized, as this means that a new MRC cannot be submitted while there is an existing MRC already (submitted) in the memory pool.

The handling of QUEUE_FULL, PENDING_CANCEL, and STALE_CANCEL are also specialized and represent special handling for corner cases given the MRC submission and payment model implemented in protocol. In the case of QUEUE_FULL, this represents where the number of MRCs in the memory pool is at the output (pay) limit, in which case the submit button is disabled and an error triangle appears suggesting that the user boost the fees if desired to try to slot in and push another MRC down. The PENDING_CANCEL represents the inverse condition from that just described, which is that the user had successfully submitted an MRC but it was pushed down in priority by another submission at a higher fee level, and there is past the pay limit and will not be paid by the staker. The STALE_CANCEL is the end stage of PENDING_CANCEL, where an unpaid MRC remains in the memory pool, but refers to a block that is no longer at the head of the chain. The tooltip for all of these error conditions has helpful commentary for the user.

Note that the "ELIGIBLE" state is the only state where the submit button is enabled.

For the ModelStatus, this controls whether the MRC status and submission widgets are displayed or hidden behind a blank screen with an information message that MRC submissions are not available. The MRC status and submission widgets are only shown when the ModelStatus is VALID. All other states result in a cover screen and an appropriate information message.

Here is a screenshot of the normal state with the wallet unlocked, where the minimum time since the last payment has been met, and the queue is empty:
![image](https://user-images.githubusercontent.com/7529186/167951890-b55488a0-3bbf-4dec-95ba-fd745f3fc0b1.png)

After submission on a full queue where the node took priority and displaced someone else due to a higher fee:
![image](https://user-images.githubusercontent.com/7529186/167952470-dc9c44d3-265e-4c34-b228-ef8703e95c89.png)

Notice that the submit button is disabled because there is a pending MRC. There is a green check box to indicate the MRC submission was successful.

This closes https://github.com/gridcoin-community/Gridcoin-Tasks/issues/218.