### PR TITLE
util: remove WSL 1 workaround in fs

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -57,36 +57,20 @@ FileLock::~FileLock()
     }
 }
 
-static bool IsWSL()
-{
-    struct utsname uname_data;
-    return uname(&uname_data) == 0 && std::string(uname_data.version).find("Microsoft") != std::string::npos;
-}
-
 bool FileLock::TryLock()
 {
     if (fd == -1) {
         return false;
     }
 
-    // Exclusive file locking is broken on WSL using fcntl (issue #18622)
-    // This workaround can be removed once the bug on WSL is fixed
-    static const bool is_wsl = IsWSL();
-    if (is_wsl) {
-        if (flock(fd, LOCK_EX | LOCK_NB) == -1) {
-            reason = GetErrorReason();
-            return false;
-        }
-    } else {
-        struct flock lock;
-        lock.l_type = F_WRLCK;
-        lock.l_whence = SEEK_SET;
-        lock.l_start = 0;
-        lock.l_len = 0;
-        if (fcntl(fd, F_SETLK, &lock) == -1) {
-            reason = GetErrorReason();
-            return false;
-        }
+    struct flock lock;
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    if (fcntl(fd, F_SETLK, &lock) == -1) {
+        reason = GetErrorReason();
+        return false;
     }
 
     return true;


### PR DESCRIPTION
> 5669afb80e350027705dc378d2ab16232567511a fs: drop old WSL1 hack. (sinetek)
> 
> Pull request description:
> 
>   Following discussion, the WSL1 patch will be removed, as WSL1 is no longer being developed by Microsoft. Instead, please upgrade to a mainstream WSL2 version. More information can be found on [the official website](https://docs.microsoft.com/en-us/windows/wsl/).
> 
> ACKs for top commit:
>   1440000bytes:
>     ACK https://github.com/bitcoin/bitcoin/pull/25898/commits/5669afb80e350027705dc378d2ab16232567511a
>   fanquake:
>     ACK 5669afb80e350027705dc378d2ab16232567511a - seems ok as-is.
> 
> Tree-SHA512: 256c13985f6dd3453caf39c7ef1c951dbdfa8457a18cd05e4624db36d8ed8a4f809bb78a7b3c82c72997e9ed3823d5566a5c2d0812d2501aba2e54bc5e6eec79