### PR TITLE
gui: Fix transaction history table column size behavior

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1420,9 +1420,12 @@ void BitcoinGUI::gotoHistoryPage()
     historyAction->setChecked(true);
     centralWidget->setCurrentWidget(transactionView);
 
+    transactionView->resizeTableColumns();
+
     exportAction->setEnabled(true);
     disconnect(exportAction, &QAction::triggered, nullptr, nullptr);
     connect(exportAction, &QAction::triggered, transactionView, &TransactionView::exportClicked);
+
 }
 
 void BitcoinGUI::gotoAddressBookPage()

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -26,6 +26,8 @@ public:
         Amount = 4
     };
 
+    static constexpr std::initializer_list<ColumnIndex> all_ColumnIndex = {Status, Date, Type, ToAddress, Amount};
+
     /** Roles to get specific information from a transaction row.
         These are independent of column.
     */

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -14,6 +14,7 @@ class QModelIndex;
 class QMenu;
 class QFrame;
 class QDateTimeEdit;
+
 QT_END_NAMESPACE
 
 /** Widget showing the transaction list for a wallet, including a filter row.
@@ -39,6 +40,9 @@ public:
         Range
     };
 
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
 private:
     WalletModel *model;
     TransactionFilterProxy *transactionProxyModel;
@@ -58,6 +62,10 @@ private:
 
     QWidget *createDateRangeWidget();
 
+    std::vector<int> m_table_column_sizes;
+    bool m_init_column_sizes_set;
+    bool m_resize_columns_in_progress;
+
 private slots:
     void contextualMenu(const QPoint &);
     void dateRangeChanged();
@@ -67,6 +75,7 @@ private slots:
     void copyAmount();
     void copyTxID();
     void updateIcons(const QString& theme);
+    void txnViewSectionResized(int index, int old_size, int new_size);
 
 signals:
     void doubleClicked(const QModelIndex&);
@@ -79,7 +88,8 @@ public slots:
     void changedAmount(const QString &amount);
     void exportClicked();
     void focusTransaction(const QModelIndex&);
-
+    void resizeTableColumns(const bool& neighbor_pair_adjust = false, const int& index = 0,
+                            const int& old_size = 0, const int& new_size = 0);
 };
 
 #endif // BITCOIN_QT_TRANSACTIONVIEW_H


### PR DESCRIPTION
The original implementation for the TransactionView used the stretch policy for the address column as a poor man's way of allowing the table to scale to the containing frame's width. This was a poor choice. It was probably done that way because it was easy.

This PR implements proportional scaling of the columns to match the containing frame, while also memorizing any user changed column widths, and allows the user resizing of all columns in the transaction history table, while maintaining the total
table width equal to the containing frame. I think this is the best behavior.

The only improvement that could be made to this would be to store the column widths in the options model so they persist, rather than using "size hints" of m_table_column_sizes({23, 120, 120, 400, 100}) on startup.

Closes #1169.