### PR TITLE
depends: update urls for dmg tools

### DIFF
--- a/depends/packages/native_ds_store.mk
+++ b/depends/packages/native_ds_store.mk
@@ -1,6 +1,6 @@
 package=native_ds_store
 $(package)_version=1.3.0
-$(package)_download_path=https://github.com/al45tair/ds_store/archive/
+$(package)_download_path=https://github.com/dmgbuild/ds_store/archive/
 $(package)_file_name=v$($(package)_version).tar.gz
 $(package)_sha256_hash=76b3280cd4e19e5179defa23fb594a9dd32643b0c80d774bd3108361d94fb46d
 $(package)_install_libdir=$(build_prefix)/lib/python3/dist-packages

--- a/depends/packages/native_mac_alias.mk
+++ b/depends/packages/native_mac_alias.mk
@@ -1,6 +1,6 @@
 package=native_mac_alias
 $(package)_version=2.2.0
-$(package)_download_path=https://github.com/al45tair/mac_alias/archive/
+$(package)_download_path=https://github.com/dmgbuild/mac_alias/archive/
 $(package)_file_name=v$($(package)_version).tar.gz
 $(package)_sha256_hash=421e6d7586d1f155c7db3e7da01ca0dacc9649a509a253ad7077b70174426499
 $(package)_install_libdir=$(build_prefix)/lib/python3/dist-packages


### PR DESCRIPTION
> These repos have migrated from https://github.com/al45tair/ to
> https://github.com/dmgbuild/, so update our URLs to point to the new
> location. Note that GitHub is also already performing the redirect
> automatically.
> 
> Guix Build (x86_64):
> ```bash
> d77fedbd1781e7106e567a43d6830f5ccecab9f234546871cb4928b1f98be989  guix-build-718d29af2339/output/arm64-apple-darwin/SHA256SUMS.part
> c96dac549214f2d5bcc496d321767b6440367677149d254242da47dcc860a121  guix-build-718d29af2339/output/arm64-apple-darwin/bitcoin-718d29af2339-arm64-apple-darwin-unsigned.dmg
> 0d3cd6b6a1c3ca4d35fd7301cd02ca7bced8ffc587b653dcd0a3c67116ae8ac6  guix-build-718d29af2339/output/arm64-apple-darwin/bitcoin-718d29af2339-arm64-apple-darwin-unsigned.tar.gz
> f86eb599d21687ddaca35bdf5400a58ec03a48823357d0182110c3c507c09c58  guix-build-718d29af2339/output/arm64-apple-darwin/bitcoin-718d29af2339-arm64-apple-darwin.tar.gz
> 6bbd4bdf2d90ab20ae4d6aa4e9a9cfef6e14f3784d0eda67fdbd0006f03a2feb  guix-build-718d29af2339/output/dist-archive/bitcoin-718d29af2339.tar.gz
> 6c8a22474864fefbcd3ad676f46f7c10696a2801f2315367b64975f55877702d  guix-build-718d29af2339/output/x86_64-apple-darwin/SHA256SUMS.part
> d9caf693e70876d30cef2a38a0e5a62f808903f51bd3c845107f6dfc4dcf7b80  guix-build-718d29af2339/output/x86_64-apple-darwin/bitcoin-718d29af2339-x86_64-apple-darwin-unsigned.dmg
> 1510f55407f61d6f1df2711b744bae6ba43ba926ff67b1eaafcb90415d8ce748  guix-build-718d29af2339/output/x86_64-apple-darwin/bitcoin-718d29af2339-x86_64-apple-darwin-unsigned.tar.gz
> 3cf52eb02345dfc14039a7f37f49f0c0ea2c067a86b245981b767a2491e160c6  guix-build-718d29af2339/output/x86_64-apple-darwin/bitcoin-718d29af2339-x86_64-apple-darwin.tar.gz
> ```
> 
> Guix Build (arm64):
> ```bash
> 3451e31b7a3bb6c44c1cca70a954e82033894770396c625f2936b36cfdde3104  guix-build-718d29af2339/output/arm64-apple-darwin/SHA256SUMS.part
> 757095bb54b407c76c03d4bc1e4ddba9247c521c815293e33273212a1255f2d7  guix-build-718d29af2339/output/arm64-apple-darwin/bitcoin-718d29af2339-arm64-apple-darwin-unsigned.dmg
> 9f5c68f3310076eb1cfa15e8325f4ff81cb7c3929efe69d1ee3e4b40f65865fc  guix-build-718d29af2339/output/arm64-apple-darwin/bitcoin-718d29af2339-arm64-apple-darwin-unsigned.tar.gz
> d8ce004001d349be6b0ea20a6d59780ebdec4e8cca445f63da72c569d558ce4e  guix-build-718d29af2339/output/arm64-apple-darwin/bitcoin-718d29af2339-arm64-apple-darwin.tar.gz
> 6bbd4bdf2d90ab20ae4d6aa4e9a9cfef6e14f3784d0eda67fdbd0006f03a2feb  guix-build-718d29af2339/output/dist-archive/bitcoin-718d29af2339.tar.gz
> 6c8a22474864fefbcd3ad676f46f7c10696a2801f2315367b64975f55877702d  guix-build-718d29af2339/output/x86_64-apple-darwin/SHA256SUMS.part
> d9caf693e70876d30cef2a38a0e5a62f808903f51bd3c845107f6dfc4dcf7b80  guix-build-718d29af2339/output/x86_64-apple-darwin/bitcoin-718d29af2339-x86_64-apple-darwin-unsigned.dmg
> 1510f55407f61d6f1df2711b744bae6ba43ba926ff67b1eaafcb90415d8ce748  guix-build-718d29af2339/output/x86_64-apple-darwin/bitcoin-718d29af2339-x86_64-apple-darwin-unsigned.tar.gz
> 3cf52eb02345dfc14039a7f37f49f0c0ea2c067a86b245981b767a2491e160c6  guix-build-718d29af2339/output/x86_64-apple-darwin/bitcoin-718d29af2339-x86_64-apple-darwin.tar.gz
> ```

`https://github.com/bitcoin/bitcoin/pull/25605`