### PR TITLE
scripted-diff: Drop Darwin version for better maintainability

### DIFF
--- a/cd/00_setup_env_mac.sh
+++ b/cd/00_setup_env_mac.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_macos_cross
 export DOCKER_NAME_TAG=ubuntu:20.04
-export HOST=x86_64-apple-darwin18
+export HOST=x86_64-apple-darwin
 export PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools libtinfo5 python3-dev python3-setuptools xorriso"
 export XCODE_VERSION=12.1
 export XCODE_BUILD_ID=12A7403

--- a/ci/test/00_setup_env_mac.sh
+++ b/ci/test/00_setup_env_mac.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_macos_cross
 export DOCKER_NAME_TAG=ubuntu:20.04  # Check that Focal can cross-compile to macos
-export HOST=x86_64-apple-darwin18
+export HOST=x86_64-apple-darwin
 export PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools libtinfo5 python3-dev python3-setuptools xorriso"
 export XCODE_VERSION=12.1
 export XCODE_BUILD_ID=12A7403

--- a/ci/test/00_setup_env_mac_host.sh
+++ b/ci/test/00_setup_env_mac_host.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export HOST=x86_64-apple-darwin18
+export HOST=x86_64-apple-darwin
 export GOAL="install"
 # We run the contrib/install_db4.sh script rather than installing the
 # Homebrew berkeley-db4 formula to add the Berkeley DB 4.8 dependency

--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -57,10 +57,10 @@ the depends directory and deploy the .dmg:
 
 ```bash
 cd depends
-make HOST=x86_64-apple-darwin18
+make HOST=x86_64-apple-darwin
 cd ..
 ./autogen.sh # not required when building from tarball
-CONFIG_SITE=$PWD/depends/x86_64-apple-darwin18/share/config.site ./configure --prefix=/
+CONFIG_SITE=$PWD/depends/x86_64-apple-darwin/share/config.site ./configure --prefix=/
 make
 make deploy
 ```

--- a/depends/README.md
+++ b/depends/README.md
@@ -22,7 +22,7 @@ Common `host-platform-triplets` for cross compilation are:
 
 - `i686-w64-mingw32` for Win32
 - `x86_64-w64-mingw32` for Win64
-- `x86_64-apple-darwin18` for macOS
+- `x86_64-apple-darwin` for macOS
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
 - `aarch64-linux-gnu` for Linux ARM 64 bit
 


### PR DESCRIPTION
> After this PR, any macOS tools version bumping in the future will touch fewer files in the repo.
> 
> Pointing a Darwin version for the `--host` system does not matter for the following reasons:
> 
>     * in terms of the resulted binaries, we should only care about the minimum supported macOS version which is a separated parameter in our build system.
> 
>     * in terms of the build system itself, the usage of the `$(host)` variable is self-consistent enough. Btw `$(host_os)` value already has the version dropped:
> 
> 
> ```
> $ make -C depends --no-print-directory print-host_os HOST=x86_64-apple-darwin19
> host_os=darwin
> ```

Ref: https://github.com/bitcoin/bitcoin/pull/23585
