### PR TITLE
gui, voting: Update pool cpids and avw rules

### DIFF
--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -86,6 +86,7 @@ public:
         m_mining_pools.push_back({ "7d0d73fe026d66fd4ab8d5d8da32a611", "grcpool.com", "https://grcpool.com/" });
         m_mining_pools.push_back({ "a914eba952be5dfcf73d926b508fd5fa", "grcpool.com-2", "https://grcpool.com/" });
         m_mining_pools.push_back({ "163f049997e8a2dee054d69a7720bf05", "grcpool.com-3", "https://grcpool.com/" });
+        m_mining_pools.push_back({ "f1f4d4e93b5b319b0a54b09dd47f1486", "grcpool.com-5", "https://grcpool.com/" });
         m_mining_pools.push_back({ "326bb50c0dd0ba9d46e15fae3484af35", "grc.arikado.pool", "https://gridcoinpool.ru/" });
     }
 

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -325,11 +325,11 @@ const std::vector<Poll::PollTypeRules> Poll::POLL_TYPE_RULES = {
     // also require the weight type of BALANCE_AND_MAGNITUDE, so therefore the
     // only poll type that can actually use BALANCE is SURVEY. All other WeightTypes are deprecated.
     {  7,  0, {} },                                // PollType::SURVEY
-    { 21, 40, { "project_name", "project_url" } }, // PollType::PROJECT
-    { 42, 50, {} },                                // PollType::DEVELOPMENT
-    { 21, 20, {} },                                // PollType::GOVERNANCE
-    { 21, 40, {} },                                // PollType::MARKETING
-    { 21, 40, {} },                                // PollType::OUTREACH
+    { 21, 20, { "project_name", "project_url" } }, // PollType::PROJECT
+    { 42, 35, {} },                                // PollType::DEVELOPMENT
+    { 21, 15, {} },                                // PollType::GOVERNANCE
+    { 21, 20, {} },                                // PollType::MARKETING
+    { 21, 20, {} },                                // PollType::OUTREACH
     { 21, 10, {} }                                 // PollType::COMMUNITY
 };
 


### PR DESCRIPTION
This PR adds the new pool CPID to the MiningPool class (the list of pool cpids), and also updates the AVW poll validation percentages to agree with the poll

    "title": "Adopt New AVW Percentage Requirements for Polls",
    "id": "c186e2fd5fa81541e74838c1f3b1268c471b55dc6c37aa1b3b9ea84ecd20801c",

which finished 01-12-2023 23:51:56 UTC and was approved.

Note that these changes do not require a mandatory, because while both the pool cpid list and the AVW validation percentages affect display of the polls in the GUI (and also the operation of pool mode in the GUI), they do not affect any protocol consensus rules.