### PR TITLE
mandatory, voting: Implement poll type validation in protocol

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -66,6 +66,7 @@ public:
         consensus.BlockV10Height = 1420000;
         consensus.BlockV11Height = 2053000;
         consensus.BlockV12Height = std::numeric_limits<int>::max();
+        consensus.PollV3Height = std::numeric_limits<int>::max();
         // Immediately post zero payment interval fees 40% for mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 14 days on mainnet
@@ -160,6 +161,7 @@ public:
         consensus.BlockV10Height = 629409;
         consensus.BlockV11Height = 1301500;
         consensus.BlockV12Height = 1871830;
+        consensus.PollV3Height = std::numeric_limits<int>::max();
         // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 10 minutes on testnet. The very short interval facilitates testing.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -161,7 +161,7 @@ public:
         consensus.BlockV10Height = 629409;
         consensus.BlockV11Height = 1301500;
         consensus.BlockV12Height = 1871830;
-        consensus.PollV3Height = std::numeric_limits<int>::max();
+        consensus.PollV3Height = 1944820;
         // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 10 minutes on testnet. The very short interval facilitates testing.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -150,6 +150,14 @@ inline bool IsV12Enabled(int nHeight)
     return nHeight >= BlockV12Height;
 }
 
+inline bool IsPollV3Enabled(int nHeight)
+{
+    // Temporary override for testing. Cf. Corresponding code in init.cpp
+    int PollV3Height = gArgs.GetArg("-pollv3height", Params().GetConsensus().PollV3Height);
+
+    return nHeight >= PollV3Height;
+}
+
 inline int GetSuperblockAgeSpacing(int nHeight)
 {
     return (fTestNet ? 86400 : (nHeight > 364500) ? 86400 : 43200);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -33,6 +33,8 @@ struct Params {
     int BlockV11Height;
     /** Block height at which v12 blocks are created */
     int BlockV12Height;
+    /** Block height at which poll v3 contract payloads are valid */
+    int PollV3Height;
     /** The fraction of rewards taken as fees in an MRC after the zero payment interval. Only consesnus critical
       * at BlockV12Height or above.
       */

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -817,6 +817,11 @@ bool BeaconRegistry::Validate(const Contract& contract, const CTransaction& tx, 
     return true;
 }
 
+bool BeaconRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
+{
+    return Validate(ctx.m_contract, ctx.m_tx, DoS);
+}
+
 void BeaconRegistry::ActivatePending(
     const std::vector<uint160>& beacon_ids,
     const int64_t superblock_time, const uint256& block_hash, const int& height)

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -620,6 +620,17 @@ public:
     bool Validate(const Contract& contract, const CTransaction& tx, int &DoS) const override;
 
     //!
+    //! \brief Determine whether a beacon contract is valid including block context. This is used
+    //! in ConnectBlock.
+    //!
+    //! \param ctx ContractContext containing the beacon data to validate.
+    //! \param DoS Misbehavior score out.
+    //!
+    //! \return  \c false If the contract fails validation.
+    //!
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+
+    //!
     //! \brief Register a beacon from contract data.
     //!
     //! \param ctx References the beacon contract and associated context.

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -309,7 +309,7 @@ public:
     //!
     bool BlockValidate(const ContractContext& ctx, int& DoS)
     {
-        return GetHandler(ctx->m_type.Value()).BlockValidate(ctx, DoS);
+        return GetHandler(ctx.m_contract.m_type.Value()).BlockValidate(ctx, DoS);
     }
 
     //!

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -896,7 +896,11 @@ void Contract::Body::ResetType(const ContractType type)
             m_payload.Reset(new TxMessage());
             break;
         case ContractType::POLL:
-            m_payload.Reset(new PollPayload());
+            // Note that the contract code expects cs_main to already be taken which
+            // means that the access to nBestHeight is safe.
+            // TODO: This ternary should be removed at the next mandatory after
+            // Kermit's Mom.
+            m_payload.Reset(new PollPayload(IsPollV3Enabled(nBestHeight) ? 3 : 2));
             break;
         case ContractType::PROJECT:
             m_payload.Reset(new Project());

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -309,7 +309,15 @@ public:
     //!
     bool BlockValidate(const ContractContext& ctx, int& DoS)
     {
-        return GetHandler(ctx.m_contract.m_type.Value()).BlockValidate(ctx, DoS);
+        if (!GetHandler(ctx.m_contract.m_type.Value()).BlockValidate(ctx, DoS)) {
+            error("%s: Contract of type %s failed validation.",
+                  __func__,
+                  ctx.m_contract.m_type.ToString());
+
+            return false;
+        }
+
+        return true;
     }
 
     //!

--- a/src/gridcoin/contract/contract.h
+++ b/src/gridcoin/contract/contract.h
@@ -6,6 +6,7 @@
 #define GRIDCOIN_CONTRACT_CONTRACT_H
 
 #include "amount.h"
+#include "gridcoin/contract/handler.h"
 #include "gridcoin/contract/payload.h"
 #include "gridcoin/support/enumbytes.h"
 #include "serialize.h"
@@ -519,6 +520,18 @@ void ApplyContracts(
 //! \return \c false When a contract in the transaction fails validation.
 //!
 bool ValidateContracts(const CTransaction& tx, int& DoS);
+
+//!
+//! \brief Perform contextual validation for the contracts in a transaction including block context. This is used
+//! in ConnectBlock.
+//!
+//! \param pindex The CBlockIndex of the block context of the transaction.
+//! \param tx The transaction to validate contracts for.
+//! \param DoS Misbehavior score out.
+//!
+//! \return  \c false If the contract fails validation.
+//!
+bool BlockValidateContracts(const CBlockIndex* const pindex, const CTransaction& tx, int& DoS);
 
 //!
 //! \brief Revert previously-applied contracts from a transaction by passing

--- a/src/gridcoin/contract/handler.h
+++ b/src/gridcoin/contract/handler.h
@@ -84,6 +84,17 @@ struct IContractHandler
     virtual bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const = 0;
 
     //!
+    //! \brief Perform contextual validation for the provided contract including block context. This is used
+    //! in ConnectBlock.
+    //!
+    //! \param ctx ContractContext to validate.
+    //! \param DoS Misbehavior score out.
+    //!
+    //! \return  \c false If the contract fails validation.
+    //!
+    virtual bool BlockValidate(const ContractContext& ctx, int& DoS) const = 0;
+
+    //!
     //! \brief Destroy the contract handler state to prepare for historical
     //! contract replay.
     //!

--- a/src/gridcoin/mrc.cpp
+++ b/src/gridcoin/mrc.cpp
@@ -207,6 +207,11 @@ bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransact
     return ValidateMRC(contract, tx, DoS);
 }
 
+bool GRC::MRCContractHandler::BlockValidate(const ContractContext& ctx, int& DoS) const
+{
+    return Validate(ctx.m_contract, ctx.m_tx, DoS);
+}
+
 namespace {
 //!
 //! \brief Sign the mrc.

--- a/src/gridcoin/mrc.h
+++ b/src/gridcoin/mrc.h
@@ -322,7 +322,27 @@ public:
     // Reset is a noop for MRC's here.
     void Reset() override {}
 
+    //!
+    //! \brief Perform contextual validation for the provided contract.
+    //!
+    //! \param contract Contract to validate.
+    //! \param tx       Transaction that contains the contract.
+    //! \param DoS      Misbehavior score out.
+    //!
+    //! \return \c false If the contract fails validation.
+    //!
     bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+
+    //!
+    //! \brief Perform contextual validation for the provided contract including block context. This is used
+    //! in ConnectBlock.
+    //!
+    //! \param ctx ContractContext to validate.
+    //! \param DoS Misbehavior score out.
+    //!
+    //! \return  \c false If the contract fails validation.
+    //!
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
 
     // Add is a noop here, because this is handled at the block level by the staker (in the miner) as with the claim.
     void Add(const ContractContext& ctx) override {}

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -307,6 +307,20 @@ public:
     }
 
     //!
+    //! \brief Perform contextual validation for the provided contract including block context. This is used
+    //! in ConnectBlock.
+    //!
+    //! \param ctx ContractContext to validate.
+    //! \param DoS Misbehavior score out.
+    //!
+    //! \return \c false If the contract fails validation.
+    //!
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override
+    {
+        return true; // No contextual validation needed yet
+    }
+
+    //!
     //! \brief Add a project to the whitelist from contract data.
     //!
     //! \param ctx References the project contract and associated context.

--- a/src/gridcoin/support/block_finder.cpp
+++ b/src/gridcoin/support/block_finder.cpp
@@ -18,12 +18,14 @@ CBlockIndex* BlockFinder::FindByHeight(int height)
     if(index != nullptr)
     {
         // Traverse towards the tail.
-        while (index && index->pprev && index->nHeight > height)
+        while (index && index->pprev && index->nHeight > height) {
             index = index->pprev;
+        }
 
         // Traverse towards the head.
-        while (index && index->pnext && index->nHeight < height)
+        while (index && index->pnext && index->nHeight < height) {
             index = index->pnext;
+        }
     }
 
     return index;
@@ -38,15 +40,33 @@ CBlockIndex* BlockFinder::FindByMinTime(int64_t time)
             ? pindexBest
             : pindexGenesisBlock;
 
-    if(index != nullptr)
+    if (index != nullptr)
     {
         // Move back until the previous block is no longer younger than "time".
-        while(index && index->pprev && index->pprev->nTime > time)
+        while (index && index->pprev && index->pprev->nTime > time) {
             index = index->pprev;
+        }
 
         // Move forward until the current block is younger than "time".
-        while(index && index->pnext && index->nTime < time)
+        while (index && index->pnext && index->nTime < time) {
             index = index->pnext;
+        }
+    }
+
+    return index;
+}
+
+// The arguments are passed by value on purpose.
+CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* index)
+{
+    // If no starting index is provided (i.e. second parameter is omitted or nullptr is passed in,
+    // then start at the Genesis Block. This is in general expensive and should be avoided.
+    if (!index) {
+        index = pindexGenesisBlock;
+    }
+
+    while (index && index->pnext && index->nTime < time) {
+        index = index->pnext;
     }
 
     return index;

--- a/src/gridcoin/support/block_finder.h
+++ b/src/gridcoin/support/block_finder.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_SUPPORT_BLOCK_FINDER_H
 #define GRIDCOIN_SUPPORT_BLOCK_FINDER_H
 
+#include <cstdint>
+
 class CBlockIndex;
 
 namespace GRC {
@@ -38,6 +40,15 @@ public:
     //! head of the chain if it is older than \p time.
     //!
     static CBlockIndex* FindByMinTime(int64_t time);
+
+    //!
+    //! \brief Find block by time going forward from given index.
+    //! \param time
+    //! \param CBlockIndex from where to start
+    //! \return CBlockIndex pointing to the youngest block which is not older than \p time, or
+    //! the head of the chain if it is older than \p time.
+    //!
+    static CBlockIndex* FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* index = nullptr);
 };
 } // namespace GRC
 

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -1102,7 +1102,23 @@ PollBuilder PollBuilder::SetAdditionalFields(std::vector<Poll::AdditionalField> 
     return AddAdditionalFields(std::move(fields));
 }
 
+PollBuilder PollBuilder::SetAdditionalFields(Poll::AdditionalFieldList fields)
+{
+    m_poll->m_additional_fields = Poll::AdditionalFieldList();
+
+    return AddAdditionalFields(std::move(fields));
+}
+
 PollBuilder PollBuilder::AddAdditionalFields(std::vector<Poll::AdditionalField> fields)
