### PR TITLE
build: allow system bdb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,12 @@ AC_ARG_ENABLE([asm],
   [use_asm=$enableval],
   [use_asm=yes])
 
+AC_ARG_ENABLE([embedded-bdb],
+  [AS_HELP_STRING([--disable-embedded-bdb],
+  [use embedded bdb instead of the system one (enabled by default)])],
+  [enable_embedded_bdb=$enableval],
+  [enable_embedded_bdb=yes])
+
 if test "$use_asm" = "yes"; then
   AC_DEFINE(USE_ASM, 1, [Define this symbol to build in assembly routines])
 fi
@@ -1212,6 +1218,30 @@ else
   AC_MSG_RESULT([no])
 fi
 
+AC_MSG_CHECKING([if embedded bdb should be used])
+if test "$enable_embedded_bdb" = "yes"; then
+  AC_MSG_RESULT(yes)
+else
+  AC_MSG_RESULT(no)
+  AC_MSG_CHECKING([if bdb 5.3 links])
+  TEMP_CXXFLAGS="$CXXFLAGS"
+  TEMP_LDFLAGS="$LDFLAGS"
+  CXXFLAGS="$CXXFLAGS $BDB_CFLAGS"
+  LDFLAGS="$LDFLAGS $BDB_LIBS"
+  AC_LANG_PUSH([C++])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    #include <db_cxx.h>]],[[
+    #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 3)
+      #error "unsupported bdb version"
+    #endif
+    Db* db = nullptr;
+    ]])],[AC_MSG_RESULT(yes)],[AC_MSG_ERROR([bdb 5.3 does not properly link])])
+  AC_LANG_POP([C++])
+  CXXFLAGS="$TEMP_CXXFLAGS"
+  LDFLAGS="$TEMP_LDFLAGS"
+fi
+AM_CONDITIONAL([EMBEDDED_BDB], [test "$enable_embedded_bdb" = "yes"])
+
 if test "$build_bitcoin_utils$build_bitcoin_libs$build_gridcoinresearchd$bitcoin_enable_qt$use_bench$use_tests" = "nononononono"; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
@@ -1290,6 +1320,8 @@ AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
 AC_SUBST(PROTOBUF_LIBS)
 AC_SUBST(QR_LIBS)
+AC_SUBST(BDB_CFLAGS)
+AC_SUBST(BDB_LIBS)
 AC_SUBST(HAVE_FDATASYNC)
 AC_SUBST(HAVE_FULLFSYNC)
 AC_SUBST(HAVE_O_CLOEXEC)
@@ -1336,7 +1368,9 @@ esac
 
 AC_CONFIG_SUBDIRS([src/univalue])
 AC_CONFIG_SUBDIRS([src/secp256k1])
-AX_SUBDIRS_CONFIGURE([src/bdb53], [[CFLAGS="-Wno-error=implicit-function-declaration"], [CXXFLAGS="-Wno-error=implicit-function-declaration"], [--disable-java], [--disable-jdbc], [--disable-replication], [--enable-cxx], [$ADDITIONAL_BDB_FLAGS]], [], [], [])
+if test "$enable_embedded_bdb" = "yes"; then
+  AX_SUBDIRS_CONFIGURE([src/bdb53], [[CFLAGS="-Wno-error=implicit-function-declaration"], [CXXFLAGS="-Wno-error=implicit-function-declaration"], [--disable-java], [--disable-jdbc], [--disable-replication], [--enable-cxx], [$ADDITIONAL_BDB_FLAGS]], [], [], [])
+fi
 
 AC_OUTPUT
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,7 @@ LIBUNIVALUE = $(UNIVALUE_LIBS)
 endif
 
 GRIDCOIN_CONFIG_INCLUDES=-I$(builddir)/config
-GRIDCOIN_INCLUDES=-I$(builddir) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -I$(builddir)/bdb53 $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS) $(UNIVALUE_CFLAGS) $(CURL_CFLAGS) $(LIBZIP_CFLAGS)
+GRIDCOIN_INCLUDES=-I$(builddir) -I$(builddir)/obj -I$(srcdir)/secp256k1/include $(BDB_CFLAGS) -I$(builddir)/bdb53 $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS) $(UNIVALUE_CFLAGS) $(CURL_CFLAGS) $(LIBZIP_CFLAGS)
 
 LIBGRIDCOIN_UTIL=libgridcoin_util.a
 LIBGRIDCOINQT=qt/libgridcoinqt.a
