### PR TITLE
gui, staking: Implement facilities for mandatory sidestakes and sidestake GUI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,7 @@ add_library(gridcoin_util STATIC
     gridcoin/scraper/scraper.cpp
     gridcoin/scraper/scraper_net.cpp
     gridcoin/scraper/scraper_registry.cpp
+    gridcoin/sidestake.cpp
     gridcoin/staking/difficulty.cpp
     gridcoin/staking/exceptions.cpp
     gridcoin/staking/kernel.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,6 +129,7 @@ GRIDCOIN_CORE_H = \
     gridcoin/scraper/scraper.h \
     gridcoin/scraper/scraper_net.h \
     gridcoin/scraper/scraper_registry.h \
+    gridcoin/sidestake.h \
     gridcoin/staking/chain_trust.h \
     gridcoin/staking/difficulty.h \
     gridcoin/staking/exceptions.h \
@@ -258,6 +259,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     gridcoin/scraper/scraper.cpp \
     gridcoin/scraper/scraper_net.cpp \
     gridcoin/scraper/scraper_registry.cpp \
+    gridcoin/sidestake.cpp \
     gridcoin/staking/difficulty.cpp \
     gridcoin/staking/exceptions.cpp \
     gridcoin/staking/kernel.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -285,6 +285,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/rpcconsole.h \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
+  qt/sidestaketablemodel.h \
   qt/signverifymessagedialog.h \
   qt/trafficgraphwidget.h \
   qt/transactiondesc.h \
@@ -372,6 +373,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/rpcconsole.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
+  qt/sidestaketablemodel.cpp \
   qt/signverifymessagedialog.cpp \
   qt/trafficgraphwidget.cpp \
   qt/transactiondesc.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -82,6 +82,7 @@ QT_FORMS_UI = \
   qt/forms/consolidateunspentwizardsendpage.ui \
   qt/forms/diagnosticsdialog.ui \
   qt/forms/editaddressdialog.ui \
+  qt/forms/editsidestakedialog.ui \
   qt/forms/favoritespage.ui \
   qt/forms/intro.ui \
   qt/forms/mrcrequestpage.ui \
@@ -143,6 +144,7 @@ QT_MOC_CPP = \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_diagnosticsdialog.cpp \
   qt/moc_editaddressdialog.cpp \
+  qt/moc_editsidestakedialog.cpp \
   qt/moc_favoritespage.cpp \
   qt/moc_guiutil.cpp \
   qt/moc_intro.cpp \
@@ -250,6 +252,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/decoration.h \
   qt/diagnosticsdialog.h \
   qt/editaddressdialog.h \
+  qt/editsidestakedialog.h \
   qt/favoritespage.h \
   qt/guiconstants.h \
   qt/guiutil.h \
@@ -342,6 +345,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/decoration.cpp \
   qt/diagnosticsdialog.cpp \
   qt/editaddressdialog.cpp \
+  qt/editsidestakedialog.cpp \
   qt/favoritespage.cpp \
   qt/guiutil.cpp \
   qt/intro.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -161,6 +161,7 @@ QT_MOC_CPP = \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sendcoinsentry.cpp \
+  qt/moc_sidestaketablemodel.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_trafficgraphwidget.cpp \
   qt/moc_transactiondesc.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -56,6 +56,7 @@ GRIDCOIN_TESTS =\
 	test/gridcoin/protocol_tests.cpp \
 	test/gridcoin/researcher_tests.cpp \
 	test/gridcoin/scraper_registry_tests.cpp \
+	test/gridcoin/sidestake_tests.cpp \
 	test/gridcoin/superblock_tests.cpp \
 	test/key_tests.cpp \
 	test/merkle_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -74,6 +74,8 @@ public:
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 14 days on mainnet
         consensus.MRCZeroPaymentInterval = 14 * 24 * 60 * 60;
+        // The maximum ratio of rewards that can be allocated to all of the mandatory sidestakes.
+        consensus.MaxMandatorySideStakeTotalAlloc = 0.25;
         // The "standard" contract replay lookback for those contract types
         // that do not have a registry db.
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
@@ -187,6 +189,8 @@ public:
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         // Zero day interval is 10 minutes on testnet. The very short interval facilitates testing.
         consensus.MRCZeroPaymentInterval = 10 * 60;
+        // The maximum ratio of rewards that can be allocated to all of the mandatory sidestakes.
+        consensus.MaxMandatorySideStakeTotalAlloc = 0.25;
         // The "standard" contract replay lookback for those contract types
         // that do not have a registry db.
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,7 +75,7 @@ public:
         // Zero day interval is 14 days on mainnet
         consensus.MRCZeroPaymentInterval = 14 * 24 * 60 * 60;
         // The maximum ratio of rewards that can be allocated to all of the mandatory sidestakes.
-        consensus.MaxMandatorySideStakeTotalAlloc = 0.25;
+        consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
         // The "standard" contract replay lookback for those contract types
         // that do not have a registry db.
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
@@ -190,7 +190,7 @@ public:
         // Zero day interval is 10 minutes on testnet. The very short interval facilitates testing.
         consensus.MRCZeroPaymentInterval = 10 * 60;
         // The maximum ratio of rewards that can be allocated to all of the mandatory sidestakes.
-        consensus.MaxMandatorySideStakeTotalAlloc = 0.25;
+        consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
         // The "standard" contract replay lookback for those contract types
         // that do not have a registry db.
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -47,6 +47,10 @@ struct Params {
       * forfeiture of fees to the staker and/or foundation. Only consensus critical at BlockV12Height or above.
       */
     int64_t MRCZeroPaymentInterval;
+    /**
+     * @brief The maximum allocation (as a floating point) that can be used by all of the mandatory sidestakes
+     */
+    double MaxMandatorySideStakeTotalAlloc;
 
     int64_t StandardContractReplayLookback;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -48,9 +48,9 @@ struct Params {
       */
     int64_t MRCZeroPaymentInterval;
     /**
-     * @brief The maximum allocation (as a floating point) that can be used by all of the mandatory sidestakes
+     * @brief The maximum allocation (as a Fraction) that can be used by all of the mandatory sidestakes
      */
-    double MaxMandatorySideStakeTotalAlloc;
+    Fraction MaxMandatorySideStakeTotalAlloc;
 
     int64_t StandardContractReplayLookback;
 

--- a/src/gridcoin/contract/payload.h
+++ b/src/gridcoin/contract/payload.h
@@ -65,6 +65,7 @@ enum class ContractType
     SCRAPER,      //!< Scraper node authorization grants and revocations.
     VOTE,         //!< A vote cast by a wallet for a poll.
     MRC,          //!< A manual rewards claim (MRC) request to pay rewards
+    SIDESTAKE,     //!< Mandatory sidestakes
     OUT_OF_BOUND, //!< Marker value for the end of the valid range.
 };
 
@@ -82,6 +83,7 @@ static constexpr GRC::ContractType CONTRACT_TYPES[] = {
     ContractType::SCRAPER,
     ContractType::VOTE,
     ContractType::MRC,
+    ContractType::SIDESTAKE,
     ContractType::OUT_OF_BOUND
 };
 

--- a/src/gridcoin/contract/registry.cpp
+++ b/src/gridcoin/contract/registry.cpp
@@ -11,6 +11,7 @@ const std::vector<GRC::ContractType> RegistryBookmarks::CONTRACT_TYPES_WITH_REG_
     ContractType::PROJECT,
     ContractType::PROTOCOL,
     ContractType::SCRAPER,
+    ContractType::SIDESTAKE
 };
 
 const std::vector<GRC::ContractType> RegistryBookmarks::CONTRACT_TYPES_SUPPORTING_REVERT = {
@@ -20,6 +21,7 @@ const std::vector<GRC::ContractType> RegistryBookmarks::CONTRACT_TYPES_SUPPORTIN
     ContractType::PROTOCOL,
     ContractType::SCRAPER,
     ContractType::VOTE,
+    ContractType::SIDESTAKE
 };
 
 } // namespace GRC

--- a/src/gridcoin/contract/registry.h
+++ b/src/gridcoin/contract/registry.h
@@ -157,8 +157,21 @@ public:
         int lowest_height = std::numeric_limits<int>::max();
 
         for (const auto& iter : m_db_heights) {
+            int db_height = iter.second;
+
+            //! When below the operational range of the sidestake contracts and registry, initialization of the sidestake
+            //! registry will report zero for height. It is undesirable to return this in the GetLowestRegistryBlockHeight()
+            //! method, because it will cause the contract replay clamp to go to the Fern mandatory blockheight. Setting
+            //! the db_height recorded in the bookmarks at V13 height for the sidestake registry for the purpose of contract
+            //! replay solves the problem.
+            //!
+            //! This code can be removed after the V13 mandatory blockheight has been reached.
+            if (iter.first == GRC::ContractType::SIDESTAKE and db_height < Params().GetConsensus().BlockV13Height) {
+                db_height = Params().GetConsensus().BlockV13Height;
+            }
+
             if (iter.second < lowest_height) {
-                lowest_height = iter.second;
+                lowest_height = db_height;
             }
         }
 

--- a/src/gridcoin/contract/registry.h
+++ b/src/gridcoin/contract/registry.h
@@ -9,6 +9,7 @@
 #include "gridcoin/beacon.h"
 #include "gridcoin/project.h"
 #include "gridcoin/protocol.h"
+#include "gridcoin/sidestake.h"
 #include "gridcoin/scraper/scraper_registry.h"
 #include "gridcoin/voting/registry.h"
 
@@ -50,6 +51,7 @@ public:
         case ContractType::PROJECT:     return GetWhitelist();
         case ContractType::PROTOCOL:    return GetProtocolRegistry();
         case ContractType::SCRAPER:     return GetScraperRegistry();
+        case ContractType::SIDESTAKE:   return GetSideStakeRegistry();
         case ContractType::UNKNOWN:
             [[fallthrough]];
         case ContractType::CLAIM:
@@ -78,6 +80,7 @@ public:
         case ContractType::PROTOCOL:    return GetProtocolRegistry();
         case ContractType::SCRAPER:     return GetScraperRegistry();
         case ContractType::VOTE:        return GetPollRegistry();
+        case ContractType::SIDESTAKE:   return GetSideStakeRegistry();
             [[fallthrough]];
         case ContractType::UNKNOWN:
             [[fallthrough]];

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -45,34 +45,34 @@ CBitcoinAddressForStorage::CBitcoinAddressForStorage(CBitcoinAddress address)
 {}
 
 // -----------------------------------------------------------------------------
-// Class: SideStake
+// Class: MandatorySideStake
 // -----------------------------------------------------------------------------
-SideStake::SideStake()
+MandatorySideStake::MandatorySideStake()
     : m_address()
       , m_allocation()
       , m_description()
       , m_timestamp(0)
       , m_hash()
       , m_previous_hash()
-      , m_status(SideStakeStatus::UNKNOWN)
+      , m_status(MandatorySideStakeStatus::UNKNOWN)
 {}
 
-SideStake::SideStake(CBitcoinAddressForStorage address, double allocation, std::string description)
+MandatorySideStake::MandatorySideStake(CBitcoinAddressForStorage address, double allocation, std::string description)
     : m_address(address)
       , m_allocation(allocation)
       , m_description(description)
       , m_timestamp(0)
       , m_hash()
       , m_previous_hash()
-      , m_status(SideStakeStatus::UNKNOWN)
+      , m_status(MandatorySideStakeStatus::UNKNOWN)
 {}
 
-SideStake::SideStake(CBitcoinAddressForStorage address,
-                     double allocation,
-                     std::string description,
-                     int64_t timestamp,
-                     uint256 hash,
-                     SideStakeStatus status)
+MandatorySideStake::MandatorySideStake(CBitcoinAddressForStorage address,
+                                       double allocation,
+                                       std::string description,
+                                       int64_t timestamp,
+                                       uint256 hash,
+                                       MandatorySideStakeStatus status)
     : m_address(address)
       , m_allocation(allocation)
       , m_description(description)
