### PR TITLE
build, qt: Fix `QMAKE_CXXFLAGS` expression for `mingw32` host

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -172,7 +172,7 @@ $(package)_config_opts_mingw32 += -no-freetype
 $(package)_config_opts_mingw32 += -xplatform win32-g++
 $(package)_config_opts_mingw32 += "QMAKE_CFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_CXX = '$($(package)_cxx)'"
-$(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"
+$(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cxxflags) $($(package)_cppflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_mingw32 += -pch


### PR DESCRIPTION
> A "copy-paste typo" was introduced in bitcoin/bitcoin#21593.
> 
> I'm sorry about that.

`https://github.com/bitcoin/bitcoin/pull/25424`