### PR TITLE
build: Replace $(AT) with .SILENT

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -63,10 +63,6 @@ host_prefix=$($(host_arch)_$(host_os)_prefix)
 build_prefix=$(host_prefix)/native
 build_host=$(build)
 
-AT_$(V):=
-AT_:=@
-AT:=$(AT_$(V))
-
 all: install
 
 include hosts/$(host_os).mk
@@ -109,12 +105,12 @@ include funcs.mk
 final_build_id_long+=$(shell $(build_SHA256SUM) config.site.in)
 final_build_id+=$(shell echo -n "$(final_build_id_long)" | $(build_SHA256SUM) | cut -c-$(HASH_LENGTH))
 $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
-	$(AT)rm -rf $(@D)
-	$(AT)mkdir -p $(@D)
-	$(AT)echo copying packages: $^
-	$(AT)echo to: $(@D)
-	$(AT)cd $(@D); $(foreach package,$^, tar xf $($(package)_cached); )
-	$(AT)touch $@
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	echo copying packages: $^
+	echo to: $(@D)
+	cd $(@D); $(foreach package,$^, tar xf $($(package)_cached); )
+	touch $@
 
 # $PATH is not preserved between ./configure and make by convention. Its
 # modification and overriding at ./configure time is (as I understand it)
@@ -141,8 +137,8 @@ $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
 # we expect them to be available in $PATH at all times, more specificity does
 # not hurt.
 $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
-	$(AT)@mkdir -p $(@D)
-	$(AT)sed -e 's|@HOST@|$(host)|' \
+	@mkdir -p $(@D)
+	sed -e 's|@HOST@|$(host)|' \
             -e 's|@CC@|$(host_CC)|' \
             -e 's|@CXX@|$(host_CXX)|' \
             -e 's|@AR@|$(host_AR)|' \
@@ -160,7 +156,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@no_upnp@|$(NO_UPNP)|' \
             -e 's|@debug@|$(DEBUG)|' \
             $< > $@
-	$(AT)touch $@
+	touch $@
 
 
 define check_or_remove_cached
@@ -200,3 +196,4 @@ download-win:
 download: download-osx download-linux download-win
 
 .PHONY: install cached download-one download-osx download-linux download-win download check-packages check-sources
+$(V).SILENT:

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -159,53 +159,53 @@ endef
 
 define int_add_cmds
 $($(1)_fetched):
-	$(AT)mkdir -p $$(@D) $(SOURCES_PATH)
-	$(AT)rm -f $$@
-	$(AT)touch $$@
-	$(AT)cd $$(@D); $(call $(1)_fetch_cmds,$(1))
-	$(AT)cd $($(1)_source_dir); $(foreach source,$($(1)_all_sources),$(build_SHA256SUM) $(source) >> $$(@);)
-	$(AT)touch $$@
+	mkdir -p $$(@D) $(SOURCES_PATH)
+	rm -f $$@
+	touch $$@
+	cd $$(@D); $(call $(1)_fetch_cmds,$(1))
+	cd $($(1)_source_dir); $(foreach source,$($(1)_all_sources),$(build_SHA256SUM) $(source) >> $$(@);)
+	touch $$@
 $($(1)_extracted): | $($(1)_fetched)
-	$(AT)echo Extracting $(1)...
-	$(AT)mkdir -p $$(@D)
-	$(AT)cd $$(@D); $(call $(1)_extract_cmds,$(1))
-	$(AT)touch $$@
+	echo Extracting $(1)...
+	mkdir -p $$(@D)
+	cd $$(@D); $(call $(1)_extract_cmds,$(1))
+	touch $$@
 $($(1)_preprocessed): | $($(1)_dependencies) $($(1)_extracted)
