### PR TITLE
net: Turn net structures into dumb storage classes (backport)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -153,6 +153,7 @@ GRIDCOIN_CORE_H = \
     miner.h \
     mruset.h \
     netbase.h \
+    netaddress.h \
     net.h \
     node/blockstorage.h \
     pbkdf2.h \
@@ -264,6 +265,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     main.cpp \
     miner.cpp \
     netbase.cpp \
+    netaddress.cpp \
     net.cpp \
     node/blockstorage.cpp \
     node/ui_interface.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -32,6 +32,7 @@ GRIDCOIN_TESTS =\
 	test/checkpoints_tests.cpp \
 	test/dos_tests.cpp \
 	test/accounting_tests.cpp \
+	test/addrman_tests.cpp \
 	test/allocator_tests.cpp \
 	test/base32_tests.cpp \
 	test/base58_tests.cpp \
@@ -59,6 +60,7 @@ GRIDCOIN_TESTS =\
 	test/mruset_tests.cpp \
 	test/multisig_tests.cpp \
 	test/netbase_tests.cpp \
+	test/net_tests.cpp \
 	test/random_tests.cpp \
 	test/rpc_tests.cpp \
 	test/sanity_tests.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1135,10 +1135,11 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
         for (auto const& strAddr : gArgs.GetArgs("-externalip"))
         {
-            CService addrLocal(strAddr, GetListenPort(), fNameLookup);
-            if (!addrLocal.IsValid())
+            CService addrLocal;
+            if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
+                AddLocal(addrLocal, LOCAL_MANUAL);
+            else
                 return InitError(strprintf(_("Cannot resolve -externalip address: '%s'"), strAddr));
-            AddLocal(CService(strAddr, GetListenPort(), fNameLookup), LOCAL_MANUAL);
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1073,7 +1073,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     CService addrProxy;
     bool fProxy = false;
     if (gArgs.IsArgSet("-proxy")) {
-        addrProxy = CService(gArgs.GetArg("-proxy", ""), 9050);
+        CService addrProxy(LookupNumeric(gArgs.GetArg("-proxy", "").c_str(), 9050));
         if (!addrProxy.IsValid())
             return InitError(strprintf(_("Invalid -proxy address: '%s'"), gArgs.GetArg("-proxy", "")));
 
@@ -1082,17 +1082,17 @@ bool AppInit2(ThreadHandlerPtr threads)
         if (!IsLimited(NET_IPV6))
             SetProxy(NET_IPV6, addrProxy);
         SetNameProxy(addrProxy);
-        
         fProxy = true;
     }
 
     // -tor can override normal proxy, -notor disables Tor entirely
     if (gArgs.IsArgSet("-tor") && (fProxy || gArgs.IsArgSet("-tor"))) {
-        CService addrOnion;
-        if (!gArgs.IsArgSet("-tor"))
+        proxyType addrOnion;
+        if (!gArgs.IsArgSet("-tor")) {
             addrOnion = addrProxy;
-        else
-            addrOnion = CService(gArgs.GetArg("-tor", ""), 9050);
+        } else {
+            CService addrProxy(LookupNumeric(gArgs.GetArg("-tor", "").c_str(), 9050));
+        }
         if (!addrOnion.IsValid())
             return InitError(strprintf(_("Invalid -tor address: '%s'"), gArgs.GetArg("-tor", "")));
         SetProxy(NET_TOR, addrOnion);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1311,11 +1311,11 @@ void ThreadDNSAddressSeed2(void* parg)
             if (HaveNameProxy()) {
                 AddOneShot(seed[1]);
             } else {
-                vector<CNetAddr> vaddr;
+                vector<CNetAddr> vIPs;
                 vector<CAddress> vAdd;
-                if (LookupHost(seed[1], vaddr))
+                if (LookupHost(seed[1], vIPs, 0, true))
                 {
-                    for (auto const& ip : vaddr)
+                    for (auto const& ip : vIPs)
                     {
                         int nOneDay = 24*3600;
                         CAddress addr = CAddress(CService(ip, GetDefaultPort()));
@@ -1324,7 +1324,15 @@ void ThreadDNSAddressSeed2(void* parg)
                         found++;
                     }
                 }
-                addrman.Add(vAdd, CNetAddr(seed[0], true));
+                // TODO: The seed name resolve may fail, yielding an IP of [::], which results in
+                // addrman assigning the same source to results from different seeds.
+                // This should switch to a hard-coded stable dummy IP for each seed name, so that the
+                // resolve is not required at all.
+                if (!vIPs.empty()) {
+                    CService seedSource;
+                    Lookup(seed[0], seedSource, 0, true);
+                    addrman.Add(vAdd, seedSource);
+                }
             }
         }
     }

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1,0 +1,760 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifdef HAVE_CONFIG_H
+#include "config/gridcoin-config.h"
+#endif
+
+#include "netaddress.h"
+#include "hash.h"
+#include "util/strencodings.h"
+#include "tinyformat.h"
+
+static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
+static const unsigned char pchOnionCat[] = {0xFD,0x87,0xD8,0x7E,0xEB,0x43};
+
+// 0xFD + sha256("bitcoin")[0:5]
+static const unsigned char g_internal_prefix[] = { 0xFD, 0x6B, 0x88, 0xC0, 0x87, 0x24 };
+
+void CNetAddr::Init()
+{
+    memset(ip, 0, sizeof(ip));
+    scopeId = 0;
+}
+
+void CNetAddr::SetIP(const CNetAddr& ipIn)
+{
+    memcpy(ip, ipIn.ip, sizeof(ip));
+}
+
+void CNetAddr::SetRaw(Network network, const uint8_t *ip_in)
+{
+    switch(network)
+    {
+        case NET_IPV4:
+            memcpy(ip, pchIPv4, 12);
+            memcpy(ip+12, ip_in, 4);
+            break;
+        case NET_IPV6:
+            memcpy(ip, ip_in, 16);
+            break;
+        default:
+            assert(!"invalid network");
+    }
+}
+
+bool CNetAddr::SetInternal(const std::string &name)
+{
+    if (name.empty()) {
+        return false;
+    }
+    unsigned char hash[32] = {};
+    CSHA256().Write((const unsigned char*)name.data(), name.size()).Finalize(hash);
+    memcpy(ip, g_internal_prefix, sizeof(g_internal_prefix));
+    memcpy(ip + sizeof(g_internal_prefix), hash, sizeof(ip) - sizeof(g_internal_prefix));
+    return true;
+}
+
+bool CNetAddr::SetSpecial(const std::string &strName)
+{
+    if (strName.size()>6 && strName.substr(strName.size() - 6, 6) == ".onion") {
+        std::vector<unsigned char> vchAddr = DecodeBase32(strName.substr(0, strName.size() - 6).c_str());
+        if (vchAddr.size() != 16-sizeof(pchOnionCat))
+            return false;
+        memcpy(ip, pchOnionCat, sizeof(pchOnionCat));
+        for (unsigned int i=0; i<16-sizeof(pchOnionCat); i++)
+            ip[i + sizeof(pchOnionCat)] = vchAddr[i];
+        return true;
+    }
+    return false;
+}
+
+CNetAddr::CNetAddr()
+{
+    Init();
+}
+
+CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
+{
+    SetRaw(NET_IPV4, (const uint8_t*)&ipv4Addr);
+}
+
+CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope)
+{
+    SetRaw(NET_IPV6, (const uint8_t*)&ipv6Addr);
+    scopeId = scope;
+}
+
+unsigned int CNetAddr::GetByte(int n) const
+{
+    return ip[15-n];
+}
+
+bool CNetAddr::IsIPv4() const
+{
+    return (memcmp(ip, pchIPv4, sizeof(pchIPv4)) == 0);
+}
+
+bool CNetAddr::IsIPv6() const
+{
+    return (!IsIPv4() && !IsTor() && !IsInternal());
+}
+
+bool CNetAddr::IsRFC1918() const
+{
+    return IsIPv4() && (
+        GetByte(3) == 10 ||
+        (GetByte(3) == 192 && GetByte(2) == 168) ||
+        (GetByte(3) == 172 && (GetByte(2) >= 16 && GetByte(2) <= 31)));
+}
+
+bool CNetAddr::IsRFC2544() const
+{
+    return IsIPv4() && GetByte(3) == 198 && (GetByte(2) == 18 || GetByte(2) == 19);
+}
+
+bool CNetAddr::IsRFC3927() const
+{
+    return IsIPv4() && (GetByte(3) == 169 && GetByte(2) == 254);
+}
+
+bool CNetAddr::IsRFC6598() const
+{
+    return IsIPv4() && GetByte(3) == 100 && GetByte(2) >= 64 && GetByte(2) <= 127;
+}
+
+bool CNetAddr::IsRFC5737() const
+{
+    return IsIPv4() && ((GetByte(3) == 192 && GetByte(2) == 0 && GetByte(1) == 2) ||
+        (GetByte(3) == 198 && GetByte(2) == 51 && GetByte(1) == 100) ||
+        (GetByte(3) == 203 && GetByte(2) == 0 && GetByte(1) == 113));
+}
+
+bool CNetAddr::IsRFC3849() const
+{
+    return GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x0D && GetByte(12) == 0xB8;
+}
+
+bool CNetAddr::IsRFC3964() const
+{
+    return (GetByte(15) == 0x20 && GetByte(14) == 0x02);
+}
+
+bool CNetAddr::IsRFC6052() const
+{
+    static const unsigned char pchRFC6052[] = {0,0x64,0xFF,0x9B,0,0,0,0,0,0,0,0};
+    return (memcmp(ip, pchRFC6052, sizeof(pchRFC6052)) == 0);
+}
+
+bool CNetAddr::IsRFC4380() const
+{
+    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0 && GetByte(12) == 0);
+}
+
+bool CNetAddr::IsRFC4862() const
+{
+    static const unsigned char pchRFC4862[] = {0xFE,0x80,0,0,0,0,0,0};
+    return (memcmp(ip, pchRFC4862, sizeof(pchRFC4862)) == 0);
+}
+
+bool CNetAddr::IsRFC4193() const
+{
+    return ((GetByte(15) & 0xFE) == 0xFC);
+}
+
+bool CNetAddr::IsRFC6145() const
+{
+    static const unsigned char pchRFC6145[] = {0,0,0,0,0,0,0,0,0xFF,0xFF,0,0};
+    return (memcmp(ip, pchRFC6145, sizeof(pchRFC6145)) == 0);
+}
+
+bool CNetAddr::IsRFC4843() const
+{
+    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x00 && (GetByte(12) & 0xF0) == 0x10);
+}
+
+bool CNetAddr::IsTor() const
+{
+    return (memcmp(ip, pchOnionCat, sizeof(pchOnionCat)) == 0);
+}
+
+bool CNetAddr::IsLocal() const
+{
+    // IPv4 loopback
+   if (IsIPv4() && (GetByte(3) == 127 || GetByte(3) == 0))
+       return true;
+
+   // IPv6 loopback (::1/128)
+   static const unsigned char pchLocal[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+   if (memcmp(ip, pchLocal, 16) == 0)
+       return true;
+
+   return false;
+}
+
+bool CNetAddr::IsMulticast() const
+{
+    return    (IsIPv4() && (GetByte(3) & 0xF0) == 0xE0)
+           || (GetByte(15) == 0xFF);
+}
+
+bool CNetAddr::IsValid() const
+{
+    // Cleanup 3-byte shifted addresses caused by garbage in size field
+    // of addr messages from versions before 0.2.9 checksum.
+    // Two consecutive addr messages look like this:
+    // header20 vectorlen3 addr26 addr26 addr26 header20 vectorlen3 addr26 addr26 addr26...
+    // so if the first length field is garbled, it reads the second batch
+    // of addr misaligned by 3 bytes.
+    if (memcmp(ip, pchIPv4+3, sizeof(pchIPv4)-3) == 0)
+        return false;
+
+    // unspecified IPv6 address (::/128)
+    unsigned char ipNone[16] = {};
+    if (memcmp(ip, ipNone, 16) == 0)
+        return false;
+
+    // documentation IPv6 address
+    if (IsRFC3849())
+        return false;
+
+    if (IsInternal())
+        return false;
+
+    if (IsIPv4())
+    {
+        // INADDR_NONE
+        uint32_t ipNone = INADDR_NONE;
+        if (memcmp(ip+12, &ipNone, 4) == 0)
+            return false;
+
+        // 0
+        ipNone = 0;
+        if (memcmp(ip+12, &ipNone, 4) == 0)
+            return false;
+    }
+
+    return true;
+}
+
+bool CNetAddr::IsRoutable() const
+{
+        return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsLocal() || IsInternal());
+}
+
+bool CNetAddr::IsInternal() const
+{
+   return memcmp(ip, g_internal_prefix, sizeof(g_internal_prefix)) == 0;
+}
+
+enum Network CNetAddr::GetNetwork() const
+{
+    if (IsInternal())
+        return NET_INTERNAL;
+
+    if (!IsRoutable())
+        return NET_UNROUTABLE;
+
+    if (IsIPv4())
+        return NET_IPV4;
+
+    if (IsTor())
+        return NET_TOR;
+
+    return NET_IPV6;
+}
+
+std::string CNetAddr::ToStringIP() const
+{
+    if (IsTor())
+        return EncodeBase32(&ip[6], 10) + ".onion";
+    if (IsInternal())
+        return EncodeBase32(ip + sizeof(g_internal_prefix), sizeof(ip) - sizeof(g_internal_prefix)) + ".internal";
+    CService serv(*this, 0);
+    struct sockaddr_storage sockaddr;
+    socklen_t socklen = sizeof(sockaddr);
+    if (serv.GetSockAddr((struct sockaddr*)&sockaddr, &socklen)) {
+        char name[1025] = "";
+        if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name, sizeof(name), nullptr, 0, NI_NUMERICHOST))
+            return std::string(name);
+    }
+    if (IsIPv4())
+        return strprintf("%u.%u.%u.%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0));
+    else
+        return strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
+                         GetByte(15) << 8 | GetByte(14), GetByte(13) << 8 | GetByte(12),
+                         GetByte(11) << 8 | GetByte(10), GetByte(9) << 8 | GetByte(8),
+                         GetByte(7) << 8 | GetByte(6), GetByte(5) << 8 | GetByte(4),
+                         GetByte(3) << 8 | GetByte(2), GetByte(1) << 8 | GetByte(0));
+}
+
+std::string CNetAddr::ToString() const
+{
+    return ToStringIP();
+}
+
+bool operator==(const CNetAddr& a, const CNetAddr& b)
+{
+    return (memcmp(a.ip, b.ip, 16) == 0);
+}
+
+bool operator!=(const CNetAddr& a, const CNetAddr& b)
+{
+    return (memcmp(a.ip, b.ip, 16) != 0);
+}
+
+bool operator<(const CNetAddr& a, const CNetAddr& b)
+{
+    return (memcmp(a.ip, b.ip, 16) < 0);
+}
+
+bool CNetAddr::GetInAddr(struct in_addr* pipv4Addr) const
+{
+    if (!IsIPv4())
+        return false;
+    memcpy(pipv4Addr, ip+12, 4);
+    return true;
+}
+
+bool CNetAddr::GetIn6Addr(struct in6_addr* pipv6Addr) const
+{
+    if (!IsIPv6()) {
+        return false;
+    }
+    memcpy(pipv6Addr, ip, 16);
+    return true;
+}
+
+// get canonical identifier of an address' group
+// no two connections will be attempted to addresses with the same group
+std::vector<unsigned char> CNetAddr::GetGroup() const
+{
+    std::vector<unsigned char> vchRet;
+    int nClass = NET_IPV6;
+    int nStartByte = 0;
+    int nBits = 16;
+
+    // all local addresses belong to the same group
+    if (IsLocal())
+    {
+        nClass = 255;
+        nBits = 0;
+    }
+    // all internal-usage addresses get their own group
+    if (IsInternal())
+    {
+        nClass = NET_INTERNAL;
+        nStartByte = sizeof(g_internal_prefix);
+        nBits = (sizeof(ip) - sizeof(g_internal_prefix)) * 8;
+    }
+    // all other unroutable addresses belong to the same group
+    else if (!IsRoutable())
+    {
+        nClass = NET_UNROUTABLE;
+        nBits = 0;
+    }
+    // for IPv4 addresses, '1' + the 16 higher-order bits of the IP
+    // includes mapped IPv4, SIIT translated IPv4, and the well-known prefix
+    else if (IsIPv4() || IsRFC6145() || IsRFC6052())
+    {
+        nClass = NET_IPV4;
+        nStartByte = 12;
+    }
+    // for 6to4 tunnelled addresses, use the encapsulated IPv4 address
+    else if (IsRFC3964())
+    {
+        nClass = NET_IPV4;
+        nStartByte = 2;
+    }
+    // for Teredo-tunnelled IPv6 addresses, use the encapsulated IPv4 address
+    else if (IsRFC4380())
+    {
+        vchRet.push_back(NET_IPV4);
+        vchRet.push_back(GetByte(3) ^ 0xFF);
+        vchRet.push_back(GetByte(2) ^ 0xFF);
+        return vchRet;
+    }
+    else if (IsTor())
+    {
+        nClass = NET_TOR;
+        nStartByte = 6;
+        nBits = 4;
+    }
+    // for he.net, use /36 groups
+    else if (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x04 && GetByte(12) == 0x70)
+        nBits = 36;
+    // for the rest of the IPv6 network, use /32 groups
+    else
+        nBits = 32;
+
+    vchRet.push_back(nClass);
+    while (nBits >= 8)
+    {
+        vchRet.push_back(GetByte(15 - nStartByte));
+        nStartByte++;
+        nBits -= 8;
+    }
+    if (nBits > 0)
+        vchRet.push_back(GetByte(15 - nStartByte) | ((1 << (8 - nBits)) - 1));
+
+    return vchRet;
+}
+
+uint64_t CNetAddr::GetHash() const
+{
+    uint256 hash = Hash(ip);
+    uint64_t nRet;
+    memcpy(&nRet, &hash, sizeof(nRet));
+    return nRet;
+}
+
+// private extensions to enum Network, only returned by GetExtNetwork,
+// and only used in GetReachabilityFrom
+static const int NET_UNKNOWN = NET_MAX + 0;
+static const int NET_TEREDO  = NET_MAX + 1;
+int static GetExtNetwork(const CNetAddr *addr)
+{
+    if (addr == nullptr)
+        return NET_UNKNOWN;
+    if (addr->IsRFC4380())
+        return NET_TEREDO;
+    return addr->GetNetwork();
+}
+
+/** Calculates a metric for how reachable (*this) is from a given partner */
+int CNetAddr::GetReachabilityFrom(const CNetAddr *paddrPartner) const
+{
+    enum Reachability {
+        REACH_UNREACHABLE,
+        REACH_DEFAULT,
+        REACH_TEREDO,
+        REACH_IPV6_WEAK,
+        REACH_IPV4,
+        REACH_IPV6_STRONG,
+        REACH_PRIVATE
+    };
+
+    if (!IsRoutable() || IsInternal())
+        return REACH_UNREACHABLE;
+
+    int ourNet = GetExtNetwork(this);
+    int theirNet = GetExtNetwork(paddrPartner);
+    bool fTunnel = IsRFC3964() || IsRFC6052() || IsRFC6145();
+
+    switch(theirNet) {
+    case NET_IPV4:
+        switch(ourNet) {
+        default:       return REACH_DEFAULT;
+        case NET_IPV4: return REACH_IPV4;
+        }
+    case NET_IPV6:
+        switch(ourNet) {
+        default:         return REACH_DEFAULT;
+        case NET_TEREDO: return REACH_TEREDO;
+        case NET_IPV4:   return REACH_IPV4;
+        case NET_IPV6:   return fTunnel ? REACH_IPV6_WEAK : REACH_IPV6_STRONG; // only prefer giving our IPv6 address if it's not tunnelled
+        }
+    case NET_TOR:
+        switch(ourNet) {
+        default:         return REACH_DEFAULT;
+        case NET_IPV4:   return REACH_IPV4; // Tor users can connect to IPv4 as well
+        case NET_TOR:    return REACH_PRIVATE;
+        }
+    case NET_TEREDO:
+        switch(ourNet) {
+        default:          return REACH_DEFAULT;
+        case NET_TEREDO:  return REACH_TEREDO;
+        case NET_IPV6:    return REACH_IPV6_WEAK;
+        case NET_IPV4:    return REACH_IPV4;
+        }
+    case NET_UNKNOWN:
+    case NET_UNROUTABLE:
+    default:
+        switch(ourNet) {
+        default:          return REACH_DEFAULT;
+        case NET_TEREDO:  return REACH_TEREDO;
+        case NET_IPV6:    return REACH_IPV6_WEAK;
+        case NET_IPV4:    return REACH_IPV4;
+        case NET_TOR:     return REACH_PRIVATE; // either from Tor, or don't care about our address
+        }
+    }
+}
+
+void CService::Init()
+{
+    port = 0;
+}
+
+CService::CService()
+{
+    Init();
+}
+
+CService::CService(const CNetAddr& cip, unsigned short portIn) : CNetAddr(cip), port(portIn)
+{
+}
+
+CService::CService(const struct in_addr& ipv4Addr, unsigned short portIn) : CNetAddr(ipv4Addr), port(portIn)
+{
+}
+
+CService::CService(const struct in6_addr& ipv6Addr, unsigned short portIn) : CNetAddr(ipv6Addr), port(portIn)
+{
+}
+
+CService::CService(const struct sockaddr_in& addr) : CNetAddr(addr.sin_addr), port(ntohs(addr.sin_port))
+{
+    assert(addr.sin_family == AF_INET);
+}
+
+CService::CService(const struct sockaddr_in6 &addr) : CNetAddr(addr.sin6_addr), port(ntohs(addr.sin6_port))
+{
+   assert(addr.sin6_family == AF_INET6);
+}
+
+bool CService::SetSockAddr(const struct sockaddr *paddr)
+{
+    switch (paddr->sa_family) {
+    case AF_INET:
+        *this = CService(*(const struct sockaddr_in*)paddr);
+        return true;
+    case AF_INET6:
+        *this = CService(*(const struct sockaddr_in6*)paddr);
+        return true;
+    default:
+        return false;
+    }
+}
+
+unsigned short CService::GetPort() const
+{
+    return port;
+}
+
+bool operator==(const CService& a, const CService& b)
+{
+    return (CNetAddr)a == (CNetAddr)b && a.port == b.port;
+}
+
+bool operator!=(const CService& a, const CService& b)
+{
+    return (CNetAddr)a != (CNetAddr)b || a.port != b.port;
+}
+
+bool operator<(const CService& a, const CService& b)
+{
+    return (CNetAddr)a < (CNetAddr)b || ((CNetAddr)a == (CNetAddr)b && a.port < b.port);
+}
+
+bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
+{
+    if (IsIPv4()) {
+        if (*addrlen < (socklen_t)sizeof(struct sockaddr_in))
+            return false;
+        *addrlen = sizeof(struct sockaddr_in);
+        struct sockaddr_in *paddrin = (struct sockaddr_in*)paddr;
+        memset(paddrin, 0, *addrlen);
+        if (!GetInAddr(&paddrin->sin_addr))
+            return false;
+        paddrin->sin_family = AF_INET;
+        paddrin->sin_port = htons(port);
+        return true;
+    }
+    if (IsIPv6()) {
+        if (*addrlen < (socklen_t)sizeof(struct sockaddr_in6))
+            return false;
+        *addrlen = sizeof(struct sockaddr_in6);
+        struct sockaddr_in6 *paddrin6 = (struct sockaddr_in6*)paddr;
+        memset(paddrin6, 0, *addrlen);
+        if (!GetIn6Addr(&paddrin6->sin6_addr))
+            return false;
+        paddrin6->sin6_family = AF_INET6;
+        paddrin6->sin6_port = htons(port);
+        return true;
+    }
+    return false;
+}
+
+std::vector<unsigned char> CService::GetKey() const
+{
+     std::vector<unsigned char> vKey;
+     vKey.resize(18);
+     memcpy(&vKey[0], ip, 16);
+     vKey[16] = port / 0x100;
+     vKey[17] = port & 0x0FF;
+     return vKey;
+}
+
+std::string CService::ToStringPort() const
+{
+    return strprintf("%u", port);
+}
+
+std::string CService::ToStringIPPort() const
+{
+    if (IsIPv4() || IsTor() || IsInternal()) {
+        return ToStringIP() + ":" + ToStringPort();
+    } else {
+        return "[" + ToStringIP() + "]:" + ToStringPort();
+    }
+}
+
+std::string CService::ToString() const
+{
+    return ToStringIPPort();
+}
+
+void CService::SetPort(unsigned short portIn)
+{
+    port = portIn;
+}
+
+CSubNet::CSubNet():
+    valid(false)
+{
+    memset(netmask, 0, sizeof(netmask));
+}
+
+CSubNet::CSubNet(const CNetAddr &addr, int32_t mask)
+{
+    valid = true;
+    network = addr;
+    // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
+    memset(netmask, 255, sizeof(netmask));
+
+    // IPv4 addresses start at offset 12, and first 12 bytes must match, so just offset n
+    const int astartofs = network.IsIPv4() ? 12 : 0;
+
+    int32_t n = mask;
+    if(n >= 0 && n <= (128 - astartofs*8)) // Only valid if in range of bits of address
+    {
+        n += astartofs*8;
+        // Clear bits [n..127]
+        for (; n < 128; ++n)
+            netmask[n>>3] &= ~(1<<(7-(n&7)));
+    } else
+        valid = false;
+
+    // Normalize network according to netmask
+    for(int x=0; x<16; ++x)
+        network.ip[x] &= netmask[x];
+}
+
+CSubNet::CSubNet(const CNetAddr &addr, const CNetAddr &mask)
+{
+    valid = true;
+    network = addr;
+    // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
+    memset(netmask, 255, sizeof(netmask));
+
+    // IPv4 addresses start at offset 12, and first 12 bytes must match, so just offset n
+    const int astartofs = network.IsIPv4() ? 12 : 0;
+
+    for(int x=astartofs; x<16; ++x)
+        netmask[x] = mask.ip[x];
+
+    // Normalize network according to netmask
+    for(int x=0; x<16; ++x)
+        network.ip[x] &= netmask[x];
+}
+
+CSubNet::CSubNet(const CNetAddr &addr):
+    valid(addr.IsValid())
+{
+    memset(netmask, 255, sizeof(netmask));
+    network = addr;
+}
+
+/**
+ * @returns True if this subnet is valid, the specified address is valid, and
+ *          the specified address belongs in this subnet.
+ */
+bool CSubNet::Match(const CNetAddr &addr) const
+{
+    if (!valid || !addr.IsValid())
+        return false;
+    for(int x=0; x<16; ++x)
+        if ((addr.ip[x] & netmask[x]) != network.ip[x])
+            return false;
+    return true;
+}
+
+/**
+ * @returns The number of 1-bits in the prefix of the specified subnet mask. If
+ *          the specified subnet mask is not a valid one, -1.
+ */
+static inline int NetmaskBits(uint8_t x)
+{
+    switch(x) {
+    case 0x00: return 0;
+    case 0x80: return 1;
+    case 0xc0: return 2;
+    case 0xe0: return 3;
+    case 0xf0: return 4;
+    case 0xf8: return 5;
+    case 0xfc: return 6;
+    case 0xfe: return 7;
+    case 0xff: return 8;
+    default: return -1;
+    }
+}
+
+std::string CSubNet::ToString() const
+{
+    /* Parse binary 1{n}0{N-n} to see if mask can be represented as /n */
+    int cidr = 0;
+    bool valid_cidr = true;
+    int n = network.IsIPv4() ? 12 : 0;
+    for (; n < 16 && netmask[n] == 0xff; ++n)
+        cidr += 8;
+    if (n < 16) {
+        int bits = NetmaskBits(netmask[n]);
+        if (bits < 0)
+            valid_cidr = false;
+        else
+            cidr += bits;
+        ++n;
+    }
+    for (; n < 16 && valid_cidr; ++n)
+        if (netmask[n] != 0x00)
+            valid_cidr = false;
+
+    /* Format output */
+    std::string strNetmask;
+    if (valid_cidr) {
+        strNetmask = strprintf("%u", cidr);
+    } else {
+        if (network.IsIPv4())
+            strNetmask = strprintf("%u.%u.%u.%u", netmask[12], netmask[13], netmask[14], netmask[15]);
+        else
+            strNetmask = strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
+                             netmask[0] << 8 | netmask[1], netmask[2] << 8 | netmask[3],
+                             netmask[4] << 8 | netmask[5], netmask[6] << 8 | netmask[7],
+                             netmask[8] << 8 | netmask[9], netmask[10] << 8 | netmask[11],
+                             netmask[12] << 8 | netmask[13], netmask[14] << 8 | netmask[15]);
+    }
+
+    return network.ToString() + "/" + strNetmask;
+}
+
+bool CSubNet::IsValid() const
+{
+    return valid;
+}
+
+bool operator==(const CSubNet& a, const CSubNet& b)
+{
+    return a.valid == b.valid && a.network == b.network && !memcmp(a.netmask, b.netmask, 16);
+}
+
+bool operator!=(const CSubNet& a, const CSubNet& b)
+{
+    return !(a==b);
+}
+
+bool operator<(const CSubNet& a, const CSubNet& b)
+{
+    return (a.network < b.network || (a.network == b.network && memcmp(a.netmask, b.netmask, 16) < 0));
+}

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -1,0 +1,183 @@
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NETADDRESS_H
+#define BITCOIN_NETADDRESS_H
+
+#if defined(HAVE_CONFIG_H)
+#include "config/gridcoin-config.h"
+#endif
+
+#include "compat.h"
+#include "serialize.h"
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#endif // BITCOIN_NETADDRESS_H
+
+enum Network
+{
+    NET_UNROUTABLE,
+    NET_IPV4,
+    NET_IPV6,
+    NET_TOR,
+    NET_CJDNS,
+    NET_INTERNAL,
+
+    NET_MAX,
+};
+
+/** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */
+class CNetAddr
+{
+    protected:
+        unsigned char ip[16]; // in network byte order
+        uint32_t scopeId; // for scoped/link-local ipv6 addresses
+
+    public:
+        CNetAddr();
+        explicit CNetAddr(const struct in_addr& ipv4Addr);
+        void Init();
+        void SetIP(const CNetAddr& ip);
+
+        /**
+        * Set raw IPv4 or IPv6 address (in network byte order)
+        * @note Only NET_IPV4 and NET_IPV6 are allowed for network.
+        */
+        void SetRaw(Network network, const uint8_t *data);
+        /**
+        * Transform an arbitrary string into a non-routable ipv6 address.
+        * Useful for mapping resolved addresses back to their source.
+        */
+        bool SetInternal(const std::string& name);
+        bool SetSpecial(const std::string &strName); // for Tor addresses
+        bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
+        bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor)
+        bool IsRFC1918() const; // IPv4 private networks (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
+        bool IsRFC2544() const; // IPv4 inter-network communcations (192.18.0.0/15)
+        bool IsRFC6598() const; // IPv4 ISP-level NAT (100.64.0.0/10)
+        bool IsRFC5737() const; // IPv4 documentation addresses (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24)
+        bool IsRFC3849() const; // IPv6 documentation address (2001:0DB8::/32)
+        bool IsRFC3927() const; // IPv4 autoconfig (169.254.0.0/16)
+        bool IsRFC3964() const; // IPv6 6to4 tunnelling (2002::/16)
+        bool IsRFC4193() const; // IPv6 unique local (FC00::/7)
+        bool IsRFC4380() const; // IPv6 Teredo tunnelling (2001::/32)
+        bool IsRFC4843() const; // IPv6 ORCHID (2001:10::/28)
+        bool IsRFC4862() const; // IPv6 autoconfig (FE80::/64)
+        bool IsRFC6052() const; // IPv6 well-known prefix (64:FF9B::/96)
+        bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96)
+        bool IsTor() const;
+        bool IsLocal() const;
+        bool IsRoutable() const;
+        bool IsInternal() const;
+        bool IsValid() const;
+        bool IsMulticast() const;
+        enum Network GetNetwork() const;
+        std::string ToString() const;
+        std::string ToStringIP() const;
+        unsigned int GetByte(int n) const;
+        uint64_t GetHash() const;
+        bool GetInAddr(struct in_addr* pipv4Addr) const;
+        std::vector<unsigned char> GetGroup() const;
+        int GetReachabilityFrom(const CNetAddr* paddrPartner = nullptr) const;
+
+        CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
+        bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
+
+        friend bool operator==(const CNetAddr& a, const CNetAddr& b);
+        friend bool operator!=(const CNetAddr& a, const CNetAddr& b);
+        friend bool operator<(const CNetAddr& a, const CNetAddr& b);
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
+        {
+            READWRITE(ip);
+        }
+
+        friend class CSubNet;
+};
+
+class CSubNet
+{
+    protected:
+        /// Network (base) address
+        CNetAddr network;
+        /// Netmask, in network byte order
+        uint8_t netmask[16];
+        /// Is this value valid? (only used to signal parse errors)
+        bool valid;
+
+    public:
+        CSubNet();
+        CSubNet(const CNetAddr &addr, int32_t mask);
+        CSubNet(const CNetAddr &addr, const CNetAddr &mask);
+
+        //constructor for single ip subnet (<ipv4>/32 or <ipv6>/128)
+        explicit CSubNet(const CNetAddr &addr);
+
+        bool Match(const CNetAddr &addr) const;
+
+        std::string ToString() const;
+        bool IsValid() const;
+
+        friend bool operator==(const CSubNet& a, const CSubNet& b);
+        friend bool operator!=(const CSubNet& a, const CSubNet& b);
+        friend bool operator<(const CSubNet& a, const CSubNet& b);
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
+        {
+            READWRITE(network);
+            READWRITE(netmask);
+            READWRITE(valid);
+        }
+};
+
+/** A combination of a network address (CNetAddr) and a (TCP) port */
+class CService : public CNetAddr
+{
+    protected:
+        unsigned short port; // host order
+
+    public:
+        CService();
+        CService(const CNetAddr& ip, unsigned short port);
+        CService(const struct in_addr& ipv4Addr, unsigned short port);
+        CService(const struct sockaddr_in& addr);
+        explicit CService(const char *pszIpPort, int portDefault);
+        explicit CService(const char *pszIpPort);
+        explicit CService(const std::string& strIpPort, int portDefault);
+        explicit CService(const std::string& strIpPort);
+        void Init();
+        void SetPort(unsigned short portIn);
+        unsigned short GetPort() const;
+        bool GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const;
+        bool SetSockAddr(const struct sockaddr* paddr);
+        friend bool operator==(const CService& a, const CService& b);
+        friend bool operator!=(const CService& a, const CService& b);
+        friend bool operator<(const CService& a, const CService& b);
+        std::vector<unsigned char> GetKey() const;
+        std::string ToString() const;
+        std::string ToStringPort() const;
+        std::string ToStringIPPort() const;
+
+        CService(const struct in6_addr& ipv6Addr, unsigned short port);
+        CService(const struct sockaddr_in6& addr);
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
+        {
+             READWRITE(ip);
+             READWRITE(WrapBigEndian(port));
+        }
+};
+

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -26,8 +26,6 @@ static CCriticalSection cs_proxyInfos;
 int nConnectTimeout = 5000;
 bool fNameLookup = false;
 
