### PR TITLE
build: add LevelDB CMake detection

### DIFF
--- a/build-aux/cmake/Findleveldb.cmake
+++ b/build-aux/cmake/Findleveldb.cmake
@@ -1,0 +1,42 @@
+# - Find LevelDB
+#
+#  LevelDB_INCLUDES  - List of LevelDB includes
+#  LevelDB_LIBRARIES - List of libraries when using LevelDB.
+#  LevelDB_FOUND     - True if LevelDB found.
+
+# Look for the header file.
+find_path(LevelDB_INCLUDE NAMES leveldb/db.h
+                          PATHS $ENV{LEVELDB_ROOT}/include /opt/local/include /usr/local/include /usr/include
+                          DOC "Path to the directory where leveldb/db.h is located." )
+
+# Look for the library.
+find_library(LevelDB_LIBRARY NAMES leveldb
+                             PATHS /usr/lib $ENV{LEVELDB_ROOT}/lib
+                             DOC "Path to leveldb library." )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(leveldb DEFAULT_MSG LevelDB_INCLUDE LevelDB_LIBRARY)
+
+if(LEVELDB_FOUND)
+  message(STATUS "Found LevelDB (include: ${LevelDB_INCLUDE}, library: ${LevelDB_LIBRARY})")
+  set(LevelDB_INCLUDES ${LevelDB_INCLUDE})
+  set(LevelDB_LIBRARIES ${LevelDB_LIBRARY})
+  mark_as_advanced(LevelDB_INCLUDE LevelDB_LIBRARY)
+
+  if(EXISTS "${LevelDB_INCLUDE}/leveldb/db.h")
+    file(STRINGS "${LevelDB_INCLUDE}/leveldb/db.h" __version_lines
+           REGEX "static const int k[^V]+Version[ \t]+=[ \t]+[0-9]+;")
+
+    foreach(__line ${__version_lines})
+      if(__line MATCHES "[^k]+kMajorVersion[ \t]+=[ \t]+([0-9]+);")
+        set(LEVELDB_VERSION_MAJOR ${CMAKE_MATCH_1})
+      elseif(__line MATCHES "[^k]+kMinorVersion[ \t]+=[ \t]+([0-9]+);")
+        set(LEVELDB_VERSION_MINOR ${CMAKE_MATCH_1})
+      endif()
+    endforeach()
+
+    if(LEVELDB_VERSION_MAJOR AND LEVELDB_VERSION_MINOR)
+      set(LEVELDB_VERSION "${LEVELDB_VERSION_MAJOR}.${LEVELDB_VERSION_MINOR}")
+    endif()
+  endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
 endif()
 
 if(SYSTEM_LEVELDB)
-    set(LIBLEVELDB leveldb::leveldb)
+    set(LIBLEVELDB leveldb)
 else()
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 


### PR DESCRIPTION
While updating a Gentoo ebuild to use the new CMake builds I encountered some nasty red text and an inability to proceed with the build. This PR adds the missing `Findleveldb.cmake` and makes it useful.