### PR TITLE
rpc: Formatting - typo correction rpc help for listresearcheraccounts

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -647,7 +647,7 @@ UniValue listresearcheraccounts(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "listresearcheraccrounts\n"
+            "listresearcheraccounts\n"
             "\n"
             "List researcher accounts in the accrual system and their current accruals.\n");
 


### PR DESCRIPTION
Path: Debug --> console --> command "help developer"
Expected Result: returns list of commands for the developer RPC.
Output: 
"
addkey <action> <keytype> <keyname> <keyvalue> <gdpr_protection_bool>
archivelog <log>
auditsnapshotaccrual [CPID] [report details]
auditsnapshotaccruals [report only mismatches]
changesettings <name=value> [name=value] ... [name=value]
convergencereport [convergence_cache_details]
currentcontractaverage
debug <bool>
deletecscrapermanifest <hash>
dumpcontracts <contract_type> <file> [txids only] [low height] [high height]
exportstats1 [maxblocks aggregate [endblock]] 
getblockstats mode [startheight [endheight]]
getlistof <keytype>
getmpart <hash>
getrecentblocks detail count
inspectaccrualsnapshot <height>
listalerts
listdata <keytype>
listmanifests [bool details] [manifest hash]
listprojects
**listresearcheraccrounts**
listsettings
logging [json array category adds] [json array category removes]
network
parseaccrualsnapshot <filespec>
parselegacysb
projects
readdata <key>
reorganize <hash>
savescraperfilemanifest <hash>
scraperreport
sendalert <message> <privatekey> <minver> <maxver> <priority> <id> [cancelupto]
sendalert2 <privatekey> <id> <subverlist> <cancellist> <expire> <priority> <message>
sendblock <blockhash>
sendscraperfilemanifest
superblockaverage
testnewsb [hint bits]
versionreport <lookback:int> <full:bool>
writedata <key> <value>
"
Error Description: display command for "listresearcheraccounts" contains a typo "listresearcheracc**_r_**ounts"
Change Description: Fix typo in display name for the help developer RPC command output.
Impact: low

Hi! I don't know very much about coding, but I want to help in anyway I can!
I have made the commit to correct the typo in the display name.
Now I am making a pull request to have my change included in the main code?

Let me know if I did this right.