### PR TITLE
rpc, mrc: Fix field name and initialization of mrc_fees_to_staker

### DIFF
--- a/src/gridcoin/claim.h
+++ b/src/gridcoin/claim.h
@@ -194,13 +194,6 @@ public:
     std::map<Cpid, uint256> m_mrc_tx_map;
 
     //!
-    //! \brief This represents the fees taken from the MRC research subsidies that are awarded to the staker.
-    //! This must be tracked because this value is added to coinstake award for the staker and must be
-    //! included in the claim validation.
-    //!
-    CAmount m_mrc_fees_to_staker;
-
-    //!
     //! \brief Initialize an empty, invalid reward claim object.
     //!
     Claim();

--- a/src/main.h
+++ b/src/main.h
@@ -311,6 +311,16 @@ private:
 
 namespace GRC {
 //!
+//! \brief A report that contains the mrc fees paid in a block.
+//!
+class MRCFees
+{
+public:
+    CAmount m_mrc_foundation_fees = 0; //!< mrc fees to the foundation
+    CAmount m_mrc_staker_fees = 0;     //!< mrc fees to the staker
+};
+
+//!
 //! \brief A report that contains the calculated subsidy claimed in a block.
 //! Produced by the CBlock::GetMint() method.
 //!
@@ -393,6 +403,7 @@ public:
     GRC::SuperblockPtr GetSuperblock() const;
     GRC::SuperblockPtr GetSuperblock(const CBlockIndex* const pindex) const;
     GRC::MintSummary GetMint() const;
+    GRC::MRCFees GetMRCFees() const;
 
     // entropy bit for stake modifier if chosen by modifier
     unsigned int GetStakeEntropyBit() const

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -262,9 +262,6 @@ bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, G
 
         // Put the mrc_tx_map in the claim
         claim.m_mrc_tx_map = mrc_tx_map;
-
-        // Put the staker_fees in the claim
-        claim.m_mrc_fees_to_staker = staker_fees;
     }
 
     // Do a dry run for the claim signature to ensure that we can sign for a
@@ -284,11 +281,11 @@ bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, G
                                        "MRC fees to foundation %s, MRC rewards %s",
              __func__,
              claim.m_mining_id.ToString(),
-             FormatMoney(claim.m_research_subsidy + claim.m_block_subsidy + claim.m_mrc_fees_to_staker),
+             FormatMoney(claim.m_research_subsidy + claim.m_block_subsidy + staker_fees),
              claim.m_magnitude,
              FormatMoney(claim.m_research_subsidy),
              FormatMoney(claim.m_block_subsidy),
-             FormatMoney(claim.m_mrc_fees_to_staker),
+             FormatMoney(staker_fees),
              FormatMoney(foundation_fees),
              FormatMoney(rewards));
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -74,7 +74,6 @@ UniValue ClaimToJson(const GRC::Claim& claim, const CBlockIndex* const pindex)
         json.pushKV("magnitude_unit", claim.m_magnitude_unit);
     }
 
-    json.pushKV("fees_to_staker", ValueFromAmount(claim.m_mrc_fees_to_staker));
     json.pushKV("m_mrc_tx_map_size", (uint64_t) claim.m_mrc_tx_map.size());
     UniValue mrcs(UniValue::VARR);
     if (claim.m_version >= 4) {
@@ -228,6 +227,14 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fP
     }
 
     result.pushKV("fees_collected", ValueFromAmount(mint.m_fees));
+
+    if (block.nVersion >= 12) {
+        GRC::MRCFees mrc_fees = block.GetMRCFees();
+
+        result.pushKV("mrc_foundation_fees", ValueFromAmount(mrc_fees.m_mrc_foundation_fees));
+        result.pushKV("mrc_staker_fees", ValueFromAmount(mrc_fees.m_mrc_staker_fees));
+    }
+
     result.pushKV("IsSuperBlock", blockindex->IsSuperblock());
     result.pushKV("IsContract", blockindex->IsContract());
 


### PR DESCRIPTION
After looking very carefully at my code as implemented, the m_mrc_fees_to_staker member variable is neither used nor serialized. It was being filled out in the miner, but not serialized. The validation methods in Validator, recompute the mrc fees and check that the fees are correct to the foundation (and therefore also the staker). As such the correct fix for this is to remove the unused member variable entirely.

I have implemented a new method in CBlock, GetMRCFees(), which does the analogous thing for MRC Fees that GetMint() does for the subsidy.

The return values of GetMRCFees() have been move to BlocktoJSON() and are conditioned on block v12 or greater.

Closes #2566.