### PR TITLE
build: Require gcc8 on Ubuntu Bionic to enable C++17 features

### DIFF
--- a/ci/test/00_setup_env_native_old.sh
+++ b/ci/test/00_setup_env_native_old.sh
@@ -8,11 +8,11 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_old
 export DOCKER_NAME_TAG=ubuntu:18.04
-export PACKAGES="libqt5gui5 libqt5core5a qtbase5-dev libqt5dbus5 qttools5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-iostreams-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libqrencode-dev libzip-dev zlib1g zlib1g-dev libcurl4-openssl-dev"
+export PACKAGES="gcc-8 g++-8 libqt5gui5 libqt5core5a qtbase5-dev libqt5dbus5 qttools5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-iostreams-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libqrencode-dev libzip-dev zlib1g zlib1g-dev libcurl4-openssl-dev"
 export RUN_UNIT_TESTS=true
 # export RUN_FUNCTIONAL_TESTS=false
 # export RUN_SECURITY_TESTS="true"
 export GOAL="install"
-export GRIDCOIN_CONFIG="--enable-reduce-exports --with-incompatible-bdb --with-gui=qt5"
+export GRIDCOIN_CONFIG="--enable-reduce-exports --with-incompatible-bdb --with-gui=qt5 CC=gcc-8 CXX=g++-8"
 export NEED_XVFB="true"
 export NO_DEPENDS=1

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -89,6 +89,10 @@ Build requirements:
 
     sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libzip-dev libfreetype-dev
 
+**For Ubuntu 18.04 gcc8 is also required**
+
+    sudo apt-get install gcc-8 g++-8
+
 Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
 
         sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev libboost-iostreams-dev libcurl4-gnutls-dev


### PR DESCRIPTION
This will allow us to incorporate C++17 features like our docs state. 
See https://github.com/bitcoin/bitcoin/pull/23060 for upstream

Required for #2564 