### PR TITLE
refactor: use the try_lock result in TryEnter

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -160,10 +160,11 @@ private:
     bool TryEnter(const char* pszName, const char* pszFile, int nLine)
     {
         EnterCritical(pszName, pszFile, nLine, (void*)(Base::mutex()), true);
-        Base::try_lock();
-        if (!Base::owns_lock())
-            LeaveCritical();
-        return Base::owns_lock();
+        if (Base::try_lock()) {
+            return true;
+        }
+        LeaveCritical();
+        return false;
     }
 
 public:


### PR DESCRIPTION
Silences some annoying discard warnings.