### PR TITLE
doc: update windows `-fstack-clash-protection` doc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -664,7 +664,8 @@ if test "$use_hardening" != "no"; then
 
   case $host in
     *mingw*)
-      dnl stack-clash-protection doesn't currently work, and likely should just be skipped for Windows.
+      dnl stack-clash-protection doesn't compile with GCC 10 and earlier.
+      dnl In any case, it is a no-op for Windows.
       dnl See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
       ;;
     *)


### PR DESCRIPTION
> 05ef059a333479e553382c2ae6ef6fde668ce3cb doc: update windows -fstack-clash-protection doc (fanquake)
> 
> Pull request description:
> 
>   Now that changes have been made in GCC, to fix the build failures.
>   See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458.
> 
> ACKs for top commit:
>   TheCharlatan:
>     ACK 05ef059a333479e553382c2ae6ef6fde668ce3cb
>   hebasto:
>     ACK 05ef059a333479e553382c2ae6ef6fde668ce3cb, I've verified that the fix commit is present in all branches starting from `gcc-11`.
> 
> Tree-SHA512: 96b79d65b46e6b9d939c8e6079e984da86987503210106d5155dbe5a6fd82d56d9983694656e27156b01bab795c766b85fc60c799813bc676bba5f3b73f9be22