### PR TITLE
rpc: add `getnodeaddresses`

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -227,6 +227,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
     // Network
     { "getaddednodeinfo"       , 0 },
+    { "getnodeaddresses"       , 0 },
     { "getblock"               , 1 },
     { "getblockbynumber"       , 0 },
     { "getblockbynumber"       , 1 },

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -80,6 +80,38 @@ UniValue addnode(const UniValue& params, bool fHelp)
     return result;
 }
 
+UniValue getnodeaddresses(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+                "getnodeaddresses [count]\n"
+                "\nReturn known addresses which can potentially be used to find new nodes in the network\n"
+                "count: How many addresses to return. Limited to the smaller of " + std::to_string(ADDRMAN_GETADDR_MAX) +
+                " or " + std::to_string(ADDRMAN_GETADDR_MAX_PCT) + "% of all known addresses. (default = 1)\n");
+    int count = 1;
+    if(!params[0].isNull())
+        count = params[0].get_int();
+
+    if (count <= 0)
+        throw JSONRPCError(-8, "Address count out of range");
+
+    // returns a shuffled list of CAddress
+    std::vector<CAddress> vAddr = addrman.GetAddr();
+    UniValue ret(UniValue::VARR);
+
+    int address_return_count = std::min<int>(count, vAddr.size());
+    for (int i = 0; i < address_return_count; ++i) {
+        UniValue obj(UniValue::VOBJ);
+        const CAddress& addr = vAddr[i];
+        obj.pushKV("time", (int)addr.nTime);
+        obj.pushKV("services", (uint64_t)addr.nServices);
+        obj.pushKV("address", addr.ToStringIP());
+        obj.pushKV("port", addr.GetPort());
+        ret.push_back(obj);
+    }
+    return ret;
+}
+
 UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -419,6 +419,7 @@ static const CRPCCommand vRPCCommands[] =
     { "clearbanned",             &clearbanned,             cat_network       },
     { "currenttime",             &currenttime,             cat_network       },
     { "getaddednodeinfo",        &getaddednodeinfo,        cat_network       },
+    { "getnodeaddresses",        &getnodeaddresses,        cat_network       },
     { "getbestblockhash",        &getbestblockhash,        cat_network       },
     { "getblock",                &getblock,                cat_network       },
     { "getblockbynumber",        &getblockbynumber,        cat_network       },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -231,6 +231,7 @@ extern UniValue changesettings(const UniValue& params, bool fHelp);
 extern UniValue clearbanned(const UniValue& params, bool fHelp);
 extern UniValue currenttime(const UniValue& params, bool fHelp);
 extern UniValue getaddednodeinfo(const UniValue& params, bool fHelp);
+extern UniValue getnodeaddresses(const UniValue& params, bool fHelp);
 extern UniValue getbestblockhash(const UniValue& params, bool fHelp);
 extern UniValue getblock(const UniValue& params, bool fHelp);
 extern UniValue getblockbynumber(const UniValue& params, bool fHelp);


### PR DESCRIPTION
The RPC call `getnodeaddresses` is added. The implementation is almost identical to the one in Bitcoin.