### PR TITLE
contrib: add nix file for compilation environment

### DIFF
--- a/contrib/default.nix
+++ b/contrib/default.nix
@@ -1,0 +1,13 @@
+let pkgs = import <nixpkgs> {};
+in
+with pkgs.stdenv;
+with pkgs.stdenv.lib;
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs.buildPackages; [ autoreconfHook libtool pkg-config qt5.wrapQtAppsHook ];
+  buildInputs = with pkgs; [ boost openssl libevent curl qt5.qttools libzip qrencode ];
+
+  shellHook = ''
+    echo "Run configure with: --with-qt-bindir=${pkgs.qt5.qtbase.dev}/bin:${pkgs.qt5.qttools.dev}/bin --with-boost-libdir=${pkgs.boost.out}/lib"
+  '';
+}


### PR DESCRIPTION
Creates a development environment that can compile Gridcoin when
used with nix-shell command. Could be useful for Nix users.