### PR TITLE
refactor: Remove unused CDataStream::rdbuf method

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -268,7 +268,6 @@ public:
     // Stream subset
     //
     bool eof() const             { return size() == 0; }
-    CDataStream* rdbuf()         { return this; }
     int in_avail() const         { return size(); }
 
     void SetType(int n)          { nType = n; }


### PR DESCRIPTION
> It is unused and seems unlikely to be ever used.

`https://github.com/bitcoin/bitcoin/pull/26258`