-static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
-
 enum Network ParseNetwork(std::string net) {
     net = ToLower(net);
     if (net == "ipv4") return NET_IPV4;
@@ -54,25 +52,35 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
     aiHint.ai_socktype = SOCK_STREAM;
     aiHint.ai_protocol = IPPROTO_TCP;
     aiHint.ai_family = AF_UNSPEC;
+#ifdef WIN32
+    aiHint.ai_flags = fAllowLookup ? 0 : AI_NUMERICHOST;
+#else
     aiHint.ai_flags = fAllowLookup ? AI_ADDRCONFIG : AI_NUMERICHOST;
-
-    struct addrinfo* aiRes = nullptr;
+#endif
+    struct addrinfo *aiRes = nullptr;
     int nErr = getaddrinfo(pszName, nullptr, &aiHint, &aiRes);
     if (nErr)
         return false;
 
     struct addrinfo *aiTrav = aiRes;
-    while (aiTrav != nullptr && (nMaxSolutions == 0 || vIP.size() < nMaxSolutions)) {
+    while (aiTrav != nullptr && (nMaxSolutions == 0 || vIP.size() < nMaxSolutions))
+    {
+        CNetAddr resolved;
         if (aiTrav->ai_family == AF_INET)
         {
             assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in));
-            vIP.push_back(CNetAddr(((struct sockaddr_in*)(aiTrav->ai_addr))->sin_addr));
+            resolved = CNetAddr(((struct sockaddr_in*)(aiTrav->ai_addr))->sin_addr);
         }
 
         if (aiTrav->ai_family == AF_INET6)
         {
             assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in6));
