### PR TITLE
gui: Disable snapshot GUI action

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -553,7 +553,8 @@ void BitcoinGUI::createMenuBar()
     file->addAction(verifyMessageAction);
     file->addSeparator();
 
-    if (!gArgs.GetBoolArg("-testnet", false))
+    // Snapshot GUI menu action disabled due to snapshot CDN abuse in 202308.
+    if (/* !gArgs.GetBoolArg("-testnet", false) */ false)
     {
         file->addAction(snapshotAction);
     }


### PR DESCRIPTION
Due to CDN abuse the GUI menu action for snapshot download is disabled by this commit. The official snapshot URL has been disabled.

The ability to use the command line for snapshot download and specify a custom snapshot URL is retained for useful development purposes.