### PR TITLE
voting: Optimize poll locks

### DIFF
--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -256,7 +256,9 @@ public:
     {
         // Don't reset the beacon registry as it is now backed by a database.
         // GetBeaconRegistry().Reset();
-        GetPollRegistry().Reset();
+
+        // Don't reset the poll registry as reorgs are properly handled.
+        // GetPollRegistry().Reset();
         GetWhitelist().Reset();
         m_appcache_handler.Reset();
     }
@@ -458,7 +460,7 @@ void GRC::ReplayContracts(CBlockIndex* pindex_end, CBlockIndex* pindex_start)
 
     LogPrint(BCLog::LogFlags::CONTRACT,	"Replaying contracts from block %" PRId64 "...", pindex->nHeight);
 
-    // This no longer includes beacons.
+    // This no longer includes beacons or polls.
     g_dispatcher.ResetHandlers();
 
     BeaconRegistry& beacons = GetBeaconRegistry();

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -620,6 +620,8 @@ void GRC::ApplyContracts(
             }
         }
 
+        // Note that for polls and votes, this rescan could overlap contracts already recorded. The handlers for polls/votes
+        // check for the existence of contracts already recorded and will prevent a double application.
         g_dispatcher.Apply({ contract, tx, pindex });
 
         // Don't track transaction message contracts in the block index:

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -954,8 +954,6 @@ void PollRegistry::Add(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_m
     } else {
         AddPoll(ctx);
     }
-
-    DetectReorg();
  }
 
 void PollRegistry::Delete(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -1075,31 +1073,23 @@ void PollRegistry::DeleteVote(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIR
 }
 
 void PollRegistry::DetectReorg()
-EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Reorg detector
     // Note that doing the reorg detection here, in the contract handler, means that we only flag a reorg IF
     // a transaction happened to occur that involves a poll or vote contract in the scope of the reorg, because
     // these handlers are only triggered by those two contract types.
-    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: registry_traversal_in_progress = %u, reorg_occurred_during_reg_traversal = %u, "
-                                    "m_block_height_hw = %i, nBestHeight = %i",
+    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: registry_traversal_in_progress = %u, reorg_occurred_during_reg_traversal = %u, ",
              __func__,
              registry_traversal_in_progress,
-             reorg_occurred_during_reg_traversal,
-             m_block_height_hw,
-             nBestHeight);
+             reorg_occurred_during_reg_traversal
+             );
 
-    if (registry_traversal_in_progress && nBestHeight < m_block_height_hw) {
+    if (registry_traversal_in_progress && g_reorg_in_progress) {
         reorg_occurred_during_reg_traversal = true;
         LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: Setting reorg_occurred_during_reg_traversal to true.", __func__);
     } else {
         reorg_occurred_during_reg_traversal = false;
         LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: Setting reorg_occurred_during_reg_traversal to false.", __func__);
-    }
-
-    if (nBestHeight > m_block_height_hw) {
-        m_block_height_hw = nBestHeight;
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: Setting m_block_height_hw to nBestHeight", __func__);
     }
 }
 // -----------------------------------------------------------------------------

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -296,7 +296,7 @@ PollRegistry& GRC::GetPollRegistry()
 
 std::string GRC::GetCurrentPollTitle()
 {
-    LOCK(cs_main);
+    LOCK(GetPollRegistry().cs_poll_registry);
 
     if (const PollReference* poll_ref = GetPollRegistry().TryLatestActive()) {
         return poll_ref->Title();
@@ -323,9 +323,8 @@ ClaimMessage GRC::PackPollMessage(const Poll& poll, const CTransaction& tx)
 // -----------------------------------------------------------------------------
 // Class: PollReference
 // -----------------------------------------------------------------------------
-
 PollReference::PollReference()
-    : m_ptxid(nullptr)
+    : m_txid(uint256{})
     , m_payload_version(0)
     , m_type(PollType::UNKNOWN)
     , m_ptitle(nullptr)
@@ -338,7 +337,7 @@ PollOption PollReference::TryReadFromDisk(CTxDB& txdb) const
 {
     CTransaction tx;
 
-    if (!txdb.ReadDiskTx(*m_ptxid, tx)) {
+    if (!txdb.ReadDiskTx(m_txid, tx)) {
         error("%s: failed to read poll tx from disk", __func__);
         return std::nullopt;
     }
@@ -366,11 +365,7 @@ PollOption PollReference::TryReadFromDisk() const
 
 uint256 PollReference::Txid() const
 {
-    if (!m_ptxid) {
-        return uint256();
-    }
-
-    return *m_ptxid;
+    return m_txid;
 }
 
 uint32_t PollReference::GetPollPayloadVersion() const
@@ -422,12 +417,12 @@ int64_t PollReference::Expiration() const
     return m_timestamp + (int64_t) (m_duration_days * 86400);
 }
 
-CBlockIndex* PollReference::GetStartingBlockIndexPtr() const
+CBlockIndex* PollReference::GetStartingBlockIndexPtr() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     uint256 block_hash;
     CTransaction tx;
 
-    GetTransaction(*m_ptxid, tx, block_hash);
+    GetTransaction(m_txid, tx, block_hash);
 
     auto iter = mapBlockIndex.find(block_hash);
 
@@ -438,7 +433,7 @@ CBlockIndex* PollReference::GetStartingBlockIndexPtr() const
     return iter->second;
 }
 
-CBlockIndex* PollReference::GetEndingBlockIndexPtr(CBlockIndex* pindex_start) const
+CBlockIndex* PollReference::GetEndingBlockIndexPtr(CBlockIndex* pindex_start) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!pindex_start) {
         pindex_start = GetStartingBlockIndexPtr();
@@ -458,7 +453,7 @@ CBlockIndex* PollReference::GetEndingBlockIndexPtr(CBlockIndex* pindex_start) co
     return nullptr;
 }
 
-std::optional<int> PollReference::GetStartingHeight() const
+std::optional<int> PollReference::GetStartingHeight() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const CBlockIndex* pindex = GetStartingBlockIndexPtr();
 
@@ -469,7 +464,7 @@ std::optional<int> PollReference::GetStartingHeight() const
     return std::nullopt;
 }
 