-            vIP.push_back(CNetAddr(((struct sockaddr_in6*)(aiTrav->ai_addr))->sin6_addr));
+            struct sockaddr_in6* s6 = (struct sockaddr_in6*) aiTrav->ai_addr;
+            resolved = CNetAddr(s6->sin6_addr, s6->sin6_scope_id);
+        }
+        /* Never allow resolving to an internal address. Consider any such result invalid */
+        if (!resolved.IsInternal()) {
+            vIP.push_back(resolved);
         }
 
         aiTrav = aiTrav->ai_next;
@@ -85,16 +93,25 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
 
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup)
 {
-    std::string str(pszName);
-    std::string strHost = str;
-    if (str.empty())
+    std::string strHost(pszName);
+    if (strHost.empty())
         return false;
-    if (boost::algorithm::starts_with(str, "[") && boost::algorithm::ends_with(str, "]"))
+    if (boost::algorithm::starts_with(strHost, "[") && boost::algorithm::ends_with(strHost, "]"))
     {
-        strHost = str.substr(1, str.size() - 2);
+        strHost = strHost.substr(1, strHost.size() - 2);
     }
 
     return LookupIntern(strHost.c_str(), vIP, nMaxSolutions, fAllowLookup);
+}
+
+bool LookupHost(const char *pszName, CNetAddr& addr, bool fAllowLookup)
+{
+    std::vector<CNetAddr> vIP;
+    LookupHost(pszName, vIP, 1, fAllowLookup);
+    if(vIP.empty())
+        return false;
+    addr = vIP.front();
+    return true;
 }
 
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions)
@@ -125,9 +142,14 @@ bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLoo
     return true;
 }
 
-bool LookupNumeric(const char *pszName, CService& addr, int portDefault)
+CService LookupNumeric(const char *pszName, int portDefault)
 {
-    return Lookup(pszName, addr, portDefault, false);
+    CService addr;
+    // "1.2:345" will fail to resolve the ip, but will still set the port.
+    // If the ip fails to resolve, re-init the result.
+    if(!Lookup(pszName, addr, portDefault, false))
+        addr = CService();
+    return addr;
 }
 
 bool LookupSubNet(const char* pszName, CSubNet& ret)
@@ -467,7 +489,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
             return ConnectSocket(addr, hSocketRet, nTimeout);
         }
     }
-    addr = CService("0.0.0.0:0");
+    addr = CService();
 
     if (!HaveNameProxy())
         return false;
@@ -480,735 +502,4 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     hSocketRet = hSocket;
     return true;
