### PR TITLE
gui, accrual: Implement accrual limit warning

### DIFF
--- a/src/gridcoin/accrual/computer.h
+++ b/src/gridcoin/accrual/computer.h
@@ -72,6 +72,12 @@ public:
     virtual CAmount PaymentPerDayLimit() const = 0;
 
     //!
+    //! \brief Return an accrual value that is nearing the limit based on accrual rate.
+    //! \return Value of near limit in CAmount units.
+    //!
+    virtual CAmount NearRewardLimit() const = 0;
+
+    //!
     //! \brief Determine whether the account exceeded the daily payment limit.
     //!
     //! \return \c true if the average daily research payment amount exceeds

--- a/src/gridcoin/accrual/newbie.h
+++ b/src/gridcoin/accrual/newbie.h
@@ -84,6 +84,16 @@ public:
         return MaxReward();
     }
 
+    CAmount NearRewardLimit() const override
+    {
+        // This returns MaxReward() - 2 * ExpectedDaily() or 1/2 of MaxReward(), whichever
+        // is greater
+
+        CAmount threshold = std::max(MaxReward() / 2, MaxReward() - 2 * ExpectedDaily());
+
+        return threshold;
+    }
+
     bool ExceededRecentPayments() const override
     {
         return RawAccrual() > PaymentPerDayLimit();

--- a/src/gridcoin/accrual/null.h
+++ b/src/gridcoin/accrual/null.h
@@ -57,6 +57,11 @@ public:
         return 0;
     }
 
+    CAmount NearRewardLimit() const override
+    {
+        return 0;
+    }
+
     bool ExceededRecentPayments() const override
     {
         return false;

--- a/src/gridcoin/accrual/research_age.h
+++ b/src/gridcoin/accrual/research_age.h
@@ -165,6 +165,16 @@ public:
         return m_account.AverageLifetimeMagnitude() * m_magnitude_unit * COIN * 5;
     }
 
+    CAmount NearRewardLimit() const override
+    {
+        // This returns MaxReward() - 2 * ExpectedDaily() or 1/2 of MaxReward(), whichever
+        // is greater
+
+        CAmount threshold = std::max(MaxReward() / 2, MaxReward() - 2 * ExpectedDaily());
+
+        return threshold;
+    }
+
     //!
     //! \brief Determine whether the account exceeded the daily payment limit.
     //!

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -361,6 +361,16 @@ public:
         return MaxReward();
     }
 
+    CAmount NearRewardLimit() const override
+    {
+        // This returns MaxReward() - 2 * ExpectedDaily() or 1/2 of MaxReward(), whichever
+        // is greater
+
+        CAmount threshold = std::max(MaxReward() / 2, MaxReward() - 2 * ExpectedDaily());
+
+        return threshold;
+    }
+
     bool ExceededRecentPayments() const override
     {
         return RawAccrual() > PaymentPerDayLimit();

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1329,6 +1329,21 @@ CAmount Researcher::Accrual() const
     return Tally::GetAccrual(*cpid, now, pindexBest);
 }
 
