### PR TITLE
depends: make fontconfig build under clang-16

### DIFF
--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -9,6 +9,7 @@ $(package)_patches=gperf_header_regen.patch
 define $(package)_set_vars
   $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
+  $(package)_cflags += -Wno-implicit-function-declaration
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
> 9cbc1c279247800d79c5f6f95c0c2d8f387aac0a depends: make fontconfig build under clang-16 (fanquake)
> 
> Pull request description:
> 
>   Use the same workaround we've applied to qrencode, and other packages. Fontconfig not building is currently a blocker for fuzz/sanitizer infra upgrades (#27298).
> 
>   For now, this is also more straightforward than bumping the package, which introduces more complexity/usage of gperf.
> 
>   Closes: #27299.
> 
> ACKs for top commit:
>   hebasto:
>     ACK 9cbc1c279247800d79c5f6f95c0c2d8f387aac0a
> 
> Tree-SHA512: 387ea1a73e3429f166ef5278305a56cb3c69b6e3fc8a21a66521738e313e3fe783f042759b396cd88e28c10918a4427fb836a8dfecc5a846723b6f6c6a7ade51