### PR TITLE
util: modify Win32LockedPageAllocator to query windows for limit.

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -200,7 +200,10 @@ void Win32LockedPageAllocator::FreeLocked(void* addr, size_t len)
 
 size_t Win32LockedPageAllocator::GetLimit()
 {
-    // TODO is there a limit on Windows, how to get it?
+    size_t min, max;
+    if(GetProcessWorkingSetSize(GetCurrentProcess(), &min, &max) != 0) {
+        return min;
+    }
     return std::numeric_limits<size_t>::max();
 }
 #endif

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -200,9 +200,9 @@ void Win32LockedPageAllocator::FreeLocked(void* addr, size_t len)
 
 size_t Win32LockedPageAllocator::GetLimit()
 {
-    size_t min, max;
+    SIZE_T min, max;
     if(GetProcessWorkingSetSize(GetCurrentProcess(), &min, &max) != 0) {
-        return min;
+        return (size_t)min;
     }
     return std::numeric_limits<size_t>::max();
 }


### PR DESCRIPTION
> This PR resolves a todo within the Win32LockedPageAllocator: `// TODO is there a limit on Windows, how to get it?`.
> The idea is to use the Windows API to get the limits like the posix based allocator does with `getrlimit`. 
> 
> I use [GetProcessWorkingSetSize](https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-getprocessworkingsetsize) to perform this task and fallback to `return std::numeric_limits<size_t>::max();` just like the posix implementation does.

`https://github.com/bitcoin/bitcoin/pull/25320`