-	$(AT)echo Preprocessing $(1)...
-	$(AT)mkdir -p $$(@D) $($(1)_patch_dir)
-	$(AT)$(foreach patch,$($(1)_patches),cd $(PATCHES_PATH)/$(1); cp $(patch) $($(1)_patch_dir) ;)
-	$(AT)cd $$(@D); $(call $(1)_preprocess_cmds, $(1))
-	$(AT)touch $$@
+	echo Preprocessing $(1)...
+	mkdir -p $$(@D) $($(1)_patch_dir)
+	$(foreach patch,$($(1)_patches),cd $(PATCHES_PATH)/$(1); cp $(patch) $($(1)_patch_dir) ;)
+	cd $$(@D); $(call $(1)_preprocess_cmds, $(1))
+	touch $$@
 $($(1)_configured): | $($(1)_preprocessed)
-	$(AT)echo Configuring $(1)...
-	$(AT)rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar xf $($(package)_cached); )
-	$(AT)mkdir -p $$(@D)
-	$(AT)+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
-	$(AT)touch $$@
+	echo Configuring $(1)...
+	rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar xf $($(package)_cached); )
+	mkdir -p $$(@D)
+	+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
+	touch $$@
 $($(1)_built): | $($(1)_configured)
-	$(AT)echo Building $(1)...
-	$(AT)mkdir -p $$(@D)
-	$(AT)+cd $$(@D); $($(1)_build_env) $(call $(1)_build_cmds, $(1))
-	$(AT)touch $$@
+	echo Building $(1)...
+	mkdir -p $$(@D)
+	+cd $$(@D); $($(1)_build_env) $(call $(1)_build_cmds, $(1))
+	touch $$@
 $($(1)_staged): | $($(1)_built)
-	$(AT)echo Staging $(1)...
-	$(AT)mkdir -p $($(1)_staging_dir)/$(host_prefix)
-	$(AT)cd $($(1)_build_dir); $($(1)_stage_env) $(call $(1)_stage_cmds, $(1))
-	$(AT)rm -rf $($(1)_extract_dir)
-	$(AT)touch $$@
+	echo Staging $(1)...
+	mkdir -p $($(1)_staging_dir)/$(host_prefix)
+	cd $($(1)_build_dir); $($(1)_stage_env) $(call $(1)_stage_cmds, $(1))
+	rm -rf $($(1)_extract_dir)
+	touch $$@
 $($(1)_postprocessed): | $($(1)_staged)
-	$(AT)echo Postprocessing $(1)...
-	$(AT)cd $($(1)_staging_prefix_dir); $(call $(1)_postprocess_cmds)
-	$(AT)touch $$@
+	echo Postprocessing $(1)...
+	cd $($(1)_staging_prefix_dir); $(call $(1)_postprocess_cmds)
+	touch $$@
 $($(1)_cached): | $($(1)_dependencies) $($(1)_postprocessed)
-	$(AT)echo Caching $(1)...
-	$(AT)cd $$($(1)_staging_dir)/$(host_prefix); find . | sort | tar --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
-	$(AT)mkdir -p $$(@D)
-	$(AT)rm -rf $$(@D) && mkdir -p $$(@D)
-	$(AT)mv $$($(1)_staging_dir)/$$(@F) $$(@)
-	$(AT)rm -rf $($(1)_staging_dir)
+	echo Caching $(1)...
+	cd $$($(1)_staging_dir)/$(host_prefix); find . | sort | tar --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
+	mkdir -p $$(@D)
+	rm -rf $$(@D) && mkdir -p $$(@D)
+	mv $$($(1)_staging_dir)/$$(@F) $$(@)
+	rm -rf $($(1)_staging_dir)
 $($(1)_cached_checksum): $($(1)_cached)
-	$(AT)cd $$(@D); $(build_SHA256SUM) $$(<F) > $$(@)
+	cd $$(@D); $(build_SHA256SUM) $$(<F) > $$(@)
 
 .PHONY: $(1)
 $(1): | $($(1)_cached_checksum)


### PR DESCRIPTION
> This reduces the amount of syntax noise in the makefiles.
Setting V=1 still enables verbose logging.
> 
> The only noticeable difference in behavior is that, unless V=1 is specified, make won't print its own messages like
make: Nothing to be done for 'all', make: 'all' is up to date, or touch , if -t is specified.

Ref: https://github.com/bitcoin/bitcoin/pull/22283
