### PR TITLE
build: pass win32-dll to LT_INIT()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ AC_PROG_OBJCXX
 ])
 
 dnl Libtool init checks.
-LT_INIT([pic-only])
+LT_INIT([pic-only win32-dll])
 
 dnl Check/return PATH for base programs.
 AC_PATH_TOOL(AR, ar)


### PR DESCRIPTION
> This is the recommended way to support building PE DLLs with modern mingw toolchains and libtool. I made a similar change upstream in the secp256k1 repo. Note that we already pass `-no-undefined` to our libtool LDFLAGS.
> 
> > This option should be used if the package has been ported to build clean
> > dlls on win32 platforms.
> > If this macro is not used, libtool will assume that the package libraries
> > are not dll clean and will build only static libraries on win32 hosts.
> 
> See: https://www.gnu.org/software/libtool/manual/libtool.html#LT_005fINIT https://www.gnu.org/software/gnulib/manual/html_node/Libtool-and-Windows.html https://autotools.io/libtool/windows.html [bitcoin-core/secp256k1#923](https://github.com/bitcoin-core/secp256k1/issues/923)
> 

Ref: https://github.com/bitcoin/bitcoin/pull/24112