### PR TITLE
init: fix daemon forking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -685,8 +685,11 @@ AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h str
 
 AC_CHECK_DECLS([strnlen])
 
-# Check for daemon(3), unrelated to --with-daemon (although used by it)
-AC_CHECK_DECLS([daemon])
+dnl These are used for daemonization in bitcoind
+AC_CHECK_DECLS([fork])
+AC_CHECK_DECLS([setsid])
+
+AC_CHECK_DECLS([pipe2])
 
 AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, be32toh, be64toh, htobe16, htobe32, htobe64],,,
 		[#if HAVE_ENDIAN_H

--- a/contrib/init/gridcoinresearchd.service
+++ b/contrib/init/gridcoinresearchd.service
@@ -1,0 +1,82 @@
+# It is not recommended to modify this file in-place, because it will
+# be overwritten during package upgrades. If you want to add further
+# options or overwrite existing ones then use
+# $ systemctl edit gridcoinresearchd.service
+# See "man systemd.service" for details.
+
+# Note that almost all daemon options could be specified in
+# /etc/gridcoin/gridcoin.conf, but keep in mind those explicitly
+# specified as arguments in ExecStart= will override those in the
+# config file.
+
+[Unit]
+Description=Gridcoin daemon
+Documentation=https://github.com/gridcoin-community/Gridcoin-Research/blob/development/doc/gridcoinresearch.conf.md
+
+# https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/bin/gridcoinresearchd -daemonwait \
+                                     -pid=/run/gridcoinresearchd/gridcoinresearchd.pid \
+                                     -conf=/etc/gridcoin/gridcoin.conf \
+                                     -datadir=/var/lib/gridcoinresearchd
+
+# Make sure the config directory is readable by the service user
+PermissionsStartOnly=true
+ExecStartPre=/bin/chgrp gridcoin /etc/gridcoin
+
+# Process management
+####################
+
+Type=forking
+PIDFile=/run/gridcoinresearchd/gridcoinresearchd.pid
+Restart=on-failure
+TimeoutStartSec=infinity
+TimeoutStopSec=600
+
+# Directory creation and permissions
+####################################
+
+# Run as gridcoin:gridcoin
+User=gridcoin
+Group=gridcoin
+
+# /run/gridcoinresearchd
+RuntimeDirectory=gridcoinresearchd
+RuntimeDirectoryMode=0710
+
+# /etc/gridcoin
+ConfigurationDirectory=gridcoin
+ConfigurationDirectoryMode=0710
+
+# /var/lib/gridcoinresearchd
+StateDirectory=gridcoinresearchd
+StateDirectoryMode=0710
+
+# Hardening measures
+####################
+
+# Provide a private /tmp and /var/tmp.
+PrivateTmp=true
+
+# Mount /usr, /boot/ and /etc read-only for the process.
+ProtectSystem=full
+
+# Deny access to /home, /root and /run/user
+ProtectHome=true
+
+# Disallow the process and all of its children to gain
+# new privileges through execve().
+NoNewPrivileges=true
+
+# Use a new /dev namespace only populated with API pseudo devices
+# such as /dev/null, /dev/zero and /dev/random.
+PrivateDevices=true
+
+# Deny the creation of writable and executable memory mappings.
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -194,6 +194,7 @@ GRIDCOIN_CORE_H = \
     util/settings.h \
     util/strencodings.h \
     util/string.h \
+    util/syserror.h \
     util/system.h \
     util/threadnames.h \
     util/time.h \
@@ -296,6 +297,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     util/settings.cpp \
     util/strencodings.cpp \
     util/string.cpp \
+    util/syserror.cpp \
     util/system.cpp \
     util/threadnames.cpp \
     util/time.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,6 +198,7 @@ GRIDCOIN_CORE_H = \
     util/system.h \
     util/threadnames.h \
     util/time.h \
+    util/tokenpipe.h \
     util.h \
     validation.h \
     version.h \
@@ -301,6 +302,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     util/system.cpp \
     util/threadnames.cpp \
     util/time.cpp \
+    util/tokenpipe.cpp \
     util.cpp \
     validation.cpp \
     wallet/db.cpp \

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -1,4 +1,9 @@
+// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
 #include <fs.h>
+#include <util/syserror.h>
 
 #ifndef WIN32
 #include <fcntl.h>
@@ -34,7 +39,7 @@ fs::path AbsPathJoin(const fs::path& base, const fs::path& path)
 #ifndef WIN32
 
 static std::string GetErrorReason() {
-    return std::strerror(errno);
+    return SysErrorString(errno);
 }
 
 FileLock::FileLock(const fs::path& file)

--- a/src/init.h
+++ b/src/init.h
@@ -1,12 +1,18 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2009-2021 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_INIT_H
 #define BITCOIN_INIT_H
 
 #include "wallet/wallet.h"
 #include <boost/thread.hpp>
+
+//! Default value for -daemon option
+static constexpr bool DEFAULT_DAEMON = false;
+//! Default value for -daemonwait option
+static constexpr bool DEFAULT_DAEMONWAIT = false;
 
 extern CWallet* pwalletMain;
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -145,7 +145,7 @@ static bool ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption
         nMinFee = GetBaseFee(txDummy, GMF_SEND);
     }
 
