### PR TITLE
rpc: use RPCErrorCode everywhere

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -52,7 +52,7 @@ UniValue addnode(const UniValue& params, bool fHelp)
         CAddress addr;
         CNode* pnode= ConnectNode(addr, strNode.c_str());
         if(!pnode)
-            throw JSONRPCError(-23, "Error: Node connection failed");
+            throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: Node connection failed");
         UniValue result(UniValue::VOBJ);
         result.pushKV("result", "ok");
         return result;
@@ -67,13 +67,13 @@ UniValue addnode(const UniValue& params, bool fHelp)
     if (strCommand == "add")
     {
         if (it != vAddedNodes.end())
-            throw JSONRPCError(-23, "Error: Node already added");
+            throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: Node already added");
         vAddedNodes.push_back(strNode);
     }
     else if(strCommand == "remove")
     {
         if (it == vAddedNodes.end())
-            throw JSONRPCError(-24, "Error: Node has not been added.");
+            throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");
         vAddedNodes.erase(it);
     }
 
@@ -95,7 +95,7 @@ UniValue getnodeaddresses(const UniValue& params, bool fHelp)
         count = params[0].get_int();
 
     if (count <= 0)
-        throw JSONRPCError(-8, "Address count out of range");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
 
     // returns a shuffled list of CAddress
     std::vector<CAddress> vAddr = addrman.GetAddr();
@@ -145,7 +145,7 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
                 break;
             }
         if (laddedNodes.size() == 0)
-            throw JSONRPCError(-24, "Error: Node has not been added.");
+            throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");
     }
 
     if (!fDns)

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -40,45 +40,74 @@ enum HTTPStatusCode
     HTTP_INTERNAL_SERVER_ERROR = 500,
 };
 
