### PR TITLE
build, refactor: Improve package version usage

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
 GCCFLAGS?=
-$(package)_version=1_73_0
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$(subst _,.,$($(package)_version))/source/
-$(package)_file_name=$(package)_$($(package)_version).tar.bz2
+$(package)_version=1.73.0
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
+$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
 $(package)_sha256_hash=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402
 $(package)_dependencies=zlib
 

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,7 +1,7 @@
 package=expat
 GCCFLAGS?=
 $(package)_version=2.4.1
-$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_4_1/
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a
 

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,7 +1,7 @@
 package=openssl
-$(package)_version=1_1_1l
+$(package)_version=1.1.1l
 $(package)_download_path=https://github.com/openssl/openssl/archive/refs/tags
-$(package)_file_name=OpenSSL_1_1_1l.tar.gz
+$(package)_file_name=OpenSSL_$(subst .,_,$($(package)_version)).tar.gz
 $(package)_sha256_hash=dac036669576e83e8523afdb3971582f8b5d33993a2d6a5af87daa035f529b4f
 
 define $(package)_set_vars


### PR DESCRIPTION
> `boost` package:
> 
>     * `.` is used as a separator in versions of other depends packages.
> 
> 
> `expat` package:
> 
>     * reuse package version in its download path
> 

Also fixed our `_` usage in OpenSSL.

Ref: https://github.com/bitcoin/bitcoin/pull/24276
