### PR TITLE
gui, researcher: Add GDPR protection display

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -163,7 +163,7 @@ public:
         consensus.BlockV11Height = 1301500;
         consensus.BlockV12Height = 1871830;
         consensus.PollV3Height = 1944820;
-        consensus.ProjectV2Height = std::numeric_limits<int>::max();
+        consensus.ProjectV2Height = 1944820;
         // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 10 minutes on testnet. The very short interval facilitates testing.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -67,6 +67,7 @@ public:
         consensus.BlockV11Height = 2053000;
         consensus.BlockV12Height = std::numeric_limits<int>::max();
         consensus.PollV3Height = std::numeric_limits<int>::max();
+        consensus.ProjectV2Height = std::numeric_limits<int>::max();
         // Immediately post zero payment interval fees 40% for mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 14 days on mainnet
@@ -162,6 +163,7 @@ public:
         consensus.BlockV11Height = 1301500;
         consensus.BlockV12Height = 1871830;
         consensus.PollV3Height = 1944820;
+        consensus.ProjectV2Height = std::numeric_limits<int>::max();
         // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 10 minutes on testnet. The very short interval facilitates testing.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -158,6 +158,14 @@ inline bool IsPollV3Enabled(int nHeight)
     return nHeight >= PollV3Height;
 }
 
