### PR TITLE
scraper, gui: Add external adapter projects indication

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -167,6 +167,8 @@ unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE GUARDED_BY(cs_ScraperGlobals) = 0
 bool REQUIRE_TEAM_WHITELIST_MEMBERSHIP GUARDED_BY(cs_ScraperGlobals) = false;
 /** Default team whitelist. Remember this will be overridden by appcache entries. */
 std::string TEAM_WHITELIST GUARDED_BY(cs_ScraperGlobals) = "Gridcoin";
+/** This is a short term place to hold projects that require an external adapter for the scrapers.*/
+std::string EXTERNAL_ADAPTER_PROJECTS GUARDED_BY(cs_ScraperGlobals) = std::string{};
 /** This is the period after the deauthorizing of a scraper in seconds before the nodes will start
  * to assign banscore to nodes sending unauthorized manifests.
  */
@@ -1365,6 +1367,7 @@ void ScraperApplyAppCacheEntries()
         ApplyCache("SCRAPER_MISBEHAVING_NODE_BANSCORE", SCRAPER_MISBEHAVING_NODE_BANSCORE);
         ApplyCache("REQUIRE_TEAM_WHITELIST_MEMBERSHIP", REQUIRE_TEAM_WHITELIST_MEMBERSHIP);
         ApplyCache("TEAM_WHITELIST", TEAM_WHITELIST);
+        ApplyCache("EXTERNAL_ADAPTER_PROJECTS", EXTERNAL_ADAPTER_PROJECTS);
         ApplyCache("SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD", SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD);
 
         _log(logattribute::INFO, "ScraperApplyAppCacheEntries",
@@ -1404,6 +1407,8 @@ void ScraperApplyAppCacheEntries()
              "REQUIRE_TEAM_WHITELIST_MEMBERSHIP = " + ToString(REQUIRE_TEAM_WHITELIST_MEMBERSHIP));
         _log(logattribute::INFO, "ScraperApplyAppCacheEntries",
              "TEAM_WHITELIST = " + TEAM_WHITELIST);
+        _log(logattribute::INFO, "ScraperApplyAppCacheEntries",
+             "EXTERNAL_ADAPTER_PROJECTS = " + EXTERNAL_ADAPTER_PROJECTS);
         _log(logattribute::INFO, "ScraperApplyAppCacheEntries",
              "SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD = " + ToString(SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD));
     }

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -274,6 +274,32 @@ template<typename T>
  */
 void ApplyCache(const std::string& key, T& result);
 
+
+const std::string GetTextForstatsobjecttype(statsobjecttype StatsObjType)
+{
+    return vstatsobjecttypestrings[static_cast<int>(StatsObjType)];
+}
+
+const std::string GetTextForscraperSBvalidationtype(scraperSBvalidationtype ScraperSBValidationType)
+{
+    return scraperSBvalidationtypestrings[static_cast<int>(ScraperSBValidationType)];
+}
+
+double MagRound(double dMag)
+{
+    return round(dMag / MAG_ROUND) * MAG_ROUND;
+}
+
+unsigned int NumScrapersForSupermajority(unsigned int nScraperCount)
+{
+    LOCK(cs_ScraperGlobals);
+
+    unsigned int nRequired = std::max(SCRAPER_CONVERGENCE_MINIMUM,
+                                      (unsigned int)std::ceil(SCRAPER_CONVERGENCE_RATIO * nScraperCount));
+
+    return nRequired;
+}
+
 // Internal functions for scraper/subscriber operation.
 /**
  * @brief Gets scrapers AppCacheSection
@@ -1126,6 +1152,13 @@ std::vector<std::string> GetTeamWhiteList()
     }
 
     return split(TEAM_WHITELIST, delimiter);
+}
+
+std::vector<std::string> GetProjectsExternalAdapterRequired()
+{
+    LOCK(cs_ScraperGlobals);
+
+    return split(EXTERNAL_ADAPTER_PROJECTS, "|");
 }
 
 

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -57,6 +57,7 @@ extern bool ALLOW_NONSCRAPER_NODE_STATS_DOWNLOAD;
 extern unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE;
 extern bool REQUIRE_TEAM_WHITELIST_MEMBERSHIP;
 extern std::string TEAM_WHITELIST;
+extern std::string EXTERNAL_ADAPTER_PROJECTS;
 extern int64_t SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD;
 
 extern CCriticalSection cs_mScrapersExt;

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -190,30 +190,21 @@ static std::vector<std::string> scraperSBvalidationtypestrings = {
  * @param StatsObjType
  * @return std::string
  */