+{
+    for (auto& field : fields) {
+        *this = AddAdditionalField(std::move(field));
+    }
+
+    return std::move(*this);
+}
+
+PollBuilder PollBuilder::AddAdditionalFields(Poll::AdditionalFieldList fields)
 {
     for (auto& field : fields) {
         *this = AddAdditionalField(std::move(field));
@@ -1116,6 +1132,7 @@ PollBuilder PollBuilder::AddAdditionalField(Poll::AdditionalField field)
     // Make sure there are no leading and trailing spaces.
     field.m_name = TrimString(field.m_name);
     field.m_value = TrimString(field.m_value);
+    field.m_required = field.m_required;
 
     if (!field.WellFormed()) {
         throw VotingError(_("The field is not well-formed."));

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -1115,6 +1115,10 @@ PollBuilder PollBuilder::AddAdditionalFields(std::vector<Poll::AdditionalField> 
         *this = AddAdditionalField(std::move(field));
     }
 
+    if (!m_poll->m_additional_fields.WellFormed(m_poll->m_type.Value())) {
+        throw VotingError(_("The field list is not well-formed."));
+    }
+
     return std::move(*this);
 }
 
@@ -1122,6 +1126,10 @@ PollBuilder PollBuilder::AddAdditionalFields(Poll::AdditionalFieldList fields)
 {
     for (auto& field : fields) {
         *this = AddAdditionalField(std::move(field));
+    }
+
+    if (!m_poll->m_additional_fields.WellFormed(m_poll->m_type.Value())) {
+        throw VotingError(_("The field list is not well-formed."));
     }
 
     return std::move(*this);

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -45,6 +45,13 @@ public:
     PollBuilder& operator=(PollBuilder&& builder);
 
     //!
+    //! \brief SetPayloadVersion
+    //!
+    //! \throws VotingError If the version is not valid for the current wallet height.
+    //!
+    PollBuilder SetPayloadVersion(uint32_t version);
+
+    //!
     //! \brief Set the type of the poll.
     //!
     //! \throws VotingError If the supplied poll type is not valid.
@@ -171,7 +178,8 @@ public:
     CWalletTx BuildContractTx(CWallet* const pwallet);
 
 private:
-    std::unique_ptr<Poll> m_poll; //!< The poll under construction.
+    std::unique_ptr<Poll> m_poll;    //!< The poll under construction.
+    uint32_t m_poll_payload_version; //!< The poll payload version appropriate for the current block height
 }; // PollBuilder
 
 //!

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -8,6 +8,7 @@
 #include "gridcoin/voting/fwd.h"
 
 #include <memory>
+#include <vector>
 
 class CWallet;
 class CWalletTx;

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -5,7 +5,7 @@
 #ifndef GRIDCOIN_VOTING_BUILDERS_H
 #define GRIDCOIN_VOTING_BUILDERS_H
 
-#include "gridcoin/voting/fwd.h"
+#include "gridcoin/voting/poll.h"
 
 #include <memory>
 #include <vector>
@@ -165,6 +165,36 @@ public:
     //! number for a poll, or if the set of choices contains a duplicate label.
     //!
     PollBuilder AddChoice(std::string label);
+
+    //!
+    //! \brief Set the set of additional fields for the poll.
+    //!
+    //! \param labels A set of AdditionalFields to set.
+    //!
+    //! \throws VotingError If any of the fields are malformed, or if the set of fields
+    //! contains a duplicate label.
+    //!
+    PollBuilder SetAdditionalFields(std::vector<Poll::AdditionalField> fields);
+
+    //!
+    //! \brief Add a set of additional fields for the poll.
+    //!
+    //! \param labels A set of AdditionalFields to add.
+    //!
+    //! \throws VotingError If any of the fields are malformed, or if the set of fields
+    //! contains a duplicate label.
+    //!
+    PollBuilder AddAdditionalFields(std::vector<Poll::AdditionalField> fields);
+
+    //!
+    //! \brief Add an additional field for the poll.
+    //!
+    //! \param AdditionalField The additional field name-value to add.
+    //!
+    //! \throws VotingError If the field is malformed, or if the set of fields
+    //! contains a duplicate label.
+    //!
+    PollBuilder AddAdditionalField(Poll::AdditionalField field);
 
     //!
     //! \brief Generate a poll contract transaction with the constructed poll.

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -169,7 +169,7 @@ public:
     //!
     //! \brief Set the set of additional fields for the poll.
     //!
-    //! \param labels A set of AdditionalFields to set.
+    //! \param field A set of AdditionalFields to set.
     //!
     //! \throws VotingError If any of the fields are malformed, or if the set of fields
     //! contains a duplicate label.
@@ -177,9 +177,19 @@ public:
     PollBuilder SetAdditionalFields(std::vector<Poll::AdditionalField> fields);
 
     //!
+    //! \brief Set the set of additional fields for the poll.
+    //!
+    //! \param fields A set of AdditionalFields to set.
+    //!
+    //! \throws VotingError If any of the fields are malformed, or if the set of fields
+    //! contains a duplicate label.
+    //!
+    PollBuilder SetAdditionalFields(Poll::AdditionalFieldList fields);
+
+    //!
     //! \brief Add a set of additional fields for the poll.
     //!
-    //! \param labels A set of AdditionalFields to add.
+    //! \param fields A set of AdditionalFields to add.
     //!
     //! \throws VotingError If any of the fields are malformed, or if the set of fields
     //! contains a duplicate label.
@@ -187,9 +197,19 @@ public:
     PollBuilder AddAdditionalFields(std::vector<Poll::AdditionalField> fields);
 
     //!
+    //! \brief Add a set of additional fields for the poll.
+    //!
+    //! \param fields A set of AdditionalFields to add.
+    //!
+    //! \throws VotingError If any of the fields are malformed, or if the set of fields
+    //! contains a duplicate label.
+    //!
+    PollBuilder AddAdditionalFields(Poll::AdditionalFieldList fields);
+
+    //!
     //! \brief Add an additional field for the poll.
     //!
-    //! \param AdditionalField The additional field name-value to add.
+    //! \param field The additional field name-value to add.
     //!
     //! \throws VotingError If the field is malformed, or if the set of fields
     //! contains a duplicate label.

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -167,42 +167,42 @@ public:
     PollBuilder AddChoice(std::string label);
 
     //!
-    //! \brief Set the set of additional fields for the poll.
+    //! \brief Set the set of additional fields for the poll. SetType() should be called beforehand.
     //!
     //! \param field A set of AdditionalFields to set.
     //!
-    //! \throws VotingError If any of the fields are malformed, or if the set of fields
-    //! contains a duplicate label.
+    //! \throws VotingError If any of the fields are malformed, if the set of fields
+    //! contains a duplicate name, or the required boolean(s) are improperly set.
     //!
     PollBuilder SetAdditionalFields(std::vector<Poll::AdditionalField> fields);
 
     //!
-    //! \brief Set the set of additional fields for the poll.
+    //! \brief Set the set of additional fields for the poll. SetType() should be called beforehand.
     //!
     //! \param fields A set of AdditionalFields to set.
     //!
     //! \throws VotingError If any of the fields are malformed, or if the set of fields
-    //! contains a duplicate label.
+    //! contains a duplicate name, or the required boolean(s) are improperly set.
     //!
     PollBuilder SetAdditionalFields(Poll::AdditionalFieldList fields);
 
     //!
-    //! \brief Add a set of additional fields for the poll.
+    //! \brief Add a set of additional fields for the poll. SetType() should be called beforehand.
     //!
     //! \param fields A set of AdditionalFields to add.
     //!
     //! \throws VotingError If any of the fields are malformed, or if the set of fields
-    //! contains a duplicate label.
+    //! contains a duplicate name, or the required boolean(s) are improperly set.
     //!
     PollBuilder AddAdditionalFields(std::vector<Poll::AdditionalField> fields);
 
     //!
-    //! \brief Add a set of additional fields for the poll.
+    //! \brief Add a set of additional fields for the poll. SetType() should be called beforehand.
     //!
     //! \param fields A set of AdditionalFields to add.
     //!
     //! \throws VotingError If any of the fields are malformed, or if the set of fields
-    //! contains a duplicate label.
+    //! contains a duplicate name, or the required boolean(s) are improperly set.
     //!
     PollBuilder AddAdditionalFields(Poll::AdditionalFieldList fields);
 
@@ -212,7 +212,7 @@ public:
     //! \param field The additional field name-value to add.
     //!
     //! \throws VotingError If the field is malformed, or if the set of fields
-    //! contains a duplicate label.
+    //! contains a duplicate name.
     //!
     PollBuilder AddAdditionalField(Poll::AdditionalField field);
 

--- a/src/gridcoin/voting/claims.h
+++ b/src/gridcoin/voting/claims.h
@@ -10,10 +10,10 @@
 #include "gridcoin/cpid.h"
 #include "gridcoin/magnitude.h"
 #include "serialize.h"
+#include "primitives/transaction.h"
 
 #include <vector>
 
-class COutPoint;
 class CTransaction;
 
 namespace GRC {

--- a/src/gridcoin/voting/fwd.h
+++ b/src/gridcoin/voting/fwd.h
@@ -6,7 +6,8 @@
 #define GRIDCOIN_VOTING_FWD_H
 
 #include "amount.h"
-
+#include <optional>
+#include <string>
 
 namespace GRC {
 

--- a/src/gridcoin/voting/fwd.h
+++ b/src/gridcoin/voting/fwd.h
@@ -34,13 +34,16 @@ constexpr size_t POLL_MAX_CHOICES_SIZE = 20;
 //! CONSENSUS: Do not remove or reorder items in this enumeration except for
 //! OUT_OF_BOUND which must remain at the end.
 //!
-//! TODO: we may add additional poll types with specialized requirements, data,
-//! or behavior such as project whitelist polls.
-//!
 enum class PollType
 {
     UNKNOWN,       //!< An invalid, non-standard, or empty poll type.
     SURVEY,        //!< For casual, opinion, and legacy polls.
+    PROJECT,       //!< Propose additions or removals of projects for research rewards eligibility.
+    DEVELOPMENT,   //!< Propose a change to Gridcoin at the protocol level.
+    GOVERNANCE,    //!< Proposals related to Gridcoin management like poll requirements or funding.
+    MARKETING,     //!< Propose marketing initiatives like ad campaigns.
+    OUTREACH,      //!< For polls about community representation, public relations, and communications.
+    COMMUNITY,     //!< For other initiatives related to the Gridcoin community not included in the above.
     OUT_OF_BOUND,  //!< Marker value for the end of the valid range.
 };
 

--- a/src/gridcoin/voting/fwd.h
+++ b/src/gridcoin/voting/fwd.h
@@ -30,6 +30,11 @@ constexpr CAmount POLL_REQUIRED_BALANCE = 100000 * COIN;
 constexpr size_t POLL_MAX_CHOICES_SIZE = 20;
 
 //!
+//! \brief The maximum number of additional fields that a poll can contain.
+//!
+constexpr size_t POLL_MAX_ADDITIONAL_FIELDS_SIZE = 16;
+
+//!
 //! \brief Describes the poll types.
 //!
 //! CONSENSUS: Do not remove or reorder items in this enumeration except for

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -50,10 +50,14 @@ public:
     PollPayload()
     {
         m_version = CURRENT_VERSION;
+    }
 
-        if (!IsPollV3Enabled(nBestHeight)) {
-            m_version = 2;
-        }
+    //!
+    //! \brief Initialize an empty, invalid poll payload with the provided version
+    //! \param version
+    //!
+    PollPayload(uint32_t version) : m_version(version)
+    {
     }
 
     //!
@@ -156,14 +160,13 @@ public:
     }
 
     //!
-    //! \brief This returns the poll type(s) that are valid for the poll (payload) version.
-    //! \return
+    //! \brief This returns the poll type(s) that are valid for the provided poll (payload) version.
     //!
-    std::vector<PollType> GetValidPollTypes() const
+    static std::vector<PollType> GetValidPollTypes(const uint32_t& version)
     {
         std::vector<PollType> poll_type;
 
-        if (m_version < 3) {
+        if (version < 3) {
             poll_type.push_back(PollType::SURVEY);
         } else {
             for (const auto& type : Poll::POLL_TYPES) {

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -48,8 +48,12 @@ public:
     //! \brief Initialize an empty, invalid poll payload.
     //!
     PollPayload()
-        : m_version(CURRENT_VERSION)
     {
+        m_version = CURRENT_VERSION;
+
+        if (!IsPollV3Enabled(nBestHeight)) {
+            m_version = 2;
+        }
     }
 
     //!
@@ -149,6 +153,27 @@ public:
     {
         // 50 GRC + a scaled fee based on the number of claimed outputs:
         return (50 * COIN) + m_claim.RequiredBurnAmount();
+    }
+
+    //!
+    //! \brief This returns the poll type(s) that are valid for the poll (payload) version.
+    //! \return
+    //!
+    std::vector<PollType> GetValidPollTypes() const
+    {
+        std::vector<PollType> poll_type;
+
+        if (m_version < 3) {
+            poll_type.push_back(PollType::SURVEY);
+        } else {
+            for (const auto& type : Poll::POLL_TYPES) {
+                if (type == PollType::UNKNOWN || type == PollType::OUT_OF_BOUND) continue;
+
+                poll_type.push_back(type);
+            }
+        }
+
+        return poll_type;
     }
 
     ADD_CONTRACT_PAYLOAD_SERIALIZE_METHODS;

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -5,11 +5,14 @@
 #ifndef GRIDCOIN_VOTING_PAYLOADS_H
 #define GRIDCOIN_VOTING_PAYLOADS_H
 
+#include "chainparams.h"
 #include "gridcoin/contract/payload.h"
 #include "gridcoin/voting/claims.h"
 #include "gridcoin/voting/poll.h"
 #include "gridcoin/voting/vote.h"
 #include "serialize.h"
+
+extern int nBestHeight;
 
 namespace GRC {
 //!
@@ -56,8 +59,15 @@ public:
     //! \param claim Testifies that the poll author owns the required balance.
     //!
     PollPayload(Poll poll, PollEligibilityClaim claim)
-        : PollPayload(CURRENT_VERSION, std::move(poll), std::move(claim))
     {
+        m_version = CURRENT_VERSION;
+
+        if (!IsPollV3Enabled(nBestHeight)) {
+            m_version = 2;
+        }
+
+        m_poll = std::move(poll);
+        m_claim = std::move(claim);
     }
 
     //!

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -25,7 +25,7 @@ public:
     //! ensure that the serialization/deserialization routines also handle all
     //! of the previous versions.
     //!
-    static constexpr uint32_t CURRENT_VERSION = 2;
+    static constexpr uint32_t CURRENT_VERSION = 3;
 
     //!
     //! \brief Version number of the serialized poll format.

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -12,8 +12,6 @@
 #include "gridcoin/voting/vote.h"
 #include "serialize.h"
 
-extern int nBestHeight;
-
 namespace GRC {
 //!
 //! \brief The body of a poll contract submitted in a transaction.

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -61,24 +61,6 @@ public:
     }
 
     //!
-    //! \brief Initialize a poll payload for submission in a transaction.
-    //!
-    //! \param poll  The body of the poll.
-    //! \param claim Testifies that the poll author owns the required balance.
-    //!
-    PollPayload(Poll poll, PollEligibilityClaim claim)
-    {
-        m_version = CURRENT_VERSION;
-
-        if (!IsPollV3Enabled(nBestHeight)) {
-            m_version = 2;
-        }
-
-        m_poll = std::move(poll);
-        m_claim = std::move(claim);
-    }
-
-    //!
     //! \brief Initialize a poll from data in a legacy contract.
     //!
     //! \param poll The body of the poll.
@@ -89,7 +71,7 @@ public:
     }
 
     //!
-    //! \brief Initialize a poll from data in a contract.
+    //! \brief Initialize a poll from data in a contract or for submission in a transaction
     //!
     //! \param version Version number of the serialized poll format.
     //! \param poll    The body of the poll.

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -371,12 +371,24 @@ bool AdditionalFieldList::WellFormed(const PollType poll_type) const
 
     for (const auto& iter : required_field_names) {
         std::optional<uint8_t> offset = OffsetOf(iter);
-
         // If the field name (entry) does not exist, return false.
         if (!offset) return false;
 
+        // If the field name (entry) m_required flag is not set properly then return false.
+        if (At(*offset)->m_required != true) return false;
+
         // If the field value is empty, return false. A required field cannot have an empty value.
         if (At(*offset)->m_value.empty()) return false;
+    }
+
+    // We also need to check whether fields that are NOT required are marked accordingly. This requires us
+    // to iterate through the m_additional_fields. If a field entry is not found in the required fields list
+    // and the field entry is marked required, then return false.
+    for (const auto& iter : m_additional_fields) {
+        if (std::find(required_field_names.begin(), required_field_names.end(), iter.m_name) == required_field_names.end()
+                && iter.m_required) {
+            return false;
+        }
     }
 
     return true;

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -206,16 +206,64 @@ const Poll::ChoiceList& Poll::Choices() const
     return m_choices;
 }
 
+std::string Poll::PollTypeToString() const
+{
+    return PollTypeToString(m_type.Value());
+}
+
+std::string Poll::PollTypeToString(const PollType& type)
+{
+    switch(type) {
+    case PollType::UNKNOWN:         return std::string{};
+    case PollType::SURVEY:          return _("Survey");
+    case PollType::PROJECT:         return _("Project Listing");
+    case PollType::DEVELOPMENT:     return _("Protocol Development");
+    case PollType::GOVERNANCE:      return _("Governance");
+    case PollType::MARKETING:       return _("Marketing");
+    case PollType::OUTREACH:        return _("Outreach");
+    case PollType::COMMUNITY:       return _("Community");
+    case PollType::OUT_OF_BOUND:    return _("Out of Bound");
+    }
+
+    assert(false); // Suppress warning
+}
+
+std::string Poll::PollTypeToDescString() const
+{
+    return PollTypeToDescString(m_type.Value());
+}
+
+
+std::string Poll::PollTypeToDescString(const PollType& type)
+{
+    switch(type) {
+    case PollType::UNKNOWN:         return std::string{};
+    case PollType::SURVEY:          return _("For opinion or casual polls without any particular requirements.");
+    case PollType::PROJECT:         return _("Propose additions or removals of computing projects for research reward "
+                                             "eligibility.");
+    case PollType::DEVELOPMENT:     return _("Propose a change to Gridcoin at the protocol level.");
+    case PollType::GOVERNANCE:      return _("Proposals related to Gridcoin management like poll requirements and funding.");
+    case PollType::MARKETING:       return _("Propose marketing initiatives like ad campaigns.");
+    case PollType::OUTREACH:        return _("For polls about community representation, public relations, and "
+                                             "communications.");
+    case PollType::COMMUNITY:       return _("For initiatives related to the Gridcoin community not covered by other "
+                                             "poll types.");
+    case PollType::OUT_OF_BOUND:    return _("Out of Bound");
+    }
+
+    assert(false); // Suppress warning
+}
+
 std::string Poll::WeightTypeToString() const
 {
     switch (m_weight_type.Value()) {
-        case PollWeightType::UNKNOWN:
-        case PollWeightType::OUT_OF_BOUND:          return _("Unknown");
-        case PollWeightType::MAGNITUDE:             return _("Magnitude");
-        case PollWeightType::BALANCE:               return _("Balance");
-        case PollWeightType::BALANCE_AND_MAGNITUDE: return _("Magnitude+Balance");
-        case PollWeightType::CPID_COUNT:            return _("CPID Count");
-        case PollWeightType::PARTICIPANT_COUNT:     return _("Participant Count");
+    case PollWeightType::UNKNOWN:               return std::string{};
+    case PollWeightType::OUT_OF_BOUND:          return _("Out of Bound");
+    case PollWeightType::MAGNITUDE:             return _("Magnitude");
+    case PollWeightType::BALANCE:               return _("Balance");
+    case PollWeightType::BALANCE_AND_MAGNITUDE: return _("Magnitude+Balance");
+    case PollWeightType::CPID_COUNT:            return _("CPID Count");
+    case PollWeightType::PARTICIPANT_COUNT:     return _("Participant Count");
     }
 
     assert(false); // Suppress warning
@@ -224,11 +272,11 @@ std::string Poll::WeightTypeToString() const
 std::string Poll::ResponseTypeToString() const
 {
     switch (m_response_type.Value()) {
-        case PollResponseType::UNKNOWN:
-        case PollResponseType::OUT_OF_BOUND:    return _("Unknown");
-        case PollResponseType::YES_NO_ABSTAIN:  return _("Yes/No/Abstain");
-        case PollResponseType::SINGLE_CHOICE:   return _("Single Choice");
-        case PollResponseType::MULTIPLE_CHOICE: return _("Multiple Choice");
+    case PollResponseType::UNKNOWN:         return std::string{};
+    case PollResponseType::OUT_OF_BOUND:    return _("Out of Bound");
+    case PollResponseType::YES_NO_ABSTAIN:  return _("Yes/No/Abstain");
+    case PollResponseType::SINGLE_CHOICE:   return _("Single Choice");
+    case PollResponseType::MULTIPLE_CHOICE: return _("Multiple Choice");
     }
 
     assert(false); // Suppress warning
@@ -317,3 +365,34 @@ void ChoiceList::Add(std::string label)
 {
     m_choices.emplace_back(std::move(label));
 }
+
+//!
+//! \brief This allows use of range based loops through the PollType enum
+//!
+const std::vector<GRC::PollType> Poll::POLL_TYPES = {
+    PollType::UNKNOWN,
+    PollType::SURVEY,
+    PollType::PROJECT,
+    PollType::DEVELOPMENT,
+    PollType::GOVERNANCE,
+    PollType::MARKETING,
+    PollType::OUTREACH,
+    PollType::COMMUNITY,
+    PollType::OUT_OF_BOUND
+};
+
+//!
+//! \brief Poll rules that are specific to poll type. Enforced for poll payload version 3+
+//!
+const std::vector<Poll::PollTypeRules> Poll::POLL_TYPE_RULES = {
+    // These must be kept in the order that corresponds to the PollType enum.
+    // min duration - min vote percent AVW
+    {  0,  0 }, // PollType::UNKNOWN
+    {  7,  0 }, // PollType::SURVEY
+    { 21, 40 }, // PollType::PROJECT
+    { 42, 50 }, // PollType::DEVELOPMENT
+    { 21, 20 }, // PollType::GOVERNANCE
+    { 21, 40 }, // PollType::MARKETING
+    { 21, 40 }, // PollType::OUTREACH
+    { 21, 10 }  // PollType::COMMUNITY
+};

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -384,34 +384,3 @@ void ChoiceList::Add(std::string label)
 {
     m_choices.emplace_back(std::move(label));
 }
-
-//!
-//! \brief This allows use of range based loops through the PollType enum
-//!
-const std::vector<GRC::PollType> Poll::POLL_TYPES = {
-    PollType::UNKNOWN,
-    PollType::SURVEY,
-    PollType::PROJECT,
-    PollType::DEVELOPMENT,
-    PollType::GOVERNANCE,
-    PollType::MARKETING,
-    PollType::OUTREACH,
-    PollType::COMMUNITY,
-    PollType::OUT_OF_BOUND
-};
-
-//!
-//! \brief Poll rules that are specific to poll type. Enforced for poll payload version 3+
-//!
-const std::vector<Poll::PollTypeRules> Poll::POLL_TYPE_RULES = {
-    // These must be kept in the order that corresponds to the PollType enum.
-    // min duration - min vote percent AVW
-    {  0,  0 }, // PollType::UNKNOWN
-    {  7,  0 }, // PollType::SURVEY
-    { 21, 40 }, // PollType::PROJECT
-    { 42, 50 }, // PollType::DEVELOPMENT
-    { 21, 20 }, // PollType::GOVERNANCE
-    { 21, 40 }, // PollType::MARKETING
-    { 21, 40 }, // PollType::OUTREACH
-    { 21, 10 }  // PollType::COMMUNITY
-};

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -223,7 +223,7 @@ std::string Poll::PollTypeToString(const PollType& type, const bool& translated)
         case PollType::MARKETING:       return _("Marketing");
         case PollType::OUTREACH:        return _("Outreach");
         case PollType::COMMUNITY:       return _("Community");
-        case PollType::OUT_OF_BOUND:    return _("Out of Bound");
+        case PollType::OUT_OF_BOUND:    break;
         }
 
         assert(false); // Suppress warning
@@ -238,7 +238,7 @@ std::string Poll::PollTypeToString(const PollType& type, const bool& translated)
         case PollType::MARKETING:       return "marketing";
         case PollType::OUTREACH:        return "outreach";
         case PollType::COMMUNITY:       return "community";
-        case PollType::OUT_OF_BOUND:    return "out of bound";
+        case PollType::OUT_OF_BOUND:    break;
         }
 
         assert(false); // Suppress warning
@@ -267,7 +267,7 @@ std::string Poll::PollTypeToDescString(const PollType& type)
                                              "communications.");
     case PollType::COMMUNITY:       return _("For initiatives related to the Gridcoin community not covered by other "
                                              "poll types.");
-    case PollType::OUT_OF_BOUND:    return _("Out of Bound");
+    case PollType::OUT_OF_BOUND:    break;
     }
 
     assert(false); // Suppress warning
@@ -277,12 +277,12 @@ std::string Poll::WeightTypeToString() const
 {
     switch (m_weight_type.Value()) {
     case PollWeightType::UNKNOWN:               return std::string{};
-    case PollWeightType::OUT_OF_BOUND:          return _("Out of Bound");
     case PollWeightType::MAGNITUDE:             return _("Magnitude");
     case PollWeightType::BALANCE:               return _("Balance");
     case PollWeightType::BALANCE_AND_MAGNITUDE: return _("Magnitude+Balance");
     case PollWeightType::CPID_COUNT:            return _("CPID Count");
     case PollWeightType::PARTICIPANT_COUNT:     return _("Participant Count");
+    case PollWeightType::OUT_OF_BOUND:          break;
     }
 
     assert(false); // Suppress warning
@@ -292,10 +292,10 @@ std::string Poll::ResponseTypeToString() const
 {
     switch (m_response_type.Value()) {
     case PollResponseType::UNKNOWN:         return std::string{};
-    case PollResponseType::OUT_OF_BOUND:    return _("Out of Bound");
     case PollResponseType::YES_NO_ABSTAIN:  return _("Yes/No/Abstain");
     case PollResponseType::SINGLE_CHOICE:   return _("Single Choice");
     case PollResponseType::MULTIPLE_CHOICE: return _("Multiple Choice");
+    case PollResponseType::OUT_OF_BOUND:    break;
     }
 
     assert(false); // Suppress warning

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -422,6 +422,11 @@ void AdditionalFieldList::Add(std::string name, std::string value, bool required
     m_additional_fields.emplace_back(std::move(additional_field));
 }
 
+void AdditionalFieldList::Add(AdditionalField field)
+{
+    m_additional_fields.emplace_back(std::move(field));
+}
+
 // -----------------------------------------------------------------------------
 // Class: Poll::ChoiceList
 // -----------------------------------------------------------------------------

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -211,21 +211,40 @@ std::string Poll::PollTypeToString() const
     return PollTypeToString(m_type.Value());
 }
 
-std::string Poll::PollTypeToString(const PollType& type)
+std::string Poll::PollTypeToString(const PollType& type, const bool& translated)
 {
-    switch(type) {
-    case PollType::UNKNOWN:         return std::string{};
-    case PollType::SURVEY:          return _("Survey");
-    case PollType::PROJECT:         return _("Project Listing");
-    case PollType::DEVELOPMENT:     return _("Protocol Development");
-    case PollType::GOVERNANCE:      return _("Governance");
-    case PollType::MARKETING:       return _("Marketing");
-    case PollType::OUTREACH:        return _("Outreach");
-    case PollType::COMMUNITY:       return _("Community");
-    case PollType::OUT_OF_BOUND:    return _("Out of Bound");
+    if (translated) {
+        switch(type) {
+        case PollType::UNKNOWN:         return _("Unknown");
+        case PollType::SURVEY:          return _("Survey");
+        case PollType::PROJECT:         return _("Project Listing");
+        case PollType::DEVELOPMENT:     return _("Protocol Development");
+        case PollType::GOVERNANCE:      return _("Governance");
+        case PollType::MARKETING:       return _("Marketing");
+        case PollType::OUTREACH:        return _("Outreach");
+        case PollType::COMMUNITY:       return _("Community");
+        case PollType::OUT_OF_BOUND:    return _("Out of Bound");
+        }
+
+        assert(false); // Suppress warning
+    } else {
+        // The untranslated versions are really meant to serve as the string equivalent of the enum values.
+        switch(type) {
+        case PollType::UNKNOWN:         return "unknown";
+        case PollType::SURVEY:          return "survey";
+        case PollType::PROJECT:         return "project";
+        case PollType::DEVELOPMENT:     return "development";
+        case PollType::GOVERNANCE:      return "governance";
+        case PollType::MARKETING:       return "marketing";
+        case PollType::OUTREACH:        return "outreach";
+        case PollType::COMMUNITY:       return "community";
+        case PollType::OUT_OF_BOUND:    return "out of bound";
+        }
+
+        assert(false); // Suppress warning
     }
 
-    assert(false); // Suppress warning
+
 }
 
 std::string Poll::PollTypeToDescString() const
@@ -237,7 +256,7 @@ std::string Poll::PollTypeToDescString() const
 std::string Poll::PollTypeToDescString(const PollType& type)
 {
     switch(type) {
-    case PollType::UNKNOWN:         return std::string{};
+    case PollType::UNKNOWN:         return _("Unknown poll type. This should never happen.");
     case PollType::SURVEY:          return _("For opinion or casual polls without any particular requirements.");
     case PollType::PROJECT:         return _("Propose additions or removals of computing projects for research reward "
                                              "eligibility.");

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -26,29 +26,38 @@ public:
     using ResponseType = EnumByte<PollResponseType>;
 
     //!
-    //! \brief Minimum duration that a poll must remain active for.
+    //! \brief Minimum duration that a poll must remain active for. This is a global rule.
     //!
     static constexpr uint32_t MIN_DURATION_DAYS = 7;
 
     //!
-    //! \brief Maximum duration that a poll cannot remain active after.
+    //! \brief Maximum duration that a poll cannot remain active after. This is a global rule.
     //!
     static constexpr uint32_t MAX_DURATION_DAYS = 180;
 
     //!
-    //! \brief Maximum allowed length of a poll title.
+    //! \brief Maximum allowed length of a poll title. This is a global rule.
     //!
     static constexpr size_t MAX_TITLE_SIZE = 80;
 
     //!
-    //! \brief Maximum allowed length of a poll URL.
+    //! \brief Maximum allowed length of a poll URL. This is a global rule.
     //!
     static constexpr size_t MAX_URL_SIZE = 100;
 
     //!
-    //! \brief Maximum allowed length of a poll question.
+    //! \brief Maximum allowed length of a poll question. This is a global rule.
     //!
     static constexpr size_t MAX_QUESTION_SIZE = 100;
+
+    //!
+    //! \brief Used for poll (payload) version 3+
+    //!
+    struct PollTypeRules
+    {
+        uint32_t m_mininum_duration;
+        uint32_t m_min_vote_percent_AVW;
+    };
 
     //!
     //! \brief Represents an answer that a voter can choose when responding to

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -60,14 +60,35 @@ public:
     };
 
     //!
-    //! \brief Allows use of the PollType enum in range based for loops as a vector.
+    //! \brief Allows use of the PollType enum in range based for loops.
     //!
-    static const std::vector<GRC::PollType> POLL_TYPES;
+    static constexpr GRC::PollType POLL_TYPES[] = {
+        PollType::UNKNOWN,
+        PollType::SURVEY,
+        PollType::PROJECT,
+        PollType::DEVELOPMENT,
+        PollType::GOVERNANCE,
+        PollType::MARKETING,
+        PollType::OUTREACH,
+        PollType::COMMUNITY,
+        PollType::OUT_OF_BOUND
+    };
 
     //!
-    //! \brief The PollTypeRules vector whose elements correspond to the PollTypes enum.
+    //! \brief Poll rules that are specific to poll type. Enforced for poll payload version 3+.
     //!
-    static const std::vector<Poll::PollTypeRules> POLL_TYPE_RULES;
+    static constexpr Poll::PollTypeRules POLL_TYPE_RULES[] = {
+        // These must be kept in the order that corresponds to the PollType enum.
+        // min duration - min vote percent AVW
+        {  0,  0 },   // PollType::UNKNOWN
+        {  7,  0 },   // PollType::SURVEY
+        { 21, 40 },   // PollType::PROJECT
+        { 42, 50 },   // PollType::DEVELOPMENT
+        { 21, 20 },   // PollType::GOVERNANCE
+        { 21, 40 },   // PollType::MARKETING
+        { 21, 40 },   // PollType::OUTREACH
+        { 21, 10 }  // PollType::COMMUNITY
+    };
 
     //!
     //! \brief Represents an answer that a voter can choose when responding to
@@ -383,6 +404,6 @@ public:
         }
     }
 }; // Poll
-}
+} // namespace GRC
 
 #endif // GRIDCOIN_VOTING_POLL_H

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -342,7 +342,7 @@ public:
     //! \brief Get the string representation of the poll type for the provided poll type.
     //! \param type
     //!
-    static std::string PollTypeToString(const PollType& type);
+    static std::string PollTypeToString(const PollType& type, const bool& translated = true);
 
     //!
     //! \brief Get the poll type description string for the poll object.

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -60,6 +60,16 @@ public:
     };
 
     //!
+    //! \brief Allows use of the PollType enum in range based for loops as a vector.
+    //!
+    static const std::vector<GRC::PollType> POLL_TYPES;
+
+    //!
+    //! \brief The PollTypeRules vector whose elements correspond to the PollTypes enum.
+    //!
+    static const std::vector<Poll::PollTypeRules> POLL_TYPE_RULES;
+
+    //!
     //! \brief Represents an answer that a voter can choose when responding to
     //! a poll.
     //!
@@ -322,6 +332,28 @@ public:
     //! \brief Get the set of possible answers to the poll.
     //!
     const ChoiceList& Choices() const;
+
+    //!
+    //! \brief Get the string representation of the poll type for the poll object.
+    //!
+    std::string PollTypeToString() const;
+
+    //!
+    //! \brief Get the string representation of the poll type for the provided poll type.
+    //! \param type
+    //!
+    static std::string PollTypeToString(const PollType& type);
+
+    //!
+    //! \brief Get the poll type description string for the poll object.
+    //!
+    std::string PollTypeToDescString() const;
+
+    //!
+    //! \brief Get the poll type description string for the provided poll type.
+    //! \param type
+    //!
+    static std::string PollTypeToDescString(const PollType& type);
 
     //!
     //! \brief Get the string representation of the poll's weight type.

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -87,7 +87,7 @@ public:
         { 21, 20 },   // PollType::GOVERNANCE
         { 21, 40 },   // PollType::MARKETING
         { 21, 40 },   // PollType::OUTREACH
-        { 21, 10 }  // PollType::COMMUNITY
+        { 21, 10 }    // PollType::COMMUNITY
     };
 
     //!

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -312,7 +312,7 @@ public:
         bool FieldExists(const std::string& name) const;
 
         //!