-}
-
-void CNetAddr::Init()
-{
-    memset(ip, 0, 16);
-}
-
-void CNetAddr::SetIP(const CNetAddr& ipIn)
-{
-    memcpy(ip, ipIn.ip, sizeof(ip));
-}
-
-static const unsigned char pchOnionCat[] = {0xFD,0x87,0xD8,0x7E,0xEB,0x43};
-
-bool CNetAddr::SetSpecial(const std::string &strName)
-{
-    if (strName.size()>6 && strName.substr(strName.size() - 6, 6) == ".onion") {
-        std::vector<unsigned char> vchAddr = DecodeBase32(strName.substr(0, strName.size() - 6).c_str());
-        if (vchAddr.size() != 16-sizeof(pchOnionCat))
-            return false;
-        memcpy(ip, pchOnionCat, sizeof(pchOnionCat));
-        for (unsigned int i=0; i<16-sizeof(pchOnionCat); i++)
-            ip[i + sizeof(pchOnionCat)] = vchAddr[i];
-        return true;
-    }
-    return false;
-}
-
-CNetAddr::CNetAddr()
-{
-    Init();
-}
-
-CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
-{
-    memcpy(ip,    pchIPv4, 12);
-    memcpy(ip+12, &ipv4Addr, 4);
-}
-
-CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr)
-{
-    memcpy(ip, &ipv6Addr, 16);
-}
-
-CNetAddr::CNetAddr(const char *pszIp)
-{
-    Init();
-    std::vector<CNetAddr> vIP;
-    if (LookupHost(pszIp, vIP, 1, false))
-        *this = vIP[0];
-}
-
-CNetAddr::CNetAddr(const std::string &strIp)
-{
-    Init();
-    std::vector<CNetAddr> vIP;
-    if (LookupHost(strIp.c_str(), vIP, 1, false))
-        *this = vIP[0];
-}
-
-unsigned int CNetAddr::GetByte(int n) const
-{
-    return ip[15-n];
-}
-
-bool CNetAddr::IsIPv4() const
-{
-    return (memcmp(ip, pchIPv4, sizeof(pchIPv4)) == 0);
-}
-
-bool CNetAddr::IsIPv6() const
-{
-    return (!IsIPv4() && !IsTor());
-}
-
-bool CNetAddr::IsRFC1918() const
-{
-    return IsIPv4() && (
-        GetByte(3) == 10 ||
-        (GetByte(3) == 192 && GetByte(2) == 168) ||
-        (GetByte(3) == 172 && (GetByte(2) >= 16 && GetByte(2) <= 31)));
-}
-
-bool CNetAddr::IsRFC3927() const
-{
-    return IsIPv4() && (GetByte(3) == 169 && GetByte(2) == 254);
-}
-
-bool CNetAddr::IsRFC3849() const
-{
-    return GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x0D && GetByte(12) == 0xB8;
-}
-
-bool CNetAddr::IsRFC3964() const
-{
-    return (GetByte(15) == 0x20 && GetByte(14) == 0x02);
-}
-
-bool CNetAddr::IsRFC6052() const
-{
-    static const unsigned char pchRFC6052[] = {0,0x64,0xFF,0x9B,0,0,0,0,0,0,0,0};
-    return (memcmp(ip, pchRFC6052, sizeof(pchRFC6052)) == 0);
-}
-
-bool CNetAddr::IsRFC4380() const
-{
-    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0 && GetByte(12) == 0);
-}
-
-bool CNetAddr::IsRFC4862() const
-{
-    static const unsigned char pchRFC4862[] = {0xFE,0x80,0,0,0,0,0,0};
-    return (memcmp(ip, pchRFC4862, sizeof(pchRFC4862)) == 0);
-}
-
-bool CNetAddr::IsRFC4193() const
-{
-    return ((GetByte(15) & 0xFE) == 0xFC);
-}
-
-bool CNetAddr::IsRFC6145() const
-{
-    static const unsigned char pchRFC6145[] = {0,0,0,0,0,0,0,0,0xFF,0xFF,0,0};
-    return (memcmp(ip, pchRFC6145, sizeof(pchRFC6145)) == 0);
-}
-
-bool CNetAddr::IsRFC4843() const
-{
-    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x00 && (GetByte(12) & 0xF0) == 0x10);
-}
-
-bool CNetAddr::IsTor() const
-{
-    return (memcmp(ip, pchOnionCat, sizeof(pchOnionCat)) == 0);
-}
-
-bool CNetAddr::IsLocal() const
-{
-    // IPv4 loopback
-   if (IsIPv4() && (GetByte(3) == 127 || GetByte(3) == 0))
-       return true;
-
-   // IPv6 loopback (::1/128)
-   static const unsigned char pchLocal[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
-   if (memcmp(ip, pchLocal, 16) == 0)
-       return true;
-
-   return false;
-}
-
-bool CNetAddr::IsMulticast() const
-{
-    return    (IsIPv4() && (GetByte(3) & 0xF0) == 0xE0)
-           || (GetByte(15) == 0xFF);
-}
-
-bool CNetAddr::IsValid() const
-{
-    // Cleanup 3-byte shifted addresses caused by garbage in size field
-    // of addr messages from versions before 0.2.9 checksum.
-    // Two consecutive addr messages look like this:
-    // header20 vectorlen3 addr26 addr26 addr26 header20 vectorlen3 addr26 addr26 addr26...
-    // so if the first length field is garbled, it reads the second batch
-    // of addr misaligned by 3 bytes.
-    if (memcmp(ip, pchIPv4+3, sizeof(pchIPv4)-3) == 0)
-        return false;
-
-    // unspecified IPv6 address (::/128)
-    unsigned char ipNone[16] = {};
-    if (memcmp(ip, ipNone, 16) == 0)
-        return false;
-
-    // documentation IPv6 address
-    if (IsRFC3849())
-        return false;
-
-    if (IsIPv4())
-    {
-        // INADDR_NONE
-        uint32_t ipNone = INADDR_NONE;
-        if (memcmp(ip+12, &ipNone, 4) == 0)
-            return false;
-
-        // 0
-        ipNone = 0;
-        if (memcmp(ip+12, &ipNone, 4) == 0)
-            return false;
-    }
-
-    return true;
-}
-
-bool CNetAddr::IsRoutable() const
-{
-    return IsValid() && !(IsRFC1918() || IsRFC3927() || IsRFC4862() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsLocal());
-}
-
-enum Network CNetAddr::GetNetwork() const
-{
-    if (!IsRoutable())
-        return NET_UNROUTABLE;
-
-    if (IsIPv4())
-        return NET_IPV4;
-
-    if (IsTor())
-        return NET_TOR;
-
-    return NET_IPV6;
-}
-
-std::string CNetAddr::ToStringIP() const
-{
-    if (IsTor())
-        return EncodeBase32(&ip[6], 10) + ".onion";
-    CService serv(*this, 0);
-    struct sockaddr_storage sockaddr;
-    socklen_t socklen = sizeof(sockaddr);
-    if (serv.GetSockAddr((struct sockaddr*)&sockaddr, &socklen)) {
-        char name[1025] = "";
-        if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name, sizeof(name), nullptr, 0, NI_NUMERICHOST))
-            return std::string(name);
-    }
-    if (IsIPv4())
-        return strprintf("%u.%u.%u.%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0));
-    else
-        return strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
-                         GetByte(15) << 8 | GetByte(14), GetByte(13) << 8 | GetByte(12),
-                         GetByte(11) << 8 | GetByte(10), GetByte(9) << 8 | GetByte(8),
-                         GetByte(7) << 8 | GetByte(6), GetByte(5) << 8 | GetByte(4),
-                         GetByte(3) << 8 | GetByte(2), GetByte(1) << 8 | GetByte(0));
-}
-
-std::string CNetAddr::ToString() const
-{
-    return ToStringIP();
-}
-
-bool operator==(const CNetAddr& a, const CNetAddr& b)
-{
-    return (memcmp(a.ip, b.ip, 16) == 0);
-}
-
-bool operator!=(const CNetAddr& a, const CNetAddr& b)
-{
-    return (memcmp(a.ip, b.ip, 16) != 0);
-}
-
-bool operator<(const CNetAddr& a, const CNetAddr& b)
-{
-    return (memcmp(a.ip, b.ip, 16) < 0);
-}
-
-bool CNetAddr::GetInAddr(struct in_addr* pipv4Addr) const
-{
-    if (!IsIPv4())
-        return false;
-    memcpy(pipv4Addr, ip+12, 4);
-    return true;
-}
-
-bool CNetAddr::GetIn6Addr(struct in6_addr* pipv6Addr) const
-{
-    if (!IsIPv6()) {
-        return false;
-    }
-    memcpy(pipv6Addr, ip, 16);
-    return true;
-}
-
-// get canonical identifier of an address' group
-// no two connections will be attempted to addresses with the same group
-std::vector<unsigned char> CNetAddr::GetGroup() const
-{
-    std::vector<unsigned char> vchRet;
-    int nClass = NET_IPV6;
-    int nStartByte = 0;
-    int nBits = 16;
-
-    // all local addresses belong to the same group
-    if (IsLocal())
-    {
-        nClass = 255;
-        nBits = 0;
-    }
-
-    // all unroutable addresses belong to the same group
-    if (!IsRoutable())
-    {
-        nClass = NET_UNROUTABLE;
-        nBits = 0;
-    }
-    // for IPv4 addresses, '1' + the 16 higher-order bits of the IP
-    // includes mapped IPv4, SIIT translated IPv4, and the well-known prefix
-    else if (IsIPv4() || IsRFC6145() || IsRFC6052())
-    {
-        nClass = NET_IPV4;
-        nStartByte = 12;
-    }
-    // for 6to4 tunnelled addresses, use the encapsulated IPv4 address
-    else if (IsRFC3964())
-    {
-        nClass = NET_IPV4;
-        nStartByte = 2;
-    }
-    // for Teredo-tunnelled IPv6 addresses, use the encapsulated IPv4 address
-    else if (IsRFC4380())
-    {
-        vchRet.push_back(NET_IPV4);
-        vchRet.push_back(GetByte(3) ^ 0xFF);
-        vchRet.push_back(GetByte(2) ^ 0xFF);
-        return vchRet;
-    }
-    else if (IsTor())
-    {
-        nClass = NET_TOR;
-        nStartByte = 6;
-        nBits = 4;
-    }
-    // for he.net, use /36 groups
-    else if (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x04 && GetByte(12) == 0x70)
-        nBits = 36;
-    // for the rest of the IPv6 network, use /32 groups
-    else
-        nBits = 32;
-
-    vchRet.push_back(nClass);
-    while (nBits >= 8)
-    {
-        vchRet.push_back(GetByte(15 - nStartByte));
-        nStartByte++;
-        nBits -= 8;
-    }
-    if (nBits > 0)
-        vchRet.push_back(GetByte(15 - nStartByte) | ((1 << (8 - nBits)) - 1));
-
-    return vchRet;
-}
-
-uint64_t CNetAddr::GetHash() const
-{
-    uint256 hash = Hash(ip);
-    uint64_t nRet;
-    memcpy(&nRet, &hash, sizeof(nRet));
-    return nRet;
-}
-
-void CNetAddr::print() const
-{
-    LogPrintf("CNetAddr(%s)", ToString());
-}
-
-// private extensions to enum Network, only returned by GetExtNetwork,
-// and only used in GetReachabilityFrom
-static const int NET_UNKNOWN = NET_MAX + 0;
-static const int NET_TEREDO  = NET_MAX + 1;
-int static GetExtNetwork(const CNetAddr *addr)
-{
-    if (addr == nullptr)
-        return NET_UNKNOWN;
-    if (addr->IsRFC4380())
-        return NET_TEREDO;
-    return addr->GetNetwork();
-}
-
-/** Calculates a metric for how reachable (*this) is from a given partner */
-int CNetAddr::GetReachabilityFrom(const CNetAddr *paddrPartner) const
-{
-    enum Reachability {
-        REACH_UNREACHABLE,
-        REACH_DEFAULT,
-        REACH_TEREDO,
-        REACH_IPV6_WEAK,
-        REACH_IPV4,
-        REACH_IPV6_STRONG,
-        REACH_PRIVATE
-    };
-
-    if (!IsRoutable())
-        return REACH_UNREACHABLE;
-
-    int ourNet = GetExtNetwork(this);
-    int theirNet = GetExtNetwork(paddrPartner);
-    bool fTunnel = IsRFC3964() || IsRFC6052() || IsRFC6145();
-
-    switch(theirNet) {
-    case NET_IPV4:
-        switch(ourNet) {
-        default:       return REACH_DEFAULT;
-        case NET_IPV4: return REACH_IPV4;
-        }
-    case NET_IPV6:
-        switch(ourNet) {
-        default:         return REACH_DEFAULT;
-        case NET_TEREDO: return REACH_TEREDO;
-        case NET_IPV4:   return REACH_IPV4;
-        case NET_IPV6:   return fTunnel ? REACH_IPV6_WEAK : REACH_IPV6_STRONG; // only prefer giving our IPv6 address if it's not tunnelled
-        }
-    case NET_TOR:
-        switch(ourNet) {
-        default:         return REACH_DEFAULT;
-        case NET_IPV4:   return REACH_IPV4; // Tor users can connect to IPv4 as well
-        case NET_TOR:    return REACH_PRIVATE;
-        }
-    case NET_TEREDO:
-        switch(ourNet) {
-        default:          return REACH_DEFAULT;
-        case NET_TEREDO:  return REACH_TEREDO;
-        case NET_IPV6:    return REACH_IPV6_WEAK;
-        case NET_IPV4:    return REACH_IPV4;
-        }
-    case NET_UNKNOWN:
-    case NET_UNROUTABLE:
-    default:
-        switch(ourNet) {
-        default:          return REACH_DEFAULT;
-        case NET_TEREDO:  return REACH_TEREDO;
-        case NET_IPV6:    return REACH_IPV6_WEAK;
-        case NET_IPV4:    return REACH_IPV4;
-        case NET_TOR:     return REACH_PRIVATE; // either from Tor, or don't care about our address
-        }
-    }
-}
-
-void CService::Init()
-{
-    port = 0;
-}
-
-CService::CService()
-{
-    Init();
-}
-
-CService::CService(const CNetAddr& cip, unsigned short portIn) : CNetAddr(cip), port(portIn)
-{
-}
-
-CService::CService(const struct in_addr& ipv4Addr, unsigned short portIn) : CNetAddr(ipv4Addr), port(portIn)
-{
-}
-
-CService::CService(const struct in6_addr& ipv6Addr, unsigned short portIn) : CNetAddr(ipv6Addr), port(portIn)
-{
-}
-
-CService::CService(const struct sockaddr_in& addr) : CNetAddr(addr.sin_addr), port(ntohs(addr.sin_port))
-{
-    assert(addr.sin_family == AF_INET);
-}
-
-CService::CService(const struct sockaddr_in6 &addr) : CNetAddr(addr.sin6_addr), port(ntohs(addr.sin6_port))
-{
-   assert(addr.sin6_family == AF_INET6);
-}
-
-bool CService::SetSockAddr(const struct sockaddr *paddr)
-{
-    switch (paddr->sa_family) {
-    case AF_INET:
-        *this = CService(*(const struct sockaddr_in*)paddr);
-        return true;
-    case AF_INET6:
-        *this = CService(*(const struct sockaddr_in6*)paddr);
-        return true;
-    default:
-        return false;
-    }
-}
-
-CService::CService(const char *pszIpPort)
-{
-    Init();
-    CService ip;
-    if (Lookup(pszIpPort, ip, 0, false))
-        *this = ip;
-}
-
-CService::CService(const char *pszIpPort, int portDefault)
-{
-    Init();
-    CService ip;
-    if (Lookup(pszIpPort, ip, portDefault, false))
-        *this = ip;
-}
-
-CService::CService(const std::string &strIpPort)
-{
-    Init();
-    CService ip;
-    if (Lookup(strIpPort.c_str(), ip, 0, false))
-        *this = ip;
-}
-
-CService::CService(const std::string &strIpPort, int portDefault)
-{
-    Init();
-    CService ip;
-    if (Lookup(strIpPort.c_str(), ip, portDefault, false))
-        *this = ip;
-}
-
-unsigned short CService::GetPort() const
-{
-    return port;
-}
-
-bool operator==(const CService& a, const CService& b)
-{
-    return (CNetAddr)a == (CNetAddr)b && a.port == b.port;
-}
-
-bool operator!=(const CService& a, const CService& b)
-{
-    return (CNetAddr)a != (CNetAddr)b || a.port != b.port;
-}
-
-bool operator<(const CService& a, const CService& b)
-{
-    return (CNetAddr)a < (CNetAddr)b || ((CNetAddr)a == (CNetAddr)b && a.port < b.port);
-}
-
-bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
-{
-    if (IsIPv4()) {
-        if (*addrlen < (socklen_t)sizeof(struct sockaddr_in))
-            return false;
-        *addrlen = sizeof(struct sockaddr_in);
-        struct sockaddr_in *paddrin = (struct sockaddr_in*)paddr;
-        memset(paddrin, 0, *addrlen);
-        if (!GetInAddr(&paddrin->sin_addr))
-            return false;
-        paddrin->sin_family = AF_INET;
-        paddrin->sin_port = htons(port);
-        return true;
-    }
-    if (IsIPv6()) {
-        if (*addrlen < (socklen_t)sizeof(struct sockaddr_in6))
-            return false;
-        *addrlen = sizeof(struct sockaddr_in6);
-        struct sockaddr_in6 *paddrin6 = (struct sockaddr_in6*)paddr;
-        memset(paddrin6, 0, *addrlen);
-        if (!GetIn6Addr(&paddrin6->sin6_addr))
-            return false;
-        paddrin6->sin6_family = AF_INET6;
-        paddrin6->sin6_port = htons(port);
-        return true;
-    }
-    return false;
-}
-
-std::vector<unsigned char> CService::GetKey() const
-{
-     std::vector<unsigned char> vKey;
-     vKey.resize(18);
-     memcpy(&vKey[0], ip, 16);
-     vKey[16] = port / 0x100;
-     vKey[17] = port & 0x0FF;
-     return vKey;
-}
-
-std::string CService::ToStringPort() const
-{
-    return strprintf("%u", port);
-}
-
-std::string CService::ToStringIPPort() const
-{
-    if (IsIPv4() || IsTor()) {
-        return ToStringIP() + ":" + ToStringPort();
-    } else {
-        return "[" + ToStringIP() + "]:" + ToStringPort();
-    }
-}
-
-std::string CService::ToString() const
-{
-    return ToStringIPPort();
-}
-
-void CService::print() const
-{
-    LogPrintf("CService(%s)", ToString());
-}
-
-void CService::SetPort(unsigned short portIn)
-{
-    port = portIn;
-}
-
-CSubNet::CSubNet():
-    valid(false)
-{
-    memset(netmask, 0, sizeof(netmask));
-}
-
-CSubNet::CSubNet(const CNetAddr &addr, int32_t mask)
-{
-    valid = true;
-    network = addr;
-    // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
-    memset(netmask, 255, sizeof(netmask));
-
-    // IPv4 addresses start at offset 12, and first 12 bytes must match, so just offset n
-    const int astartofs = network.IsIPv4() ? 12 : 0;
-
-    int32_t n = mask;
-    if(n >= 0 && n <= (128 - astartofs*8)) // Only valid if in range of bits of address
-    {
-        n += astartofs*8;
-        // Clear bits [n..127]
-        for (; n < 128; ++n)
-            netmask[n>>3] &= ~(1<<(7-(n&7)));
-    } else
-        valid = false;
-
-    // Normalize network according to netmask
-    for(int x=0; x<16; ++x)
-        network.ip[x] &= netmask[x];
-}
-
-CSubNet::CSubNet(const CNetAddr &addr, const CNetAddr &mask)
-{
-    valid = true;
-    network = addr;
-    // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
-    memset(netmask, 255, sizeof(netmask));
-
-    // IPv4 addresses start at offset 12, and first 12 bytes must match, so just offset n
-    const int astartofs = network.IsIPv4() ? 12 : 0;
-
-    for(int x=astartofs; x<16; ++x)
-        netmask[x] = mask.ip[x];
-
-    // Normalize network according to netmask
-    for(int x=0; x<16; ++x)
-        network.ip[x] &= netmask[x];
-}
-
-CSubNet::CSubNet(const CNetAddr &addr):
-    valid(addr.IsValid())
-{
-    memset(netmask, 255, sizeof(netmask));
-    network = addr;
-}
-
-/**
- * @returns True if this subnet is valid, the specified address is valid, and
- *          the specified address belongs in this subnet.
- */
-bool CSubNet::Match(const CNetAddr &addr) const
-{
-    if (!valid || !addr.IsValid())
-        return false;
-    for(int x=0; x<16; ++x)
-        if ((addr.ip[x] & netmask[x]) != network.ip[x])
-            return false;
-    return true;
-}
-
-/**
- * @returns The number of 1-bits in the prefix of the specified subnet mask. If
- *          the specified subnet mask is not a valid one, -1.
- */
-static inline int NetmaskBits(uint8_t x)
-{
-    switch(x) {
-    case 0x00: return 0;
-    case 0x80: return 1;
-    case 0xc0: return 2;
-    case 0xe0: return 3;
-    case 0xf0: return 4;
-    case 0xf8: return 5;
-    case 0xfc: return 6;
-    case 0xfe: return 7;
-    case 0xff: return 8;
-    default: return -1;
-    }
-}
-
-std::string CSubNet::ToString() const
-{
-    /* Parse binary 1{n}0{N-n} to see if mask can be represented as /n */
-    int cidr = 0;
-    bool valid_cidr = true;
-    int n = network.IsIPv4() ? 12 : 0;
-    for (; n < 16 && netmask[n] == 0xff; ++n)
-        cidr += 8;
-    if (n < 16) {
-        int bits = NetmaskBits(netmask[n]);
-        if (bits < 0)
-            valid_cidr = false;
-        else
-            cidr += bits;
-        ++n;
-    }
-    for (; n < 16 && valid_cidr; ++n)
-        if (netmask[n] != 0x00)
-            valid_cidr = false;
-
-    /* Format output */
-    std::string strNetmask;
-    if (valid_cidr) {
-        strNetmask = strprintf("%u", cidr);
-    } else {
-        if (network.IsIPv4())
-            strNetmask = strprintf("%u.%u.%u.%u", netmask[12], netmask[13], netmask[14], netmask[15]);
-        else
-            strNetmask = strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
-                             netmask[0] << 8 | netmask[1], netmask[2] << 8 | netmask[3],
-                             netmask[4] << 8 | netmask[5], netmask[6] << 8 | netmask[7],
-                             netmask[8] << 8 | netmask[9], netmask[10] << 8 | netmask[11],
-                             netmask[12] << 8 | netmask[13], netmask[14] << 8 | netmask[15]);
-    }
-
-    return network.ToString() + "/" + strNetmask;
-}
-
-bool CSubNet::IsValid() const
-{
-    return valid;
-}
-
-bool operator==(const CSubNet& a, const CSubNet& b)
-{
-    return a.valid == b.valid && a.network == b.network && !memcmp(a.netmask, b.netmask, 16);
-}
-
-bool operator<(const CSubNet& a, const CSubNet& b)
-{
-    return (a.network < b.network || (a.network == b.network && memcmp(a.netmask, b.netmask, 16) < 0));
 }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -460,10 +460,12 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
     CService nameProxy;
     GetNameProxy(nameProxy);
 
