### PR TITLE
gui: implement INSUFFICIENT_MATURE_FUNDS status for the mrcmodel

### DIFF
--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -30,7 +30,8 @@ enum class MRCRequestStatus
     ZERO_PAYOUT,
     EXCESSIVE_FEE,
     WALLET_LOCKED,
-    SUBMIT_ERROR
+    SUBMIT_ERROR,
+    INSUFFICIENT_MATURE_FUNDS
 };
 
 //!
@@ -59,7 +60,8 @@ public:
         NOT_VALID_RESEARCHER,
         INVALID_BLOCK_VERSION,
         OUT_OF_SYNC,
-        NO_BLOCK_UPDATE_FROM_INIT
+        NO_BLOCK_UPDATE_FROM_INIT,
+        INSUFFICIENT_MATURE_FUNDS
     };
 
     WalletModel* getWalletModel();

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -6,7 +6,7 @@
 #include "qspinbox.h"
 #include "sync.h"
 #include "mrcrequestpage.h"
-#include "ui_mrcrequestpage.h"
+#include "forms/ui_mrcrequestpage.h"
 #include "walletmodel.h"
 #include "optionsmodel.h"
 #include "qt/decoration.h"
@@ -266,6 +266,11 @@ void MRCRequestPage::showMRCStatus(const MRCModel::ModelStatus& status) {
     case MRCModel::ModelStatus::NO_BLOCK_UPDATE_FROM_INIT:
         ui->waitForBlockUpdateLabel->setText(tr("A block update must have occurred after wallet start or sync to submit "
                                                 "MRCs."));
+        ui->waitForNextBlockUpdateFrame->show();
+        ui->mrcStatusSubmitFrame->hide();
+        return;
+    case MRCModel::ModelStatus::INSUFFICIENT_MATURE_FUNDS:
+        ui->waitForBlockUpdateLabel->setText(tr("You must have a mature balance of at least 1 GRC to submit an MRC."));
         ui->waitForNextBlockUpdateFrame->show();
         ui->mrcStatusSubmitFrame->hide();
         return;


### PR DESCRIPTION
If less than 1 GRC of mature funds is detected in the wallet, then the next block update frame (wait frame) is displayed, hiding the MRC submission form, and an appropriate error message is displayed.

Closes #2623.