-        //! \brief Get the choice offset of the specified field name.
+        //! \brief Get the offset of the specified field name.
         //!
         //! \param label The additional field name to find the offset of.
         //!

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -334,6 +334,11 @@ public:
         //!
         void Add(std::string name, std::string value, bool required);
 
+        //!
+        //! \brief Add an additional field to the poll.
+        //!
+        void Add(AdditionalField field);
+
         ADD_SERIALIZE_METHODS;
 
         template <typename Stream, typename Operation>

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -903,6 +903,20 @@ bool PollRegistry::Validate(const Contract& contract, const CTransaction& tx, in
     return true;
 }
 
+bool PollRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
+{
+    const auto payload = ctx->SharePayloadAs<PollPayload>();
+
+    // This is why we had to introduce BlockValidate, and this is critical
+    // to ensure that v2 poll payloads are not allowed in blocks for the v3
+    // height and beyond.
+    if (IsPollV3Enabled(ctx.m_pindex->nHeight) && payload->m_version < 3) {
+        return false;
+    }
+
+    return Validate(ctx.m_contract, ctx.m_tx, DoS);
+}
+
 void PollRegistry::Add(const ContractContext& ctx)
 {
     if (ctx->m_type == ContractType::VOTE) {

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -84,10 +84,16 @@ public:
             return false;
         }
 
-        // Can't have poll types other than SURVEY for v2 polls
-        if (m_payload.m_version == 2 && m_payload.m_poll.m_type != PollType::SURVEY) {
+        // Make sure poll type is valid for the version of the poll payload.
+        // The only valid type for v2 polls is SURVEY.
+        // The valid types for v3 polls are SURVEY, PROJECT, DEVELOPMENT, GOVERNANCE, MARKETING, OUTREACH,
+        // and COMMUNITY.
+        std::vector<PollType> valid_poll_types = m_payload.GetValidPollTypes();
+
+        if (std::find(valid_poll_types.begin(), valid_poll_types.end(), m_payload.m_poll.m_type.Value())
+                == valid_poll_types.end()) {
             DoS = 25;
-            LogPrint(LogFlags::CONTRACT, "%s: rejected v2 poll payload with improper type", __func__);
+            LogPrint(LogFlags::CONTRACT, "%s: rejected poll payload with improper type", __func__);
             return false;
         }
 

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -88,7 +88,7 @@ public:
         // The only valid type for v2 polls is SURVEY.
         // The valid types for v3 polls are SURVEY, PROJECT, DEVELOPMENT, GOVERNANCE, MARKETING, OUTREACH,
         // and COMMUNITY.
-        std::vector<PollType> valid_poll_types = m_payload.GetValidPollTypes();
+        std::vector<PollType> valid_poll_types = GRC::PollPayload::GetValidPollTypes(m_payload.m_version);
 
         if (std::find(valid_poll_types.begin(), valid_poll_types.end(), m_payload.m_poll.m_type.Value())
                 == valid_poll_types.end()) {

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -53,22 +53,6 @@ public:
     }
 };
 
-//!
-//! \brief Poll rules that are specific to poll type. Enforced for poll payload version 3+
-//!
-const Poll::PollTypeRules g_poll_type_rules[] = {
-    // These must be kept in the order that corresponds to the PollType enum.
-    // min duration - min vote percent AVW
-    {  0,  0 }, // PollType::UNKNOWN
-    {  7,  0 }, // PollType::SURVEY
-    { 21, 40 }, // PollType::PROJECT
-    { 42, 50 }, // PollType::DEVELOPMENT
-    { 21, 20 }, // PollType::GOVERNANCE
-    { 21, 40 }, // PollType::MARKETING
-    { 21, 40 }, // PollType::OUTREACH
-    { 21, 10 }  // PollType::COMMUNITY
-};
-
 class PollValidator
 {
 public:
@@ -110,7 +94,7 @@ public:
         // Poll payload v3+ validations which depend on poll type
         if (m_payload.m_version >= 3) {
             // Select the rules for the poll type in the payload.
-            Poll::PollTypeRules poll_type_rules = g_poll_type_rules[m_payload.m_poll.m_type.Raw()];
+            Poll::PollTypeRules poll_type_rules = Poll::POLL_TYPE_RULES[m_payload.m_poll.m_type.Raw()];
 
             if (m_payload.m_poll.m_duration_days < poll_type_rules.m_mininum_duration) {
                 DoS = 25;

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -311,6 +311,8 @@ ClaimMessage GRC::PackPollMessage(const Poll& poll, const CTransaction& tx)
 
 PollReference::PollReference()
     : m_ptxid(nullptr)
+    , m_payload_version(0)
+    , m_type(PollType::UNKNOWN)
     , m_ptitle(nullptr)
     , m_timestamp(0)
     , m_duration_days(0)
@@ -354,6 +356,16 @@ uint256 PollReference::Txid() const
     }
 
     return *m_ptxid;
+}
+
+uint32_t PollReference::GetPollPayloadVersion() const
+{
+    return m_payload_version;
+}
+
+PollType PollReference::GetPollType() const
+{
+    return m_type;
 }
 
 const std::string& PollReference::Title() const
@@ -909,6 +921,8 @@ void PollRegistry::AddPoll(const ContractContext& ctx)
 
         PollReference& poll_ref = result_pair.first->second;
         poll_ref.m_ptitle = &title;
+        poll_ref.m_payload_version = payload->m_version;
+        poll_ref.m_type = payload->m_poll.m_type.Value();
         poll_ref.m_timestamp = ctx.m_tx.nTime;
         poll_ref.m_duration_days = payload->m_poll.m_duration_days;
 

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -920,6 +920,13 @@ bool PollRegistry::Validate(const Contract& contract, const CTransaction& tx, in
 
 bool PollRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
 {
+    // Vote contract claims do not affect consensus. Vote claim validation
+    // occurs on-demand while computing the results of the poll:
+    //
+    if (ctx.m_contract.m_type == ContractType::VOTE) {
+        return true;
+    }
+
     const auto payload = ctx->SharePayloadAs<PollPayload>();
 
     // This is why we had to introduce BlockValidate, and this is critical

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -383,6 +383,17 @@ public:
     bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
 
     //!
+    //! \brief Perform contextual validation for the provided contract including block context. This is used
+    //! in ConnectBlock.
+    //!
+    //! \param ctx ContractContext to validate.
+    //! \param DoS Misbehavior score out.
+    //!
+    //! \return  \c false If the contract fails validation.
+    //!
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+
+    //!
     //! \brief Register a poll or vote from contract data.
     //!
     //! \param ctx References the poll or vote contract and associated context.

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -123,7 +123,7 @@ public:
     //!
     //! \return pointer to block index object.
     //!
-    CBlockIndex* GetEndingBlockIndexPtr() const;
+    CBlockIndex* GetEndingBlockIndexPtr(CBlockIndex* pindex_start = nullptr) const;
 
     //!
     //! \brief Get the starting block height for the poll.

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -8,6 +8,8 @@
 #include "gridcoin/contract/handler.h"
 #include "gridcoin/voting/filter.h"
 #include "gridcoin/voting/fwd.h"
+#include "uint256.h"
+#include <map>
 
 class CTxDB;
 
@@ -54,6 +56,16 @@ public:
     //! \brief Get the hash of the transaction that contains the associated poll.
     //!
     uint256 Txid() const;
+
+    //!
+    //! \brief Get the poll (payload) version
+    //!
+    uint32_t GetPollPayloadVersion() const;
+
+    //!
+    //! \brief Get the poll type
+    //!
+    PollType GetPollType() const;
 
     //!
     //! \brief Get the title of the associated poll.
@@ -127,6 +139,11 @@ public:
     //!
     std::optional<int> GetEndingHeight() const;
 
+    //!
+    //! \brief Computes the Active Vote Weight for the poll, which is used to determine whether the poll is validated.
+    //! \param result: The actual tabulated votes (poll result)
+    //! \return ActiveVoteWeight
+    //!
     std::optional<CAmount> GetActiveVoteWeight(const PollResultOption &result) const;
 
     //!
@@ -146,6 +163,8 @@ public:
 
 private:
     const uint256* m_ptxid;       //!< Hash of the poll transaction.
+    uint32_t m_payload_version;   //!< Version of the poll (payload).
+    PollType m_type;              //!< Type of the poll.
     const std::string* m_ptitle;  //!< Title of the poll.
     int64_t m_timestamp;          //!< Timestamp of the poll transaction.
     uint32_t m_duration_days;     //!< Number of days the poll remains active.

--- a/src/gridcoin/voting/result.h
+++ b/src/gridcoin/voting/result.h
@@ -77,11 +77,14 @@ public:
         bool Empty() const;
     };
 
-    const Poll m_poll;               //!< The poll associated with the result.
-    Weight m_total_weight;           //!< Aggregate weight of all the votes submitted.
-    size_t m_invalid_votes;          //!< Number of votes that failed validation.
-    std::vector<Cpid> m_pools_voted; //!< Cpids of pools that actually voted
-    bool m_finished;                 //!< Whether the poll finished as of this result.
+    const Poll m_poll;                            //!< The poll associated with the result.
+    Weight m_total_weight;                        //!< Aggregate weight of all the votes submitted.
+    size_t m_invalid_votes;                       //!< Number of votes that failed validation.
+    std::vector<Cpid> m_pools_voted;              //!< Cpids of pools that actually voted.
+    std::optional<CAmount> m_active_vote_weight;  //!< Active vote weight of poll.
+    std::optional<double> m_vote_percent_avw;     //!< Vote weight percent of AVW.
+    std::optional<bool> m_poll_results_validated; //!< Whether the poll's AVW is >= the minimum AVW for the poll.
+    bool m_finished;                              //!< Whether the poll finished as of this result.
 
     //!
     //! \brief The aggregated voting weight tallied for each poll choice.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -571,6 +571,9 @@ void SetupServerArgs()
     hidden_args.emplace_back("-foundationaddress");
     hidden_args.emplace_back("-foundationsidestakeallocation");
 
+    // Temporary for poll v3 testing
+    hidden_args.emplace_back("-pollv3height");
+
     // -boinckey should now be removed entirely. It is put here to prevent the executable erroring out on
     // an invalid parameter for old clients that may have left the argument in.
     hidden_args.emplace_back("-boinckey");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1957,7 +1957,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
                 }
 
                 int DoS = 0;
-                if (nVersion >= 11 && !GRC::ValidateContracts(tx, DoS)) {
+                if (nVersion >= 11 && !GRC::BlockValidateContracts(pindex, tx, DoS)) {
                     return tx.DoS(DoS, error("%s: invalid contract in tx %s, assigning DoS misbehavior of %i",
                                              __func__,
                                              tx.GetHash().ToString(),

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -311,6 +311,10 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev,
 
     int nHeight = pindexPrev->nHeight + 1;
 
+    // This is specifically for BlockValidateContracts, and only the nHeight is filled in.
+    CBlockIndex* pindex_contract_validate = new CBlockIndex();
+    pindex_contract_validate->nHeight = nHeight;
+
     // Create coinbase tx
     CTransaction &CoinBase = block.vtx[0];
     CoinBase.nTime = block.nTime;
@@ -372,10 +376,14 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev,
 
             // Double-check that contracts pass contextual validation again so
             // that we don't include a transaction that disrupts validation of
-            // the block:
+            // the block. Note that this is especially important now that there
+            // are block level rules that cannot be checked for transactions
+            // that are just in the mempool. Note that the only block level rules
+            // currently implemented depend on block height only, so the
+            // pindex_contract_validate only has the block height filled out.
             //
             int DoS = 0; // Unused here.
-            if (!tx.GetContracts().empty() && !GRC::ValidateContracts(tx, DoS)) {
+            if (!tx.GetContracts().empty() && !GRC::BlockValidateContracts(pindex_contract_validate, tx, DoS)) {
                 LogPrint(BCLog::LogFlags::MINER,
                     "%s: contract failed contextual validation. Skipped tx %s",
                     __func__,

--- a/src/qt/forms/voting/pollcard.ui
+++ b/src/qt/forms/voting/pollcard.ui
@@ -59,18 +59,42 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item alignment="Qt::AlignTop">
-       <widget class="QLabel" name="titleLabel">
-        <property name="text">
-         <string notr="true">Title</string>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="titleLabel">
+          <property name="text">
+           <string notr="true">Title</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::PlainText</enum>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="typeLabel">
+          <property name="text">
+           <string>Poll Type</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout" columnstretch="0,10000,0,10000,0,10000">

--- a/src/qt/forms/voting/pollcard.ui
+++ b/src/qt/forms/voting/pollcard.ui
@@ -206,16 +206,36 @@
        <number>0</number>
       </property>
       <item alignment="Qt::AlignVCenter">
-       <widget class="QLabel" name="magnitudeLabel">
+       <widget class="QLabel" name="balanceLabel">
         <property name="text">
          <string>Balance</string>
         </property>
        </widget>
       </item>
       <item alignment="Qt::AlignVCenter">
-       <widget class="QLabel" name="balanceLabel">
+       <widget class="QLabel" name="magnitudeLabel">
         <property name="text">
          <string>Magnitude</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="validatedLabel">
+        <property name="text">
+         <string>Validated</string>
         </property>
        </widget>
       </item>

--- a/src/qt/forms/voting/pollcard.ui
+++ b/src/qt/forms/voting/pollcard.ui
@@ -240,6 +240,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="invalidLabel">
+        <property name="text">
+         <string>Invalid</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -972,7 +972,8 @@ VoteWizard #pageTitleLabel {
 }
 
 PollCard #balanceLabel,
-PollCard #magnitudeLabel {
+PollCard #magnitudeLabel,
+PollCard #typeLabel {
     border: 0.065em solid rgb(115, 131, 161);
     border-radius: 0.65em;
     padding: 0.1em 0.3em;

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -986,6 +986,13 @@ PollCard #validatedLabel {
     color: rgb(0, 131, 0);
 }
 
+PollCard #invalidLabel {
+    border: 0.065em solid rgb(150, 0, 0);
+    border-radius: 0.65em;
+    padding: 0.1em 0.3em;
+    color: rgb(150, 0, 0);
+}
+
 PollCard #remainingLabel,
 PollResultChoiceItem #percentageLabel,
 PollResultChoiceItem #weightLabel,

--- a/src/qt/res/stylesheets/dark_stylesheet.qss
+++ b/src/qt/res/stylesheets/dark_stylesheet.qss
@@ -979,6 +979,13 @@ PollCard #magnitudeLabel {
     color: rgb(115, 131, 161);
 }
 
+PollCard #validatedLabel {
+    border: 0.065em solid rgb(0, 131, 0);
+    border-radius: 0.65em;
+    padding: 0.1em 0.3em;
+    color: rgb(0, 131, 0);
+}
+
 PollCard #remainingLabel,
 PollResultChoiceItem #percentageLabel,
 PollResultChoiceItem #weightLabel,

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -961,6 +961,13 @@ PollCard #validatedLabel {
     color: rgb(0, 131, 0);
 }
 
+PollCard #invalidLabel {
+    border: 0.065em solid rgb(150, 0, 0);
+    border-radius: 0.65em;
+    padding: 0.1em 0.3em;
+    color: rgb(150, 0, 0);
+}
+
 PollCard #remainingLabel,
 PollResultChoiceItem #percentageLabel,
 PollResultChoiceItem #weightLabel,

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -947,7 +947,8 @@ PollWizardTypePage #typeTextLabel {
 }
 
 PollCard #balanceLabel,
-PollCard #magnitudeLabel {
+PollCard #magnitudeLabel,
+PollCard #typeLabel {
     border: 0.065em solid rgb(115, 131, 161);
     border-radius: 0.65em;
     padding: 0.1em 0.3em;

--- a/src/qt/res/stylesheets/light_stylesheet.qss
+++ b/src/qt/res/stylesheets/light_stylesheet.qss
@@ -954,6 +954,13 @@ PollCard #magnitudeLabel {
     color: rgb(115, 131, 161);
 }
 
