### PR TITLE
gui: Add missing resizeTableColumns to fix send address book column widths

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -38,11 +38,13 @@ void SendCoinsEntry::on_pasteButton_clicked()
 
 void SendCoinsEntry::on_addressBookButton_clicked()
 {
-    if(!model)
+    if (!model)
         return;
     AddressBookPage dlg(AddressBookPage::ForSending, AddressBookPage::SendingTab, this);
     dlg.setModel(model->getAddressTableModel());
-    if(dlg.exec())
+    dlg.open();
+    dlg.resizeTableColumns();
+    if (dlg.exec())
     {
         ui->payTo->setText(dlg.getReturnValue());
         ui->payAmount->setFocus();

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -83,6 +83,8 @@ void SignVerifyMessageDialog::on_addressBookButton_SM_clicked()
     {
         AddressBookPage dlg(AddressBookPage::ForSending, AddressBookPage::ReceivingTab, this);
         dlg.setModel(model->getAddressTableModel());
+        dlg.open();
+        dlg.resizeTableColumns();
         if (dlg.exec())
         {
             setAddress_SM(dlg.getReturnValue());
@@ -172,6 +174,8 @@ void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
     {
         AddressBookPage dlg(AddressBookPage::ForSending, AddressBookPage::SendingTab, this);
         dlg.setModel(model->getAddressTableModel());
+        dlg.open();
+        dlg.resizeTableColumns();
         if (dlg.exec())
         {
             setAddress_VM(dlg.getReturnValue());


### PR DESCRIPTION
This small PR inserts the missing call to resizeTableColumns() for the AddessBookPage in the SendCoinsEntry class. This closes #2563.