### PR TITLE
wallet: Implement option to disable keypoll refill and increase initial key pool size

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -432,7 +432,7 @@ void SetupServerArgs()
     // Wallet
     argsman.AddArg("-upgradewallet", "Upgrade wallet to latest format",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    argsman.AddArg("-keypool=<n>", "Set key pool size to <n> (default: 100)",
+    argsman.AddArg("-keypool=<n>", "Set key pool size to <n> (default: 1000)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-rescan", "Rescan the block chain for missing wallet transactions",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -432,7 +432,7 @@ void SetupServerArgs()
     // Wallet
     argsman.AddArg("-upgradewallet", "Upgrade wallet to latest format",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    argsman.AddArg("-keypool=<n>", "Set key pool size to <n> (default: 1000)",
+    argsman.AddArg("-keypool=<n>", strprintf("Set key pool size to <n> (default: %u)", DEFAULT_KEYPOOL_SIZE),
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-rescan", "Rescan the block chain for missing wallet transactions",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2072,7 +2072,7 @@ UniValue keypoolrefill(const UniValue& params, bool fHelp)
                 "Fills the keypool.\n"
                 + HelpRequiringPassphrase());
 
-    unsigned int nSize = max(gArgs.GetArg("-keypool", 100), (int64_t)0);
+    unsigned int nSize = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
     if (params.size() > 0) {
         if (params[0].get_int() < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2331,7 +2331,7 @@ bool CWallet::NewKeyPool()
         if (IsLocked())
             return false;
 
-        int64_t nKeys = max(gArgs.GetArg("-keypool", 100), (int64_t)0);
+        int64_t nKeys = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
         for (int i = 0; i < nKeys; i++)
         {
             int64_t nIndex = i+1;
@@ -2358,7 +2358,7 @@ bool CWallet::TopUpKeyPool(unsigned int nSize)
         if (nSize > 0)
             nTargetSize = nSize;
         else
-            nTargetSize = max(gArgs.GetArg("-keypool", 100), (int64_t)0);
+            nTargetSize = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
 
         while (setKeyPool.size() < (nTargetSize + 1))
         {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -44,6 +44,8 @@ enum WalletFeature
     FEATURE_LATEST = 60000
 };
 
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+
 /** A key pool entry */
 class CKeyPool
 {


### PR DESCRIPTION
Okay redo this part due to confusion:

1) increase the default keypool size to 1000 instead of 100. This was suggested in the issue as another way to do it as bitcoin has increased that.

2) add an option to allow a user to disable automatic keypool but not by default.