### PR TITLE
rpc: Change capitalization, remove whitespace of rpc keys

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2957,11 +2957,11 @@ UniValue SuperblockReport(int lookback, bool displaycontract, std::string cpid)
 
                 if (cpid_parsed)
                 {
-                    c.pushKV("Magnitude", superblock.m_cpids.MagnitudeOf(*cpid_parsed).Floating());
+                    c.pushKV("magnitude", superblock.m_cpids.MagnitudeOf(*cpid_parsed).Floating());
                 }
 
                 if (displaycontract)
-                    c.pushKV("Contract Contents", SuperblockToJson(superblock));
+                    c.pushKV("contract_contents", SuperblockToJson(superblock));
 
                 results.push_back(c);
 


### PR DESCRIPTION
All other keys of this rpc command are written in lower case and the space is replaced by an underscore. The rpc command is not really useful for normal users and a consistent naming of the keys is better in my opinion. Therefore I have adjusted these two keys.