-const std::string GetTextForstatsobjecttype(statsobjecttype StatsObjType)
-{
-    return vstatsobjecttypestrings[static_cast<int>(StatsObjType)];
-}
+const std::string GetTextForstatsobjecttype(statsobjecttype StatsObjType);
 
 /**
  * @brief Returns text that corresponds to the input scraperSBvalidationtype
  * @param ScraperSBValidationType
  * @return std::string
  */
-const std::string GetTextForscraperSBvalidationtype(scraperSBvalidationtype ScraperSBValidationType)
-{
-    return scraperSBvalidationtypestrings[static_cast<int>(ScraperSBValidationType)];
-}
+const std::string GetTextForscraperSBvalidationtype(scraperSBvalidationtype ScraperSBValidationType);
 
 /**
  * @brief Rounds the double floating point magnitude according to the global parameter MAG_ROUND.
  * @param dMag
  * @return double
  */
-double MagRound(double dMag)
-{
-    return round(dMag / MAG_ROUND) * MAG_ROUND;
-}
+double MagRound(double dMag);
 
 /**
  * @brief Returns the number of scrapers required for a supermajority when determining a convergence. This is a CONSENSUS
@@ -221,14 +212,9 @@ double MagRound(double dMag)
  * @param nScraperCount
  * @return unsigned int
  */
-unsigned int NumScrapersForSupermajority(unsigned int nScraperCount)
-{
-    LOCK(cs_ScraperGlobals);
+unsigned int NumScrapersForSupermajority(unsigned int nScraperCount);
 
-    unsigned int nRequired = std::max(SCRAPER_CONVERGENCE_MINIMUM,
-                                      (unsigned int)std::ceil(SCRAPER_CONVERGENCE_RATIO * nScraperCount));
-
-    return nRequired;
-}
+/** Gets a vector of projects that require an external adapter for the scrapers to pull statistics. */
+std::vector<std::string> GetProjectsExternalAdapterRequired();
 
 #endif // GRIDCOIN_SCRAPER_SCRAPER_H

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -10,6 +10,7 @@
 #include "gridcoin/project.h"
 #include "gridcoin/quorum.h"
 #include "gridcoin/researcher.h"
+#include "gridcoin/scraper/scraper.h"
 #include "node/ui_interface.h"
 
 #include "qt/bitcoinunits.h"
@@ -444,6 +445,13 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
     //
 
     const WhitelistSnapshot whitelist = GetWhitelist().Snapshot();
+
+    // This is temporary implementation of the suppression of "not attached" for projects that
+    // are whitelisted that require an external adapter, and so will not be attached as a native
+    // BOINC project. This will be replaced by a field in the Projects class at the next mandatory
+    // (5.5.0.0).
+    std::vector<std::string> external_adapter_projects = GetProjectsExternalAdapterRequired();
+
     std::vector<ExplainMagnitudeProject> explain_mag;
     std::map<std::string, ProjectRow> rows;
 
@@ -511,7 +519,14 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
         row.m_whitelisted = true;
         row.m_name = QString::fromStdString(project.DisplayName()).toLower();
         row.m_magnitude = 0.0;
-        row.m_error = tr("Not attached");
+
+        if (std::find(external_adapter_projects.begin(),
+                      external_adapter_projects.end(),
+                      project.m_name) == external_adapter_projects.end()) {
+            row.m_error = tr("Not attached");
+        } else {
+            row.m_error = tr("Uses external adapter");
+        }
 
         for (const auto& explain_mag_project : explain_mag) {
             if (explain_mag_project.m_name == project.m_name) {


### PR DESCRIPTION
This is a temporary (until the next mandatory) implementation of the ability to designate by protocol the list of projects that use external adapters for the scrapers, also therefore are not attached to BOINC on the hosts. This also modifies the message for projects found in that protocol entry to indicate "Uses external adapter" rather than "Not attached" to reduce confusion on the projects GUI table.

This implementation will be replaced by a new field in the Projects class at the next mandatory.