### PR TITLE
init: Add init error message if -printtoconsole and -daemon specified simultaneously

### DIFF
--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -196,6 +196,16 @@ bool AppInit(int argc, char* argv[])
             return !CommandLineRPC(argc, argv);
         }
 
+        if (gArgs.GetBoolArg("-printtoconsole", false) && gArgs.GetBoolArg("-daemon", DEFAULT_DAEMON)) {
+            return InitError("-printtoconsole && -daemon cannot be specified at the same time,\n"
+                             "because Gridcoin follows proper daemonization and disconnects the\n"
+                             "console when the process is forked. This is consistent with Bitcoin\n"
+                             "Core. Please see https://github.com/bitcoin/bitcoin/issues/10132.\n"
+                             "If you are not specifying -daemon as a startup parameter, but only\n"
+                             "-printtoconsole, and you are geting this error, please check the\n"
+                             "gridcoinresearch.conf and comment out daemon=1, or use -nodaemon.");
+        }
+
         // -server defaults to true for gridcoinresearchd but not for the GUI so do this here
         gArgs.SoftSetBoolArg("-server", true);
         // Initialize logging as early as possible.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -575,8 +575,13 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
 #if HAVE_DECL_FORK
-    argsman.AddArg("-daemon", strprintf("Run in the background as a daemon and accept commands (default: %d)", DEFAULT_DAEMON), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-daemonwait", strprintf("Wait for initialization to be finished before exiting. This implies -daemon (default: %d)", DEFAULT_DAEMONWAIT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-daemon",
+                   strprintf("Run in the background as a daemon and accept commands (default: %d)", DEFAULT_DAEMON),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-daemonwait",
+                   strprintf("Wait for initialization to be finished before exiting. "
+                             "This implies -daemon (default: %d)", DEFAULT_DAEMONWAIT),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #else
     hidden_args.emplace_back("-daemon");
     hidden_args.emplace_back("-daemonwait");


### PR DESCRIPTION
This PR adds an error message to the console output if gridcoinresearchd is started and -printtoconsole and -deamon are specified simultaneously. This occurs before the daemon fork.

Closes #2559.