+PollCard #validatedLabel {
+    border: 0.065em solid rgb(0, 131, 0);
+    border-radius: 0.65em;
+    padding: 0.1em 0.3em;
+    color: rgb(0, 131, 0);
+}
+
 PollCard #remainingLabel,
 PollResultChoiceItem #percentageLabel,
 PollResultChoiceItem #weightLabel,

--- a/src/qt/voting/poll_types.cpp
+++ b/src/qt/voting/poll_types.cpp
@@ -22,11 +22,17 @@ struct PollTypeDefinition
 
 PollTypes::PollTypes()
 {
-    // Load from core Poll class.
+    // Load from core Poll class. Note we do not use PollPayload::GetValidPollTypes, because with poll v2 the UI supported
+    // the other poll types from a user perspective, but in fact only submitted the polls as "SURVEY" in the core.
+    // GetValidPollTypes will only return SURVEY for v2, so it is not appropriate to use here.
+    //
+    // I am not particularly fond of how this is crosswired into the GUI code here, but it will suffice for now.
+    // TODO: refactor poll types between core and UI.
     for (const auto& type : GRC::Poll::POLL_TYPES) {
         if (type == GRC::PollType::OUT_OF_BOUND) continue;
 
         emplace_back();
+        // Note that these use the default value for the translated boolean, which is true.
         back().m_name = QString::fromStdString(GRC::Poll::PollTypeToString(type));
         back().m_description = QString::fromStdString(GRC::Poll::PollTypeToDescString(type));
         back().m_min_duration_days = GRC::Poll::POLL_TYPE_RULES[(int) type].m_mininum_duration;

--- a/src/qt/voting/poll_types.cpp
+++ b/src/qt/voting/poll_types.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "gridcoin/voting/poll.h"
 #include "qt/voting/poll_types.h"
 
 #include <QCoreApplication>
@@ -13,45 +14,6 @@ struct PollTypeDefinition
     const char* m_description;
     int m_min_duration_days;
 };
-
-const PollTypeDefinition g_poll_types[] = {
-    { "Unknown", "Unknown", 0 },
-    {
-        QT_TRANSLATE_NOOP("PollTypes", "Project Listing"),
-        QT_TRANSLATE_NOOP("PollTypes", "Propose additions or removals of computing projects for research reward eligibility."),
-        21, // min duration days
-    },
-    {
-        QT_TRANSLATE_NOOP("PollTypes", "Protocol Development"),
-        QT_TRANSLATE_NOOP("PollTypes", "Propose a change to Gridcoin at the protocol level."),
-        42, // min duration days
-    },
-    {
-        QT_TRANSLATE_NOOP("PollTypes", "Governance"),
-        QT_TRANSLATE_NOOP("PollTypes", "Proposals related to Gridcoin management like poll requirements and funding."),
-        21, // min duration days
-    },
-    {
-        QT_TRANSLATE_NOOP("PollTypes", "Marketing"),
-        QT_TRANSLATE_NOOP("PollTypes", "Propose marketing initiatives like ad campaigns."),
-        21, // min duration days
-    },
-    {
-        QT_TRANSLATE_NOOP("PollTypes", "Outreach"),
-        QT_TRANSLATE_NOOP("PollTypes", "For polls about community representation, public relations, and communications."),
-        21, // min duration days
-    },
-    {
-        QT_TRANSLATE_NOOP("PollTypes", "Community"),
-        QT_TRANSLATE_NOOP("PollTypes", "For other initiatives related to the Gridcoin community."),
-        21, // min duration days
-    },
-    {
-        QT_TRANSLATE_NOOP("PollTypes", "Survey"),
-        QT_TRANSLATE_NOOP("PollTypes", "For opinion or casual polls without any particular requirements."),
-        7, // min duration days
-    },
-};
 } // Anonymous namespace
 
 // -----------------------------------------------------------------------------
