### PR TITLE
test: Fix Wambiguous-reversed-operator compiler warning, drop boost::assign

### DIFF
--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -1,7 +1,4 @@
 #include <boost/assert.hpp>
-#include <boost/assign/list_of.hpp>
-#include <boost/assign/list_inserter.hpp>
-#include <boost/assign/std/vector.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/tuple/tuple.hpp>
 
@@ -16,7 +13,6 @@
 #include "wallet/ismine.h"
 
 using namespace std;
-using namespace boost::assign;
 
 typedef vector<unsigned char> valtype;
 
@@ -76,20 +72,19 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     CScript s;
 
     // Test a AND b:
-    keys.clear();
-    keys += key[0],key[1]; // magic operator+= from boost.assign
+    keys.assign(1,key[0]);
+    keys.push_back(key[1]);
     s = sign_multisig(a_and_b, keys, txTo[0], 0);
     BOOST_CHECK(VerifyScript(s, a_and_b, txTo[0], 0, 0));
 
     for (int i = 0; i < 4; i++)
     {
-        keys.clear();
-        keys += key[i];
+        keys.assign(1,key[i]);
         s = sign_multisig(a_and_b, keys, txTo[0], 0);
         BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, txTo[0], 0, 0), strprintf("a&b 1: %d", i));
 
-        keys.clear();
-        keys += key[1],key[i];
+        keys.assign(1,key[1]);
+        keys.push_back(key[i]);
         s = sign_multisig(a_and_b, keys, txTo[0], 0);
         BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, txTo[0], 0, 0), strprintf("a&b 2: %d", i));
     }
@@ -97,8 +92,7 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     // Test a OR b:
     for (int i = 0; i < 4; i++)
     {
-        keys.clear();
-        keys += key[i];
+        keys.assign(1,key[i]);
         s = sign_multisig(a_or_b, keys, txTo[1], 0);
         if (i == 0 || i == 1)
             BOOST_CHECK_MESSAGE(VerifyScript(s, a_or_b, txTo[1], 0, 0), strprintf("a|b: %d", i));
@@ -116,8 +110,8 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
         {
-            keys.clear();
-            keys += key[i],key[j];
+            keys.assign(1,key[i]);
+            keys.push_back(key[j]);
             s = sign_multisig(escrow, keys, txTo[2], 0);
             if (i < j && i < 3 && j < 3)
                 BOOST_CHECK_MESSAGE(VerifyScript(s, escrow, txTo[2], 0, 0), strprintf("escrow 1: %d %d", i, j));

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -40,13 +40,13 @@ public:
         READWRITE(txval);
     }
 
-    bool operator==(const CSerializeMethodsTestSingle& rhs)
+    bool operator==(const CSerializeMethodsTestSingle& rhs) const
     {
-        return  intval == rhs.intval && \
-                boolval == rhs.boolval && \
-                stringval == rhs.stringval && \
-                strcmp(charstrval, rhs.charstrval) == 0 && \
-                txval == rhs.txval;
+        return intval == rhs.intval &&
+               boolval == rhs.boolval &&
+               stringval == rhs.stringval &&
+               strcmp(charstrval, rhs.charstrval) == 0 &&
+               txval == rhs.txval;
     }
 };
 

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -63,9 +63,7 @@ EXPECTED_BOOST_INCLUDES=(
     boost/asio/ssl.hpp
     boost/asio/system_timer.hpp
     boost/assert.hpp
-    boost/assign/list_inserter.hpp
     boost/assign/list_of.hpp
-    boost/assign/std/vector.hpp
     boost/bind/bind.hpp
     boost/date_time.hpp
     boost/date_time/gregorian/greg_date.hpp


### PR DESCRIPTION
Ref: https://github.com/bitcoin/bitcoin/pull/24406/commits/fafc4eb3637be0a85644c89c355fe68678a62c17

Ref: https://github.com/bitcoin/bitcoin/commit/9b1ab860ff00180142d9e514f3e1b6a91c86df7a