### PR TITLE
gui: Fix expired pending beacon display

### DIFF
--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,8 +1,8 @@
 package=zlib
-$(package)_version=1.2.13
+$(package)_version=1.3
 $(package)_download_path=https://www.zlib.net
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+$(package)_sha256_hash=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 
 define $(package)_set_vars
 $(package)_config_opts= CC="$($(package)_cc)"

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1884,7 +1884,7 @@ void BitcoinGUI::updateBeaconIcon()
 
     if (researcherModel->hasPendingBeacon()) {
         labelBeaconIcon->setToolTip(tr("CPID: %1\n"
-                                       "Time left to activate: %2"
+                                       "Time left to activate: %2\n"
                                        "%3")
                                     .arg(researcherModel->formatCpid(),
                                          researcherModel->formatTimeToPendingBeaconExpiration(),

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -276,7 +276,17 @@ bool ResearcherModel::hasActiveBeacon() const
 
 bool ResearcherModel::hasPendingBeacon() const
 {
-    return m_pending_beacon.operator bool();
+    if (!m_pending_beacon.operator bool()) {
+        return false;
+    }
+
+    // If here, a pending beacon is present. Determine if expired
+    // while pending. No need to actually clean the pending entry
+    // up. It will be eventually cleaned by the contract handler via
+    // the ActivatePending call.
+    GRC::PendingBeacon pending_beacon(*m_pending_beacon);
+
+    return !pending_beacon.PendingExpired(GetAdjustedTime());
 }
 
 bool ResearcherModel::hasRenewableBeacon() const

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -93,6 +93,11 @@ public:
     bool hasEligibleProjects() const;
     bool hasPoolProjects() const;
     bool hasActiveBeacon() const;
+
+    //!
+    //! \brief hasPendingBeacon returns true if m_pending_beacon is not null and also not expired while pending.
+    //! \return boolean
+    //!
     bool hasPendingBeacon() const;
     bool hasRenewableBeacon() const;
     bool beaconExpired() const;


### PR DESCRIPTION
This small PR should fix the issue where a pending beacon expires at 3 days, but the superblock has not actually posted yet, which means no trigger is called to delete the expired pending beacon, and therefore the GUI shows negative time to expiry.