### PR TITLE
ci: do not silently fail

### DIFF
--- a/ci/test_run_all.sh
+++ b/ci/test_run_all.sh
@@ -6,9 +6,14 @@
 
 export LC_ALL=C.UTF-8
 
+# latest_stage.log will contain logs for a silenced stage if it
+# fails.
+trap "cat latest_stage.log" EXIT
+
 set -o errexit; source ./ci/test/00_setup_env.sh
 set -o errexit; source ./ci/test/03_before_install.sh
-set -o errexit; source ./ci/test/04_install.sh &> 04.log || (cat 04.log && exit 1)
-set -o errexit; source ./ci/test/05_before_script.sh &> 05.log || (cat 05.log && exit 1)
+set -o errexit; source ./ci/test/04_install.sh &> latest_stage.log
+set -o errexit; source ./ci/test/05_before_script.sh &> latest_stage.log
+echo -n > latest_stage.log
 set -o errexit; source ./ci/test/06_script_a.sh
 set -o errexit; source ./ci/test/06_script_b.sh


### PR DESCRIPTION
Fixes #2699.

Error condition tested by injecting a custom error message and false into 04_install.sh: [commit](https://github.com/div72/Gridcoin-Research/commit/74b37bbadfca4d222dcdc4195cdae6fd997ac208) [log](https://github.com/div72/Gridcoin-Research/actions/runs/7316020988/job/19930232338#step:5:14)

Success condition tested by checking no extra output at the end is present on a successful CI run: [log](https://github.com/div72/Gridcoin-Research/actions/runs/7316025847/job/19930241882#step:5:2430)