+inline bool IsProjectV2Enabled(int nHeight)
+{
+    // Temporary override for testing. Cf. Corresponding code in init.cpp
+    int ProjectV2Height = gArgs.GetArg("-projectv2height", Params().GetConsensus().ProjectV2Height);
+
+    return nHeight >= ProjectV2Height;
+}
+
 inline int GetSuperblockAgeSpacing(int nHeight)
 {
     return (fTestNet ? 86400 : (nHeight > 364500) ? 86400 : 43200);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -35,6 +35,8 @@ struct Params {
     int BlockV12Height;
     /** Block height at which poll v3 contract payloads are valid */
     int PollV3Height;
+    /** Block height at which project v2 contracts are allowed */
+    int ProjectV2Height;
     /** The fraction of rewards taken as fees in an MRC after the zero payment interval. Only consesnus critical
       * at BlockV12Height or above.
       */

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -3,7 +3,6 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "main.h"
-#include "gridcoin/contract/contract.h"
 #include "gridcoin/project.h"
 
 #include <algorithm>
@@ -27,17 +26,23 @@ Whitelist& GRC::GetWhitelist()
 
 constexpr uint32_t Project::CURRENT_VERSION; // For clang
 
-Project::Project() : m_timestamp(0)
-{
-}
-
-Project::Project(std::string name, std::string url)
-    : Project(std::move(name), std::move(url), 0)
+Project::Project()
+    : m_timestamp(0)
+    , m_gdpr_controls(false)
 {
 }
 
 Project::Project(std::string name, std::string url, int64_t timestamp)
-    : m_name(std::move(name)), m_url(std::move(url)), m_timestamp(timestamp)
+    : Project(std::move(name), std::move(url), timestamp, CURRENT_VERSION, false)
+{
+}
+
+Project::Project(std::string name, std::string url, int64_t timestamp, uint32_t version, bool gdpr_controls)
+    : m_version(version)
+    , m_name(std::move(name))
+    , m_url(std::move(url))
+    , m_timestamp(timestamp)
+    , m_gdpr_controls(gdpr_controls)
 {
 }
 

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -81,6 +81,17 @@ std::string Project::StatsUrl(const std::string& type) const
     return BaseUrl() + "stats/" + type + ".gz";
 }
 
+std::optional<bool> Project::HasGDPRControls() const
+{
+    std::optional<bool> has_gdpr_controls;
+
+    if (m_version >= 2) {
+        has_gdpr_controls = m_gdpr_controls;
+    }
+
+    return has_gdpr_controls;
+}
+
 // -----------------------------------------------------------------------------
 // Class: WhitelistSnapshot
 // -----------------------------------------------------------------------------

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -6,6 +6,7 @@
 #define GRIDCOIN_PROJECT_H
 
 #include "amount.h"
+#include "contract/contract.h"
 #include "gridcoin/contract/handler.h"
 #include "gridcoin/contract/payload.h"
 #include "serialize.h"
@@ -29,7 +30,7 @@ public:
     //! ensure that the serialization/deserialization routines also handle all
     //! of the previous versions.
     //!
-    static constexpr uint32_t CURRENT_VERSION = 1;
+    static constexpr uint32_t CURRENT_VERSION = 2;
 
     //!
     //! \brief The maximum number of characters allowed for a serialized project
@@ -53,9 +54,10 @@ public:
     //!
     uint32_t m_version = CURRENT_VERSION;
 
-    std::string m_name;   //!< As it exists in the contract key field.
-    std::string m_url;    //!< As it exists in the contract value field.
-    int64_t m_timestamp;  //!< Timestamp of the contract.
+    std::string m_name;                  //!< As it exists in the contract key field.
+    std::string m_url;                   //!< As it exists in the contract value field.
+    int64_t m_timestamp;                 //!< Timestamp of the contract.
+    bool m_gdpr_controls;                //!< Boolean to indicate whether project has GDPR stats export controls.
 
     //!
     //! \brief Initialize an empty, invalid project object.
@@ -67,17 +69,19 @@ public:
     //!
     //! \param name      Project name from contract message key.
     //! \param url       Project URL from contract message value.
+    //! \param timestamp Contract timestamp.
     //!
-    Project(std::string name, std::string url);
+    Project(std::string name, std::string url, int64_t timestamp = 0);
 
     //!
     //! \brief Initialize a \c Project using data from the contract.
     //!
-    //! \param name      Project name from contract message key.
-    //! \param url       Project URL from contract message value.
-    //! \param timestamp Contract timestamp.
+    //! \param name          Project name from contract message key.
+    //! \param url           Project URL from contract message value.
+    //! \param timestamp     Contract timestamp.
+    //! \param gdpr_controls Boolean to indicate gdpr stats export controls enforced
     //!
-    Project(std::string name, std::string url, int64_t timestamp);
+    Project(std::string name, std::string url, int64_t timestamp, uint32_t version, bool gdpr_controls = false);
 
     //!
     //! \brief Get the type of contract that this payload contains data for.
@@ -97,8 +101,20 @@ public:
     //!
     bool WellFormed(const ContractAction action) const override
     {
-        return !m_name.empty()
-            && (action == ContractAction::REMOVE || !m_url.empty());
+        if (m_name.empty()) {
+            return false;
+        }
+
+        if (action != ContractAction::REMOVE && m_url.empty()) {
+            return false;
+        }
+
+        // m_gdpr_controls is not serialized unless the contract version is v2+
+        if (m_version < 2 && m_gdpr_controls) {
+            return false;
+        }
+
+        return true;
     }
 
     //!
@@ -163,6 +179,10 @@ public:
 
         if (contract_action != ContractAction::REMOVE) {
             READWRITE(LIMITED_STRING(m_url, MAX_URL_SIZE));
+
+            if (m_version >= 2) {
+                READWRITE(m_gdpr_controls);
+            }
         }
     }
 };

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -166,6 +166,11 @@ public:
     //!
     std::string StatsUrl(const std::string& type = "") const;
 
+    //!
+    //! \brief Returns true if project has project stats GDPR export controls
+    //!
+    std::optional<bool> HasGDPRControls() const;
+
     ADD_CONTRACT_PAYLOAD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -596,6 +596,9 @@ void SetupServerArgs()
     // Temporary for poll v3 testing
     hidden_args.emplace_back("-pollv3height");
 
+    // Temporary for project v2 testing
+    hidden_args.emplace_back("-projectv2height");
+
     // -boinckey should now be removed entirely. It is put here to prevent the executable erroring out on
     // an invalid parameter for old clients that may have left the argument in.
     hidden_args.emplace_back("-boinckey");

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -203,7 +203,7 @@ QVariant ProjectTableModel::data(const QModelIndex &index, int role) const
                     }
                     break;
                 case GDPRControls:
