### PR TITLE
gui: Fix filter by type in Transaction View

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -1,6 +1,7 @@
 #include "transactionrecord.h"
 #include "wallet/wallet.h"
 #include "base58.h"
+#include <QObject>
 
 /* Return positive answer if transaction should be shown in list. */
 bool TransactionRecord::showTransaction(const CWalletTx &wtx, bool datetime_limit_flag, const int64_t &datetime_limit)
@@ -359,6 +360,54 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     }
 
     return parts;
+}
+
+QString TransactionRecord::TypeToString() const
+{
+    return TypeToString(type);
+}
+
+QString TransactionRecord::TypeToString(const Type& type, const bool& translated)
+{
+    if (translated) {
+        switch(type) {
+        case Other:                 return QObject::tr("Other");
+        case Generated:             return QObject::tr("Mined");
+        case SendToAddress:         return QObject::tr("Sent to Address");
+        case SendToOther:           return QObject::tr("Sent to Other");
+        case RecvWithAddress:       return QObject::tr("Received with Address");
+        case RecvFromOther:         return QObject::tr("Received from Other");
+        case SendToSelf:            return QObject::tr("Self");
+        case BeaconAdvertisement:   return QObject::tr("Beacon Advertisements");
+        case Poll:                  return QObject::tr("Polls");
+        case Vote:                  return QObject::tr("Votes");
+        case Message:               return QObject::tr("Messages");
+        case MRC:                   return QObject::tr("MRCs");
+        }
+
+        assert(false); // Suppress warning
+    } else {
+        switch(type) {
+        case Other:                 return "Other";
+        case Generated:             return "Mined";
+        case SendToAddress:         return "Sent to Address";
+        case SendToOther:           return "Sent to Other";
+        case RecvWithAddress:       return "Received with Address";
+        case RecvFromOther:         return "Received from Other";
+        case SendToSelf:            return "Self";
+        case BeaconAdvertisement:   return "Beacon Advertisements";
+        case Poll:                  return "Polls";
+        case Vote:                  return "Votes";
+        case Message:               return "Messages";
+        case MRC:                   return "MRCs";
+        }
+
+        assert(false); // Suppress warning
+    }
+
+    // This will never be reached. Put it in anyway to prevent control reaches end of non-void function warning
+    // from some compiler versions.
+    return QString{};
 }
 
 void TransactionRecord::updateStatus(const CWalletTx &wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -87,6 +87,18 @@ public:
         MRC
     };
 
+    static constexpr std::initializer_list<Type> TYPES {Other,
+                                                       Generated,
+                                                       SendToAddress,
+                                                       RecvWithAddress,
+                                                       RecvFromOther,
+                                                       SendToSelf,
+                                                       BeaconAdvertisement,
+                                                       Poll,
+                                                       Vote,
+                                                       Message,
+                                                       MRC};
+
     /** Number of confirmation recommended for accepting a transaction */
     static const int RecommendedNumConfirmations = 10;
 
@@ -113,6 +125,9 @@ public:
      */
     static bool showTransaction(const CWalletTx &wtx, bool datetime_limit_flag = false, const int64_t &datetime_limit = 0);
     static QList<TransactionRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx);
+
+    QString TypeToString() const;
+    static QString TypeToString(const Type& type, const bool& translated = true);
 
     /** @name Immutable transaction attributes
       @{*/

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -81,14 +81,15 @@ TransactionView::TransactionView(QWidget *parent)
     filterFrameLayout->addWidget(dateWidget);
 
     typeWidget = new QComboBox(this);
+
+    // Add catch-all
     typeWidget->addItem(tr("All Types"), TransactionFilterProxy::ALL_TYPES);
-    typeWidget->addItem(tr("Received with"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) |
-                                        TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
-    typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
-                                  TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
-    typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
-    typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
-    typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
+
+    // Add types from TransactionRecord Type enum.
+    for (const auto& iter : TransactionRecord::TYPES) {
+        typeWidget->addItem(TransactionRecord::TypeToString(iter), TransactionFilterProxy::TYPE(iter));
+    }
+
     filterFrameLayout->addWidget(typeWidget);
 
     filterFrameLayout->addStretch();


### PR DESCRIPTION
This small PR implements a TypeToString and standard initializer list for the Type enum in the TransactionRecord class to ensure that all types are included for filtering in the GUI combobox. This ensures we only have to make changes/additions in one place in the future for this.

Closes #2707.