-std::optional<int> PollReference::GetEndingHeight() const
+std::optional<int> PollReference::GetEndingHeight() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CBlockIndex* pindex = GetEndingBlockIndexPtr();
 
@@ -484,6 +479,9 @@ std::optional<CAmount> PollReference::GetActiveVoteWeight(const PollResultOption
 {
     // Instrument this so we can log real time performance.
     g_timer.InitTimer(__func__, LogInstance().WillLogCategory(BCLog::LogFlags::VOTE));
+
+    // Unfortunately, cs_main must be locked for the duration of this method, because it uses the chain index pointers.
+    LOCK(cs_main);
 
     // Get the start and end of the poll.
     CBlockIndex* const pindex_start = GetStartingBlockIndexPtr();
@@ -731,13 +729,14 @@ void PollReference::UnlinkVote(const uint256 txid)
 // -----------------------------------------------------------------------------
 // Class: PollRegistry
 // -----------------------------------------------------------------------------
-
 const PollRegistry::Sequence PollRegistry::Polls() const
 {
+    LOCK(GetPollRegistry().cs_poll_registry);
+
     return Sequence(m_polls);
 }
 
-const PollReference* PollRegistry::TryLatestActive() const
+const PollReference* PollRegistry::TryLatestActive() const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     int64_t now = GetAdjustedTime();
 
@@ -764,7 +763,7 @@ const PollReference* PollRegistry::TryLatestActive() const
     return latest_not_expired;
 }
 
-const PollReference* PollRegistry::TryByTxid(const uint256 txid) const
+const PollReference* PollRegistry::TryByTxid(const uint256 txid) const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     const auto iter = m_polls_by_txid.find(txid);
 
@@ -775,12 +774,12 @@ const PollReference* PollRegistry::TryByTxid(const uint256 txid) const
     return iter->second;
 }
 
-PollReference* PollRegistry::TryBy(const uint256 txid)
+PollReference* PollRegistry::TryBy(const uint256 txid) EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return const_cast<PollReference*>(TryByTxid(txid));
 }
 
-const PollReference* PollRegistry::TryByTitle(const std::string& title) const
+const PollReference* PollRegistry::TryByTitle(const std::string& title) const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     const auto iter = m_polls.find(title);
 
@@ -791,12 +790,13 @@ const PollReference* PollRegistry::TryByTitle(const std::string& title) const
     return &iter->second;
 }
 
-PollReference* PollRegistry::TryBy(const std::string& title)
+PollReference* PollRegistry::TryBy(const std::string& title) EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return const_cast<PollReference*>(TryByTitle(title));
 }
 
 const PollReference* PollRegistry::TryByTxidWithAddHistoricalPollAndVotes(const uint256 txid)
+EXCLUSIVE_LOCKS_REQUIRED(cs_main, PollRegistry::cs_poll_registry)
 {
     // Check and see if it is already in the registry and return the existing ref immediately if found. (This is
     // the equivalent of the plain TryByTxid() functionality.)
@@ -883,9 +883,13 @@ const PollReference* PollRegistry::TryByTxidWithAddHistoricalPollAndVotes(const 
 
 void PollRegistry::Reset()
 {
+    LOCK(cs_poll_registry);
+
     m_polls.clear();
     m_polls_by_txid.clear();
     m_latest_poll = nullptr;
+    registry_traversal_in_progress = false;
+    reorg_occurred_during_reg_traversal = false;
 }
 
 bool PollRegistry::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const
@@ -939,17 +943,27 @@ bool PollRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
     return Validate(ctx.m_contract, ctx.m_tx, DoS);
 }
 
-void PollRegistry::Add(const ContractContext& ctx)
+void PollRegistry::Add(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    LOCK(cs_poll_registry);
+
+    DetectReorg();
+
     if (ctx->m_type == ContractType::VOTE) {
         AddVote(ctx);
     } else {
         AddPoll(ctx);
     }
-}
 
-void PollRegistry::Delete(const ContractContext& ctx)
+    DetectReorg();
+ }
+
+void PollRegistry::Delete(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    LOCK(cs_poll_registry);
+
+    DetectReorg();
+
     if (ctx->m_type == ContractType::VOTE) {
         DeleteVote(ctx);
     } else {
@@ -957,7 +971,7 @@ void PollRegistry::Delete(const ContractContext& ctx)
     }
 }
 