@@ -60,10 +22,13 @@ const PollTypeDefinition g_poll_types[] = {
 
 PollTypes::PollTypes()
 {
-    for (const auto& type : g_poll_types) {
+    // Load from core Poll class.
+    for (const auto& type : GRC::Poll::POLL_TYPES) {
+        if (type == GRC::PollType::OUT_OF_BOUND) continue;
+
         emplace_back();
-        back().m_name = QCoreApplication::translate("PollTypes", type.m_name);
-        back().m_description = QCoreApplication::translate("PollTypes", type.m_description);
-        back().m_min_duration_days = type.m_min_duration_days;
+        back().m_name = QString::fromStdString(GRC::Poll::PollTypeToString(type));
+        back().m_description = QString::fromStdString(GRC::Poll::PollTypeToDescString(type));
+        back().m_min_duration_days = GRC::Poll::POLL_TYPE_RULES[(int) type].m_mininum_duration;
     }
 }

--- a/src/qt/voting/poll_types.h
+++ b/src/qt/voting/poll_types.h
@@ -19,6 +19,9 @@ public:
 class PollTypes : public std::vector<PollTypeItem>
 {
 public:
+    //!
+    //! \brief The PollType enum. Please see the enum class PollType in voting/fwd.h in the core.
+    //!
     enum PollType
     {
         PollTypeUnknown,

--- a/src/qt/voting/poll_types.h
+++ b/src/qt/voting/poll_types.h
@@ -19,21 +19,6 @@ public:
 class PollTypes : public std::vector<PollTypeItem>
 {
 public:
-    //!
-    //! \brief The PollType enum. Please see the enum class PollType in voting/fwd.h in the core.
-    //!
-    enum PollType
-    {
-        PollTypeUnknown,
-        PollTypeProject,
-        PollTypeDevelopment,
-        PollTypeGovernance,
-        PollTypeMarketing,
-        PollTypeOutreach,
-        PollTypeCommunity,
-        PollTypeSurvey,
-    };
-
     PollTypes();
 };
 

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -19,6 +19,14 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
     ui->setupUi(this);
 
     ui->titleLabel->setText(poll_item.m_title);
+
+    ui->typeLabel->setText(poll_item.m_type_str);
+    if (poll_item.m_version >= 3) {
+        ui->typeLabel->show();
+    } else {
+        ui->typeLabel->hide();
+    }
+
     ui->expirationLabel->setText(GUIUtil::dateTimeStr(poll_item.m_expiration));
     ui->voteCountLabel->setText(QString::number(poll_item.m_total_votes));
     ui->totalWeightLabel->setText(QString::number(poll_item.m_total_weight));

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -30,7 +30,8 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
         ui->balanceLabel->hide();
     }
 
-    if (!(poll_item.m_weight_type == 1 || poll_item.m_weight_type == 3)) {
+    if (!(poll_item.m_weight_type == (int)GRC::PollWeightType::MAGNITUDE ||
+          poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE_AND_MAGNITUDE)) {
         ui->magnitudeLabel->hide();
     }
 

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -25,8 +25,8 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
     ui->activeVoteWeightLabel->setText(QString::number(poll_item.m_active_weight));
     ui->votePercentAVWLabel->setText(QString::number(poll_item.m_vote_percent_AVW, 'f', 4) + '\%');
 
-    // See voting/fwd.h, the enum class PollWeightType
-    if (!(poll_item.m_weight_type == 2 || poll_item.m_weight_type == 3)) {
+    if (!(poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE ||
+          poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE_AND_MAGNITUDE)) {
         ui->balanceLabel->hide();
     }
 

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -24,6 +24,20 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
     ui->totalWeightLabel->setText(QString::number(poll_item.m_total_weight));
     ui->activeVoteWeightLabel->setText(QString::number(poll_item.m_active_weight));
     ui->votePercentAVWLabel->setText(QString::number(poll_item.m_vote_percent_AVW, 'f', 4) + '\%');
+
+    // See voting/fwd.h, the enum class PollWeightType
+    if (!(poll_item.m_weight_type == 2 || poll_item.m_weight_type == 3)) {
+        ui->balanceLabel->hide();
+    }
+
+    if (!(poll_item.m_weight_type == 1 || poll_item.m_weight_type == 3)) {
+        ui->magnitudeLabel->hide();
+    }
+
+    if (poll_item.m_validated.toString() == QString{} || !poll_item.m_validated.toBool()) {
+        ui->validatedLabel->hide();
+    }
+
     ui->topAnswerLabel->setText(poll_item.m_top_answer);
 
     if (!poll_item.m_finished) {

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -35,8 +35,18 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
         ui->magnitudeLabel->hide();
     }
 
-    if (poll_item.m_validated.toString() == QString{} || !poll_item.m_validated.toBool()) {
+    if (poll_item.m_validated.toString() == QString{} || (!poll_item.m_validated.toBool() && !poll_item.m_finished)) {
+        // Hide both validated and invalid tags if less than v3 poll, or, not valid and not finished
         ui->validatedLabel->hide();
+        ui->invalidLabel->hide();
+    } else if (poll_item.m_validated.toBool()) {
+        // Show validated if v3 poll and valid by vote weight % of AVW, even if not finished
+        ui->validatedLabel->show();
+        ui->invalidLabel->hide();
+    } else if (!poll_item.m_validated.toBool() && poll_item.m_finished) {
+        // Show invalid if v3 poll and invalid by vote weight % of AVW and finished
+        ui->validatedLabel->hide();
+        ui->invalidLabel->show();
     }
 
     ui->topAnswerLabel->setText(poll_item.m_top_answer);

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -23,6 +23,7 @@ public:
 
         m_columns
             << tr("Title")
+            << tr("Poll Type")
             << tr("Expiration")
             << tr("Weight Type")
             << tr("Votes")
@@ -61,6 +62,12 @@ public:
                 switch (index.column()) {
                     case PollTableModel::Title:
                         return row->m_title;
+                    case PollTableModel::PollType:
+                        if (row->m_version >= 3) {
+                            return row->m_type_str;
+                        } else {
+                            return QString{};
+                        }
                     case PollTableModel::Expiration:
                         return GUIUtil::dateTimeStr(row->m_expiration);
                     case PollTableModel::WeightType:
@@ -95,6 +102,8 @@ public:
                 switch (index.column()) {
                     case PollTableModel::Title:
                         return row->m_title;
+                    case PollTableModel::PollType:
+                        return row->m_type_str;
                     case PollTableModel::Expiration:
                         return row->m_expiration;
                     case PollTableModel::WeightType:

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -28,6 +28,7 @@ public:
             << tr("Votes")
             << tr("Total Weight")
             << tr("% of Active Vote Weight")
+            << tr("Validated")
             << tr("Top Answer");
     }
 
@@ -63,13 +64,15 @@ public:
                     case PollTableModel::Expiration:
                         return GUIUtil::dateTimeStr(row->m_expiration);
                     case PollTableModel::WeightType:
-                        return row->m_weight_type;
+                        return row->m_weight_type_str;
                     case PollTableModel::TotalVotes:
                         return row->m_total_votes;
                     case PollTableModel::TotalWeight:
                         return QString::number(row->m_total_weight);
                     case PollTableModel::VotePercentAVW:
                         return QString::number(row->m_vote_percent_AVW, 'f', 4);
+                    case PollTableModel::Validated:
+                        return row->m_validated;
                     case PollTableModel::TopAnswer:
                         return row->m_top_answer;
                 } // no default case, so the compiler can warn about missing cases
@@ -82,6 +85,8 @@ public:
                     case PollTableModel::TotalWeight:
                         // Pass-through case
                     case PollTableModel::VotePercentAVW:
+                        // Pass-through case
+                    case PollTableModel::Validated:
                         return QVariant(Qt::AlignRight | Qt::AlignVCenter);
                 }
                 break;
@@ -93,13 +98,15 @@ public:
                     case PollTableModel::Expiration:
                         return row->m_expiration;
                     case PollTableModel::WeightType:
-                        return row->m_weight_type;
+                        return row->m_weight_type_str;
                     case PollTableModel::TotalVotes:
                         return row->m_total_votes;
                     case PollTableModel::TotalWeight:
                         return QVariant::fromValue(row->m_total_weight);
                     case PollTableModel::VotePercentAVW:
                         return QVariant::fromValue(row->m_vote_percent_AVW);
+                    case PollTableModel::Validated:
+                        return row->m_validated;
                     case PollTableModel::TopAnswer:
                         return row->m_top_answer;
                 } // no default case, so the compiler can warn about missing cases

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -27,6 +27,7 @@ public:
         TotalVotes,
         TotalWeight,
         VotePercentAVW,
+        Validated,
         TopAnswer,
     };
 

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -22,6 +22,7 @@ public:
     enum ColumnIndex
     {
         Title,
+        PollType,
         Expiration,
         WeightType,
         TotalVotes,

--- a/src/qt/voting/pollwizarddetailspage.cpp
+++ b/src/qt/voting/pollwizarddetailspage.cpp
@@ -229,7 +229,7 @@ void PollWizardDetailsPage::initializePage()
     ui->durationField->setMinimum(poll_type.m_min_duration_days);
     ui->durationField->setValue(poll_type.m_min_duration_days);
 
-    if (type_id != PollTypes::PollTypeSurvey) {
+    if (type_id != (int) GRC::PollType::SURVEY) {
         ui->pollTypeAlert->show();
         ui->weightTypeList->setCurrentIndex(1); // Magnitude+Balance
         ui->weightTypeList->setDisabled(true);
@@ -238,7 +238,7 @@ void PollWizardDetailsPage::initializePage()
         ui->weightTypeList->setEnabled(true);
     }
 
-    if (type_id == PollTypes::PollTypeProject) {
+    if (type_id == (int) GRC::PollType::PROJECT) {
         ui->titleField->setText(QStringLiteral("[%1] %2")
             .arg(poll_type.m_name)
             .arg(field("projectPollTitle").toString()));

--- a/src/qt/voting/pollwizarddetailspage.cpp
+++ b/src/qt/voting/pollwizarddetailspage.cpp
@@ -267,7 +267,11 @@ bool PollWizardDetailsPage::validatePage()
         return false;
     }
 
+    const int type_id = field("pollType").toInt();
+    const GRC::PollType& core_poll_type = GRC::Poll::POLL_TYPES[type_id];
+
     const VotingResult result = m_voting_model->sendPoll(
+        core_poll_type,
         field("title").toString(),
         field("durationDays").toInt(),
         field("question").toString(),

--- a/src/qt/voting/pollwizardtypepage.cpp
+++ b/src/qt/voting/pollwizardtypepage.cpp
@@ -32,7 +32,7 @@ PollWizardTypePage::PollWizardTypePage(QWidget* parent)
     type_proxy->setVisible(false);
 
     registerField("pollType*", type_proxy);
-    setField("pollType", PollTypes::PollTypeUnknown);
+    setField("pollType", (int) GRC::PollType::UNKNOWN);
 
     #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
         connect(
@@ -76,7 +76,7 @@ void PollWizardTypePage::setPollTypes(const PollTypes* const poll_types)
 int PollWizardTypePage::nextId() const
 {
     switch (field("pollType").toInt()) {
-        case PollTypes::PollTypeProject:
+        case (int) GRC:: PollType::PROJECT:
             return PollWizard::PageProject;
     }
 

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -57,7 +57,8 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
     item.m_url = QString::fromStdString(poll.m_url).trimmed();
     item.m_start_time = QDateTime::fromMSecsSinceEpoch(poll.m_timestamp * 1000);
     item.m_expiration = QDateTime::fromMSecsSinceEpoch(poll.Expiration() * 1000);
-    item.m_weight_type = QString::fromStdString(poll.WeightTypeToString());
+    item.m_weight_type = poll.m_weight_type.Raw();
+    item.m_weight_type_str = QString::fromStdString(poll.WeightTypeToString());
     item.m_response_type = QString::fromStdString(poll.ResponseTypeToString());
     item.m_total_votes = result->m_votes.size();
     item.m_total_weight = result->m_total_weight / COIN;
@@ -70,6 +71,11 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
     item.m_vote_percent_AVW = 0;
     if (result->m_vote_percent_avw) {
         item.m_vote_percent_AVW = *result->m_vote_percent_avw;
+    }
+
+    item.m_validated = QString{};
+    if (result->m_poll_results_validated) {
+        item.m_validated = true;
     }
 
     item.m_finished = result->m_finished;

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -75,7 +75,7 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
 
     item.m_validated = QString{};
     if (result->m_poll_results_validated) {
-        item.m_validated = true;
+        item.m_validated = *result->m_poll_results_validated;
     }
 
     item.m_finished = result->m_finished;

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -62,15 +62,14 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
     item.m_total_votes = result->m_votes.size();
     item.m_total_weight = result->m_total_weight / COIN;
 
-    if (auto active_vote_weight = ref.GetActiveVoteWeight(result)) {
-        item.m_active_weight = *active_vote_weight / COIN;
-    } else {
-        item.m_active_weight = 0;
+    item.m_active_weight = 0;
+    if (result->m_active_vote_weight) {
+        item.m_active_weight = *result->m_active_vote_weight / COIN;
     }
 
     item.m_vote_percent_AVW = 0;
-    if (item.m_active_weight > 0) {
-        item.m_vote_percent_AVW = (double) item.m_total_weight / (double) item.m_active_weight * 100.0;
+    if (result->m_vote_percent_avw) {
+        item.m_vote_percent_AVW = *result->m_vote_percent_avw;
     }
 
     item.m_finished = result->m_finished;

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -53,7 +53,9 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
 
     PollItem item;
     item.m_id = QString::fromStdString(iter->Ref().Txid().ToString());
+    item.m_version = ref.GetPollPayloadVersion();
     item.m_title = QString::fromStdString(poll.m_title).replace("_", " ");
+    item.m_type_str = QString::fromStdString(poll.PollTypeToString());
     item.m_question = QString::fromStdString(poll.m_question).replace("_", " ");
     item.m_url = QString::fromStdString(poll.m_url).trimmed();
     item.m_start_time = QDateTime::fromMSecsSinceEpoch(poll.m_timestamp * 1000);

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -27,6 +27,7 @@ using namespace GRC;
 using LogFlags = BCLog::LogFlags;
 
 extern CCriticalSection cs_main;
+extern int nBestHeight;
 
 namespace {
 //!

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -49,6 +49,8 @@ class PollItem
 {
 public:
     QString m_id;
+    uint32_t m_version;
+    QString m_type_str;
     QString m_title;
     QString m_question;
     QString m_url;

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -13,6 +13,7 @@
 #include <QDateTime>
 #include <QObject>
 #include <vector>
+#include <QVariant>
 
 namespace GRC {
 class PollRegistry;
@@ -53,13 +54,15 @@ public:
     QString m_url;
     QDateTime m_start_time;
     QDateTime m_expiration;
-    QString m_weight_type;
+    int m_weight_type;
+    QString m_weight_type_str;
     QString m_response_type;
     QString m_top_answer;
     uint32_t m_total_votes;
     uint64_t m_total_weight;
     uint64_t m_active_weight;
     double m_vote_percent_AVW;
+    QVariant m_validated;
     bool m_finished;
     bool m_multiple_choice;
     std::vector<VoteResultItem> m_choices;

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -7,15 +7,14 @@
 
 #include "amount.h"
 #include "gridcoin/voting/filter.h"
-#include "gridcoin/voting/fwd.h"
 #include "qt/voting/poll_types.h"
+#include "gridcoin/voting/poll.h"
 
 #include <QDateTime>
 #include <QObject>
 #include <vector>
 
 namespace GRC {
-class Poll;
 class PollRegistry;
 }
 
@@ -114,6 +113,7 @@ public:
     CAmount estimatePollFee() const;
 
     VotingResult sendPoll(
+        const GRC::PollType& type,
         const QString& title,
         const int duration_days,
         const QString& question,
@@ -121,12 +121,13 @@ public:
         const int weight_type,
         const int response_type,
         const QStringList& choices) const;
+
     VotingResult sendVote(
         const QString& poll_id,
         const std::vector<uint8_t>& choice_offsets) const;
 
 signals:
-    void newPollReceived() const;
+    void newPollReceived();
 
 private:
     GRC::PollRegistry& m_registry;

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -7,6 +7,7 @@
 
 #include "amount.h"
 #include "gridcoin/voting/filter.h"
+#include "gridcoin/voting/fwd.h"
 #include "qt/voting/poll_types.h"
 
 #include <QDateTime>

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -233,9 +233,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "showblock"              , 0 },
 
     // Voting
-    { "addpoll"                , 1 },
-    { "addpoll"                , 4 },
+    { "addpoll"                , 2 },
     { "addpoll"                , 5 },
+    { "addpoll"                , 6 },
     { "listpolls"              , 0 },
     { "votebyid"               , 1 },
     { "votebyid"               , 2 },

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -101,9 +101,16 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
     json.pushKV("invalid_votes", (uint64_t)result.m_invalid_votes);
     json.pushKV("total_weight", ValueFromAmount(result.m_total_weight));
 
-    if (auto active_vote_weight = poll_ref.GetActiveVoteWeight(result)) {
-        json.pushKV("active_vote_weight", ValueFromAmount(*active_vote_weight));
-        json.pushKV("vote_percent_avw", (double) result.m_total_weight / (double) *active_vote_weight * 100.0);
+    if (result.m_active_vote_weight) {
+        json.pushKV("active_vote_weight", ValueFromAmount(*result.m_active_vote_weight));
+    }
+
+    if (result.m_vote_percent_avw) {
+        json.pushKV("vote_percent_avw", *result.m_vote_percent_avw);
+    }
+
+    if (result.m_poll_results_validated) {
+        json.pushKV("poll_results_validated", *result.m_poll_results_validated);
     }
 
     if (!result.m_votes.empty()) {

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -59,10 +59,12 @@ UniValue PollToJson(const Poll& poll, const uint256 txid)
     json.pushKV("id", txid.ToString());
     json.pushKV("question", poll.m_question);
     json.pushKV("url", poll.m_url);
-    json.pushKV("poll_type", (int)poll.m_type.Raw());
-    json.pushKV("sharetype", poll.WeightTypeToString());
-    json.pushKV("weight_type", (int)poll.m_weight_type.Raw());
-    json.pushKV("response_type", (int)poll.m_response_type.Raw());
+    json.pushKV("poll_type", poll.PollTypeToString());
+    json.pushKV("poll_type_id", (int)poll.m_type.Raw());
+    json.pushKV("weight_type", poll.WeightTypeToString());
+    json.pushKV("weight_type_id", (int)poll.m_weight_type.Raw());
+    json.pushKV("response_type", poll.ResponseTypeToString());
+    json.pushKV("response_type_id", (int)poll.m_response_type.Raw());
     json.pushKV("duration_days", (int)poll.m_duration_days);
     json.pushKV("expiration", TimestampToHRDate(poll.Expiration()));
     json.pushKV("timestamp", TimestampToHRDate(poll.m_timestamp));

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -59,6 +59,7 @@ UniValue PollToJson(const Poll& poll, const uint256 txid)
     json.pushKV("id", txid.ToString());
     json.pushKV("question", poll.m_question);
     json.pushKV("url", poll.m_url);
+    json.pushKV("poll_type", (int)poll.m_type.Raw());
     json.pushKV("sharetype", poll.WeightTypeToString());
     json.pushKV("weight_type", (int)poll.m_weight_type.Raw());
     json.pushKV("response_type", (int)poll.m_response_type.Raw());

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -293,6 +293,7 @@ UniValue SubmitVote(const Poll& poll, VoteBuilder builder)
 
 UniValue addpoll(const UniValue& params, bool fHelp)
 {
+    uint32_t payload_version = 0;
     std::vector<PollType> valid_poll_types;
 
     {
@@ -302,7 +303,9 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
         LOCK(cs_main);
 
-        valid_poll_types = GRC::PollPayload::GetValidPollTypes(IsPollV3Enabled(nBestHeight) ? 3 : 2);
+        payload_version = IsPollV3Enabled(nBestHeight) ? 3 : 2;
+
+        valid_poll_types = GRC::PollPayload::GetValidPollTypes(payload_version);
     }
 
     std::stringstream types_ss;
@@ -359,6 +362,7 @@ UniValue addpoll(const UniValue& params, bool fHelp)
     }
 
     PollBuilder builder = PollBuilder()
+        .SetPayloadVersion(payload_version)
         .SetType(poll_type)
         .SetTitle(params[1].get_str())
         .SetDuration(params[2].get_int())

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -51,6 +51,25 @@ UniValue PollChoicesToJson(const Poll::ChoiceList& choices)
     return json;
 }
 
+UniValue PollAdditionalFieldsToJson(const Poll::AdditionalFieldList fields)
+{
+    UniValue json(UniValue::VARR);
+
+    for (size_t i = 0; i < fields.size(); ++i) {
+        UniValue field(UniValue::VOBJ);
+        UniValue field_value(UniValue::VOBJ);
+
+        field_value.pushKV("value", fields.At(i)->m_value);
+        field_value.pushKV("required", fields.At(i)->m_required);
+
+        field.pushKV(fields.At(i)->m_name, field_value);
+
+        json.push_back(field);
+    }
+
+    return json;
+}
+
 UniValue PollToJson(const Poll& poll, const uint256 txid)
 {
     UniValue json(UniValue::VOBJ);
@@ -59,6 +78,7 @@ UniValue PollToJson(const Poll& poll, const uint256 txid)
     json.pushKV("id", txid.ToString());
     json.pushKV("question", poll.m_question);
     json.pushKV("url", poll.m_url);
+    json.pushKV("additional_fields", PollAdditionalFieldsToJson(poll.AdditionalFields()));
     json.pushKV("poll_type", poll.PollTypeToString());
     json.pushKV("poll_type_id", (int)poll.m_type.Raw());
     json.pushKV("weight_type", poll.WeightTypeToString());
@@ -318,28 +338,30 @@ UniValue addpoll(const UniValue& params, bool fHelp)
         types_ss << ToLower(Poll::PollTypeToString(type, false));
     }
 
-    if (fHelp || params.size() != 8) {
+    if (params.size() == 0) {
         std::string e = strprintf(
-                    "addpoll <type> <title> <days> <question> <answer1;answer2...> <weighttype> <responsetype> <url>\n"
+                    "addpoll <type> <title> <days> <question> <answer1;answer2...> <weighttype> <responsetype> <url> "
+                    "<required_field_name1=value1;required_field_name2=value2...>\n"
                     "\n"
-                    "<type> ---------> Type of poll. Valid types are: %s.\n"
-                    "<title> --------> Title for the poll\n"
-                    "<days> ---------> Number of days that the poll will run\n"
-                    "<question> -----> Prompt that voters shall answer\n"
-                    "<answers> ------> Answers for voters to choose from. Separate answers with semicolons (;)\n"
-                    "<weighttype> ---> Weighing method for the poll: 1 = Balance, 2 = Magnitude + Balance\n"
-                    "<responsetype> -> 1 = yes/no/abstain, 2 = single-choice, 3 = multiple-choice\n"
-                    "<url> ----------> Discussion web page URL for the poll\n"
+                    "<type> -----------> Type of poll. Valid types are: %s.\n"
+                    "<title> ----------> Title for the poll\n"
+                    "<days> -----------> Number of days that the poll will run\n"
+                    "<question> -------> Prompt that voters shall answer\n"
+                    "<answers> --------> Answers for voters to choose from. Separate answers with semicolons (;)\n"
+                    "<weighttype> -----> Weighing method for the poll: 1 = Balance, 2 = Magnitude + Balance\n"
+                    "<responsetype> ---> 1 = yes/no/abstain, 2 = single-choice, 3 = multiple-choice\n"
+                    "<url> ------------> Discussion web page URL for the poll\n"
+                    "<required fields>-> Required additional field(s) if any (see below)\n"
                     "\n"
                     "Add a poll to the network.\n"
                     "Requires 100K GRC balance. Costs 50 GRC.\n"
-                    "Provide an empty string for <answers> when choosing \"yes/no/abstain\" for <responsetype>.\n",
+                    "Provide an empty string for <answers> when choosing \"yes/no/abstain\" for <responsetype>.\n"
+                    "Certain poll types may require additional fields. You can see these with addpoll <type> \n"
+                    "with no other parameters.",
                     types_ss.str());
 
         throw std::runtime_error(e);
     }
-
-    EnsureWalletIsUnlocked();
 
     std::string type_string = ToLower(params[0].get_str());
 
@@ -361,6 +383,55 @@ UniValue addpoll(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_PARAMETER, e);
     }
 
+    const std::vector<std::string>& required_fields = Poll::POLL_TYPE_RULES[(int) poll_type].m_required_fields;
+    std::stringstream required_fields_ss;
+
+    for (const auto& required_field : required_fields) {
+        if (required_fields_ss.str() != std::string{}) {
+            required_fields_ss << ", ";
+        }
+
+        required_fields_ss << required_field;
+    }
+
+    if (params.size() == 1) {
+        std::string e = strprintf(
+                    "For addpoll %s, the required fields are the following: %s.\n",
+                    ToLower(params[0].get_str()),
+                    required_fields.empty() ? "none" : required_fields_ss.str());
+
+        throw std::runtime_error(e);
+    }
+
+    size_t required_number_of_params = required_fields.empty() ? 8 : 9;
+
+    if (fHelp || params.size() < required_number_of_params) {
+        std::string e = strprintf(
+                    "addpoll <type> <title> <days> <question> <answer1;answer2...> <weighttype> <responsetype> <url> "
+                    "<required_field_name1=value1;required_field_name2=value2...>\n"
+                    "\n"
+                    "<type> -----------> Type of poll. Valid types are: %s.\n"
+                    "<title> ----------> Title for the poll\n"
+                    "<days> -----------> Number of days that the poll will run\n"
+                    "<question> -------> Prompt that voters shall answer\n"
+                    "<answers> --------> Answers for voters to choose from. Separate answers with semicolons (;)\n"
+                    "<weighttype> -----> Weighing method for the poll: 1 = Balance, 2 = Magnitude + Balance\n"
+                    "<responsetype> ---> 1 = yes/no/abstain, 2 = single-choice, 3 = multiple-choice\n"
+                    "<url> ------------> Discussion web page URL for the poll\n"
+                    "<required fields>-> Required additional field(s) if any (see below)\n"
+                    "\n"
+                    "Add a poll to the network.\n"
+                    "Requires 100K GRC balance. Costs 50 GRC.\n"
+                    "Provide an empty string for <answers> when choosing \"yes/no/abstain\" for <responsetype>.\n"
+                    "Certain poll types may require additional fields. You can see these with addpoll <type> \n"
+                    "with no other parameters.",
+                    types_ss.str());
+
+        throw std::runtime_error(e);
+    }
+
+    EnsureWalletIsUnlocked();
+
     PollBuilder builder = PollBuilder()
         .SetPayloadVersion(payload_version)
         .SetType(poll_type)
@@ -373,6 +444,39 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
     if (!params[4].isNull() && !params[4].get_str().empty()) {
         builder = builder.SetChoices(split(params[4].get_str(), ";"));
+    }
+
+    if (params.size() == 9 && !params[8].isNull() && !params[8].get_str().empty()) {
+        std::vector<std::string> name_value_pairs = split(params[8].get_str(), ";");
+        Poll::AdditionalFieldList fields;
+
+        for (const auto& name_value_pair : name_value_pairs) {
+            std::vector v_field = split(name_value_pair, "=");
+            bool required = true;
+
+            if (v_field.size() != 2) {
+                throw std::runtime_error("Required fields parameter for poll is malformed.");
+            }
+
+            std::string field_name = TrimString(v_field[0]);
+            std::string field_value = TrimString(v_field[1]);
+
+            if (std::find(required_fields.begin(), required_fields.end(), field_name) == required_fields.end()) {
+                required = false;
+            }
+
+            Poll::AdditionalField field(field_name, field_value, required);
+
+            fields.Add(field);
+        }
+
+        // TODO: Extend Wellformed to do a duplicate check on the field name? This is done in the builder anyway. This
+        // makes sure that at least the required fields have been provided and that they are well formed.
+        if (!fields.WellFormed(poll_type)) {
+            throw std::runtime_error("Required field list is malformed.");
+        }
+
+        builder = builder.AddAdditionalFields(fields);
     }
 
     std::pair<CWalletTx, std::string> result_pair;

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -57,12 +57,10 @@ UniValue PollAdditionalFieldsToJson(const Poll::AdditionalFieldList fields)
 
     for (size_t i = 0; i < fields.size(); ++i) {
         UniValue field(UniValue::VOBJ);
-        UniValue field_value(UniValue::VOBJ);
 
-        field_value.pushKV("value", fields.At(i)->m_value);
-        field_value.pushKV("required", fields.At(i)->m_required);
-
-        field.pushKV(fields.At(i)->m_name, field_value);
+        field.pushKV("name", fields.At(i)->m_name);
+        field.pushKV("value", fields.At(i)->m_value);
+        field.pushKV("required", fields.At(i)->m_required);
 
         json.push_back(field);
     }

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -302,7 +302,7 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
         LOCK(cs_main);
 
-        valid_poll_types = GRC::PollPayload::GetValidPollTypes(IsPollV3Enabled(nBestHeight));
+        valid_poll_types = GRC::PollPayload::GetValidPollTypes(IsPollV3Enabled(nBestHeight) ? 3 : 2);
     }
 
     std::stringstream types_ss;

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -302,11 +302,7 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
         LOCK(cs_main);
 
-        // This will implicitly set the proper poll (payload) version based on nHeight, which also requires the lock
-        // on cs_main.
-        PollPayload dummy_poll_payload;
-
-        valid_poll_types = dummy_poll_payload.GetValidPollTypes();
+        valid_poll_types = GRC::PollPayload::GetValidPollTypes(IsPollV3Enabled(nBestHeight));
     }
 
     std::stringstream types_ss;


### PR DESCRIPTION
This PR implements poll type validation for poll submission and receipt in protocol. It also implements the display of AVW validation in both RPC and the GUI, fixes the poll ending height by time problem discussed in #2407, and addresses a number of subtle bugs I discovered along the way.

Closes #1788.
Closes #2407.