### PR TITLE
gui: Resize Header Column with Additional Text

### DIFF
--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -133,7 +133,7 @@ ProjectTableModel::ProjectTableModel(ResearcherModel *model, const bool extended
         << tr("Whitelist")
         << tr("Has GDPR Controls")
         << tr("Magnitude")
-        << tr("Avg. Credit")
+        << tr("Recent Avg. Credit")
         << tr("CPID");
 }
 

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -186,7 +186,7 @@ QVariant ProjectTableModel::data(const QModelIndex &index, int role) const
                 case Magnitude:
                     return row->m_magnitude;
                 case RecentAverageCredit:
-                    return row->m_rac;
+                    return QString::number(row->m_rac, 'f', 0);
             }
             break;
 


### PR DESCRIPTION
Problem:
The column for "Avg. Credit" in the Researcher Configuration under the Projects Tab is not wide enough to accommodate 1 million+ average credit amounts without showing them in scientific notation. The column is not resizable.

Observations:
It appears that the column width is dictated by the longest field text string or header text length within the column.  There are 2 exceptions:
- The integer "Avg. Credit" column that is showing a scientific notation instead of resizing to be shown in the standard form.
- The text "CPID" column that automatically resizes when you increase/decrease the width of the overall window.

Solution:
My solution is to add the text "Recent " to the text for the "Avg. Credit" header to accommodate larger numbers in their standard form. This should be sufficient to accommodate the largest RAC in the standard form.

Justification:
I believe this to the easiest and safest way to increase the field length to show larger numbers in their standard form without refactoring the table.  It will also bring congruence between the terminology used by BOINC and the Gridcoin Wallet.

_Leaving this as a draft to receive feedback before marking Ready for review._ 