### PR TITLE
scraper: Change open mode from append to truncate for auth file

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -1197,7 +1197,7 @@ public:
         std::string outfile = project + "_auth.dat";
         fs::path poutfile = GetDataDir() / outfile;
 
-        oauthdata.open(poutfile, std::ios_base::out | std::ios_base::app);
+        oauthdata.open(poutfile, std::ios_base::out | std::ios_base::trunc);
 
         if (!oauthdata.is_open())
             _log(logattribute::CRITICAL, "auth_data", "Failed to open auth data file");


### PR DESCRIPTION
There is no need to retain prior history in this file, as old eTags are worthless in this context. Using append mode results in a slowing growing file over time as the scraper operates, which wastes storage and slows processing.