-    if(nFeeRequired < nMinFee || nFeeRequired <= nTransactionFee || fDaemon)
+    if (nFeeRequired < nMinFee || nFeeRequired <= nTransactionFee)
         return true;
     bool payFee = false;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,8 +29,6 @@ using namespace std;
 bool fPrintToConsole = false;
 bool fRequestShutdown = false;
 std::atomic<bool> fShutdown = false;
-bool fDaemon = false;
-bool fServer = false;
 bool fCommandLine = false;
 bool fTestNet = false;
 bool fNoListen = false;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -168,17 +168,6 @@ bool WildcardMatch(const string& str, const string& mask)
     return WildcardMatch(str.c_str(), mask.c_str());
 }
 
-#ifndef WIN32
-void CreatePidFile(const fs::path &path, pid_t pid)
-{
-    fsbridge::ofstream file{path};
-    if (file)
-    {
-        tfm::format(file, "%d\n", pid);
-    }
-}
-#endif
-
 /**
  * Ignores exceptions thrown by Boost's create_directories if the requested directory exists.
  * Specifically handles case where path p exists, but it wasn't possible for the user to

--- a/src/util.h
+++ b/src/util.h
@@ -98,9 +98,6 @@ bool TryCreateDirectories(const fs::path& p);
 
 std::string TimestampToHRDate(double dtm);
 
-#ifndef WIN32
-void CreatePidFile(const fs::path &path, pid_t pid);
-#endif
 bool DirIsWritable(const fs::path& directory);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 bool TryCreateDirectories(const fs::path& p);

--- a/src/util.h
+++ b/src/util.h
@@ -79,8 +79,6 @@ extern int GetDayOfYear(int64_t timestamp);
 extern bool fPrintToConsole;
 extern bool fRequestShutdown;
 extern std::atomic<bool> fShutdown;
-extern bool fDaemon;
-extern bool fServer;
 extern bool fCommandLine;
 extern bool fTestNet;
 extern bool fNoListen;

--- a/src/util/syserror.cpp
+++ b/src/util/syserror.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2020-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/gridcoin-config.h>
+#endif
+
+#include <tinyformat.h>
+#include <util/syserror.h>
+
+#include <cstring>
+
+std::string SysErrorString(int err)
+{
+    char buf[1024];
+    /* Too bad there are three incompatible implementations of the
+     * thread-safe strerror. */
+    const char *s = nullptr;
+#ifdef WIN32
+    if (strerror_s(buf, sizeof(buf), err) == 0) s = buf;
+#else
+#ifdef STRERROR_R_CHAR_P /* GNU variant can return a pointer outside the passed buffer */
+    s = strerror_r(err, buf, sizeof(buf));
+#else /* POSIX variant always returns message in buffer */
+    if (strerror_r(err, buf, sizeof(buf)) == 0) s = buf;
+#endif
+#endif
+    if (s != nullptr) {
+        return strprintf("%s (%d)", s, err);
+    } else {
+        return strprintf("Unknown error (%d)", err);
+    }
+}

--- a/src/util/syserror.h
+++ b/src/util/syserror.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2010-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_SYSERROR_H
+#define BITCOIN_UTIL_SYSERROR_H
+
+#include <string>
+
+/** Return system error string from errno value. Use this instead of
+ * std::strerror, which is not thread-safe. For network errors use
+ * NetworkErrorString from sock.h instead.
+ */
+std::string SysErrorString(int err);
+
+#endif // BITCOIN_UTIL_SYSERROR_H

--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+#include <util/tokenpipe.h>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/gridcoin-config.h>
+#endif
+
+#ifndef WIN32
+
+#include <errno.h>
+#include <fcntl.h>
+#include <optional>
+#include <unistd.h>
+
+TokenPipeEnd TokenPipe::TakeReadEnd()
+{
+    TokenPipeEnd res(m_fds[0]);
+    m_fds[0] = -1;
+    return res;
+}
+
+TokenPipeEnd TokenPipe::TakeWriteEnd()
+{
+    TokenPipeEnd res(m_fds[1]);
+    m_fds[1] = -1;
+    return res;
+}
+
+TokenPipeEnd::TokenPipeEnd(int fd) : m_fd(fd)
+{
+}
+
+TokenPipeEnd::~TokenPipeEnd()
+{
+    Close();
+}
+
+int TokenPipeEnd::TokenWrite(uint8_t token)
+{
+    while (true) {
+        ssize_t result = write(m_fd, &token, 1);
+        if (result < 0) {
+            // Failure. It's possible that the write was interrupted by a signal,
+            // in that case retry.
+            if (errno != EINTR) {
+                return TS_ERR;
+            }
+        } else if (result == 0) {
+            return TS_EOS;
+        } else { // ==1
+            return 0;
+        }
+    }
+}
+
+int TokenPipeEnd::TokenRead()
+{
+    uint8_t token;
+    while (true) {
+        ssize_t result = read(m_fd, &token, 1);
+        if (result < 0) {
+            // Failure. Check if the read was interrupted by a signal,
+            // in that case retry.
+            if (errno != EINTR) {
+                return TS_ERR;
+            }
+        } else if (result == 0) {
+            return TS_EOS;
+        } else { // ==1
+            return token;
+        }
+    }
+    return token;
+}
+
+void TokenPipeEnd::Close()
+{
+    if (m_fd != -1) close(m_fd);
+    m_fd = -1;
+}
+
+std::optional<TokenPipe> TokenPipe::Make()
+{
+    int fds[2] = {-1, -1};
+#if HAVE_O_CLOEXEC && HAVE_DECL_PIPE2
+    if (pipe2(fds, O_CLOEXEC) != 0) {
+        return std::nullopt;
+    }
+#else
+    if (pipe(fds) != 0) {
+        return std::nullopt;
+    }
+#endif
+    return TokenPipe(fds);
+}
+
+TokenPipe::~TokenPipe()
+{
+    Close();
+}
+
+void TokenPipe::Close()
+{
+    if (m_fds[0] != -1) close(m_fds[0]);
+    if (m_fds[1] != -1) close(m_fds[1]);
+    m_fds[0] = m_fds[1] = -1;
+}
+
+#endif // WIN32

