### PR TITLE
build(nsis): Write registry keys to HKLM instead of HKCU, Install shortcuts for all users, Fix INSTALLDIR removal bug

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -173,8 +173,8 @@ Function .onInit
     ${IfThen} $0 == "" ${|} Return ${|}
     ${IfNot} ${Cmd} \
         'MessageBox MB_YESNO|MB_ICONEXCLAMATION \
-          "An old version is found to be installed on your system. \
-          Uninstallation will proceed first to migrate registry entries and shortcuts. Continue?" \
+          "An old version is found on your system and will be uninstalled first to migrate registry entries and shortcuts. \
+          Your wallet data will not be affected. Continue?" \
           /SD IDYES IDYES'
       Abort
     ${EndIf}

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -69,7 +69,7 @@ VIAddVersionKey CompanyWebsite "${URL}"
 VIAddVersionKey FileVersion "${VERSION}"
 VIAddVersionKey FileDescription "Installer for @PACKAGE_NAME@"
 VIAddVersionKey LegalCopyright "Copyright (C) 2014-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@"
-InstallDirRegKey HKCU "${REGKEY}" Path
+InstallDirRegKey HKLM "${REGKEY}" Path
 ShowUninstDetails show
 
 # Installer sections
@@ -83,11 +83,11 @@ Section -Main SEC0000
     File /oname=COPYING.txt @abs_top_srcdir@/COPYING
     File /oname=CHANGELOG.md @abs_top_srcdir@/CHANGELOG.md
     SetOutPath $INSTDIR
-    WriteRegStr HKCU "${REGKEY}\Components" Main 1
+    WriteRegStr HKLM "${REGKEY}\Components" Main 1
 SectionEnd
 
 Section -post SEC0001
-    WriteRegStr HKCU "${REGKEY}" Path $INSTDIR
+    WriteRegStr HKLM "${REGKEY}" Path $INSTDIR
     SetOutPath $INSTDIR
     WriteUninstaller $INSTDIR\uninstall.exe
     !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
@@ -96,14 +96,14 @@ Section -post SEC0001
     CreateShortcut "$SMPROGRAMS\$StartMenuGroup\@PACKAGE_NAME@ (testnet, @WINDOWS_BITS@-bit).lnk" "$INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@" "-testnet" "$INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@" 1
     CreateShortcut "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk" $INSTDIR\uninstall.exe
     !insertmacro MUI_STARTMENU_WRITE_END
-    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayName "$(^Name)"
-    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayVersion "${VERSION}"
-    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" Publisher "${COMPANY}"
-    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" URLInfoAbout "${URL}"
-    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayIcon $INSTDIR\uninstall.exe
-    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
-    WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
-    WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayName "$(^Name)"
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayVersion "${VERSION}"
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" Publisher "${COMPANY}"
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" URLInfoAbout "${URL}"
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayIcon $INSTDIR\uninstall.exe
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
+    WriteRegDWORD HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
+    WriteRegDWORD HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
     WriteRegStr HKCR "@PACKAGE_TARNAME@" "URL Protocol" ""
     WriteRegStr HKCR "@PACKAGE_TARNAME@" "" "URL:Bitcoin"
     WriteRegStr HKCR "@PACKAGE_TARNAME@\DefaultIcon" "" $INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@
@@ -113,7 +113,7 @@ SectionEnd
 # Macro for selecting uninstaller sections
 !macro SELECT_UNSECTION SECTION_NAME UNSECTION_ID
     Push $R0
-    ReadRegStr $R0 HKCU "${REGKEY}\Components" "${SECTION_NAME}"
+    ReadRegStr $R0 HKLM "${REGKEY}\Components" "${SECTION_NAME}"
     StrCmp $R0 1 0 next${UNSECTION_ID}
     !insertmacro SelectSection "${UNSECTION_ID}"
     GoTo done${UNSECTION_ID}
@@ -128,11 +128,11 @@ Section /o -un.Main UNSEC0000
     Delete /REBOOTOK $INSTDIR\@GRIDCOIN_GUI_NAME@@EXEEXT@
     RMDir /r /REBOOTOK $INSTDIR\daemon
     RMDir /r /REBOOTOK $INSTDIR\doc
-    DeleteRegValue HKCU "${REGKEY}\Components" Main
+    DeleteRegValue HKLM "${REGKEY}\Components" Main
 SectionEnd
 
 Section -un.post UNSEC0001
-    DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)"
+    DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\@PACKAGE_NAME@ (testnet, @WINDOWS_BITS@-bit).lnk"
@@ -142,10 +142,10 @@ Section -un.post UNSEC0001
     Delete /REBOOTOK $INSTDIR\uninstall.exe
     Delete /REBOOTOK $INSTDIR\debug.log
     Delete /REBOOTOK $INSTDIR\db.log
-    DeleteRegValue HKCU "${REGKEY}" StartMenuGroup
-    DeleteRegValue HKCU "${REGKEY}" Path
-    DeleteRegKey /IfEmpty HKCU "${REGKEY}\Components"
-    DeleteRegKey /IfEmpty HKCU "${REGKEY}"
+    DeleteRegValue HKLM "${REGKEY}" StartMenuGroup
+    DeleteRegValue HKLM "${REGKEY}" Path
+    DeleteRegKey /IfEmpty HKLM "${REGKEY}\Components"
+    DeleteRegKey /IfEmpty HKLM "${REGKEY}"
     DeleteRegKey HKCR "@PACKAGE_TARNAME@"
     RmDir /REBOOTOK $SMPROGRAMS\$StartMenuGroup
     RmDir /REBOOTOK $INSTDIR
