### PR TITLE
gui, projects: Implement greylist state for projects in GUI projects table

### DIFF
--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -198,8 +198,12 @@ QVariant ProjectTableModel::data(const QModelIndex &index, int role) const
                     }
                     break;
                 case Whitelisted:
-                    if (row->m_whitelisted) {
+                    if (row->m_whitelisted == ProjectRow::WhiteListStatus::True) {
                         return QIcon(":/icons/round_green_check");
+                    } else if (row->m_whitelisted == ProjectRow::WhiteListStatus::Greylisted) {
+                        return QIcon(":/icons/warning");
+                    } else if (row->m_whitelisted == ProjectRow::WhiteListStatus::False) {
+                        return QIcon(":/icons/white_and_red_x");
                     }
                     break;
                 case GDPRControls:

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -59,7 +59,14 @@ enum class BeaconStatus
 class ProjectRow
 {
 public:
-    bool m_whitelisted;
+    enum WhiteListStatus
+    {
+        False,
+        Greylisted,
+        True
+    };
+
+    WhiteListStatus m_whitelisted;
     std::optional<bool> m_gdpr_controls;
     QString m_name;
     QString m_cpid;


### PR DESCRIPTION
This commit introduces a greylist state for whitelisted entries. Currently this state corresponds to projects on the whitelist that are excluded from the scraper convergence and therefore superblock. It also implements an "X" for not whitelisted to increase visibility of that.

Closes #2694.

![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/1804587e-ad34-469f-b5e0-f2f10dad5e60)