-void PollRegistry::AddPoll(const ContractContext& ctx)
+void PollRegistry::AddPoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main, PollRegistry::cs_poll_registry)
 {
     const auto payload = ctx->SharePayloadAs<PollPayload>();
     std::string poll_title = payload->m_poll.m_title;
@@ -982,7 +996,7 @@ void PollRegistry::AddPoll(const ContractContext& ctx)
         m_latest_poll = &poll_ref;
 
         auto result_pair = m_polls_by_txid.emplace(ctx.m_tx.GetHash(), &poll_ref);
-        poll_ref.m_ptxid = &result_pair.first->first;
+        poll_ref.m_txid = result_pair.first->first;
 
         if (fQtActive && !poll_ref.Expired(GetAdjustedTime())) {
             uiInterface.NewPollReceived(poll_ref.Time());
@@ -990,7 +1004,7 @@ void PollRegistry::AddPoll(const ContractContext& ctx)
     }
 }
 
-void PollRegistry::AddVote(const ContractContext& ctx)
+void PollRegistry::AddVote(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main, PollRegistry::cs_poll_registry)
 {
     if (ctx->m_version >= 2) {
         const auto vote = ctx->SharePayloadAs<Vote>();
@@ -1022,7 +1036,7 @@ void PollRegistry::AddVote(const ContractContext& ctx)
     }
 }
 
-void PollRegistry::DeletePoll(const ContractContext& ctx)
+void PollRegistry::DeletePoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main, PollRegistry::cs_poll_registry)
 {
     const auto payload = ctx->SharePayloadAs<PollPayload>();
 
@@ -1036,7 +1050,7 @@ void PollRegistry::DeletePoll(const ContractContext& ctx)
     m_latest_poll = nullptr;
 }
 
-void PollRegistry::DeleteVote(const ContractContext& ctx)
+void PollRegistry::DeleteVote(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main, PollRegistry::cs_poll_registry)
 {
     if (ctx->m_version >= 2) {
         const auto vote = ctx->SharePayloadAs<Vote>();
@@ -1060,23 +1074,51 @@ void PollRegistry::DeleteVote(const ContractContext& ctx)
     }
 }
 
+void PollRegistry::DetectReorg()
+EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    // Reorg detector
+    // Note that doing the reorg detection here, in the contract handler, means that we only flag a reorg IF
+    // a transaction happened to occur that involves a poll or vote contract in the scope of the reorg, because
+    // these handlers are only triggered by those two contract types.
+    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: registry_traversal_in_progress = %u, reorg_occurred_during_reg_traversal = %u, "
+                                    "m_block_height_hw = %i, nBestHeight = %i",
+             __func__,
+             registry_traversal_in_progress,
+             reorg_occurred_during_reg_traversal,
+             m_block_height_hw,
+             nBestHeight);
+
+    if (registry_traversal_in_progress && nBestHeight < m_block_height_hw) {
+        reorg_occurred_during_reg_traversal = true;
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: Setting reorg_occurred_during_reg_traversal to true.", __func__);
+    } else {
+        reorg_occurred_during_reg_traversal = false;
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: Setting reorg_occurred_during_reg_traversal to false.", __func__);
+    }
+
+    if (nBestHeight > m_block_height_hw) {
+        m_block_height_hw = nBestHeight;
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: Setting m_block_height_hw to nBestHeight", __func__);
+    }
+}
 // -----------------------------------------------------------------------------
 // Class: PollRegistry::Sequence
 // -----------------------------------------------------------------------------
 
 using Sequence = PollRegistry::Sequence;
 
-Sequence::Sequence(const PollMapByTitle& polls, const FilterFlag flags)
+Sequence::Sequence(const PollMapByTitle& polls, const FilterFlag flags) EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
     : m_polls(polls), m_flags(flags)
 {
 }
 
-Sequence Sequence::Where(const FilterFlag flags) const
+Sequence Sequence::Where(const FilterFlag flags) const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return Sequence(m_polls, flags);
 }
 
-Sequence Sequence::OnlyActive(const bool active_only) const
+Sequence Sequence::OnlyActive(const bool active_only) const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     int flags = m_flags;
 
@@ -1087,7 +1129,7 @@ Sequence Sequence::OnlyActive(const bool active_only) const
     return Sequence(m_polls, static_cast<FilterFlag>(flags));
 }
 
-Sequence::Iterator Sequence::begin() const
+Sequence::Iterator Sequence::begin() const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     int64_t now = 0;
 
@@ -1098,7 +1140,7 @@ Sequence::Iterator Sequence::begin() const
     return Iterator(m_polls.begin(), m_polls.end(), m_flags, now);
 }
 
-Sequence::Iterator Sequence::end() const
+Sequence::Iterator Sequence::end() const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return Iterator(m_polls.end());
 }
@@ -1126,12 +1168,12 @@ Iterator::Iterator(BaseIterator end) : m_iter(end), m_end(end)
 {
 }
 
-const PollReference& Iterator::Ref() const
+const PollReference& Iterator::Ref() const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return m_iter->second;
 }
 
-PollOption Iterator::TryPollFromDisk() const
+PollOption Iterator::TryPollFromDisk() const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return m_iter->second.TryReadFromDisk();
 }
@@ -1146,7 +1188,7 @@ Iterator::pointer Iterator::operator->() const
     return this;
 }
 
-Iterator& Iterator::operator++()
+Iterator& Iterator::operator++() EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     ++m_iter;
     SeekNextMatch();
@@ -1154,7 +1196,7 @@ Iterator& Iterator::operator++()
     return *this;
 }
 
