### PR TITLE
miner: Miner Logger bug fix

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1729,7 +1729,7 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
             if (LogInstance().WillLogCategory(BCLog::LogFlags::MINER) && fMiner)
             {
                 LogPrintf("SelectCoinsForStaking: UTXO=%s (BalanceToConsider=%.8f >= Value=%.8f)",
-                          pcoin->vout[i].GetHash().ToString(),
+                          pcoin->GetHash().ToString(),
                           BalanceToConsider / (double) COIN,
                           pcoin->vout[i].nValue / (double) COIN);
             }


### PR DESCRIPTION
Fix miner logging bug (Visual Only).

GetHash from the utxo itself and not create one via the output which is non existent to begin with giving a false UTXO= for log.