-    CService addrResolved(CNetAddr(strDest, fNameLookup && !HaveNameProxy()), port);
-    if (addrResolved.IsValid()) {
-        addr = addrResolved;
-        return ConnectSocket(addr, hSocketRet, nTimeout);
+    CService addrResolved;
+    if (Lookup(strDest.c_str(), addrResolved, port, fNameLookup && !HaveNameProxy())) {
+        if (addrResolved.IsValid()) {
+            addr = addrResolved;
+            return ConnectSocket(addr, hSocketRet, nTimeout);
+        }
     }
     addr = CService("0.0.0.0:0");
 
@@ -522,19 +524,19 @@ CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr)
     memcpy(ip, &ipv6Addr, 16);
 }
 
-CNetAddr::CNetAddr(const char *pszIp, bool fAllowLookup)
+CNetAddr::CNetAddr(const char *pszIp)
 {
     Init();
     std::vector<CNetAddr> vIP;
-    if (LookupHost(pszIp, vIP, 1, fAllowLookup))
+    if (LookupHost(pszIp, vIP, 1, false))
         *this = vIP[0];
 }
 
-CNetAddr::CNetAddr(const std::string &strIp, bool fAllowLookup)
+CNetAddr::CNetAddr(const std::string &strIp)
 {
     Init();
     std::vector<CNetAddr> vIP;
-    if (LookupHost(strIp.c_str(), vIP, 1, fAllowLookup))
+    if (LookupHost(strIp.c_str(), vIP, 1, false))
         *this = vIP[0];
 }
 
@@ -948,35 +950,35 @@ bool CService::SetSockAddr(const struct sockaddr *paddr)
     }
 }
 
-CService::CService(const char *pszIpPort, bool fAllowLookup)
+CService::CService(const char *pszIpPort)
 {
     Init();
     CService ip;
-    if (Lookup(pszIpPort, ip, 0, fAllowLookup))
+    if (Lookup(pszIpPort, ip, 0, false))
         *this = ip;
 }
 
-CService::CService(const char *pszIpPort, int portDefault, bool fAllowLookup)
+CService::CService(const char *pszIpPort, int portDefault)
 {
     Init();
     CService ip;
-    if (Lookup(pszIpPort, ip, portDefault, fAllowLookup))
+    if (Lookup(pszIpPort, ip, portDefault, false))
         *this = ip;
 }
 
-CService::CService(const std::string &strIpPort, bool fAllowLookup)
+CService::CService(const std::string &strIpPort)
 {
     Init();
     CService ip;
-    if (Lookup(strIpPort.c_str(), ip, 0, fAllowLookup))
+    if (Lookup(strIpPort.c_str(), ip, 0, false))
         *this = ip;
 }
 
-CService::CService(const std::string &strIpPort, int portDefault, bool fAllowLookup)
+CService::CService(const std::string &strIpPort, int portDefault)
 {
     Init();
     CService ip;
-    if (Lookup(strIpPort.c_str(), ip, portDefault, fAllowLookup))
+    if (Lookup(strIpPort.c_str(), ip, portDefault, false))
         *this = ip;
 }
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -39,8 +39,8 @@ class CNetAddr
     public:
         CNetAddr();
         CNetAddr(const struct in_addr& ipv4Addr);
-        explicit CNetAddr(const char *pszIp, bool fAllowLookup = false);
-        explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
+        explicit CNetAddr(const char *pszIp);
+        explicit CNetAddr(const std::string &strIp);
         void Init();
         void SetIP(const CNetAddr& ip);
         bool SetSpecial(const std::string &strName); // for Tor addresses
@@ -141,10 +141,10 @@ class CService : public CNetAddr
         CService(const CNetAddr& ip, unsigned short port);
         CService(const struct in_addr& ipv4Addr, unsigned short port);
         CService(const struct sockaddr_in& addr);
-        explicit CService(const char *pszIpPort, int portDefault, bool fAllowLookup = false);
-        explicit CService(const char *pszIpPort, bool fAllowLookup = false);
-        explicit CService(const std::string& strIpPort, int portDefault, bool fAllowLookup = false);
-        explicit CService(const std::string& strIpPort, bool fAllowLookup = false);
+        explicit CService(const char *pszIpPort, int portDefault);
+        explicit CService(const char *pszIpPort);
+        explicit CService(const std::string& strIpPort, int portDefault);
+        explicit CService(const std::string& strIpPort);
         void Init();
         void SetPort(unsigned short portIn);
         unsigned short GetPort() const;
@@ -180,9 +180,9 @@ bool GetProxy(enum Network net, proxyType& proxyInfoOut);
 bool IsProxy(const CNetAddr& addr);
 bool SetNameProxy(const CService& addrProxy);
 bool HaveNameProxy();
-bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
-bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
-bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault = 0, bool fAllowLookup = true, unsigned int nMaxSolutions = 0);
+bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup);
+bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLookup);
+bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool LookupSubNet(const char *pszName, CSubNet& subnet);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "compat.h"
+#include "netaddress.h"
 #include "serialize.h"
 
 extern int nConnectTimeout;
@@ -18,160 +19,6 @@ extern bool fNameLookup;
 #undef SetPort
 #endif
 
-enum Network
-{
-    NET_UNROUTABLE,
-    NET_IPV4,
-    NET_IPV6,
-    NET_TOR,
-    NET_CJDNS,
-    NET_INTERNAL,
-
-    NET_MAX,
-};
-
-/** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */
-class CNetAddr
-{
-    protected:
-        unsigned char ip[16]; // in network byte order
-
-    public:
-        CNetAddr();
-        CNetAddr(const struct in_addr& ipv4Addr);
-        explicit CNetAddr(const char *pszIp);
-        explicit CNetAddr(const std::string &strIp);
-        void Init();
-        void SetIP(const CNetAddr& ip);
-        bool SetSpecial(const std::string &strName); // for Tor addresses
-        bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
-        bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor)
-        bool IsRFC1918() const; // IPv4 private networks (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
-        bool IsRFC3849() const; // IPv6 documentation address (2001:0DB8::/32)
-        bool IsRFC3927() const; // IPv4 autoconfig (169.254.0.0/16)
-        bool IsRFC3964() const; // IPv6 6to4 tunnelling (2002::/16)
-        bool IsRFC4193() const; // IPv6 unique local (FC00::/15)
-        bool IsRFC4380() const; // IPv6 Teredo tunnelling (2001::/32)
-        bool IsRFC4843() const; // IPv6 ORCHID (2001:10::/28)
-        bool IsRFC4862() const; // IPv6 autoconfig (FE80::/64)
-        bool IsRFC6052() const; // IPv6 well-known prefix (64:FF9B::/96)
-        bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96)
-        bool IsTor() const;
-        bool IsLocal() const;
-        bool IsRoutable() const;
-        bool IsValid() const;
-        bool IsMulticast() const;
-        enum Network GetNetwork() const;
-        std::string ToString() const;
-        std::string ToStringIP() const;
-        unsigned int GetByte(int n) const;
-        uint64_t GetHash() const;
-        bool GetInAddr(struct in_addr* pipv4Addr) const;
-        std::vector<unsigned char> GetGroup() const;
-        int GetReachabilityFrom(const CNetAddr* paddrPartner = nullptr) const;
-        void print() const;
-
-        CNetAddr(const struct in6_addr& pipv6Addr);
-        bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
-
-        friend bool operator==(const CNetAddr& a, const CNetAddr& b);
-        friend bool operator!=(const CNetAddr& a, const CNetAddr& b);
-        friend bool operator<(const CNetAddr& a, const CNetAddr& b);
-
-        ADD_SERIALIZE_METHODS;
-
-        template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action)
-        {
-            READWRITE(ip);
-        }
-
-        friend class CSubNet;
-};
-
-
-
-class CSubNet
-{
-    protected:
-        /// Network (base) address
-        CNetAddr network;
-        /// Netmask, in network byte order
-        uint8_t netmask[16];
-        /// Is this value valid? (only used to signal parse errors)
-        bool valid;
-
-    public:
-        CSubNet();
-        CSubNet(const CNetAddr &addr, int32_t mask);
-        CSubNet(const CNetAddr &addr, const CNetAddr &mask);
-
-        //constructor for single ip subnet (<ipv4>/32 or <ipv6>/128)
-        explicit CSubNet(const CNetAddr &addr);
-
-        bool Match(const CNetAddr &addr) const;
-
-        std::string ToString() const;
-        bool IsValid() const;
-
-        friend bool operator==(const CSubNet& a, const CSubNet& b);
-        friend bool operator!=(const CSubNet& a, const CSubNet& b) { return !(a == b); }
-        friend bool operator<(const CSubNet& a, const CSubNet& b);
-
-        ADD_SERIALIZE_METHODS;
-
-        template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action)
-        {
-            READWRITE(network);
-            READWRITE(netmask);
-            READWRITE(valid);
-        }
-};
-
-
-/** A combination of a network address (CNetAddr) and a (TCP) port */
-class CService : public CNetAddr
-{
-    protected:
-        unsigned short port; // host order
-
-    public:
-        CService();
-        CService(const CNetAddr& ip, unsigned short port);
-        CService(const struct in_addr& ipv4Addr, unsigned short port);
-        CService(const struct sockaddr_in& addr);
-        explicit CService(const char *pszIpPort, int portDefault);
-        explicit CService(const char *pszIpPort);
-        explicit CService(const std::string& strIpPort, int portDefault);
-        explicit CService(const std::string& strIpPort);
-        void Init();
-        void SetPort(unsigned short portIn);
-        unsigned short GetPort() const;
-        bool GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const;
-        bool SetSockAddr(const struct sockaddr* paddr);
-        friend bool operator==(const CService& a, const CService& b);
-        friend bool operator!=(const CService& a, const CService& b);
-        friend bool operator<(const CService& a, const CService& b);
-        std::vector<unsigned char> GetKey() const;
-        std::string ToString() const;
-        std::string ToStringPort() const;
-        std::string ToStringIPPort() const;
-        void print() const;
-
-        CService(const struct in6_addr& ipv6Addr, unsigned short port);
-        CService(const struct sockaddr_in6& addr);
-
-        ADD_SERIALIZE_METHODS;
-
-        template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action)
-        {
-             READWRITE(ip);
-             READWRITE(WrapBigEndian(port));
-        }
-};
-
 typedef CService proxyType;
 
 enum Network ParseNetwork(std::string net);