-                    if (row->m_gdpr_controls && *row->m_gdpr_controls) {
+                    if (row->m_gdpr_controls && *row->m_gdpr_controls && row->m_error.isEmpty()) {
                         if (row->m_rac <= 0) {
                                 return QIcon(":/icons/warning");
                             } else {

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -38,6 +38,14 @@ public:
                 return pLeft->m_error < pRight->m_error;
             case ProjectTableModel::Whitelisted:
                 return pLeft->m_whitelisted < pRight->m_whitelisted;
+            case ProjectTableModel::GDPRControls:
+                if (pLeft->m_gdpr_controls && pRight->m_gdpr_controls) {
+                    return *pLeft->m_gdpr_controls < *pRight->m_gdpr_controls;
+                } else if (!pLeft->m_gdpr_controls && pRight->m_gdpr_controls) {
+                    return true;
+                } else if (!pRight->m_gdpr_controls) {
+                    return false;
+                }
             case ProjectTableModel::Magnitude:
                 return pLeft->m_magnitude < pRight->m_magnitude;
             case ProjectTableModel::RecentAverageCredit:
@@ -123,6 +131,7 @@ ProjectTableModel::ProjectTableModel(ResearcherModel *model, const bool extended
         << tr("Name")
         << tr("Eligible")
         << tr("Whitelist")
+        << tr("Has GDPR Controls")
         << tr("Magnitude")
         << tr("Avg. Credit")
         << tr("CPID");
@@ -167,6 +176,11 @@ QVariant ProjectTableModel::data(const QModelIndex &index, int role) const
                         return row->m_error;
                     }
                     break;
+                case GDPRControls:
+                    if (row->m_gdpr_controls) {
+                        return *row->m_gdpr_controls;
+                    }
+                    break;
                 case Cpid:
                     return row->m_cpid;
                 case Magnitude:
@@ -186,6 +200,15 @@ QVariant ProjectTableModel::data(const QModelIndex &index, int role) const
                 case Whitelisted:
                     if (row->m_whitelisted) {
                         return QIcon(":/icons/round_green_check");
+                    }
+                    break;
+                case GDPRControls:
+                    if (row->m_gdpr_controls && *row->m_gdpr_controls) {
+                        if (row->m_rac <= 0) {
+                                return QIcon(":/icons/warning");
+                            } else {
+                                return QIcon(":/icons/round_green_check");
+                        }
                     }
                     break;
             }

--- a/src/qt/researcher/projecttablemodel.h
+++ b/src/qt/researcher/projecttablemodel.h
@@ -21,6 +21,7 @@ public:
         Name,
         Eligible,
         Whitelisted,
+        GDPRControls,
         Magnitude,
         RecentAverageCredit,
         Cpid,

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -505,6 +505,7 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
         }
 
         ProjectRow row;
+        row.m_gdpr_controls = project.HasGDPRControls();
         row.m_whitelisted = true;
         row.m_name = QString::fromStdString(project.DisplayName()).toLower();
         row.m_magnitude = 0.0;

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -481,6 +481,8 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
                 }
             }
 
