### PR TITLE
build: Change actions runner image to Focal, Force Lint to use 22.04, Change cd runner version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,11 +18,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: current time for cache
         run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
       - name: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
               ./depends/built

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             ./ci/test_run_all.sh
     lint:
         name: Lint
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
         - name: checkout
           uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 jobs:
     test-linux:
         name: ${{ matrix.name }}
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         strategy:
             matrix:
                 include:


### PR DESCRIPTION
This addresses the CI linter failure we have been seeing on forks. GitHub is currently [phasing in 22.04](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/), but it is not always used. Since we require 22.04 for clang-format-14, force it.

While researching this, I found that Github is [deprecating Bionic's runner](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) tomorrow. Let's update that to Focal.

Also addresses the cd runner version which was missed in #2606 