+CAmount Researcher::AccrualNearLimit() const
+{
+    const CpidOption cpid = m_mining_id.TryCpid();
+
+    if (!cpid || !pindexBest) {
+        return false;
+    }
+
+    const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
+
+    LOCK(cs_main);
+
+    return Tally::AccrualNearLimit(*cpid, now, pindexBest);
+}
+
 ResearcherStatus Researcher::Status() const
 {
     if (Eligible()) {

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -551,6 +551,12 @@ public:
     CAmount Accrual() const;
 
     //!
+    //! \brief Value of account accrual that is near MaxReward() based on accrual rate..
+    //! \return CAmount value. This is implemented in IAccrualComputer::NearRewardLimit().
+    //!
+    CAmount AccrualNearLimit() const;
+
+    //!
     //! \brief Get a value that indicates how the wallet participates in the
     //! research reward protocol.
     //!

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1090,6 +1090,14 @@ CAmount Tally::GetAccrual(
     return GetComputer(cpid, payment_time, last_block_ptr)->Accrual();
 }
 
+CAmount Tally::AccrualNearLimit(
+        const Cpid cpid,
+        const int64_t payment_time,
+        const CBlockIndex* const last_block_ptr)
+{
+    return (GetComputer(cpid, payment_time, last_block_ptr)->NearRewardLimit()) ;
+}
+
 //!
 //! \brief Compute "catch-up" accrual to correct for newbie accrual bug.
 //!

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -134,6 +134,22 @@ public:
         const CBlockIndex* const last_block_ptr);
 
     //!
+    //! \brief A value of the accrual that is near the MaxReward for the accrual computer in context based on
+    //! the rate of accrual. This is defined in the implementation of the virtual method NearRewardLimit()
+    //! in IAccrualComputer.
+    //!
+    //! \param cpid           CPID to calculate research accrual for.
+    //! \param payment_time   Time of payment to calculate rewards at.
+    //! \param last_block_ptr Refers to the block for the reward.
+    //!
+    //! \return CAmount of account accrual that is near the MaxReward.
+    //!
+    static CAmount AccrualNearLimit(
+            const Cpid cpid,
+            const int64_t payment_time,
+            const CBlockIndex* const last_block_ptr);
+
+    //!
     //! \brief Compute "catch-up" accrual to correct for newbie accrual bug.
     //!
     //! \param cpid for which to calculate the accrual correction.

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>948</width>
-    <height>635</height>
+    <height>755</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -788,10 +788,10 @@
                 <property name="spacing">
                  <number>12</number>
                 </property>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="statusTextLabel">
+                <item row="1" column="0">
+                 <widget class="QLabel" name="magnitudeTextLabel">
                   <property name="text">
-                   <string>Status:</string>
+                   <string>Magnitude:</string>
                   </property>
                   <property name="isRowHeader" stdset="0">
                    <bool>true</bool>
@@ -817,16 +817,6 @@
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="magnitudeTextLabel">
-                  <property name="text">
-                   <string>Magnitude:</string>
-                  </property>
-                  <property name="isRowHeader" stdset="0">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
                 <item row="1" column="1">
                  <widget class="QLabel" name="magnitudeLabel">
                   <property name="sizePolicy">
@@ -843,16 +833,6 @@
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="accrualTextLabel">
-                  <property name="text">
-                   <string>Pending Reward:</string>
-                  </property>
-                  <property name="isRowHeader" stdset="0">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
                 <item row="2" column="1">
                  <widget class="QLabel" name="accrualLabel">
                   <property name="sizePolicy">
@@ -866,6 +846,48 @@
                   </property>
                   <property name="textInteractionFlags">
                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="statusTextLabel">
+                  <property name="text">
+                   <string>Status:</string>
+                  </property>
+                  <property name="isRowHeader" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="accrualTextLabel">
+                  <property name="text">
+                   <string>Pending Reward:</string>
+                  </property>
+                  <property name="isRowHeader" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="2">
+                 <widget class="QLabel" name="accrualLimitWarningIconlabel">
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>You are approaching the accrual limit of 16384 GRC. If you have a relatively low balance, you should request payment via MRC so that you do not lose earned rewards.</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="pixmap">
+                   <pixmap resource="../bitcoin.qrc">:/icons/warning</pixmap>
+                  </property>
+                  <property name="scaledContents">
+                   <bool>true</bool>
                   </property>
                  </widget>
                 </item>
@@ -1108,6 +1130,8 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -153,6 +153,10 @@ OverviewPage::OverviewPage(QWidget *parent) :
     ui->stakingGridLayout->setVerticalSpacing(verticalSpacing);
     ui->researcherGridLayout->setVerticalSpacing(verticalSpacing);
 
+    // scale warning icon
+    int warning_icon_size = GRC::ScalePx(this, 21);
+    ui->accrualLimitWarningIconlabel->setMaximumSize(QSize(warning_icon_size, warning_icon_size));
+
     // Recent Transactions
     ui->listTransactions->setItemDelegate(txdelegate);
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
@@ -285,6 +289,7 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
     bool showImmature = immatureBalance != 0;
     ui->immatureLabel->setVisible(showImmature);
     ui->immatureTextLabel->setVisible(showImmature);
+
 }
 
 void OverviewPage::setHeight(int height, int height_of_peers, bool in_sync)
@@ -501,7 +506,14 @@ void OverviewPage::updatePendingAccrual()
         unit = walletModel->getOptionsModel()->getDisplayUnit();
     }
 
