### PR TITLE
prevector: enforce is_trivially_copyable_v

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -35,6 +35,8 @@
  */
 template<unsigned int N, typename T, typename Size = uint32_t, typename Diff = int32_t>
 class prevector {
+    static_assert(std::is_trivially_copyable_v<T>);
+
 public:
     typedef Size size_type;
     typedef Diff difference_type;
@@ -411,15 +413,7 @@ public:
         // representation (with capacity N and size <= N).
         iterator p = first;
         char* endp = (char*)&(*end());
-        if (!std::is_trivially_destructible<T>::value) {
-            while (p != last) {
-                (*p).~T();
-                _size--;
-                ++p;
-            }
-        } else {
-            _size -= last - p;
-        }
+        _size -= last - p;
         memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
         return first;
     }
@@ -464,9 +458,6 @@ public:
     }
 
     ~prevector() {
-        if (!std::is_trivially_destructible<T>::value) {
-            clear();
-        }
         if (!is_direct()) {
             free(_union.indirect_contents.indirect);
             _union.indirect_contents.indirect = nullptr;


### PR DESCRIPTION
> prevector uses `memmove` to move around data, that means it can only be used with types that are trivially copyable. That implies that the types are trivially destructible, thus the checks for `is_trivially_destructible` are not needed.

`https://github.com/bitcoin/bitcoin/pull/24962`