### PR TITLE
log: Use consistent wording in random.cpp log

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -97,7 +97,7 @@ static void ReportHardwareRand()
     // This must be done in a separate function, as InitHardwareRand() may be indirectly called
     // from global constructors, before logging is initialized.
     if (g_rdseed_supported) {
-        LogPrintf("Using RdSeed as additional entropy source\n");
+        LogPrintf("Using RdSeed as an additional entropy source\n");
     }
     if (g_rdrand_supported) {
         LogPrintf("Using RdRand as an additional entropy source\n");


### PR DESCRIPTION
> It's a trivial change, but it bothers me a bit that two log lines in a row aren't grammatically identical while following exactly the same pattern. I've read `contributing.md` and I'm aware that changes like this are usually being ignored and dropped, but I decided to leave it here anyway in case someone feels the same way about inconsistent log messages or grammar =)

`https://github.com/bitcoin/bitcoin/pull/25440`