-Iterator Iterator::operator++(int)
+Iterator Iterator::operator++(int) EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     Iterator copy(*this);
     ++(*this);
@@ -1162,17 +1204,17 @@ Iterator Iterator::operator++(int)
     return copy;
 }
 
-bool Iterator::operator==(const Iterator& other) const
+bool Iterator::operator==(const Iterator& other) const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return m_iter == other.m_iter;
 }
 
-bool Iterator::operator!=(const Iterator& other) const
+bool Iterator::operator!=(const Iterator& other) const EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     return m_iter != other.m_iter;
 }
 
-void Iterator::SeekNextMatch()
+void Iterator::SeekNextMatch() EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     if (m_flags == FilterFlag::NO_FILTER) {
         return;

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -427,7 +427,6 @@ public:
     //!
     void DetectReorg();
 
-    std::atomic<int> m_block_height_hw = 0;                        //!< High water block height from contracts.
     std::atomic<bool> registry_traversal_in_progress = false;      //!< Boolean that registry traversal is in progress.
     std::atomic<bool> reorg_occurred_during_reg_traversal = false; //!< Boolean to indicate whether a reorg occurred.
 

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -8,12 +8,25 @@
 #include "gridcoin/contract/handler.h"
 #include "gridcoin/voting/filter.h"
 #include "gridcoin/voting/fwd.h"
+#include "sync.h"
 #include "uint256.h"
+#include <atomic>
 #include <map>
 
 class CTxDB;
 
 namespace GRC {
+
+//!
+//! \brief Thrown when a reorg/fork occurs during a poll registry traversal.
+//!
+class InvalidDuetoReorgFork : public std::exception
+{
+public:
+    InvalidDuetoReorgFork()
+    {
+    }
+};
 
 class Contract;
 class PollRegistry;
@@ -162,7 +175,7 @@ public:
     void UnlinkVote(const uint256 txid);
 
 private:
-    const uint256* m_ptxid;       //!< Hash of the poll transaction.
+    uint256 m_txid;               //!< Hash of the poll transaction.
     uint32_t m_payload_version;   //!< Version of the poll (payload).
     PollType m_type;              //!< Type of the poll.
     const std::string* m_ptitle;  //!< Title of the poll.
@@ -183,6 +196,8 @@ class PollRegistry : public IContractHandler
 public:
     using PollMapByTitle = std::map<std::string, PollReference>;
     using PollMapByTxid = std::map<uint256, PollReference*>;
+
+    CCriticalSection cs_poll_registry;  //!< Lock for poll registry.
 
     //!
     //! \brief A traversable, immutable sequence of the polls in the registry.
@@ -267,10 +282,10 @@ public:
             bool operator!=(const Iterator& other) const;
 
         private:
-            BaseIterator m_iter; //!< The current position.
-            BaseIterator m_end;  //!< Element after the end of the sequence.
-            FilterFlag m_flags;  //!< Attributes to filter polls by.
-            int64_t m_now;       //!< Current time in seconds.
+            BaseIterator m_iter GUARDED_BY(cs_poll_registry); //!< The current position.
+            BaseIterator m_end GUARDED_BY(cs_poll_registry);  //!< Element after the end of the sequence.
+            FilterFlag m_flags GUARDED_BY(cs_poll_registry);  //!< Attributes to filter polls by.
+            int64_t m_now GUARDED_BY(cs_poll_registry);       //!< Current time in seconds.
 
             //!
             //! \brief Advance the iterator to the next item that matches the
@@ -314,8 +329,8 @@ public:
         Iterator end() const;
 
     private:
-        const PollMapByTitle& m_polls; //!< Poll references in the registry.
-        FilterFlag m_flags;            //!< Attributes to filter polls by.
+        const PollMapByTitle& m_polls GUARDED_BY(cs_poll_registry) ; //!< Poll references in the registry.
+        FilterFlag m_flags GUARDED_BY(cs_poll_registry) ;            //!< Attributes to filter polls by.
     }; // Sequence
 
     //!
@@ -407,10 +422,19 @@ public:
     //!
     void Delete(const ContractContext& ctx) override;
 
+    //!
+    //! \brief Detect reorganizations that would affect registry traversal.
+    //!
+    void DetectReorg();
+
+    std::atomic<int> m_block_height_hw = 0;                        //!< High water block height from contracts.
+    std::atomic<bool> registry_traversal_in_progress = false;      //!< Boolean that registry traversal is in progress.
+    std::atomic<bool> reorg_occurred_during_reg_traversal = false; //!< Boolean to indicate whether a reorg occurred.
+
 private:
-    PollMapByTitle m_polls;             //!< Poll references keyed by title.
-    PollMapByTxid m_polls_by_txid;      //!< Poll references keyed by TXID.
-    const PollReference* m_latest_poll; //!< Cache for the most recent poll.
+    PollMapByTitle m_polls GUARDED_BY(cs_poll_registry);             //!< Poll references keyed by title.
+    PollMapByTxid m_polls_by_txid GUARDED_BY(cs_poll_registry);      //!< Poll references keyed by TXID.
+    const PollReference* m_latest_poll GUARDED_BY(cs_poll_registry); //!< Cache for the most recent poll.
 
     //!
     //! \brief Get the poll with the specified title.

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -169,6 +169,8 @@ public:
     //!
     VoteDetail Resolve(const VoteCandidate& candidate)
     {
+        g_timer.GetTimes(std::string{"Begin "} + std::string{__func__}, "buildPollTable");
+
         const Vote& vote = candidate.Vote();
         const ClaimMessage message = candidate.PackMessage();
 
@@ -181,6 +183,7 @@ public:
             detail.m_magnitude = Resolve(vote.m_claim.m_magnitude_claim, message);
         }
 
+        g_timer.GetTimes(std::string{"End "} + std::string{__func__}, "buildPollTable");
         return detail;
     }
 
