### PR TITLE
Fix and optimize ResendWalletTransactions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -5,6 +5,7 @@
 
 
 #include "chainparams.h"
+#include "gridcoin/support/block_finder.h"
 #include "util.h"
 #include "util/threadnames.h"
 #include "net.h"
@@ -451,6 +452,8 @@ void SetupServerArgs()
     argsman.AddArg("-keypool=<n>", strprintf("Set key pool size to <n> (default: %u for HD, %u for pre-HD wallets)", DEFAULT_KEYPOOL_SIZE, DEFAULT_KEYPOOL_SIZE_PRE_HD),
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-rescan", "Rescan the block chain for missing wallet transactions",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    argsman.AddArg("-rescanmrcrequests", "Rescan the block chain for missing mrc request transactions",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-salvagewallet", "Attempt to recover private keys from a corrupt wallet.dat",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
@@ -1318,16 +1321,59 @@ bool AppInit2(ThreadHandlerPtr threads)
     RegisterWallet(pwalletMain);
 
     CBlockIndex *pindexRescan = pindexBest;
+    bool mrc_request_correction_scan_complete = false;
+
     if (gArgs.GetBoolArg("-rescan"))
         pindexRescan = pindexGenesisBlock;
     else
     {
         CWalletDB walletdb(walletFileName.string());
+
         CBlockLocator locator;
-        if (walletdb.ReadBestBlock(locator))
+        if (walletdb.ReadBestBlock(locator)) {
             pindexRescan = locator.GetBlockIndex();
+        }
+
+        walletdb.ReadAttribute("mrc_request_correction_scan_complete", mrc_request_correction_scan_complete);
     }
-    if (pindexBest != pindexRescan && pindexBest && pindexRescan && pindexBest->nHeight > pindexRescan->nHeight)
+
+    // If rescan is NOT specified and mrc_request_correction_scan_complete is false and the wallet best height
+    // is greater than the V12 height, where MRC requests became possible, then perform a correction rescan for
+    // MRC requests from the BlockV12Height block to the wallet best height - 1. From the wallet best height to
+    // the block chain height will be handled by the normal rescan block below.
+    // -rescanmrcrequests can be specified as a startup parameter regardless of the state of the
+    // mrc_request_correction_scan_complete flag.
+    if (!gArgs.GetBoolArg("-rescan")
+            && (!mrc_request_correction_scan_complete || gArgs.GetBoolArg("-rescanmrcrequests"))
+            && pindexRescan->nHeight > Params().GetConsensus().BlockV12Height) {
+        CBlockIndex *pindexMRCRequestRescan = GRC::BlockFinder::FindByHeight(Params().GetConsensus().BlockV12Height);
+        uiInterface.InitMessage(_("Rescanning for MRC requests..."));
+        LogPrintf("INFO: %s: Rescanning from block height %i to %i for missing MRC request transactions",
+                 __func__, pindexMRCRequestRescan->nHeight, pindexRescan->nHeight - 1);
+
+        g_timer.GetTimes("mrc request correction scan start", "init");
+
+        int mrc_requests_added = 0;
+
+        pwalletMain->ScanForMRCRequests(pindexMRCRequestRescan, pindexRescan, true);
+
+        LogPrintf("INFO: %u: %i missing MRC request transactions added to wallet.",
+                  __func__, mrc_requests_added);
+
+        g_timer.GetTimes("mrc request correction scan complete", "init");
+
+        CWalletDB walletdb(walletFileName.string());
+        mrc_request_correction_scan_complete = true;
+        if (!walletdb.WriteAttribute("mrc_request_correction_scan_complete", mrc_request_correction_scan_complete)) {
+            error("%s: Unable to update mrc request correction scan attribute in wallet db.", __func__);
+        }
+    }
+
+    // If -rescan was not requested, but the wallet height is less than the block database height, then we
+    // must rescan from the wallet height to the block database height anyway to catch the wallet up. If rescan
+    // was requested, then this starts from genesis. If the pindexRescan->nHeight (i.e. wallet best height was
+    // less than or equal to the BlockV12Height, then the MRC request rescan above did not occur.
+    if (pindexBest && pindexRescan && pindexBest != pindexRescan && pindexBest->nHeight > pindexRescan->nHeight)
     {
         uiInterface.InitMessage(_("Rescanning..."));
         LogPrintf("Rescanning last %i blocks (from block %i)...", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1210,12 +1210,20 @@ void CWallet::ResendWalletTransactions(bool fForce)
     if (!fForce)
     {
         // Do this infrequently and randomly to avoid giving away
-        // that these are our transactions.
+        // that these are our transactions. Also only do if the wallet
+        // is in sync. During initial block loads, etc. using a transferred
+        // wallet.dat file, the unconfirmed status of the transactions may not be correct.
+        if (IsInitialBlockDownload() || OutOfSyncByAge()) {
+            return;
+        }
+
         static int64_t nNextTime;
         if ( GetAdjustedTime() < nNextTime)
             return;
         bool fFirst = (nNextTime == 0);
-        nNextTime =  GetAdjustedTime() + GetRand(30 * 60);
+
+        // Choose a random time up to about 10 blocks at target spacing.
+        nNextTime =  GetAdjustedTime() + GetRand(GetTargetSpacing(nBestHeight) * 10);
         if (fFirst)
             return;
 
@@ -1226,43 +1234,87 @@ void CWallet::ResendWalletTransactions(bool fForce)
         nLastTime =  GetAdjustedTime();
     }
 
-    // Rebroadcast any of our txes that aren't in a block yet, and clean up invalid transactions.
-    std::vector<CTransaction> to_be_erased;
+    std::map<uint256, CTransaction> to_be_erased;
+
+    unsigned int txns_relayed = 0;
+    unsigned int txns_failed_validation = 0;
+    unsigned int txns_erased_from_wallet = 0;
 
     CTxDB txdb("r");
     {
         LOCK(cs_wallet);
-        // Sort them in chronological order
+        // Sort them in chronological order.
         multimap<unsigned int, CWalletTx*> mapSorted;
+
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: mapWallet.size() = %u.",
+                 __func__,
+                 mapWallet.size());
+
         for (auto &item : mapWallet)
         {
             CWalletTx& wtx = item.second;
-            // Don't rebroadcast until it's had plenty of time that
-            // it should have gotten in already by now.
-            if (fForce || g_nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
-                mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
+
+            // Resend only if hashBlock is null AND not in the mainchain AND not in the mempool (this is depth = -1).
+            if (wtx.hashBlock.IsNull() && wtx.GetDepthInMainChain() == -1) {
+                // Don't rebroadcast until it's had plenty of time that it should have gotten in already by now.
+                // Here we are using time of approximately 5 blocks at target spacing.
+                if (fForce || g_nTimeBestReceived - (int64_t)wtx.nTimeReceived > GetTargetSpacing(nBestHeight) * 5)
+                    mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
+            }
         }
+
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: Candidate transactions for sending: mapSorted.size() = %u",
+                 __func__,
+                 mapSorted.size());
 
         for (auto const &item : mapSorted)
         {
             CWalletTx& wtx = *item.second;
+
             if (wtx.RevalidateTransaction(txdb)) {
                 // Transaction is valid for relaying.
                 wtx.RelayWalletTransaction(txdb);
+
+                ++txns_relayed;
             } else {
-                LogPrintf("ResendWalletTransactions() : CheckTransaction failed for transaction %s. Transaction will be "
-                          "erased.", wtx.GetHash().ToString());
-                to_be_erased.push_back(wtx);
+                LogPrintf("WARNING: %s: CheckTransaction failed for transaction %s. Transaction will be "
+                          "erased.",
+                          __func__,
+                          wtx.GetHash().ToString());
+
+                to_be_erased.insert(std::make_pair(wtx.GetHash(), wtx));
+
+                ++txns_failed_validation;
             }
         }
     }
 
-    for (const auto& wtx : to_be_erased) {
-        LogPrintf("%s: Erasing invalid transaction %s.", __func__, wtx.GetHash().ToString());
-        EraseFromWallet(wtx.GetHash());
-        mempool.remove((CTransaction) wtx);
-        NotifyTransactionChanged(this, wtx.GetHash(), CT_DELETED);
+    if (to_be_erased.size()) {
+        LogPrint(BCLog::LogFlags::VERBOSE, "WARNING: %s: to_be_erased.size() = %u", __func__, to_be_erased.size());
     }
+
+    for (const auto& wtx : to_be_erased) {
+
+        const CTransaction& tx = wtx.second;
+
+        if (EraseFromWallet(wtx.first)) {
+            LogPrintf("WARNING %s: Erased invalid transaction %s from the wallet.", __func__, wtx.first.ToString());
+
+            ++txns_erased_from_wallet;
+        } else {
+            LogPrintf("WARNING %s: Unable to erase invalid transaction %s from the wallet.",
+                      __func__, wtx.first.ToString());
+        }
+
+        NotifyTransactionChanged(this, tx.GetHash(), CT_DELETED);
+    }
+
+    LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: %u transactions relayed, %u transactions failed validation, "
+                                       "%u transactions erased from wallet.",
+             __func__,
+             txns_relayed,
+             txns_failed_validation,
+             txns_erased_from_wallet);
 }
 
 bool CWalletTx::RevalidateTransaction(CTxDB& txdb)
@@ -1286,6 +1338,7 @@ bool CWalletTx::RevalidateTransaction(CTxDB& txdb)
     }
 
     // Validate any contracts published in the transaction:
