### PR TITLE
wallet, rpc: Add missing assignment of fCompressed in dumpprivkey

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -284,7 +284,7 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) 
 bool CKey::Load(const CPrivKey &seckey, const CPubKey &vchPubKey, bool fSkipCheck=false) {
     if (!ec_seckey_import_der(secp256k1_context_sign, (unsigned char*)begin(), seckey.data(), seckey.size()))
         return false;
-    fCompressed = vchPubKey.IsCompressed();
+    fCompressed = seckey.size() == CKey::COMPRESSED_SIZE;
     fValid = true;
 
     if (fSkipCheck)

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -40,6 +40,7 @@ public:
         CKey key;
         if (!GetKey(address, key))
             return false;
+        fCompressed = key.IsCompressed();
         vchSecret.assign(key.begin(), key.end());
         return true;
     }


### PR DESCRIPTION
The virtual bool method GetSecret in CKeyStore did not properly set the parameter fCompressed. This causes dumpprivkey to return the wrong key values for compressed keys based on the random data in the uninitialized fCompressed parameter fed into GetSecret.

Closes #2678.

This is a serious issue and will result in a new release tomorrow as soon as the fix is verified by the original poster.