### PR TITLE
gui, voting: Implement information for wallet holder's votes on poll info cards

### DIFF
--- a/src/gridcoin/voting/result.h
+++ b/src/gridcoin/voting/result.h
@@ -5,6 +5,7 @@
 #ifndef GRIDCOIN_VOTING_RESULT_H
 #define GRIDCOIN_VOTING_RESULT_H
 
+#include "wallet/ismine.h"
 #include "gridcoin/cpid.h"
 #include "gridcoin/magnitude.h"
 #include "gridcoin/voting/fwd.h"
@@ -57,6 +58,7 @@ public:
         Weight m_amount;       //!< Total balance resolved for the vote.
         MiningId m_mining_id;  //!< CPID for the vote, if any.
         Magnitude m_magnitude; //!< Magnitude resolved for the vote.
+        isminetype m_ismine;         //!< True if the vote is from the wallet holder.
 
         //!
         //! \brief The selected poll choice offsets and the associated voting
@@ -75,6 +77,8 @@ public:
         //! \return \c true if the vote claims no balance or magnitude weight.
         //!
         bool Empty() const;
+
+        VoteDetail& operator=(const VoteDetail& b);
     };
 
     const Poll m_poll;                            //!< The poll associated with the result.
@@ -85,6 +89,8 @@ public:
     std::optional<double> m_vote_percent_avw;     //!< Vote weight percent of AVW.
     std::optional<bool> m_poll_results_validated; //!< Whether the poll's AVW is >= the minimum AVW for the poll.
     bool m_finished;                              //!< Whether the poll finished as of this result.
+    bool m_self_voted;                            //!< Whether the wallet holder voted.
+    VoteDetail m_self_vote_detail;                //!< The vote detail from the wallet holder's (last) vote
 
     //!
     //! \brief The aggregated voting weight tallied for each poll choice.

--- a/src/qt/forms/voting/pollcard.ui
+++ b/src/qt/forms/voting/pollcard.ui
@@ -101,38 +101,17 @@
         <property name="verticalSpacing">
          <number>3</number>
         </property>
-        <item row="1" column="4">
-         <widget class="QLabel" name="votePercentAVWTextLabel">
+        <item row="1" column="2">
+         <widget class="QLabel" name="totalWeightTextLabel">
           <property name="text">
-           <string>% of AVW:</string>
+           <string>Total Weight:</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="voteCountTextLabel">
+        <item row="1" column="5">
+         <widget class="QLabel" name="votePercentAVWLabel">
           <property name="text">
-           <string>Votes:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="expirationLabel">
-          <property name="text">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="expirationTextLabel">
-          <property name="text">
-           <string>Expiration:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="totalWeightLabel">
-          <property name="text">
-           <string notr="true"/>
+           <string/>
           </property>
          </widget>
         </item>
@@ -149,17 +128,10 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="3">
-         <widget class="QLabel" name="voteCountLabel">
+        <item row="1" column="0">
+         <widget class="QLabel" name="topAnswerTextLabel">
           <property name="text">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="totalWeightTextLabel">
-          <property name="text">
-           <string>Total Weight:</string>
+           <string>Top Answer:</string>
           </property>
          </widget>
         </item>
@@ -170,10 +142,45 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="topAnswerTextLabel">
+        <item row="1" column="4">
+         <widget class="QLabel" name="votePercentAVWTextLabel">
           <property name="text">
-           <string>Top Answer:</string>
+           <string>% of AVW:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="voteCountTextLabel">
+          <property name="text">
+           <string>Votes:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLabel" name="totalWeightLabel">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="expirationTextLabel">
+          <property name="text">
+           <string>Expiration:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QLabel" name="voteCountLabel">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="expirationLabel">
+          <property name="text">
+           <string notr="true"/>
           </property>
          </widget>
         </item>
