### PR TITLE
voting: Change m_additional_fields serialization

### DIFF
--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -10,6 +10,7 @@
 #include "gridcoin/contract/handler.h"
 #include "gridcoin/contract/payload.h"
 #include "serialize.h"
+#include "pubkey.h"
 
 #include <memory>
 #include <vector>
@@ -58,6 +59,7 @@ public:
     std::string m_url;                   //!< As it exists in the contract value field.
     int64_t m_timestamp;                 //!< Timestamp of the contract.
     bool m_gdpr_controls;                //!< Boolean to indicate whether project has GDPR stats export controls.
+    CPubKey m_public_key;                //!< Project public key.
 
     //!
     //! \brief Initialize an empty, invalid project object.
@@ -187,6 +189,7 @@ public:
 
             if (m_version >= 2) {
                 READWRITE(m_gdpr_controls);
+                READWRITE(m_public_key);
             }
         }
     }

--- a/src/gridcoin/voting/payloads.h
+++ b/src/gridcoin/voting/payloads.h
@@ -169,6 +169,13 @@ public:
     {
         READWRITE(m_version);
         READWRITE(m_poll);
+
+        // The poll m_additional_fields is serialized here rather than in the poll class, because it depends on the
+        // payload version.
+        if (m_version >= 3) {
+            READWRITE(m_poll.m_additional_fields);
+        }
+
         READWRITE(m_claim);
     }
 }; // PollPayload

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -321,15 +321,7 @@ const std::vector<Poll::PollTypeRules> Poll::POLL_TYPE_RULES = {
     // These must be kept in the order that corresponds to the PollType enum.
     // { min duration, min vote percent AVW, { vector of required additional fieldnames } }
     {  0,  0, {} },                                // PollType::UNKNOWN
-    // Note there is NO payload version protection on the vector of required additional fieldnames
-    // and all payloads less than v3 only allowed PollType::SURVEY. Furthermore, the serialization
-    // of the poll class additional fields depends only on whether the poll type is SURVEY. The net
-    // of this is that the required additional fieldnames need to remain an empty vector for SURVEY.
-    //
-    // If a new SURVEY type is needed in the future with additional fields, a new enum entry should
-    // be created for it.
-    //
-    // In addition note that any poll type that has a min vote percent AVW requirement must
+    // Note that any poll type that has a min vote percent AVW requirement must
     // also require the weight type of BALANCE_AND_MAGNITUDE, so therefore the
     // only poll type that can actually use BALANCE is SURVEY. All other WeightTypes are deprecated.
     {  7,  0, {} },                                // PollType::SURVEY

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -558,19 +558,8 @@ public:
             READWRITE(m_choices);
         }
 
-        // Note: this is a little dirty but works, because all polls prior to v3 are SURVEY, and the
-        // additional fields for survey is an empty vector. Therefore this serialization will only
-        // be operative if a poll type other than survey is used, and this cannot occur until v3+.
-        // Refer to the comments in POLL_TYPE_RULES. This is necessary because the only other solution would be
-        // to pass the poll payload version into the poll object, which would be problematic.
-        //
-        // TODO: Remove COMMUNITY after finishing isolated fork testing. (Community was used to test v3 polls
-        // before the introduction of additional fields, and therefore the community polls on the isolated
-        // testing fork do not have the m_additional_fields serialization and removal of the COMMUNITY below
-        // will result in an serialization I/O error.
-        if (m_type != PollType::SURVEY && m_type != PollType::COMMUNITY) {
-            READWRITE(m_additional_fields);
-        }
+        // Note that m_additional_fields is not serialized here, but rather in the PollPayload class. This
+        // is because it depends on the poll payload version, which is not available here.
     }
 }; // Poll
 } // namespace GRC

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -177,7 +177,8 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_add)
             << GRC::Project::CURRENT_VERSION
             << std::string("Enigma")
             << std::string("http://enigma.test/@")
-            << true;
+            << true
+            << CPubKey{};
 
     CDataStream streamv2(SER_NETWORK, PROTOCOL_VERSION);
     projectv2.Serialize(streamv2, GRC::ContractAction::ADD);
@@ -204,14 +205,19 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_add)
     BOOST_CHECK_EQUAL(projectv1.m_url, "http://enigma.test/@");
     BOOST_CHECK_EQUAL(projectv1.m_timestamp, 0);
     BOOST_CHECK_EQUAL(projectv1.m_gdpr_controls, false);
+    BOOST_CHECK(projectv1.m_public_key == CPubKey{});
 
     BOOST_CHECK(projectv1.WellFormed(GRC::ContractAction::ADD) == true);
+
+    CPubKey public_key = CPubKey(ParseHex(
+        "111111111111111111111111111111111111111111111111111111111111111111"));
 
     CDataStream streamv2 = CDataStream(SER_NETWORK, PROTOCOL_VERSION)
         << GRC::Project::CURRENT_VERSION
         << std::string("Enigma")
         << std::string("http://enigma.test/@")
-        << true;
+        << true
+        << public_key;
 
     GRC::Project projectv2;
     projectv2.Unserialize(streamv2, GRC::ContractAction::ADD);
@@ -221,6 +227,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_add)
     BOOST_CHECK_EQUAL(projectv2.m_url, "http://enigma.test/@");
     BOOST_CHECK_EQUAL(projectv2.m_timestamp, 0);
     BOOST_CHECK_EQUAL(projectv2.m_gdpr_controls, true);
+    BOOST_CHECK(projectv2.m_public_key == public_key);
 
     BOOST_CHECK(projectv2.WellFormed(GRC::ContractAction::ADD) == true);
 
@@ -274,6 +281,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_delete)
     BOOST_CHECK_EQUAL(projectv1.m_url, "");
     BOOST_CHECK_EQUAL(projectv1.m_timestamp, 0);
     BOOST_CHECK_EQUAL(projectv1.m_gdpr_controls, false);
+    BOOST_CHECK(projectv1.m_public_key == CPubKey{});
 
     BOOST_CHECK(projectv1.WellFormed(GRC::ContractAction::REMOVE) == true);
 
@@ -288,7 +296,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_delete)
     BOOST_CHECK_EQUAL(projectv2.m_name, "Enigma");
     BOOST_CHECK_EQUAL(projectv2.m_url, "");
     BOOST_CHECK_EQUAL(projectv2.m_timestamp, 0);
-    BOOST_CHECK_EQUAL(projectv1.m_gdpr_controls, false);
+    BOOST_CHECK_EQUAL(projectv2.m_gdpr_controls, false);
+    BOOST_CHECK(projectv2.m_public_key == CPubKey{});
 
     BOOST_CHECK(projectv2.WellFormed(GRC::ContractAction::REMOVE) == true);
 }


### PR DESCRIPTION
I was not happy about the poll serialization for poll v3. This fixes it properly. Note that I collapsed and reforked my four node fork from testnet and retested both the poll v3 and project v2 transition, along with all different poll types and the project v2 records, and also synced from zero.

This is going to require another mandatory testnet build. The hardfork height is not being changed.

I have to fixup the unit test suite. I will do this tomorrow morning.