@@ -802,6 +805,8 @@ public:
     //!
     void CountVotes(PollResult& result, const std::vector<uint256>& vote_txids)
     {
+        g_timer.GetTimes(std::string{"Begin "} + std::string{__func__}, "buildPollTable");
+
         m_votes.reserve(vote_txids.size());
 
         for (const auto& txid : reverse_iterate(vote_txids)) {
@@ -821,6 +826,8 @@ public:
         }
 
         result.m_pools_voted = m_pools_voted;
+
+        g_timer.GetTimes(std::string{"End "} + std::string{__func__}, "buildPollTable");
     }
 
 private:
@@ -913,6 +920,8 @@ private:
     //!
     void ProcessVote(const VoteCandidate& candidate)
     {
+        g_timer.GetTimes(std::string{"Begin "} + std::string{__func__}, "buildPollTable");
+
         VoteDetail detail = m_resolver.Resolve(candidate);
 
         if (detail.Empty()) {
@@ -950,6 +959,8 @@ private:
         }
 
         m_votes.emplace_back(std::move(detail));
+
+        g_timer.GetTimes(std::string{"End "} + std::string{__func__}, "buildPollTable");
     }
 
     //!
@@ -1133,6 +1144,8 @@ PollResult::PollResult(Poll poll)
 
 PollResultOption PollResult::BuildFor(const PollReference& poll_ref)
 {
+    g_timer.GetTimes(std::string{"Begin "} + std::string{__func__}, "buildPollTable");
+
     if (PollOption poll = poll_ref.TryReadFromDisk()) {
         CTxDB txdb("r");
         PollResult result(std::move(*poll));
@@ -1165,8 +1178,12 @@ PollResultOption PollResult::BuildFor(const PollReference& poll_ref)
             }
         }
 
+        g_timer.GetTimes(std::string{"End "} + std::string{__func__}, "buildPollTable");
+
         return result;
     }
+
+    g_timer.GetTimes(std::string{"End "} + std::string{__func__}, "buildPollTable");
 
     return std::nullopt;
 }

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -1167,6 +1167,9 @@ PollResultOption PollResult::BuildFor(const PollReference& poll_ref)
                 ResolveMoneySupplyForPoll(result.m_poll));
         }
 
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: number of votes = %u for poll %s",
+                 __func__, poll_ref.Votes().size(), result.m_poll.m_title);
+
         counter.CountVotes(result, poll_ref.Votes());
 
         if (auto active_vote_weight = poll_ref.GetActiveVoteWeight(result)) {

--- a/src/main.h
+++ b/src/main.h
@@ -85,6 +85,7 @@ extern int nBestHeight;
 extern arith_uint256 nBestChainTrust;
 extern uint256 hashBestChain;
 extern CBlockIndex* pindexBest;
+extern std::atomic<bool> g_reorg_in_progress;
 extern const std::string strMessageMagic;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -2,7 +2,7 @@
 #include <QListView>
 
 #include "overviewpage.h"
-#include "ui_overviewpage.h"
+#include "forms/ui_overviewpage.h"
 
 #ifndef Q_MOC_RUN
 #include "qt/decoration.h"

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -43,6 +43,8 @@ void NewPollReceived(VotingModel* model, int64_t poll_time)
 
 std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& iter)
 {
+    g_timer.GetTimes(std::string{"Begin "} + std::string{__func__}, "buildPollTable");
+
     const PollReference& ref = iter->Ref();
     const PollResultOption result = PollResult::BuildFor(ref);
 
@@ -113,6 +115,7 @@ std::optional<PollItem> BuildPollItem(const PollRegistry::Sequence::Iterator& it
         item.m_top_answer = QString::fromStdString(result->WinnerLabel()).replace("_", " ");
     }
 
+    g_timer.GetTimes(std::string{"End "} + std::string{__func__}, "buildPollTable");
     return item;
 }
 } // Anonymous namespace
