### PR TITLE
build: Check std::system for -[alert|block|wallet]notify

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -768,6 +768,29 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ]
 )
 
+AC_MSG_CHECKING([for std::system])
+AC_LINK_IFELSE(
+    [ AC_LANG_PROGRAM(
+        [[ #include <cstdlib> ]],
+        [[ int nErr = std::system(""); ]]
+    )],
+    [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_STD__SYSTEM, 1, Define to 1 if you have the `std::system' function.)],
+    [ AC_MSG_RESULT(no) ]
+)
+
+AC_MSG_CHECKING([for ::_wsystem])
+AC_LINK_IFELSE(
+    [ AC_LANG_PROGRAM(
+        [[ ]],
+        [[ int nErr = ::_wsystem(""); ]]
+    )],
+    [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_WSYSTEM, 1, Define to 1 if you have the `::wsystem' function.)],
+    [ AC_MSG_RESULT(no) ]
+)
+
+# Define to 1 if std::system or ::wsystem (Windows) is available
+AC_DEFINE([HAVE_SYSTEM], [HAVE_STD__SYSTEM || HAVE_WSYSTEM], [std::system or ::wsystem])
+
 dnl Our minimum supported glibc is 2.17, however support for thread_local
 dnl did not arrive in glibc until 2.18.
 if test "$use_thread_local" = "yes" || test "$use_thread_local" = "auto"; then

--- a/configure.ac
+++ b/configure.ac
@@ -768,13 +768,14 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ]
 )
 
+have_any_system=no
 AC_MSG_CHECKING([for std::system])
 AC_LINK_IFELSE(
     [ AC_LANG_PROGRAM(
         [[ #include <cstdlib> ]],
         [[ int nErr = std::system(""); ]]
     )],
-    [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_STD__SYSTEM, 1, Define to 1 if you have the `std::system' function.)],
+    [ AC_MSG_RESULT(yes); have_any_system=yes],
     [ AC_MSG_RESULT(no) ]
 )
 
@@ -784,12 +785,13 @@ AC_LINK_IFELSE(
         [[ ]],
         [[ int nErr = ::_wsystem(""); ]]
     )],
-    [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_WSYSTEM, 1, Define to 1 if you have the `::wsystem' function.)],
+    [ AC_MSG_RESULT(yes); have_any_system=yes],
     [ AC_MSG_RESULT(no) ]
 )
 
-# Define to 1 if std::system or ::wsystem (Windows) is available
-AC_DEFINE([HAVE_SYSTEM], [HAVE_STD__SYSTEM || HAVE_WSYSTEM], [std::system or ::wsystem])
+if test "x$have_any_system" != "xno"; then
+  AC_DEFINE(HAVE_SYSTEM, 1, Define to 1 if std::system or ::wsystem is available.)
+fi
 
 dnl Our minimum supported glibc is 2.17, however support for thread_local
 dnl did not arrive in glibc until 2.18.

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -258,6 +258,7 @@ bool CAlert::ProcessAlert(bool fThread)
         if(AppliesToMe())
         {
             uiInterface.NotifyAlertChanged(GetHash(), CT_NEW);
+        #if defined(HAVE_SYSTEM)
             std::string strCmd = gArgs.GetArg("-alertnotify", "");
             if (!strCmd.empty())
             {
@@ -282,6 +283,7 @@ bool CAlert::ProcessAlert(bool fThread)
                 else
                     runCommand(strCmd);
             }
+        #endif
         }
     }
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -258,7 +258,7 @@ bool CAlert::ProcessAlert(bool fThread)
         if(AppliesToMe())
         {
             uiInterface.NotifyAlertChanged(GetHash(), CT_NEW);
-        #if defined(HAVE_SYSTEM)
+        #if HAVE_SYSTEM
             std::string strCmd = gArgs.GetArg("-alertnotify", "");
             if (!strCmd.empty())
             {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -337,7 +337,7 @@ void SetupServerArgs()
     argsman.AddArg("-mininput=<amt>", "When creating transactions, ignore inputs with value less than this (default: 0.01)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-testnet", "Use the test network", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-#if defined(HAVE_SYSTEM)
+#if HAVE_SYSTEM
     argsman.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-walletnotify=<cmd>", "Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)",
@@ -347,7 +347,7 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-enforcecanonical", "Enforce transaction scripts to use canonical PUSH operators (default: 1)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-#if defined(HAVE_SYSTEM)
+#if HAVE_SYSTEM
     argsman.AddArg("-alertnotify=<cmd>", "Execute command when a relevant alert is received or we see a really long fork"
                                          " (%s in cmd is replaced by message)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -337,17 +337,21 @@ void SetupServerArgs()
     argsman.AddArg("-mininput=<amt>", "When creating transactions, ignore inputs with value less than this (default: 0.01)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-testnet", "Use the test network", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+#if defined(HAVE_SYSTEM)
     argsman.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-walletnotify=<cmd>", "Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+#endif
     argsman.AddArg("-confchange", "Require confirmations for change (default: 0)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-enforcecanonical", "Enforce transaction scripts to use canonical PUSH operators (default: 1)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+#if defined(HAVE_SYSTEM)
     argsman.AddArg("-alertnotify=<cmd>", "Execute command when a relevant alert is received or we see a really long fork"
                                          " (%s in cmd is replaced by message)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+#endif
     argsman.AddArg("-blockminsize=<n>", "Set minimum block size in bytes (default: 0)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blockmaxsize=<n>", strprintf("Set maximum block size in bytes (default: %u)", MAX_BLOCK_SIZE_GEN/2),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1277,7 +1277,7 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     else
         LogPrintf("{SBC} new best {%s %d} ; ",hashBestChain.ToString(), nBestHeight);
 
-#if defined(HAVE_SYSTEM)
+    #if HAVE_SYSTEM
     std::string strCmd = gArgs.GetArg("-blocknotify", "");
     if (!fIsInitialDownload && !strCmd.empty())
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1277,12 +1277,14 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     else
         LogPrintf("{SBC} new best {%s %d} ; ",hashBestChain.ToString(), nBestHeight);
 
+#if defined(HAVE_SYSTEM)
     std::string strCmd = gArgs.GetArg("-blocknotify", "");
     if (!fIsInitialDownload && !strCmd.empty())
     {
         boost::replace_all(strCmd, "%s", hashBestChain.GetHex());
         boost::thread t(runCommand, strCmd); // thread runs free
     }
+    #endif
 
     uiInterface.NotifyBlocksChanged(
         fIsInitialDownload,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -368,6 +368,7 @@ std::vector<std::string> split(const std::string& s, const std::string& delim)
     return elems;
 }
 
+#if defined(HAVE_SYSTEM)
 void runCommand(std::string strCommand)
 {
 #ifndef WIN32
@@ -378,6 +379,7 @@ void runCommand(std::string strCommand)
     if (nErr)
         LogPrintf("runCommand error: system(%s) returned %d", strCommand, nErr);
 }
+#endif
 
 void RenameThread(const char* name)
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -368,7 +368,7 @@ std::vector<std::string> split(const std::string& s, const std::string& delim)
     return elems;
 }
 
-#if defined(HAVE_SYSTEM)
+#if HAVE_SYSTEM
 void runCommand(std::string strCommand)
 {
 #ifndef WIN32

--- a/src/util.h
+++ b/src/util.h
@@ -114,7 +114,9 @@ std::string GetFileContents(const fs::path filepath);
 int64_t GetTimeOffset();
 int64_t GetAdjustedTime();
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample);
+#if defined(HAVE_SYSTEM)
 void runCommand(std::string strCommand);
+#endif
 
 //!
 //! \brief Round double value to N decimal places.

--- a/src/util.h
+++ b/src/util.h
@@ -114,7 +114,7 @@ std::string GetFileContents(const fs::path filepath);
 int64_t GetTimeOffset();
 int64_t GetAdjustedTime();
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample);
-#if defined(HAVE_SYSTEM)
+#if HAVE_SYSTEM
 void runCommand(std::string strCommand);
 #endif
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -538,12 +538,14 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb)
         NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
 
         // notify an external script when a wallet transaction comes in or is updated
+        #if defined(HAVE_SYSTEM)
         std::string strCmd = gArgs.GetArg("-walletnotify", "");
         if (!strCmd.empty())
         {
             boost::replace_all(strCmd, "%s", hash.GetHex());
             boost::thread t(runCommand, strCmd); // thread runs free
         }
+        #endif
 
     }
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -538,7 +538,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb)
         NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
 
         // notify an external script when a wallet transaction comes in or is updated
-        #if defined(HAVE_SYSTEM)
+        #if HAVE_SYSTEM
         std::string strCmd = gArgs.GetArg("-walletnotify", "");
         if (!strCmd.empty())
         {


### PR DESCRIPTION
> Platforms such as iOs and Universal Windows Platform do not support launching a process through system().

Ref: https://github.com/bitcoin/bitcoin/pull/15457

Also includes fix `build: use #if HAVE_SYSTEM instead of defined(HAVE_SYSTEM)` from
https://github.com/bitcoin/bitcoin/pull/16344

Also includes `build: improve check for ::(w)system` from 
https://github.com/bitcoin/bitcoin/pull/22845