### PR TITLE
build: Fix x86_64 <-> arm64 cross-compiling for macOS

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -20,3 +20,8 @@ darwin_OTOOL:=$(shell xcrun -f otool)
 darwin_NM:=$(shell xcrun -f nm)
 darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
 darwin_native_toolchain=
+
+x86_64_darwin_CFLAGS = -arch x86_64
+x86_64_darwin_CXXFLAGS = $(x86_64_darwin_CFLAGS)
+aarch64_darwin_CFLAGS = -arch arm64
+aarch64_darwin_CXXFLAGS = $(aarch64_darwin_CFLAGS)

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -21,7 +21,7 @@ darwin_NM:=$(shell xcrun -f nm)
 darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
 darwin_native_toolchain=
 
-x86_64_darwin_CFLAGS = -arch x86_64
-x86_64_darwin_CXXFLAGS = $(x86_64_darwin_CFLAGS)
-aarch64_darwin_CFLAGS = -arch arm64
-aarch64_darwin_CXXFLAGS = $(aarch64_darwin_CFLAGS)
+x86_64_darwin_CFLAGS += -arch x86_64
+x86_64_darwin_CXXFLAGS += -arch x86_64
+aarch64_darwin_CFLAGS += -arch arm64
+aarch64_darwin_CXXFLAGS += -arch arm64


### PR DESCRIPTION
> Currently, on master ([111c3e0](https://github.com/bitcoin/bitcoin/commit/111c3e06b35b7867f2e0f740e988f648ac6c325d)), dependencies are built for the build system architecture, not the provided host.
> 
> On Intel-based macOS Big Sur 11.6.1 (20G224):
> 
> ```
> % make -C depends HOST=arm64-apple-darwin20
> % lipo -info depends/arm64-apple-darwin20/lib/libsqlite3.a 
> Non-fat file: depends/arm64-apple-darwin20/lib/libsqlite3.a is architecture: x86_64
> ```
> 
> On M1-based macOS Monterey 12.0.1 (21A559) the `boost` package building fails with multiple errors like that:
> 
> ```
> % make -C depends boost HOST=x86_64-apple-darwin19
> ...
> error: option 'cf-protection=return' cannot be specified on this target
> error: option 'cf-protection=branch' cannot be specified on this target
> 2 errors generated.
> ```
> 
> This PR allows to cross-compile as follows:
> 
>     * on Intel-based macOS Big Sur 11.6.1 (20G224):
> 
> 
> ```
> % make -C depends HOST=arm64-apple-darwin20
> % lipo -info depends/arm64-apple-darwin20/lib/libsqlite3.a 
> Non-fat file: depends/arm64-apple-darwin20/lib/libsqlite3.a is architecture: arm64
> % CONFIG_SITE=$PWD/depends/arm64-apple-darwin20/share/config.site ./configure
> % make
> % lipo -info src/qt/bitcoin-qt 
> Non-fat file: src/qt/bitcoin-qt is architecture: arm64
> ```
> 
>     * on M1-based macOS Monterey 12.0.1 (21A559):
> 
> 
> ```
> % make -C depends HOST=x86_64-apple-darwin19
> % CONFIG_SITE=$PWD/depends/x86_64-apple-darwin19/share/config.site ./configure
> % make
> % lipo -info src/qt/bitcoin-qt
> Non-fat file: src/qt/bitcoin-qt is architecture: x86_64
> ```
> 
> No behavior change for other builder-host pairs.

Ref: https://github.com/bitcoin/bitcoin/pull/23603

Also fixes a regression in the above PR, Ref: https://github.com/bitcoin/bitcoin/pull/23817