@@ -184,8 +191,43 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="5">
-         <widget class="QLabel" name="votePercentAVWLabel">
+        <item row="2" column="1">
+         <widget class="QLabel" name="myLastVoteAnswerLabel">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="myLastVoteAnswerTextLabel">
+          <property name="text">
+           <string>Your Last Vote:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QLabel" name="myVoteWeightTextLabel">
+          <property name="text">
+           <string>Your Vote Weight:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLabel" name="myVoteWeightLabel">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="4">
+         <widget class="QLabel" name="myPercentAVWTextLabel">
+          <property name="text">
+           <string>Your % of AVW:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="5">
+         <widget class="QLabel" name="myPercentAVWLabel">
           <property name="text">
            <string/>
           </property>

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -33,6 +33,32 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
     ui->activeVoteWeightLabel->setText(QString::number(poll_item.m_active_weight));
     ui->votePercentAVWLabel->setText(QString::number(poll_item.m_vote_percent_AVW, 'f', 4) + '\%');
 
+    if (!poll_item.m_self_voted) {
+        ui->myLastVoteAnswerLabel->setText("No Vote");
+        ui->myVoteWeightLabel->setText("N/A");
+        ui->myPercentAVWLabel->setText("N/A");
+    } else {
+        QString choices_str;
+
+        int64_t my_total_weight = 0;
+
+        for (const auto& choice : poll_item.m_self_vote_detail.m_responses) {
+            if (!choices_str.isEmpty()) {
+                choices_str += ", " + QString(poll_item.m_choices[choice.first].m_label);
+            } else {
+                choices_str = QString(poll_item.m_choices[choice.first].m_label);
+            }
+
+            my_total_weight += choice.second / COIN;
+        }
+
+        ui->myLastVoteAnswerLabel->setText(choices_str);
+        ui->myVoteWeightLabel->setText(QString::number(my_total_weight));
+        if (poll_item.m_active_weight) ui->myPercentAVWLabel->setText(QString::number((double) my_total_weight
+                                                                                      / (double) poll_item.m_active_weight
+                                                                                      * (double) 100.0, 'f', 4) + '\%');
+    }
+
     if (!(poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE ||
           poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE_AND_MAGNITUDE)) {
         ui->balanceLabel->hide();

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -104,6 +104,11 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
             result->m_responses[i].m_weight / COIN);
     }
 
+    item.m_self_voted = result->m_self_voted;
+    if (result->m_self_voted) {
+        item.m_self_vote_detail = result->m_self_vote_detail;
+    }
+
     if (!result->m_votes.empty()) {
         item.m_top_answer = QString::fromStdString(result->WinnerLabel()).replace("_", " ");
     }

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -9,6 +9,7 @@
 #include "gridcoin/voting/filter.h"
 #include "qt/voting/poll_types.h"
 #include "gridcoin/voting/poll.h"
+#include "gridcoin/voting/result.h"
 
 #include <QDateTime>
 #include <QObject>
@@ -83,6 +84,8 @@ public:
     bool m_multiple_choice;
     std::vector<AdditionalFieldEntry> m_additional_field_entries;
     std::vector<VoteResultItem> m_choices;
+    bool m_self_voted;
+    GRC::PollResult::VoteDetail m_self_vote_detail;
 };
 
 //!


### PR DESCRIPTION
This small PR adds information for the wallet holder's vote for each poll on the poll card UI.

Here is an example of two polls on testnet. The walletholder has voted on the first one listed, but not yet on the second.
![image](https://user-images.githubusercontent.com/7529186/203903346-a5512c95-e232-4512-bab1-3c66e8f6a28e.png)

Here is an example of a wallet holder that voted for two choices in the second (multiple-choice) poll. Notice that both choices are listed. The "My Vote Weight" shows the total of both choices.
![image](https://user-images.githubusercontent.com/7529186/203903708-e98ca29d-c422-45fb-b06f-f2b37b885341.png)

The vote details show the vote weight distributed to each choice equally.
![image](https://user-images.githubusercontent.com/7529186/203903611-a0c054f8-545b-4a84-9633-6744549a1a02.png)
