### PR TITLE
gui: don't show datadir error msgbox if arg isn't specified

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -229,13 +229,15 @@ std::optional<std::string> ReadClientStateXml()
 
     LogPrintf("WARNING: Unable to obtain BOINC CPIDs.");
 
-    uiInterface.ThreadSafeMessageBox(strprintf("Could not access BOINC data directory \"%s\". "
-                                               "Please check that the directory exists and check the directory "
-                                               "and client_state.xml file permissions.",
-                                               path.string()),
-                                     "", CClientUIInterface::ICON_ERROR
-                                     | CClientUIInterface::BTN_OK
-                                     | CClientUIInterface::MODAL);
+    if (!path.empty()) {
+        uiInterface.ThreadSafeMessageBox(strprintf("Could not access BOINC data directory \"%s\". "
+                                                   "Please check that the directory exists and check the directory "
+                                                   "and client_state.xml file permissions.",
+                                                   path.string()),
+                                         "Error", CClientUIInterface::ICON_ERROR
+                                         | CClientUIInterface::BTN_OK
+                                         | CClientUIInterface::MODAL);
+    }
 
     return std::nullopt;
 }


### PR DESCRIPTION
Pre-#2524 ReadClientStateXml only logged the failure of trying to access client_state.xml, however in that commit this behaviour was changed to create a message box. This is sub-optimal experience for new users who have not yet installed BOINC, people aiming to go Folding@Home only if the poll passes and me who does development work on a secondary device where the datadir is constantly discarded.

Also the caption is set as message boxes are shown as `{caption}: {message}` to CLI users.