### PR TITLE
gui: Fix wallet overview displaying lower-case poll name

### DIFF
--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -386,7 +386,7 @@ const std::string& PollReference::Title() const
         return empty;
     }
 
-    return *m_ptitle;
+    return m_title;
 }
 
 const std::vector<uint256>& PollReference::Votes() const
@@ -984,15 +984,14 @@ void PollRegistry::AddPoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(
     // The title used as the key for the m_poll map keyed by title, and also checked for duplicates, should
     // not be case-sensitive, regardless of whether v1 or v2+. We should not be allowing the insertion of two v2 polls
     // with the same title except for a difference in case.
-    poll_title = ToLower(poll_title);
-
-    auto result_pair = m_polls.emplace(std::move(poll_title), PollReference());
+    auto result_pair = m_polls.emplace(ToLower(poll_title), PollReference());
 
     if (result_pair.second) {
         const std::string& title = result_pair.first->first;
 
         PollReference& poll_ref = result_pair.first->second;
         poll_ref.m_ptitle = &title;
+        poll_ref.m_title = poll_title;
         poll_ref.m_payload_version = payload->m_version;
         poll_ref.m_type = payload->m_poll.m_type.Value();
         poll_ref.m_timestamp = ctx.m_tx.nTime;

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -1071,11 +1071,7 @@ void PollRegistry::DeletePoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIR
 {
     const auto payload = ctx->SharePayloadAs<PollPayload>();
 
-    if (ctx->m_version >= 2) {
-        m_polls.erase(payload->m_poll.m_title);
-    } else {
-        m_polls.erase(boost::to_lower_copy(payload->m_poll.m_title));
-    }
+    m_polls.erase(ToLower(payload->m_poll.m_title));
 
     m_polls_by_txid.erase(ctx.m_tx.GetHash());
     m_latest_poll = nullptr;

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -178,7 +178,8 @@ private:
     uint256 m_txid;               //!< Hash of the poll transaction.
     uint32_t m_payload_version;   //!< Version of the poll (payload).
     PollType m_type;              //!< Type of the poll.
-    const std::string* m_ptitle;  //!< Title of the poll.
+    const std::string* m_ptitle;  //!< Title of the poll for indexing/mapping purposes.
+    std::string m_title;          //!< Original title of the poll for display purposes.
     int64_t m_timestamp;          //!< Timestamp of the poll transaction.
     uint32_t m_duration_days;     //!< Number of days the poll remains active.
     std::vector<uint256> m_votes; //!< Hashes of the linked vote transactions.


### PR DESCRIPTION
Fixes #2638

Basically just added `m_title` as a data member to the `PollReference` object and copied the original poll name into there.

This preserves the lower-case poll name that is used for mapping to poll references but allows us to access a different member for the original name.