### PR TITLE
diag: fix researcher mode check

### DIFF
--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -532,14 +532,15 @@ public:
          */
 
         const GRC::BeaconRegistry& beacons = GRC::GetBeaconRegistry();
-        const GRC::CpidOption cpid = GRC::Researcher::Get()->Id().TryCpid();
-        if (const GRC::BeaconOption beacon = beacons.Try(*cpid)) {
-            if (!beacon->Expired(GetAdjustedTime())) {
-                return true;
-            }
-            for (const auto& beacon_ptr : beacons.FindPending(*cpid)) {
-                if (!beacon_ptr->Expired(GetAdjustedTime())) {
+        if (const GRC::CpidOption cpid = GRC::Researcher::Get()->Id().TryCpid()) {
+            if (const GRC::BeaconOption beacon = beacons.Try(*cpid)) {
+                if (!beacon->Expired(GetAdjustedTime())) {
                     return true;
+                }
+                for (const auto& beacon_ptr : beacons.FindPending(*cpid)) {
+                    if (!beacon_ptr->Expired(GetAdjustedTime())) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -147,7 +147,7 @@ public:
 
         m_hasEligibleProjects = researcher->Id().Which() == GRC::MiningId::Kind::CPID;
         m_hasPoolProjects = researcher->Projects().ContainsPool();
-        m_researcher_mode = !(configured_for_investor_mode || (!m_hasEligibleProjects && m_hasPoolProjects));
+        m_researcher_mode = !(configured_for_investor_mode || (!m_hasEligibleProjects && !m_hasPoolProjects));
     }
 
     /**


### PR DESCRIPTION
Fixes a non-deterministic crash that can happen due to a std::optional being dereferenced when it has no value:
https://github.com/gridcoin-community/Gridcoin-Research/blob/8477d94403f168d7fdb189654b98a2fa4da5615f/src/wallet/diagnose.h#L536

Sadly it's non-deterministic, as dereferencing a non-valued std::optional is UB; compilers/stdlib is allowed to not have any checks. It results in a randomized garbage CPID being read on the machine I'm currently on.