@@ -181,9 +28,10 @@ bool IsProxy(const CNetAddr& addr);
 bool SetNameProxy(const CService& addrProxy);
 bool HaveNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup);
+bool LookupHost(const char *pszName, CNetAddr& addr, bool fAllowLookup);
 bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLookup);
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
-bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
+CService LookupNumeric(const char *pszName, int portDefault = 0);
 bool LookupSubNet(const char *pszName, CSubNet& subnet);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -59,6 +59,9 @@ class CMessageHeader
 
 /** nServices flags */
 enum ServiceFlags : uint64_t {
+    // NOTE: When adding here, be sure to update serviceFlagToStr too
+    // Nothing
+    NODE_NONE = 0,
     // NODE_NETWORK means that the node is capable of serving the complete block chain.
     NODE_NETWORK = (1 << 0),
 };

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -374,9 +374,10 @@ bool OptionsDialog::eventFilter(QObject *object, QEvent *event)
     {
         if (object == ui->proxyIp)
         {
-            CService addr;
+            CService serv(LookupNumeric(ui->proxyIp->text().toStdString().c_str(), 9050));
+            proxyType addrProxy = proxyType(serv, true);
             /* Check proxyIp for a valid IPv4/IPv6 address and emit the proxyIpValid signal */
-            emit proxyIpValid(ui->proxyIp, LookupNumeric(ui->proxyIp->text().toStdString().c_str(), addr));
+            emit proxyIpValid(ui->proxyIp, addrProxy.IsValid());
         }
 
         if (object == ui->stakingEfficiency)

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -1,0 +1,548 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include "addrman.h"
+#include <string>
+#include <boost/test/unit_test.hpp>
+
+#include "hash.h"
+#include "netbase.h"
+#include "random.h"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(addrman_tests)
+
+class CAddrManTest : public CAddrMan
+{
+    uint64_t state;
+
+public:
+    CAddrManTest()
+    {
+        state = 1;
+    }
+
+    //! Ensure that bucket placement is always the same for testing purposes.
+    void MakeDeterministic()
+    {
+        nKey.SetNull();
+        insecure_rand = FastRandomContext(true);
+    }
+
+    int RandomInt(int nMax)
+    {
+        state = (CHashWriter(SER_GETHASH, 0) << state).GetCheapHash();
+        return (unsigned int)(state % nMax);
+    }
+
+    CAddrInfo* Find(const CNetAddr& addr, int* pnId = NULL)
+    {
+        return CAddrMan::Find(addr, pnId);
+    }
+
+    CAddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId = NULL)
+    {
+        return CAddrMan::Create(addr, addrSource, pnId);
+    }
+
+    void Delete(int nId)
+    {
+        CAddrMan::Delete(nId);
+    }
+};
+
+static CNetAddr ResolveIP(const char* ip)
+{
+    CNetAddr addr;
+    BOOST_CHECK_MESSAGE(LookupHost(ip, addr, false), strprintf("failed to resolve: %s", ip));
+    return addr;
+}
+
+static CNetAddr ResolveIP(std::string ip)
+{
+    return ResolveIP(ip.c_str());
+}
+
+static CService ResolveService(const char* ip, int port = 0)
+{
+    CService serv;
+    BOOST_CHECK_MESSAGE(Lookup(ip, serv, port, false), strprintf("failed to resolve: %s:%i", ip, port));
+    return serv;
+}
+
+static CService ResolveService(std::string ip, int port = 0)
+{
+    return ResolveService(ip.c_str(), port);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_simple)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    CNetAddr source = ResolveIP("252.2.2.2");
+
+    // Test 1: Does Addrman respond correctly when empty.
+    BOOST_CHECK(addrman.size() == 0);
+    CAddrInfo addr_null = addrman.Select();
+    BOOST_CHECK(addr_null.ToString() == "[::]:0");
+
+    // Test 2: Does Addrman::Add work as expected.
+    CService addr1 = ResolveService("250.1.1.1", 8333);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 1);
+    CAddrInfo addr_ret1 = addrman.Select();
+
+    BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
+
+    // Test 3: Does IP address deduplication work correctly.
+    //  Expected dup IP should not be added.
+    CService addr1_dup = ResolveService("250.1.1.1", 8333);
+    addrman.Add(CAddress(addr1_dup, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 1);
+
+
+    // Test 5: New table has one addr and we add a diff addr we should
+    //  have two addrs.
+    CService addr2 = ResolveService("250.1.1.2", 8333);
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 2);
+
+    // Test 6: AddrMan::Clear() should empty the new table.
+    addrman.Clear();
+    BOOST_CHECK(addrman.size() == 0);
+    CAddrInfo addr_null2 = addrman.Select();
+    BOOST_CHECK(addr_null2.ToString() == "[::]:0");
+}
+
+BOOST_AUTO_TEST_CASE(addrman_ports)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    CNetAddr source = ResolveIP("252.2.2.2");
+
+    BOOST_CHECK(addrman.size() == 0);
+
+    // Test 7; Addr with same IP but diff port does not replace existing addr.
+    CService addr1 = ResolveService("250.1.1.1", 8333);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 1);
+
+    CService addr1_port = ResolveService("250.1.1.1", 8334);
+    addrman.Add(CAddress(addr1_port, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 1);
+    CAddrInfo addr_ret2 = addrman.Select();
+    BOOST_CHECK(addr_ret2.ToString() == "250.1.1.1:8333");
+
+    // Test 8: Add same IP but diff port to tried table, it doesn't get added.
+    //  Perhaps this is not ideal behavior but it is the current behavior.
+    addrman.Good(CAddress(addr1_port, NODE_NONE));
+    BOOST_CHECK(addrman.size() == 1);
+    bool newOnly = true;
+    CAddrInfo addr_ret3 = addrman.Select(newOnly);
+    BOOST_CHECK(addr_ret3.ToString() == "250.1.1.1:8333");
+}
+
+
+BOOST_AUTO_TEST_CASE(addrman_select)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    CNetAddr source = ResolveIP("252.2.2.2");
+
+    // Test 9: Select from new with 1 addr in new.
+    CService addr1 = ResolveService("250.1.1.1", 8333);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 1);
+
+    bool newOnly = true;
+    CAddrInfo addr_ret1 = addrman.Select(newOnly);
+    BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
+
+    // Test 10: move addr to tried, select from new expected nothing returned.
+    addrman.Good(CAddress(addr1, NODE_NONE));
+    BOOST_CHECK(addrman.size() == 1);
+    CAddrInfo addr_ret2 = addrman.Select(newOnly);
+    BOOST_CHECK(addr_ret2.ToString() == "[::]:0");
+
+    CAddrInfo addr_ret3 = addrman.Select();
+    BOOST_CHECK(addr_ret3.ToString() == "250.1.1.1:8333");
+
+    BOOST_CHECK(addrman.size() == 1);
+
+
+    // Add three addresses to new table.
+    CService addr2 = ResolveService("250.3.1.1", 8333);
+    CService addr3 = ResolveService("250.3.2.2", 9999);
+    CService addr4 = ResolveService("250.3.3.3", 9999);
+
+    addrman.Add(CAddress(addr2, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr3, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr4, NODE_NONE), ResolveService("250.4.1.1", 8333));
+
+    // Add three addresses to tried table.
+    CService addr5 = ResolveService("250.4.4.4", 8333);
+    CService addr6 = ResolveService("250.4.5.5", 7777);
+    CService addr7 = ResolveService("250.4.6.6", 8333);
+
+    addrman.Add(CAddress(addr5, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr5, NODE_NONE));
+    addrman.Add(CAddress(addr6, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr6, NODE_NONE));
+    addrman.Add(CAddress(addr7, NODE_NONE), ResolveService("250.1.1.3", 8333));
+    addrman.Good(CAddress(addr7, NODE_NONE));
+
+    // Test 11: 6 addrs + 1 addr from last test = 7.
+    BOOST_CHECK(addrman.size() == 7U);
+
+    // Test 12: Select pulls from new and tried regardless of port number.
+    std::set<uint16_t> ports;
+    for (int i = 0; i < 20; ++i) {
+        ports.insert(addrman.Select().GetPort());
+    }
+    BOOST_CHECK_EQUAL(ports.size(), 3U);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_new_collisions)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    CNetAddr source = ResolveIP("252.2.2.2");
+
+    BOOST_CHECK(addrman.size() == 0);
+
+    for (unsigned int i = 1; i < 18; i++) {
+        CService addr = ResolveService("250.1.1." + boost::to_string(i));
+        addrman.Add(CAddress(addr, NODE_NONE), source);
+
+        //Test 13: No collision in new table yet.
+        BOOST_CHECK(addrman.size() == i);
+    }
+
+    //Test 14: new table collision!
+    CService addr1 = ResolveService("250.1.1.18");
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 17);
+
+    CService addr2 = ResolveService("250.1.1.19");
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 18);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    CNetAddr source = ResolveIP("252.2.2.2");
+
+    BOOST_CHECK(addrman.size() == 0);
+
+    for (unsigned int i = 1; i < 80; i++) {
+        CService addr = ResolveService("250.1.1." + boost::to_string(i));
+        addrman.Add(CAddress(addr, NODE_NONE), source);
+        addrman.Good(CAddress(addr, NODE_NONE));
+
+        //Test 15: No collision in tried table yet.
+        BOOST_TEST_MESSAGE(addrman.size());
+        BOOST_CHECK(addrman.size() == i);
+    }
+
+    //Test 16: tried table collision!
+    CService addr1 = ResolveService("250.1.1.80");
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 79);
+
+    CService addr2 = ResolveService("250.1.1.81");
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
+    BOOST_CHECK(addrman.size() == 80);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_find)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    BOOST_CHECK(addrman.size() == 0);
+
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
+    CAddress addr3 = CAddress(ResolveService("251.255.2.1", 8333), NODE_NONE);
+
+    CNetAddr source1 = ResolveIP("250.1.2.1");
+    CNetAddr source2 = ResolveIP("250.1.2.2");
+
+    addrman.Add(addr1, source1);
+    addrman.Add(addr2, source2);
+    addrman.Add(addr3, source1);
+
+    // Test 17: ensure Find returns an IP matching what we searched on.
+    CAddrInfo* info1 = addrman.Find(addr1);
+    BOOST_CHECK(info1);
+    if (info1)
+        BOOST_CHECK(info1->ToString() == "250.1.2.1:8333");
+
+    // Test 18; Find does not discriminate by port number.
+    CAddrInfo* info2 = addrman.Find(addr2);
+    BOOST_CHECK(info2);
+    if (info2)
+        BOOST_CHECK(info2->ToString() == info1->ToString());
+
+    // Test 19: Find returns another IP matching what we searched on.
+    CAddrInfo* info3 = addrman.Find(addr3);
+    BOOST_CHECK(info3);
+    if (info3)
+        BOOST_CHECK(info3->ToString() == "251.255.2.1:8333");
+}
+
+BOOST_AUTO_TEST_CASE(addrman_create)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    BOOST_CHECK(addrman.size() == 0);
+
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CNetAddr source1 = ResolveIP("250.1.2.1");
+
+    int nId;
+    CAddrInfo* pinfo = addrman.Create(addr1, source1, &nId);
+
+    // Test 20: The result should be the same as the input addr.
+    BOOST_CHECK(pinfo->ToString() == "250.1.2.1:8333");
+
+    CAddrInfo* info2 = addrman.Find(addr1);
+    BOOST_CHECK(info2->ToString() == "250.1.2.1:8333");
+}
+
+
+BOOST_AUTO_TEST_CASE(addrman_delete)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    BOOST_CHECK(addrman.size() == 0);
+
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CNetAddr source1 = ResolveIP("250.1.2.1");
+
+    int nId;
+    addrman.Create(addr1, source1, &nId);
+
+    // Test 21: Delete should actually delete the addr.
+    BOOST_CHECK(addrman.size() == 1);
+    addrman.Delete(nId);
+    BOOST_CHECK(addrman.size() == 0);
+    CAddrInfo* info2 = addrman.Find(addr1);
+    BOOST_CHECK(info2 == NULL);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_getaddr)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    // Test 22: Sanity check, GetAddr should never return anything if addrman
+    //  is empty.
+    BOOST_CHECK(addrman.size() == 0);
+    vector<CAddress> vAddr1 = addrman.GetAddr();
+    BOOST_CHECK(vAddr1.size() == 0);
+
+    CAddress addr1 = CAddress(ResolveService("250.250.2.1", 8333), NODE_NONE);
+    addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
+    CAddress addr2 = CAddress(ResolveService("250.251.2.2", 9999), NODE_NONE);
+    addr2.nTime = GetAdjustedTime();
+    CAddress addr3 = CAddress(ResolveService("251.252.2.3", 8333), NODE_NONE);
+    addr3.nTime = GetAdjustedTime();
+    CAddress addr4 = CAddress(ResolveService("252.253.3.4", 8333), NODE_NONE);
+    addr4.nTime = GetAdjustedTime();
+    CAddress addr5 = CAddress(ResolveService("252.254.4.5", 8333), NODE_NONE);
+    addr5.nTime = GetAdjustedTime();
+    CNetAddr source1 = ResolveIP("250.1.2.1");
+    CNetAddr source2 = ResolveIP("250.2.3.3");
+
+    // Test 23: Ensure GetAddr works with new addresses.
+    addrman.Add(addr1, source1);
+    addrman.Add(addr2, source2);
+    addrman.Add(addr3, source1);
+    addrman.Add(addr4, source2);
+    addrman.Add(addr5, source1);
+
+    // GetAddr returns 23% of addresses, 23% of 5 is 1 rounded down.
+    BOOST_CHECK(addrman.GetAddr().size() == 1);
+
+    // Test 24: Ensure GetAddr works with new and tried addresses.
+    addrman.Good(CAddress(addr1, NODE_NONE));
+    addrman.Good(CAddress(addr2, NODE_NONE));
+    BOOST_CHECK(addrman.GetAddr().size() == 1);
+
+    // Test 25: Ensure GetAddr still returns 23% when addrman has many addrs.
+    for (unsigned int i = 1; i < (8 * 256); i++) {
+        int octet1 = i % 256;
+        int octet2 = (i / 256) % 256;
+        int octet3 = (i / (256 * 2)) % 256;
+        string strAddr = boost::to_string(octet1) + "." + boost::to_string(octet2) + "." + boost::to_string(octet3) + ".23";
+        CAddress addr = CAddress(ResolveService(strAddr), NODE_NONE);
+
+        // Ensure that for all addrs in addrman, isTerrible == false.
+        addr.nTime = GetAdjustedTime();
+        addrman.Add(addr, ResolveIP(strAddr));
+        if (i % 8 == 0)
+            addrman.Good(addr);
+    }
+    vector<CAddress> vAddr = addrman.GetAddr();
+
+    size_t percent23 = (addrman.size() * 23) / 100;
+    BOOST_CHECK(vAddr.size() == percent23);
+    BOOST_CHECK(vAddr.size() == 461);
+    // (Addrman.size() < number of addresses added) due to address collisions.
+    BOOST_CHECK(addrman.size() == 2007);
+}
+
+
+BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    CAddress addr1 = CAddress(ResolveService("250.1.1.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(ResolveService("250.1.1.1", 9999), NODE_NONE);
+
+    CNetAddr source1 = ResolveIP("250.1.1.1");
+
+
+    CAddrInfo info1 = CAddrInfo(addr1, source1);
+
+    uint256 nKey1 = (uint256)(CHashWriter(SER_GETHASH, 0) << 1).GetHash();
+    uint256 nKey2 = (uint256)(CHashWriter(SER_GETHASH, 0) << 2).GetHash();
+
+
+    BOOST_CHECK(info1.GetTriedBucket(nKey1) == 40);
+
+    // Test 26: Make sure key actually randomizes bucket placement. A fail on
+    //  this test could be a security issue.
+    BOOST_CHECK(info1.GetTriedBucket(nKey1) != info1.GetTriedBucket(nKey2));
+
+    // Test 27: Two addresses with same IP but different ports can map to
+    //  different buckets because they have different keys.
+    CAddrInfo info2 = CAddrInfo(addr2, source1);
+
+    BOOST_CHECK(info1.GetKey() != info2.GetKey());
+    BOOST_CHECK(info1.GetTriedBucket(nKey1) != info2.GetTriedBucket(nKey1));
+
+    set<int> buckets;
+    for (int i = 0; i < 255; i++) {
+        CAddrInfo infoi = CAddrInfo(
+            CAddress(ResolveService("250.1.1." + boost::to_string(i)), NODE_NONE),
+            ResolveIP("250.1.1." + boost::to_string(i)));
+        int bucket = infoi.GetTriedBucket(nKey1);
+        buckets.insert(bucket);
+    }
+    // Test 28: IP addresses in the same group (\16 prefix for IPv4) should
+    //  never get more than 8 buckets
+    BOOST_CHECK(buckets.size() == 8);
+
+    buckets.clear();
+    for (int j = 0; j < 255; j++) {
+        CAddrInfo infoj = CAddrInfo(
+            CAddress(ResolveService("250." + boost::to_string(j) + ".1.1"), NODE_NONE),
+            ResolveIP("250." + boost::to_string(j) + ".1.1"));
+        int bucket = infoj.GetTriedBucket(nKey1);
+        buckets.insert(bucket);
+    }
+    // Test 29: IP addresses in the different groups should map to more than
+    //  8 buckets.
+    BOOST_CHECK(buckets.size() == 160);
+}
+
+BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
+{
+    CAddrManTest addrman;
+
+    // Set addrman addr placement to be deterministic.
+    addrman.MakeDeterministic();
+
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
+
+    CNetAddr source1 = ResolveIP("250.1.2.1");
+
+    CAddrInfo info1 = CAddrInfo(addr1, source1);
+
+    uint256 nKey1 = (uint256)(CHashWriter(SER_GETHASH, 0) << 1).GetHash();
+    uint256 nKey2 = (uint256)(CHashWriter(SER_GETHASH, 0) << 2).GetHash();
+
+    BOOST_CHECK(info1.GetNewBucket(nKey1) == 786);
+
+    // Test 30: Make sure key actually randomizes bucket placement. A fail on
+    //  this test could be a security issue.
+    BOOST_CHECK(info1.GetNewBucket(nKey1) != info1.GetNewBucket(nKey2));
+
+    // Test 31: Ports should not effect bucket placement in the addr
+    CAddrInfo info2 = CAddrInfo(addr2, source1);
+    BOOST_CHECK(info1.GetKey() != info2.GetKey());
+    BOOST_CHECK(info1.GetNewBucket(nKey1) == info2.GetNewBucket(nKey1));
+
+    set<int> buckets;
+    for (int i = 0; i < 255; i++) {
+        CAddrInfo infoi = CAddrInfo(
+            CAddress(ResolveService("250.1.1." + boost::to_string(i)), NODE_NONE),
+            ResolveIP("250.1.1." + boost::to_string(i)));
+        int bucket = infoi.GetNewBucket(nKey1);
+        buckets.insert(bucket);
+    }
+    // Test 32: IP addresses in the same group (\16 prefix for IPv4) should
+    //  always map to the same bucket.
+    BOOST_CHECK(buckets.size() == 1);
+
+    buckets.clear();
+    for (int j = 0; j < 4 * 255; j++) {
+        CAddrInfo infoj = CAddrInfo(CAddress(
+                                        ResolveService(
+                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1"), NODE_NONE),
+            ResolveIP("251.4.1.1"));
+        int bucket = infoj.GetNewBucket(nKey1);
+        buckets.insert(bucket);
+    }
+    // Test 33: IP addresses in the same source groups should map to no more
+    //  than 64 buckets.
+    BOOST_CHECK(buckets.size() <= 64);
+
+    buckets.clear();
+    for (int p = 0; p < 255; p++) {
+        CAddrInfo infoj = CAddrInfo(
+            CAddress(ResolveService("250.1.1.1"), NODE_NONE),
+            ResolveIP("250." + boost::to_string(p) + ".1.1"));
+        int bucket = infoj.GetNewBucket(nKey1);
+        buckets.insert(bucket);
+    }
+    // Test 34: IP addresses in the different source groups should map to more
+    //  than 64 buckets.
+    BOOST_CHECK(buckets.size() > 64);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) 2012-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include "addrman.h"
+#include <string>
+#include <boost/test/unit_test.hpp>
+#include "hash.h"
+#include "serialize.h"
+#include "streams.h"
+#include "net.h"
+#include "netbase.h"
+#include "addrdb.h"
+#include "chainparams.h"
+#include "clientversion.h"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(net_tests)
+
+class CAddrManSerializationMock : public CAddrMan
+{
+public:
+    virtual void Serialize(CDataStream& s) const = 0;
+
+    //! Ensure that bucket placement is always the same for testing purposes.
+    void MakeDeterministic()
+    {
+        nKey.SetNull();
+        insecure_rand = FastRandomContext(true);
+    }
+};
+
+class CAddrManUncorrupted : public CAddrManSerializationMock
+{
+public:
+    void Serialize(CDataStream& s) const
+    {
+        CAddrMan::Serialize(s);
+    }
+};
+
+class CAddrManCorrupted : public CAddrManSerializationMock
+{
+public:
+    void Serialize(CDataStream& s) const
+    {
+        // Produces corrupt output that claims addrman has 20 addrs when it only has one addr.
+        unsigned char nVersion = 1;
+        s << nVersion;
+        s << ((unsigned char)32);
+        s << nKey;
+        s << 10; // nNew
+        s << 10; // nTried
+
+        int nUBuckets = ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30);
+        s << nUBuckets;
+
+        CService serv;
+        Lookup("252.1.1.1", serv, 7777, false);
+        CAddress addr = CAddress(serv, NODE_NONE);
+        CNetAddr resolved;
+        LookupHost("252.2.2.2", resolved, false);
+        CAddrInfo info = CAddrInfo(addr, resolved);
+        s << info;
+    }
+};
+
+CDataStream AddrmanToStream(CAddrManSerializationMock& addrman)
+{
+    CDataStream ssPeersIn(SER_DISK, CLIENT_VERSION);
+    ssPeersIn << Params().MessageStart();
+    ssPeersIn << addrman;
+    std::string str = ssPeersIn.str();
+    vector<unsigned char> vchData(str.begin(), str.end());
+    return CDataStream(vchData, SER_DISK, CLIENT_VERSION);
+}
+
+BOOST_AUTO_TEST_CASE(caddrdb_read)
+{
+    CAddrManUncorrupted addrmanUncorrupted;
+    addrmanUncorrupted.MakeDeterministic();
+
+    CService addr1, addr2, addr3;
+    Lookup("250.7.1.1", addr1, 8333, false);
+    Lookup("250.7.2.2", addr2, 9999, false);
+    Lookup("250.7.3.3", addr3, 9999, false);
+
+    // Add three addresses to new table.
+    CService source;
+    Lookup("252.5.1.1", source, 8333, false);
+    addrmanUncorrupted.Add(CAddress(addr1, NODE_NONE), source);
+    addrmanUncorrupted.Add(CAddress(addr2, NODE_NONE), source);
+    addrmanUncorrupted.Add(CAddress(addr3, NODE_NONE), source);
+
+    // Test that the de-serialization does not throw an exception.
+    CDataStream ssPeers1 = AddrmanToStream(addrmanUncorrupted);
+    bool exceptionThrown = false;
+    CAddrMan addrman1;
+
+    BOOST_CHECK(addrman1.size() == 0);
+    try {
+        unsigned char pchMsgTmp[4];
+        ssPeers1 >> pchMsgTmp;
+        ssPeers1 >> addrman1;
+    } catch (const std::exception& e) {
+        exceptionThrown = true;
+    }
+
+    BOOST_CHECK(addrman1.size() == 3);
+    BOOST_CHECK(exceptionThrown == false);
+
+    // Test that CAddrDB::Read creates an addrman with the correct number of addrs.
+    CDataStream ssPeers2 = AddrmanToStream(addrmanUncorrupted);
+
+    CAddrMan addrman2;
+    CAddrDB adb;
+    BOOST_CHECK(addrman2.size() == 0);
+    adb.Read(addrman2, ssPeers2);
+    BOOST_CHECK(addrman2.size() == 3);
+}
+
+
+BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
+{
+    CAddrManCorrupted addrmanCorrupted;
+    addrmanCorrupted.MakeDeterministic();
+
+    // Test that the de-serialization of corrupted addrman throws an exception.
+    CDataStream ssPeers1 = AddrmanToStream(addrmanCorrupted);
+    bool exceptionThrown = false;
+    CAddrMan addrman1;
+    BOOST_CHECK(addrman1.size() == 0);
+    try {
+        unsigned char pchMsgTmp[4];
+        ssPeers1 >> pchMsgTmp;
+        ssPeers1 >> addrman1;
+    } catch (const std::exception& e) {
+        exceptionThrown = true;
+    }
+    // Even through de-serialization failed addrman is not left in a clean state.
+    BOOST_CHECK(addrman1.size() == 1);
+    BOOST_CHECK(exceptionThrown);
+
+    // Test that CAddrDB::Read leaves addrman in a clean state if de-serialization fails.
+    CDataStream ssPeers2 = AddrmanToStream(addrmanCorrupted);
+
+    CAddrMan addrman2;
+    CAddrDB adb;
+    BOOST_CHECK(addrman2.size() == 0);
+    adb.Read(addrman2, ssPeers2);
+    BOOST_CHECK(addrman2.size() == 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include "util.h"
 
 #include "netbase.h"
 #include "util/strencodings.h"
@@ -11,37 +12,62 @@ using namespace std;
 
 BOOST_AUTO_TEST_SUITE(netbase_tests)
 
+static CNetAddr ResolveIP(const char* ip)
+{
+    CNetAddr addr;
+    LookupHost(ip, addr, false);
+    return addr;
+}
+
+static CSubNet ResolveSubNet(const char* subnet)
+{
+    CSubNet ret;
+    LookupSubNet(subnet, ret);
+    return ret;
+}
+
+
+static CNetAddr CreateInternal(const char* host)
+{
+    CNetAddr addr;
+    addr.SetInternal(host);
+    return addr;
+}
+
 BOOST_AUTO_TEST_CASE(netbase_networks)
 {
-    BOOST_CHECK(CNetAddr("127.0.0.1").GetNetwork()                              == NET_UNROUTABLE);
-    BOOST_CHECK(CNetAddr("::1").GetNetwork()                                    == NET_UNROUTABLE);
-    BOOST_CHECK(CNetAddr("8.8.8.8").GetNetwork()                                == NET_IPV4);
-    BOOST_CHECK(CNetAddr("2001::8888").GetNetwork()                             == NET_IPV6);
-    BOOST_CHECK(CNetAddr("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetNetwork() == NET_TOR);
+    BOOST_CHECK(ResolveIP("127.0.0.1").GetNetwork()                              == NET_UNROUTABLE);
+    BOOST_CHECK(ResolveIP("::1").GetNetwork()                                    == NET_UNROUTABLE);
+    BOOST_CHECK(ResolveIP("8.8.8.8").GetNetwork()                                == NET_IPV4);
+    BOOST_CHECK(ResolveIP("2001::8888").GetNetwork()                             == NET_IPV6);
+    BOOST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetNetwork() == NET_TOR);
+    BOOST_CHECK(CreateInternal("foo.com").GetNetwork()                           == NET_INTERNAL);
 }
 
 BOOST_AUTO_TEST_CASE(netbase_properties)
 {
-    BOOST_CHECK(CNetAddr("127.0.0.1").IsIPv4());
-    BOOST_CHECK(CNetAddr("::FFFF:192.168.1.1").IsIPv4());
-    BOOST_CHECK(CNetAddr("::1").IsIPv6());
-    BOOST_CHECK(CNetAddr("10.0.0.1").IsRFC1918());
-    BOOST_CHECK(CNetAddr("192.168.1.1").IsRFC1918());
-    BOOST_CHECK(CNetAddr("172.31.255.255").IsRFC1918());
-    BOOST_CHECK(CNetAddr("2001:0DB8::").IsRFC3849());
-    BOOST_CHECK(CNetAddr("169.254.1.1").IsRFC3927());
-    BOOST_CHECK(CNetAddr("2002::1").IsRFC3964());
-    BOOST_CHECK(CNetAddr("FC00::").IsRFC4193());
-    BOOST_CHECK(CNetAddr("2001::2").IsRFC4380());
-    BOOST_CHECK(CNetAddr("2001:10::").IsRFC4843());
-    BOOST_CHECK(CNetAddr("FE80::").IsRFC4862());
-    BOOST_CHECK(CNetAddr("64:FF9B::").IsRFC6052());
-    BOOST_CHECK(CNetAddr("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").IsTor());
-    BOOST_CHECK(CNetAddr("127.0.0.1").IsLocal());
-    BOOST_CHECK(CNetAddr("::1").IsLocal());
-    BOOST_CHECK(CNetAddr("8.8.8.8").IsRoutable());
-    BOOST_CHECK(CNetAddr("2001::1").IsRoutable());
-    BOOST_CHECK(CNetAddr("127.0.0.1").IsValid());
+    BOOST_CHECK(ResolveIP("127.0.0.1").IsIPv4());
+    BOOST_CHECK(ResolveIP("::FFFF:192.168.1.1").IsIPv4());
+    BOOST_CHECK(ResolveIP("::1").IsIPv6());
+    BOOST_CHECK(ResolveIP("10.0.0.1").IsRFC1918());
+    BOOST_CHECK(ResolveIP("192.168.1.1").IsRFC1918());
+    BOOST_CHECK(ResolveIP("172.31.255.255").IsRFC1918());
+    BOOST_CHECK(ResolveIP("2001:0DB8::").IsRFC3849());
+    BOOST_CHECK(ResolveIP("169.254.1.1").IsRFC3927());
+    BOOST_CHECK(ResolveIP("2002::1").IsRFC3964());
+    BOOST_CHECK(ResolveIP("FC00::").IsRFC4193());
+    BOOST_CHECK(ResolveIP("2001::2").IsRFC4380());
+    BOOST_CHECK(ResolveIP("2001:10::").IsRFC4843());
+    BOOST_CHECK(ResolveIP("FE80::").IsRFC4862());
+    BOOST_CHECK(ResolveIP("64:FF9B::").IsRFC6052());
+    BOOST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").IsTor());
+    BOOST_CHECK(ResolveIP("127.0.0.1").IsLocal());
+    BOOST_CHECK(ResolveIP("::1").IsLocal());
+    BOOST_CHECK(ResolveIP("8.8.8.8").IsRoutable());
+    BOOST_CHECK(ResolveIP("2001::1").IsRoutable());
+    BOOST_CHECK(ResolveIP("127.0.0.1").IsValid());
+    BOOST_CHECK(CreateInternal("FD6B:88C0:8724:edb1:8e4:3588:e546:35ca").IsInternal());
+    BOOST_CHECK(CreateInternal("bar.com").IsInternal());
 }
 
 bool static TestSplitHost(string test, string host, int port)
@@ -73,9 +99,7 @@ BOOST_AUTO_TEST_CASE(netbase_splithost)
 
 bool static TestParse(string src, string canon)
 {
-    CService addr;
-    if (!LookupNumeric(src.c_str(), addr, 65535))
-        return canon == "";
+    CService addr(LookupNumeric(src.c_str(), 65535));
     return canon == addr.ToString();
 }
 
@@ -87,34 +111,189 @@ BOOST_AUTO_TEST_CASE(netbase_lookupnumeric)
     BOOST_CHECK(TestParse("::", "[::]:65535"));
     BOOST_CHECK(TestParse("[::]:8333", "[::]:8333"));
     BOOST_CHECK(TestParse("[127.0.0.1]", "127.0.0.1:65535"));
-    BOOST_CHECK(TestParse(":::", ""));
+    BOOST_CHECK(TestParse(":::", "[::]:0"));
+
+    // verify that an internal address fails to resolve
+    BOOST_CHECK(TestParse("[fd6b:88c0:8724:1:2:3:4:5]", "[::]:0"));
+    // and that a one-off resolves correctly
+    BOOST_CHECK(TestParse("[fd6c:88c0:8724:1:2:3:4:5]", "[fd6c:88c0:8724:1:2:3:4:5]:65535"));
 }
 
 BOOST_AUTO_TEST_CASE(onioncat_test)
 {
     // values from https://web.archive.org/web/20121122003543/http://www.cypherpunk.at/onioncat/wiki/OnionCat
-    CNetAddr addr1("5wyqrzbvrdsumnok.onion");
-    CNetAddr addr2("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca");
+    CNetAddr addr1(ResolveIP("5wyqrzbvrdsumnok.onion"));
+    CNetAddr addr2(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca"));
     BOOST_CHECK(addr1 == addr2);
     BOOST_CHECK(addr1.IsTor());
     BOOST_CHECK(addr1.ToStringIP() == "5wyqrzbvrdsumnok.onion");
     BOOST_CHECK(addr1.IsRoutable());
 }
 
+BOOST_AUTO_TEST_CASE(subnet_test)
+{
+
+    BOOST_CHECK(ResolveSubNet("1.2.3.0/24") == ResolveSubNet("1.2.3.0/255.255.255.0"));
+    BOOST_CHECK(ResolveSubNet("1.2.3.0/24") != ResolveSubNet("1.2.4.0/255.255.255.0"));
+    BOOST_CHECK(ResolveSubNet("1.2.3.0/24").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(!ResolveSubNet("1.2.2.0/24").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(ResolveSubNet("1.2.3.4").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(ResolveSubNet("1.2.3.4/32").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(!ResolveSubNet("1.2.3.4").Match(ResolveIP("5.6.7.8")));
+    BOOST_CHECK(!ResolveSubNet("1.2.3.4/32").Match(ResolveIP("5.6.7.8")));
+    BOOST_CHECK(ResolveSubNet("::ffff:127.0.0.1").Match(ResolveIP("127.0.0.1")));
+    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:8")));
+    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:9")));
+    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:0/112").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    BOOST_CHECK(ResolveSubNet("192.168.0.1/24").Match(ResolveIP("192.168.0.2")));
+    BOOST_CHECK(ResolveSubNet("192.168.0.20/29").Match(ResolveIP("192.168.0.18")));
+    BOOST_CHECK(ResolveSubNet("1.2.2.1/24").Match(ResolveIP("1.2.2.4")));
+    BOOST_CHECK(ResolveSubNet("1.2.2.110/31").Match(ResolveIP("1.2.2.111")));
+    BOOST_CHECK(ResolveSubNet("1.2.2.20/26").Match(ResolveIP("1.2.2.63")));
+    // All-Matching IPv6 Matches arbitrary IPv4 and IPv6
+    BOOST_CHECK(ResolveSubNet("::/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    BOOST_CHECK(ResolveSubNet("::/0").Match(ResolveIP("1.2.3.4")));
+    // All-Matching IPv4 does not Match IPv6
+    BOOST_CHECK(!ResolveSubNet("0.0.0.0/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    // Invalid subnets Match nothing (not even invalid addresses)
+    BOOST_CHECK(!CSubNet().Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(!ResolveSubNet("").Match(ResolveIP("4.5.6.7")));
+    BOOST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("0.0.0.0")));
+    BOOST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("hab")));
+    // Check valid/invalid
+    BOOST_CHECK(ResolveSubNet("1.2.3.0/0").IsValid());
+    BOOST_CHECK(!ResolveSubNet("1.2.3.0/-1").IsValid());
+    BOOST_CHECK(ResolveSubNet("1.2.3.0/32").IsValid());
+    BOOST_CHECK(!ResolveSubNet("1.2.3.0/33").IsValid());
+    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/0").IsValid());
+    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/33").IsValid());
+    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/-1").IsValid());
+    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/128").IsValid());
+    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/129").IsValid());
+    BOOST_CHECK(!ResolveSubNet("fuzzy").IsValid());
+
+    //CNetAddr constructor test
+    BOOST_CHECK(CSubNet(ResolveIP("127.0.0.1")).IsValid());
+    BOOST_CHECK(CSubNet(ResolveIP("127.0.0.1")).Match(ResolveIP("127.0.0.1")));
+    BOOST_CHECK(!CSubNet(ResolveIP("127.0.0.1")).Match(ResolveIP("127.0.0.2")));
+    BOOST_CHECK(CSubNet(ResolveIP("127.0.0.1")).ToString() == "127.0.0.1/32");
+
+    CSubNet subnet = CSubNet(ResolveIP("1.2.3.4"), 32);
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
+    subnet = CSubNet(ResolveIP("1.2.3.4"), 8);
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
+    subnet = CSubNet(ResolveIP("1.2.3.4"), 0);
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
+
+    subnet = CSubNet(ResolveIP("1.2.3.4"), ResolveIP("255.255.255.255"));
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
+    subnet = CSubNet(ResolveIP("1.2.3.4"), ResolveIP("255.0.0.0"));
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
+    subnet = CSubNet(ResolveIP("1.2.3.4"), ResolveIP("0.0.0.0"));
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
+
+    BOOST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).IsValid());
+    BOOST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).Match(ResolveIP("1:2:3:4:5:6:7:8")));
+    BOOST_CHECK(!CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).Match(ResolveIP("1:2:3:4:5:6:7:9")));
+    BOOST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).ToString() == "1:2:3:4:5:6:7:8/128");
+
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.255");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.254");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/31");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.252");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/30");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.248");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/29");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.240");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/28");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.224");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/27");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.192");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/26");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.128");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/25");
+    subnet = ResolveSubNet("1.2.3.4/255.255.255.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/24");
+    subnet = ResolveSubNet("1.2.3.4/255.255.254.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.2.0/23");
+    subnet = ResolveSubNet("1.2.3.4/255.255.252.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/22");
+    subnet = ResolveSubNet("1.2.3.4/255.255.248.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/21");
+    subnet = ResolveSubNet("1.2.3.4/255.255.240.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/20");
+    subnet = ResolveSubNet("1.2.3.4/255.255.224.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/19");
+    subnet = ResolveSubNet("1.2.3.4/255.255.192.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/18");
+    subnet = ResolveSubNet("1.2.3.4/255.255.128.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/17");
+    subnet = ResolveSubNet("1.2.3.4/255.255.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/16");
+    subnet = ResolveSubNet("1.2.3.4/255.254.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/15");
+    subnet = ResolveSubNet("1.2.3.4/255.252.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/14");
+    subnet = ResolveSubNet("1.2.3.4/255.248.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/13");
+    subnet = ResolveSubNet("1.2.3.4/255.240.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/12");
+    subnet = ResolveSubNet("1.2.3.4/255.224.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/11");
+    subnet = ResolveSubNet("1.2.3.4/255.192.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/10");
+    subnet = ResolveSubNet("1.2.3.4/255.128.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/9");
+    subnet = ResolveSubNet("1.2.3.4/255.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
+    subnet = ResolveSubNet("1.2.3.4/254.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/7");
+    subnet = ResolveSubNet("1.2.3.4/252.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/6");
+    subnet = ResolveSubNet("1.2.3.4/248.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/5");
+    subnet = ResolveSubNet("1.2.3.4/240.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/4");
+    subnet = ResolveSubNet("1.2.3.4/224.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/3");
+    subnet = ResolveSubNet("1.2.3.4/192.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/2");
+    subnet = ResolveSubNet("1.2.3.4/128.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/1");
+    subnet = ResolveSubNet("1.2.3.4/0.0.0.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
+
+    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/128");
+    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:0000:0000:0000:0000:0000:0000:0000");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1::/16");
+    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/0000:0000:0000:0000:0000:0000:0000:0000");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "::/0");
+    subnet = ResolveSubNet("1.2.3.4/255.255.232.0");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/255.255.232.0");
+    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
+    BOOST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
+}
+
 BOOST_AUTO_TEST_CASE(netbase_getgroup)
 {
-    BOOST_CHECK(CNetAddr("127.0.0.1").GetGroup() == boost::assign::list_of(0)); // Local -> !Routable()
-    BOOST_CHECK(CNetAddr("257.0.0.1").GetGroup() == boost::assign::list_of(0)); // !Valid -> !Routable()
-    BOOST_CHECK(CNetAddr("10.0.0.1").GetGroup() == boost::assign::list_of(0)); // RFC1918 -> !Routable()
-    BOOST_CHECK(CNetAddr("169.254.1.1").GetGroup() == boost::assign::list_of(0)); // RFC3927 -> !Routable()
-    BOOST_CHECK(CNetAddr("1.2.3.4").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // IPv4
-    BOOST_CHECK(CNetAddr("::FFFF:0:102:304").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC6145
-    BOOST_CHECK(CNetAddr("64:FF9B::102:304").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC6052
-    BOOST_CHECK(CNetAddr("2002:102:304:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC3964
-    BOOST_CHECK(CNetAddr("2001:0:9999:9999:9999:9999:FEFD:FCFB").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC4380
-    BOOST_CHECK(CNetAddr("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetGroup() == boost::assign::list_of((unsigned char)NET_TOR)(239)); // Tor
-    BOOST_CHECK(CNetAddr("2001:470:abcd:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(4)(112)(175)); //he.net
-    BOOST_CHECK(CNetAddr("2001:2001:9999:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(32)(1)); //IPv6
+    BOOST_CHECK(ResolveIP("127.0.0.1").GetGroup() == std::vector<unsigned char>({0})); // Local -> !Routable()
+    BOOST_CHECK(ResolveIP("257.0.0.1").GetGroup() == std::vector<unsigned char>({0})); // !Valid -> !Routable()
+    BOOST_CHECK(ResolveIP("10.0.0.1").GetGroup() == std::vector<unsigned char>({0})); // RFC1918 -> !Routable()
+    BOOST_CHECK(ResolveIP("169.254.1.1").GetGroup() == std::vector<unsigned char>({0})); // RFC3927 -> !Routable()
+    BOOST_CHECK(ResolveIP("1.2.3.4").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_IPV4, 1, 2})); // IPv4
+    BOOST_CHECK(ResolveIP("::FFFF:0:102:304").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_IPV4, 1, 2})); // RFC6145
+    BOOST_CHECK(ResolveIP("64:FF9B::102:304").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_IPV4, 1, 2})); // RFC6052
+    BOOST_CHECK(ResolveIP("2002:102:304:9999:9999:9999:9999:9999").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_IPV4, 1, 2})); // RFC3964
+    BOOST_CHECK(ResolveIP("2001:0:9999:9999:9999:9999:FEFD:FCFB").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_IPV4, 1, 2})); // RFC4380
+    BOOST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_TOR, 239})); // Tor
+    BOOST_CHECK(ResolveIP("2001:470:abcd:9999:9999:9999:9999:9999").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_IPV6, 32, 1, 4, 112, 175})); //he.net
+    BOOST_CHECK(ResolveIP("2001:2001:9999:9999:9999:9999:9999:9999").GetGroup() == std::vector<unsigned char>({(unsigned char)NET_IPV6, 32, 1, 32, 1})); //IPv6
+
+    // baz.net sha256 hash: 12929400eb4607c4ac075f087167e75286b179c693eb059a01774b864e8fe505
+    std::vector<unsigned char> internal_group = {NET_INTERNAL, 0x12, 0x92, 0x94, 0x00, 0xeb, 0x46, 0x07, 0xc4, 0xac, 0x07};
+    BOOST_CHECK(CreateInternal("baz.net").GetGroup() == internal_group);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a backport of https://github.com/bitcoin/bitcoin/pull/8128 and https://github.com/bitcoin/bitcoin/pull/7868. 

As @jamescowens said in https://github.com/gridcoin-community/Gridcoin-Research/issues/2558, it probably doesn't make sense to port all the old commits until we finally get to the latest state. However, this backport helps with porting new code because it introduces "netaddress.{cpp,h}" and therefore makes "netbase.{cpp,h}" a bit leaner. This simplifies the backport of newer "netaddress.{cpp,h}" files. Also, tests for addrman have been added and some netbase tests have been updated. For testing I changed the proxy settings and ran the wallet through a proxy and started the wallet with "--proxy".