### PR TITLE
depends: no-longer nuke libc++abi.so* in native_clang package

### DIFF
--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -5,10 +5,6 @@ $(package)_download_file=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubunt
 $(package)_file_name=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_sha256_hash=48b83ef827ac2c213d5b64f5ad7ed082c8bcb712b46644e0dc5045c6f462c231
 
-define $(package)_preprocess_cmds
-  rm -f $($(package)_extract_dir)/lib/libc++abi.so*
-endef
-
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_version)/include && \
   mkdir -p $($(package)_staging_prefix_dir)/bin && \


### PR DESCRIPTION
> 9ae854da193f3c4bda38a75e96f9b989b289baab depends: no-longer nuke libc++abi.so* in native_clang package (fanquake)
> 
> Pull request description:
> 
>   We weren't copying it over in any case.
> 
> ACKs for top commit:
>   hebasto:
>     ACK 9ae854da193f3c4bda38a75e96f9b989b289baab
>   theuni:
>     Sure. utACK no-op 9ae854da193f3c4bda38a75e96f9b989b289baab.
> 
> Tree-SHA512: 3cc7f18f27c1b498f930bc1a09283aa04ba673d3c1a5220d8462213f0a06b74bc34989f23404402850de518cba35ddab900a54f7f0fac112fc86664e4155f8cb