-// Bitcoin RPC error codes
+//! Gridcoin RPC error codes
 enum RPCErrorCode
 {
-    // Standard JSON-RPC 2.0 errors
+    //! Standard JSON-RPC 2.0 errors
+    // RPC_INVALID_REQUEST is internally mapped to HTTP_BAD_REQUEST (400).
+    // It should not be used for application-layer errors.
     RPC_INVALID_REQUEST  = -32600,
+    // RPC_METHOD_NOT_FOUND is internally mapped to HTTP_NOT_FOUND (404).
+    // It should not be used for application-layer errors.
     RPC_METHOD_NOT_FOUND = -32601,
     RPC_INVALID_PARAMS   = -32602,
+    // RPC_INTERNAL_ERROR should only be used for genuine errors in gridcoind
+    // (for example datadir corruption).
     RPC_INTERNAL_ERROR   = -32603,
     RPC_PARSE_ERROR      = -32700,
 
-    // General application defined errors
-    RPC_MISC_ERROR                  = -1,  // std::exception thrown in command handling
-    RPC_TYPE_ERROR                  = -3,  // Unexpected type was passed as parameter
-    RPC_INVALID_ADDRESS_OR_KEY      = -5,  // Invalid address or key
-    RPC_OUT_OF_MEMORY               = -7,  // Ran out of memory during operation
-    RPC_INVALID_PARAMETER           = -8,  // Invalid, missing or duplicate parameter
-    RPC_DATABASE_ERROR              = -20, // Database error
-    RPC_DESERIALIZATION_ERROR       = -22, // Error parsing or validating structure in raw format
-    RPC_DEPRECATED                  = -23, // Use for deprecated commands
+    //! General application defined errors
+    RPC_MISC_ERROR                  = -1,  //!< std::exception thrown in command handling
+    RPC_TYPE_ERROR                  = -3,  //!< Unexpected type was passed as parameter
+    RPC_INVALID_ADDRESS_OR_KEY      = -5,  //!< Invalid address or key
+    RPC_OUT_OF_MEMORY               = -7,  //!< Ran out of memory during operation
+    RPC_INVALID_PARAMETER           = -8,  //!< Invalid, missing or duplicate parameter
+    RPC_DATABASE_ERROR              = -20, //!< Database error
+    RPC_DESERIALIZATION_ERROR       = -22, //!< Error parsing or validating structure in raw format
+    RPC_VERIFY_ERROR                = -25, //!< General error during transaction or block submission
+    RPC_VERIFY_REJECTED             = -26, //!< Transaction or block was rejected by network rules
+    RPC_VERIFY_ALREADY_IN_CHAIN     = -27, //!< Transaction already in chain
+    RPC_IN_WARMUP                   = -28, //!< Client still warming up
+    RPC_METHOD_DEPRECATED           = -32, //!< RPC method is deprecated
 
-    // P2P client errors
-    RPC_CLIENT_NOT_CONNECTED        = -9,  // Gridcoin is not connected
-    RPC_CLIENT_IN_INITIAL_DOWNLOAD  = -10, // Still downloading initial blocks
-    RPC_CLIENT_NODE_ALREADY_ADDED   = -23, // Node is already added
-    RPC_CLIENT_NODE_NOT_ADDED       = -24, // Node has not been added before
-    RPC_CLIENT_NODE_NOT_CONNECTED   = -29, // Node to disconnect not found in connected nodes
-    RPC_CLIENT_INVALID_IP_OR_SUBNET = -30, // Invalid IP/Subnet
-    RPC_CLIENT_P2P_DISABLED         = -31, // No valid connection manager instance found
+    //! Aliases for backward compatibility
+    RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,
+    RPC_TRANSACTION_REJECTED        = RPC_VERIFY_REJECTED,
+    RPC_TRANSACTION_ALREADY_IN_CHAIN= RPC_VERIFY_ALREADY_IN_CHAIN,
 
-    // Wallet errors
-    RPC_WALLET_ERROR                = -4,  // Unspecified problem with wallet (key not found etc.)
-    RPC_WALLET_INSUFFICIENT_FUNDS   = -6,  // Not enough funds in wallet or account
-    RPC_WALLET_INVALID_ACCOUNT_NAME = -11, // Invalid account name
-    RPC_WALLET_KEYPOOL_RAN_OUT      = -12, // Keypool ran out, call keypoolrefill first
-    RPC_WALLET_UNLOCK_NEEDED        = -13, // Enter the wallet passphrase with walletpassphrase first
-    RPC_WALLET_PASSPHRASE_INCORRECT = -14, // The wallet passphrase entered was incorrect
-    RPC_WALLET_WRONG_ENC_STATE      = -15, // Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
-    RPC_WALLET_ENCRYPTION_FAILED    = -16, // Failed to encrypt the wallet
-    RPC_WALLET_ALREADY_UNLOCKED     = -17, // Wallet is already unlocked
+    //! P2P client errors
+    RPC_CLIENT_NOT_CONNECTED        = -9,  //!< Gridcoin is not connected
+    RPC_CLIENT_IN_INITIAL_DOWNLOAD  = -10, //!< Still downloading initial blocks
+    RPC_CLIENT_NODE_ALREADY_ADDED   = -23, //!< Node is already added
+    RPC_CLIENT_NODE_NOT_ADDED       = -24, //!< Node has not been added before
+    RPC_CLIENT_NODE_NOT_CONNECTED   = -29, //!< Node to disconnect not found in connected nodes
+    RPC_CLIENT_INVALID_IP_OR_SUBNET = -30, //!< Invalid IP/Subnet
+    RPC_CLIENT_P2P_DISABLED         = -31, //!< No valid connection manager instance found
+    RPC_CLIENT_NODE_CAPACITY_REACHED= -34, //!< Max number of outbound or block-relay connections already open
+
+    //! Chain errors
+    RPC_CLIENT_MEMPOOL_DISABLED     = -33, //!< No mempool instance found
+
+    //! Wallet errors
+    RPC_WALLET_ERROR                = -4,  //!< Unspecified problem with wallet (key not found etc.)
+    RPC_WALLET_INSUFFICIENT_FUNDS   = -6,  //!< Not enough funds in wallet or account
+    RPC_WALLET_INVALID_LABEL_NAME   = -11, //!< Invalid label name
+    RPC_WALLET_KEYPOOL_RAN_OUT      = -12, //!< Keypool ran out, call keypoolrefill first
+    RPC_WALLET_UNLOCK_NEEDED        = -13, //!< Enter the wallet passphrase with walletpassphrase first
+    RPC_WALLET_PASSPHRASE_INCORRECT = -14, //!< The wallet passphrase entered was incorrect
+    RPC_WALLET_WRONG_ENC_STATE      = -15, //!< Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
+    RPC_WALLET_ENCRYPTION_FAILED    = -16, //!< Failed to encrypt the wallet
+    RPC_WALLET_ALREADY_UNLOCKED     = -17, //!< Wallet is already unlocked
+    RPC_WALLET_NOT_FOUND            = -18, //!< Invalid wallet specified
+    RPC_WALLET_NOT_SPECIFIED        = -19, //!< No wallet specified (error when there are multiple wallets loaded)
+    RPC_WALLET_ALREADY_LOADED       = -35, //!< This same wallet is already loaded
+    RPC_WALLET_ALREADY_EXISTS       = -36, //!< There is already a wallet with the same name
+
+    //! Backwards compatible aliases
+    RPC_WALLET_INVALID_ACCOUNT_NAME = RPC_WALLET_INVALID_LABEL_NAME,
+
+    //! Unused reserved codes, kept around for backwards compatibility. Do not reuse.
+    RPC_FORBIDDEN_BY_SAFE_MODE      = -2,  //!< Server is in safe mode, and command is not allowed in safe mode
 };
 
 //


### PR DESCRIPTION
There were still a few places where an int was used directly as error code. I replaced these with the appropriate enum entry. Also the error code `-23` was assigned to both `RPC_DEPRECATED` and `RPC_CLIENT_NODE_ALREADY_ADDED`. I replaced the definition of the whole enum with the enum from upstream. This fixes this issue and introduces some more entries which we might use in the future.