+            row.m_gdpr_controls = whitelist_project->HasGDPRControls();
+
             rows.emplace(whitelist_project->m_name, std::move(row));
         } else {
             row.m_whitelisted = false;

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include "amount.h"
 #include <QObject>
+#include <optional>
 
 QT_BEGIN_NAMESPACE
 class QIcon;
@@ -59,6 +60,7 @@ class ProjectRow
 {
 public:
     bool m_whitelisted;
+    std::optional<bool> m_gdpr_controls;
     QString m_name;
     QString m_cpid;
     double m_magnitude = 0.0;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2004,6 +2004,11 @@ UniValue listprojects(const UniValue& params, bool fHelp)
         entry.pushKV("base_url", project.BaseUrl());
         entry.pushKV("display_url", project.DisplayUrl());
         entry.pushKV("stats_url", project.StatsUrl());
+
+        if (project.HasGDPRControls()) {
+            entry.pushKV("gdpr_controls", *project.HasGDPRControls());
+        }
+
         entry.pushKV("time", DateTimeStrFormat(project.m_timestamp));
 
         res.pushKV(project.m_name, entry);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1700,45 +1700,107 @@ UniValue superblocks(const UniValue& params, bool fHelp)
 //!
 //! To de-whitelist a project:
 //!
+//!     addkey delete project projectname
+//!
+//!     or
+//!
 //!     addkey delete project projectname 1
 //!
 //! Key examples:
 //!
-//!     addkey add project milkyway@home http://milkyway.cs.rpi.edu/milkyway/@
-//!     addkey delete project milkyway@home 1
+//!     v1: addkey add project milkyway@home http://milkyway.cs.rpi.edu/milkyway/@
+//!     v2: addkey add project milkyway@home http://milkyway.cs.rpi.edu/milkyway/@ true
+//!     v1 or v2: addkey delete project milkyway@home
+//!     v1 or v2: addkey delete project milkyway@home 1 (last parameter is a dummy)
+//!     v2: addkey delete project milkyway@home 1 false (last two parameters are dummies)
 //!
 //! GRC will only memorize the *last* value it finds for a key in the highest
 //! block.
 //!
 UniValue addkey(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 4)
-        throw runtime_error(
-                "addkey <action> <keytype> <keyname> <keyvalue>\n"
-                "\n"
-                "<action> ---> Specify add or delete of key\n"
-                "<keytype> --> Specify keytype ex: project\n"
-                "<keyname> --> Specify keyname ex: milky\n"
-                "<keyvalue> -> Specify keyvalue ex: 1\n"
-                "\n"
-                "Add a key to the network\n");
+    bool project_v2_enabled = false;
 
-    if (pwalletMain->IsLocked()) {
-        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
-    }
+    {
+        LOCK(cs_main);
 
-    GRC::Contract::Type type = GRC::Contract::Type::Parse(params[1].get_str());
-
-    if (type == GRC::ContractType::UNKNOWN) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown contract type.");
+        project_v2_enabled = IsProjectV2Enabled(nBestHeight);
     }
 
     GRC::ContractAction action = GRC::ContractAction::UNKNOWN;
+    GRC::Contract::Type type = GRC::ContractType::UNKNOWN;
+    size_t required_param_count = 4;
+    size_t param_count_max = 4;
 
-    if (params[0].get_str() == "add") {
-        action = GRC::ContractAction::ADD;
-    } else if (params[0].get_str() == "delete") {
-        action = GRC::ContractAction::REMOVE;
+    if (params.size()) {
+        if (params[0].get_str() == "add") {
+            action = GRC::ContractAction::ADD;
+        } else if (params[0].get_str() == "delete") {
+            action = GRC::ContractAction::REMOVE;
+        }
+    }
+
+    if (params.size() >= 2) {
+        type = GRC::Contract::Type::Parse(params[1].get_str());
+    }
+
+    // We only need to specify five parameters if v2 project contracts are enabled AND the action is add AND
+    // the key type is project.
+    if (project_v2_enabled
+            && params.size()
+            && action == GRC::ContractAction::ADD
+            && type == GRC::ContractType::PROJECT) {
+        required_param_count = 5;
+        param_count_max = 5;
+    }
+
+    if (type == GRC::ContractType::PROJECT && action == GRC::ContractAction::REMOVE) {
+        required_param_count = 3;
+
+        // This is for compatibility with scripts for project administration that may put something in the
+        // fourth parameter because it was originally required even though ignored. The same principal applies
+        // to v2, where the last two parameters for a remove can be supplied, but they will be ignored.
+        if (project_v2_enabled) {
+            param_count_max = 5;
+        }
+    }
+
+    if (fHelp || params.size() < required_param_count || params.size() > param_count_max) {
+        std::string error_string;
+
+        if (project_v2_enabled) {
+            error_string = "addkey <action> <keytype> <keyname> <keyvalue> <gdpr_protection_bool>\n"
+                           "\n"
+                           "<action> ---> Specify add or delete of key\n"
+                           "<keytype> --> Specify keytype ex: project\n"
+                           "<keyname> --> Specify keyname ex: milky\n"
+                           "<keyvalue> -> Specify keyvalue ex: 1\n"
+                           "\n"
+                           "For project keytype only\n"
+                           "<gdpr_protection_bool> -> true if GDPR stats export protection is enforced for project\n"
+                           "\n"
+                           "Add a key to the network";
+        } else {
+            error_string = "addkey <action> <keytype> <keyname> <keyvalue>\n"
+                           "\n"
+                           "<action> ---> Specify add or delete of key\n"
+                           "<keytype> --> Specify keytype ex: project\n"
+                           "<keyname> --> Specify keyname ex: milky\n"
+                           "<keyvalue> -> Specify keyvalue ex: 1\n"
+                           "\n"
+                           "Add a key to the network";
+        }
+
+        throw runtime_error(error_string);
+    }
+
+    if (pwalletMain->IsLocked()) {
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED,
+                           "Error: Please enter the wallet passphrase with walletpassphrase first.");
+    }
+
+    if (type == GRC::ContractType::UNKNOWN) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown contract type.");
     }
 
     if (action == GRC::ContractAction::UNKNOWN) {
@@ -1748,19 +1810,51 @@ UniValue addkey(const UniValue& params, bool fHelp)
     GRC::Contract contract;
 
     switch (type.Value()) {
-        case GRC::ContractType::PROJECT:
-            contract = GRC::MakeContract<GRC::Project>(
-                action,
-                params[2].get_str(),  // Name
-                params[3].get_str()); // URL
-            break;
-        default:
-            contract = GRC::MakeLegacyContract(
-                type.Value(),
-                action,
-                params[2].get_str(),   // key
-                params[3].get_str());  // value
-            break;
+    case GRC::ContractType::PROJECT:
+        if (action == GRC::ContractAction::ADD) {
+            if (project_v2_enabled) {
+                contract = GRC::MakeContract<GRC::Project>(
+                            action,
+                            params[2].get_str(),  // Name
+                            params[3].get_str(),  // URL
+                            int64_t{0},           // Default zero timestamp
+                            uint32_t{2},          // Contract version number, 2
+                            params[4].getBool()); // GDPR stats export protection enforced boolean
+
+            } else {
+                contract = GRC::MakeContract<GRC::Project>(
+                            action,
+                            params[2].get_str(),  // Name
+                            params[3].get_str(),  // URL
+                            int64_t{0},           // Default zero timestamp
+                            uint32_t{1});         // Contract version number, 1
+            }
+        } else if (action == GRC::ContractAction::REMOVE) {
+            if (project_v2_enabled) {
+                contract = GRC::MakeContract<GRC::Project>(
+                            action,
+                            params[2].get_str(),  // Name
+                            std::string{},        // URL ignored
+                            int64_t{0},           // Default zero timestamp
+                            uint32_t{2});         // Contract version number, 2
+
+            } else {
+                contract = GRC::MakeContract<GRC::Project>(
+                            action,
+                            params[2].get_str(),  // Name
+                            std::string{},        // URL ignored
+                            int64_t{0},           // Default zero timestamp
+                            uint32_t{1});         // Contract version number, 1
+            }
+        }
+        break;
+    default:
+        contract = GRC::MakeLegacyContract(
+                    type.Value(),
+                    action,
+                    params[2].get_str(),   // key
+                    params[3].get_str());  // value
+        break;
     }
 
     if (!contract.RequiresMasterKey()) {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -194,6 +194,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "superblocks"            , 1 },
 
     // Developer
+    { "addkey"                 , 4 },
     { "auditsnapshotaccrual"   , 1 },
     { "auditsnapshotaccruals"  , 0 },
     { "convergencereport"      , 0 },

--- a/src/test/gridcoin/contract_tests.cpp
+++ b/src/test/gridcoin/contract_tests.cpp
@@ -110,7 +110,7 @@ struct TestMessage
             GRC::Contract::CURRENT_VERSION,
             GRC::ContractType::PROJECT,
             GRC::ContractAction::ADD,
-            GRC::ContractPayload::Make<GRC::Project>("test", "test", 123));
+            GRC::ContractPayload::Make<GRC::Project>("test", "test", 123, 1));
     }
 
     //!


### PR DESCRIPTION
This PR adds the status of GDPR protection to the projects table in the GUI. It requires a mandatory because it changes the version of the Project contract to accommodate the m_gdpr_controls boolean. On testnet this will be a separate mandatory from the MRC mandatory that already happened that will coincide with the Poll v3 mandatory coming up. This will be coordinated (at the same height) with the MRC mandatory for Kermit's Mom on the production release. Closes #2437.