### PR TITLE
beacon, registry: Fix beacon history stall

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -153,7 +153,7 @@ inline bool IsV12Enabled(int nHeight)
     return nHeight >= Params().GetConsensus().BlockV12Height;
 }
 
-inline bool IsV13Enabled(int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+inline bool IsV13Enabled(int nHeight)
 {
     // The argument driven override temporarily here to facilitate testing.
 

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -355,9 +355,13 @@ std::vector<Beacon_ptr> BeaconRegistry::FindPending(const Cpid& cpid) const
 
 const BeaconOption BeaconRegistry::FindHistorical(const uint256& hash)
 {
-    BeaconOption beacon = m_beacon_db.find(hash)->second;
+    auto beacon_iter = m_beacon_db.find(hash);
 
-    return beacon;
+    if (beacon_iter != m_beacon_db.end()) {
+        return beacon_iter->second;
+    }
+
+    return {};
 }
 
 bool BeaconRegistry::ContainsActive(const Cpid& cpid, const int64_t now) const

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -311,6 +311,11 @@ const BeaconRegistry::PendingBeaconMap& BeaconRegistry::PendingBeacons() const
     return m_pending;
 }
 
+const std::set<Beacon_ptr>& BeaconRegistry::ExpiredBeacons() const
+{
+    return m_expired_pending;
+}
+
 BeaconOption BeaconRegistry::Try(const Cpid& cpid) const
 {
     const auto iter = m_beacons.find(cpid);
@@ -987,7 +992,8 @@ void BeaconRegistry::ActivatePending(
         }
     }
 
-    // Activate the pending beacons that are not expired with respect to pending age.
+    // Activate the pending beacons that are not expired with respect to pending age as of the time of verification (the
+    // committing of the superblock).
     for (const auto& iter_pair : verified_beacons) {
 
         Beacon_ptr last_pending_beacon = iter_pair.second;

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -171,7 +171,7 @@ bool Beacon::Expired(const int64_t now) const
 
 bool Beacon::Renewable(const int64_t now) const
 {
-    return Age(now) > RENEWAL_AGE;
+    return (!Expired(now) && Age(now) > RENEWAL_AGE);
 }
 
 bool Beacon::Renewed() const

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -800,127 +800,100 @@ int BeaconRegistry::GetDBHeight()
 Beacon_ptr BeaconRegistry::GetBeaconChainletRoot(Beacon_ptr beacon,
                                                  std::shared_ptr<std::vector<std::pair<uint256, int64_t>>> beacon_chain_out)
 {
-    Cpid cpid = beacon->m_cpid;
-
-    // The chain head itself.
-    auto beacon_iter = m_beacon_db.find(beacon->m_hash);
-
-   if (beacon_iter == m_beacon_db.end()) {
-        // Beacon chainlet chainhead cannot be found. This is fatal.
-
-        error("%s: Beacon chainlet is corrupted at chainhead for cpid %s: timestamp = %s" PRId64 ", ctx_hash = %s,"
-              "prev_beacon_ctx_hash = %s, status = %s: not found in the registry.",
+    const auto ChainletErrorHandle = [this](unsigned int i, Beacon_ptr beacon, std::string error_message) {
+        error("%s: Beacon chainlet is corrupted at link %u for cpid %s: timestamp = %s" PRId64 ", ctx_hash = %s,"
+              "prev_beacon_ctx_hash = %s, status = %s: %s.",
               __func__,
+              i,
               beacon->m_cpid.ToString(),
               beacon->m_timestamp,
               beacon->m_hash.GetHex(),
               beacon->m_previous_hash.GetHex(),
-              beacon->StatusToString());
+              beacon->StatusToString(),
+              error_message);
 
-        std::string str_error = strprintf("ERROR: %s: Beacon chainlet is corrupted at chainhead for cpid %s: timestamp = %s"
-                                          PRId64 ", ctx_hash = %s, prev_beacon_ctx_hash = %s, status = %s: not found "
-                                          "in the registry.",
+        std::string str_error = strprintf("ERROR: %s: Beacon chainlet is corrupted at link %u for cpid %s: timestamp = %s"
+                                          PRId64 ", ctx_hash = %s, prev_beacon_ctx_hash = %s, status = %s: %s.",
                                           __func__,
+                                          i,
                                           beacon->m_cpid.ToString(),
                                           beacon->m_timestamp,
                                           beacon->m_hash.GetHex(),
                                           beacon->m_previous_hash.GetHex(),
-                                          beacon->StatusToString());
+                                          beacon->StatusToString(),
+                                          error_message);
 
         Reset();
 
         uiInterface.ThreadSafeMessageBox(str_error, "Gridcoin", CClientUIInterface::MSG_ERROR);
 
-        throw std::runtime_error(std::string {"The beacon registry is corrupted and Gridcoin cannot continue. Please restart."});
-    }
+        throw std::runtime_error(std::string {"The beacon registry is corrupted and will be rebuilt on the next start. "
+                                             "Please restart."});
+    };
 
-    // Given that we have had rare situations where somehow circularity has occurred in the beacon chainlet, which either
-    // results in the current hash and previous hash being the same, or even suspected previous hash of another entry pointing
-    // back to a beacon in a circular manner, this vector is used to detect the circularity.
-    std::vector<uint256> encountered_hashes { beacon->m_hash };
-
-    if (beacon_chain_out != nullptr) {
-        LogPrint(BCLog::LogFlags::ACCRUAL, "INFO %s: chainlet head beacon for cpid %s: timestamp = %" PRId64 ", ctx_hash = %s,"
+    const auto ChainletLinkLog = [&beacon_chain_out](unsigned int i, Beacon_ptr beacon) {
+        LogPrint(BCLog::LogFlags::ACCRUAL, "INFO %s: beacon chainlet link %u for cpid %s: timestamp = %" PRId64 ", ctx_hash = %s,"
                                            " prev_beacon_ctx_hash = %s, status = %s.",
                  __func__,
+                 i,
                  beacon->m_cpid.ToString(),
                  beacon->m_timestamp,
                  beacon->m_hash.GetHex(),
                  beacon->m_previous_hash.GetHex(),
                  beacon->StatusToString());
 
+        if (beacon_chain_out == nullptr) {
+            return;
+        }
+
         beacon_chain_out->push_back(std::make_pair(beacon->m_hash, beacon->m_timestamp));
+    };
+
+    unsigned int i = 0;
+
+    // Given that we have had rare situations where somehow circularity has occurred in the beacon chainlet, which either
+    // results in the current hash and previous hash being the same, or even suspected previous hash of another entry pointing
+    // back to a beacon in a circular manner, this vector is used to detect the circularity.
+    std::vector<uint256> encountered_hashes;
+
+    // The chain head itself. (This uses a scope to separate beacon_iter.)
+    {
+        auto beacon_iter = m_beacon_db.find(beacon->m_hash);
+
+        if (beacon_iter == m_beacon_db.end()) {
+            // Beacon chainlet chainhead cannot be found. This is fatal.
+            ChainletErrorHandle(i, beacon, "not found in the registry");
+        }
+
+        // Make sure status is renewed or active.
+        if (beacon_iter->second->m_status != BeaconStatusForStorage::ACTIVE
+            && beacon_iter->second->m_status != BeaconStatusForStorage::RENEWAL) {
+            ChainletErrorHandle(i, beacon, "beacon status is not active or renewal");
+        }
+
+        encountered_hashes.push_back(beacon->m_hash);
+
+        ChainletLinkLog(i, beacon);
+
+        ++i;
     }
 
     // Walk back the entries in the historical beacon map linked by renewal prev tx hash until the first
     // beacon in the renewal chain is found (the original advertisement). The accrual starts no earlier
     // than here.
-    unsigned int i = 0;
-
     while (beacon->Renewed())
     {
         // Select previous beacon in chainlet
         auto beacon_iter = m_beacon_db.find(beacon->m_previous_hash);
 
         if (beacon_iter == m_beacon_db.end()) {
-            // Linked beacon in chainlet cannot be found. This is fatal.
-
-            error("%s: Beacon chainlet is corrupted at %u links back for cpid %s: timestamp = %s" PRId64 ", ctx_hash = %s,"
-                  "prev_beacon_ctx_hash = %s, status = %s: prev_beacon not found in the registry.",
-                  __func__,
-                  i + 1,
-                  beacon->m_cpid.ToString(),
-                  beacon->m_timestamp,
-                  beacon->m_hash.GetHex(),
-                  beacon->m_previous_hash.GetHex(),
-                  beacon->StatusToString());
-
-            std::string str_error = strprintf("ERROR: %s: Beacon chainlet is corrupted at %u links back for cpid %s: timestamp = %s"
-                                              PRId64 ", ctx_hash = %s, prev_beacon_ctx_hash = %s, status = %s: prev_beacon not found "
-                                              "in the registry.",
-                  __func__,
-                  i + 1,
-                  beacon->m_cpid.ToString(),
-                  beacon->m_timestamp,
-                  beacon->m_hash.GetHex(),
-                  beacon->m_previous_hash.GetHex(),
-                  beacon->StatusToString());
-
-            Reset();
-
-            uiInterface.ThreadSafeMessageBox(str_error, "Gridcoin", CClientUIInterface::MSG_ERROR);
-
-            throw std::runtime_error(std::string {"The beacon registry is corrupted and Gridcoin cannot continue. Please restart."});
+            ChainletErrorHandle(i, beacon, "previous beacon not found in the registry");
         }
 
         if (std::find(encountered_hashes.begin(), encountered_hashes.end(), beacon->m_previous_hash) != encountered_hashes.end()) {
             // If circularity is found this is an indication of corruption of beacon state and is fatal.
             // Produce an error message, reset the beacon registry, and require a restart of the node.
-
-            error("%s: Circularity encountered in beacon ownership chain for beacon with CPID %s, starting at hash %s, "
-                  "at %u linked entries back from the start, with offending hash %s.",
-                  __func__,
-                  cpid.ToString(),
-                  beacon->m_hash.GetHex(),
-                  i + 1,
-                  beacon->m_previous_hash.GetHex());
-
-            std::string str_error = strprintf("ERROR: %s: Circularity encountered in beacon ownership chain for beacon with CPID %s, "
-                                              "starting at hash %s, at %u linked entries back from the start, with offending hash %s.\n"
-                                              "\n"
-                                              "The client cannot continue and the beacon history has been reset and will be rebuilt "
-                                              "on the next restart. Please restart Gridcoin.",
-                                              __func__,
-                                              cpid.ToString(),
-                                              beacon->m_hash.GetHex(),
-                                              i + 1,
-                                              beacon->m_previous_hash.GetHex());
-
-            Reset();
-
-            uiInterface.ThreadSafeMessageBox(str_error, "Gridcoin", CClientUIInterface::MSG_ERROR);
-
-            throw std::runtime_error(std::string {"The beacon registry is corrupted and Gridcoin cannot continue. Please restart."});
+            ChainletErrorHandle(i, beacon, "circularity encountered");
         }
 
         // Reassign previous beacon to beacon.
@@ -929,51 +902,34 @@ Beacon_ptr BeaconRegistry::GetBeaconChainletRoot(Beacon_ptr beacon,
         encountered_hashes.push_back(beacon->m_hash);
 
         if (beacon_chain_out != nullptr) {
-            LogPrint(BCLog::LogFlags::ACCRUAL, "INFO %s: beacon %u links back for cpid %s: timestamp = %" PRId64 ", ctx_hash = %s,"
-                                               " prev_beacon_ctx_hash = %s, status = %s.",
-                     __func__,
-                     i + 1,
-                     beacon->m_cpid.ToString(),
-                     beacon->m_timestamp,
-                     beacon->m_hash.GetHex(),
-                     beacon->m_previous_hash.GetHex(),
-                     beacon->StatusToString());
-
-            beacon_chain_out->push_back(std::make_pair(beacon->m_hash, beacon->m_timestamp));
+            ChainletLinkLog(i, beacon);
         }
 
         ++i;
     }
 
-    // Check of initial advertised beacon's previous hash.
-    if (std::find(encountered_hashes.begin(), encountered_hashes.end(), beacon->m_previous_hash) != encountered_hashes.end()) {
-        // If circularity is found this is an indication of corruption of beacon state and is fatal.
-        // Produce an error message, reset the beacon registry, and require a restart of the node.
+    // Check of initial advertised beacon's previous hash. This should point to the pending beacon that was activated and not
+    // anywhere else.
+    {
+        // Select previous beacon in chainlet
+        auto beacon_iter = m_beacon_db.find(beacon->m_previous_hash);
 
-        error("%s: Circularity encountered in beacon ownership chain for beacon with CPID %s, starting at hash %s, "
-              "at %u linked entries back from the start, with offending hash %s.",
-              __func__,
-              cpid.ToString(),
-              beacon->m_hash.GetHex(),
-              i + 1,
-              beacon->m_previous_hash.GetHex());
+        if (beacon_iter == m_beacon_db.end()) {
+            ChainletErrorHandle(i, beacon, "previous beacon not found in the registry");
+        }
 
-        std::string str_error = strprintf("ERROR: %s: Circularity encountered in beacon ownership chain for beacon with CPID %s, "
-                                          "starting at hash %s, at %u linked entries back from the start, with offending hash %s.\n"
-                                          "\n"
-                                          "The client cannot continue and the beacon history has been reset and will be rebuilt "
-                                          "on the next restart. Please restart Gridcoin.",
-                                          __func__,
-                                          cpid.ToString(),
-                                          beacon->m_hash.GetHex(),
-                                          i + 1,
-                                          beacon->m_previous_hash.GetHex());
+        // Make sure status of previous beacon is pending.
+        if (beacon_iter->second->m_status != BeaconStatusForStorage::PENDING) {
+            ChainletErrorHandle(i, beacon, "previous beacon to the beacon marked active is not pending");
+        }
 
-        Reset();
+        if (std::find(encountered_hashes.begin(), encountered_hashes.end(), beacon->m_previous_hash) != encountered_hashes.end()) {
+            // If circularity is found this is an indication of corruption of beacon state and is fatal.
+            // Produce an error message, reset the beacon registry, and require a restart of the node.
+            ChainletErrorHandle(i, beacon, "circularity encountered");
+        }
 
-        uiInterface.ThreadSafeMessageBox(str_error, "Gridcoin", CClientUIInterface::MSG_ERROR);
-
-        throw std::runtime_error(std::string {"The beacon registry is corrupted and Gridcoin cannot continue. Please restart."});
+        // Note that we do not actually walk back to the pending beacon. The parameter beacon remains at the activated beacon.
     }
 
     return beacon;

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -811,6 +811,7 @@ public:
                        BeaconStatusForStorage,
                        BeaconMap,
                        PendingBeaconMap,
+                       std::set<Beacon_ptr>,
                        HistoricalBeaconMap> BeaconDB;
 
 private:

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -13,7 +13,6 @@
 #include "gridcoin/contract/registry_db.h"
 #include "gridcoin/cpid.h"
 #include "gridcoin/support/enumbytes.h"
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -767,6 +766,18 @@ public:
     //! \return The number of elements passivated.
     //!
     uint64_t PassivateDB();
+
+    //!
+    //! \brief This function walks the linked beacon entries back (using the m_previous_hash member) from a provided
+    //! beacon to find the initial advertisement. Note that this does NOT traverse non-continuous beacon ownership,
+    //! which occurs when a beacon is allowed to expire and must be reverified under a new key.
+    //!
+    //! \param beacon smart shared pointer to beacon entry to begin walking back
+    //! \param beacon_chain_out shared pointer to UniValue beacon chain out report array
+    //! \return root (advertisement) beacon entry smart shared pointer
+    //!
+    Beacon_ptr GetBeaconChainletRoot(Beacon_ptr beacon,
+                                     std::shared_ptr<std::vector<std::pair<uint256, int64_t>>> beacon_chain_out = nullptr);
 
     //!
     //! \brief Returns whether IsContract correction is needed in ReplayContracts during initialization

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -544,13 +544,10 @@ public:
     //! Version 0: <= 5.2.0.0
     //! Version 1: = 5.2.1.0
     //! Version 2: 5.2.1.0 with hotfix and > 5.2.1.0
-    //!
-    //! The current version of the beacon db is 2. No changes to the underlying storage have
-    //! occurred during the refactor to the registry db template, so this version remains unchanged
-    //! through 5.4.2.0+
+    //! Version 3: 5.4.5.5+
     //!
     BeaconRegistry()
-        : m_beacon_db(2)
+        : m_beacon_db(3)
     {
     };
 

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -589,6 +589,12 @@ public:
     const PendingBeaconMap& PendingBeacons() const;
 
     //!
+    //! \brief Get the set of beacons that have expired while pending (awaiting verification)
+    //! \return A reference to the expired pending beacon set.
+    //!
+    const std::set<Beacon_ptr>& ExpiredBeacons() const;
+
+    //!
     //! \brief Get the beacon for the specified CPID.
     //!
     //! \param cpid The researcher's CPID to look up a beacon for.

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -806,6 +806,22 @@ private:
     PendingBeaconMap m_pending; //!< Contains beacons awaiting verification.
 
     //!
+    //! \brief Contains pending beacons that have expired.
+    //!
+    //! Contains pending beacons that have expired but need to be retained until the next SB (activation) to ensure a
+    //! reorganization will successfully resurrect expired pending beacons back into pending ones up to the depth equal to one SB to
+    //! the next, which is about 960 blocks. The reason this is necessary is two fold: 1) it makes the lookup for expired
+    //! pending beacons in the deactivate method much simpler in the case of a reorg across a SB boundary, and 2) it holds
+    //! a reference to the pending beacon shared pointer object in the history map, which prevents it from being passivated.
+    //! Otherwise, a passivation event, which would remove the pending deleted beacons, followed by a reorganization across
+    //! SB boundary could have a small possibility of removing a pending beacon that could be verified in the alternative SB
+    //! eventually staked.
+    //!
+    //! This set is cleared and repopulated at each SB accepted by the node with the current expired pending beacons.
+    //!
+    std::set<Beacon_ptr> m_expired_pending;
+
+    //!
     //! \brief The member variable that is the instance of the beacon database. This is private to the
     //! beacon registry and is only accessible by beacon registry functions.
     //!

--- a/src/gridcoin/contract/registry_db.h
+++ b/src/gridcoin/contract/registry_db.h
@@ -26,9 +26,11 @@ namespace GRC {
 //! M:  the map type for the entries
 //! P:  the map type for pending entries. This is really only used for beacons. In all other registries it is typedef'd to
 //!     the same as M.
+//! X:  the map type for expired pending entries. This is really only used for beacons. In all other registries it is typedef'd to
+//!     the same as M.
 //! H:  the historical map type for historical entries
 //!
-template<class E, class SE, class S, class M, class P, class H>
+template<class E, class SE, class S, class M, class P, class X, class H>
 class RegistryDB
 {
 public:
@@ -62,10 +64,12 @@ public:
     //! \param entries The map of current entries.
     //! \param pending_entries. The map of pending entries. This is not used in the general template, only in the beacons
     //! specialization.
+    //! \param expired_entries. The map of expired pending entries. This is not used in the geenral template, only in the
+    //! beacons specialization.
     //!
     //! \return block height up to and including which the entry records were stored.
     //!
-    int Initialize(M& entries, P& pending_entries)
+    int Initialize(M& entries, P& pending_entries, X& expired_entries)
     {
         bool status = true;
         int height = 0;
@@ -169,7 +173,7 @@ public:
             m_historical[iter.second.m_hash] = std::make_shared<E>(entry);
             entry_ptr& historical_entry_ptr = m_historical[iter.second.m_hash];
 
-            HandleCurrentHistoricalEntries(entries, pending_entries, entry,
+            HandleCurrentHistoricalEntries(entries, pending_entries, expired_entries, entry,
                                                 historical_entry_ptr, recnum, key_type);
 
             number_passivated += (uint64_t) HandlePreviousHistoricalEntries(historical_entry_ptr);
@@ -199,7 +203,7 @@ public:
     //! \param recnum
     //! \param key_type
     //!
-    void HandleCurrentHistoricalEntries(M& entries, P& pending_entries, const E& entry,
+    void HandleCurrentHistoricalEntries(M& entries, P& pending_entries, X& expired_entries, const E& entry,
                                         entry_ptr& historical_entry_ptr, const uint64_t& recnum,
                                         const std::string& key_type)
     {

--- a/src/gridcoin/contract/registry_db.h
+++ b/src/gridcoin/contract/registry_db.h
@@ -330,8 +330,8 @@ public:
 
         LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: Passivated %" PRId64 " elements from %s entry db.",
                  __func__,
-                 KeyType(),
-                 number_passivated);
+                 number_passivated,
+                 KeyType());
 
         // Set needs passivation flag to false after passivating the db.
         m_needs_passivation = false;

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -495,7 +495,7 @@ int Whitelist::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_project_db.Initialize(m_project_entries, m_pending_project_entries);
+    int height = m_project_db.Initialize(m_project_entries, m_pending_project_entries, m_expired_project_entries);
 
     LogPrint(LogFlags::CONTRACT, "INFO: %s: m_project_db size after load: %u", __func__, m_project_db.size());
     LogPrint(LogFlags::CONTRACT, "INFO: %s: m_project_entries size after load: %u", __func__, m_project_entries.size());

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -618,13 +618,15 @@ public:
     static void RunDBPassivation();
 
     //!
-    //! \brief Specializes the template RegistryDB for the ScraperEntry class
+    //! \brief Specializes the template RegistryDB for the ScraperEntry class. Note that std::set<ProjectEntry> is not
+    //! actually used.
     //!
     typedef RegistryDB<ProjectEntry,
                        ProjectEntry,
                        ProjectEntryStatus,
                        ProjectEntryMap,
                        PendingProjectEntryMap,
+                       std::set<ProjectEntry>,
                        HistoricalProjectEntryMap> ProjectEntryDB;
 
 private:
@@ -643,6 +645,8 @@ private:
 
     ProjectEntryMap m_project_entries;                   //!< The set of whitelisted projects.
     PendingProjectEntryMap m_pending_project_entries {}; //!< Not actually used. Only to satisfy the template.
+
+    std::set<ProjectEntry> m_expired_project_entries {}; //!< Not actually used. Only to satisfy the template.
 
     ProjectEntryDB m_project_db; //!< The project db member
 public:

--- a/src/gridcoin/protocol.cpp
+++ b/src/gridcoin/protocol.cpp
@@ -482,7 +482,7 @@ int ProtocolRegistry::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_protocol_db.Initialize(m_protocol_entries, m_pending_protocol_entries);
+    int height = m_protocol_db.Initialize(m_protocol_entries, m_pending_protocol_entries, m_expired_protocol_entries);
 
     LogPrint(LogFlags::CONTRACT, "INFO: %s: m_protocol_db size after load: %u", __func__, m_protocol_db.size());
     LogPrint(LogFlags::CONTRACT, "INFO: %s: m_protocol_entries size after load: %u", __func__, m_protocol_entries.size());

--- a/src/gridcoin/protocol.h
+++ b/src/gridcoin/protocol.h
@@ -567,13 +567,15 @@ public:
     static void RunDBPassivation();
 
     //!
-    //! \brief Specializes the template RegistryDB for the ProtocolEntry class
+    //! \brief Specializes the template RegistryDB for the ProtocolEntry class. Note that std::set<ProtocolEntry>
+    //! is not actually used.
     //!
     typedef RegistryDB<ProtocolEntry,
                        ProtocolEntry,
                        ProtocolEntryStatus,
                        ProtocolEntryMap,
                        PendingProtocolEntryMap,
+                       std::set<ProtocolEntry>,
                        HistoricalProtocolEntryMap> ProtocolEntryDB;
 
 private:
@@ -592,6 +594,8 @@ private:
 
     ProtocolEntryMap m_protocol_entries;                   //!< Contains the current protocol entries including entries marked DELETED.
     PendingProtocolEntryMap m_pending_protocol_entries {}; //!< Not used. Only to satisfy the template.
+
+    std::set<ProtocolEntry> m_expired_protocol_entries {}; //!< Not used. Only to satisfy the template.
 
     ProtocolEntryDB m_protocol_db;
 

--- a/src/gridcoin/scraper/scraper_registry.cpp
+++ b/src/gridcoin/scraper/scraper_registry.cpp
@@ -527,7 +527,7 @@ int ScraperRegistry::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_scraper_db.Initialize(m_scrapers, m_pending_scrapers);
+    int height = m_scraper_db.Initialize(m_scrapers, m_pending_scrapers, m_expired_scraper_entries);
 
     LogPrint(LogFlags::SCRAPER, "INFO: %s: m_scraper_db size after load: %u", __func__, m_scraper_db.size());
     LogPrint(LogFlags::SCRAPER, "INFO: %s: m_scrapers size after load: %u", __func__, m_scrapers.size());

--- a/src/gridcoin/scraper/scraper_registry.h
+++ b/src/gridcoin/scraper/scraper_registry.h
@@ -606,13 +606,15 @@ public:
     static void RunDBPassivation();
 
     //!
-    //! \brief Specializes the template RegistryDB for the ScraperEntry class
+    //! \brief Specializes the template RegistryDB for the ScraperEntry class. Note that std::set<ScraperEntry> is
+    //! not actually used.
     //!
     typedef RegistryDB<ScraperEntry,
                        ScraperEntry,
                        ScraperEntryStatus,
                        ScraperMap,
                        PendingScraperMap,
+                       std::set<ScraperEntry>,
                        HistoricalScraperMap> ScraperEntryDB;
 
 private:
@@ -631,6 +633,8 @@ private:
 
     ScraperMap m_scrapers;                   //!< Contains the current scraper entries, including entries marked DELETED.
     PendingScraperMap m_pending_scrapers {}; //!< Not actually used for scrapers. To satisfy the template only.
+
+    std::set<ScraperEntry> m_expired_scraper_entries {}; //!< Not actually used for scrapers. To satisfy the template only.
 
     ScraperEntryDB m_scraper_db;
 

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -712,7 +712,7 @@ int SideStakeRegistry::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_sidestake_db.Initialize(m_mandatory_sidestake_entries, m_pending_sidestake_entries);
+    int height = m_sidestake_db.Initialize(m_mandatory_sidestake_entries, m_pending_sidestake_entries, m_expired_sidestake_entries);
 
     SubscribeToCoreSignals();
 

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -783,13 +783,15 @@ public:
     static void RunDBPassivation();
 
     //!
-    //! \brief Specializes the template RegistryDB for the SideStake class
+    //! \brief Specializes the template RegistryDB for the SideStake class. Note that std::set<MandatorySideStake>
+    //! is not actually used.
     //!
     typedef RegistryDB<MandatorySideStake,
                        MandatorySideStake,
                        MandatorySideStake::MandatorySideStakeStatus,
                        MandatorySideStakeMap,
                        PendingSideStakeMap,
+                       std::set<SideStake>,
                        HistoricalSideStakeMap> SideStakeDB;
 
 private:
@@ -826,6 +828,8 @@ private:
     LocalSideStakeMap m_local_sidestake_entries;          //!< Contains the local (non-contract) sidestake entries.
     MandatorySideStakeMap m_mandatory_sidestake_entries;  //!< Contains the mandatory sidestake entries, including DELETED.
     PendingSideStakeMap m_pending_sidestake_entries {};   //!< Not used. Only to satisfy the template.
+
+    std::set<SideStake> m_expired_sidestake_entries {};   //!< Not used. Only to satisfy the template.
 
     SideStakeDB m_sidestake_db;                           //!< The internal sidestake db object for leveldb persistence.
 

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1228,15 +1228,12 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
         return accrual;
     }
 
-    Beacon_ptr beacon_ptr = beacon;
+    Beacon_ptr beacon_ptr;
 
     // Walk back the entries in the historical beacon map linked by renewal prev tx hash until the first
     // beacon in the renewal chain is found (the original advertisement). The accrual starts no earlier
     // than here.
-    while (beacon_ptr->Renewed())
-    {
-        beacon_ptr = beacons.GetBeaconDB().find(beacon_ptr->m_previous_hash)->second;
-    }
+    beacon_ptr = beacons.GetBeaconChainletRoot(beacon);
 
     const CBlockIndex* pindex_baseline = GRC::Tally::GetBaseline();
 

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1233,7 +1233,11 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
     // Walk back the entries in the historical beacon map linked by renewal prev tx hash until the first
     // beacon in the renewal chain is found (the original advertisement). The accrual starts no earlier
     // than here.
-    beacon_ptr = beacons.GetBeaconChainletRoot(beacon);
+    try {
+        beacon_ptr = beacons.GetBeaconChainletRoot(beacon);
+    } catch (std::runtime_error& e) {
+        std::abort();
+    }
 
     const CBlockIndex* pindex_baseline = GRC::Tally::GetBaseline();
 

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -255,8 +255,6 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
     // This is similar to createmrcrequest in many ways, but the state tracking is more complicated.
 
-    LOCK(cs_main);
-
     // Record initial block height during init run.
     if (!m_init_block_height) {
         m_init_block_height = pindexBest->nHeight;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -300,46 +300,24 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
 
     GRC::Beacon_ptr beacon_ptr = beacon_try;
 
-    LogPrint(BCLog::LogFlags::ACCRUAL, "INFO %s: active beacon: timestamp = %" PRId64 ", ctx_hash = %s,"
-                                       " prev_beacon_ctx_hash = %s",
-             __func__,
-             beacon_ptr->m_timestamp,
-             beacon_ptr->m_hash.GetHex(),
-             beacon_ptr->m_previous_hash.GetHex());
+    std::vector<std::pair<uint256, int64_t>> beacon_chain_out {};
+
+    std::shared_ptr<std::vector<std::pair<uint256, int64_t>>> beacon_chain_out_ptr
+        = std::make_shared<std::vector<std::pair<uint256, int64_t>>>(beacon_chain_out);
 
     UniValue beacon_chain(UniValue::VARR);
-    UniValue beacon_chain_entry(UniValue::VOBJ);
 
-    beacon_chain_entry.pushKV("ctx_hash", beacon_ptr->m_hash.GetHex());
-    beacon_chain_entry.pushKV("timestamp",  beacon_ptr->m_timestamp);
-    beacon_chain.push_back(beacon_chain_entry);
+    beacon_ptr = beacons.GetBeaconChainletRoot(beacon_ptr, beacon_chain_out_ptr);
 
-    // This walks back the entries in the historical beacon map linked by renewal prev tx hash until the first
-    // beacon in the renewal chain is found (the original advertisement). The accrual starts no earlier than here.
-    uint64_t renewals = 0;
-    // The renewals <= 100 is simply to prevent an infinite loop if there is a problem with the beacon chain in the registry. This
-    // was an issue in post Fern beacon db work, but has been resolved and not encountered since. Still makes sense to leave the
-    // limit in, which represents 41 years worth of beacon chain at the 150 day standard auto-renewal cycle.
-    while (beacon_ptr->Renewed() && renewals <= 100)
-    {
-        auto iter = beacons.GetBeaconDB().find(beacon_ptr->m_previous_hash);
+    for (const auto& iter : *beacon_chain_out_ptr) {
+        UniValue beacon_chain_entry(UniValue::VOBJ);
 
-        beacon_ptr = iter->second;
-
-        LogPrint(BCLog::LogFlags::ACCRUAL, "INFO %s: renewal %u beacon: timestamp = %" PRId64 ", ctx_hash = %s,"
-                                           " prev_beacon_ctx_hash = %s.",
-                 __func__,
-                 renewals,
-                 beacon_ptr->m_timestamp,
-                 beacon_ptr->m_hash.GetHex(),
-                 beacon_ptr->m_previous_hash.GetHex());
-
-        beacon_chain_entry.pushKV("ctx_hash", beacon_ptr->m_hash.GetHex());
-        beacon_chain_entry.pushKV("timestamp", beacon_ptr->m_timestamp);
+        beacon_chain_entry.pushKV("ctx_hash", iter.first.GetHex());
+        beacon_chain_entry.pushKV("timestamp",  iter.second);
         beacon_chain.push_back(beacon_chain_entry);
-
-        ++renewals;
     }
+
+    int64_t renewals = beacon_chain_out_ptr->size() - 1;
 
     bool retry_from_baseline = false;
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -307,7 +307,11 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
 
     UniValue beacon_chain(UniValue::VARR);
 
-    beacon_ptr = beacons.GetBeaconChainletRoot(beacon_ptr, beacon_chain_out_ptr);
+    try {
+        beacon_ptr = beacons.GetBeaconChainletRoot(beacon_ptr, beacon_chain_out_ptr);
+    } catch (std::runtime_error& e) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, e.what());
+    }
 
     for (const auto& iter : *beacon_chain_out_ptr) {
         UniValue beacon_chain_entry(UniValue::VOBJ);

--- a/src/test/gridcoin/beacon_tests.cpp
+++ b/src/test/gridcoin/beacon_tests.cpp
@@ -182,7 +182,6 @@ public:
                     if (beacon != nullptr) {
                         std::cout << "add beacon record: "
                                   << "blockheight = " << ctx.m_pindex->nHeight
-                                  << ", hash = " << beacon->m_hash.GetHex()
                                   << ", cpid = " << beacon->m_cpid.ToString()
                                   << ", public key = " << HexStr(beacon->m_public_key)
                                   << ", address = " << beacon->GetAddress().ToString()
@@ -203,7 +202,6 @@ public:
                     if (beacon != nullptr) {
                         std::cout << "delete beacon record: "
                                   << "blockheight = " << ctx.m_pindex->nHeight
-                                  << ", hash = " << beacon->m_hash.GetHex()
                                   << ", cpid = " << beacon->m_cpid.ToString()
                                   << ", public key = " << HexStr(beacon->m_public_key)
                                   << ", address = " << beacon->GetAddress().ToString()
@@ -242,7 +240,6 @@ public:
                     if (activated_beacon != nullptr) {
                         std::cout << "activated beacon record: "
                                   << "blockheight = " << pindex->nHeight
-                                  << ", hash = " << activated_beacon->m_hash.GetHex()
                                   << ", cpid = " << activated_beacon->m_cpid.ToString()
                                   << ", public key = " << HexStr(activated_beacon->m_public_key)
                                   << ", address = " << activated_beacon->GetAddress().ToString()
@@ -258,7 +255,6 @@ public:
                     if (iter != nullptr) {
                         std::cout << "expired beacon record: "
                                   << "blockheight = " << pindex->nHeight
-                                  << ", hash = " << iter->m_hash.GetHex()
                                   << ", cpid = " << iter->m_cpid.ToString()
                                   << ", public key = " << HexStr(iter->m_public_key)
                                   << ", address = " << iter->GetAddress().ToString()
@@ -279,17 +275,6 @@ public:
         for (const auto& iter : registry.Beacons())
         {
             m_beacons_init[iter.first] = *iter.second;
-
-            std::cout << "init beacon record: "
-                      << "hash = " << iter.second->m_hash.GetHex()
-                      << ", cpid = " << iter.second->m_cpid.ToString()
-                      << ", public key = " << HexStr(iter.second->m_public_key)
-                      << ", address = " << iter.second->GetAddress().ToString()
-                      << ", timestamp = " << iter.second->m_timestamp
-                      << ", hash = " << iter.second->m_hash.GetHex()
-                      << ", prev beacon hash = " << iter.second->m_previous_hash.GetHex()
-                      << ", status = " << iter.second->StatusToString()
-                      << std::endl;
         }
 
         m_init_number_beacons = m_beacons_init.size();
@@ -314,6 +299,16 @@ public:
             // Create a copy of the referenced beacon object with a shared pointer to it and store.
             m_local_historical_beacon_map_init[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
 
+            std::cout << "init beacon db record: "
+                      << ", cpid = " << beacon_ptr->m_cpid.ToString()
+                      << ", public key = " << HexStr(beacon_ptr->m_public_key)
+                      << ", address = " << beacon_ptr->GetAddress().ToString()
+                      << ", timestamp = " << beacon_ptr->m_timestamp
+                      << ", hash = " << beacon_ptr->m_hash.GetHex()
+                      << ", prev beacon hash = " << beacon_ptr->m_previous_hash.GetHex()
+                      << ", status = " << beacon_ptr->StatusToString()
+                      << std::endl;
+
             init_beacon_db_iter = init_beacon_db.advance(init_beacon_db_iter);
         }
 
@@ -331,17 +326,6 @@ public:
         for (const auto& iter : registry.Beacons())
         {
             m_beacons_reinit[iter.first] = *iter.second;
-
-            std::cout << "reinit beacon record: "
-                      << "hash = " << iter.second->m_hash.GetHex()
-                      << ", cpid = " << iter.second->m_cpid.ToString()
-                      << ", public key = " << HexStr(iter.second->m_public_key)
-                      << ", address = " << iter.second->GetAddress().ToString()
-                      << ", timestamp = " << iter.second->m_timestamp
-                      << ", hash = " << iter.second->m_hash.GetHex()
-                      << ", prev beacon hash = " << iter.second->m_previous_hash.GetHex()
-                      << ", status = " << iter.second->StatusToString()
-                      << std::endl;
         }
 
         m_reinit_number_beacons = m_beacons_reinit.size();
@@ -365,6 +349,16 @@ public:
 
             // Create a copy of the referenced beacon object with a shared pointer to it and store.
             m_local_historical_beacon_map_reinit[hash] = std::make_shared<GRC::Beacon>(*beacon_ptr);
+
+            std::cout << "init beacon db record: "
+                      << ", cpid = " << beacon_ptr->m_cpid.ToString()
+                      << ", public key = " << HexStr(beacon_ptr->m_public_key)
+                      << ", address = " << beacon_ptr->GetAddress().ToString()
+                      << ", timestamp = " << beacon_ptr->m_timestamp
+                      << ", hash = " << beacon_ptr->m_hash.GetHex()
+                      << ", prev beacon hash = " << beacon_ptr->m_previous_hash.GetHex()
+                      << ", status = " << beacon_ptr->StatusToString()
+                      << std::endl;
 
             reinit_beacon_db_iter = reinit_beacon_db.advance(reinit_beacon_db_iter);
         }


### PR DESCRIPTION
We have had some problems with beacon history causing the wallet to get stuck. The symptoms are the wallet stops syncing and one thread is constantly running. This is cleared by having the users start the wallet with -clearbeaconhistory, which clears out the leveldb beacon registry area and rebuilds it from a contract replay. This would indicate that the beacon chainlets are somehow corrupted and causing an infinite loop during the chainlet walkback that is done in several consensus critical areas.

This PR corrects some flaws found in the beacon contract handling code, refactors chainlet walkbacks that were in several places in the code into one BeaconRegistry::GetBeaconChainletRoot, which also has corruption detection, and also expands the logging in the beacon test harness to help with troubleshooting. Code comments have also been corrected and updated.