### PR TITLE
Properly include Boost Array header

### DIFF
--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -14,6 +14,7 @@
 #include "net.h"
 #include "util.h"
 #include <atomic>
+#include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/system_timer.hpp>

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -57,6 +57,7 @@ EXPECTED_BOOST_INCLUDES=(
     boost/algorithm/string/predicate.hpp
     boost/algorithm/string/replace.hpp
     boost/algorithm/string/split.hpp
+    boost/array.hpp
     boost/asio.hpp
     boost/asio/ip/udp.hpp
     boost/asio/ip/v6_only.hpp


### PR DESCRIPTION
With Boost 1.84 the Boost Array header no longer seems to be implicitly
included by other Boost headers we are using. Thus, our usages of
boost::array run into an incomplete type.

This includes boost/array.hpp everywhere we explicitly use boost::array
to ensure we do not depend on implicit includes.