@@ -237,16 +240,20 @@ QStringList VotingModel::getActiveProjectUrls() const
 
 std::vector<PollItem> VotingModel::buildPollTable(const PollFilterFlag flags) const
 {
+    g_timer.InitTimer(__func__, LogInstance().WillLogCategory(BCLog::LogFlags::VOTE));
+    g_timer.GetTimes(std::string{"Begin "} + std::string{__func__}, __func__);
+
     std::vector<PollItem> items;
 
     LOCK(cs_main);
 
     for (const auto& iter : m_registry.Polls().Where(flags)) {
-        if (std::optional<PollItem> item = BuildPollItem(iter)) {
+         if (std::optional<PollItem> item = BuildPollItem(iter)) {
             items.push_back(std::move(*item));
         }
     }
 
+    g_timer.GetTimes(std::string{"End "} + std::string{__func__}, __func__);
     return items;
 }
 

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -14,6 +14,7 @@
 #include "gridcoin/voting/result.h"
 #include "gridcoin/voting/payloads.h"
 #include "logging.h"
+#include "main.h"
 #include "qt/clientmodel.h"
 #include "qt/voting/votingmodel.h"
 #include "qt/walletmodel.h"
@@ -245,13 +246,73 @@ std::vector<PollItem> VotingModel::buildPollTable(const PollFilterFlag flags) co
 
     std::vector<PollItem> items;
 
-    LOCK(cs_main);
+    m_registry.registry_traversal_in_progress = true;
 
-    for (const auto& iter : m_registry.Polls().Where(flags)) {
-         if (std::optional<PollItem> item = BuildPollItem(iter)) {
-            items.push_back(std::move(*item));
+    bool fork_reorg_during_run = false;
+
+    // We do up to three tries if there was a reorg/fork during the middle of the run. This is more than enough.
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+        for (const auto& iter : WITH_LOCK(m_registry.cs_poll_registry, return m_registry.Polls().Where(flags))) {
+            // Note that we are implementing a coarse-grained fork/rollback detector here.
+            // We do this because we have eliminated the cs_main lock to free up the GUI.
+            // Instead we have reversed the locking scheme and have the contract actions (add/delete)
+            // place a lock on cs_poll_registry when they make an update. This preserves the integrity
+            // of the registry itself. It also will preserve the integrity of transaction access in leveldb,
+            // PROVIDED that a rollback/reorg has not happened during this run. The main state
+            // will not change during the individual BuildPollItem calls, because BuildPollItem places
+            // a lock on cs_poll_registry for its duration. This means a contract change from the
+            // contract interface handler will block on it, given that it also puts a lock on
+            // cs_poll_registry. I am a little worried about holding up main for this, but that was happening
+            // on a recursive lock on cs_main before for the ENTIRE run, and this is certainly better.
+            // Transactions that have not been rolled back by a reorg can be safely accessed for reading
+            // by another thread as we are doing here.
+
+            try {
+                if (std::optional<PollItem> item = BuildPollItem(iter)) {
+                    items.push_back(std::move(*item));
+                }
+            } catch (InvalidDuetoReorgFork& e) {
+                LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: Invalidated due to reorg/fork. Starting over.",
+                         __func__);
+            }
+
+            // This must be AFTER BuildPollItem. If a reorg occurred during reg traversal that could invalidate
+            // a Ref pointed to by the sequence, the increment of the iterator to the next position must be
+            // prevented to avoid a segfault. A new Sequence must be formed and the loop started over.
+
+            if (m_registry.reorg_occurred_during_reg_traversal) {
+                items.clear();
+                fork_reorg_during_run = true;
+
+                g_timer.GetTimes(std::string{"Restart due to reorg "} + std::string{__func__}, __func__);
+
+                // Break from the poll registry traversal loop
+                break;
+            }
         }
+
+        // exit retry loop if no fork/reorg during run
+        if (!fork_reorg_during_run) break;
+
+        // Periodically recheck until reorg/fork has cleared. The reorg_occurred_during_reg_traversal will
+        // be cleared by the DetectReorg function as soon as the blockheight reaches the high water mark recorded
+        // before.
+        while (m_registry.reorg_occurred_during_reg_traversal) {
+            // Return here is for thread interrrupt during shutdown.
+            if (!MilliSleep(1000)) return items;
+
+            LOCK(cs_main);
+
+            m_registry.PollRegistry::DetectReorg();
+        }
+
+        // If the fork_reorg_during_run was set (true), then this run through the loop is invalid due to a
+        // fork/reorg. Now that reorg_occurred_during_reg_traversal has cleared, reset to false for another try.
+        fork_reorg_during_run = false;
     }
+
+    m_registry.registry_traversal_in_progress = false;
 
     g_timer.GetTimes(std::string{"End "} + std::string{__func__}, __func__);
     return items;

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -551,9 +551,9 @@ UniValue getpollresults(const UniValue& params, bool fHelp)
 
     const std::string title_or_id = params[0].get_str();
 
-    LOCK(GetPollRegistry().cs_poll_registry);
-
-    if (const PollReference* ref = TryPollByTitleOrId(title_or_id)) {
+    // We only need to lock the registry to retrieve the reference. If there is a reorg during the PollResultToJson, it will
+    // throw.
+    if (const PollReference* ref = WITH_LOCK(GetPollRegistry().cs_poll_registry, return TryPollByTitleOrId(title_or_id))) {
         return PollResultToJson(*ref);
     }
 
@@ -704,9 +704,9 @@ UniValue votedetails(const UniValue& params, bool fHelp)
 
     const std::string title_or_id = params[0].get_str();
 
-    LOCK(GetPollRegistry().cs_poll_registry);
-
-    if (const PollReference* ref = TryPollByTitleOrId(title_or_id)) {
+    // We only need to lock the registry to retrieve the reference. If there is a reorg during the PollResultToJson, it will
+    // throw.
+    if (const PollReference* ref = WITH_LOCK(GetPollRegistry().cs_poll_registry, return TryPollByTitleOrId(title_or_id))) {
         return VoteDetailsToJson(*ref);
     }
 

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -164,13 +164,21 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
 
 UniValue PollResultToJson(const PollReference& poll_ref)
 {
+    GetPollRegistry().registry_traversal_in_progress = true;
+
     try {
-        if (const PollResultOption result = PollResult::BuildFor(poll_ref)) {
+         if (const PollResultOption result = PollResult::BuildFor(poll_ref)) {
+            GetPollRegistry().registry_traversal_in_progress = false;
+
             return PollResultToJson(*result, poll_ref);
         }
     } catch (InvalidDuetoReorgFork& e) {
+        GetPollRegistry().registry_traversal_in_progress = false;
+
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk due to reorg in progress during inquiry.");
     }
+
+    GetPollRegistry().registry_traversal_in_progress = false;
 
     throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk");
 }

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -13,7 +13,7 @@
 using namespace GRC;
 
 namespace {
-const PollReference* TryPollByTitleOrId(const std::string& title_or_id)
+const PollReference* TryPollByTitleOrId(const std::string& title_or_id) EXCLUSIVE_LOCKS_REQUIRED(PollRegistry::cs_poll_registry)
 {
     PollRegistry& registry = GetPollRegistry();
 
@@ -22,7 +22,7 @@ const PollReference* TryPollByTitleOrId(const std::string& title_or_id)
 
         // This will return a ref to the poll in the registry if found, or, try and load it and return the ref if
         // the load is successful.
-        if (const PollReference* ref = registry.TryByTxidWithAddHistoricalPollAndVotes(txid)) {
+        if (const PollReference* ref = WITH_LOCK(cs_main, return registry.TryByTxidWithAddHistoricalPollAndVotes(txid))) {
             return ref;
         }
     }
@@ -107,12 +107,16 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
     json.pushKV("poll_title", poll_ref.Title());
     json.pushKV("poll_expired", poll_ref.Expired(GetAdjustedTime()));
 
-    if (auto start_height = poll_ref.GetStartingHeight()) {
-        json.pushKV("starting_block_height", *start_height);
-    }
+    {
+        LOCK(cs_main);
 
-    if (auto end_height = poll_ref.GetEndingHeight()) {
-        json.pushKV("ending_block_height", *end_height);
+        if (auto start_height = poll_ref.GetStartingHeight()) {
+            json.pushKV("starting_block_height", *start_height);
+        }
+
+        if (auto end_height = poll_ref.GetEndingHeight()) {
+            json.pushKV("ending_block_height", *end_height);
+        }
     }
 
     json.pushKV("votes", (uint64_t)poll_ref.Votes().size());
@@ -160,8 +164,12 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
 
 UniValue PollResultToJson(const PollReference& poll_ref)
 {
-    if (const PollResultOption result = PollResult::BuildFor(poll_ref)) {
-        return PollResultToJson(*result, poll_ref);
+    try {
+        if (const PollResultOption result = PollResult::BuildFor(poll_ref)) {
+            return PollResultToJson(*result, poll_ref);
+        }
+    } catch (InvalidDuetoReorgFork& e) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk due to reorg in progress during inquiry.");
     }
 
     throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk");
@@ -201,8 +209,12 @@ UniValue VoteDetailsToJson(const PollResult& result)
 
 UniValue VoteDetailsToJson(const PollReference& poll_ref)
 {
-    if (const PollResultOption result = PollResult::BuildFor(poll_ref)) {
-        return VoteDetailsToJson(*result);
+    try {
+        if (const PollResultOption result = PollResult::BuildFor(poll_ref)) {
+            return VoteDetailsToJson(*result);
+        }
+    } catch (InvalidDuetoReorgFork& e) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk due to reorg in progress during inquiry.");
     }
 
     throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk.");
@@ -279,6 +291,8 @@ UniValue SubmitVote(const Poll& poll, VoteBuilder builder)
 
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
+        // Note that a lock on cs_poll_registry does NOT need to be taken here.
+        // This lock will be taken by the contract handler.
         result_pair = SendContract(builder.BuildContractTx(pwalletMain));
     }
 
@@ -363,7 +377,7 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
     std::string type_string = ToLower(params[0].get_str());
 
-    PollType poll_type;
+    PollType poll_type = PollType::UNKNOWN;
 
     bool valid_type_parameter = false;
 
@@ -481,6 +495,8 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
+        // Note that a lock on cs_poll_registry does NOT need to be taken here.
+        // This lock will be taken by the contract handler.
         result_pair = SendContract(builder.BuildContractTx(pwalletMain));
     }
 
@@ -508,7 +524,7 @@ UniValue listpolls(const UniValue& params, bool fHelp)
 
     const bool active = params.size() > 0 ? !params[0].get_bool() : true;
 
-    LOCK(cs_main);
+    LOCK(GetPollRegistry().cs_poll_registry);
 
     for (const auto& iter : GetPollRegistry().Polls().OnlyActive(active)) {
         if (const PollOption poll = iter->TryPollFromDisk()) {
@@ -531,7 +547,7 @@ UniValue getpollresults(const UniValue& params, bool fHelp)
 
     const std::string title_or_id = params[0].get_str();
 
-    LOCK(cs_main);
+    LOCK(GetPollRegistry().cs_poll_registry);
 
     if (const PollReference* ref = TryPollByTitleOrId(title_or_id)) {
         return PollResultToJson(*ref);
@@ -609,7 +625,7 @@ UniValue vote(const UniValue& params, bool fHelp)
     PollOption poll;
 
     {
-        LOCK(cs_main);
+        LOCK(GetPollRegistry().cs_poll_registry);
 
         if (const PollReference* ref = GetPollRegistry().TryByTitle(title)) {
             poll = ref->TryReadFromDisk();
@@ -646,7 +662,7 @@ UniValue votebyid(const UniValue& params, bool fHelp)
     PollOption poll;
 
     {
-        LOCK(cs_main);
+        LOCK(GetPollRegistry().cs_poll_registry);
 
         if (const PollReference* ref = GetPollRegistry().TryByTxid(poll_id)) {
             poll = ref->TryReadFromDisk();
@@ -680,7 +696,7 @@ UniValue votedetails(const UniValue& params, bool fHelp)
 
     const std::string title_or_id = params[0].get_str();
 
-    LOCK(cs_main);
+    LOCK(GetPollRegistry().cs_poll_registry);
 
     if (const PollReference* ref = TryPollByTitleOrId(title_or_id)) {
         return VoteDetailsToJson(*ref);

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -543,7 +543,11 @@ UniValue getpollresults(const UniValue& params, bool fHelp)
                 "\n"
                 "<poll_title_or_id> --> Title or ID of the poll.\n"
                 "\n"
-                "Display the results for the specified poll.\n");
+                "Display the results for the specified poll.\n"
+                "\n"
+                "Note that in the small chance that a blockchain reorg occurs during\n"
+                "the tally for the poll, this call will return an error. Retrying\n"
+                "should succeed.");
 
     const std::string title_or_id = params[0].get_str();
 
@@ -692,7 +696,11 @@ UniValue votedetails(const UniValue& params, bool fHelp)
                 "\n"
                 "<poll_title_or_id> --> Title or ID of the poll.\n"
                 "\n"
-                "Display the vote details for the specified poll.\n");
+                "Display the vote details for the specified poll.\n"
+                "\n"
+                "Note that in the small chance that a blockchain reorg occurs during\n"
+                "the tally for the vote details, this call will return an error. Retrying\n"
+                "should succeed.");
 
     const std::string title_or_id = params[0].get_str();
 


### PR DESCRIPTION
This PR implements a new locking scheme for the poll registry and related structures/methods. Closes #2618.

Voting in Gridcoin is a high reliability, high integrity subsystem that is built up from polls that are published by wallet holders in accordance with protocol rules for polls, and votes by walletholders. Polls and voting were completely redone in Fern to address integrity issues and further enhanced in major milestones since then.

One thing that hasn't changed since Fern...  due to the complexity of tallying the votes and the desire to conserve memory footprint, the results for polls are built dynamically on demand by either the GUI or rpc. The GUI offers a (re)fresh of the entire polling/results based on a single button push, while the rpc splits up the poll listing and poll results into separate rpc functions, as this is more amenable to scripting. During the GUI poll update, if there are a number of polls that have high participation, the GUI can experience lockups for minutes at a time on slow computers (i.e. a slow processor and/or especially a slow disk, such as a traditional spinning HDD, especially if it is connected via USB). This is because while the poll GUI refresh was implemented on a separate thread, a lock was taken on cs_main for the entire update. This lock eventually becomes blocking to the cs_main taken at regular intervals by the core (driven by the net code), and therefore the core and GUI both block until the poll refresh is done and the lock on cs_main by the poll refresh is released. While this is a simple approach to insuring absolute integrity to the poll refresh, because it locks the entire wallet state, it suffers from poor usability.

There are a number of things that can be done to address these issues and have already been enumerated in #2618. This PR represents the implementation of the 1st improvement.

This PR removes the cs_main lock that was being taken in VotingModel::buildPollTable and instead inverts the locking scheme. A new lock to protect the poll registry and related structures has been implemented, cs_poll_registry. This lock is used for critical structures in the poll registry for polls and voting and also the GUI code that is executed by the refresh thread. This ensures protection of the registry state. 

In general it is dangerous to access transaction state from the core without cs_main taken, unless you really know what you are doing. In this instance I have implemented a reorg/fork detection scheme that occurs between the contract handlers, the registry itself, and the buildPollTable GUI method. Note that during the registry traversal for the poll refresh, the cs_poll_registry lock is only taken to generate the sequence for the range loop.  The BuildPollItem and associated machinery, instead of taking and maintaining the cs_poll_registry lock, or the cs_main lock, deep within the call structure in the ProcessVoteCandidate, a check of the atomic boolean reorg_occurred_during_reg_traversal is made for each vote before it is processed. This reorg_occurred_during_reg_traversal is in the poll registry, but does not require the cs_poll_registry lock, because it is atomic. It is set by the contract handler virtual function Add and Delete for polls/votes as part of a reorg/fork detection routine. Note that when the ProcessVoteCandidate method encounters that flag as set, it immediately throws InvalidDuetoReorgFork(), a new error, which bubbles up to the try around the BuildPollItem() and immediately aborts the tally. Then a waiting loop is entered that checks at one second intervals to see if the reorg/fork has cleared.

Note that this PR does not address performance issues involving the tallying of votes on slow machines, but instead makes sure that the GUI and core are responsive during this process, which may take minutes on a slow computer, and that the final tally is accurate at least at the height incurred at the start of the poll refresh or higher. For polls and voting to scale to much larger participants we will have to implement a different approach, but this will involve a tradeoff in more memory usage.

Note that static thread safety analysis keywords were implemented here which allow clang to detect thread safety issues. On a related note, a full deadlock analysis due to possible lock order issues has not been conducted yet