### PR TITLE
util: Diagnose lib - Implement changes to solve crash on some Boost 1.66 machines

### DIFF
--- a/src/wallet/diagnose.cpp
+++ b/src/wallet/diagnose.cpp
@@ -4,6 +4,7 @@
 
 #include "diagnose.h"
 #include "net.h"
+#include "random.h"
 
 namespace DiagnoseLib {
 
@@ -12,14 +13,12 @@ bool Diagnose::m_researcher_mode = false;
 bool Diagnose::m_hasEligibleProjects = false;
 bool Diagnose::m_hasPoolProjects = false;
 bool Diagnose::m_configured_for_investor_mode = false;
-// const ResearcherModel* Diagnose::m_researcher_model = nullptr;
 std::unordered_map<Diagnose::TestNames, Diagnose*> Diagnose::m_name_to_test_map;
 CCriticalSection Diagnose::cs_diagnostictests;
 boost::asio::io_service Diagnose::s_ioService;
 
 /**
  * The function check the time is correct on your PC. It checks the skew in the clock.
- *
  */
 void VerifyClock::clkReportResults(const int64_t& time_offset, const bool& timeout_during_check)
 {
@@ -28,6 +27,8 @@ void VerifyClock::clkReportResults(const int64_t& time_offset, const bool& timeo
 
     if (!timeout_during_check) {
         if (abs64(time_offset) < 3 * 60) {
+            m_results_tip = "";
+            m_results_string = "";
             m_results = PASS;
         } else if (abs64(time_offset) < 5 * 60) {
             m_results_tip = "You should check your time and time zone settings for your computer.";
@@ -52,30 +53,9 @@ void VerifyClock::clkReportResults(const int64_t& time_offset, const bool& timeo
     m_startedTesting = false;
 }
 
-/*
- * Function that will be called when the Socket Send To is done
- */
-void VerifyClock::sockSendToHandle(
-    const boost::system::error_code& error, // Result of operation.
-    std::size_t bytes_transferred           // Number of bytes sent.
-)
-{
-    if (error) {
-        clkReportResults(0, true);
-    } else {
-        boost::asio::ip::udp::endpoint sender_endpoint;
-
-        m_udpSocket.async_receive_from(
-            boost::asio::buffer(m_recvBuf),
-            sender_endpoint,
-            boost::bind(&VerifyClock::sockRecvHandle, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-    }
-}
-
 void VerifyClock::sockRecvHandle(
     const boost::system::error_code& error, // Result of operation.
     std::size_t bytes_transferred           // Number of bytes received.
-
 )
 {
     if (error) {
@@ -86,29 +66,29 @@ void VerifyClock::sockRecvHandle(
             uint32_t DateTimeIn = reinterpret_cast<unsigned char>(m_recvBuf.at(nNTPCount)) + (reinterpret_cast<unsigned char>(m_recvBuf.at(nNTPCount + 1)) << 8) + (reinterpret_cast<unsigned char>(m_recvBuf.at(nNTPCount + 2)) << 16) + (reinterpret_cast<unsigned char>(m_recvBuf.at(nNTPCount + 3)) << 24);
             time_t tmit = ntohl(DateTimeIn) - 2208988800U;
 
-            m_udpSocket.close();
-
             boost::posix_time::ptime localTime = boost::posix_time::microsec_clock::universal_time();
             boost::posix_time::ptime networkTime = boost::posix_time::from_time_t(tmit);
             boost::posix_time::time_duration timeDiff = networkTime - localTime;
 
             clkReportResults(timeDiff.total_seconds());
 
-            return;
-        } else // The other state here is a socket or other indeterminate error such as a timeout (coming from clkSocketError).
-        {
+            // The timer cancel has to be here AND in timerHandle, because you need to cancel the
+            // timer if EITHER this completes first OR the 10 second timeout has happened, whichever
+            // occurs first. In the case that this completes very fast (which is most of the time),
+            // waiting 10 seconds for the timer to expire to report is not desirable.
+            m_timer.cancel();
+        } else { // The other state here is a socket or other indeterminate error.
             clkReportResults(0, true);
-
-            return;
         }
     }
+
     m_udpSocket.close();
 }
 
 void VerifyClock::timerHandle(
     const boost::system::error_code& error)
 {
-    if (m_startedTesting) {
+    if (m_startedTesting && error != boost::asio::error::operation_aborted) {
         m_udpSocket.close();
         m_timer.cancel();
         clkReportResults(0, true);
@@ -122,13 +102,17 @@ void VerifyClock::connectToNTPHost()
 {
     m_startedTesting = true;
     boost::asio::ip::udp::resolver resolver(s_ioService);
+
     try {
+        FastRandomContext rng;
+
+        std::string ntp_host = m_ntp_hosts[rng.randrange(m_ntp_hosts.size())];
+
 #if BOOST_VERSION > 106501
         // results_type is only in boost 1.66 and above.
         boost::asio::ip::udp::resolver::results_type receiver_endpoint;
 
-        receiver_endpoint = resolver.resolve(boost::asio::ip::udp::v4(),
-                                             "pool.ntp.org", "ntp");
+        receiver_endpoint = resolver.resolve(boost::asio::ip::udp::v4(), ntp_host, "ntp");
 
         if (receiver_endpoint == boost::asio::ip::udp::resolver::iterator()) {
             // If can not connect to server, then finish the test with a warning.
@@ -138,20 +122,37 @@ void VerifyClock::connectToNTPHost()
                 m_udpSocket.close();
             m_udpSocket.open(boost::asio::ip::udp::v4());
 
-            m_udpSocket.async_send_to(boost::asio::buffer(m_sendBuf), *receiver_endpoint,
-                                      boost::bind(&VerifyClock::sockSendToHandle, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
+            // Let's put the send here to reduce the complexity of this. No need for the send to be async.
+            size_t bytes_transferred = 0;
+
+            try {
+                bytes_transferred = m_udpSocket.send_to(boost::asio::buffer(m_sendBuf), *receiver_endpoint);
+            } catch (boost::system::error_code& e) {
+                clkReportResults(0, true);
+            }
+
+            if (bytes_transferred != 48) {
+                clkReportResults(0, true);
+            } else {
+                boost::asio::ip::udp::endpoint sender_endpoint;
+
+                m_udpSocket.async_receive_from(
+                    boost::asio::buffer(m_recvBuf),
+                    sender_endpoint,
+                    boost::bind(&VerifyClock::sockRecvHandle, this,
+                                boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
+            }
         }
 
 #else
         boost::asio::ip::udp::resolver::query query(
             boost::asio::ip::udp::v4(),
-            "pool.ntp.org",
+            ntp_host,
             "ntp");
 
         boost::asio::ip::udp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-        boost::asio::ip::udp::resolver::iterator end;
 
-        if (endpoint_iterator == end) {
+        if (endpoint_iterator == boost::asio::ip::udp::resolver::iterator()) {
             // If can not connect to server, then finish the test with a warning.
             clkReportResults(0, true);
         } else {
@@ -159,14 +160,30 @@ void VerifyClock::connectToNTPHost()
                 m_udpSocket.close();
             m_udpSocket.open(boost::asio::ip::udp::v4());
 
-            // There is only going to be one valid entry in the iterator.
-            m_udpSocket.async_send_to(boost::asio::buffer(m_sendBuf), *endpoint_iterator,
-                                      boost::bind(&VerifyClock::sockSendToHandle, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-        };
+            // Let's put the send here to reduce the complexity of this. No need for the send to be async.
+            size_t bytes_transferred = 0;
+
+            try {
+                bytes_transferred = m_udpSocket.send_to(boost::asio::buffer(m_sendBuf), *endpoint_iterator);
+            } catch (boost::system::error_code& e) {
+                clkReportResults(0, true);
+            }
+
+            if (bytes_transferred != 48) {
+                clkReportResults(0, true);
+            } else {
+                boost::asio::ip::udp::endpoint sender_endpoint;
+
+                m_udpSocket.async_receive_from(
+                    boost::asio::buffer(m_recvBuf),
+                    sender_endpoint,
+                    boost::bind(&VerifyClock::sockRecvHandle, this,
+                                boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
+            }
+        }
 #endif
     } catch (...) {
         clkReportResults(0, true);
-        return;
     }
 }
 

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -365,7 +365,7 @@ public:
             }
             clkReportResults(time_offset);
         } else {
-            m_timer.expires_after(std::chrono::seconds(10));
+            m_timer.expires_at(std::chrono::system_clock::now() + std::chrono::seconds(10));
             m_timer.async_wait(boost::bind(&VerifyClock::timerHandle, this, boost::asio::placeholders::error));
 
             connectToNTPHost();

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -16,7 +16,7 @@
 #include <atomic>
 #include <boost/asio.hpp>
 #include <boost/asio/ip/udp.hpp>
-#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/system_timer.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <iomanip>
@@ -333,7 +333,7 @@ class VerifyClock : public Diagnose
 private:
     std::vector<std::string> m_ntp_hosts = {"0.pool.ntp.org" , "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"};
     boost::asio::ip::udp::socket m_udpSocket;
-    boost::asio::steady_timer m_timer;
+    boost::asio::system_timer m_timer;
 
     boost::array<unsigned char, 48> m_sendBuf = {0x1b, 0, 0, 0, 0, 0, 0, 0, 0};
     boost::array<unsigned char, 1024> m_recvBuf;
@@ -364,13 +364,12 @@ public:
             }
             clkReportResults(time_offset);
         } else {
-            s_ioService.reset();
-
-            m_timer.expires_at(std::chrono::steady_clock::now() + std::chrono::seconds(10));
+            m_timer.expires_after(std::chrono::seconds(10));
             m_timer.async_wait(boost::bind(&VerifyClock::timerHandle, this, boost::asio::placeholders::error));
 
             connectToNTPHost();
 
+            s_ioService.reset();
             s_ioService.run();
         }
     }

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -338,6 +338,7 @@ private:
     boost::array<unsigned char, 48> m_sendBuf = {0x1b, 0, 0, 0, 0, 0, 0, 0, 0};
     boost::array<unsigned char, 1024> m_recvBuf;
     bool m_startedTesting = false;
+    boost::asio::ip::udp::endpoint m_sender_endpoint; // This has to be here to guarantee it is available for the callback
 
     void clkReportResults(const int64_t& time_offset, const bool& timeout_during_check = false);
     void sockRecvHandle(const boost::system::error_code& error, std::size_t bytes_transferred);

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -208,7 +208,7 @@ public:
                             "on the cause for no sync.";
         } else {
             m_results = Diagnose::PASS;
-            m_results_tip = "Passed";
+            m_results_tip = "";
         }
         m_results_string = "";
     }

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -408,6 +408,10 @@ public:
     }
 };
 
+/**
+ * Diagnose class to verify the BOINC path is accessible and the client_state.xml file is readable.
+ * Only run if the wallet is in research mode.
+ */
 class VerifyBoincPath : public Diagnose
 {
 public:

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -61,7 +61,7 @@ EXPECTED_BOOST_INCLUDES=(
     boost/asio/ip/udp.hpp
     boost/asio/ip/v6_only.hpp
     boost/asio/ssl.hpp
-    boost/asio/steady_timer.hpp
+    boost/asio/system_timer.hpp
     boost/assert.hpp
     boost/assign/list_inserter.hpp
     boost/assign/list_of.hpp

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -61,6 +61,7 @@ EXPECTED_BOOST_INCLUDES=(
     boost/asio/ip/udp.hpp
     boost/asio/ip/v6_only.hpp
     boost/asio/ssl.hpp
+    boost/asio/steady_timer.hpp
     boost/assert.hpp
     boost/assign/list_inserter.hpp
     boost/assign/list_of.hpp


### PR DESCRIPTION
Also straighten out timeout timer implementation. (Boost deadline timer is no longer recommended.)
Do a little cleanup.

The pool.ntp.org pool resolver does not seem to work well in all cases. This also implements a simple random selector that picks 0, 1, 2, and 3.pool.ntp.org randomly and appears to avoid timeouts better.