@@ -82,48 +82,44 @@ SideStake::SideStake(CBitcoinAddressForStorage address,
       , m_status(status)
 {}
 
-bool SideStake::WellFormed() const
+bool MandatorySideStake::WellFormed() const
 {
     return m_address.IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
 }
 
-CBitcoinAddressForStorage SideStake::Key() const
+CBitcoinAddressForStorage MandatorySideStake::Key() const
 {
     return m_address;
 }
 
-std::pair<std::string, std::string> SideStake::KeyValueToString() const
+std::pair<std::string, std::string> MandatorySideStake::KeyValueToString() const
 {
     return std::make_pair(m_address.ToString(), StatusToString());
 }
 
-std::string SideStake::StatusToString() const
+std::string MandatorySideStake::StatusToString() const
 {
     return StatusToString(m_status.Value());
 }
 
-std::string SideStake::StatusToString(const SideStakeStatus& status, const bool& translated) const
+std::string MandatorySideStake::StatusToString(const MandatorySideStakeStatus& status, const bool& translated) const
 {
     if (translated) {
         switch(status) {
-        case SideStakeStatus::UNKNOWN:         return _("Unknown");
-        case SideStakeStatus::ACTIVE:          return _("Active");
-        case SideStakeStatus::INACTIVE:        return _("Inactive");
-        case SideStakeStatus::DELETED:         return _("Deleted");
-        case SideStakeStatus::MANDATORY:       return _("Mandatory");
-        case SideStakeStatus::OUT_OF_BOUND:    break;
+        case MandatorySideStakeStatus::UNKNOWN:         return _("Unknown");
+        case MandatorySideStakeStatus::DELETED:         return _("Deleted");
+        case MandatorySideStakeStatus::MANDATORY:       return _("Mandatory");
+        case MandatorySideStakeStatus::OUT_OF_BOUND:    break;
         }
 
         assert(false); // Suppress warning
     } else {
         // The untranslated versions are really meant to serve as the string equivalent of the enum values.
         switch(status) {
-        case SideStakeStatus::UNKNOWN:         return "Unknown";
-        case SideStakeStatus::ACTIVE:          return "Active";
-        case SideStakeStatus::INACTIVE:        return "Inactive";
-        case SideStakeStatus::DELETED:         return "Deleted";
-        case SideStakeStatus::MANDATORY:       return "Mandatory";
-        case SideStakeStatus::OUT_OF_BOUND:    break;
+        case MandatorySideStakeStatus::UNKNOWN:         return "Unknown";
+        case MandatorySideStakeStatus::DELETED:         return "Deleted";
+        case MandatorySideStakeStatus::MANDATORY:       return "Mandatory";
+        case MandatorySideStakeStatus::OUT_OF_BOUND:    break;
         }
 
         assert(false); // Suppress warning
@@ -134,12 +130,13 @@ std::string SideStake::StatusToString(const SideStakeStatus& status, const bool&
     return std::string{};
 }
 
-bool SideStake::operator==(SideStake b)
+bool MandatorySideStake::operator==(MandatorySideStake b)
 {
     bool result = true;
 
     result &= (m_address == b.m_address);
     result &= (m_allocation == b.m_allocation);
+    result &= (m_description == b.m_description);
     result &= (m_timestamp == b.m_timestamp);
     result &= (m_hash == b.m_hash);
     result &= (m_previous_hash == b.m_previous_hash);
@@ -148,9 +145,166 @@ bool SideStake::operator==(SideStake b)
     return result;
 }
 
-bool SideStake::operator!=(SideStake b)
+bool MandatorySideStake::operator!=(MandatorySideStake b)
 {
     return !(*this == b);
+}
+
+// -----------------------------------------------------------------------------
+// Class: LocalSideStake
+// -----------------------------------------------------------------------------
+LocalSideStake::LocalSideStake()
+    : m_address()
+      , m_allocation()
+      , m_description()
+      , m_status(LocalSideStakeStatus::UNKNOWN)
+{}
+
+LocalSideStake::LocalSideStake(CBitcoinAddressForStorage address, double allocation, std::string description)
+    : m_address(address)
+      , m_allocation(allocation)
+      , m_description(description)
+      , m_status(LocalSideStakeStatus::UNKNOWN)
+{}
+
+LocalSideStake::LocalSideStake(CBitcoinAddressForStorage address,
+                               double allocation,
+                               std::string description,
+                               LocalSideStakeStatus status)
+    : m_address(address)
+      , m_allocation(allocation)
+      , m_description(description)
+      , m_status(status)
+{}
+
+bool LocalSideStake::WellFormed() const
+{
+    return m_address.IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
+}
+
+std::string LocalSideStake::StatusToString() const
+{
+    return StatusToString(m_status.Value());
+}
+
+std::string LocalSideStake::StatusToString(const LocalSideStakeStatus& status, const bool& translated) const
+{
+    if (translated) {
+        switch(status) {
+        case LocalSideStakeStatus::UNKNOWN:         return _("Unknown");
+        case LocalSideStakeStatus::ACTIVE:          return _("Active");
+        case LocalSideStakeStatus::INACTIVE:        return _("Inactive");
+        case LocalSideStakeStatus::OUT_OF_BOUND:    break;
+        }
+
+        assert(false); // Suppress warning
+    } else {
+        // The untranslated versions are really meant to serve as the string equivalent of the enum values.
+        switch(status) {
+        case LocalSideStakeStatus::UNKNOWN:         return "Unknown";
+        case LocalSideStakeStatus::ACTIVE:          return "Active";
+        case LocalSideStakeStatus::INACTIVE:        return "Inactive";
+        case LocalSideStakeStatus::OUT_OF_BOUND:    break;
+        }
+
+        assert(false); // Suppress warning
+    }
+
+           // This will never be reached. Put it in anyway to prevent control reaches end of non-void function warning
+           // from some compiler versions.
+    return std::string{};
+}
+
+bool LocalSideStake::operator==(LocalSideStake b)
+{
+    bool result = true;
+
+    result &= (m_address == b.m_address);
+    result &= (m_allocation == b.m_allocation);
+    result &= (m_description == b.m_description);
+    result &= (m_status == b.m_status);
+
+    return result;
+}
+
+bool LocalSideStake::operator!=(LocalSideStake b)
+{
+    return !(*this == b);
+}
+
+// -----------------------------------------------------------------------------
+// Class: SideStake
+// -----------------------------------------------------------------------------
+SideStake::SideStake()
+    : m_local_sidestake_ptr(nullptr)
+      , m_mandatory_sidestake_ptr(nullptr)
+      , m_mandatory(false)
+{}
+
+SideStake::SideStake(LocalSideStake_ptr sidestake_ptr)
+    : m_local_sidestake_ptr(sidestake_ptr)
+      , m_mandatory_sidestake_ptr(nullptr)
+      , m_mandatory(false)
+{}
+
+SideStake::SideStake(MandatorySideStake_ptr sidestake_ptr)
+    : m_local_sidestake_ptr(nullptr)
+      , m_mandatory_sidestake_ptr(sidestake_ptr)
+      , m_mandatory(true)
+{}
+
+bool SideStake::IsMandatory() const
+{
+    return m_mandatory;
+}
+
+CBitcoinAddress SideStake::GetAddress() const
+{
+    if (IsMandatory()) {
+        return m_mandatory_sidestake_ptr->m_address;
+    } else {
+        return m_local_sidestake_ptr->m_address;
+    }
+}
+
+double SideStake::GetAllocation() const
+{
+    if (IsMandatory()) {
+        return m_mandatory_sidestake_ptr->m_allocation;
+    } else {
+        return m_local_sidestake_ptr->m_allocation;
+    }
+}
+
+std::string SideStake::GetDescription() const
+{
+    if (IsMandatory()) {
+        return m_mandatory_sidestake_ptr->m_description;
+    } else {
+        return m_local_sidestake_ptr->m_description;
+    }
+}
+
+SideStake::Status SideStake::GetStatus() const
+{
+    Status status;
+
+    if (IsMandatory()) {
+        status = m_mandatory_sidestake_ptr->m_status;
+    } else {
+        status = m_local_sidestake_ptr->m_status;
+    }
+
+    return status;
+}
+
+std::string SideStake::StatusToString() const
+{
+    if (IsMandatory()) {
+        return m_mandatory_sidestake_ptr->StatusToString();
+    } else {
+        return m_local_sidestake_ptr->StatusToString();
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -169,21 +323,21 @@ SideStakePayload::SideStakePayload(const uint32_t version,
                                    CBitcoinAddressForStorage address,
                                    double allocation,
                                    std::string description,
-                                   SideStakeStatus status)
+                                   MandatorySideStake::MandatorySideStakeStatus status)
     : IContractPayload()
       , m_version(version)
-      , m_entry(SideStake(address, allocation, description, 0, uint256{}, status))
+      , m_entry(MandatorySideStake(address, allocation, description, 0, uint256{}, status))
 {
 }
 
-SideStakePayload::SideStakePayload(const uint32_t version, SideStake entry)
+SideStakePayload::SideStakePayload(const uint32_t version, MandatorySideStake entry)
     : IContractPayload()
       , m_version(version)
       , m_entry(std::move(entry))
 {
 }
 
-SideStakePayload::SideStakePayload(SideStake entry)
+SideStakePayload::SideStakePayload(MandatorySideStake entry)
     : SideStakePayload(CURRENT_VERSION, std::move(entry))
 {
 }
@@ -197,12 +351,12 @@ const std::vector<SideStake_ptr> SideStakeRegistry::SideStakeEntries() const
 
     LOCK(cs_lock);
 
-    for (const auto& entry : m_sidestake_entries) {
-        sidestakes.push_back(entry.second);
+    for (const auto& entry : m_mandatory_sidestake_entries) {
+        sidestakes.push_back(std::make_shared<SideStake>(entry.second));
     }
 
     for (const auto& entry : m_local_sidestake_entries) {
-        sidestakes.push_back(entry.second);
+        sidestakes.push_back(std::make_shared<SideStake>(entry.second));
     }
 
     return sidestakes;
@@ -223,11 +377,12 @@ const std::vector<SideStake_ptr> SideStakeRegistry::ActiveSideStakeEntries(const
 
     // Do mandatory sidestakes first.
     if (!local_only) {
-        for (const auto& entry : m_sidestake_entries)
+        for (const auto& entry : m_mandatory_sidestake_entries)
         {
-            if (entry.second->m_status == SideStakeStatus::MANDATORY && allocation_sum + entry.second->m_allocation <= 1.0) {
+            if (entry.second->m_status == MandatorySideStake::MandatorySideStakeStatus::MANDATORY
+                && allocation_sum + entry.second->m_allocation <= 1.0) {
                 if ((include_zero_alloc && entry.second->m_allocation == 0.0) || entry.second->m_allocation > 0.0) {
-                    sidestakes.push_back(entry.second);
+                    sidestakes.push_back(std::make_shared<SideStake>(entry.second));
                     allocation_sum += entry.second->m_allocation;
                 }
             }
@@ -242,9 +397,10 @@ const std::vector<SideStake_ptr> SideStakeRegistry::ActiveSideStakeEntries(const
 
         for (const auto& entry : m_local_sidestake_entries)
         {
-            if (entry.second->m_status == SideStakeStatus::ACTIVE && allocation_sum + entry.second->m_allocation <= 1.0) {
+            if (entry.second->m_status == LocalSideStake::LocalSideStakeStatus::ACTIVE
+                && allocation_sum + entry.second->m_allocation <= 1.0) {
                 if ((include_zero_alloc && entry.second->m_allocation == 0.0) || entry.second->m_allocation > 0.0) {
-                    sidestakes.push_back(entry.second);
+                    sidestakes.push_back(std::make_shared<SideStake>(entry.second));
                     allocation_sum += entry.second->m_allocation;
                 }
             }
@@ -261,17 +417,17 @@ std::vector<SideStake_ptr> SideStakeRegistry::Try(const CBitcoinAddressForStorag
     std::vector<SideStake_ptr> result;
 
     if (!local_only) {
-        const auto mandatory_entry = m_sidestake_entries.find(key);
+        const auto mandatory_entry = m_mandatory_sidestake_entries.find(key);
 
-        if (mandatory_entry != m_sidestake_entries.end()) {
-            result.push_back(mandatory_entry->second);
+        if (mandatory_entry != m_mandatory_sidestake_entries.end()) {
+            result.push_back(std::make_shared<SideStake>(mandatory_entry->second));
         }
     }
 
     const auto local_entry = m_local_sidestake_entries.find(key);
 
     if (local_entry != m_local_sidestake_entries.end()) {
-        result.push_back(local_entry->second);
+        result.push_back(std::make_shared<SideStake>(local_entry->second));
     }
 
     return result;
@@ -284,8 +440,14 @@ std::vector<SideStake_ptr> SideStakeRegistry::TryActive(const CBitcoinAddressFor
     std::vector<SideStake_ptr> result;
 
     for (const auto& iter : Try(key, local_only)) {
-        if (iter->m_status == SideStakeStatus::MANDATORY || iter->m_status == SideStakeStatus::ACTIVE) {
-            result.push_back(iter);
+        if (iter->IsMandatory()) {
+            if (std::get<MandatorySideStake::Status>(iter->GetStatus()) == MandatorySideStake::MandatorySideStakeStatus::MANDATORY) {
+                result.push_back(iter);
+            }
+        } else {
+            if (std::get<LocalSideStake::Status>(iter->GetStatus()) == LocalSideStake::LocalSideStakeStatus::ACTIVE) {
+                result.push_back(iter);
+            }
         }
     }
 
@@ -296,7 +458,7 @@ void SideStakeRegistry::Reset()
 {
     LOCK(cs_lock);
 
-    m_sidestake_entries.clear();
+    m_mandatory_sidestake_entries.clear();
     m_sidestake_db.clear();
 }
 
@@ -320,17 +482,17 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
     // Ensure status is DELETED if the contract action was REMOVE, regardless of what was actually
     // specified.
     if (ctx->m_action == ContractAction::REMOVE) {
-        payload.m_entry.m_status = SideStakeStatus::DELETED;
+        payload.m_entry.m_status = MandatorySideStake::MandatorySideStakeStatus::DELETED;
     }
 
     LOCK(cs_lock);
 
-    auto sidestake_entry_pair_iter = m_sidestake_entries.find(payload.m_entry.m_address);
+    auto sidestake_entry_pair_iter = m_mandatory_sidestake_entries.find(payload.m_entry.m_address);
 
-    SideStake_ptr current_sidestake_entry_ptr = nullptr;
+    MandatorySideStake_ptr current_sidestake_entry_ptr = nullptr;
 
     // Is there an existing SideStake entry in the map?
-    bool current_sidestake_entry_present = (sidestake_entry_pair_iter != m_sidestake_entries.end());
+    bool current_sidestake_entry_present = (sidestake_entry_pair_iter != m_mandatory_sidestake_entries.end());
 
     // If so, then get a smart pointer to it.
     if (current_sidestake_entry_present) {
@@ -356,7 +518,7 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
              payload.m_entry.StatusToString()
              );
 
-    SideStake& historical = payload.m_entry;
+    MandatorySideStake& historical = payload.m_entry;
 
     if (!m_sidestake_db.insert(ctx.m_tx.GetHash(), height, historical))
     {
@@ -370,26 +532,31 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
     }
 
     // Finally, insert the new SideStake entry (payload) smart pointer into the m_sidestake_entries map.
-    m_sidestake_entries[payload.m_entry.m_address] = m_sidestake_db.find(ctx.m_tx.GetHash())->second;
+    m_mandatory_sidestake_entries[payload.m_entry.m_address] = m_sidestake_db.find(ctx.m_tx.GetHash())->second;
 
     return;
-}
-
-void SideStakeRegistry::NonContractAdd(const SideStake& sidestake, const bool& save_to_file)
-{
-    LOCK(cs_lock);
-
-    // Using this form of insert because we want the latest record with the same key to override any previous one.
-    m_local_sidestake_entries[sidestake.m_address] = std::make_shared<SideStake>(sidestake);
-
-    if (save_to_file) {
-        SaveLocalSideStakesToConfig();
-    }
 }
 
 void SideStakeRegistry::Add(const ContractContext& ctx)
 {
     AddDelete(ctx);
+}
+
+void SideStakeRegistry::Delete(const ContractContext& ctx)
+{
+    AddDelete(ctx);
+}
+
+void SideStakeRegistry::NonContractAdd(const LocalSideStake& sidestake, const bool& save_to_file)
+{
+    LOCK(cs_lock);
+
+           // Using this form of insert because we want the latest record with the same key to override any previous one.
+    m_local_sidestake_entries[sidestake.m_address] = std::make_shared<LocalSideStake>(sidestake);
+
+    if (save_to_file) {
+        SaveLocalSideStakesToConfig();
+    }
 }
 
 void SideStakeRegistry::NonContractDelete(const CBitcoinAddressForStorage& address, const bool& save_to_file)
@@ -407,11 +574,6 @@ void SideStakeRegistry::NonContractDelete(const CBitcoinAddressForStorage& addre
     }
 }
 
-void SideStakeRegistry::Delete(const ContractContext& ctx)
-{
-    AddDelete(ctx);
-}
-
 void SideStakeRegistry::Revert(const ContractContext& ctx)
 {
     const auto payload = ctx->SharePayloadAs<SideStakePayload>();
@@ -421,9 +583,9 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
     // resurrect.
     LOCK(cs_lock);
 
-    auto entry_to_revert = m_sidestake_entries.find(payload->m_entry.m_address);
+    auto entry_to_revert = m_mandatory_sidestake_entries.find(payload->m_entry.m_address);
 
-    if (entry_to_revert == m_sidestake_entries.end()) {
+    if (entry_to_revert == m_mandatory_sidestake_entries.end()) {
         error("%s: The SideStake entry for key %s to revert was not found in the SideStake entry map.",
               __func__,
               entry_to_revert->second->m_address.ToString());
@@ -440,7 +602,7 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
            // Revert the ADD or REMOVE action. Unlike the beacons, this is symmetric.
     if (ctx->m_action == ContractAction::ADD || ctx->m_action == ContractAction::REMOVE) {
         // Erase the record from m_sidestake_entries.
-        if (m_sidestake_entries.erase(payload->m_entry.m_address) == 0) {
+        if (m_mandatory_sidestake_entries.erase(payload->m_entry.m_address) == 0) {
             error("%s: The SideStake entry to erase during a SideStake entry revert for key %s was not found.",
                   __func__,
                   key.ToString());
@@ -474,7 +636,7 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
 
         // Resurrect the entry prior to the reverted one. It is safe to use the bracket form here, because of the protection
         // of the logic above. There cannot be any entry in m_sidestake_entries with that key value left if we made it here.
-        m_sidestake_entries[resurrect_entry->second->m_address] = resurrect_entry->second;
+        m_mandatory_sidestake_entries[resurrect_entry->second->m_address] = resurrect_entry->second;
     }
 }
 
@@ -506,12 +668,12 @@ int SideStakeRegistry::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_sidestake_db.Initialize(m_sidestake_entries, m_pending_sidestake_entries);
+    int height = m_sidestake_db.Initialize(m_mandatory_sidestake_entries, m_pending_sidestake_entries);
 
     SubscribeToCoreSignals();
 
     LogPrint(LogFlags::CONTRACT, "INFO: %s: m_sidestake_db size after load: %u", __func__, m_sidestake_db.size());
-    LogPrint(LogFlags::CONTRACT, "INFO: %s: m_sidestake_entries size after load: %u", __func__, m_sidestake_entries.size());
+    LogPrint(LogFlags::CONTRACT, "INFO: %s: m_sidestake_entries size after load: %u", __func__, m_mandatory_sidestake_entries.size());
 
     // Add the local sidestakes specified in the config file(s) to the local sidestakes map.
     LoadLocalSideStakesFromConfig();
@@ -544,7 +706,7 @@ void SideStakeRegistry::ResetInMemoryOnly()
     LOCK(cs_lock);
 
     m_local_sidestake_entries.clear();
-    m_sidestake_entries.clear();
+    m_mandatory_sidestake_entries.clear();
     m_sidestake_db.clear_in_memory_only();
 }
 
@@ -567,7 +729,7 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
         return;
     }
 
-    std::vector<SideStake> vSideStakes;
+    std::vector<LocalSideStake> vLocalSideStakes;
     std::vector<std::tuple<std::string, std::string, std::string>> raw_vSideStakeAlloc;
     double dSumAllocation = 0.0;
 
@@ -631,8 +793,9 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
 
     // First, determine allocation already taken by mandatory sidestakes, because they must be allocated first.
     for (const auto& entry : SideStakeEntries()) {
-        if (entry->m_status == SideStakeStatus::MANDATORY) {
-            dSumAllocation += entry->m_allocation;
+        if (entry->IsMandatory()
+            && std::get<MandatorySideStake::Status>(entry->GetStatus()) == MandatorySideStake::MandatorySideStakeStatus::MANDATORY) {
+            dSumAllocation += entry->GetAllocation();
         }
     }
 
@@ -679,19 +842,17 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
             break;
         }
 
-        SideStake sidestake(static_cast<CBitcoinAddressForStorage>(address),
-                            dAllocation,
-                            std::get<2>(entry),
-                            0,
-                            uint256{},
-                            SideStakeStatus::ACTIVE);
+        LocalSideStake sidestake(static_cast<CBitcoinAddressForStorage>(address),
+                                 dAllocation,
+                                 std::get<2>(entry),
+                                 LocalSideStake::LocalSideStakeStatus::ACTIVE);
 
         // This will add or update (replace) a non-contract entry in the registry for the local sidestake.
         NonContractAdd(sidestake, false);
 
         // This is needed because we need to detect entries in the registry map that are no longer in the config file to mark
         // them deleted.
-        vSideStakes.push_back(sidestake);
+        vLocalSideStakes.push_back(sidestake);
 
         LogPrint(BCLog::LogFlags::MINER, "INFO: %s: SideStakeAlloc Address %s, Allocation %f",
                  __func__, sAddress, dAllocation);
@@ -700,13 +861,13 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
     for (auto& entry : m_local_sidestake_entries)
     {
         // Only look at active entries. The others are NA for this alignment.
-        if (entry.second->m_status == SideStakeStatus::ACTIVE) {
-            auto iter = std::find(vSideStakes.begin(), vSideStakes.end(), *entry.second);
+        if (entry.second->m_status == LocalSideStake::LocalSideStakeStatus::ACTIVE) {
+            auto iter = std::find(vLocalSideStakes.begin(), vLocalSideStakes.end(), *entry.second);
 
-            if (iter == vSideStakes.end()) {
+            if (iter == vLocalSideStakes.end()) {
                 // Entry in map is no longer found in config files, so mark map entry inactive.
 
-                entry.second->m_status = SideStakeStatus::INACTIVE;
+                entry.second->m_status = LocalSideStake::LocalSideStakeStatus::INACTIVE;
             }
         }
     }

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -663,7 +663,7 @@ bool SideStakeRegistry::Validate(const Contract& contract, const CTransaction& t
 
 bool SideStakeRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
 {
-    return Validate(ctx.m_contract, ctx.m_tx, DoS);
+    return (IsV13Enabled(ctx.m_pindex->nHeight) && Validate(ctx.m_contract, ctx.m_tx, DoS));
 }
 
 int SideStakeRegistry::Initialize()

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2014-2023 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "sidestake.h"
+#include "node/ui_interface.h"
+
+using namespace GRC;
+
+// -----------------------------------------------------------------------------
+// Class: SideStake
+// -----------------------------------------------------------------------------
+SideStake::SideStake()
+    : m_address()
+      , m_allocation()
+      , m_timestamp(0)
+      , m_hash()
+      , m_previous_hash()
+      , m_status(SideStakeStatus::UNKNOWN)
+{}
+
+SideStake::SideStake(CBitcoinAddress address, double allocation)
+    : m_address(address)
+      , m_allocation(allocation)
+      , m_timestamp(0)
+      , m_hash()
+      , m_previous_hash()
+      , m_status(SideStakeStatus::UNKNOWN)
+{}
+
+SideStake::SideStake(CBitcoinAddress address, double allocation, int64_t timestamp, uint256 hash)
+    : m_address(address)
+      , m_allocation(allocation)
+      , m_timestamp(timestamp)
+      , m_hash(hash)
+      , m_previous_hash()
+      , m_status(SideStakeStatus::UNKNOWN)
+{}
+
+bool SideStake::WellFormed() const
+{
+    return m_address.IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
+}
+
+std::pair<std::string, std::string> SideStake::KeyValueToString() const
+{
+    return std::make_pair(m_address.ToString(), StatusToString());
+}
+
+std::string SideStake::StatusToString() const
+{
+    return StatusToString(m_status.Value());
+}
+
+std::string SideStake::StatusToString(const SideStakeStatus& status, const bool& translated) const
+{
+    if (translated) {
+        switch(status) {
+        case SideStakeStatus::UNKNOWN:         return _("Unknown");
+        case SideStakeStatus::ACTIVE:          return _("Active");
+        case SideStakeStatus::INACTIVE:        return _("Inactive");
+        case SideStakeStatus::DELETED:         return _("Deleted");
+        case SideStakeStatus::MANDATORY:       return _("Mandatory");
+        case SideStakeStatus::OUT_OF_BOUND:    break;
+        }
+
+        assert(false); // Suppress warning
+    } else {
+        // The untranslated versions are really meant to serve as the string equivalent of the enum values.
+        switch(status) {
+        case SideStakeStatus::UNKNOWN:         return "Unknown";
+        case SideStakeStatus::ACTIVE:          return "Active";
+        case SideStakeStatus::INACTIVE:        return "Inactive";
+        case SideStakeStatus::DELETED:         return "Deleted";
+        case SideStakeStatus::MANDATORY:       return "Mandatory";
+        case SideStakeStatus::OUT_OF_BOUND:    break;
+        }
+
+        assert(false); // Suppress warning
+    }
+
+           // This will never be reached. Put it in anyway to prevent control reaches end of non-void function warning
+           // from some compiler versions.
+    return std::string{};
+}
+
+bool SideStake::operator==(SideStake b)
+{
+    bool result = true;
+
+    result &= (m_address == b.m_address);
+    result &= (m_allocation == b.m_allocation);
+    result &= (m_timestamp == b.m_timestamp);
+    result &= (m_hash == b.m_hash);
+    result &= (m_previous_hash == b.m_previous_hash);
+    result &= (m_status == b.m_status);
+
+    return result;
+}
+
+bool SideStake::operator!=(SideStake b)
+{
+    return !(*this == b);
+}

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -49,15 +49,17 @@ CBitcoinAddressForStorage::CBitcoinAddressForStorage(CBitcoinAddress address)
 SideStake::SideStake()
     : m_key()
       , m_allocation()
+      , m_description()
       , m_timestamp(0)
       , m_hash()
       , m_previous_hash()
       , m_status(SideStakeStatus::UNKNOWN)
 {}
 
-SideStake::SideStake(CBitcoinAddressForStorage address, double allocation)
+SideStake::SideStake(CBitcoinAddressForStorage address, double allocation, std::string description)
     : m_key(address)
       , m_allocation(allocation)
+      , m_description(description)
       , m_timestamp(0)
       , m_hash()
       , m_previous_hash()
@@ -66,11 +68,13 @@ SideStake::SideStake(CBitcoinAddressForStorage address, double allocation)
 
 SideStake::SideStake(CBitcoinAddressForStorage address,
                      double allocation,
+                     std::string description,
                      int64_t timestamp,
                      uint256 hash,
                      SideStakeStatus status)
     : m_key(address)
       , m_allocation(allocation)
+      , m_description(description)
       , m_timestamp(timestamp)
       , m_hash(hash)
       , m_previous_hash()
@@ -163,10 +167,11 @@ SideStakePayload::SideStakePayload(uint32_t version)
 SideStakePayload::SideStakePayload(const uint32_t version,
                                    CBitcoinAddressForStorage key,
                                    double value,
+                                   std::string description,
                                    SideStakeStatus status)
     : IContractPayload()
       , m_version(version)
-      , m_entry(SideStake(key, value, 0, uint256{}, status))
+      , m_entry(SideStake(key, value, description, 0, uint256{}, status))
 {
 }
 
@@ -603,6 +608,7 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
 
         SideStake sidestake(static_cast<CBitcoinAddressForStorage>(address),
                             dAllocation,
+                            std::string {},
                             0,
                             uint256{},
                             SideStakeStatus::ACTIVE);

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -211,12 +211,18 @@ const std::vector<SideStake_ptr> SideStakeRegistry::ActiveSideStakeEntries()
         }
     }
 
-    // Followed by local active sidestakes
-    for (const auto& entry : m_sidestake_entries)
-    {
-        if (entry.second->m_status == SideStakeStatus::ACTIVE && allocation_sum + entry.second->m_allocation <= 1.0) {
-            sidestakes.push_back(entry.second);
-            allocation_sum += entry.second->m_allocation;
+    // Followed by local active sidestakes if sidestaking is enabled. Note that mandatory sidestaking cannot be disabled.
+    bool fEnableSideStaking = gArgs.GetBoolArg("-enablesidestaking");
+
+    if (fEnableSideStaking) {
+        LogPrint(BCLog::LogFlags::MINER, "INFO: %s: fEnableSideStaking = %u", __func__, fEnableSideStaking);
+
+        for (const auto& entry : m_sidestake_entries)
+        {
+            if (entry.second->m_status == SideStakeStatus::ACTIVE && allocation_sum + entry.second->m_allocation <= 1.0) {
+                sidestakes.push_back(entry.second);
+                allocation_sum += entry.second->m_allocation;
+            }
         }
     }
 

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -191,9 +191,21 @@ SideStakePayload::SideStakePayload(SideStake entry)
 // -----------------------------------------------------------------------------
 // Class: SideStakeRegistry
 // -----------------------------------------------------------------------------
-const SideStakeRegistry::SideStakeMap& SideStakeRegistry::SideStakeEntries() const
+const std::vector<SideStake_ptr> SideStakeRegistry::SideStakeEntries() const
 {
-    return m_sidestake_entries;
+    std::vector<SideStake_ptr> sidestakes;
+
+    LOCK(cs_lock);
+
+    for (const auto& entry : m_sidestake_entries) {
+        sidestakes.push_back(entry.second);
+    }
+
+    for (const auto& entry : m_local_sidestake_entries) {
+        sidestakes.push_back(entry.second);
+    }
+
+    return sidestakes;
 }
 
 const std::vector<SideStake_ptr> SideStakeRegistry::ActiveSideStakeEntries()
@@ -586,8 +598,8 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
 
     // First, determine allocation already taken by mandatory sidestakes, because they must be allocated first.
     for (const auto& entry : SideStakeEntries()) {
-        if (entry.second->m_status == SideStakeStatus::MANDATORY) {
-            dSumAllocation += entry.second->m_allocation;
+        if (entry->m_status == SideStakeStatus::MANDATORY) {
+            dSumAllocation += entry->m_allocation;
         }
     }
 

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -172,6 +172,20 @@ const SideStakeRegistry::SideStakeMap& SideStakeRegistry::SideStakeEntries() con
     return m_sidestake_entries;
 }
 
+const std::vector<SideStake_ptr> SideStakeRegistry::ActiveSideStakeEntries() const
+{
+    std::vector<SideStake_ptr> sidestakes;
+
+    for (const auto& entry : m_sidestake_entries)
+    {
+        if (entry.second->m_status == SideStakeStatus::ACTIVE || entry.second->m_status == SideStakeStatus::MANDATORY) {
+            sidestakes.push_back(entry.second);
+        }
+    }
+
+    return sidestakes;
+}
+
 SideStakeOption SideStakeRegistry::Try(const CBitcoinAddressForStorage& key) const
 {
     LOCK(cs_lock);

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -33,6 +33,7 @@ SideStakeRegistry& GRC::GetSideStakeRegistry()
     return g_sidestake_entries;
 }
 
+/*
 // -----------------------------------------------------------------------------
 // Class: CBitcoinAddressForStorage
 // -----------------------------------------------------------------------------
@@ -43,135 +44,30 @@ CBitcoinAddressForStorage::CBitcoinAddressForStorage()
 CBitcoinAddressForStorage::CBitcoinAddressForStorage(CBitcoinAddress address)
     : CBitcoinAddress(address)
 {}
-
-// -----------------------------------------------------------------------------
-// Class: MandatorySideStake
-// -----------------------------------------------------------------------------
-MandatorySideStake::MandatorySideStake()
-    : m_address()
-      , m_allocation()
-      , m_description()
-      , m_timestamp(0)
-      , m_hash()
-      , m_previous_hash()
-      , m_status(MandatorySideStakeStatus::UNKNOWN)
-{}
-
-MandatorySideStake::MandatorySideStake(CBitcoinAddressForStorage address, double allocation, std::string description)
-    : m_address(address)
-      , m_allocation(allocation)
-      , m_description(description)
-      , m_timestamp(0)
-      , m_hash()
-      , m_previous_hash()
-      , m_status(MandatorySideStakeStatus::UNKNOWN)
-{}
-
-MandatorySideStake::MandatorySideStake(CBitcoinAddressForStorage address,
-                                       double allocation,
-                                       std::string description,
-                                       int64_t timestamp,
-                                       uint256 hash,
-                                       MandatorySideStakeStatus status)
-    : m_address(address)
-      , m_allocation(allocation)
-      , m_description(description)
-      , m_timestamp(timestamp)
-      , m_hash(hash)
-      , m_previous_hash()
-      , m_status(status)
-{}
-
-bool MandatorySideStake::WellFormed() const
-{
-    return m_address.IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
-}
-
-CBitcoinAddressForStorage MandatorySideStake::Key() const
-{
-    return m_address;
-}
-
-std::pair<std::string, std::string> MandatorySideStake::KeyValueToString() const
-{
-    return std::make_pair(m_address.ToString(), StatusToString());
-}
-
-std::string MandatorySideStake::StatusToString() const
-{
-    return StatusToString(m_status.Value());
-}
-
-std::string MandatorySideStake::StatusToString(const MandatorySideStakeStatus& status, const bool& translated) const
-{
-    if (translated) {
-        switch(status) {
-        case MandatorySideStakeStatus::UNKNOWN:         return _("Unknown");
-        case MandatorySideStakeStatus::DELETED:         return _("Deleted");
-        case MandatorySideStakeStatus::MANDATORY:       return _("Mandatory");
-        case MandatorySideStakeStatus::OUT_OF_BOUND:    break;
-        }
-
-        assert(false); // Suppress warning
-    } else {
-        // The untranslated versions are really meant to serve as the string equivalent of the enum values.
-        switch(status) {
-        case MandatorySideStakeStatus::UNKNOWN:         return "Unknown";
-        case MandatorySideStakeStatus::DELETED:         return "Deleted";
-        case MandatorySideStakeStatus::MANDATORY:       return "Mandatory";
-        case MandatorySideStakeStatus::OUT_OF_BOUND:    break;
-        }
-
-        assert(false); // Suppress warning
-    }
-
-           // This will never be reached. Put it in anyway to prevent control reaches end of non-void function warning
-           // from some compiler versions.
-    return std::string{};
-}
-
-bool MandatorySideStake::operator==(MandatorySideStake b)
-{
-    bool result = true;
-
-    result &= (m_address == b.m_address);
-    result &= (m_allocation == b.m_allocation);
-    result &= (m_description == b.m_description);
-    result &= (m_timestamp == b.m_timestamp);
-    result &= (m_hash == b.m_hash);
-    result &= (m_previous_hash == b.m_previous_hash);
-    result &= (m_status == b.m_status);
-
-    return result;
-}
-
-bool MandatorySideStake::operator!=(MandatorySideStake b)
-{
-    return !(*this == b);
-}
+*/
 
 // -----------------------------------------------------------------------------
 // Class: LocalSideStake
 // -----------------------------------------------------------------------------
 LocalSideStake::LocalSideStake()
-    : m_address()
+    : m_destination()
       , m_allocation()
       , m_description()
       , m_status(LocalSideStakeStatus::UNKNOWN)
 {}
 
-LocalSideStake::LocalSideStake(CBitcoinAddressForStorage address, double allocation, std::string description)
-    : m_address(address)
+LocalSideStake::LocalSideStake(CTxDestination destination, double allocation, std::string description)
+    : m_destination(destination)
       , m_allocation(allocation)
       , m_description(description)
       , m_status(LocalSideStakeStatus::UNKNOWN)
 {}
 
-LocalSideStake::LocalSideStake(CBitcoinAddressForStorage address,
+LocalSideStake::LocalSideStake(CTxDestination destination,
                                double allocation,
                                std::string description,
                                LocalSideStakeStatus status)
-    : m_address(address)
+    : m_destination(destination)
       , m_allocation(allocation)
       , m_description(description)
       , m_status(status)
@@ -179,7 +75,7 @@ LocalSideStake::LocalSideStake(CBitcoinAddressForStorage address,
 
 bool LocalSideStake::WellFormed() const
 {
-    return m_address.IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
+    return CBitcoinAddress(m_destination).IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
 }
 
 std::string LocalSideStake::StatusToString() const
@@ -219,7 +115,7 @@ bool LocalSideStake::operator==(LocalSideStake b)
 {
     bool result = true;
 
-    result &= (m_address == b.m_address);
+    result &= (m_destination == b.m_destination);
     result &= (m_allocation == b.m_allocation);
     result &= (m_description == b.m_description);
     result &= (m_status == b.m_status);
@@ -228,6 +124,112 @@ bool LocalSideStake::operator==(LocalSideStake b)
 }
 
 bool LocalSideStake::operator!=(LocalSideStake b)
+{
+    return !(*this == b);
+}
+
+// -----------------------------------------------------------------------------
+// Class: MandatorySideStake
+// -----------------------------------------------------------------------------
+MandatorySideStake::MandatorySideStake()
+    : m_destination()
+      , m_allocation()
+      , m_description()
+      , m_timestamp(0)
+      , m_hash()
+      , m_previous_hash()
+      , m_status(MandatorySideStakeStatus::UNKNOWN)
+{}
+
+MandatorySideStake::MandatorySideStake(CTxDestination destination, double allocation, std::string description)
+    : m_destination(destination)
+      , m_allocation(allocation)
+      , m_description(description)
+      , m_timestamp(0)
+      , m_hash()
+      , m_previous_hash()
+      , m_status(MandatorySideStakeStatus::UNKNOWN)
+{}
+
+MandatorySideStake::MandatorySideStake(CTxDestination destination,
+                                       double allocation,
+                                       std::string description,
+                                       int64_t timestamp,
+                                       uint256 hash,
+                                       MandatorySideStakeStatus status)
+    : m_destination(destination)
+      , m_allocation(allocation)
+      , m_description(description)
+      , m_timestamp(timestamp)
+      , m_hash(hash)
+      , m_previous_hash()
+      , m_status(status)
+{}
+
+bool MandatorySideStake::WellFormed() const
+{
+    return CBitcoinAddress(m_destination).IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
+}
+
+CTxDestination MandatorySideStake::Key() const
+{
+    return m_destination;
+}
+
+std::pair<std::string, std::string> MandatorySideStake::KeyValueToString() const
+{
+    return std::make_pair(CBitcoinAddress(m_destination).ToString(), StatusToString());
+}
+
+std::string MandatorySideStake::StatusToString() const
+{
+    return StatusToString(m_status.Value());
+}
+
+std::string MandatorySideStake::StatusToString(const MandatorySideStakeStatus& status, const bool& translated) const
+{
+    if (translated) {
+        switch(status) {
+        case MandatorySideStakeStatus::UNKNOWN:         return _("Unknown");
+        case MandatorySideStakeStatus::DELETED:         return _("Deleted");
+        case MandatorySideStakeStatus::MANDATORY:       return _("Mandatory");
+        case MandatorySideStakeStatus::OUT_OF_BOUND:    break;
+        }
+
+        assert(false); // Suppress warning
+    } else {
+        // The untranslated versions are really meant to serve as the string equivalent of the enum values.
+        switch(status) {
+        case MandatorySideStakeStatus::UNKNOWN:         return "Unknown";
+        case MandatorySideStakeStatus::DELETED:         return "Deleted";
+        case MandatorySideStakeStatus::MANDATORY:       return "Mandatory";
+        case MandatorySideStakeStatus::OUT_OF_BOUND:    break;
+        }
+
+        assert(false); // Suppress warning
+    }
+
+           // This will never be reached. Put it in anyway to prevent control reaches end of non-void function warning
+           // from some compiler versions.
+    return std::string{};
+}
+
+bool MandatorySideStake::operator==(MandatorySideStake b)
+{
+    bool result = true;
+
+    result &= (m_destination == b.m_destination);
+    result &= (m_allocation == b.m_allocation);
+    result &= (m_description == b.m_description);
+    result &= (m_timestamp == b.m_timestamp);
+    result &= (m_hash == b.m_hash);
+    result &= (m_previous_hash == b.m_previous_hash);
+    result &= (m_status == b.m_status);
+
+    return result;
+}
+
+bool MandatorySideStake::operator!=(MandatorySideStake b)
 {
     return !(*this == b);
 }
@@ -258,12 +260,12 @@ bool SideStake::IsMandatory() const
     return m_mandatory;
 }
 
-CBitcoinAddress SideStake::GetAddress() const
+CTxDestination SideStake::GetDestination() const
 {
     if (IsMandatory()) {
-        return m_mandatory_sidestake_ptr->m_address;
+        return m_mandatory_sidestake_ptr->m_destination;
     } else {
-        return m_local_sidestake_ptr->m_address;
+        return m_local_sidestake_ptr->m_destination;
     }
 }
 
@@ -320,13 +322,13 @@ SideStakePayload::SideStakePayload(uint32_t version)
 }
 
 SideStakePayload::SideStakePayload(const uint32_t version,
-                                   CBitcoinAddressForStorage address,
+                                   CTxDestination destination,
                                    double allocation,
                                    std::string description,
                                    MandatorySideStake::MandatorySideStakeStatus status)
     : IContractPayload()
       , m_version(version)
-      , m_entry(MandatorySideStake(address, allocation, description, 0, uint256{}, status))
+      , m_entry(MandatorySideStake(destination, allocation, description, 0, uint256{}, status))
 {
 }
 
@@ -410,7 +412,7 @@ const std::vector<SideStake_ptr> SideStakeRegistry::ActiveSideStakeEntries(const
     return sidestakes;
 }
 
-std::vector<SideStake_ptr> SideStakeRegistry::Try(const CBitcoinAddressForStorage& key, const bool& local_only) const
+std::vector<SideStake_ptr> SideStakeRegistry::Try(const CTxDestination& key, const bool& local_only) const
 {
     LOCK(cs_lock);
 
@@ -433,7 +435,7 @@ std::vector<SideStake_ptr> SideStakeRegistry::Try(const CBitcoinAddressForStorag
     return result;
 }
 
-std::vector<SideStake_ptr> SideStakeRegistry::TryActive(const CBitcoinAddressForStorage& key, const bool& local_only) const
+std::vector<SideStake_ptr> SideStakeRegistry::TryActive(const CTxDestination& key, const bool& local_only) const
 {
     LOCK(cs_lock);
 
@@ -487,7 +489,7 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
 
     LOCK(cs_lock);
 
-    auto sidestake_entry_pair_iter = m_mandatory_sidestake_entries.find(payload.m_entry.m_address);
+    auto sidestake_entry_pair_iter = m_mandatory_sidestake_entries.find(payload.m_entry.m_destination);
 
     MandatorySideStake_ptr current_sidestake_entry_ptr = nullptr;
 
@@ -510,7 +512,7 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
              __func__,
              ctx->m_version,
              payload.m_version,
-             payload.m_entry.m_address.ToString(),
+             CBitcoinAddress(payload.m_entry.m_destination).ToString(),
              payload.m_entry.m_allocation,
              payload.m_entry.m_timestamp,
              payload.m_entry.m_hash.ToString(),
@@ -526,13 +528,13 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
                                      "the SideStake entry db record already exists. This can be expected on a restart "
                                      "of the wallet to ensure multiple contracts in the same block get stored/replayed.",
                  __func__,
-                 historical.m_address.ToString(),
+                 CBitcoinAddress(historical.m_destination).ToString(),
                  historical.m_allocation,
                  historical.m_hash.GetHex());
     }
 
     // Finally, insert the new SideStake entry (payload) smart pointer into the m_sidestake_entries map.
-    m_mandatory_sidestake_entries[payload.m_entry.m_address] = m_sidestake_db.find(ctx.m_tx.GetHash())->second;
+    m_mandatory_sidestake_entries[payload.m_entry.m_destination] = m_sidestake_db.find(ctx.m_tx.GetHash())->second;
 
     return;
 }
@@ -552,18 +554,18 @@ void SideStakeRegistry::NonContractAdd(const LocalSideStake& sidestake, const bo
     LOCK(cs_lock);
 
            // Using this form of insert because we want the latest record with the same key to override any previous one.
-    m_local_sidestake_entries[sidestake.m_address] = std::make_shared<LocalSideStake>(sidestake);
+    m_local_sidestake_entries[sidestake.m_destination] = std::make_shared<LocalSideStake>(sidestake);
 
     if (save_to_file) {
         SaveLocalSideStakesToConfig();
     }
 }
 
-void SideStakeRegistry::NonContractDelete(const CBitcoinAddressForStorage& address, const bool& save_to_file)
+void SideStakeRegistry::NonContractDelete(const CTxDestination& destination, const bool& save_to_file)
 {
     LOCK(cs_lock);
 
-    auto sidestake_entry_pair_iter = m_local_sidestake_entries.find(address);
+    auto sidestake_entry_pair_iter = m_local_sidestake_entries.find(destination);
 
     if (sidestake_entry_pair_iter != m_local_sidestake_entries.end()) {
         m_local_sidestake_entries.erase(sidestake_entry_pair_iter);
@@ -583,12 +585,12 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
     // resurrect.
     LOCK(cs_lock);
 
-    auto entry_to_revert = m_mandatory_sidestake_entries.find(payload->m_entry.m_address);
+    auto entry_to_revert = m_mandatory_sidestake_entries.find(payload->m_entry.m_destination);
 
     if (entry_to_revert == m_mandatory_sidestake_entries.end()) {
         error("%s: The SideStake entry for key %s to revert was not found in the SideStake entry map.",
               __func__,
-              entry_to_revert->second->m_address.ToString());
+              CBitcoinAddress(entry_to_revert->second->m_destination).ToString());
 
         // If there is no record in the current m_sidestake_entries map, then there is nothing to do here. This
         // should not occur.
@@ -596,16 +598,16 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
     }
 
            // If this is not a null hash, then there will be a prior entry to resurrect.
-    CBitcoinAddressForStorage key = entry_to_revert->second->m_address;
+    CTxDestination key = entry_to_revert->second->m_destination;
     uint256 resurrect_hash = entry_to_revert->second->m_previous_hash;
 
            // Revert the ADD or REMOVE action. Unlike the beacons, this is symmetric.
     if (ctx->m_action == ContractAction::ADD || ctx->m_action == ContractAction::REMOVE) {
         // Erase the record from m_sidestake_entries.
-        if (m_mandatory_sidestake_entries.erase(payload->m_entry.m_address) == 0) {
+        if (m_mandatory_sidestake_entries.erase(payload->m_entry.m_destination) == 0) {
             error("%s: The SideStake entry to erase during a SideStake entry revert for key %s was not found.",
                   __func__,
-                  key.ToString());
+                  CBitcoinAddress(key).ToString());
             // If the record to revert is not found in the m_sidestake_entries map, no point in continuing.
             return;
         }
@@ -614,7 +616,7 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
         if (!m_sidestake_db.erase(ctx.m_tx.GetHash())) {
             error("%s: The db entry to erase during a SideStake entry revert for key %s was not found.",
                   __func__,
-                  key.ToString());
+                  CBitcoinAddress(key).ToString());
 
             // Unlike the above we will keep going even if this record is not found, because it is identical to the
             // m_sidestake_entries record above. This should not happen, because during contract adds and removes,
@@ -630,13 +632,13 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
         if (resurrect_entry == m_sidestake_db.end()) {
             error("%s: The prior entry to resurrect during a SideStake entry ADD revert for key %s was not found.",
                   __func__,
-                  key.ToString());
+                  CBitcoinAddress(key).ToString());
             return;
         }
 
         // Resurrect the entry prior to the reverted one. It is safe to use the bracket form here, because of the protection
         // of the logic above. There cannot be any entry in m_sidestake_entries with that key value left if we made it here.
-        m_mandatory_sidestake_entries[resurrect_entry->second->m_address] = resurrect_entry->second;
+        m_mandatory_sidestake_entries[resurrect_entry->second->m_destination] = resurrect_entry->second;
     }
 }
 
@@ -842,7 +844,7 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
             break;
         }
 
-        LocalSideStake sidestake(static_cast<CBitcoinAddressForStorage>(address),
+        LocalSideStake sidestake(address.Get(),
                                  dAllocation,
                                  std::get<2>(entry),
                                  LocalSideStake::LocalSideStakeStatus::ACTIVE);
@@ -899,7 +901,7 @@ bool SideStakeRegistry::SaveLocalSideStakesToConfig()
             separator = ",";
         }
 
-        addresses += separator + iter.second->m_address.ToString();
+        addresses += separator + CBitcoinAddress(iter.second->m_destination).ToString();
         allocations += separator + ToString(iter.second->m_allocation * 100.0);
         descriptions += separator + iter.second->m_description;
 

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -6,12 +6,26 @@
 #include "node/ui_interface.h"
 
 using namespace GRC;
+using LogFlags = BCLog::LogFlags;
+
+namespace {
+SideStakeRegistry g_sidestake_entries;
+} // anonymous namespace
+
+// -----------------------------------------------------------------------------
+// Global Functions
+// -----------------------------------------------------------------------------
+
+SideStakeRegistry& GRC::GetSideStakeRegistry()
+{
+    return g_sidestake_entries;
+}
 
 // -----------------------------------------------------------------------------
 // Class: SideStake
 // -----------------------------------------------------------------------------
 SideStake::SideStake()
-    : m_address()
+    : m_key()
       , m_allocation()
       , m_timestamp(0)
       , m_hash()
@@ -19,8 +33,8 @@ SideStake::SideStake()
       , m_status(SideStakeStatus::UNKNOWN)
 {}
 
-SideStake::SideStake(CBitcoinAddress address, double allocation)
-    : m_address(address)
+SideStake::SideStake(CBitcoinAddressForStorage address, double allocation)
+    : m_key(address)
       , m_allocation(allocation)
       , m_timestamp(0)
       , m_hash()
@@ -28,8 +42,8 @@ SideStake::SideStake(CBitcoinAddress address, double allocation)
       , m_status(SideStakeStatus::UNKNOWN)
 {}
 
-SideStake::SideStake(CBitcoinAddress address, double allocation, int64_t timestamp, uint256 hash)
-    : m_address(address)
+SideStake::SideStake(CBitcoinAddressForStorage address, double allocation, int64_t timestamp, uint256 hash)
+    : m_key(address)
       , m_allocation(allocation)
       , m_timestamp(timestamp)
       , m_hash(hash)
@@ -39,12 +53,17 @@ SideStake::SideStake(CBitcoinAddress address, double allocation, int64_t timesta
 
 bool SideStake::WellFormed() const
 {
-    return m_address.IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
+    return m_key.IsValid() && m_allocation >= 0.0 && m_allocation <= 1.0;
+}
+
+CBitcoinAddressForStorage SideStake::Key() const
+{
+    return m_key;
 }
 
 std::pair<std::string, std::string> SideStake::KeyValueToString() const
 {
-    return std::make_pair(m_address.ToString(), StatusToString());
+    return std::make_pair(m_key.ToString(), StatusToString());
 }
 
 std::string SideStake::StatusToString() const
@@ -88,7 +107,7 @@ bool SideStake::operator==(SideStake b)
 {
     bool result = true;
 
-    result &= (m_address == b.m_address);
+    result &= (m_key == b.m_key);
     result &= (m_allocation == b.m_allocation);
     result &= (m_timestamp == b.m_timestamp);
     result &= (m_hash == b.m_hash);
@@ -102,3 +121,341 @@ bool SideStake::operator!=(SideStake b)
 {
     return !(*this == b);
 }
+
+// -----------------------------------------------------------------------------
+// Class: SideStakePayload
+// -----------------------------------------------------------------------------
+
+constexpr uint32_t SideStakePayload::CURRENT_VERSION; // For clang
+
+SideStakePayload::SideStakePayload(uint32_t version)
+    : IContractPayload()
+      , m_version(version)
+{
+}
+
+SideStakePayload::SideStakePayload(const uint32_t version, CBitcoinAddressForStorage key, double value, SideStakeStatus status)
+    : IContractPayload()
+      , m_version(version)
+      , m_entry(SideStake(key, value, status))
+{
+}
+
+SideStakePayload::SideStakePayload(const uint32_t version, SideStake entry)
+    : IContractPayload()
+      , m_version(version)
+      , m_entry(std::move(entry))
+{
+}
+
+SideStakePayload::SideStakePayload(SideStake entry)
+    : SideStakePayload(CURRENT_VERSION, std::move(entry))
+{
+}
+
+// -----------------------------------------------------------------------------
+// Class: SideStakeRegistry
+// -----------------------------------------------------------------------------
+const SideStakeRegistry::SideStakeMap& SideStakeRegistry::SideStakeEntries() const
+{
+    return m_sidestake_entries;
+}
+
+SideStakeOption SideStakeRegistry::Try(const CBitcoinAddressForStorage& key) const
+{
+    LOCK(cs_lock);
+
+    const auto iter = m_sidestake_entries.find(key);
+
+    if (iter == m_sidestake_entries.end()) {
+        return nullptr;
+    }
+
+    return iter->second;
+}
+
+SideStakeOption SideStakeRegistry::TryActive(const CBitcoinAddressForStorage& key) const
+{
+    LOCK(cs_lock);
+
+    if (const SideStakeOption SideStake_entry = Try(key)) {
+        if (SideStake_entry->m_status == SideStakeStatus::ACTIVE || SideStake_entry->m_status == SideStakeStatus::MANDATORY) {
+            return SideStake_entry;
+        }
+    }
+
+    return nullptr;
+}
+
+void SideStakeRegistry::Reset()
+{
+    LOCK(cs_lock);
+
+    m_sidestake_entries.clear();
+    m_sidestake_db.clear();
+}
+
+void SideStakeRegistry::AddDelete(const ContractContext& ctx)
+{
+    // Poor man's mock. This is to prevent the tests from polluting the LevelDB database
+    int height = -1;
+
+    if (ctx.m_pindex)
+    {
+        height = ctx.m_pindex->nHeight;
+    }
+
+    SideStakePayload payload = ctx->CopyPayloadAs<SideStakePayload>();
+
+           // Fill this in from the transaction context because these are not done during payload
+           // initialization.
+    payload.m_entry.m_hash = ctx.m_tx.GetHash();
+    payload.m_entry.m_timestamp = ctx.m_tx.nTime;
+
+           // Ensure status is DELETED if the contract action was REMOVE, regardless of what was actually
+           // specified.
+    if (ctx->m_action == ContractAction::REMOVE) {
+        payload.m_entry.m_status = SideStakeStatus::DELETED;
+    }
+
+    LOCK(cs_lock);
+
+    auto sidestake_entry_pair_iter = m_sidestake_entries.find(payload.m_entry.m_key);
+
+    SideStake_ptr current_sidestake_entry_ptr = nullptr;
+
+           // Is there an existing SideStake entry in the map?
+    bool current_sidestake_entry_present = (sidestake_entry_pair_iter != m_sidestake_entries.end());
+
+           // If so, then get a smart pointer to it.
+    if (current_sidestake_entry_present) {
+        current_sidestake_entry_ptr = sidestake_entry_pair_iter->second;
+
+               // Set the payload m_entry's prev entry ctx hash = to the existing entry's hash.
+        payload.m_entry.m_previous_hash = current_sidestake_entry_ptr->m_hash;
+    } else { // Original entry for this SideStake entry key
+        payload.m_entry.m_previous_hash = uint256 {};
+    }
+
+    LogPrint(LogFlags::CONTRACT, "INFO: %s: SideStake entry add/delete: contract m_version = %u, payload "
+                                 "m_version = %u, key = %s, value = %f, m_timestamp = %" PRId64 ", "
+                                 "m_hash = %s, m_previous_hash = %s, m_status = %s",
+             __func__,
+             ctx->m_version,
+             payload.m_version,
+             payload.m_entry.m_key.ToString(),
+             payload.m_entry.m_allocation,
+             payload.m_entry.m_timestamp,
+             payload.m_entry.m_hash.ToString(),
+             payload.m_entry.m_previous_hash.ToString(),
+             payload.m_entry.StatusToString()
+             );
+
+    SideStake& historical = payload.m_entry;
+
+    if (!m_sidestake_db.insert(ctx.m_tx.GetHash(), height, historical))
+    {
+        LogPrint(LogFlags::CONTRACT, "INFO: %s: In recording of the SideStake entry for key %s, value %f, hash %s, "
+                                     "the SideStake entry db record already exists. This can be expected on a restart "
+                                     "of the wallet to ensure multiple contracts in the same block get stored/replayed.",
+                 __func__,
+                 historical.m_key.ToString(),
+                 historical.m_allocation,
+                 historical.m_hash.GetHex());
+    }
+
+           // Finally, insert the new SideStake entry (payload) smart pointer into the m_sidestake_entries map.
+    m_sidestake_entries[payload.m_entry.m_key] = m_sidestake_db.find(ctx.m_tx.GetHash())->second;
+
+    return;
+}
+
+void SideStakeRegistry::NonContractAdd(SideStake& sidestake)
+{
+    // Using this form of insert because we want the latest record with the same key to override any previous one.
+    m_sidestake_entries[sidestake.m_key] = std::make_shared<SideStake>(sidestake);
+}
+
+void SideStakeRegistry::Add(const ContractContext& ctx)
+{
+    AddDelete(ctx);
+}
+
+void SideStakeRegistry::NonContractDelete(CBitcoinAddressForStorage& address)
+{
+    auto sidestake_entry_pair_iter = m_sidestake_entries.find(address);
+
+    if (sidestake_entry_pair_iter != m_sidestake_entries.end()) {
+        m_sidestake_entries.erase(sidestake_entry_pair_iter);
+    }
+}
+
+void SideStakeRegistry::Delete(const ContractContext& ctx)
+{
+    AddDelete(ctx);
+}
+
+void SideStakeRegistry::Revert(const ContractContext& ctx)
+{
+    const auto payload = ctx->SharePayloadAs<SideStakePayload>();
+
+           // For SideStake entries, both adds and removes will have records to revert in the m_sidestake_entries map,
+           // and also, if not the first entry for that SideStake key, will have a historical record to
+           // resurrect.
+    LOCK(cs_lock);
+
+    auto entry_to_revert = m_sidestake_entries.find(payload->m_entry.m_key);
+
+    if (entry_to_revert == m_sidestake_entries.end()) {
+        error("%s: The SideStake entry for key %s to revert was not found in the SideStake entry map.",
+              __func__,
+              entry_to_revert->second->m_key.ToString());
+
+               // If there is no record in the current m_sidestake_entries map, then there is nothing to do here. This
+               // should not occur.
+        return;
+    }
+
+           // If this is not a null hash, then there will be a prior entry to resurrect.
+    CBitcoinAddressForStorage key = entry_to_revert->second->m_key;
+    uint256 resurrect_hash = entry_to_revert->second->m_previous_hash;
+
+           // Revert the ADD or REMOVE action. Unlike the beacons, this is symmetric.
+    if (ctx->m_action == ContractAction::ADD || ctx->m_action == ContractAction::REMOVE) {
+        // Erase the record from m_sidestake_entries.
+        if (m_sidestake_entries.erase(payload->m_entry.m_key) == 0) {
+            error("%s: The SideStake entry to erase during a SideStake entry revert for key %s was not found.",
+                  __func__,
+                  key.ToString());
+            // If the record to revert is not found in the m_sidestake_entries map, no point in continuing.
+            return;
+        }
+
+               // Also erase the record from the db.
+        if (!m_sidestake_db.erase(ctx.m_tx.GetHash())) {
+            error("%s: The db entry to erase during a SideStake entry revert for key %s was not found.",
+                  __func__,
+                  key.ToString());
+
+                   // Unlike the above we will keep going even if this record is not found, because it is identical to the
+                   // m_sidestake_entries record above. This should not happen, because during contract adds and removes,
+                   // entries are made simultaneously to the m_sidestake_entries and m_sidestake_db.
+        }
+
+        if (resurrect_hash.IsNull()) {
+            return;
+        }
+
+        auto resurrect_entry = m_sidestake_db.find(resurrect_hash);
+
+        if (resurrect_entry == m_sidestake_db.end()) {
+            error("%s: The prior entry to resurrect during a SideStake entry ADD revert for key %s was not found.",
+                  __func__,
+                  key.ToString());
+            return;
+        }
+
+               // Resurrect the entry prior to the reverted one. It is safe to use the bracket form here, because of the protection
+               // of the logic above. There cannot be any entry in m_sidestake_entries with that key value left if we made it here.
+        m_sidestake_entries[resurrect_entry->second->m_key] = resurrect_entry->second;
+    }
+}
+
+bool SideStakeRegistry::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const
+{
+    if (contract.m_version < 1) {
+        return true;
+    }
+
+    const auto payload = contract.SharePayloadAs<SideStakePayload>();
+
+    if (contract.m_version >= 3 && payload->m_version < 2) {
+        DoS = 25;
+        error("%s: Legacy SideStake entry contract in contract v3", __func__);
+        return false;
+    }
+
+    if (!payload->WellFormed(contract.m_action.Value())) {
+        DoS = 25;
+        error("%s: Malformed SideStake entry contract", __func__);
+        return false;
+    }
+
+    return true;
+}
+
+bool SideStakeRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
+{
+    return Validate(ctx.m_contract, ctx.m_tx, DoS);
+}
+
+int SideStakeRegistry::Initialize()
+{
+    LOCK(cs_lock);
+
+    int height = m_sidestake_db.Initialize(m_sidestake_entries, m_pending_sidestake_entries);
+
+    LogPrint(LogFlags::CONTRACT, "INFO: %s: m_sidestake_db size after load: %u", __func__, m_sidestake_db.size());
+    LogPrint(LogFlags::CONTRACT, "INFO: %s: m_sidestake_entries size after load: %u", __func__, m_sidestake_entries.size());
+
+    return height;
+}
+
+void SideStakeRegistry::SetDBHeight(int& height)
+{
+    LOCK(cs_lock);
+
+    m_sidestake_db.StoreDBHeight(height);
+}
+
+int SideStakeRegistry::GetDBHeight()
+{
+    int height = 0;
+
+    LOCK(cs_lock);
+
+    m_sidestake_db.LoadDBHeight(height);
+
+    return height;
+}
+
+void SideStakeRegistry::ResetInMemoryOnly()
+{
+    LOCK(cs_lock);
+
+    m_sidestake_entries.clear();
+    m_sidestake_db.clear_in_memory_only();
+}
+
+uint64_t SideStakeRegistry::PassivateDB()
+{
+    LOCK(cs_lock);
+
+    return m_sidestake_db.passivate_db();
+}
+
+SideStakeRegistry::SideStakeDB &SideStakeRegistry::GetSideStakeDB()
+{
+    return m_sidestake_db;
+}
+
+// This is static and called by the scheduler.
+void SideStakeRegistry::RunDBPassivation()
+{
+    TRY_LOCK(cs_main, locked_main);
+
+    if (!locked_main)
+    {
+        return;
+    }
+
+    SideStakeRegistry& SideStake_entries = GetSideStakeRegistry();
+
+    SideStake_entries.PassivateDB();
+}
+
+template<> const std::string SideStakeRegistry::SideStakeDB::KeyType()
+{
+    return std::string("SideStake");
+}
+

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -69,6 +69,8 @@ public:
 
     double m_allocation;                //!< The allocation is a double precision floating point between 0.0 and 1.0 inclusive
 
+    std::string m_description;            //!< The description of the sidestake (optional)
+
     int64_t m_timestamp;                //!< Time of the sidestake contract transaction.
 
     uint256 m_hash;                     //!< The hash of the transaction that contains a mandatory sidestake.
@@ -88,17 +90,19 @@ public:
     //!
     //! \param address
     //! \param allocation
+    //! \param description (optional)
     //!
-    SideStake(CBitcoinAddressForStorage address, double allocation);
+    SideStake(CBitcoinAddressForStorage address, double allocation, std::string description);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters.
     //!
     //! \param address
     //! \param allocation
+    //! \param description (optional)
     //! \param status
     //!
-    SideStake(CBitcoinAddressForStorage address, double allocation, SideStakeStatus status);
+    SideStake(CBitcoinAddressForStorage address, double allocation, std::string description, SideStakeStatus status);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters. This form is normally used to construct a
@@ -106,11 +110,12 @@ public:
     //!
     //! \param address
     //! \param allocation
+    //! \param description (optional)
     //! \param timestamp
     //! \param hash
     //! \param status
     //!
-    SideStake(CBitcoinAddressForStorage address, double allocation, int64_t timestamp, uint256 hash, SideStakeStatus status);
+    SideStake(CBitcoinAddressForStorage address, double allocation, std::string description, int64_t timestamp, uint256 hash, SideStakeStatus status);
 
     //!
     //! \brief Determine whether a sidestake contains each of the required elements.
@@ -176,6 +181,7 @@ public:
     {
         READWRITE(m_key);
         READWRITE(m_allocation);
+        READWRITE(m_description);
         READWRITE(m_timestamp);
         READWRITE(m_hash);
         READWRITE(m_previous_hash);
@@ -242,7 +248,8 @@ public:
     //! \param value. Value string for the sidestake entry
     //! \param status. Status of the sidestake entry
     //!
-    SideStakePayload(const uint32_t version, CBitcoinAddressForStorage key, double value, SideStakeStatus status);
+    SideStakePayload(const uint32_t version, CBitcoinAddressForStorage key, double value,
+                     std::string description, SideStakeStatus status);
 
     //!
     //! \brief Initialize a sidestake entry payload from the given sidestake entry

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -17,6 +17,9 @@ namespace GRC {
 class CBitcoinAddressForStorage : public CBitcoinAddress
 {
 public:
+    CBitcoinAddressForStorage();
+
+    CBitcoinAddressForStorage(CBitcoinAddress address);
 
     ADD_SERIALIZE_METHODS;
 
@@ -419,6 +422,7 @@ public:
     //!
     //! \brief Allows local (voluntary) sidestakes to be added to the in-memory map and not persisted to
     //! the registry db.
+    //!
     //! \param SideStake object to add
     //!
     void NonContractAdd(SideStake& sidestake);
@@ -427,6 +431,7 @@ public:
     //! \brief Add a sidestake entry to the registry from contract data. For the sidestake registry
     //! both Add and Delete actually call a common helper function AddDelete, because the action
     //! is actually symmetric to both.
+    //!
     //! \param ctx
     //!
     void Add(const ContractContext& ctx) override;
@@ -498,6 +503,12 @@ public:
     //! \return The number of elements passivated.
     //!
     uint64_t PassivateDB();
+
+    //!
+    //! \brief This method parses the config file for local sidestakes. It is based on the original GetSideStakingStatusAndAlloc()
+    //! that was in miner.cpp prior to the implementation of the SideStake class.
+    //!
+    void LoadLocalSideStakesFromConfig();
 
     //!
     //! \brief A static function that is called by the scheduler to run the sidestake entry database passivation.

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -106,8 +106,9 @@ public:
     //! \param allocation
     //! \param timestamp
     //! \param hash
+    //! \param status
     //!
-    SideStake(CBitcoinAddressForStorage address, double allocation, int64_t timestamp, uint256 hash);
+    SideStake(CBitcoinAddressForStorage address, double allocation, int64_t timestamp, uint256 hash, SideStakeStatus status);
 
     //!
     //! \brief Determine whether a sidestake contains each of the required elements.
@@ -374,7 +375,7 @@ public:
     //!
     //! \return A vector of smart pointers to sidestake entries.
     //!
-    const std::vector<SideStake_ptr> ActiveSideStakeEntries() const;
+    const std::vector<SideStake_ptr> ActiveSideStakeEntries();
 
     //!
     //! \brief Get the current sidestake entry for the specified key string.

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -408,9 +408,11 @@ public:
     //! Mandatory sidestakes come before local ones, and the method ensures that the sidestakes
     //! returned do not total an allocation greater than 1.0.
     //!
+    //! \param bool true to return local sidestakes only
+    //!
     //! \return A vector of smart pointers to sidestake entries.
     //!
-    const std::vector<SideStake_ptr> ActiveSideStakeEntries();
+    const std::vector<SideStake_ptr> ActiveSideStakeEntries(const bool& local_only, const bool& include_zero_alloc);
 
     //!
     //! \brief Get the current sidestake entry for the specified key string.
@@ -472,8 +474,9 @@ public:
     //! the registry db.
     //!
     //! \param SideStake object to add
+    //! \param bool save_to_file if true causes SaveLocalSideStakesToConfig() to be called.
     //!
-    void NonContractAdd(SideStake& sidestake);
+    void NonContractAdd(const SideStake& sidestake, const bool& save_to_file = true);
 
     //!
     //! \brief Add a sidestake entry to the registry from contract data. For the sidestake registry
@@ -487,9 +490,11 @@ public:
     //!
     //! \brief Provides for deletion of local (voluntary) sidestakes from the in-memory map that are not persisted
     //! to the registry db. Deletion is by the map key (CBitcoinAddress).
-    //! \param address
     //!
-    void NonContractDelete(CBitcoinAddressForStorage& address);
+    //! \param address
+    //! \param bool save_to_file if true causes SaveLocalSideStakesToConfig() to be called.
+    //!
+    void NonContractDelete(const CBitcoinAddressForStorage& address, const bool& save_to_file = true);
 
     //!
     //! \brief Mark a sidestake entry deleted in the registry from contract data. For the sidestake registry

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -558,7 +558,7 @@ public:
     //!
     //! \return A vector of smart pointers to sidestake entries.
     //!
-    const std::vector<SideStake_ptr> ActiveSideStakeEntries(const bool& local_only, const bool& include_zero_alloc);
+    const std::vector<SideStake_ptr> ActiveSideStakeEntries(const bool& local_only, const bool& include_zero_alloc) const;
 
     //!
     //! \brief Get the current sidestake entry for the specified destination.
@@ -745,6 +745,12 @@ private:
     //! \return bool true if successful.
     //!
     bool SaveLocalSideStakesToConfig();
+
+    //!
+    //! \brief Provides the total allocation for all active mandatory sidestakes as a floating point fraction.
+    //! \return total active mandatory sidestake allocation as a double.
+    //!
+    double GetMandatoryAllocationsTotal() const;
 
     void SubscribeToCoreSignals();
     void UnsubscribeFromCoreSignals();

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -1,0 +1,141 @@
+// Copyright (c) 2014-2023 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_SIDESTAKE_H
+#define GRIDCOIN_SIDESTAKE_H
+
+#include "base58.h"
+#include "gridcoin/support/enumbytes.h"
+#include "serialize.h"
+
+namespace GRC {
+
+enum class SideStakeStatus
+{
+    UNKNOWN,
+    ACTIVE,         //!< A user specified sidestake that is active
+    INACTIVE,       //!< A user specified sidestake that is inactive
+    DELETED,        //!< A mandatory sidestake that has been deleted by contract
+    MANDATORY,      //!< An active mandatory sidetake by contract
+    OUT_OF_BOUND
+};
+
+class SideStake
+{
+    using Status = EnumByte<SideStakeStatus>;
+
+    CBitcoinAddress m_address;
+
+    double m_allocation;
+
+    int64_t m_timestamp;        //!< Time of the sidestake contract transaction.
+
+    uint256 m_hash;             //!< The hash of the transaction that contains a mandatory sidestake.
+
+    uint256 m_previous_hash;    //!< The m_hash of the previous mandatory sidestake allocation with the same address.
+
+    Status m_status;            //!< The status of the sidestake. It is of type int instead of enum for serialization.
+
+    //!
+    //! \brief Initialize an empty, invalid sidestake instance.
+    //!
+    SideStake();
+
+    //!
+    //! \brief Initialize a sidestake instance with the provided address and allocation. This is used to construct a user
+    //! specified sidestake.
+    //!
+    //! \param address
+    //! \param allocation
+    //!
+    SideStake(CBitcoinAddress address, double allocation);
+
+    //!
+    //! \brief Initial a sidestake instance with the provided parameters. This form is normally used to construct a
+    //! mandatory sidestake from a contract.
+    //!
+    //! \param address
+    //! \param allocation
+    //! \param timestamp
+    //! \param hash
+    //!
+    SideStake(CBitcoinAddress address, double allocation, int64_t timestamp, uint256 hash);
+
+    //!
+    //! \brief Determine whether a sidestake contains each of the required elements.
+    //! \return true if the sidestake is well-formed.
+    //!
+    bool WellFormed() const;
+
+    //!
+    //! \brief Provides the sidestake address and status (value) as a pair of strings.
+    //! \return std::pair of strings
+    //!
+    std::pair<std::string, std::string> KeyValueToString() const;
+
+           //!
+           //! \brief Returns the string representation of the current sidestake status
+           //!
+           //! \return Translated string representation of sidestake status
+           //!
+    std::string StatusToString() const;
+
+           //!
+           //! \brief Returns the translated or untranslated string of the input sidestake status
+           //!
+           //! \param status. SideStake status
+           //! \param translated. True for translated, false for not translated. Defaults to true.
+           //!
+           //! \return SideStake status string.
+           //!
+    std::string StatusToString(const SideStakeStatus& status, const bool& translated = true) const;
+
+    //!
+    //! \brief Comparison operator overload used in the unit test harness.
+    //!
+    //! \param b The right hand side sidestake to compare for equality.
+    //!
+    //! \return Equal or not.
+    //!
+
+    bool operator==(SideStake b);
+
+    //!
+    //! \brief Comparison operator overload used in the unit test harness.
+    //!
+    //! \param b The right hand side sidestake to compare for equality.
+    //!
+    //! \return Equal or not.
+    //!
+
+    bool operator!=(SideStake b);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(m_address);
+        READWRITE(m_allocation);
+        READWRITE(m_timestamp);
+        READWRITE(m_hash);
+        READWRITE(m_previous_hash);
+        READWRITE(m_status);
+    }
+};
+
+//!
+//! \brief The type that defines a shared pointer to a sidestake
+//!
+typedef std::shared_ptr<SideStake> SideStake_ptr;
+
+//!
+//! \brief A type that either points to some sidestake or does not.
+//!
+typedef const SideStake_ptr SideStakeOption;
+
+
+} // namespace GRC
+
+#endif // GRIDCOIN_SIDESTAKE_H

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -15,6 +15,7 @@
 
 namespace GRC {
 
+/*
 //!
 //! \brief The CBitcoinAddressForStorage class. This is a very small extension of the CBitcoinAddress class that
 //! provides serialization/deserialization.
@@ -38,10 +39,11 @@ public:
         READWRITE(vchData);
     }
 };
+*/
 
 //!
 //! \brief The LocalSideStake class. This class formalizes the local sidestake, which is a directive to apportion
-//! a percentage of the total stake value to a designated address. This address must be a valid address, but
+//! a percentage of the total stake value to a designated destination. This destination must be valid, but
 //! may or may not be owned by the staker. This is the primary mechanism to do automatic "donations" to
 //! defined network addresses.
 //!
@@ -64,7 +66,7 @@ public:
     //!
     using Status = EnumByte<LocalSideStakeStatus>;
 
-    CBitcoinAddressForStorage m_address; //!< The Gridcoin Address of the sidestake destination.
+    CTxDestination m_destination;        //!< The destination of the sidestake.
 
     double m_allocation;                 //!< The allocation is a double precision floating point between 0.0 and 1.0 inclusive
 
@@ -79,24 +81,24 @@ public:
     LocalSideStake();
 
     //!
-    //! \brief Initialize a sidestake instance with the provided address and allocation. This is used to construct a user
+    //! \brief Initialize a sidestake instance with the provided destination and allocation. This is used to construct a user
     //! specified sidestake.
     //!
-    //! \param address
+    //! \param destination
     //! \param allocation
     //! \param description (optional)
     //!
-    LocalSideStake(CBitcoinAddressForStorage address, double allocation, std::string description);
+    LocalSideStake(CTxDestination destination, double allocation, std::string description);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters.
     //!
-    //! \param address
+    //! \param destination
     //! \param allocation
     //! \param description (optional)
     //! \param status
     //!
-    LocalSideStake(CBitcoinAddressForStorage address, double allocation, std::string description, LocalSideStakeStatus status);
+    LocalSideStake(CTxDestination destination, double allocation, std::string description, LocalSideStakeStatus status);
 
     //!
     //! \brief Determine whether a sidestake contains each of the required elements.
@@ -144,7 +146,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        READWRITE(m_address);
+        READWRITE(m_destination);
         READWRITE(m_allocation);
         READWRITE(m_description);
         READWRITE(m_status);
@@ -158,7 +160,7 @@ typedef std::shared_ptr<LocalSideStake> LocalSideStake_ptr;
 
 //!
 //! \brief The MandatorySideStake class. This class formalizes the mandatory sidestake, which is a directive to apportion
-//! a percentage of the total stake value to a designated address. This address must be a valid address, but
+//! a percentage of the total stake value to a designated destination. This destination must be valid, but
 //! may or may not be owned by the staker. This is the primary mechanism to do automatic "donations" to
 //! defined network addresses.
 //!
@@ -180,7 +182,7 @@ public:
     //!
     using Status = EnumByte<MandatorySideStakeStatus>;
 
-    CBitcoinAddressForStorage m_address; //!< The Gridcoin Address of the sidestake destination.
+    CTxDestination m_destination;        //!< The destination of the sidestake.
 
     double m_allocation;                 //!< The allocation is a double precision floating point between 0.0 and 1.0 inclusive
 
@@ -190,7 +192,7 @@ public:
 
     uint256 m_hash;                      //!< The hash of the transaction that contains a mandatory sidestake.
 
-    uint256 m_previous_hash;             //!< The m_hash of the previous mandatory sidestake allocation with the same address.
+    uint256 m_previous_hash;             //!< The m_hash of the previous mandatory sidestake allocation with the same destination.
 
     Status m_status;                     //!< The status of the sidestake. It is of type int instead of enum for serialization.
 
@@ -200,37 +202,37 @@ public:
     MandatorySideStake();
 
     //!
-    //! \brief Initialize a sidestake instance with the provided address and allocation. This is used to construct a user
+    //! \brief Initialize a sidestake instance with the provided destination and allocation. This is used to construct a user
     //! specified sidestake.
     //!
-    //! \param address
+    //! \param destination
     //! \param allocation
     //! \param description (optional)
     //!
-    MandatorySideStake(CBitcoinAddressForStorage address, double allocation, std::string description);
+    MandatorySideStake(CTxDestination destination, double allocation, std::string description);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters.
     //!
-    //! \param address
+    //! \param destination
     //! \param allocation
     //! \param description (optional)
     //! \param status
     //!
-    MandatorySideStake(CBitcoinAddressForStorage address, double allocation, std::string description, MandatorySideStakeStatus status);
+    MandatorySideStake(CTxDestination destination, double allocation, std::string description, MandatorySideStakeStatus status);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters. This form is normally used to construct a
     //! mandatory sidestake from a contract.
     //!
-    //! \param address
+    //! \param destination
     //! \param allocation
     //! \param description (optional)
     //! \param timestamp
     //! \param hash
     //! \param status
     //!
-    MandatorySideStake(CBitcoinAddressForStorage address, double allocation, std::string description, int64_t timestamp,
+    MandatorySideStake(CTxDestination destination, double allocation, std::string description, int64_t timestamp,
               uint256 hash, MandatorySideStakeStatus status);
 
     //!
@@ -240,15 +242,15 @@ public:
     bool WellFormed() const;
 
     //!
-    //! \brief This is the standardized method that returns the key value (in this case the address) for the sidestake entry (for
+    //! \brief This is the standardized method that returns the key value (in this case the destination) for the sidestake entry (for
     //! the registry_db.h template.)
     //!
-    //! \return CBitcoinAddress key value for the sidestake entry
+    //! \return CTxDestination key value for the sidestake entry
     //!
-    CBitcoinAddressForStorage Key() const;
+    CTxDestination Key() const;
 
     //!
-    //! \brief Provides the sidestake address and status as a pair of strings.
+    //! \brief Provides the sidestake destination address and status as a pair of strings.
     //! \return std::pair of strings
     //!
     std::pair<std::string, std::string> KeyValueToString() const;
@@ -293,7 +295,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        READWRITE(m_address);
+        READWRITE(m_destination);
         READWRITE(m_allocation);
         READWRITE(m_description);
         READWRITE(m_timestamp);
@@ -328,7 +330,7 @@ public:
 
     bool IsMandatory() const;
 
-    CBitcoinAddress GetAddress() const;
+    CTxDestination GetDestination() const;
     double GetAllocation() const;
     std::string GetDescription() const;
     Status GetStatus() const;
@@ -377,15 +379,15 @@ public:
     SideStakePayload(uint32_t version = CURRENT_VERSION);
 
     //!
-    //! \brief Initialize a sidestakeEntryPayload from a sidestake address, allocation,
+    //! \brief Initialize a sidestakeEntryPayload from a sidestake destination, allocation,
     //! description, and status.
     //!
-    //! \param address. Address for the sidestake entry
+    //! \param destination. Destination for the sidestake entry
     //! \param allocation. Allocation for the sidestake entry
     //! \param description. Description string for the sidstake entry
     //! \param status. Status of the sidestake entry
     //!
-    SideStakePayload(const uint32_t version, CBitcoinAddressForStorage address, double allocation,
+    SideStakePayload(const uint32_t version, CTxDestination destination, double allocation,
                      std::string description, MandatorySideStake::MandatorySideStakeStatus status);
 
     //!
@@ -440,7 +442,7 @@ public:
                                                 "m_entry.StatusToString() = %s",
                      __func__,
                      valid,
-                     m_entry.m_address.ToString(),
+                     CBitcoinAddress(m_entry.m_destination).ToString(),
                      m_entry.m_allocation,
                      m_entry.StatusToString()
                      );
@@ -456,7 +458,7 @@ public:
     //!
     std::string LegacyKeyString() const override
     {
-        return m_entry.m_address.ToString();
+        return CBitcoinAddress(m_entry.m_destination).ToString();
     }
 
     //!
@@ -511,18 +513,18 @@ public:
           };
 
     //!
-    //! \brief The type that keys local sidestake entries by their addresses. Note that the entries
+    //! \brief The type that keys local sidestake entries by their destinations. Note that the entries
     //! in this map are actually smart shared pointer wrappers, so that the same actual object
     //! can be held by both this map and the historical map without object duplication.
     //!
-    typedef std::map<CBitcoinAddressForStorage, LocalSideStake_ptr> LocalSideStakeMap;
+    typedef std::map<CTxDestination, LocalSideStake_ptr> LocalSideStakeMap;
 
     //!
-    //! \brief The type that keys mandatory sidestake entries by their addresses. Note that the entries
+    //! \brief The type that keys mandatory sidestake entries by their destinations. Note that the entries
     //! in this map are actually smart shared pointer wrappers, so that the same actual object
     //! can be held by both this map and the historical map without object duplication.
     //!
-    typedef std::map<CBitcoinAddressForStorage, MandatorySideStake_ptr> MandatorySideStakeMap;
+    typedef std::map<CTxDestination, MandatorySideStake_ptr> MandatorySideStakeMap;
 
     //!
     //! \brief PendingSideStakeMap. This is not actually used but defined to satisfy the template.
@@ -559,27 +561,27 @@ public:
     const std::vector<SideStake_ptr> ActiveSideStakeEntries(const bool& local_only, const bool& include_zero_alloc);
 
     //!
-    //! \brief Get the current sidestake entry for the specified address.
+    //! \brief Get the current sidestake entry for the specified destination.
     //!
-    //! \param key The address of the sidestake entry.
+    //! \param key The destination of the sidestake entry.
     //! \param local_only If true causes Try to only check the local sidestake map. Defaults to false.
     //!
-    //! \return A vector of smart pointers to entries matching the provided address. Up to two elements
+    //! \return A vector of smart pointers to entries matching the provided destination. Up to two elements
     //! are returned, mandatory entry first, unless local only boolean is set true.
     //!
-    std::vector<SideStake_ptr> Try(const CBitcoinAddressForStorage& key, const bool& local_only = false) const;
+    std::vector<SideStake_ptr> Try(const CTxDestination& key, const bool& local_only = false) const;
 
     //!
-    //! \brief Get the current sidestake entry for the specified address if it has a status of ACTIVE or MANDATORY.
+    //! \brief Get the current sidestake entry for the specified destination if it has a status of ACTIVE or MANDATORY.
     //!
-    //! \param key The address of the sidestake entry.
+    //! \param key The destination of the sidestake entry.
     //! \param local_only If true causes Try to only check the local sidestake map. Defaults to false.
     //!
-    //! \return A vector of smart pointers to entries matching the provided address that are in status of
+    //! \return A vector of smart pointers to entries matching the provided destination that are in status of
     //! MANDATORY or ACTIVE. Up to two elements are returned, mandatory entry first, unless local only boolean
     //! is set true.
     //!
-    std::vector<SideStake_ptr> TryActive(const CBitcoinAddressForStorage& key, const bool& local_only = false) const;
+    std::vector<SideStake_ptr> TryActive(const CTxDestination& key, const bool& local_only = false) const;
 
     //!
     //! \brief Destroy the contract handler state in case of an error in loading
@@ -641,12 +643,12 @@ public:
 
     //!
     //! \brief Provides for deletion of local (voluntary) sidestakes from the in-memory local map that are not persisted
-    //! to the registry db. Deletion is by the map key (CBitcoinAddress).
+    //! to the registry db. Deletion is by the map key (CTxDestination).
     //!
-    //! \param address
+    //! \param destination
     //! \param bool save_to_file if true causes SaveLocalSideStakesToConfig() to be called.
     //!
-    void NonContractDelete(const CBitcoinAddressForStorage& address, const bool& save_to_file = true);
+    void NonContractDelete(const CTxDestination& destination, const bool& save_to_file = true);
 
     //!
     //! \brief Revert the registry state for the sidestake entry to the state prior

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -577,6 +577,9 @@ private:
     //!
     void AddDelete(const ContractContext& ctx);
 
+    void SubscribeToCoreSignals();
+    void UnsubscribeFromCoreSignals();
+
     SideStakeMap m_sidestake_entries;                   //!< Contains the current sidestake entries including entries marked DELETED.
     PendingSideStakeMap m_pending_sidestake_entries {}; //!< Not used. Only to satisfy the template.
 

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -368,6 +368,15 @@ public:
     const SideStakeMap& SideStakeEntries() const;
 
     //!
+    //! \brief Get the collection of active sidestake entries. This is presented as a vector of
+    //! smart pointers to the relevant sidestake entries in the database. The entries included have
+    //! the status of active (for local sidestakes) and/or mandatory (for contract sidestakes).
+    //!
+    //! \return A vector of smart pointers to sidestake entries.
+    //!
+    const std::vector<SideStake_ptr> ActiveSideStakeEntries() const;
+
+    //!
     //! \brief Get the current sidestake entry for the specified key string.
     //!
     //! \param key The key string of the sidestake entry.

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -6,10 +6,30 @@
 #define GRIDCOIN_SIDESTAKE_H
 
 #include "base58.h"
+#include "gridcoin/contract/handler.h"
+#include "gridcoin/contract/payload.h"
+#include "gridcoin/contract/registry_db.h"
 #include "gridcoin/support/enumbytes.h"
 #include "serialize.h"
 
 namespace GRC {
+
+class CBitcoinAddressForStorage : public CBitcoinAddress
+{
+public:
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        // Note that (de)serializing the raw underlying vector char data for the address is safe here
+        // because this is only used in this module and validations were performed before serialization into
+        // storage.
+        READWRITE(vchData);
+    }
+};
+
 
 enum class SideStakeStatus
 {
@@ -21,21 +41,36 @@ enum class SideStakeStatus
     OUT_OF_BOUND
 };
 
+//!
+//! \brief The SideStake class. This class formalizes the "sidestake", which is a directive to apportion
+//! a percentage of the total stake value to a designated address. This address must be a valid address, but
+//! may or may not be owned by the staker. This is the primary mechanism to do automatic "donations" to
+//! defined network addresses.
+//!
+//! The class supports two modes of operation. Local (voluntary) entries will be picked up from the config file(s)
+//! and will be managed dynamically based on the initial load of the config file + the r-w file + any changes to
+//! in any GUI implementation on top of this. Mandatory entries will be picked up by contract handlers similar to
+//! other contract types (cf. protocol entries).
+//!
 class SideStake
 {
+public:
+    //!
+    //! \brief Wrapped Enumeration of sidestake entry status, mainly for serialization/deserialization.
+    //!
     using Status = EnumByte<SideStakeStatus>;
 
-    CBitcoinAddress m_address;
+    CBitcoinAddressForStorage m_key;    //!< The key here is the Gridcoin Address of the sidestake destination.
 
-    double m_allocation;
+    double m_allocation;                //!< The allocation is a double precision floating point between 0.0 and 1.0 inclusive
 
-    int64_t m_timestamp;        //!< Time of the sidestake contract transaction.
+    int64_t m_timestamp;                //!< Time of the sidestake contract transaction.
 
-    uint256 m_hash;             //!< The hash of the transaction that contains a mandatory sidestake.
+    uint256 m_hash;                     //!< The hash of the transaction that contains a mandatory sidestake.
 
-    uint256 m_previous_hash;    //!< The m_hash of the previous mandatory sidestake allocation with the same address.
+    uint256 m_previous_hash;            //!< The m_hash of the previous mandatory sidestake allocation with the same address.
 
-    Status m_status;            //!< The status of the sidestake. It is of type int instead of enum for serialization.
+    Status m_status;                    //!< The status of the sidestake. It is of type int instead of enum for serialization.
 
     //!
     //! \brief Initialize an empty, invalid sidestake instance.
@@ -49,10 +84,19 @@ class SideStake
     //! \param address
     //! \param allocation
     //!
-    SideStake(CBitcoinAddress address, double allocation);
+    SideStake(CBitcoinAddressForStorage address, double allocation);
 
     //!
-    //! \brief Initial a sidestake instance with the provided parameters. This form is normally used to construct a
+    //! \brief Initialize a sidestake instance with the provided parameters.
+    //!
+    //! \param address
+    //! \param allocation
+    //! \param status
+    //!
+    SideStake(CBitcoinAddressForStorage address, double allocation, SideStakeStatus status);
+
+    //!
+    //! \brief Initialize a sidestake instance with the provided parameters. This form is normally used to construct a
     //! mandatory sidestake from a contract.
     //!
     //! \param address
@@ -60,7 +104,7 @@ class SideStake
     //! \param timestamp
     //! \param hash
     //!
-    SideStake(CBitcoinAddress address, double allocation, int64_t timestamp, uint256 hash);
+    SideStake(CBitcoinAddressForStorage address, double allocation, int64_t timestamp, uint256 hash);
 
     //!
     //! \brief Determine whether a sidestake contains each of the required elements.
@@ -69,26 +113,34 @@ class SideStake
     bool WellFormed() const;
 
     //!
+    //! \brief This is the standardized method that returns the key value for the sidestake entry (for
+    //! the registry_db.h template.)
+    //!
+    //! \return CBitcoinAddress key value for the sidestake entry
+    //!
+    CBitcoinAddressForStorage Key() const;
+
+    //!
     //! \brief Provides the sidestake address and status (value) as a pair of strings.
     //! \return std::pair of strings
     //!
     std::pair<std::string, std::string> KeyValueToString() const;
 
-           //!
-           //! \brief Returns the string representation of the current sidestake status
-           //!
-           //! \return Translated string representation of sidestake status
-           //!
+    //!
+    //! \brief Returns the string representation of the current sidestake status
+    //!
+    //! \return Translated string representation of sidestake status
+    //!
     std::string StatusToString() const;
 
-           //!
-           //! \brief Returns the translated or untranslated string of the input sidestake status
-           //!
-           //! \param status. SideStake status
-           //! \param translated. True for translated, false for not translated. Defaults to true.
-           //!
-           //! \return SideStake status string.
-           //!
+    //!
+    //! \brief Returns the translated or untranslated string of the input sidestake status
+    //!
+    //! \param status. SideStake status
+    //! \param translated. True for translated, false for not translated. Defaults to true.
+    //!
+    //! \return SideStake status string.
+    //!
     std::string StatusToString(const SideStakeStatus& status, const bool& translated = true) const;
 
     //!
@@ -116,7 +168,7 @@ class SideStake
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        READWRITE(m_address);
+        READWRITE(m_key);
         READWRITE(m_allocation);
         READWRITE(m_timestamp);
         READWRITE(m_hash);
@@ -135,7 +187,363 @@ typedef std::shared_ptr<SideStake> SideStake_ptr;
 //!
 typedef const SideStake_ptr SideStakeOption;
 
+//!
+//! \brief The body of a sidestake entry contract. Note that this body is bimodal. It
+//! supports both the personality of the "LegacyPayload", and also the new native
+//! sidestakeEntry format. In the Contract::Body::ConvertFromLegacy call, by the time
+//! this call has been reached, the contract will have already been deserialized.
+//! This will follow the legacy mode. For contracts at version 3+, the
+//! Contract::SharePayload() will NOT call the ConvertFromLegacy. Note that because
+//! the existing legacyPayloads are not versioned, the deserialization of
+//! the payload first (de)serializes m_key, which is guaranteed to exist in either
+//! legacy or native. If the key is empty, then payload v2+ is being deserialized
+//! and the m_version and m_value are (de)serialized. This is ugly
+//! but necessary to deal with the unversioned Legacy Payloads and maintain
+//! compatibility.
+//!
+class SideStakePayload : public IContractPayload
+{
+public:
+    //!
+    //! \brief Version number of the current format for a serialized sidestake entry.
+    //!
+    //! CONSENSUS: Increment this value when introducing a breaking change and
+    //! ensure that the serialization/deserialization routines also handle all
+    //! of the previous versions.
+    //!
+    static constexpr uint32_t CURRENT_VERSION = 1;
 
+    //!
+    //! \brief Version number of the serialized sidestake entry format.
+    //!
+    //! Version 1: Initial version:
+    //!
+    uint32_t m_version = CURRENT_VERSION;
+
+    SideStake m_entry; //!< The sidestake entry in the payload.
+
+    //!
+    //! \brief Initialize an empty, invalid sidestake entry payload.
+    //!
+    SideStakePayload(uint32_t version = CURRENT_VERSION);
+
+    //!
+    //! \brief Initialize a sidestakeEntryPayload from a sidestake entry constructed from
+    //! string key and value. Not to be used for version 1 payloads. Will assert. Does NOT
+    //! initialize hash fields.
+    //!
+    //! \param key. Key string for the sidestake entry
+    //! \param value. Value string for the sidestake entry
+    //! \param status. Status of the sidestake entry
+    //!
+    SideStakePayload(const uint32_t version, CBitcoinAddressForStorage key, double value, SideStakeStatus status);
+
+    //!
+    //! \brief Initialize a sidestake entry payload from the given sidestake entry
+    //! with the provided version number (and format).
+    //!
+    //! \param version Version of the serialized sidestake entry format.
+    //! \param sidestake_entry The sidestake entry itself.
+    //!
+    SideStakePayload(const uint32_t version, SideStake sidestake_entry);
+
+    //!
+    //! \brief Initialize a sidestake entry payload from the given sidestake entry
+    //! with the CURRENT_VERSION.
+    //!
+    //! \param sidestake_entry The sidestake entry itself.
+    //!
+    SideStakePayload(SideStake sidestake_entry);
+
+    //!
+    //! \brief Get the type of contract that this payload contains data for.
+    //!
+    GRC::ContractType ContractType() const override
+    {
+        return GRC::ContractType::SIDESTAKE;
+    }
+
+    //!
+    //! \brief Determine whether the instance represents a complete payload.
+    //!
+    //! \return \c true if the payload contains each of the required elements.
+    //!
+    bool WellFormed(const ContractAction action) const override
+    {
+        if (m_version <= 0 || m_version > CURRENT_VERSION) {
+            return false;
+        }
+
+        return m_entry.WellFormed();
+    }
+
+    //!
+    //! \brief Get a string for the key used to construct a legacy contract.
+    //!
+    std::string LegacyKeyString() const override
+    {
+        return m_entry.m_key.ToString();
+    }
+
+    //!
+    //! \brief Get a string for the value used to construct a legacy contract.
+    //!
+    std::string LegacyValueString() const override
+    {
+        return ToString(m_entry.m_allocation);
+    }
+
+    //!
+    //! \brief Get the burn fee amount required to send a particular contract. This
+    //! is the same as the LegacyPayload to insure compatibility between the sidestake
+    //! registry and non-upgraded nodes before the block v13/contract version 3 height
+    //!
+    //! \return Burn fee in units of 1/100000000 GRC.
+    //!
+    CAmount RequiredBurnAmount() const override
+    {
+        return Contract::STANDARD_BURN_AMOUNT;
+    }
+
+    ADD_CONTRACT_PAYLOAD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(
+        Stream& s,
+        Operation ser_action,
+        const ContractAction contract_action)
+    {
+        READWRITE(m_version);
+        READWRITE(m_entry);
+    }
+}; // SideStakePayload
+
+//!
+//! \brief Stores and manages sidestake entries.
+//!
+class SideStakeRegistry : public IContractHandler
+{
+public:
+    //!
+    //! \brief sidestakeRegistry constructor. The parameter is the version number of the underlying
+    //! sidestake entry db. This must be incremented when implementing format changes to the sidestake
+    //! entries to force a reinit.
+    //!
+    //! Version 1: TBD.
+    //!
+    SideStakeRegistry()
+        : m_sidestake_db(1)
+          {
+          };
+
+    //!
+    //! \brief The type that keys sidestake entries by their key strings. Note that the entries
+    //! in this map are actually smart shared pointer wrappers, so that the same actual object
+    //! can be held by both this map and the historical map without object duplication.
+    //!
+    typedef std::map<CBitcoinAddressForStorage, SideStake_ptr> SideStakeMap;
+
+    //!
+    //! \brief PendingSideStakeMap. This is not actually used but defined to satisfy the template.
+    //!
+    typedef SideStakeMap PendingSideStakeMap;
+
+    //!
+    //! \brief The type that keys historical sidestake entries by the contract hash (txid).
+    //! Note that the entries in this map are actually smart shared pointer wrappers, so that
+    //! the same actual object can be held by both this map and the (current) sidestake entry map
+    //! without object duplication.
+    //!
+    typedef std::map<uint256, SideStake_ptr> HistoricalSideStakeMap;
+
+    //!
+    //! \brief Get the collection of current sidestake entries. Note that this INCLUDES deleted
+    //! sidestake entries.
+    //!
+    //! \return \c A reference to the current sidestake entries stored in the registry.
+    //!
+    const SideStakeMap& SideStakeEntries() const;
+
+    //!
+    //! \brief Get the current sidestake entry for the specified key string.
+    //!
+    //! \param key The key string of the sidestake entry.
+    //!
+    //! \return An object that either contains a reference to some sidestake entry if it exists
+    //! for the key or does not.
+    //!
+    SideStakeOption Try(const CBitcoinAddressForStorage& key) const;
+
+    //!
+    //! \brief Get the current sidestake entry for the specified key string if it has a status of ACTIVE or MANDATORY.
+    //!
+    //! \param key The key string of the sidestake entry.
+    //!
+    //! \return An object that either contains a reference to some sidestake entry if it exists
+    //! for the key and is in the required status or does not.
+    //!
+    SideStakeOption TryActive(const CBitcoinAddressForStorage& key) const;
+
+    //!
+    //! \brief Destroy the contract handler state in case of an error in loading
+    //! the sidestake entry registry state from LevelDB to prepare for reload from contract
+    //! replay. This is not used for sidestake entries, unless -clearSideStakehistory is specified
+    //! as a startup argument, because contract replay storage and full reversion has
+    //! been implemented for sidestake entries.
+    //!
+    void Reset() override;
+
+    //!
+    //! \brief Determine whether a sidestake entry contract is valid.
+    //!
+    //! \param contract Contains the sidestake entry contract to validate.
+    //! \param tx       Transaction that contains the contract.
+    //! \param DoS      Misbehavior out.
+    //!
+    //! \return \c true if the contract contains a valid sidestake entry.
+    //!
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+
+    //!
+    //! \brief Determine whether a sidestake entry contract is valid including block context. This is used
+    //! in ConnectBlock. Note that for sidestake entries this simply calls Validate as there is no
+    //! block level specific validation to be done.
+    //!
+    //! \param ctx ContractContext containing the sidestake entry data to validate.
+    //! \param DoS Misbehavior score out.
+    //!
+    //! \return  \c false If the contract fails validation.
+    //!
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+
+    //!
+    //! \brief Allows local (voluntary) sidestakes to be added to the in-memory map and not persisted to
+    //! the registry db.
+    //! \param SideStake object to add
+    //!
+    void NonContractAdd(SideStake& sidestake);
+
+    //!
+    //! \brief Add a sidestake entry to the registry from contract data. For the sidestake registry
+    //! both Add and Delete actually call a common helper function AddDelete, because the action
+    //! is actually symmetric to both.
+    //! \param ctx
+    //!
+    void Add(const ContractContext& ctx) override;
+
+    //!
+    //! \brief Provides for deletion of local (voluntary) sidestakes from the in-memory map that are not persisted
+    //! to the registry db. Deletion is by the map key (CBitcoinAddress).
+    //! \param address
+    //!
+    void NonContractDelete(CBitcoinAddressForStorage& address);
+
+    //!
+    //! \brief Mark a sidestake entry deleted in the registry from contract data. For the sidestake registry
+    //! both Add and Delete actually call a common helper function AddDelete, because the action
+    //! is actually symmetric to both.
+    //! \param ctx
+    //!
+    void Delete(const ContractContext& ctx) override;
+
+    //!
+    //! \brief Revert the registry state for the sidestake entry to the state prior
+    //! to this ContractContext application. This is typically an issue
+    //! during reorganizations, where blocks are disconnected.
+    //!
+    //! \param ctx References the sidestake entry contract and associated context.
+    //!
+    void Revert(const ContractContext& ctx) override;
+
+    //!
+    //! \brief Initialize the sidestakeRegistry, which now includes restoring the state of the sidestakeRegistry from
+    //! LevelDB on wallet start.
+    //!
+    //! \return Block height of the database restored from LevelDB. Zero if no LevelDB sidestake entry data is found or
+    //! there is some issue in LevelDB sidestake entry retrieval. (This will cause the contract replay to change scope
+    //! and initialize the sidestakeRegistry from contract replay and store in LevelDB.)
+    //!
+    int Initialize() override;
+
+    //!
+    //! \brief Gets the block height through which is stored in the sidestake entry registry database.
+    //!
+    //! \return block height.
+    //!
+    int GetDBHeight() override;
+
+    //!
+    //! \brief Function normally only used after a series of reverts during block disconnects, because
+    //! block disconnects are done in groups back to a common ancestor, and will include a series of reverts.
+    //! This is essentially atomic, and therefore the final (common) height only needs to be set once. TODO:
+    //! reversion should be done with a vector argument of the contract contexts, along with a final height to
+    //! clean this up and move the logic to here from the calling function.
+    //!
+    //! \param height to set the storage DB bookmark.
+    //!
+    void SetDBHeight(int& height) override;
+
+    //!
+    //! \brief Resets the maps in the sidestakeRegistry but does not disturb the underlying LevelDB
+    //! storage. This is only used during testing in the testing harness.
+    //!
+    void ResetInMemoryOnly();
+
+    //!
+    //! \brief Passivates the elements in the sidestake db, which means remove from memory elements in the
+    //! historical map that are not referenced by the active entry map. The backing store of the element removed
+    //! from memory is retained and will be transparently restored if find() is called on the hash key
+    //! for the element.
+    //!
+    //! \return The number of elements passivated.
+    //!
+    uint64_t PassivateDB();
+
+    //!
+    //! \brief A static function that is called by the scheduler to run the sidestake entry database passivation.
+    //!
+    static void RunDBPassivation();
+
+    //!
+    //! \brief Specializes the template RegistryDB for the SideStake class
+    //!
+    typedef RegistryDB<SideStake,
+                       SideStake,
+                       SideStakeStatus,
+                       SideStakeMap,
+                       PendingSideStakeMap,
+                       HistoricalSideStakeMap> SideStakeDB;
+
+private:
+    //!
+    //! \brief Protects the registry with multithreaded access. This is implemented INTERNAL to the registry class.
+    //!
+    mutable CCriticalSection cs_lock;
+
+    //!
+    //! \brief Private helper method for the Add and Delete methods above. They both use identical code (with
+    //! different input statuses).
+    //!
+    //! \param ctx The contract context for the add or delete.
+    //!
+    void AddDelete(const ContractContext& ctx);
+
+    SideStakeMap m_sidestake_entries;                   //!< Contains the current sidestake entries including entries marked DELETED.
+    PendingSideStakeMap m_pending_sidestake_entries {}; //!< Not used. Only to satisfy the template.
+
+    SideStakeDB m_sidestake_db;
+
+public:
+
+    SideStakeDB& GetSideStakeDB();
+}; // sidestakeRegistry
+
+//!
+//! \brief Get the global sidestake entry registry.
+//!
+//! \return Current global sidestake entry registry instance.
+//!
+SideStakeRegistry& GetSideStakeRegistry();
 } // namespace GRC
 
 #endif // GRIDCOIN_SIDESTAKE_H

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -399,7 +399,7 @@ public:
     //!
     //! \return \c A reference to the current sidestake entries stored in the registry.
     //!
-    const SideStakeMap& SideStakeEntries() const;
+    const std::vector<SideStake_ptr> SideStakeEntries() const;
 
     //!
     //! \brief Get the collection of active sidestake entries. This is presented as a vector of

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -16,6 +16,50 @@
 namespace GRC {
 
 //!
+//! \brief The Allocation class extends the Fraction class to provide functionality useful for sidestake allocations.
+//!
+class Allocation : public Fraction
+{
+public:
+    //!
+    //! \brief Default constructor. Creates a zero allocation fraction.
+    //!
+    Allocation();
+
+    //!
+    //! \brief Allocation constructor from a double input. This multiplies the double by 1000, rounds, casts to int64_t,
+    //! and then constructs Fraction(x, 1000, true), which essentially creates a fraction representative of the double
+    //! to the third decimal place.
+    //!
+    //! \param double allocation
+    //!
+    Allocation(const double& allocation);
+
+    //!
+    //! \brief Initialize an allocation from a Fraction. This is primarily used for casting. Note that no attempt to
+    //! limit the denominator size or simplify the fraction is made.
+    //!
+    //! \param Fraction f
+    //!
+    Allocation(const Fraction& f);
+
+    //!
+    //! \brief Allocations extend the Fraction class and can also represent the result of the allocation constructed fraction
+    //! and the result of the muliplication of that fraction times the reward, which is in CAmount (i.e. int64_t).
+    //!
+    //! \return CAmount of the Fraction representation of the actual allocation.
+    //!
+    CAmount ToCAmount() const;
+
+    //!
+    //! \brief Returns a double equivalent of the allocation fraction multiplied times 100.
+    //!
+    //! \return double percent representation of the allocation fraction.
+    //!
+    double ToPercent() const;
+};
+
+//!
 //! \brief The LocalSideStake class. This class formalizes the local sidestake, which is a directive to apportion
 //! a percentage of the total stake value to a designated destination. This destination must be valid, but
 //! may or may not be owned by the staker. This is the primary mechanism to do automatic "donations" to
@@ -40,13 +84,13 @@ public:
     //!
     using Status = EnumByte<LocalSideStakeStatus>;
 
-    CTxDestination m_destination;        //!< The destination of the sidestake.
+    CTxDestination m_destination; //!< The destination of the sidestake.
 
-    double m_allocation;                 //!< The allocation is a double precision floating point between 0.0 and 1.0 inclusive
+    Allocation m_allocation;      //!< The allocation is a Fraction in the form x / 1000 where x is between 0 and 1000 inclusive.
 
-    std::string m_description;           //!< The description of the sidestake (optional)
+    std::string m_description;    //!< The description of the sidestake (optional)
 
-    Status m_status;                     //!< The status of the sidestake. It is of type int instead of enum for serialization.
+    Status m_status;              //!< The status of the sidestake. It is of type int instead of enum for serialization.
 
 
     //!
@@ -62,7 +106,7 @@ public:
     //! \param allocation
     //! \param description (optional)
     //!
-    LocalSideStake(CTxDestination destination, double allocation, std::string description);
+    LocalSideStake(CTxDestination destination, Allocation allocation, std::string description);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters.
@@ -72,7 +116,7 @@ public:
     //! \param description (optional)
     //! \param status
     //!
-    LocalSideStake(CTxDestination destination, double allocation, std::string description, LocalSideStakeStatus status);
+    LocalSideStake(CTxDestination destination, Allocation allocation, std::string description, LocalSideStakeStatus status);
 
     //!
     //! \brief Determine whether a sidestake contains each of the required elements.
@@ -156,19 +200,19 @@ public:
     //!
     using Status = EnumByte<MandatorySideStakeStatus>;
 
-    CTxDestination m_destination;        //!< The destination of the sidestake.
+    CTxDestination m_destination; //!< The destination of the sidestake.
 
-    double m_allocation;                 //!< The allocation is a double precision floating point between 0.0 and 1.0 inclusive
+    Allocation m_allocation;      //!< The allocation is a Fraction in the form x / 1000 where x is between 0 and 1000 inclusive.
 
-    std::string m_description;           //!< The description of the sidestake (optional)
+    std::string m_description;    //!< The description of the sidestake (optional)
 
-    int64_t m_timestamp;                 //!< Time of the sidestake contract transaction.
+    int64_t m_timestamp;          //!< Time of the sidestake contract transaction.
 
-    uint256 m_hash;                      //!< The hash of the transaction that contains a mandatory sidestake.
+    uint256 m_hash;               //!< The hash of the transaction that contains a mandatory sidestake.
 
-    uint256 m_previous_hash;             //!< The m_hash of the previous mandatory sidestake allocation with the same destination.
+    uint256 m_previous_hash;      //!< The m_hash of the previous mandatory sidestake allocation with the same destination.
 
-    Status m_status;                     //!< The status of the sidestake. It is of type int instead of enum for serialization.
+    Status m_status;              //!< The status of the sidestake. It is of type EnumByte instead of enum for serialization.
 
     //!
     //! \brief Initialize an empty, invalid sidestake instance.
@@ -183,7 +227,7 @@ public:
     //! \param allocation
     //! \param description (optional)
     //!
-    MandatorySideStake(CTxDestination destination, double allocation, std::string description);
+    MandatorySideStake(CTxDestination destination, Allocation allocation, std::string description);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters.
@@ -193,7 +237,7 @@ public:
     //! \param description (optional)
     //! \param status
     //!
-    MandatorySideStake(CTxDestination destination, double allocation, std::string description, MandatorySideStakeStatus status);
+    MandatorySideStake(CTxDestination destination, Allocation allocation, std::string description, MandatorySideStakeStatus status);
 
     //!
     //! \brief Initialize a sidestake instance with the provided parameters. This form is normally used to construct a
@@ -206,7 +250,7 @@ public:
     //! \param hash
     //! \param status
     //!
-    MandatorySideStake(CTxDestination destination, double allocation, std::string description, int64_t timestamp,
+    MandatorySideStake(CTxDestination destination, Allocation allocation, std::string description, int64_t timestamp,
               uint256 hash, MandatorySideStakeStatus status);
 
     //!
@@ -329,9 +373,9 @@ public:
     CTxDestination GetDestination() const;
     //!
     //! \brief Gets the allocation of the sidestake
-    //! \return A double between 0.0 and 1.0 inclusive representing the allocation fraction of the sidestake
+    //! \return A Fraction representing the allocation fraction of the sidestake.
     //!
-    double GetAllocation() const;
+    Allocation GetAllocation() const;
     //!
     //! \brief Gets the description of the sidestake
     //! \return The description string of the sidestake
@@ -412,7 +456,7 @@ public:
     //! \param description. Description string for the sidstake entry
     //! \param status. Status of the sidestake entry
     //!
-    SideStakePayload(const uint32_t version, CTxDestination destination, double allocation,
+    SideStakePayload(const uint32_t version, CTxDestination destination, Allocation allocation,
                      std::string description, MandatorySideStake::MandatorySideStakeStatus status);
 
     //!
@@ -468,7 +512,7 @@ public:
                      __func__,
                      valid,
                      CBitcoinAddress(m_entry.m_destination).ToString(),
-                     m_entry.m_allocation,
+                     m_entry.m_allocation.ToPercent(),
                      m_entry.StatusToString()
                      );
 
@@ -491,7 +535,7 @@ public:
     //!
     std::string LegacyValueString() const override
     {
-        return ToString(m_entry.m_allocation);
+        return ToString(m_entry.m_allocation.ToDouble());
     }
 
     //!
@@ -771,10 +815,10 @@ private:
     bool SaveLocalSideStakesToConfig();
 
     //!
-    //! \brief Provides the total allocation for all active mandatory sidestakes as a floating point fraction.
-    //! \return total active mandatory sidestake allocation as a double.
+    //! \brief Provides the total allocation for all active mandatory sidestakes as a Fraction.
+    //! \return total active mandatory sidestake allocation as a Fraction.
     //!
-    double GetMandatoryAllocationsTotal() const;
+    Allocation GetMandatoryAllocationsTotal() const;
 
     void SubscribeToCoreSignals();
     void UnsubscribeFromCoreSignals();

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -317,6 +317,20 @@ typedef std::shared_ptr<MandatorySideStake> MandatorySideStake_ptr;
 class SideStake
 {
 public:
+    enum class Type {
+        UNKNOWN,
+        LOCAL,
+        MANDATORY,
+        OUT_OF_BOUND
+    };
+
+    enum FilterFlag  : uint8_t {
+        NONE      = 0b00,
+        LOCAL     = 0b01,
+        MANDATORY = 0b10,
+        ALL       = 0b11,
+    };
+
     //!
     //! \brief A variant to hold the two different types of sidestake status enums.
     //!
@@ -339,7 +353,7 @@ public:
 private:
     LocalSideStake_ptr m_local_sidestake_ptr;
     MandatorySideStake_ptr m_mandatory_sidestake_ptr;
-    bool m_mandatory;
+    Type m_type;
 };
 
 //!
@@ -554,34 +568,34 @@ public:
     //! Mandatory sidestakes come before local ones, and the method ensures that the sidestakes
     //! returned do not total an allocation greater than 1.0.
     //!
-    //! \param bool true to return local sidestakes only
+    //! \param bitmask filter to return mandatory only, local only, or all
     //!
     //! \return A vector of smart pointers to sidestake entries.
     //!
-    const std::vector<SideStake_ptr> ActiveSideStakeEntries(const bool& local_only, const bool& include_zero_alloc) const;
+    const std::vector<SideStake_ptr> ActiveSideStakeEntries(const SideStake::FilterFlag& filter, const bool& include_zero_alloc) const;
 
     //!
     //! \brief Get the current sidestake entry for the specified destination.
     //!
     //! \param key The destination of the sidestake entry.
-    //! \param local_only If true causes Try to only check the local sidestake map. Defaults to false.
+    //! \param bitmask filter to try mandatory only, local only, or all
     //!
     //! \return A vector of smart pointers to entries matching the provided destination. Up to two elements
     //! are returned, mandatory entry first, unless local only boolean is set true.
     //!
-    std::vector<SideStake_ptr> Try(const CTxDestination& key, const bool& local_only = false) const;
+    std::vector<SideStake_ptr> Try(const CTxDestination& key, const SideStake::FilterFlag& filter) const;
 
     //!
     //! \brief Get the current sidestake entry for the specified destination if it has a status of ACTIVE or MANDATORY.
     //!
     //! \param key The destination of the sidestake entry.
-    //! \param local_only If true causes Try to only check the local sidestake map. Defaults to false.
+    //! \param bitmask filter to try mandatory only, local only, or all
     //!
     //! \return A vector of smart pointers to entries matching the provided destination that are in status of
     //! MANDATORY or ACTIVE. Up to two elements are returned, mandatory entry first, unless local only boolean
     //! is set true.
     //!
-    std::vector<SideStake_ptr> TryActive(const CTxDestination& key, const bool& local_only = false) const;
+    std::vector<SideStake_ptr> TryActive(const CTxDestination& key, const SideStake::FilterFlag& filter) const;
 
     //!
     //! \brief Destroy the contract handler state in case of an error in loading

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -433,6 +433,13 @@ void SetupServerArgs()
                                                    "if -enablesidestaking is set. If set along with -sidestakeaddresses "
                                                    "overrides the -sidestake entries.",
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);
+    argsman.AddArg("-sidestakedescriptions=string1,string2,...,stringN>", "Sidestake entry description. There can be as many "
+                                                                          "specified as desired. Only six per stake can be sent. "
+                                                                          "If more than six are specified. Six are randomly chosen "
+                                                                          "for each stake. Only active if -enablesidestaking is set. "
+                                                                          "If set along with -sidestakeaddresses overrides the "
+                                                                          "-sidestake entries.",
+                   ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);
     argsman.AddArg("-enablestakesplit", "Enable unspent output spitting when staking to optimize staking efficiency "
                                         "(default: 0",
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1334,11 +1334,14 @@ void StakeMiner(CWallet *pwallet)
         // nMinStakeSplitValue and dEfficiency are out parameters.
         bool fEnableStakeSplit = GetStakeSplitStatusAndParams(nMinStakeSplitValue, dEfficiency, nDesiredStakeOutputValue);
 
-        bool fEnableSideStaking = gArgs.GetBoolArg("-enablesidestaking");
-
         // Note that fEnableSideStaking is now processed internal to ActiveSideStakeEntries. The sidestaking flag only
         // controls local sidestakes. If there exists mandatory sidestakes, they occur regardless of the flag.
         vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(false, false);
+
+        // If the vSideStakeAlloc is not empty, then set fEnableSideStaking to true. Note that vSideStakeAlloc will not be empty
+        // if non-zero allocation mandatory sidestakes are set OR local sidestaking is turned on by the -enablesidestaking config
+        // option.
+        bool fEnableSideStaking = (!vSideStakeAlloc.empty());
 
         // wait for next round
         if (!MilliSleep(nMinerSleep)) return;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -921,11 +921,11 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
             (iterSideStake != vSideStakeAlloc.end()) && (nOutputsUsed <= nMaxSideStakeOutputs);
             ++iterSideStake)
         {
-            CBitcoinAddress& address = iterSideStake->get()->m_key;
+            CBitcoinAddress& address = iterSideStake->get()->m_address;
             if (!address.IsValid())
             {
                 LogPrintf("WARN: SplitCoinStakeOutput: ignoring sidestake invalid address %s.",
-                          iterSideStake->get()->m_key.ToString());
+                          iterSideStake->get()->m_address.ToString());
                 continue;
             }
 
@@ -935,7 +935,7 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
             {
                 LogPrintf("WARN: SplitCoinStakeOutput: distribution %f too small to address %s.",
                           CoinToDouble(nReward * iterSideStake->get()->m_allocation),
-                          iterSideStake->get()->m_key.ToString()
+                          iterSideStake->get()->m_address.ToString()
                           );
                 continue;
             }
@@ -977,7 +977,7 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
             LogPrintf("SplitCoinStakeOutput: create sidestake UTXO %i value %f to address %s",
                       nOutputsUsed,
                       CoinToDouble(nReward * iterSideStake->get()->m_allocation),
-                      iterSideStake->get()->m_key.ToString()
+                      iterSideStake->get()->m_address.ToString()
                       );
             dSumAllocation += iterSideStake->get()->m_allocation;
             nRemainingStakeOutputValue -= nSideStake;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -921,7 +921,7 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
             (iterSideStake != vSideStakeAlloc.end()) && (nOutputsUsed <= nMaxSideStakeOutputs);
             ++iterSideStake)
         {
-            CBitcoinAddress address = iterSideStake->get()->GetAddress();
+            CBitcoinAddress address(iterSideStake->get()->GetDestination());
             double allocation = iterSideStake->get()->GetAllocation();
 
             if (!address.IsValid())

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1320,7 +1320,7 @@ void StakeMiner(CWallet *pwallet)
 
         // Note that fEnableSideStaking is now processed internal to ActiveSideStakeEntries. The sidestaking flag only
         // controls local sidestakes. If there exists mandatory sidestakes, they occur regardless of the flag.
-        vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
+        vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(false, false);
 
         // wait for next round
         if (!MilliSleep(nMinerSleep)) return;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1318,10 +1318,9 @@ void StakeMiner(CWallet *pwallet)
 
         bool fEnableSideStaking = gArgs.GetBoolArg("-enablesidestaking");
 
-        LogPrint(BCLog::LogFlags::MINER, "INFO: %s: fEnableSideStaking = %u", __func__, fEnableSideStaking);
-
-        // vSideStakeAlloc is an out parameter.
-        if (fEnableSideStaking) vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
+        // Note that fEnableSideStaking is now processed internal to ActiveSideStakeEntries. The sidestaking flag only
+        // controls local sidestakes. If there exists mandatory sidestakes, they occur regardless of the flag.
+        vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
 
         // wait for next round
         if (!MilliSleep(nMinerSleep)) return;

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,11 +8,13 @@
 #define BITCOIN_MINER_H
 
 #include "main.h"
+#include "gridcoin/sidestake.h"
+
 
 class CWallet;
 class CWalletTx;
 
-typedef std::vector< std::pair<std::string, double> > SideStakeAlloc;
+typedef std::vector<GRC::SideStake_ptr> SideStakeAlloc;
 
 extern unsigned int nMinerSleep;
 
@@ -24,7 +26,6 @@ static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
 void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStakeSplit, bool &fEnableSideStaking,
                           SideStakeAlloc &vSideStakeAlloc, double &dEfficiency);
 unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency);
-SideStakeAlloc GetSideStakingStatusAndAlloc();
 bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue);
 
 bool CreateMRCRewards(CBlock &blocknew,

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -34,6 +34,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::TranslateSig> Translate;
     boost::signals2::signal<CClientUIInterface::NotifyBlocksChangedSig> NotifyBlocksChanged;
     boost::signals2::signal<CClientUIInterface::UpdateMessageBoxSig> UpdateMessageBox;
+    boost::signals2::signal<CClientUIInterface::RwSettingsUpdatedSig> RwSettingsUpdated;
 };
 static UISignals g_ui_signals;
 
@@ -63,6 +64,7 @@ ADD_SIGNALS_IMPL_WRAPPER(QueueShutdown);
 ADD_SIGNALS_IMPL_WRAPPER(Translate);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyBlocksChanged);
 ADD_SIGNALS_IMPL_WRAPPER(UpdateMessageBox);
+ADD_SIGNALS_IMPL_WRAPPER(RwSettingsUpdated);
 
 void CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
 void CClientUIInterface::UpdateMessageBox(const std::string& version, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, message); }
@@ -84,7 +86,7 @@ void CClientUIInterface::NewPollReceived(int64_t poll_time) { return g_ui_signal
 void CClientUIInterface::NewVoteReceived(const uint256& poll_txid) { return g_ui_signals.NewVoteReceived(poll_txid); }
 void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }
 void CClientUIInterface::NotifyScraperEvent(const scrapereventtypes& ScraperEventtype, ChangeType status, const std::string& message) { return g_ui_signals.NotifyScraperEvent(ScraperEventtype, status, message); }
-
+void CClientUIInterface::RwSettingsUpdated() { return g_ui_signals.RwSettingsUpdated(); }
 
 bool InitError(const std::string &str)
 {

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -138,6 +138,9 @@ public:
     /** New vote received **/
     ADD_SIGNALS_DECL_WRAPPER(NewVoteReceived, void, const uint256& poll_txid);
 
+    /** Read-write settings file updated **/
+    ADD_SIGNALS_DECL_WRAPPER(RwSettingsUpdated, void);
+
     /**
      * New, updated or cancelled alert.
      * @note called with lock cs_mapAlerts held.

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(gridcoinqt STATIC
     rpcconsole.cpp
     sendcoinsdialog.cpp
     sendcoinsentry.cpp
+    sidestaketablemodel.cpp
     signverifymessagedialog.cpp
     trafficgraphwidget.cpp
     transactiondesc.cpp
@@ -122,6 +123,7 @@ set_source_files_properties(
     mrcmodel.cpp
     qtipcserver.cpp
     researcher/researchermodel.cpp
+    sidestaketablemodel.cpp
     transactiondesc.cpp
     transactiontablemodel.cpp
     voting/votingmodel.cpp

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(gridcoinqt STATIC
     decoration.cpp
     diagnosticsdialog.cpp
     editaddressdialog.cpp
+    editsidestakedialog.cpp
     favoritespage.cpp
     guiutil.cpp
     intro.cpp

--- a/src/qt/editsidestakedialog.cpp
+++ b/src/qt/editsidestakedialog.cpp
@@ -59,10 +59,10 @@ void EditSideStakeDialog::loadRow(int row)
 {
     m_row = row;
 
-    ui->addressLineEdit->setText(model->index(row, SideStakeTableModel::Address, QModelIndex()).data().toString());
-    ui->allocationLineEdit->setText(model->index(row, SideStakeTableModel::Allocation, QModelIndex()).data().toString());
-    ui->descriptionLineEdit->setText(model->index(row, SideStakeTableModel::Description, QModelIndex()).data().toString());
-    ui->statusLineEdit->setText(model->index(row, SideStakeTableModel::Status, QModelIndex()).data().toString());
+    ui->addressLineEdit->setText(model->index(row, SideStakeTableModel::Address, QModelIndex()).data(Qt::EditRole).toString());
+    ui->allocationLineEdit->setText(model->index(row, SideStakeTableModel::Allocation, QModelIndex()).data(Qt::EditRole).toString());
+    ui->descriptionLineEdit->setText(model->index(row, SideStakeTableModel::Description, QModelIndex()).data(Qt::EditRole).toString());
+    ui->statusLineEdit->setText(model->index(row, SideStakeTableModel::Status, QModelIndex()).data(Qt::EditRole).toString());
 }
 
 bool EditSideStakeDialog::saveCurrentRow()

--- a/src/qt/editsidestakedialog.cpp
+++ b/src/qt/editsidestakedialog.cpp
@@ -1,0 +1,149 @@
+// Copyright (c) 2014-2023 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "editsidestakedialog.h"
+#include "ui_editsidestakedialog.h"
+#include "sidestaketablemodel.h"
+#include "guiutil.h"
+#include "qt/decoration.h"
+
+#include <QMessageBox>
+
+EditSideStakeDialog::EditSideStakeDialog(Mode mode, QWidget* parent)
+    : QDialog(parent)
+      , ui(new Ui::EditSideStakeDialog)
+      , mode(mode)
+      , model(nullptr)
+{
+    ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
+
+    GUIUtil::setupAddressWidget(ui->addressLineEdit, this);
+
+    switch (mode)
+    {
+    case NewSideStake:
+        setWindowTitle(tr("New SideStake"));
+        ui->statusLineEdit->setEnabled(false);
+        ui->statusLabel->setHidden(true);
+        ui->statusLineEdit->setHidden(true);
+        break;
+    case EditSideStake:
+        setWindowTitle(tr("Edit SideStake"));
+        ui->addressLineEdit->setEnabled(false);
+        ui->statusLabel->setHidden(false);
+        ui->statusLineEdit->setHidden(false);
+        ui->statusLineEdit->setEnabled(false);
+        break;
+    }
+
+}
+
+EditSideStakeDialog::~EditSideStakeDialog()
+{
+    delete ui;
+}
+
+void EditSideStakeDialog::setModel(SideStakeTableModel* model)
+{
+    this->model = model;
+    if (!model) {
+        return;
+    }
+
+}
+
+void EditSideStakeDialog::loadRow(int row)
+{
+    m_row = row;
+
+    ui->addressLineEdit->setText(model->index(row, SideStakeTableModel::Address, QModelIndex()).data().toString());
+    ui->allocationLineEdit->setText(model->index(row, SideStakeTableModel::Allocation, QModelIndex()).data().toString());
+    ui->descriptionLineEdit->setText(model->index(row, SideStakeTableModel::Description, QModelIndex()).data().toString());
+    ui->statusLineEdit->setText(model->index(row, SideStakeTableModel::Status, QModelIndex()).data().toString());
+}
+
+bool EditSideStakeDialog::saveCurrentRow()
+{
+    if (!model) {
+        return false;
+    }
+
+    bool success = true;
+
+    switch (mode)
+    {
+    case NewSideStake:
+        address = model->addRow(ui->addressLineEdit->text(),
+                                ui->allocationLineEdit->text(),
+                                ui->descriptionLineEdit->text());
+
+        if (address.isEmpty()) {
+            success = false;
+        }
+
+        break;
+    case EditSideStake:
+        QModelIndex index = model->index(m_row, SideStakeTableModel::Allocation, QModelIndex());
+        model->setData(index, ui->allocationLineEdit->text(), Qt::EditRole);
+
+        if (model->getEditStatus() == SideStakeTableModel::OK || model->getEditStatus() == SideStakeTableModel::NO_CHANGES) {
+            index = model->index(m_row, SideStakeTableModel::Description, QModelIndex());
+            model->setData(index, ui->descriptionLineEdit->text(), Qt::EditRole);
+
+            if (model->getEditStatus() == SideStakeTableModel::OK || model->getEditStatus() == SideStakeTableModel::NO_CHANGES) {
+                break;
+            }
+        }
+
+        success = false;
+
+        break;
+    }
+
+    return success;
+}
+
+void EditSideStakeDialog::accept()
+{
+    if (!model) {
+        return;
+    }
+
+    if (!saveCurrentRow())
+    {
+        switch (model->getEditStatus())
+        {
+        case SideStakeTableModel::OK:
+            // Failed with unknown reason. Just reject.
+            break;
+        case SideStakeTableModel::NO_CHANGES:
+            // No changes were made during edit operation. Just reject.
+            break;
+        case SideStakeTableModel::INVALID_ADDRESS:
+            QMessageBox::warning(this, windowTitle(),
+                                 tr("The entered address \"%1\" is not "
+                                    "a valid Gridcoin address.").arg(ui->addressLineEdit->text()),
+                                 QMessageBox::Ok, QMessageBox::Ok);
+            break;
+        case SideStakeTableModel::DUPLICATE_ADDRESS:
+            QMessageBox::warning(this, windowTitle(),
+                                 tr("The entered address \"%1\" already "
+                                    "has a local sidestake entry.").arg(ui->addressLineEdit->text()),
+                                 QMessageBox::Ok, QMessageBox::Ok);
+            break;
+        case SideStakeTableModel::INVALID_ALLOCATION:
+            QMessageBox::warning(this, windowTitle(),
+                                 tr("The entered allocation is not valid. Check to make sure that the "
+                                    "allocation is greater than zero and when added to the other allocations "
+                                    "totals less than 100.").arg(ui->allocationLineEdit->text()),
+                                 QMessageBox::Ok, QMessageBox::Ok);
+        }
+
+        return;
+    }
+
+    QDialog::accept();
+}

--- a/src/qt/editsidestakedialog.cpp
+++ b/src/qt/editsidestakedialog.cpp
@@ -138,7 +138,14 @@ void EditSideStakeDialog::accept()
             QMessageBox::warning(this, windowTitle(),
                                  tr("The entered allocation is not valid. Check to make sure that the "
                                     "allocation is greater than zero and when added to the other allocations "
-                                    "totals less than 100.").arg(ui->allocationLineEdit->text()),
+                                    "totals less than 100."),
+                                 QMessageBox::Ok, QMessageBox::Ok);
+            break;
+        case SideStakeTableModel::INVALID_DESCRIPTION:
+            QMessageBox::warning(this, windowTitle(),
+                                 tr("The entered description is not valid. Check to make sure that the "
+                                    "description only contains letters, numbers, spaces, periods, or "
+                                    "underscores."),
                                  QMessageBox::Ok, QMessageBox::Ok);
         }
 

--- a/src/qt/editsidestakedialog.h
+++ b/src/qt/editsidestakedialog.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2014-2023 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_EDITSIDESTAKEDIALOG_H
+#define BITCOIN_QT_EDITSIDESTAKEDIALOG_H
+
+#include <QDialog>
+
+QT_BEGIN_NAMESPACE
+class QDataWidgetMapper;
+QT_END_NAMESPACE
+
+namespace Ui {
+class EditSideStakeDialog;
+}
+class SideStakeTableModel;
+
+/** Dialog for editing an address and associated information.
+ */
+class EditSideStakeDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    enum Mode {
+        NewSideStake,
+        EditSideStake
+    };
+
+    explicit EditSideStakeDialog(Mode mode, QWidget* parent = nullptr);
+    ~EditSideStakeDialog();
+
+    void setModel(SideStakeTableModel* model);
+    void loadRow(int row);
+
+public slots:
+    void accept();
+
+private:
+    bool saveCurrentRow();
+
+    Ui::EditSideStakeDialog *ui;
+    Mode mode;
+    SideStakeTableModel *model;
+    int m_row;
+
+    QString address;
+};
+#endif // BITCOIN_QT_EDITSIDESTAKEDIALOG_H

--- a/src/qt/forms/editsidestakedialog.ui
+++ b/src/qt/forms/editsidestakedialog.ui
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EditSideStakeDialog</class>
+ <widget class="QDialog" name="EditSideStakeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add or Edit SideStake</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="1">
+      <spacer name="verticalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="addressLabel">
+       <property name="text">
+        <string>Address</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="addressLineEdit"/>
+     </item>
+     <item row="2" column="1">
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="allocationLabel">
+       <property name="text">
+        <string>Allocation</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="allocationLineEdit"/>
+     </item>
+     <item row="4" column="1">
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="descriptionLabel">
+       <property name="text">
+        <string>Description</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="descriptionLineEdit"/>
+     </item>
+     <item row="6" column="1">
+      <spacer name="verticalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLineEdit" name="statusLineEdit"/>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="statusLabel">
+       <property name="text">
+        <string>Status</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <spacer name="verticalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>EditSideStakeDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>EditSideStakeDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -16,8 +16,8 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="tabPosition">
       <enum>QTabWidget::North</enum>
@@ -245,93 +245,122 @@
       <attribute name="title">
        <string>Staking</string>
       </attribute>
-      <widget class="QWidget" name="layoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>651</width>
-         <height>291</height>
-        </rect>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_StakeSplit">
-        <item>
-         <widget class="QCheckBox" name="enableStaking">
-          <property name="toolTip">
-           <string>This enables or disables staking (the default is enabled). Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
-          </property>
-          <property name="text">
-           <string>Enable Staking</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="enableStakeSplit">
-          <property name="toolTip">
-           <string>This enables or disables splitting of stake outputs to optimize staking (default disabled). Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
-          </property>
-          <property name="text">
-           <string>Enable Stake Splitting</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_StakeSplit">
-          <item>
-           <widget class="QLabel" name="stakingEfficiencyLabel">
-            <property name="text">
-             <string>Target Efficiency</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QValidatedLineEdit" name="stakingEfficiency">
-            <property name="toolTip">
-             <string>Valid values are between 75 and 98 percent. Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="minPostSplitOutputValueLabel">
-            <property name="text">
-             <string>Min Post Split UTXO</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QValidatedLineEdit" name="minPostSplitOutputValue">
-            <property name="toolTip">
-             <string>Valid values are 800 or greater. Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_StakeSplit">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="enableSideStaking">
-          <property name="text">
-           <string>Enable Locally Specified Sidestaking</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QTableWidget" name="sidestakingTableWidget"/>
-        </item>
-       </layout>
-      </widget>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_StakeSplit">
+         <item>
+          <widget class="QCheckBox" name="enableStaking">
+           <property name="toolTip">
+            <string>This enables or disables staking (the default is enabled). Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
+           </property>
+           <property name="text">
+            <string>Enable Staking</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="enableStakeSplit">
+           <property name="toolTip">
+            <string>This enables or disables splitting of stake outputs to optimize staking (default disabled). Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
+           </property>
+           <property name="text">
+            <string>Enable Stake Splitting</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_StakeSplit">
+           <item>
+            <widget class="QLabel" name="stakingEfficiencyLabel">
+             <property name="text">
+              <string>Target Efficiency</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QValidatedLineEdit" name="stakingEfficiency">
+             <property name="toolTip">
+              <string>Valid values are between 75 and 98 percent. Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="minPostSplitOutputValueLabel">
+             <property name="text">
+              <string>Min Post Split UTXO</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QValidatedLineEdit" name="minPostSplitOutputValue">
+             <property name="toolTip">
+              <string>Valid values are 800 or greater. Note that a change to this setting will permanently override the config file with an entry in the settings file.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_StakeSplit">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="enableSideStaking">
+           <property name="text">
+            <string>Enable Locally Specified Sidestaking</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QTableView" name="sidestakingTableView">
+           <property name="sortingEnabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayoutSideStake">
+           <item>
+            <widget class="QPushButton" name="pushButtonNewSideStake">
+             <property name="text">
+              <string>New</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButtonEditSideStake">
+             <property name="text">
+              <string>Edit</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_SideStake">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="tabWindow">
       <attribute name="title">
@@ -544,7 +573,7 @@
      </widget>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_Buttons">
      <item>
       <spacer name="horizontalSpacer_1">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -251,7 +251,7 @@
          <x>10</x>
          <y>10</y>
          <width>651</width>
-         <height>135</height>
+         <height>171</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_StakeSplit">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -334,12 +334,20 @@
              <property name="text">
               <string>New</string>
              </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+             </property>
             </widget>
            </item>
            <item>
             <widget class="QPushButton" name="pushButtonEditSideStake">
              <property name="text">
               <string>Edit</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/edit</normaloff>:/icons/edit</iconset>
              </property>
             </widget>
            </item>
@@ -663,6 +671,8 @@
    <header>qvaluecombobox.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -320,6 +320,13 @@
           </item>
          </layout>
         </item>
+        <item>
+         <widget class="QCheckBox" name="enableSideStaking">
+          <property name="text">
+           <string>Enable Locally Specified Sidestaking</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </widget>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -251,7 +251,7 @@
          <x>10</x>
          <y>10</y>
          <width>651</width>
-         <height>171</height>
+         <height>291</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_StakeSplit">
@@ -326,6 +326,9 @@
            <string>Enable Locally Specified Sidestaking</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="sidestakingTableWidget"/>
         </item>
        </layout>
       </widget>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -342,12 +342,29 @@
            </item>
            <item>
             <widget class="QPushButton" name="pushButtonEditSideStake">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="text">
               <string>Edit</string>
              </property>
              <property name="icon">
               <iconset resource="../bitcoin.qrc">
                <normaloff>:/icons/edit</normaloff>:/icons/edit</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButtonDeleteSideStake">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Delete</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../bitcoin.qrc">
+               <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
              </property>
             </widget>
            </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -206,7 +206,7 @@ void OptionsDialog::setModel(OptionsModel *model)
         ui->sidestakingTableView->installEventFilter(this);
 
         connect(this, &OptionsDialog::sidestakeAllocationInvalid, this, &OptionsDialog::handleSideStakeAllocationInvalid);
-
+        connect(this, &OptionsDialog::sidestakeDescriptionInvalid, this, &OptionsDialog::handleSideStakeDescriptionInvalid);
     }
 
     /* update the display unit, to not use the default ("BTC") */
@@ -631,6 +631,10 @@ bool OptionsDialog::eventFilter(QObject *object, QEvent *event)
         if (model->getSideStakeTableModel()->getEditStatus() == SideStakeTableModel::INVALID_ALLOCATION) {
             emit sidestakeAllocationInvalid();
         }
+
+        if (model->getSideStakeTableModel()->getEditStatus() == SideStakeTableModel::INVALID_DESCRIPTION) {
+            emit sidestakeDescriptionInvalid();
+        }
     }
 
    return QDialog::eventFilter(object, event);
@@ -665,6 +669,17 @@ void OptionsDialog::handleSideStakeAllocationInvalid()
                          tr("The entered allocation is not valid and is reverted. Check to make sure "
                             "that the allocation is greater than or equal to zero and when added to the other "
                             "allocations totals less than 100."),
+                         QMessageBox::Ok, QMessageBox::Ok);
+}
+
+void OptionsDialog::handleSideStakeDescriptionInvalid()
+{
+    model->getSideStakeTableModel()->refresh();
+
+    QMessageBox::warning(this, windowTitle(),
+                         tr("The entered description is not valid. Check to make sure that the "
+                            "description only contains letters, numbers, spaces, periods, or "
+                            "underscores."),
                          QMessageBox::Ok, QMessageBox::Ok);
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -650,8 +650,7 @@ void OptionsDialog::sidestakeSelectionChanged()
         if (indexes.size() > 1) {
             ui->pushButtonEditSideStake->setEnabled(false);
             ui->pushButtonDeleteSideStake->setEnabled(false);
-        } else if (static_cast<GRC::SideStake*>(indexes.at(0).internalPointer())->m_status
-                   == GRC::SideStakeStatus::MANDATORY) {
+        } else if (static_cast<GRC::SideStake*>(indexes.at(0).internalPointer())->IsMandatory()) {
             ui->pushButtonEditSideStake->setEnabled(false);
             ui->pushButtonDeleteSideStake->setEnabled(false);
         } else {

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -11,6 +11,7 @@
 #include "miner.h"
 #include "sidestaketablemodel.h"
 #include "editsidestakedialog.h"
+#include "logging.h"
 
 #include <QSortFilterProxyModel>
 #include <QDir>
@@ -30,6 +31,8 @@ OptionsDialog::OptionsDialog(QWidget* parent)
       , fStakingEfficiencyValid(true)
       , fMinStakeSplitValueValid(true)
       , fPollExpireNotifyValid(true)
+      , m_init_column_sizes_set(false)
+      , m_resize_columns_in_progress(false)
 {
     ui->setupUi(this);
 
@@ -171,10 +174,24 @@ void OptionsDialog::setModel(OptionsModel *model)
         ui->sidestakingTableView->setColumnWidth(SideStakeTableModel::Allocation, GRC::ScalePx(this, ALLOCATION_COLUMN_WIDTH));
         ui->sidestakingTableView->setColumnWidth(SideStakeTableModel::Description, GRC::ScalePx(this, DESCRIPTION_COLUMN_WIDTH));
         ui->sidestakingTableView->setColumnWidth(SideStakeTableModel::Status, GRC::ScalePx(this, STATUS_COLUMN_WIDTH));
-        ui->sidestakingTableView->horizontalHeader()->setStretchLastSection(true);
         ui->sidestakingTableView->setShowGrid(true);
 
+        // Set table column sizes vector for sidestake table proportional resize algorithm.
+        m_table_column_sizes = {GRC::ScalePx(this, ADDRESS_COLUMN_WIDTH),
+                                GRC::ScalePx(this, ALLOCATION_COLUMN_WIDTH),
+                                GRC::ScalePx(this, DESCRIPTION_COLUMN_WIDTH),
+                                GRC::ScalePx(this, STATUS_COLUMN_WIDTH)};
+
         ui->sidestakingTableView->sortByColumn(0, Qt::AscendingOrder);
+
+        // Insures initial size of sidestake table and (header) columns are correct as of the context directly
+        // after tab selection.
+        connect(ui->tabWidget, &QTabWidget::currentChanged, this, &OptionsDialog::tabWidgetSelectionChanged);
+
+        // Insures that header width remains constant and columns are resized correctly when a column delimiter is
+        // dragged to resize one column.
+        connect(ui->sidestakingTableView->horizontalHeader(), &QHeaderView::sectionResized,
+                this, &OptionsDialog::sidestakeTableSectionResized);
 
         connect(ui->enableSideStaking, &QCheckBox::toggled, this, &OptionsDialog::hideSideStakeEdit);
         connect(ui->enableSideStaking, &QCheckBox::toggled, this, &OptionsDialog::refreshSideStakeTableModel);
@@ -609,22 +626,14 @@ bool OptionsDialog::eventFilter(QObject *object, QEvent *event)
         }
     }
 
-<<<<<<< HEAD
-=======
     // This is required to provide immediate feedback on invalid allocation entries on in place editing.
-    if (object == ui->sidestakingTableView)
-    {
+    if (object == ui->sidestakingTableView) {
         if (model->getSideStakeTableModel()->getEditStatus() == SideStakeTableModel::INVALID_ALLOCATION) {
-            LogPrint(BCLog::LogFlags::VERBOSE, "INFO %s: event type = %i",
-                     __func__,
-                     (int) event->type());
-
             emit sidestakeAllocationInvalid();
         }
     }
 
->>>>>>> 71b6deb3e (Implementation of EditSideStakeDialog)
-    return QDialog::eventFilter(object, event);
+   return QDialog::eventFilter(object, event);
 }
 
 void OptionsDialog::sidestakeSelectionChanged()
@@ -662,4 +671,110 @@ void OptionsDialog::handleSideStakeAllocationInvalid()
 void OptionsDialog::updateSideStakeTableView()
 {
     ui->sidestakingTableView->update();
+}
+
+void OptionsDialog::resizeSideStakeTableColumns(const bool& neighbor_pair_adjust, const int& index,
+                                         const int& old_size, const int& new_size)
+{
+    // This prevents unwanted recursion to here from addressBookSectionResized.
+    m_resize_columns_in_progress = true;
+
+    if (!model) {
+        m_resize_columns_in_progress = false;
+
+        return;
+    }
+
+    if (!m_init_column_sizes_set) {
+        for (int i = 0; i < (int) m_table_column_sizes.size(); ++i) {
+            ui->sidestakingTableView->horizontalHeader()->resizeSection(i, m_table_column_sizes[i]);
+
+
+            LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: section size = %i",
+                     __func__,
+                     ui->sidestakingTableView->horizontalHeader()->sectionSize(i));
+        }
+
+        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: header width = %i",
+                 __func__,
+                 ui->sidestakingTableView->horizontalHeader()->width()
+                 );
+
+        m_init_column_sizes_set = true;
+        m_resize_columns_in_progress = false;
+
+        return;
+    }
+
+    if (neighbor_pair_adjust) {
+        if (index != SideStakeTableModel::all_ColumnIndex.size() - 1) {
+            int new_neighbor_section_size = ui->sidestakingTableView->horizontalHeader()->sectionSize(index + 1)
+                                            + old_size - new_size;
+
+            ui->sidestakingTableView->horizontalHeader()->resizeSection(
+                index + 1, new_neighbor_section_size);
+
+                   // This detects and deals with the case where the resize of a column tries to force the neighbor
+                   // to a size below its minimum, in which case we have to reverse out the attempt.
+            if (ui->sidestakingTableView->horizontalHeader()->sectionSize(index + 1)
+                != new_neighbor_section_size) {
+                ui->sidestakingTableView->horizontalHeader()->resizeSection(
+                    index,
+                    ui->sidestakingTableView->horizontalHeader()->sectionSize(index)
+                        + new_neighbor_section_size
+                        - ui->sidestakingTableView->horizontalHeader()->sectionSize(index + 1));
+            }
+        } else {
+            // Do not allow the last column to be resized because there is no adjoining neighbor to the right
+            // and we are maintaining the total width fixed to the size of the containing frame.
+            ui->sidestakingTableView->horizontalHeader()->resizeSection(index, old_size);
+        }
+
+        m_resize_columns_in_progress = false;
+
+        return;
+    }
+
+           // This is the proportional resize case when the window is resized.
+    const int width = ui->sidestakingTableView->horizontalHeader()->width() - 5;
+
+    int orig_header_width = 0;
+
+    for (const auto& iter : SideStakeTableModel::all_ColumnIndex) {
+        orig_header_width += ui->sidestakingTableView->horizontalHeader()->sectionSize(iter);
+    }
+
+    if (!width || !orig_header_width) return;
+
+    for (const auto& iter : SideStakeTableModel::all_ColumnIndex) {
+        int section_size = ui->sidestakingTableView->horizontalHeader()->sectionSize(iter);
+
+        ui->sidestakingTableView->horizontalHeader()->resizeSection(
+            iter, section_size * width / orig_header_width);
+    }
+
+    m_resize_columns_in_progress = false;
+}
+
+void OptionsDialog::resizeEvent(QResizeEvent *event)
+{
+    resizeSideStakeTableColumns();
+
+    QWidget::resizeEvent(event);
+}
+
+void OptionsDialog::sidestakeTableSectionResized(int index, int old_size, int new_size)
+{
+    // Avoid implicit recursion between resizeTableColumns and addressBookSectionResized
+    if (m_resize_columns_in_progress) return;
+
+    resizeSideStakeTableColumns(true, index, old_size, new_size);
+}
+
+void OptionsDialog::tabWidgetSelectionChanged(int index)
+{
+    // Index = 2 is the sidestaking tab for the current tab order.
+    if (index == 2) {
+        resizeSideStakeTableColumns();
+    }
 }

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -188,6 +188,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->enableStakeSplit, OptionsModel::EnableStakeSplit);
     mapper->addMapping(ui->stakingEfficiency, OptionsModel::StakingEfficiency);
     mapper->addMapping(ui->minPostSplitOutputValue, OptionsModel::MinStakeSplitValue);
+    mapper->addMapping(ui->enableSideStaking, OptionsModel::EnableSideStaking);
 
     /* Window */
     mapper->addMapping(ui->disableTransactionNotifications, OptionsModel::DisableTrxNotifications);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -40,6 +40,9 @@ private slots:
     void on_cancelButton_clicked();
     void on_applyButton_clicked();
 
+    void newSideStakeButton_clicked();
+    void editSideStakeButton_clicked();
+
     void showRestartWarning_Proxy();
     void showRestartWarning_Lang();
     void updateDisplayUnit();
@@ -48,10 +51,13 @@ private slots:
     void hideLimitTxnDisplayDate();
     void hideStakeSplitting();
     void hidePollExpireNotify();
+    void hideSideStakeEdit();
     void handleProxyIpValid(QValidatedLineEdit *object, bool fState);
     void handleStakingEfficiencyValid(QValidatedLineEdit *object, bool fState);
     void handleMinStakeSplitValueValid(QValidatedLineEdit *object, bool fState);
     void handlePollExpireNotifyValid(QValidatedLineEdit *object, bool fState);
+
+    void refreshSideStakeTableModel();
 
 signals:
     void proxyIpValid(QValidatedLineEdit *object, bool fValid);
@@ -69,6 +75,15 @@ private:
     bool fStakingEfficiencyValid;
     bool fMinStakeSplitValueValid;
     bool fPollExpireNotifyValid;
+
+    enum SideStakeTableColumnWidths
+    {
+        ADDRESS_COLUMN_WIDTH = 200,
+        ALLOCATION_COLUMN_WIDTH = 80,
+        DESCRIPTION_COLUMN_WIDTH = 130,
+        BANSUBNET_COLUMN_WIDTH = 150,
+        STATUS_COLUMN_WIDTH = 150
+    };
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -22,8 +22,13 @@ public:
     void setModel(OptionsModel *model);
     void setMapper();
 
+public slots:
+    void resizeSideStakeTableColumns(const bool& neighbor_pair_adjust = false, const int& index = 0,
+                            const int& old_size = 0, const int& new_size = 0);
+
 protected:
-    bool eventFilter(QObject *object, QEvent *event);
+    bool eventFilter(QObject *object, QEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 private slots:
     /* enable only apply button */
@@ -61,6 +66,8 @@ private slots:
 
     void refreshSideStakeTableModel();
 
+    void tabWidgetSelectionChanged(int index);
+
 signals:
     void proxyIpValid(QValidatedLineEdit *object, bool fValid);
     void stakingEfficiencyValid(QValidatedLineEdit *object, bool fValid);
@@ -79,18 +86,25 @@ private:
     bool fMinStakeSplitValueValid;
     bool fPollExpireNotifyValid;
 
+    std::vector<int> m_table_column_sizes;
+    bool m_init_column_sizes_set;
+    bool m_resize_columns_in_progress;
+
     enum SideStakeTableColumnWidths
     {
         ADDRESS_COLUMN_WIDTH = 200,
-        ALLOCATION_COLUMN_WIDTH = 80,
+        ALLOCATION_COLUMN_WIDTH = 50,
         DESCRIPTION_COLUMN_WIDTH = 130,
-        BANSUBNET_COLUMN_WIDTH = 150,
-        STATUS_COLUMN_WIDTH = 150
+        STATUS_COLUMN_WIDTH = 50
     };
 
 private slots:
     void sidestakeSelectionChanged();
     void updateSideStakeTableView();
+
+    /** Resize address book table columns based on incoming signal */
+    void sidestakeTableSectionResized(int index, int old_size, int new_size);
+
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -42,6 +42,7 @@ private slots:
 
     void newSideStakeButton_clicked();
     void editSideStakeButton_clicked();
+    void deleteSideStakeButton_clicked();
 
     void showRestartWarning_Proxy();
     void showRestartWarning_Lang();
@@ -56,6 +57,7 @@ private slots:
     void handleStakingEfficiencyValid(QValidatedLineEdit *object, bool fState);
     void handleMinStakeSplitValueValid(QValidatedLineEdit *object, bool fState);
     void handlePollExpireNotifyValid(QValidatedLineEdit *object, bool fState);
+    void handleSideStakeAllocationInvalid();
 
     void refreshSideStakeTableModel();
 
@@ -64,6 +66,7 @@ signals:
     void stakingEfficiencyValid(QValidatedLineEdit *object, bool fValid);
     void minStakeSplitValueValid(QValidatedLineEdit *object, bool fValid);
     void pollExpireNotifyValid(QValidatedLineEdit *object, bool fValid);
+    void sidestakeAllocationInvalid();
 
 private:
     Ui::OptionsDialog *ui;
@@ -84,6 +87,10 @@ private:
         BANSUBNET_COLUMN_WIDTH = 150,
         STATUS_COLUMN_WIDTH = 150
     };
+
+private slots:
+    void sidestakeSelectionChanged();
+    void updateSideStakeTableView();
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -63,6 +63,7 @@ private slots:
     void handleMinStakeSplitValueValid(QValidatedLineEdit *object, bool fState);
     void handlePollExpireNotifyValid(QValidatedLineEdit *object, bool fState);
     void handleSideStakeAllocationInvalid();
+    void handleSideStakeDescriptionInvalid();
 
     void refreshSideStakeTableModel();
 
@@ -74,6 +75,7 @@ signals:
     void minStakeSplitValueValid(QValidatedLineEdit *object, bool fValid);
     void pollExpireNotifyValid(QValidatedLineEdit *object, bool fValid);
     void sidestakeAllocationInvalid();
+    void sidestakeDescriptionInvalid();
 
 private:
     Ui::OptionsDialog *ui;
@@ -93,8 +95,8 @@ private:
     enum SideStakeTableColumnWidths
     {
         ADDRESS_COLUMN_WIDTH = 200,
-        ALLOCATION_COLUMN_WIDTH = 50,
-        DESCRIPTION_COLUMN_WIDTH = 130,
+        ALLOCATION_COLUMN_WIDTH = 60,
+        DESCRIPTION_COLUMN_WIDTH = 150,
         STATUS_COLUMN_WIDTH = 50
     };
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -155,6 +155,9 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case EnableStakeSplit:
             // This comes from the core and is a read-write setting (see below).
             return QVariant(gArgs.GetBoolArg("-enablestakesplit"));
+        case EnableSideStaking:
+            // This comes from the core and is a read-write setting (see below).
+            return QVariant(gArgs.GetBoolArg("-enablesidestaking"));
         case StakingEfficiency:
             // This comes from the core and is a read-write setting (see below).
             return QVariant((double) gArgs.GetArg("-stakingefficiency", (int64_t) 90));
@@ -310,9 +313,14 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case EnableStakeSplit:
             // This is a core setting stored in the read-write settings file and once set will override the read-only
             //config file.
-            //fStakeSplitEnabled = value.toBool();
             gArgs.ForceSetArg("-enablestakesplit", value.toBool() ? "1" : "0");
             updateRwSetting("enablestakesplit", gArgs.GetBoolArg("-enablestakesplit"));
+            break;
+        case EnableSideStaking:
+            // This is a core setting stored in the read-write settings file and once set will override the read-only
+            //config file.
+            gArgs.ForceSetArg("-enablesidestaking", value.toBool() ? "1" : "0");
+            updateRwSetting("enablesidestaking", gArgs.GetBoolArg("-enablesidestaking"));
             break;
         case StakingEfficiency:
             // This is a core setting stored in the read-write settings file and once set will override the read-only

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -79,6 +79,8 @@ void OptionsModel::Init()
     if (settings.contains("dataDir") && dataDir != GUIUtil::getDefaultDataDirectory()) {
         gArgs.SoftSetArg("-datadir", GUIUtil::qstringToBoostPath(settings.value("dataDir").toString()).string());
     }
+
+    m_sidestake_model = new SideStakeTableModel(this);
 }
 
 int OptionsModel::rowCount(const QModelIndex & parent) const
@@ -468,4 +470,9 @@ void OptionsModel::setMaskValues(bool privacy_mode)
 QString OptionsModel::getDataDir()
 {
     return dataDir;
+}
+
+SideStakeTableModel* OptionsModel::getSideStakeTableModel()
+{
+    return m_sidestake_model;
 }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -41,6 +41,7 @@ public:
         DataDir,                 // QString
         EnableStaking,           // bool
         EnableStakeSplit,        // bool
+        EnableSideStaking,       // bool
         StakingEfficiency,       // double
         MinStakeSplitValue,      // int
         PollExpireNotification,  // double

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -1,6 +1,7 @@
 #ifndef BITCOIN_QT_OPTIONSMODEL_H
 #define BITCOIN_QT_OPTIONSMODEL_H
 
+#include "sidestaketablemodel.h"
 #include <QAbstractListModel>
 #include <QDate>
 
@@ -78,6 +79,8 @@ public:
     QString getCurrentStyle();
     QString getDataDir();
 
+    SideStakeTableModel* getSideStakeTableModel();
+
     /* Explicit setters */
     void setCurrentStyle(QString theme);
     void setMaskValues(bool privacy_mode);
@@ -101,6 +104,8 @@ private:
     QString language;
     QString walletStylesheet;
     QString dataDir;
+
+    SideStakeTableModel* m_sidestake_model;
 
 signals:
     void displayUnitChanged(int unit);

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -36,7 +36,7 @@ bool SideStakeLessThan::operator()(const GRC::SideStake& left, const GRC::SideSt
 
     switch (static_cast<SideStakeTableModel::ColumnIndex>(m_column)) {
     case SideStakeTableModel::Address:
-        return pLeft->m_key < pRight->m_key;
+        return pLeft->m_address < pRight->m_address;
     case SideStakeTableModel::Allocation:
         return pLeft->m_allocation < pRight->m_allocation;
     case SideStakeTableModel::Description:
@@ -131,7 +131,7 @@ QVariant SideStakeTableModel::data(const QModelIndex &index, int role) const
     if (role == Qt::DisplayRole || role == Qt::EditRole) {
         switch (column) {
         case Address:
-            return QString::fromStdString(rec->m_key.ToString());
+            return QString::fromStdString(rec->m_address.ToString());
         case Allocation:
             return rec->m_allocation * 100.0;
         case Description:
@@ -182,7 +182,7 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
         address.SetString(value.toString().toStdString());
 
 
-        if (rec->m_key == address) {
+        if (rec->m_address == address) {
             m_edit_status = NO_CHANGES;
             return false;
         } else if (!address.IsValid()) {
@@ -210,7 +210,7 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
         GRC::SideStake orig_sidestake = *rec;
 
         for (const auto& entry : registry.ActiveSideStakeEntries(false, true)) {
-            if (entry->m_key == orig_sidestake.m_key) {
+            if (entry->m_address == orig_sidestake.m_address) {
                 continue;
             }
 
@@ -233,10 +233,10 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
         }
 
         // Delete the original sidestake
-        registry.NonContractDelete(orig_sidestake.m_key, false);
+        registry.NonContractDelete(orig_sidestake.m_address, false);
 
         // Add back the sidestake with the modified allocation
-        registry.NonContractAdd(GRC::SideStake(orig_sidestake.m_key,
+        registry.NonContractAdd(GRC::SideStake(orig_sidestake.m_address,
                                                value.toDouble() / 100.0,
                                                orig_sidestake.m_description,
                                                int64_t {0},
@@ -264,10 +264,10 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
         GRC::SideStake orig_sidestake = *rec;
 
         // Delete the original sidestake
-        registry.NonContractDelete(orig_sidestake.m_key, false);
+        registry.NonContractDelete(orig_sidestake.m_address, false);
 
         // Add back the sidestake with the modified allocation
-        registry.NonContractAdd(GRC::SideStake(orig_sidestake.m_key,
+        registry.NonContractAdd(GRC::SideStake(orig_sidestake.m_address,
                                                orig_sidestake.m_allocation,
                                                san_value,
                                                int64_t {0},
@@ -400,7 +400,7 @@ bool SideStakeTableModel::removeRows(int row, int count, const QModelIndex &pare
         return false;
     }
 
-    GRC::GetSideStakeRegistry().NonContractDelete(rec->m_key);
+    GRC::GetSideStakeRegistry().NonContractDelete(rec->m_address);
 
     updateSideStakeTableModel();
 

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -1,0 +1,3 @@
+// Copyright (c) 2014-2023 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -1,3 +1,267 @@
 // Copyright (c) 2014-2023 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <qt/sidestaketablemodel.h>
+#include <qt/optionsmodel.h>
+#include <node/ui_interface.h>
+
+#include <QList>
+#include <QTimer>
+#include <QDebug>
+
+SideStakeLessThan::SideStakeLessThan(int column, Qt::SortOrder order)
+    : m_column(column)
+      , m_order(order)
+{}
+
+bool SideStakeLessThan::operator()(const GRC::SideStake& left, const GRC::SideStake& right) const
+{
+    const GRC::SideStake* pLeft = &left;
+    const GRC::SideStake* pRight = &right;
+
+    if (m_order == Qt::DescendingOrder) {
+        std::swap(pLeft, pRight);
+    }
+
+    switch (static_cast<SideStakeTableModel::ColumnIndex>(m_column)) {
+    case SideStakeTableModel::Address:
+        return pLeft->m_key < pRight->m_key;
+    case SideStakeTableModel::Allocation:
+        return pLeft->m_allocation < pRight->m_allocation;
+    case SideStakeTableModel::Description:
+        return pLeft->m_description.compare(pRight->m_description) < 0;
+    case SideStakeTableModel::Status:
+        return pLeft->m_status < pRight->m_status;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
+class SideStakeTablePriv
+{
+public:
+    QList<GRC::SideStake> m_cached_sidestakes;
+    int m_sort_column{-1};
+    Qt::SortOrder m_sort_order;
+
+    void refreshSideStakes()
+    {
+        m_cached_sidestakes.clear();
+
+        std::vector<GRC::SideStake_ptr> core_sidestakes = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
+
+        m_cached_sidestakes.reserve(core_sidestakes.size());
+
+        for (const auto& entry : core_sidestakes) {
+            m_cached_sidestakes.append(*entry);
+        }
+
+        if (m_sort_column >= 0) {
+            std::stable_sort(m_cached_sidestakes.begin(), m_cached_sidestakes.end(), SideStakeLessThan(m_sort_column, m_sort_order));
+        }
+    }
+
+    int size()
+    {
+        return m_cached_sidestakes.size();
+    }
+
+    GRC::SideStake* index(int idx)
+    {
+        if (idx >= 0 && idx < m_cached_sidestakes.size()) {
+            return &m_cached_sidestakes[idx];
+        }
+
+        return nullptr;
+    }
+
+};
+
+SideStakeTableModel::SideStakeTableModel(OptionsModel* parent)
+    : QAbstractTableModel(parent)
+{
+    m_columns << tr("Address") << tr("Allocation") << tr("Description") << tr("Status");
+    m_priv.reset(new SideStakeTablePriv());
+
+    // load initial data
+    refresh();
+}
+
+SideStakeTableModel::~SideStakeTableModel()
+{
+  // Intentionally left empty
+}
+
+int SideStakeTableModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    return m_priv->size();
+}
+
+int SideStakeTableModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    return m_columns.length();
+}
+
+QVariant SideStakeTableModel::data(const QModelIndex &index, int role) const
+{
+    if(!index.isValid())
+        return QVariant();
+
+    GRC::SideStake* rec = static_cast<GRC::SideStake*>(index.internalPointer());
+
+    const auto column = static_cast<ColumnIndex>(index.column());
+    if (role == Qt::DisplayRole) {
+        switch (column) {
+        case Address:
+            return QString::fromStdString(rec->m_key.ToString());
+        case Allocation:
+            return rec->m_allocation * 100.0;
+        case Description:
+            return QString::fromStdString(rec->m_description);
+        case Status:
+            return QString::fromStdString(rec->StatusToString());
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
+    } else if (role == Qt::TextAlignmentRole) {
+        switch (column) {
+        case Address:
+            return QVariant(Qt::AlignLeft | Qt::AlignVCenter);
+        case Allocation:
+            return QVariant(Qt::AlignRight | Qt::AlignVCenter);
+        case Description:
+            return QVariant(Qt::AlignLeft | Qt::AlignVCenter);
+        case Status:
+            return QVariant(Qt::AlignCenter | Qt::AlignVCenter);
+        default:
+            return QVariant();
+        }
+    }
+
+    return QVariant();
+}
+
+QVariant SideStakeTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Horizontal)
+    {
+        if(role == Qt::DisplayRole && section < m_columns.size())
+        {
+            return m_columns[section];
+        }
+    }
+    return QVariant();
+}
+
+Qt::ItemFlags SideStakeTableModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid()) return Qt::NoItemFlags;
+
+    Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    return retval;
+}
+
+QModelIndex SideStakeTableModel::index(int row, int column, const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    GRC::SideStake* data = m_priv->index(row);
+
+    if (data)
+        return createIndex(row, column, data);
+    return QModelIndex();
+}
+
+QString SideStakeTableModel::addRow(const QString &address, const QString &allocation, const QString description)
+{
+    GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
+
+    CBitcoinAddress sidestake_address;
+    sidestake_address.SetString(address.toStdString());
+
+    double sidestake_allocation = 0.0;
+
+    std::string sidestake_description = description.toStdString();
+
+    m_edit_status = OK;
+
+    if (!sidestake_address.IsValid()) {
+        m_edit_status = INVALID_ADDRESS;
+        return QString();
+    }
+
+    // Check for duplicate local sidestakes. Here we use the actual core sidestake registry rather than the
+    // UI model.
+    std::vector<GRC::SideStake_ptr> core_local_sidestake = registry.Try(sidestake_address, true);
+
+    if (!core_local_sidestake.empty()) {
+        m_edit_status = DUPLICATE_ADDRESS;
+        return QString();
+    }
+
+    if (!ParseDouble(allocation.toStdString(), &sidestake_allocation)
+        && (sidestake_allocation < 0.0 || sidestake_allocation > 1.0)) {
+        m_edit_status = INVALID_ALLOCATION;
+        return QString();
+    }
+
+    sidestake_allocation /= 100.0;
+
+    registry.NonContractAdd(GRC::SideStake(sidestake_address,
+                                           sidestake_allocation,
+                                           sidestake_description,
+                                           int64_t {0},
+                                           uint256 {},
+                                           GRC::SideStakeStatus::ACTIVE));
+
+    updateSideStakeTableModel();
+
+    return QString::fromStdString(sidestake_address.ToString());
+}
+
+SideStakeTableModel::EditStatus SideStakeTableModel::getEditStatus() const
+{
+    return m_edit_status;
+}
+
+void SideStakeTableModel::refresh()
+{
+    Q_EMIT layoutAboutToBeChanged();
+    m_priv->refreshSideStakes();
+    Q_EMIT layoutChanged();
+}
+
+void SideStakeTableModel::sort(int column, Qt::SortOrder order)
+{
+    m_priv->m_sort_column = column;
+    m_priv->m_sort_order = order;
+    refresh();
+}
+
+void SideStakeTableModel::updateSideStakeTableModel()
+{
+    refresh();
+
+    emit updateSideStakeTableModelSig();
+}
+
+static void RwSettingsUpdated(SideStakeTableModel* sidestake_model)
+{
+    qDebug() << QString("%1").arg(__func__);
+    QMetaObject::invokeMethod(sidestake_model, "updateSideStakeTableModel", Qt::QueuedConnection);
+}
+
+void SideStakeTableModel::subscribeToCoreSignals()
+{
+    // Connect signals to client
+    uiInterface.RwSettingsUpdated_connect(boost::bind(RwSettingsUpdated, this));
+}
+
+void SideStakeTableModel::unsubscribeFromCoreSignals()
+{
+    // Disconnect signals from client (currently no-op).
+}

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -334,8 +334,11 @@ Qt::ItemFlags SideStakeTableModel::flags(const QModelIndex &index) const
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
 
-    if (!rec->IsMandatory()
-        && std::get<GRC::LocalSideStake::Status>(rec->GetStatus()) == GRC::LocalSideStake::LocalSideStakeStatus::ACTIVE
+    GRC::SideStake::Status status = rec->GetStatus();
+    GRC::LocalSideStake::Status* local_status_ptr = std::get_if<GRC::LocalSideStake::Status>(&status);
+
+    if (!rec->IsMandatory() && local_status_ptr
+        && *local_status_ptr == GRC::LocalSideStake::LocalSideStakeStatus::ACTIVE
         && (index.column() == Allocation || index.column() == Description)) {
         retval |= Qt::ItemIsEditable;
     }

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -81,7 +81,8 @@ public:
     {
         m_cached_sidestakes.clear();
 
-        std::vector<GRC::SideStake_ptr> core_sidestakes = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(false, true);
+        std::vector<GRC::SideStake_ptr> core_sidestakes
+            = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true);
 
         m_cached_sidestakes.reserve(core_sidestakes.size());
 
@@ -211,7 +212,7 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
             return false;
         }
 
-        std::vector<GRC::SideStake_ptr> sidestakes = registry.Try(address.Get(), true);
+        std::vector<GRC::SideStake_ptr> sidestakes = registry.Try(address.Get(), GRC::SideStake::FilterFlag::LOCAL);
 
         if (!sidestakes.empty()) {
             m_edit_status = DUPLICATE_ADDRESS;
@@ -235,7 +236,7 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
         std::string orig_description = rec->GetDescription();
         GRC::SideStake::Status orig_status = rec->GetStatus();
 
-        for (const auto& entry : registry.ActiveSideStakeEntries(false, true)) {
+        for (const auto& entry : registry.ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true)) {
             CTxDestination destination = entry->GetDestination();
             double allocation = entry->GetAllocation();
 
@@ -370,12 +371,12 @@ QString SideStakeTableModel::addRow(const QString &address, const QString &alloc
 
     // Check for duplicate local sidestakes. Here we use the actual core sidestake registry rather than the
     // UI model.
-    std::vector<GRC::SideStake_ptr> core_local_sidestake = registry.Try(sidestake_address.Get(), true);
+    std::vector<GRC::SideStake_ptr> core_local_sidestake = registry.Try(sidestake_address.Get(), GRC::SideStake::FilterFlag::LOCAL);
 
     double prior_total_allocation = 0.0;
 
     // Get total allocation of all active/mandatory sidestake entries
-    for (const auto& entry : registry.ActiveSideStakeEntries(false, true)) {
+    for (const auto& entry : registry.ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true)) {
         prior_total_allocation += entry->GetAllocation() * 100.0;
     }
 

--- a/src/qt/sidestaketablemodel.h
+++ b/src/qt/sidestaketablemodel.h
@@ -58,7 +58,8 @@ public:
         NO_CHANGES,             /**< No changes were made during edit operation */
         INVALID_ADDRESS,        /**< Unparseable address */
         DUPLICATE_ADDRESS,      /**< Address already in sidestake registry */
-        INVALID_ALLOCATION      /**< Allocation is invalid (i.e. not parseable or not between 0.0 and 100.0) */
+        INVALID_ALLOCATION,     /**< Allocation is invalid (i.e. not parseable or not between 0.0 and 100.0) */
+        INVALID_DESCRIPTION     /**< Description contains an invalid character */
     };
 
     /** @name Methods overridden from QAbstractTableModel

--- a/src/qt/sidestaketablemodel.h
+++ b/src/qt/sidestaketablemodel.h
@@ -28,6 +28,10 @@ private:
     Qt::SortOrder m_order;
 };
 
+//!
+//! \brief The SideStakeTableModel class represents the core sidestake registry as a model which can be consumed
+//! and updated by the GUI.
+//!
 class SideStakeTableModel : public QAbstractTableModel
 {
     Q_OBJECT
@@ -57,9 +61,11 @@ public:
     int rowCount(const QModelIndex &parent) const;
     int columnCount(const QModelIndex &parent) const;
     QVariant data(const QModelIndex &index, int role) const;
+    bool setData(const QModelIndex &index, const QVariant &value, int role);
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
     QModelIndex index(int row, int column, const QModelIndex &parent) const;
     Qt::ItemFlags flags(const QModelIndex &index) const;
+    bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex());
     void sort(int column, Qt::SortOrder order);
     /*@}*/
 
@@ -80,11 +86,12 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
-    void updateSideStakeTableModel();
-
 signals:
 
     void updateSideStakeTableModelSig();
+
+public slots:
+    void updateSideStakeTableModel();
 };
 
 #endif // BITCOIN_QT_SIDESTAKETABLEMODEL_H

--- a/src/qt/sidestaketablemodel.h
+++ b/src/qt/sidestaketablemodel.h
@@ -47,6 +47,11 @@ public:
         Status
     };
 
+    static constexpr std::initializer_list<ColumnIndex> all_ColumnIndex = {Address,
+                                                                           Allocation,
+                                                                           Description,
+                                                                           Status};
+
     /** Return status of edit/insert operation */
     enum EditStatus {
         OK,                     /**< Everything ok */

--- a/src/qt/sidestaketablemodel.h
+++ b/src/qt/sidestaketablemodel.h
@@ -1,0 +1,8 @@
+// Copyright (c) 2014-2023 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SIDESTAKETABLEMODEL_H
+#define BITCOIN_QT_SIDESTAKETABLEMODEL_H
+
+#endif // BITCOIN_QT_SIDESTAKETABLEMODEL_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2472,7 +2472,7 @@ UniValue addkey(const UniValue& params, bool fHelp)
     case GRC::ContractType::SIDESTAKE:
     {
         if (block_v13_enabled) {
-            GRC::CBitcoinAddressForStorage sidestake_address;
+            CBitcoinAddress sidestake_address;
             if (!sidestake_address.SetString(params[2].get_str())) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Address specified for the sidestake is invalid.");
             }
@@ -2499,7 +2499,7 @@ UniValue addkey(const UniValue& params, bool fHelp)
                 contract_version,                                            // Contract version number (3+)
                 action,                                                      // Contract action
                 uint32_t {1},                                                // Contract payload version number
-                sidestake_address,                                           // Sidestake address
+                sidestake_address.Get(),                                     // Sidestake destination
                 allocation,                                                  // Sidestake allocation
                 description,                                                 // Sidestake description
                 GRC::MandatorySideStake::MandatorySideStakeStatus::MANDATORY // sidestake status

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2496,14 +2496,14 @@ UniValue addkey(const UniValue& params, bool fHelp)
             }
 
             contract = GRC::MakeContract<GRC::SideStakePayload>(
-                        contract_version,               // Contract version number (3+)
-                        action,                         // Contract action
-                        uint32_t {1},                   // Contract payload version number
-                        sidestake_address,              // Sidestake address
-                        allocation,                     // Sidestake allocation
-                        description,                    // Sidestake description
-                        GRC::SideStakeStatus::MANDATORY // sidestake status
-                        );
+                contract_version,                                            // Contract version number (3+)
+                action,                                                      // Contract action
+                uint32_t {1},                                                // Contract payload version number
+                sidestake_address,                                           // Sidestake address
+                allocation,                                                  // Sidestake allocation
+                description,                                                 // Sidestake description
+                GRC::MandatorySideStake::MandatorySideStakeStatus::MANDATORY // sidestake status
+                );
         } else {
              throw JSONRPCError(RPC_INVALID_PARAMETER, "Sidestake contracts are not valid for block version less than v13.");
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2485,7 +2485,7 @@ UniValue addkey(const UniValue& params, bool fHelp)
             // We have to do our own conversion here because the 4th parameter type specifier cannot be set other
             // than string in the client.cpp file.
             double allocation = 0.0;
-            if (!ParseDouble(params[3].get_str(), &allocation)) {
+            if (params.size() > 3 && !ParseDouble(params[3].get_str(), &allocation)) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid allocation specified.");
             }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -201,7 +201,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "superblocks"            , 1 },
 
     // Developer
-    { "addkey"                 , 4 },
     { "auditsnapshotaccrual"   , 1 },
     { "auditsnapshotaccruals"  , 0 },
     { "beaconaudit"            , 0 },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -117,7 +117,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     // sidestakes are always included.
     for (const auto& alloc : vSideStakeAlloc)
     {
-        sidestakingalloc.pushKV("address", alloc->m_key.ToString());
+        sidestakingalloc.pushKV("address", alloc->m_address.ToString());
         sidestakingalloc.pushKV("allocation_pct", alloc->m_allocation * 100);
         sidestakingalloc.pushKV("status", alloc->StatusToString());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -117,7 +117,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     // sidestakes are always included.
     for (const auto& alloc : vSideStakeAlloc)
     {
-        sidestakingalloc.pushKV("address", alloc->GetAddress().ToString());
+        sidestakingalloc.pushKV("address", CBitcoinAddress(alloc->GetDestination()).ToString());
         sidestakingalloc.pushKV("allocation_pct", alloc->GetAllocation() * 100);
         sidestakingalloc.pushKV("status", alloc->StatusToString());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -108,7 +108,8 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     }
     obj.pushKV("stake-splitting", stakesplitting);
 
-    vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
+    // This is what the miner sees...
+    vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(false, false);
 
     sidestaking.pushKV("local_side_staking_enabled", fEnableSideStaking);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -110,20 +110,20 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     }
     obj.pushKV("stake-splitting", stakesplitting);
 
-    sidestaking.pushKV("side-staking-enabled", fEnableSideStaking);
-    if (fEnableSideStaking)
-    {
-        for (const auto& alloc : vSideStakeAlloc)
-        {
-            sidestakingalloc.pushKV("address", alloc->m_key.ToString());
-            sidestakingalloc.pushKV("allocation-pct", alloc->m_allocation * 100);
-            sidestakingalloc.pushKV("status", alloc->StatusToString());
+    sidestaking.pushKV("local_side_staking_enabled", fEnableSideStaking);
 
-            vsidestakingalloc.push_back(sidestakingalloc);
-        }
-        sidestaking.pushKV("side-staking-allocations", vsidestakingalloc);
+    // Note that if local_side_staking_enabled is true, then local sidestakes will be applicable and shown. Mandatory
+    // sidestakes are always included.
+    for (const auto& alloc : vSideStakeAlloc)
+    {
+        sidestakingalloc.pushKV("address", alloc->m_key.ToString());
+        sidestakingalloc.pushKV("allocation_pct", alloc->m_allocation * 100);
+        sidestakingalloc.pushKV("status", alloc->StatusToString());
+
+        vsidestakingalloc.push_back(sidestakingalloc);
     }
-    obj.pushKV("side-staking", sidestaking);
+    sidestaking.pushKV("side_staking_allocations", vsidestakingalloc);
+    obj.pushKV("side_staking", sidestaking);
 
     obj.pushKV("difficulty",    diff);
     obj.pushKV("errors",        GetWarnings("statusbar"));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -98,7 +98,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
 
     bool fEnableSideStaking = gArgs.GetBoolArg("-enablesidestaking");
 
-    if (fEnableSideStaking) vSideStakeAlloc = GetSideStakingStatusAndAlloc();
+    if (fEnableSideStaking) vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
 
     stakesplitting.pushKV("stake-splitting-enabled", fEnableStakeSplit);
     if (fEnableStakeSplit)
@@ -115,8 +115,8 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     {
         for (const auto& alloc : vSideStakeAlloc)
         {
-            sidestakingalloc.pushKV("address", alloc.first);
-            sidestakingalloc.pushKV("allocation-pct", alloc.second * 100);
+            sidestakingalloc.pushKV("address", alloc->m_key.ToString());
+            sidestakingalloc.pushKV("allocation-pct", alloc->m_allocation * 100);
 
             vsidestakingalloc.push_back(sidestakingalloc);
         }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -117,8 +117,8 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     // sidestakes are always included.
     for (const auto& alloc : vSideStakeAlloc)
     {
-        sidestakingalloc.pushKV("address", alloc->m_address.ToString());
-        sidestakingalloc.pushKV("allocation_pct", alloc->m_allocation * 100);
+        sidestakingalloc.pushKV("address", alloc->GetAddress().ToString());
+        sidestakingalloc.pushKV("allocation_pct", alloc->GetAllocation() * 100);
         sidestakingalloc.pushKV("status", alloc->StatusToString());
 
         vsidestakingalloc.push_back(sidestakingalloc);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -117,6 +117,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
         {
             sidestakingalloc.pushKV("address", alloc->m_key.ToString());
             sidestakingalloc.pushKV("allocation-pct", alloc->m_allocation * 100);
+            sidestakingalloc.pushKV("status", alloc->StatusToString());
 
             vsidestakingalloc.push_back(sidestakingalloc);
         }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -98,8 +98,6 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
 
     bool fEnableSideStaking = gArgs.GetBoolArg("-enablesidestaking");
 
-    if (fEnableSideStaking) vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
-
     stakesplitting.pushKV("stake-splitting-enabled", fEnableStakeSplit);
     if (fEnableStakeSplit)
     {
@@ -109,6 +107,8 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
         stakesplitting.pushKV("stake-splitting-params", stakesplittingparam);
     }
     obj.pushKV("stake-splitting", stakesplitting);
+
+    vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries();
 
     sidestaking.pushKV("local_side_staking_enabled", fEnableSideStaking);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -109,7 +109,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     obj.pushKV("stake-splitting", stakesplitting);
 
     // This is what the miner sees...
-    vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(false, false);
+    vSideStakeAlloc = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, false);
 
     sidestaking.pushKV("local_side_staking_enabled", fEnableSideStaking);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -118,7 +118,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     for (const auto& alloc : vSideStakeAlloc)
     {
         sidestakingalloc.pushKV("address", CBitcoinAddress(alloc->GetDestination()).ToString());
-        sidestakingalloc.pushKV("allocation_pct", alloc->GetAllocation() * 100);
+        sidestakingalloc.pushKV("allocation_pct", alloc->GetAllocation().ToPercent());
         sidestakingalloc.pushKV("status", alloc->StatusToString());
 
         vsidestakingalloc.push_back(sidestakingalloc);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -253,7 +253,7 @@ UniValue SideStakePayloadToJson (const GRC::ContractPayload& payload)
     UniValue out(UniValue::VOBJ);
 
     out.pushKV("address", CBitcoinAddress(sidestake.m_entry.m_destination).ToString());
-    out.pushKV("allocation", sidestake.m_entry.m_allocation);
+    out.pushKV("allocation", sidestake.m_entry.m_allocation.ToPercent());
     out.pushKV("description", sidestake.m_entry.m_description);
     out.pushKV("status", sidestake.m_entry.StatusToString());
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -11,6 +11,7 @@
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/mrc.h"
 #include "gridcoin/project.h"
+#include "gridcoin/sidestake.h"
 #include "gridcoin/staking/difficulty.h"
 #include "gridcoin/superblock.h"
 #include "gridcoin/support/block_finder.h"
@@ -245,6 +246,20 @@ UniValue VotePayloadToJson(const GRC::ContractPayload& payload)
     return out;
 }
 
+UniValue SideStakePayloadToJson (const GRC::ContractPayload& payload)
+{
+    const auto& sidestake = payload.As<GRC::SideStakePayload>();
+
+    UniValue out(UniValue::VOBJ);
+
+    out.pushKV("address", CBitcoinAddress(sidestake.m_entry.m_destination).ToString());
+    out.pushKV("allocation", sidestake.m_entry.m_allocation);
+    out.pushKV("description", sidestake.m_entry.m_description);
+    out.pushKV("status", sidestake.m_entry.StatusToString());
+
+    return out;
+}
+
 UniValue LegacyVotePayloadToJson(const GRC::ContractPayload& payload)
 {
     const auto& vote = payload.As<GRC::LegacyVote>();
@@ -294,6 +309,9 @@ UniValue ContractToJson(const GRC::Contract& contract)
             break;
         case GRC::ContractType::MRC:
             out.pushKV("body", MRCToJson(contract.CopyPayloadAs<GRC::MRC>()));
+            break;
+        case GRC::ContractType::SIDESTAKE:
+            out.pushKV("body", SideStakePayloadToJson(contract.SharePayload()));
             break;
         default:
             out.pushKV("body", LegacyContractPayloadToJson(contract.SharePayload()));

--- a/src/script.h
+++ b/src/script.h
@@ -17,6 +17,7 @@
 #include "keystore.h"
 #include "prevector.h"
 #include <util/hash_type.h>
+#include "serialize.h"
 #include "wallet/ismine.h"
 
 typedef std::vector<unsigned char> valtype;
@@ -30,7 +31,14 @@ public:
     CScriptID() : BaseHash() {}
     explicit CScriptID(const CScript& in);
     explicit CScriptID(const uint160& in) : BaseHash(in) {}
-//    explicit CScriptID(const ScriptHash& in);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(m_hash);
+    }
 };
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
@@ -85,6 +93,13 @@ public:
     friend bool operator==(const CNoDestination &a, const CNoDestination &b) { return true; }
     friend bool operator!=(const CNoDestination &a, const CNoDestination &b) { return false; }
     friend bool operator<(const CNoDestination &a, const CNoDestination &b) { return true; }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {}
+
 };
 
 /** A txout script template with a specific destination. It is either:

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(test_gridcoin
     gridcoin/protocol_tests.cpp
     gridcoin/researcher_tests.cpp
     gridcoin/scraper_registry_tests.cpp
+    gridcoin/sidestake_tests.cpp
     gridcoin/superblock_tests.cpp
     key_tests.cpp
     merkle_tests.cpp

--- a/src/test/gridcoin/sidestake_tests.cpp
+++ b/src/test/gridcoin/sidestake_tests.cpp
@@ -22,6 +22,30 @@ BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_trivial)
     BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
 }
 
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double_below_minimum)
+{
+    GRC::Allocation allocation((double) 0.0000499999);
+
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), true);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), false);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double_minimum)
+{
+    GRC::Allocation allocation((double) 0.0001);
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 1);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 10000);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), false);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), true);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+}
+
 BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double)
 {
     GRC::Allocation allocation((double) 0.0005);
@@ -33,6 +57,45 @@ BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double)
     BOOST_CHECK_EQUAL(allocation.IsPositive(), true);
     BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
     BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double_one_percent)
+{
+    GRC::Allocation allocation((double) 0.01);
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 1);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 100);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), false);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), true);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double_just_below_unity)
+{
+    GRC::Allocation allocation((double) 0.9999);
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 9999);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 10000);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), false);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), true);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double_maximum_before_multiplication)
+{
+    GRC::Allocation allocation((double) 1.0);
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 1);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 1);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), false);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), true);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 1);
 }
 
 BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_fraction)
@@ -69,7 +132,7 @@ BOOST_AUTO_TEST_CASE(sidestake_Allocation_multiplication_and_derivation_of_alloc
 
     // Allocations that are initialized from doubles are rounded to the nearest 1/10000. This is the worst case
     // therefore, in terms of numerator and denominator.
-    GRC::Allocation allocation(Fraction(9999, 10000, true));
+    GRC::Allocation allocation(0.9999);
 
     BOOST_CHECK_EQUAL(allocation.GetNumerator(), 9999);
     BOOST_CHECK_EQUAL(allocation.GetDenominator(), 10000);
@@ -77,16 +140,8 @@ BOOST_AUTO_TEST_CASE(sidestake_Allocation_multiplication_and_derivation_of_alloc
 
     CAmount max_accrual = 16384 * COIN;
 
-    CAmount output = static_cast<GRC::Allocation>(allocation * max_accrual).ToCAmount();
-
-    BOOST_CHECK_EQUAL(output, int64_t {1638236160000});
-
-    GRC::Allocation computed_output_alloc(Fraction(output, max_accrual, true));
-
-    // This is what the mandatory sidestake validation does at its core. The actual check is >=
-    // because it is allowed for the output to have an allocation to the destination greater than required.
-    // This test is for exactness, so it is checking whether it is equal.
-    BOOST_CHECK(computed_output_alloc == allocation);
+    CAmount actual_output = static_cast<GRC::Allocation>(allocation * max_accrual).ToCAmount();
+    BOOST_CHECK_EQUAL(actual_output, int64_t {1638236160000});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/sidestake_tests.cpp
+++ b/src/test/gridcoin/sidestake_tests.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2024 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include <util.h>
+#include <gridcoin/sidestake.h>
+
+BOOST_AUTO_TEST_SUITE(sidestake_tests)
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_trivial)
+{
+    GRC::Allocation allocation;
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 0);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 1);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), true);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), false);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_double)
+{
+    GRC::Allocation allocation((double) 0.0005);
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 1);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 2000);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), false);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), true);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_from_fraction)
+{
+    GRC::Allocation allocation(Fraction(2500, 10000));
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 2500);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 10000);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), false);
+    BOOST_CHECK_EQUAL(allocation.IsZero(), false);
+    BOOST_CHECK_EQUAL(allocation.IsPositive(), true);
+    BOOST_CHECK_EQUAL(allocation.IsNonNegative(), true);
+    BOOST_CHECK_EQUAL(allocation.ToCAmount(), (CAmount) 0);
+
+    allocation.Simplify();
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 1);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 4);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_ToPercent)
+{
+    GRC::Allocation allocation((double) 0.0005);
+
+    BOOST_CHECK(std::abs(allocation.ToPercent() - (double) 0.05) < 1e-08);
+}
+
+BOOST_AUTO_TEST_CASE(sidestake_Allocation_multiplication_and_derivation_of_allocation)
+{
+    // Multiplication is a very common operation with Allocations, because
+    // the general pattern is to multiply the allocation times a CAmount rewards
+    // to determine the rewards in Halfords (CAmount) to put on the output.
+
+    // Allocations that are initialized from doubles are rounded to the nearest 1/10000. This is the worst case
+    // therefore, in terms of numerator and denominator.
+    GRC::Allocation allocation(Fraction(9999, 10000, true));
+
+    BOOST_CHECK_EQUAL(allocation.GetNumerator(), 9999);
+    BOOST_CHECK_EQUAL(allocation.GetDenominator(), 10000);
+    BOOST_CHECK_EQUAL(allocation.IsSimplified(), true);
+
+    CAmount max_accrual = 16384 * COIN;
+
+    CAmount output = static_cast<GRC::Allocation>(allocation * max_accrual).ToCAmount();
+
+    BOOST_CHECK_EQUAL(output, int64_t {1638236160000});
+
+    GRC::Allocation computed_output_alloc(Fraction(output, max_accrual, true));
+
+    // This is what the mandatory sidestake validation does at its core. The actual check is >=
+    // because it is allowed for the output to have an allocation to the destination greater than required.
+    // This test is for exactness, so it is checking whether it is equal.
+    BOOST_CHECK(computed_output_alloc == allocation);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1476,4 +1476,12 @@ BOOST_AUTO_TEST_CASE(util_Fraction_logic_negation)
     BOOST_CHECK_EQUAL(!Fraction(), true);
 }
 
+BOOST_AUTO_TEST_CASE(util_Fraction_ToString)
+{
+    Fraction fraction(123, 10000);
+
+    BOOST_CHECK_EQUAL(fraction.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(fraction.ToString(),"123/10000");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.h
+++ b/src/util.h
@@ -557,8 +557,17 @@ public:
 private:
     int msb(const int64_t& n) const
     {
-        // Log2 is O(1) both time and space-wise and so is the best choice here.
-        return (static_cast<int>(floor(log2(std::abs(n)))));
+        int64_t abs_n = std::abs(n);
+
+        int index = 0;
+
+        for (; index <= 63; ++index) {
+            if (abs_n >> index == 0) {
+                break;
+            }
+        }
+
+        return index;
     }
 
     int64_t overflow_mult(const int64_t& a, const int64_t& b) const

--- a/src/util.h
+++ b/src/util.h
@@ -6,11 +6,13 @@
 #ifndef BITCOIN_UTIL_H
 #define BITCOIN_UTIL_H
 
+#include "arith_uint256.h"
 #include "uint256.h"
 #include "fwd.h"
 #include "hash.h"
 
 #include <memory>
+#include <numeric>
 #include <utility>
 #include <map>
 #include <vector>
@@ -160,27 +162,118 @@ inline int64_t abs64(int64_t n)
     return (n >= 0 ? n : -n);
 }
 
-// Small class to represent fractions. We could do more sophisticated things like reduction using GCD, and overloaded
-// multiplication, but we don't need it, because this is used in very limited places, and we actually in many of the
-// algorithms where this needs to be used need to carefully control the order of multiplication and division using the
-// numerator and denominator.
+//!
+//! \brief Class to represent fractions and common fraction operations with built in simplification. This supports integer operations
+//! for consensus critical code where floating point would cause problems across different architectures and/or compiler
+//! implementations.
+//!
+//! In particular this class is used for sidestake allocations, both the allocation "percentage", and the CAmount allocations
+//! resulting from muliplying the allocation (fraction) times the CAmount rewards.
+//!
 class Fraction {
 public:
-    Fraction() {}
+    //!
+    //! \brief Trivial zero fraction constructor
+    //!
+    Fraction()
+        : m_numerator(0)
+        , m_denominator(1)
+        , m_simplified(true)
+    {}
 
+    //!
+    //! \brief Copy constructor
+    //!
+    //! \param Fraction f
+    //!
+    Fraction(const Fraction& f)
+        : Fraction(f.GetNumerator(), f.GetDenominator())
+    {}
+
+    //!
+    //! \brief Constructor with simplification boolean directive
+    //!
+    //! \param Fraction f
+    //! \param boolean simplify
+    //!
+    Fraction(const Fraction& f, const bool& simplify)
+        : Fraction(f.GetNumerator(), f.GetDenominator(), simplify)
+    {}
+
+    //!
+    //! \brief Constructor from numerator and denominator
+    //!
+    //! \param in64t_t numerator
+    //! \param int64_t denominator
+    //!
     Fraction(const int64_t& numerator,
              const int64_t& denominator)
         : m_numerator(numerator)
         , m_denominator(denominator)
+        , m_simplified(false)
     {
         if (m_denominator == 0) {
             throw std::out_of_range("denominator specified is zero");
         }
+
+        if (std::gcd(m_numerator, m_denominator) == 1 && m_denominator > 0) {
+            m_simplified = true;
+        }
     }
 
-    bool isNonZero()
+    //!
+    //! \brief Constructor from numerator and denominator with simplification boolean directive
+    //!
+    //! \param int64_t numerator
+    //! \param int64_t denominator
+    //! \param boolean simplify
+    //!
+    Fraction(const int64_t& numerator,
+             const int64_t& denominator,
+             const bool& simplify)
+        : Fraction(numerator, denominator)
     {
-        return m_denominator != 0 && m_numerator != 0;
+        if (!m_simplified && simplify) {
+            Simplify();
+        }
+    }
+
+    ~Fraction()
+    {}
+
+    //!
+    //! \brief Constructor from input int64_t integer (i.e. denominator = 1).
+    //!
+    //! \param numerator
+    //!
+    Fraction(const int64_t& numerator)
+        : Fraction(numerator, 1)
+    {}
+
+    bool IsZero() const
+    {
+        // The denominator cannot be zero by construction rules.
+        return m_numerator == 0;
+    }
+
+    bool IsNonZero() const
+    {
+        return !IsZero();
+    }
+
+    bool IsPositive() const
+    {
+        return (m_denominator > 0 && m_numerator > 0) || (m_denominator < 0 && m_numerator < 0);
+    }
+
+    bool IsNonNegative() const
+    {
+        return IsPositive() || IsZero();
+    }
+
+    bool IsNegative() const
+    {
+        return !IsNonNegative();
     }
 
     constexpr int64_t GetNumerator() const
@@ -193,9 +286,326 @@ public:
         return m_denominator;
     }
 
+    bool IsSimplified() const
+    {
+        return m_simplified;
+    }
+
+    void Simplify()
+    {
+        // Check whether already simplified, if so, nothing to do.
+        if (m_simplified) {
+            return;
+        }
+
+        // Nice that we are at C++17! :)
+        int64_t gcd = std::gcd(m_numerator, m_denominator);
+
+        // If both numerator and denominator are negative,
+        // change the sign of gcd to flip both to positive.
+        if (m_numerator < 0 && m_denominator < 0) {
+            gcd = -gcd;
+        }
+
+        m_numerator = m_numerator / gcd;
+        m_denominator = m_denominator / gcd;
+
+        // Since the case where both are less than zero has already been changed to +/+,
+        // If we have m_denominator < 0, we must have m_numerator >= 0. So move the negative
+        // sign to the numerator and make the denominator positive. This simplifies the equality
+        // comparison.
+        if (m_denominator < 0) {
+            m_denominator = -m_denominator;
+            m_numerator = -m_numerator;
+        }
+
+        m_simplified = true;
+    }
+
+    double ToDouble() const
+    {
+        return (double) m_numerator / (double) m_denominator;
+    }
+
+    Fraction operator=(const Fraction& rhs)
+    {
+        m_numerator = rhs.GetNumerator();
+        m_denominator = rhs.GetDenominator();
+
+        return *this;
+    }
+
+    bool operator!()
+    {
+        return IsZero();
+    }
+
+    Fraction operator+(const Fraction& rhs) const
+    {
+        Fraction slhs(*this, true);
+        Fraction srhs(rhs, true);
+
+        // If the same denominator (and remember these are already reduced to simplest form) just add the numerators and put
+        // over the common denominator...
+        if (slhs.GetDenominator() == srhs.GetDenominator()) {
+            return Fraction(overflow_add(slhs.GetNumerator(), srhs.GetNumerator()), slhs.GetDenominator(), true);
+        }
+
+        // Otherwise do the full pattern of getting a common denominator and adding, then simplify...
+        return Fraction(overflow_add(overflow_mult(slhs.GetNumerator(), srhs.GetDenominator()),
+                                     overflow_mult(slhs.GetDenominator(), srhs.GetNumerator())),
+                        overflow_mult(slhs.GetDenominator(), srhs.GetDenominator()),
+                        true);
+    }
+
+    Fraction operator+(const int64_t& rhs) const
+    {
+        Fraction slhs(*this, true);
+
+        return Fraction(overflow_add(slhs.GetNumerator(), overflow_mult(slhs.GetDenominator(), rhs)), slhs.GetDenominator(), true);
+    }
+
+    Fraction operator-(const Fraction& rhs) const
+    {
+        return (*this + Fraction(-rhs.GetNumerator(), rhs.GetDenominator()));
+    }
+
+    Fraction operator-(const int64_t& rhs) const
+    {
+        return (*this + -rhs);
+    }
+
+    Fraction operator*(const Fraction& rhs) const
+    {
+        Fraction slhs(*this, true);
+        Fraction srhs(rhs, true);
+
+        return Fraction(overflow_mult(slhs.GetNumerator(), srhs.GetNumerator()),
+                        overflow_mult(slhs.GetDenominator(), srhs.GetDenominator()),
+                        true);
+    }
+
+    Fraction operator*(const int64_t& rhs) const
+    {
+        Fraction slhs(*this, true);
+
+        return Fraction(overflow_mult(slhs.GetNumerator(), rhs), slhs.GetDenominator(), true);
+    }
+
+    Fraction operator/(const Fraction& rhs) const
+    {
+        return (*this * Fraction(rhs.GetDenominator(), rhs.GetNumerator()));
+    }
+
+    Fraction operator/(const int64_t& rhs) const
+    {
+        Fraction slhs(*this, true);
+
+        return Fraction(slhs.GetNumerator(), overflow_mult(slhs.GetDenominator(), rhs), true);
+    }
+
+    Fraction operator+=(const Fraction& rhs)
+    {
+        Simplify();
+
+        *this = *this + rhs;
+
+        return *this;
+    }
+
+    Fraction operator+=(const int64_t& rhs)
+    {
+        Simplify();
+
+        *this = *this + rhs;
+
+        return *this;
+    }
+
+    Fraction operator-=(const Fraction& rhs)
+    {
+        Simplify();
+
+        *this = *this - rhs;
+
+        return *this;
+    }
+
+    Fraction operator-=(const int64_t& rhs)
+    {
+        Simplify();
+
+        *this = *this - rhs;
+
+        return *this;
+    }
+
+    Fraction operator*=(const Fraction& rhs)
+    {
+        Simplify();
+
+        *this = *this * rhs;
+
+        return *this;
+    }
+
+    Fraction operator*=(const int64_t& rhs)
+    {
+        Simplify();
+
+        *this = *this * rhs;
+
+        return *this;
+    }
+
+    Fraction operator/=(const Fraction& rhs)
+    {
+        Simplify();
+
+        *this = *this / rhs;
+
+        return *this;
+    }
+
+    Fraction operator/=(const int64_t& rhs)
+    {
+        Simplify();
+
+        *this = *this / rhs;
+
+        return *this;
+    }
+
+    bool operator==(const Fraction& rhs) const
+    {
+        Fraction slhs(*this, true);
+        Fraction srhs(rhs, true);
+
+        return (slhs.GetNumerator() == srhs.GetNumerator() && slhs.GetDenominator() == slhs.GetDenominator());
+    }
+
+    bool operator!=(const Fraction& rhs) const
+    {
+        return !(*this == rhs);
+    }
+
+    bool operator<=(const Fraction& rhs) const
+    {
+        return (rhs - *this).IsNonNegative();
+    }
+
+    bool operator>=(const Fraction& rhs) const
+    {
+        return (*this - rhs).IsNonNegative();
+    }
+
+    bool operator<(const Fraction& rhs) const
+    {
+        return (rhs - *this).IsPositive();
+    }
+
+    bool operator>(const Fraction& rhs) const
+    {
+        return (*this - rhs).IsPositive();
+    }
+
+    bool operator==(const int64_t& rhs) const
+    {
+        return (*this == Fraction(rhs));
+    }
+
+    bool operator!=(const int64_t& rhs) const
+    {
+        return !(*this == rhs);
+    }
+
+    bool operator<=(const int64_t& rhs) const
+    {
+        return *this <= Fraction(rhs);
+    }
+
+    bool operator>=(const int64_t& rhs) const
+    {
+        return *this >= Fraction(rhs);
+    }
+
+    bool operator<(const int64_t& rhs) const
+    {
+        return *this < Fraction(rhs);
+    }
+
+    bool operator>(const int64_t& rhs) const
+    {
+        return *this > Fraction(rhs);
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(m_numerator);
+        READWRITE(m_denominator);
+        READWRITE(m_simplified);
+    }
+
 private:
-    int64_t m_numerator = 0;
-    int64_t m_denominator = 1;
+    int msb(const int64_t& n) const
+    {
+        // Log2 is O(1) both time and space-wise and so is the best choice here.
+        return (static_cast<int>(floor(log2(std::abs(n)))));
+    }
+
+    int64_t overflow_mult(const int64_t& a, const int64_t& b) const
+    {
+        if (a == 0 || b == 0) {
+            return 0;
+        }
+
+        // A 64-bit integer with the lower 32 bits filled has value 2^32 - 1. Multiplying two of these, a * b, together
+        // is (2^32 - 1) * (2^32 - 1) = 2^64 - 2^33 + 1 > 2^63. Log2(2^63) = msb(a) + msb(b) - 1. So a quick overflow limit...
+
+        if (msb(a) + msb(b) > 63) {
+            throw std::overflow_error("fraction multiplication results in an overflow");
+        }
+
+        return a * b;
+    }
+
+    int64_t overflow_add(const int64_t& a, const int64_t& b) const
+    {
+        if (a == 0) {
+            return b;
+        }
+
+        if (b == 0) {
+            return a;
+        }
+
+        if (a > 0 && b > 0) {
+            if (a <= std::numeric_limits<int64_t>::max() - b) {
+                return a + b;
+            } else {
+                throw std::overflow_error("fraction addition of a + b where a > 0 and b > 0 results in an overflow");
+            }
+        }
+
+        if (a < 0 && b < 0) {
+            // Remember b is negative here, so the difference below is GREATER than std::numeric_limits<int64_t>::min().
+            if (a >= std::numeric_limits<int64_t>::min() - b) {
+                return a + b;
+            } else {
+                throw std::overflow_error("fraction addition of a + b where a < 0 and b < 0 results in an overflow");
+            }
+        }
+
+        // The only thing left is that a and b are opposite in sign, so addition cannot overflow.
+        return a + b;
+    }
+
+    int64_t m_numerator;
+    int64_t m_denominator;
+    bool m_simplified;
 };
 
 inline std::string leftTrim(std::string src, char chr)

--- a/src/util.h
+++ b/src/util.h
@@ -335,6 +335,11 @@ public:
         return *this;
     }
 
+    std::string ToString() const
+    {
+        return strprintf("%" PRId64 "/" "%" PRId64, m_numerator, m_denominator);
+    }
+
     bool operator!()
     {
         return IsZero();

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -21,6 +21,7 @@ static const std::string SAFE_CHARS[] =
     CHARS_ALPHA_NUM + " .,;-_?@", // SAFE_CHARS_UA_COMMENT
     CHARS_ALPHA_NUM + ".-_", // SAFE_CHARS_FILENAME
     CHARS_ALPHA_NUM + "!*'();:@&=+$,/?#[]-_.~%", // SAFE_CHARS_URI
+    CHARS_ALPHA_NUM + " .-_" // SAFE_CHARS_CSV
 };
 
 std::string SanitizeString(const std::string& str, int rule)

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -28,6 +28,7 @@ enum SafeChars
     SAFE_CHARS_UA_COMMENT, //!< BIP-0014 subset
     SAFE_CHARS_FILENAME, //!< Chars allowed in filenames
     SAFE_CHARS_URI, //!< Chars allowed in URIs (RFC 3986)
+    SAFE_CHARS_CSV //!< Chars allowed in fields stored as comma separated values
 };
 
 /**

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "node/ui_interface.h"
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <util/check.h>
@@ -1154,6 +1155,9 @@ bool updateRwSetting(const std::string& name, const util::SettingsValue& value)
             settings.rw_settings[name] = value;
         }
     });
+
+    uiInterface.RwSettingsUpdated();
+
     return gArgs.WriteSettingsFile();
 }
 
@@ -1169,6 +1173,9 @@ bool updateRwSettings(const std::vector<std::pair<std::string, util::SettingsVal
             }
         }
     });
+
+    uiInterface.RwSettingsUpdated();
+
     return gArgs.WriteSettingsFile();
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -844,7 +844,7 @@ private:
                 // For block version 13 and higher, check to ensure that mandatory sidestakes appear as outputs with the correct
                 // allocations.
                 if (m_block.nVersion >= 13) {
-                    // Record the script public key for the base coinstake so we can reuse.
+                    // Record the base coinstake destination.
                     CTxDestination coinstake_destination;
                     ExtractDestination(m_block.vtx[1].vout[1].scriptPubKey, coinstake_destination);
 
@@ -867,6 +867,7 @@ private:
 
                     unsigned int validated_mandatory_sidestakes = 0;
 
+                    // Skip the empty output at index 0, stop at the index before the start of MRC's.
                     for (unsigned int i = 1; i < mrc_start_index; ++i) {
                         CTxDestination output_destination;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -889,7 +889,7 @@ private:
                             CAmount required_output = static_cast<GRC::Allocation>(mandatory_sidestake[0]->GetAllocation()
                                                                                    * total_owed_to_staker).ToCAmount();
 
-                            if (actual_output == required_output) {
+                            if (actual_output >= required_output) {
 
                                 ++validated_mandatory_sidestakes;
                             } else {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1934,6 +1934,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
             || (IsV10Enabled(nHeight) && block.nVersion < 10)
             || (IsV11Enabled(nHeight) && block.nVersion < 11)
             || (IsV12Enabled(nHeight) && block.nVersion < 12)
+            || (IsV13Enabled(nHeight) && block.nVersion < 13)
             ) {
         return block.DoS(20, error("%s: reject too old nVersion = %d", __func__, block.nVersion));
     } else if ((!IsProtocolV2(nHeight) && block.nVersion >= 7)
@@ -1942,6 +1943,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
                || (!IsV10Enabled(nHeight) && block.nVersion >= 10)
                || (!IsV11Enabled(nHeight) && block.nVersion >= 11)
                || (!IsV12Enabled(nHeight) && block.nVersion >= 12)
+               || (!IsV13Enabled(nHeight) && block.nVersion >= 13)
                ) {
         return block.DoS(100, error("%s: reject too new nVersion = %d", __func__, block.nVersion));
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -109,6 +109,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me);
 bool CheckBlockSignature(const CBlock& block);
 
 unsigned int GetCoinstakeOutputLimit(const int& block_version);
+unsigned int GetMandatorySideStakeOutputLimit(const int& block_version);
 Fraction FoundationSideStakeAllocation();
 CBitcoinAddress FoundationSideStakeAddress();
 unsigned int GetMRCOutputLimit(const int& block_version, bool include_foundation_sidestake);


### PR DESCRIPTION
This PR is responsive to longstanding feature requests regarding sidestaking. It formalizes the SideStake class in Gridcoin and changes the core to use this class rather than simply pulling from the config repeatedly. The registry pattern for other contracts with db backing has been used to support mandatory (contract originated) sidestakes as a future-proofing for sidestake functionality, especially as it relates to the planned benefactor next layer. Mandatory sidestakes will not be available until block v13, the next major protocol change (mandatory), but the local sidestake facilities work correctly now. _**[Update - mandatory sidestake operation post block v13 fork has been tested, debugged, and verified to operate correctly by using an isolated test network forked from testnet for v13 testing.]**_

~~Validation of coinstake transactions by stakers on AcceptBlock to ensure that mandated sidestakes are present with the correct allocation has not yet been implemented. This will be implemented by another PR as we get closer to a v13 hardfork.~~ Full mandatory sidestake validation for block v13+ has been implemented.

The SideStakeRegistry supports both contract originated (mandatory) and local (optional) sidestakes, the latter of which are backed by the client configs. Proper triggering via core signal of the updating of the registry on using changesettings to dynamically change the sidestaking using the command line has been implemented. This allows the miner to simply do an in memory call rather than the more expensive calls to GetArg each miner loop invocations.

Sidestakes can now have descriptions and also have a status. The status values are for local sidestakes
    ACTIVE,         //!< A user specified sidestake that is active
    INACTIVE,       //!< A user specified sidestake that is inactive

For mandatory sidestakes
    DELETED,        //!< A mandatory sidestake that has been deleted by contract
    MANDATORY,      //!< An active mandatory sidestake by contract

A table view has been added to the options dialog on the staking tab to allow viewing and editing the sidestakes. Only user specified (local - optional) sidestakes can be edited. Editing can be done in place or using the edit button.

Note that the PR is flagged mandatory since it includes code that activates at the next block version, although the GUI part of the PR along with local sidestaking functions beforehand.

The sidestake table in options...
![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/cce6a8e6-c69e-4d46-a391-09114e1166eb)

Adding a new local sidestake...
![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/6c9792b6-e50d-4754-b2de-33ef50b62bd1)

Editing an existing sidestake in place...
![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/244f7623-fd64-428a-a2be-0ccfe7842417)

Trying to put in an invalid allocation (i.e. total adds up to more than 100%)...
![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/250e473e-da28-43d8-af18-8c3012ff31aa)

Editing an existing sidestake using the edit button...
![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/e26c3344-7466-4cf2-bb9b-8542d684aeae)

Address validity is checked for the sidestakes on add, and also when signaled from the core.

Note that the maximum total allocation that can be assigned to mandatory sidestakes is 0.25 (25%).

Note that using changesettings rpc to change the settings via the core side will result in a change in the GUI via automatic update of the core and signaling to the GUI model and view.

Here is where the sidestake "state" is stored for local sidestakes. It goes into the gridcoinsettings.json file.
![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/a12682ce-ff4d-483c-aa22-c8ec5f3fd259)

If there are traditional sidestake entries in the read-only config file, gridcoinresearch.conf, these will be properly picked up for the core and GUI. If any new sidestake is inserted or edit is made, override values in the new format will be placed into the json file and take precedence over what is in the conf file.

Here is a short video demonstrating the new functionality...
https://www.youtube.com/watch?v=Iy1f5lT71Rk