@@ -163,7 +163,7 @@ Function .onInit
     ${If} ${RunningX64}
       ; disable registry redirection (enable access to 64-bit portion of registry)
       SetRegView 64
-      ReadRegStr $INSTDIR HKCU "${REGKEY}" "Path"
+      ReadRegStr $INSTDIR HKLM "${REGKEY}" "Path"
       StrCmp $INSTDIR "" 0 rununin
       StrCpy $INSTDIR $PROGRAMFILES64\GridcoinResearch
     ${Else}
@@ -171,7 +171,7 @@ Function .onInit
       Abort
     ${EndIf}
 !else
-    ReadRegStr $INSTDIR HKCU "${REGKEY}" "Path"
+    ReadRegStr $INSTDIR HKLM "${REGKEY}" "Path"
     StrCmp $INSTDIR "" 0 rununin
     StrCpy $INSTDIR $PROGRAMFILES\GridcoinResearch
 !endif
@@ -182,7 +182,7 @@ FunctionEnd
 
 # Uninstaller functions
 Function un.onInit
-    ReadRegStr $INSTDIR HKCU "${REGKEY}" Path
+    ReadRegStr $INSTDIR HKLM "${REGKEY}" Path
     !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuGroup
     !insertmacro SELECT_UNSECTION Main ${UNSEC0000}
 FunctionEnd

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -168,10 +168,14 @@ Function .onInit
       Abort
     ${EndIf}
 !endif
-    ; Check for stale HKCU registry entries and uninstall if found
+    ; Check for HKCU Path registry and prompt for uninstallation if found
     ReadRegStr $0 HKCU "${REGKEY}" "Path"
     ${IfThen} $0 == "" ${|} Return ${|}
-    ${IfNot} ${Cmd} 'MessageBox MB_YESNO|MB_ICONEXCLAMATION "Old version with stale registry entries detected. Uninstallation will proceed first. Continue?" /SD IDYES IDYES'
+    ${IfNot} ${Cmd} \
+        'MessageBox MB_YESNO|MB_ICONEXCLAMATION \
+          "An old version is found to be installed on your system. \
+          Uninstallation will proceed first to migrate registry entries and shortcuts. Continue?" \
+          /SD IDYES IDYES'
       Abort
     ${EndIf}
     ReadRegStr $1 HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" "UninstallString"

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -159,30 +159,37 @@ SectionEnd
 # Installer functions
 Function .onInit
     InitPluginsDir
+    SetShellVarContext all
 !if "@WINDOWS_BITS@" == "64"
     ${If} ${RunningX64}
-      ; disable registry redirection (enable access to 64-bit portion of registry)
-      SetRegView 64
-      ReadRegStr $INSTDIR HKLM "${REGKEY}" "Path"
-      StrCmp $INSTDIR "" 0 rununin
-      StrCpy $INSTDIR $PROGRAMFILES64\GridcoinResearch
+      SetRegView 64 ; disable registry redirection (enable access to 64-bit portion of registry)
     ${Else}
-      MessageBox MB_OK|MB_ICONSTOP "Cannot install 64-bit version on a 32-bit system."
+      MessageBox MB_OK|MB_ICONSTOP "Cannot install 64-bit version on a 32-bit system." /SD IDOK
       Abort
     ${EndIf}
-!else
-    ReadRegStr $INSTDIR HKLM "${REGKEY}" "Path"
-    StrCmp $INSTDIR "" 0 rununin
-    StrCpy $INSTDIR $PROGRAMFILES\GridcoinResearch
 !endif
-    rununin:
-      Exec $INSTDIR\uninst.exe
-      Delete $INSTDIR\*"
+    ; Check for stale HKCU registry entries and uninstall if found
+    ReadRegStr $0 HKCU "${REGKEY}" "Path"
+    ${IfThen} $0 == "" ${|} Return ${|}
+    ${IfNot} ${Cmd} 'MessageBox MB_YESNO|MB_ICONEXCLAMATION "Old version with stale registry entries detected. Uninstallation will proceed first. Continue?" /SD IDYES IDYES'
+      Abort
+    ${EndIf}
+    ReadRegStr $1 HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" "UninstallString"
+    ${If} ${Silent}
+      StrCpy $1 "$1 /S"
+    ${EndIf}
+    ExecWait "$1 _?=$0" $0
+    ${IfThen} $0 != 0 ${|} Abort ${|}
 FunctionEnd
 
 # Uninstaller functions
 Function un.onInit
-    ReadRegStr $INSTDIR HKLM "${REGKEY}" Path
+    SetShellVarContext all
+!if "@WINDOWS_BITS@" == "64"
+    ${If} ${RunningX64}
+      SetRegView 64 ; disable registry redirection (enable access to 64-bit portion of registry)
+    ${EndIf}
+!endif
     !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuGroup
     !insertmacro SELECT_UNSECTION Main ${UNSEC0000}
 FunctionEnd


### PR DESCRIPTION
This is the proper root key to write registries for machine-wide installation. Winget was having problems due to this inconsistency: https://github.com/microsoft/winget-pkgs/issues/47655