+
     if (!tx.GetContracts().empty()) {
         if (!CheckContracts(tx, mapInputs, pindexBest->nHeight)) {
             return error("%s: CheckContracts found invalid contract in tx %s", __func__, tx.GetHash().ToString());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1143,7 +1143,6 @@ int CWallet::ScanForMRCRequests(CBlockIndex* pindexStart, CBlockIndex* pindexEnd
                 {
                     if (!tx.GetContracts().empty()
                             && tx.GetContracts()[0].m_type == GRC::ContractType::MRC
-                            && mapWallet.find(tx.GetHash()) == mapWallet.end()
                             && AddToWalletIfInvolvingMe(tx, &block, fUpdate))
                         ret++;
                 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -247,6 +247,7 @@ public:
     bool EraseFromWallet(uint256 hash);
     void WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* pwalletdb);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
+    int ScanForMRCRequests(CBlockIndex* pindexStart, CBlockIndex* pindexEnd, bool fUpdate = false);
     void ReacceptWalletTransactions();
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -248,6 +248,15 @@ public:
     void WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* pwalletdb);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
+
+
+    //!
+    //! \brief This method resends wallet transactions that have not been confirmed on the chain. The original implementation
+    //! was based on old Bitcoin code and was really bad. This new revision adapts some of the ideas from the Bitcoin Core
+    //! current master (~v22), but to straighten everything out requires a full port of the newer Bitcoin wallet code.
+    //!
+    //! \param fForce
+    //!
     void ResendWalletTransactions(bool fForce = false);
     int64_t GetBalance() const;
     int64_t GetUnconfirmedBalance() const;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -223,7 +223,6 @@ public:
     template<typename T>
     bool ReadAttribute(const std::string& attribute, T& value)
     {
-        nWalletDBUpdated++;
         return Read(std::make_pair(std::string("attribute"), attribute), value);
     }
 private:

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -212,6 +212,20 @@ public:
         nWalletDBUpdated++;
         return Write(std::string("backuptime"), backup_time);
     }
+
+    template<typename T>
+    bool WriteAttribute(const std::string& attribute, const T& value)
+    {
+        nWalletDBUpdated++;
+        return Write(std::make_pair(std::string("attribute"), attribute), value);
+    }
+
+    template<typename T>
+    bool ReadAttribute(const std::string& attribute, T& value)
+    {
+        nWalletDBUpdated++;
+        return Read(std::make_pair(std::string("attribute"), attribute), value);
+    }
 private:
     bool WriteAccountingEntry(const uint64_t nAccEntryNum, const CAccountingEntry& acentry);
 public:


### PR DESCRIPTION
This PR corrects and optimizes the behavior of ResendWalletTransactions.

The original function did not have the proper filtering, and was essentially queuing up every transaction in the wallet to be resent. This bug has been present forever. Note that it was made worse when the transaction validation was tightened in 5.4.1.2 to strictly check GRC contracts. It also had the unintended impact of possibly deleting MRC request transactions (NOT the payments) from the wallet database.

This PR implements a targeted automatic rescan to recover those.