### PR TITLE
rpc: fix invalid parameter error codes for {sign,verify}message RPCs

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -458,7 +458,7 @@ UniValue signmessage(const UniValue& params, bool fHelp)
 
     CBitcoinAddress addr(strAddress);
     if (!addr.IsValid())
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
 
     CKeyID keyID;
     if (!addr.GetKeyID(keyID))
@@ -495,7 +495,7 @@ UniValue verifymessage(const UniValue& params, bool fHelp)
 
     CBitcoinAddress addr(strAddress);
     if (!addr.IsValid())
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
 
     CKeyID keyID;
     if (!addr.GetKeyID(keyID))
@@ -505,7 +505,7 @@ UniValue verifymessage(const UniValue& params, bool fHelp)
     vector<unsigned char> vchSig = DecodeBase64(strSign.c_str(), &fInvalid);
 
     if (fInvalid)
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
+        throw JSONRPCError(RPC_TYPE_ERROR, "Malformed base64 encoding");
 
     CDataStream ss(SER_GETHASH, 0);
     ss << strMessageMagic;


### PR DESCRIPTION
> RPCs that accept address parameters usually return the intended error code `RPC_INVALID_ADDRESS_OR_KEY` (-5) if a passed address is invalid. The two exceptions to the rule are `signmessage` and `verifymessage`, which return `RPC_TYPE_ERROR` (-3) in this case instead. Oddly enough `verifymessage` returns `RPC_INVALID_ADDRESS_OR_KEY` when the _signature_ was malformed, where `RPC_TYPE_ERROR` would be more approriate.
> 
> This PR fixes these inaccuracies...
> 
> master branch:
> 
> ```
> $ ./bitcoin-cli signmessage invalid_addr message
> error code: -3
> error message:
> Invalid address
> $ ./bitcoin-cli verifymessage invalid_addr dummy_sig message
> error code: -3
> error message:
> Invalid address
> $ ./bitcoin-cli verifymessage 12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX invalid_sig message
> error code: -5
> error message:
> Malformed base64 encoding
> ```
> 
> PR branch:
> 
> ```
> $ ./bitcoin-cli signmessage invalid_addr message
> error code: -5
> error message:
> Invalid address
> $ ./bitcoin-cli verifymessage invalid_addr dummy_sig message
> error code: -5
> error message:
> Invalid address
> $ ./bitcoin-cli verifymessage 12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX invalid_sig message
> error code: -3
> error message:
> Malformed base64 encoding
> ```

Ref: https://github.com/bitcoin/bitcoin/pull/18466