-    ui->accrualLabel->setText(researcherModel->formatAccrual(unit));
+    bool near_limit = false;
+
+    ui->accrualLabel->setText(researcherModel->formatAccrual(unit, near_limit));
+    if (near_limit) {
+        ui->accrualLimitWarningIconlabel->show();
+    } else {
+        ui->accrualLimitWarningIconlabel->hide();
+    }
 }
 
 void OverviewPage::updateResearcherAlert()

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -317,6 +317,11 @@ bool ResearcherModel::needsBeaconAuth() const
     return m_beacon->m_public_key != m_pending_beacon->m_public_key;
 }
 
+CAmount ResearcherModel::accrualNearLimit() const
+{
+    return m_researcher->AccrualNearLimit();
+}
+
 CAmount ResearcherModel::getAccrual() const
 {
     return m_researcher->Accrual();
@@ -353,15 +358,22 @@ QString ResearcherModel::formatMagnitude() const
     return text;
 }
 
-QString ResearcherModel::formatAccrual(const int display_unit) const
+QString ResearcherModel::formatAccrual(const int display_unit, bool& near_limit) const
 {
     QString text;
+
+    // We only do the actual accrual calculation once. The AccrualNearLimit() is lighter.
+    CAmount accrual = m_researcher->Accrual();
+
+    near_limit = (accrual >= m_researcher->AccrualNearLimit());
 
     if (outOfSync()) {
         text = "...";
     } else {
-        text = BitcoinUnits::formatWithPrivacy(display_unit, m_researcher->Accrual(), m_privacy_enabled);
+        text = BitcoinUnits::formatWithPrivacy(display_unit, accrual, m_privacy_enabled);
     }
+
+
 
     return text;
 }

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -101,12 +101,13 @@ public:
     bool hasSplitCpid() const;
     bool needsBeaconAuth() const;
 
+    CAmount accrualNearLimit() const;
     CAmount getAccrual() const;
 
     QString email() const;
     QString formatCpid() const;
     QString formatMagnitude() const;
-    QString formatAccrual(const int display_unit) const;
+    QString formatAccrual(const int display_unit, bool& near_limit) const;
     QString formatStatus() const;
     QString formatBoincPath() const;
 

--- a/src/qt/researcher/researcherwizardsummarypage.cpp
+++ b/src/qt/researcher/researcherwizardsummarypage.cpp
@@ -94,7 +94,9 @@ void ResearcherWizardSummaryPage::refreshSummary()
     ui->cpidLabel->setText(m_researcher_model->formatCpid());
     ui->statusLabel->setText(m_researcher_model->formatStatus());
     ui->magnitudeLabel->setText(m_researcher_model->formatMagnitude());
-    ui->accrualLabel->setText(m_researcher_model->formatAccrual(unit));
+
+    bool near_limit = false;
+    ui->accrualLabel->setText(m_researcher_model->formatAccrual(unit, near_limit));
     ui->reviewBeaconAuthButton->setVisible(m_researcher_model->needsBeaconAuth());
 
     ui->beaconDetailsIconLabel->setPixmap(


### PR DESCRIPTION
Closes #2635.

The design of this PR implements a NearRewardLimit, or AccrualNearLimit, which has to be propagated several layers through the architecture. Note that this method provides a CAmount threshold which represents a value that is less than the MaxReward of 16384 by two days of accrual at the current magnitude, or 1/2 of the MaxReward, whichever is greater. The first condition is motivated by the notion of giving someone 2 days notice to do an MRC before they start losing GRC to the accrual cap. The second deals with the corner case where a person's mag is so high that 2 days of accrual subtracted from the MaxReward would yield a nonsensical alerting value. The maximum magnitude is 32767, so the maximum per day GRC accrual is 8191.75. 2x that value is 16383.5, which means the alerting value would be 0.5 GRC, or essentially immediate. So the 1/2 of the MaxReward condition starts to constrain the warning time at approximately one half of the max magnitude. At max magnitude the alerting time will only be approximately one day.

The "out parameter" for the boolean in FormatAccrual is so that the Accrual() method does not have to be called more than once for the GUI update. This update is on a timer loop and is called repeatedly. Accrual is much heavier than AccrualNearLimit.