### PR TITLE
gui: Enhance MRC request form to avoid fee boost field confusion

### DIFF
--- a/src/qt/forms/mrcrequestpage.ui
+++ b/src/qt/forms/mrcrequestpage.ui
@@ -159,7 +159,7 @@
         <item row="6" column="1">
          <widget class="QLabel" name="mrcMinimumSubmitFee">
           <property name="toolTip">
-           <string>The calculated minimum fee for the MRC. This may not be sufficient to submit the MRC if the queue is already full. In that case, you need to use the MRC fee boost to raise the fee to get your MRC in the queue.</string>
+           <string>The calculated minimum fee for the MRC. This may not be sufficient to submit the MRC if the queue is already full. In that case, the MRC Fee Boost field will appear and you need to use it to raise the fee to get your MRC in the queue.</string>
           </property>
           <property name="text">
            <string/>
@@ -226,19 +226,26 @@
            <string>MRC Fee Boost</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QPushButton" name="mrcFeeBoostRaiseToMinimumButton">
+          <property name="toolTip">
+           <string>This will automatically boost the MRC fee you are paying to get your MRC request in the queue.</string>
+          </property>
           <property name="text">
            <string>Raise to Minimum For Submit</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="BitcoinAmountField" name="mrcFeeBoostSpinBox"/>
+         <widget class="BitcoinAmountField" name="mrcFeeBoostSpinBox">
+          <property name="toolTip">
+           <string>This appears if the queue is full and you need to boost the fee you will pay out of your rewards to displace someone else in the queue. It is NOT the amount of reward to be redeemed!</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -149,8 +149,11 @@ void MRCRequestPage::updateMRCStatus()
 
             ui->mrcMinimumSubmitFee->setText(tr("N/A"));
 
+            ui->mrcFeeBoostLabel->hide();
             ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(false);
             ui->mrcFeeBoostRaiseToMinimumButton->hide();
+            ui->mrcFeeBoostSpinBox->setEnabled(false);
+            ui->mrcFeeBoostSpinBox->hide();
 
             ui->SubmittedIconLabel->show();
             ui->ErrorIconLabel->hide();
@@ -165,8 +168,11 @@ void MRCRequestPage::updateMRCStatus()
 
             ui->mrcMinimumSubmitFee->setText(tr("N/A"));
 
+            ui->mrcFeeBoostLabel->hide();
             ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(false);
             ui->mrcFeeBoostRaiseToMinimumButton->hide();
+            ui->mrcFeeBoostSpinBox->setEnabled(false);
+            ui->mrcFeeBoostSpinBox->hide();
 
             ui->SubmittedIconLabel->hide();
             ui->ErrorIconLabel->show();
@@ -181,8 +187,11 @@ void MRCRequestPage::updateMRCStatus()
 
             ui->mrcMinimumSubmitFee->setText(tr("N/A"));
 
+            ui->mrcFeeBoostLabel->hide();
             ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(false);
             ui->mrcFeeBoostRaiseToMinimumButton->hide();
+            ui->mrcFeeBoostSpinBox->setEnabled(false);
+            ui->mrcFeeBoostSpinBox->hide();
 
             ui->SubmittedIconLabel->hide();
             ui->ErrorIconLabel->show();
@@ -198,11 +207,17 @@ void MRCRequestPage::updateMRCStatus()
             ui->mrcMinimumSubmitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCMinimumSubmitFee()));
 
             if (m_mrc_model->getMRCReward() > m_mrc_model->getMRCQueuePayLimitFee()) {
+                ui->mrcFeeBoostLabel->show();
                 ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(true);
                 ui->mrcFeeBoostRaiseToMinimumButton->show();
+                ui->mrcFeeBoostSpinBox->setEnabled(true);
+                ui->mrcFeeBoostSpinBox->show();
             } else {
+                ui->mrcFeeBoostLabel->hide();
                 ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(false);
                 ui->mrcFeeBoostRaiseToMinimumButton->hide();
+                ui->mrcFeeBoostSpinBox->setEnabled(false);
+                ui->mrcFeeBoostSpinBox->hide();
             }
 
             ui->SubmittedIconLabel->hide();
@@ -218,6 +233,12 @@ void MRCRequestPage::updateMRCStatus()
 
             ui->mrcMinimumSubmitFee->setText(tr("N/A"));
 
+            ui->mrcFeeBoostLabel->hide();
+            ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(false);
+            ui->mrcFeeBoostRaiseToMinimumButton->hide();
+            ui->mrcFeeBoostSpinBox->setEnabled(false);
+            ui->mrcFeeBoostSpinBox->hide();
+
             ui->SubmittedIconLabel->hide();
             ui->ErrorIconLabel->show();
             ui->ErrorIconLabel->setToolTip(message);
@@ -232,8 +253,11 @@ void MRCRequestPage::updateMRCStatus()
 
         ui->mrcMinimumSubmitFee->setText(BitcoinUnits::formatWithUnit(display_unit, m_mrc_model->getMRCMinimumSubmitFee()));
 
+        ui->mrcFeeBoostLabel->hide();
         ui->mrcFeeBoostRaiseToMinimumButton->setEnabled(false);
         ui->mrcFeeBoostRaiseToMinimumButton->hide();
+        ui->mrcFeeBoostSpinBox->setEnabled(false);
+        ui->mrcFeeBoostSpinBox->hide();
 
         ui->mrcSubmitButton->setEnabled(true);
         ui->mrcSubmitButton->setToolTip(message);


### PR DESCRIPTION
This commit implements functionality to hide the fee boost field unless the MRC queue is full and fee boost is actually needed to submit the MRC request. After several months of experience with MRC in production, it has become apparent that some people were unnecessarily putting GRC in the fee boost field, or outright mistaking it for the amount of rewards to redeem.