### PR TITLE
ci: bump MacOS version to 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
           run: |
             ./ci/test_run_all.sh
     test-macos:
-        name: macOS 11 native  [GOAL install]  [GUI]  [no depends]
-        runs-on: macos-11
+        name: macOS 12 native  [GOAL install]  [GUI]  [no depends]
+        runs-on: macos-12
         env:
             DANGER_RUN_CI_ON_HOST: true
             CI_USE_APT_INSTALL: no


### PR DESCRIPTION
Current MacOS runners are on MacOS 11.7 (Big Sur) while Homebrew only provides binary builds for Monterey(12) and above. This causes the runner to timeout while building Qt. Bump the version so that we can use the binary caches.