### PR TITLE
util: Fix missing if statement protecting std::optional assignment in diagnose.h

### DIFF
--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -532,17 +532,19 @@ public:
          */
 
         const GRC::BeaconRegistry& beacons = GRC::GetBeaconRegistry();
-        const GRC::CpidOption cpid = GRC::Researcher::Get()->Id().TryCpid();
-        if (const GRC::BeaconOption beacon = beacons.Try(*cpid)) {
-            if (!beacon->Expired(GetAdjustedTime())) {
-                return true;
-            }
-            for (const auto& beacon_ptr : beacons.FindPending(*cpid)) {
-                if (!beacon_ptr->Expired(GetAdjustedTime())) {
+        if (const GRC::CpidOption cpid = GRC::Researcher::Get()->Id().TryCpid()) {
+            if (const GRC::BeaconOption beacon = beacons.Try(*cpid)) {
+                if (!beacon->Expired(GetAdjustedTime())) {
                     return true;
+                }
+                for (const auto& beacon_ptr : beacons.FindPending(*cpid)) {
+                    if (!beacon_ptr->Expired(GetAdjustedTime())) {
+                        return true;
+                    }
                 }
             }
         }
+
         return false;
     }
     void runCheck()


### PR DESCRIPTION
in diagnose.h. The assignment of the cpid in hasActiveBeacon, which is a std::optional, was not protected by an if statement.