### PR TITLE
fs: fully initialize `_OVERLAPPED` for win32

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -123,7 +123,7 @@ bool FileLock::TryLock()
     if (hFile == INVALID_HANDLE_VALUE) {
         return false;
     }
-    _OVERLAPPED overlapped = {0};
+    _OVERLAPPED overlapped = {};
     if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
         reason = GetErrorReason();
         return false;


### PR DESCRIPTION
> ```bash
> fs.cpp: In member function ‘bool fsbridge::FileLock::TryLock()’:
> fs.cpp:129:32: error: missing initializer for member ‘_OVERLAPPED::InternalHigh’ [-Werror=missing-field-initializers]
>   129 |     _OVERLAPPED overlapped = {0};
>       |                                ^
> fs.cpp:129:32: error: missing initializer for member ‘_OVERLAPPED::<anonymous>’ [-Werror=missing-field-initializers]
> fs.cpp:129:32: error: missing initializer for member ‘_OVERLAPPED::hEvent’ [-Werror=missing-field-initializers]
> ```
> 
> Came up in #25972. That PR is now rebased on this change.
> 
> Closes: #26006

`https://github.com/bitcoin/bitcoin/pull/26090`