@@ -429,7 +429,11 @@ gridcoinresearchd_LDADD = \
  $(LIBSECP256K1)
 
 if ENABLE_WALLET
+if EMBEDDED_BDB
 gridcoinresearchd_LDADD += $(LIBDB)
+else
+gridcoinresearchd_LDADD += $(BDB_LIBS)
+endif
 endif
 
 gridcoinresearchd_LDADD += $(CURL_LIBS) $(BOOST_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(LIBZIP_LIBS)

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -668,7 +668,11 @@ qt_gridcoinresearch_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(QT_LDFLAGS) $(LIBTOOL
 qt_gridcoinresearch_LIBTOOLFLAGS = $(AM_LIBTOOLFLAGS) --tag CXX
 
 if ENABLE_WALLET
+if EMBEDDED_BDB
 qt_gridcoinresearch_LDADD += $(LIBDB)
+else
+qt_gridcoinresearch_LDADD += $(BDB_LIBS)
+endif
 endif
 
 

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -30,7 +30,11 @@ qt_test_test_gridcoin_qt_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(QT_LDFLAGS) $(LI
 qt_test_test_gridcoin_qt_CXXFLAGS = $(AM_CXXFLAGS) $(QT_PIE_FLAGS)
 
 if ENABLE_WALLET
+if EMBEDDED_BDB
 qt_test_test_gridcoin_qt_LDADD += $(LIBDB)
+else
+qt_test_test_gridcoin_qt_LDADD += $(BDB_LIBS)
+endif
 endif
 
 CLEAN_GRIDCOIN_QT_TEST = $(TEST_QT_MOC_CPP) qt/test/*.gcda qt/test/*.gcno

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -88,7 +88,11 @@ test_test_gridcoin_LDADD += $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(LIBGR
 test_test_gridcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) -static
 
 if ENABLE_WALLET
+if EMBEDDED_BDB
 test_test_gridcoin_LDADD += $(LIBDB)
+else
+test_test_gridcoin_LDADD += $(BDB_LIBS)
+endif
 endif
 
 nodist_test_test_gridcoin_SOURCES = $(GENERATED_TEST_FILES)


### PR DESCRIPTION
Closes #2663.
Tested with the following script:
```bash
#!/usr/bin/env bash

set -e

CLEAN_CLONE="/tmp/gridcoin-$RANDOM"

git clone --depth=1 --single-branch --branch=embedded-bdb https://github.com/div72/Gridcoin-Research.git $CLEAN_CLONE

cp -r $CLEAN_CLONE /tmp/gridcoin-embedded-bdb-in-tree
cp -r $CLEAN_CLONE /tmp/gridcoin-embedded-bdb-out-of-tree
cp -r $CLEAN_CLONE /tmp/gridcoin-system-bdb-in-tree
cp -r $CLEAN_CLONE /tmp/gridcoin-system-bdb-out-of-tree

cd /tmp/gridcoin-embedded-bdb-in-tree
./autogen.sh
./configure
make -j$(nproc --ignore=1)
! ldd src/gridcoinresearchd | grep libdb

cd /tmp/gridcoin-system-bdb-in-tree
./autogen.sh
./configure BDB_LIBS="-ldb_cxx-5.3" BDB_CFLAGS="-I/usr/include/db5.3" --disable-embedded-bdb
make -j$(nproc --ignore=1)
ldd src/gridcoinresearchd | grep libdb

cd /tmp/gridcoin-embedded-bdb-out-of-tree
./autogen.sh
mkdir build && cd build
../configure
make -j$(nproc --ignore=1)
! ldd src/gridcoinresearchd | grep libdb

cd /tmp/gridcoin-system-bdb-out-of-tree
./autogen.sh
mkdir build && cd build
../configure BDB_LIBS="-ldb_cxx-5.3" BDB_CFLAGS="-I/usr/include/db5.3" --disable-embedded-bdb
make -j$(nproc --ignore=1)
ldd src/gridcoinresearchd | grep libdb

rm -rf $CLEAN_CLONE /tmp/gridcoin-embedded-bdb-in-tree /tmp/gridcoin-embedded-bdb-out-of-tree /tmp/gridcoin-system-bdb-in-tree /tmp/gridcoin-system-bdb-out-of-tree
```