### PR TITLE
refactor: remove unused c-string variant of atoi64()

### DIFF
--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -440,15 +440,6 @@ std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
     return out.str();
 }
 
-int64_t atoi64(const char* psz)
-{
-#ifdef _MSC_VER
-    return _atoi64(psz);
-#else
-    return strtoll(psz, nullptr, 10);
-#endif
-}
-
 int64_t atoi64(const std::string& str)
 {
 #ifdef _MSC_VER

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -55,7 +55,6 @@ std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
 
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
-int64_t atoi64(const char* psz);
 int64_t atoi64(const std::string& str);
 int atoi(const std::string& str);
 


### PR DESCRIPTION
> This is another micro-PR "removing old cruft with potentially sharp edges" (quote by practicalswift, see https://github.com/bitcoin/bitcoin/pull/19739). Gets rid of the c-string variant of the function `atoi64()`, which is not used in our code.

Ref: https://github.com/bitcoin/bitcoin/pull/19750