### PR TITLE
Define MAX_DIGITS_BTC for magic number in BitcoinUnits::format

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -3,6 +3,8 @@
 
 #include <QStringList>
 
+static constexpr auto MAX_DIGITS_BTC = 16;
+
 BitcoinUnits::BitcoinUnits(QObject *parent):
         QAbstractListModel(parent),
         unitlist(availableUnits())
@@ -99,7 +101,9 @@ QString BitcoinUnits::format(int unit, qint64 n, bool fPlus, bool justify)
     qint64 remainder = n_abs % coin;
     QString quotient_str = QString::number(quotient);
 
-    if (justify) quotient_str = quotient_str.rightJustified(16 - num_decimals, ' ');
+    if (justify) {
+        quotient_str = quotient_str.rightJustified(MAX_DIGITS_BTC - num_decimals, ' ');
+    }
 
     QString remainder_str = QString::number(remainder).rightJustified(num_decimals, '0');
 


### PR DESCRIPTION
Incredibly minor, but we should keep in line with upstream.

> A magic number snuck in with [bitcoin/bitcoin#16432](https://github.com/bitcoin/bitcoin/pull/16432)

Ref: https://github.com/bitcoin-core/gui/pull/153