### PR TITLE
contrib: Check for `patch` command, Check for `wget` command

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2017-2019 The Bitcoin Core developers
+# Copyright (c) 2017-2021 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -65,6 +65,12 @@ http_get() {
 
   sha256_check "${3}" "${2}"
 }
+
+# Ensure the commands we use exist on the system
+if ! check_exists patch; then
+    echo "Command-line tool 'patch' not found.  Install patch and try again."
+    exit 1
+fi
 
 mkdir -p "${BDB_PREFIX}"
 http_get "${BDB_URL}" "${BDB_VERSION}.tar.gz" "${BDB_HASH}"

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -59,8 +59,11 @@ http_get() {
     echo "File ${2} already exists; not downloading again"
   elif check_exists curl; then
     curl --insecure --retry 5 "${1}" -o "${2}"
-  else
+  elif check_exists wget; then
     wget --no-check-certificate "${1}" -O "${2}"
+  else
+    echo "Simple transfer utilities 'curl' and 'wget' not found. Please install one of them and try again."
+    exit 1
   fi
 
   sha256_check "${3}" "${2}"
@@ -68,7 +71,7 @@ http_get() {
 
 # Ensure the commands we use exist on the system
 if ! check_exists patch; then
-    echo "Command-line tool 'patch' not found.  Install patch and try again."
+    echo "Command-line tool 'patch' not found. Install patch and try again."
     exit 1
 fi
 


### PR DESCRIPTION
> I found while running the contrib/install_db4.sh patch that it would fail suddenly with "patch: command not found". I'd rather see it fail early before doing any work, allow me to install the patch command, and then run again. (CentOS Linux) Here's a PR proposed to fix it.

Ref: https://github.com/bitcoin/bitcoin/pull/23579

> This PR is motivated by https://github.com/bitcoin/bitcoin/commit/7bb8eb0bc352b47ee962283898f9becbb4f36c62 commit (see also https://github.com/bitcoin/bitcoin/pull/23579) and ensures that install_db4.sh will check for curl and wget utilities. Currently, the conditional statement in the http_get() function assumes that wget is always available but we actually do not know it since there is no check or validation for the wget command. So let's make sure that we check for both commands and print an error message if they are missing.

Ref: https://github.com/bitcoin/bitcoin/pull/23658