### PR TITLE
build: use builddir instead of srcdir for bdb 5.3 include

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,7 @@ LIBUNIVALUE = $(UNIVALUE_LIBS)
 endif
 
 GRIDCOIN_CONFIG_INCLUDES=-I$(builddir)/config
-GRIDCOIN_INCLUDES=-I$(builddir) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -I$(srcdir)/bdb53 $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS) $(UNIVALUE_CFLAGS) $(CURL_CFLAGS) $(LIBZIP_CFLAGS)
+GRIDCOIN_INCLUDES=-I$(builddir) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -I$(builddir)/bdb53 $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS) $(UNIVALUE_CFLAGS) $(CURL_CFLAGS) $(LIBZIP_CFLAGS)
 
 LIBGRIDCOIN_UTIL=libgridcoin_util.a
 LIBGRIDCOINQT=qt/libgridcoinqt.a


### PR DESCRIPTION
BDB 5.3 generates the headers to include in the build directory. For most cases, this will not matter as most builds are done in tree where source directory and build directory are the same. However since CD builds are done out of tree, using srcdir leads to an issue where the include files are generated in the build directory while automake expects them to be in the source directory.

Normally this would also be a problem with the CI, however since CI does an in-tree configure first the needed include files are also generated in source which leads to the build system finding them.

https://github.com/gridcoin-community/Gridcoin-Research/blob/c15046c54acc478c20ee0de6f20aa6626c1adcfe/ci/test/06_script_a.sh#L24