### PR TITLE
build: update CI for linter and actions version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
             OS_NAME: linux
         steps:
         - name: checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: current time for cache
           run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
         - name: cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: |
                 ./depends/built
@@ -55,11 +55,11 @@ jobs:
             OS_NAME: macos
         steps:
         - name: checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: current time for cache
           run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
         - name: cache
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: |
                 ./ci/scratch/.ccache
@@ -87,9 +87,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - name: checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: setup-python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v3
           with:
             python-version: 3.9
         - name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         - name: setup-python
           uses: actions/setup-python@v2
           with:
-            python-version: 3.6
+            python-version: 3.9
         - name: lint
           run: |
             set -o errexit; source ./ci/lint/04_install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1040,7 +1040,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
    Fork is set to trigger at block 1420000.
  - Raise coinstake output count limit to 8 #1261 (@tomasbrod).
  - Port of Bitcoin hash implementation #1208 (@jamescowens).
- - Minor canges for the build documentation #1091 (@Lenni).
+ - Minor changes for the build documentation #1091 (@Lenni).
  - Allow sendmany to be used without an account specified #1158 (@Foggyx420).
 ### Fixed
  - Fix `cpids` and `validcpids` not returning the correct data #1233
@@ -1074,7 +1074,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
  - Compatibility with boost-1.67 (@denravonska)
  - Calculations to reduce network time offset (@jamescowens)
  - Feedback for addnode RPC command (@tomasbrod)
- - Added data acquisiton commands (@tomasbrod):
+ - Added data acquisition commands (@tomasbrod):
     - getrecentblocks
     - exportstats1
     - getsupervotes
@@ -1409,7 +1409,7 @@ Internal test version used to sort out the forks.
 
 ### Fixed
  - High CPU usage #349 (@tomasbrod)
- - Repetetive block signing #295 (@tomasbrod)
+ - Repetitive block signing #295 (@tomasbrod)
  - Staking creates 1 cent output #311 (@tomasbrod)
  - Client no longer has to be restarted for a beacon to activate #253
    (@Foggyx420).

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -6,11 +6,11 @@
 
 export LC_ALL=C
 
-./ci/retry/retry sudo apt update && sudo apt install -y clang-format-9
-sudo update-alternatives --install /usr/bin/clang-format      clang-format      $(which clang-format-9     ) 100
-sudo update-alternatives --install /usr/bin/clang-format-diff clang-format-diff $(which clang-format-diff-9) 100
+./ci/retry/retry sudo apt update && sudo apt install -y clang-format-14
+sudo update-alternatives --install /usr/bin/clang-format      clang-format      $(which clang-format-14     ) 100
+sudo update-alternatives --install /usr/bin/clang-format-diff clang-format-diff $(which clang-format-diff-14) 100
 
-./ci/retry/retry pip3 install codespell==2.1.0
+./ci/retry/retry pip3 install codespell==2.2.2
 ./ci/retry/retry pip3 install flake8==4.0.1
 ./ci/retry/retry pip3 install mypy==0.942
 ./ci/retry/retry pip3 install vulture==2.3

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -297,7 +297,7 @@ bool AppInit(int argc, char* argv[])
                 if (token) { // Success
                     exit(EXIT_SUCCESS);
                 } else { // fRet = false or token read error (premature exit).
-                    tfm::format(std::cerr, "Error during initializaton - check debug.log for details\n");
+                    tfm::format(std::cerr, "Error during initialization - check debug.log for details\n");
                     exit(EXIT_FAILURE);
                 }
             }

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -24,3 +24,5 @@ nin
 inout
 smoe
 sur
+clen
+siz


### PR DESCRIPTION
The CI environment no longer has Python 3.6. Update to use 3.9. Also update clang-format to 14, codespell to 2.2.2, and also update actions version in ci.yml to v3.

Note that BitCoin core has removed clang-format altogether from the linter, so @div72 or @barton2526 will put up a PR in the future to remove it here too.