### PR TITLE
banman: use GetPerformanceCounter instead of GetRandBytes

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -40,9 +40,7 @@ template <typename Data>
 bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data& data)
 {
     // Generate random temporary filename
-    unsigned short randv = 0;
-    GetRandBytes((unsigned char*)&randv, sizeof(randv));
-    std::string tmpfn = strprintf("%s.%04x", prefix, randv);
+    std::string tmpfn = strprintf("%s.%" PRIx64, prefix, GetPerformanceCounter());
 
     // open temp output file, and associate with CAutoFile
     fs::path pathTmp = GetDataDir() / tmpfn;


### PR DESCRIPTION
BanMan does a flush on shutdown which calls GetRandBytes in order to get a temporary filename to write to. Since this happens at shutdown the RNGState powering GetRandBytes could already be destructed which can lead to a segfault.