--- a/src/util/tokenpipe.h
+++ b/src/util/tokenpipe.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_TOKENPIPE_H
+#define BITCOIN_UTIL_TOKENPIPE_H
+
+#ifndef WIN32
+
+#include <cstdint>
+#include <optional>
+
+/** One end of a token pipe. */
+class TokenPipeEnd
+{
+private:
+    int m_fd = -1;
+
+public:
+    TokenPipeEnd(int fd = -1);
+    ~TokenPipeEnd();
+
+    /** Return value constants for TokenWrite and TokenRead. */
+    enum Status {
+        TS_ERR = -1, //!< I/O error
+        TS_EOS = -2, //!< Unexpected end of stream
+    };
+
+    /** Write token to endpoint.
+     *
+     * @returns 0       If successful.
+     *          <0 if error:
+     *            TS_ERR  If an error happened.
+     *            TS_EOS  If end of stream happened.
+     */
+    int TokenWrite(uint8_t token);
+
+    /** Read token from endpoint.
+     *
+     * @returns >=0     Token value, if successful.
+     *          <0 if error:
+     *            TS_ERR  If an error happened.
+     *            TS_EOS  If end of stream happened.
+     */
+    int TokenRead();
+
+    /** Explicit close function.
+     */
+    void Close();
+
+    /** Return whether endpoint is open.
+     */
+    bool IsOpen() { return m_fd != -1; }
+
+    // Move-only class.
+    TokenPipeEnd(TokenPipeEnd&& other)
+    {
+        m_fd = other.m_fd;
+        other.m_fd = -1;
+    }
+    TokenPipeEnd& operator=(TokenPipeEnd&& other)
+    {
+        Close();
+        m_fd = other.m_fd;
+        other.m_fd = -1;
+        return *this;
+    }
+    TokenPipeEnd(const TokenPipeEnd&) = delete;
+    TokenPipeEnd& operator=(const TokenPipeEnd&) = delete;
+};
+
+/** An interprocess or interthread pipe for sending tokens (one-byte values)
+ * over.
+ */
+class TokenPipe
+{
+private:
+    int m_fds[2] = {-1, -1};
+
+    TokenPipe(int fds[2]) : m_fds{fds[0], fds[1]} {}
+
+public:
+    ~TokenPipe();
+
+    /** Create a new pipe.
+     * @returns The created TokenPipe, or an empty std::nullopt in case of error.
+     */
+    static std::optional<TokenPipe> Make();
+
+    /** Take the read end of this pipe. This can only be called once,
+     * as the object will be moved out.
+     */
+    TokenPipeEnd TakeReadEnd();
+
+    /** Take the write end of this pipe. This should only be called once,
+     * as the object will be moved out.
+     */
+    TokenPipeEnd TakeWriteEnd();
+
+    /** Close and end of the pipe that hasn't been moved out.
+     */
+    void Close();
+
+    // Move-only class.
+    TokenPipe(TokenPipe&& other)
+    {
+        for (int i = 0; i < 2; ++i) {
+            m_fds[i] = other.m_fds[i];
+            other.m_fds[i] = -1;
+        }
+    }
+    TokenPipe& operator=(TokenPipe&& other)
+    {
+        Close();
+        for (int i = 0; i < 2; ++i) {
+            m_fds[i] = other.m_fds[i];
+            other.m_fds[i] = -1;
+        }
+        return *this;
+    }
+    TokenPipe(const TokenPipe&) = delete;
+    TokenPipe& operator=(const TokenPipe&) = delete;
+};
+
+#endif // WIN32
+
+#endif // BITCOIN_UTIL_TOKENPIPE_H


### PR DESCRIPTION
Currently, the parent calls the shutdown routine after forking; removing the child's PID file in the process. This PR fixes that and introduces some refactoring coupled with the addition of the `-daemonwait` functionality.