### PR TITLE
rpc: Repair auditsnapshotaccrual rpc function

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -57,7 +57,7 @@ class CNetAddr
         bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
         bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor)
         bool IsRFC1918() const; // IPv4 private networks (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
-        bool IsRFC2544() const; // IPv4 inter-network communcations (192.18.0.0/15)
+        bool IsRFC2544() const; // IPv4 inter-network communications (192.18.0.0/15)
         bool IsRFC6598() const; // IPv4 ISP-level NAT (100.64.0.0/10)
         bool IsRFC5737() const; // IPv4 documentation addresses (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24)
         bool IsRFC3849() const; // IPv6 documentation address (2001:0DB8::/32)


### PR DESCRIPTION
The function now properly handles expired beacons where new beacons with the same CPID were advertised afterwards (i.e. two or more beacon chains).

It also deals properly with a 1 Halford difference that is appearing between the audit and the blockchain calcs for newbies.