### PR TITLE
refactor: Fix compilation warnings

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -113,11 +113,11 @@ bool CAlert::Cancels(const CAlert& alert) const
     return (alert.nID <= nCancel || setCancel.count(alert.nID));
 }
 
-bool CAlert::AppliesTo(int nVersion, std::string strSubVerIn) const
+bool CAlert::AppliesTo(int version, std::string strSubVerIn) const
 {
     // TODO: rework for client-version-embedded-in-strSubVer ?
     return (IsInEffect() &&
-            nMinVer <= nVersion && nVersion <= nMaxVer &&
+            nMinVer <= version && version <= nMaxVer &&
             (setSubVer.empty() || setSubVer.count(strSubVerIn)));
 }
 

--- a/src/alert.h
+++ b/src/alert.h
@@ -94,7 +94,7 @@ public:
     uint256 GetHash() const;
     bool IsInEffect() const;
     bool Cancels(const CAlert& alert) const;
-    bool AppliesTo(int nVersion, std::string strSubVerIn) const;
+    bool AppliesTo(int version, std::string strSubVerIn) const;
     bool AppliesToMe() const;
     bool RelayTo(CNode* pnode) const;
     bool CheckSignature() const;

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -1313,7 +1313,7 @@ template<> void BeaconRegistry::BeaconDB::HandleCurrentHistoricalEntries(GRC::Be
     }
 
     if (entry.m_status == BeaconStatusForStorage::ACTIVE) {
-        // Note that in the orginal activation, all the activations happen for a superblock, and then the expired_entry set is
+        // Note that in the original activation, all the activations happen for a superblock, and then the expired_entry set is
         // cleared and then new expired entries recorded from the just committed SB. This method operates at the record level, but
         // clearing the expired_entries for each ACTIVE record posting will achieve the same effect, because the entries are ordered
         // the proper way. It is a little bit of undesired work, but it is not worth the complexity of feeding the boundaries

--- a/src/gridcoin/contract/registry_db.h
+++ b/src/gridcoin/contract/registry_db.h
@@ -64,7 +64,7 @@ public:
     //! \param entries The map of current entries.
     //! \param pending_entries. The map of pending entries. This is not used in the general template, only in the beacons
     //! specialization.
-    //! \param expired_entries. The map of expired pending entries. This is not used in the geenral template, only in the
+    //! \param expired_entries. The map of expired pending entries. This is not used in the general template, only in the
     //! beacons specialization.
     //!
     //! \return block height up to and including which the entry records were stored.
@@ -230,7 +230,7 @@ public:
     }
 
     //!
-    //! \brief Handles the passivation of previous historical entries that have been superceded by current entries.
+    //! \brief Handles the passivation of previous historical entries that have been superseded by current entries.
     //!
     //! \param historical_entry_ptr. Shared smart pointer to current historical entry already inserted into historical map.
     //!

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -214,8 +214,8 @@ void InitializeContracts(CBlockIndex* pindexBest)
     // for polls and votes. The reason for this is quite simple. Polls and votes are UNIQUE. The reversion of an add
     // is simply to delete them. The wallet startup replay requirement is still required for polls and votes, because
     // the Poll/Vote classes do not have a backing registry db yet.
-    const int& start_height = std::min(std::max(db_heights.GetLowestRegistryBlockHeight(), V11_height),
-                                       lookback_window_low_height);
+    int start_height = std::min(std::max(db_heights.GetLowestRegistryBlockHeight(), V11_height),
+                                lookback_window_low_height);
 
     LogPrintf("Gridcoin: Starting contract replay from height %i.", start_height);
 

--- a/src/gridcoin/md5.c
+++ b/src/gridcoin/md5.c
@@ -6,7 +6,7 @@
  * The implementation was written so as to conform with Netscapes SSL.
  *
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
+ * the following conditions are adhered to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -31,7 +31,7 @@
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
@@ -49,7 +49,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * The licence and distribution terms for any publically available version or
+ * The licence and distribution terms for any publicly available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.] */
@@ -244,7 +244,7 @@ uint8_t *GRC__MD5(const uint8_t *data, size_t len, uint8_t out[MD5_DIGEST_LENGTH
 
 // As pointed out by Wei Dai <weidai@eskimo.com>, the above can be
 // simplified to the code below.  Wei attributes these optimizations
-// to Peter Gutmann's SHS code, and he attributes it to Rich Schroeppel.
+// to Peter Gutmann's SSH code, and he attributes it to Rich Schroeppel.
 #define F(b, c, d) ((((c) ^ (d)) & (b)) ^ (d))
 #define G(b, c, d) ((((b) ^ (c)) & (d)) ^ (c))
 #define H(b, c, d) ((b) ^ (c) ^ (d))

--- a/src/gridcoin/mrc.cpp
+++ b/src/gridcoin/mrc.cpp
@@ -280,8 +280,6 @@ bool TrySignMRC(
     CBlockIndex* pindex,
     GRC::MRC& mrc) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    AssertLockHeld(cs_main);
-
     // lock needs to be taken on pwallet here.
     LOCK(pwallet->cs_wallet);
 

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -721,7 +721,7 @@ private: // SuperblockValidator classes
         std::vector<ResolvedPart> m_resolved_parts;
 
         //!
-        //! \brief Divisor set by the \c ProjectCombiner for iteraton over each
+        //! \brief Divisor set by the \c ProjectCombiner for iteration over each
         //! convergence combination.
         //!
         size_t m_combiner_mask;

--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -98,10 +98,18 @@ namespace
             {
                 pg->lastruntime = currenttime;
 
+#if LIBCURL_VERSION_NUM >= 0x073700
+                curl_off_t speed;
+#else
                 double speed;
+#endif
                 CURLcode result;
 
+#if LIBCURL_VERSION_NUM >= 0x073700
+                result = curl_easy_getinfo(curl, CURLINFO_SPEED_DOWNLOAD_T, &speed);
+#else
                 result = curl_easy_getinfo(curl, CURLINFO_SPEED_DOWNLOAD, &speed);
+#endif
 
                 // Download speed update
                 if (result == CURLE_OK)

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -208,7 +208,7 @@ std::map<uint256, std::shared_ptr<CScraperManifest>> CScraperManifest::mapManife
 ConvergedScraperStats ConvergedScraperStatsCache GUARDED_BY(cs_ConvergedScraperStatsCache) = {};
 
 /**
- * @brief Scraper loggger function
+ * @brief Scraper logger function
  * @param eType
  * @param sCall
  * @param sMessage

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -45,7 +45,7 @@ public:
 
     //!
     //! \brief Allocations extend the Fraction class and can also represent the result of the allocation constructed fraction
-    //! and the result of the muliplication of that fraction times the reward, which is in CAmount (i.e. int64_t).
+    //! and the result of the multiplication of that fraction times the reward, which is in CAmount (i.e. int64_t).
     //!
     //! \return CAmount of the Fraction representation of the actual allocation.
     //!

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -1020,7 +1020,7 @@ PollBuilder PollBuilder::SetTitle(std::string title)
             ToString(Poll::MAX_TITLE_SIZE)));
     }
 
-    m_poll->m_title = std::move(title);
+    m_poll->m_title = title;
 
     return std::move(*this);
 }
@@ -1037,7 +1037,7 @@ PollBuilder PollBuilder::SetUrl(std::string url)
             ToString(Poll::MAX_URL_SIZE)));
     }
 
-    m_poll->m_url = std::move(url);
+    m_poll->m_url = url;
 
     return std::move(*this);
 }
@@ -1050,7 +1050,7 @@ PollBuilder PollBuilder::SetQuestion(std::string question)
             ToString(Poll::MAX_QUESTION_SIZE)));
     }
 
-    m_poll->m_question = std::move(question);
+    m_poll->m_question = question;
 
     return std::move(*this);
 }
@@ -1059,13 +1059,13 @@ PollBuilder PollBuilder::SetChoices(std::vector<std::string> labels)
 {
     m_poll->m_choices = Poll::ChoiceList();
 
-    return AddChoices(std::move(labels));
+    return AddChoices(labels);
 }
 
 PollBuilder PollBuilder::AddChoices(std::vector<std::string> labels)
 {
     for (auto& label : labels) {
-        *this = AddChoice(std::move(label));
+        *this = AddChoice(label);
     }
 
     return std::move(*this);
@@ -1096,7 +1096,7 @@ PollBuilder PollBuilder::AddChoice(std::string label)
         throw VotingError(strprintf(_("Duplicate poll choice: %s"), label));
     }
 
-    m_poll->m_choices.Add(std::move(label));
+    m_poll->m_choices.Add(label);
 
     return std::move(*this);
 }
@@ -1105,20 +1105,20 @@ PollBuilder PollBuilder::SetAdditionalFields(std::vector<Poll::AdditionalField> 
 {
     m_poll->m_additional_fields = Poll::AdditionalFieldList();
 
-    return AddAdditionalFields(std::move(fields));
+    return AddAdditionalFields(fields);
 }
 
 PollBuilder PollBuilder::SetAdditionalFields(Poll::AdditionalFieldList fields)
 {
     m_poll->m_additional_fields = Poll::AdditionalFieldList();
 
-    return AddAdditionalFields(std::move(fields));
+    return AddAdditionalFields(fields);
 }
 
 PollBuilder PollBuilder::AddAdditionalFields(std::vector<Poll::AdditionalField> fields)
 {
     for (auto& field : fields) {
-        *this = AddAdditionalField(std::move(field));
+        *this = AddAdditionalField(field);
     }
 
     if (!m_poll->m_additional_fields.WellFormed(m_poll->m_type.Value())) {
@@ -1131,7 +1131,7 @@ PollBuilder PollBuilder::AddAdditionalFields(std::vector<Poll::AdditionalField> 
 PollBuilder PollBuilder::AddAdditionalFields(Poll::AdditionalFieldList fields)
 {
     for (auto& field : fields) {
-        *this = AddAdditionalField(std::move(field));
+        *this = AddAdditionalField(field);
     }
 
     if (!m_poll->m_additional_fields.WellFormed(m_poll->m_type.Value())) {
@@ -1177,7 +1177,7 @@ PollBuilder PollBuilder::AddAdditionalField(Poll::AdditionalField field)
         throw VotingError(strprintf(_("Duplicate poll additional field: %s"), field.m_name));
     }
 
-    m_poll->m_additional_fields.Add(std::move(field));
+    m_poll->m_additional_fields.Add(field);
 
     return std::move(*this);
 }

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -109,6 +109,11 @@ public:
     {
         LOCK(pwalletMain->cs_wallet);
 
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: vote contract tx hash %s ismine status %i",
+                 __func__,
+                 m_tx.GetHash().GetHex(),
+                 pwalletMain->IsMine(m_tx));
+
         return pwalletMain->IsMine(m_tx);
     }
 
@@ -1256,6 +1261,7 @@ void PollResult::TallyVote(VoteDetail detail)
         if (detail.m_ismine != ISMINE_NO) {
             bool choice_found = false;
 
+            // If the response offset entry already exists, then append to the existing entry...
             for (auto& choice : m_self_vote_detail.m_responses) {
                 if (choice.first == response_offset) {
                     choice.second += response_weight;
@@ -1264,6 +1270,7 @@ void PollResult::TallyVote(VoteDetail detail)
                 }
             }
 
+            // Otherwise make a new m_responses entry to represent the response offset and the associated weight.
             if (!choice_found) {
                 m_self_vote_detail.m_responses.push_back(std::make_pair(response_offset, response_weight));
             }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -479,7 +479,6 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev,
                        - 2) * coinstake_output_ser_size;
         }
 
-        uint64_t nBlockTx = 0;
         int nBlockSigOps = 100;
 
         std::make_heap(vecPriority.begin(), vecPriority.end());
@@ -626,7 +625,6 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev,
 
             block.vtx.push_back(tx);
             nBlockSize += nTxSize;
-            ++nBlockTx;
             nBlockSigOps += nTxSigOps;
             nFees += nTxFees;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -939,7 +939,7 @@ void SplitCoinStakeOutput(CBlock &blocknew, int64_t &nReward, bool &fEnableStake
     CScript SideStakeScriptPubKey;
     GRC::Allocation SumAllocation;
 
-    // Lambda for sidestake allocation. This iterates throught the provided sidestake vector until either all elements processed,
+    // Lambda for sidestake allocation. This iterates through the provided sidestake vector until either all elements processed,
     // the maximum number of sidestake outputs is reached via the provided output_limit, or accumulated allocation will exceed 100%.
     const auto allocate_sidestakes = [&](SideStakeAlloc sidestakes, unsigned int output_limit) {
         for (auto iterSideStake = sidestakes.begin();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1560,14 +1560,12 @@ void ThreadOpenConnections2(void* parg)
 
         // Only connect out to one peer per network group (/16 for IPv4).
         // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
-        int nOutbound = 0;
         set<vector<unsigned char> > setConnected;
         {
             LOCK(cs_vNodes);
             for (auto const& pnode : vNodes) {
                 if (!pnode->fInbound) {
                     setConnected.insert(pnode->addr.GetGroup());
-                    nOutbound++;
                 }
             }
         }

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -42,7 +42,7 @@ public:
     const QString &getReturnValue() const { return returnValue; }
 
 public slots:
-    void done(int retval);
+    void done(int retval) override;
     void exportClicked();
     void changeFilter(const QString& needle);
     void resizeTableColumns(const bool& neighbor_pair_adjust = false, const int& index = 0,

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -48,7 +48,7 @@ QString dateTimeStr(qint64 nTime)
 
 QString formatPingTime(double dPingTime)
 {
-    return (dPingTime == std::numeric_limits<int64_t>::max()/1e6 || dPingTime == 0) ?
+    return (dPingTime >= static_cast<double>(std::numeric_limits<int64_t>::max()) / 1e6 || dPingTime <= 0) ?
         QObject::tr("N/A") : 
         QObject::tr("%1 ms").arg(QString::number((int)(dPingTime * 1000), 10));
 }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -216,7 +216,7 @@ public:
             //
             // If a status update is needed (blocks came in since last check),
             //  update the status of this transaction from the wallet. Otherwise,
-            // simply re-use the cached status.
+            // simply reuse the cached status.
             TRY_LOCK(cs_main, lockMain);
             if(lockMain)
             {

--- a/src/qt/voting/additionalfieldstablemodel.cpp
+++ b/src/qt/voting/additionalfieldstablemodel.cpp
@@ -177,7 +177,7 @@ void AdditionalFieldsTableModel::refresh()
             ->reload(additional_fields);
 }
 
-Qt::SortOrder AdditionalFieldsTableModel::sort(int column)
+Qt::SortOrder AdditionalFieldsTableModel::custom_sort(int column)
 {
     if (sortColumn() == column) {
         QSortFilterProxyModel::sort(column, static_cast<Qt::SortOrder>(!sortOrder()));

--- a/src/qt/voting/additionalfieldstablemodel.h
+++ b/src/qt/voting/additionalfieldstablemodel.h
@@ -42,7 +42,7 @@ public:
 
 public slots:
     void refresh();
-    Qt::SortOrder sort(int column);
+    Qt::SortOrder custom_sort(int column);
 
 private:
     const PollItem* m_poll_item;

--- a/src/qt/voting/polltab.cpp
+++ b/src/qt/voting/polltab.cpp
@@ -205,7 +205,7 @@ void PollTab::filter(const QString& needle)
 
 void PollTab::sort(const int column)
 {
-    const Qt::SortOrder order = m_polltable_model->sort(column);
+    const Qt::SortOrder order = m_polltable_model->custom_sort(column);
     ui->table->horizontalHeader()->setSortIndicator(column, order);
 }
 

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -15,7 +15,6 @@
 
 using namespace GRC;
 
-namespace {
 PollTableDataModel::PollTableDataModel()
 {
     qRegisterMetaType<QList<QPersistentModelIndex>>();
@@ -189,7 +188,6 @@ void PollTableDataModel::handlePollStaleFlag(QString poll_txid_string)
 
     emit layoutChanged();
 }
-} // Anonymous namespace
 
 // -----------------------------------------------------------------------------
 // Class: PollTableModel

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -292,7 +292,7 @@ void PollTableModel::changeTitleFilter(const QString& pattern)
     emit layoutChanged();
 }
 
-Qt::SortOrder PollTableModel::sort(int column)
+Qt::SortOrder PollTableModel::custom_sort(int column)
 {
     if (sortColumn() == column) {
         QSortFilterProxyModel::sort(column, static_cast<Qt::SortOrder>(!sortOrder()));

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -15,7 +15,6 @@
 class PollItem;
 class VotingModel;
 
-namespace {
 class PollTableDataModel : public QAbstractTableModel
 {
 public:
@@ -35,7 +34,6 @@ private:
     std::vector<PollItem> m_rows;
 
 };
-} // Anonymous namespace
 
 class PollTableModel : public QSortFilterProxyModel
 {

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -78,7 +78,7 @@ signals:
 public slots:
     void refresh();
     void changeTitleFilter(const QString& pattern);
-    Qt::SortOrder sort(int column);
+    Qt::SortOrder custom_sort(int column);
 
     void handlePollStaleFlag(QString poll_txid_string);
 

--- a/src/qt/voting/pollwizarddetailspage.cpp
+++ b/src/qt/voting/pollwizarddetailspage.cpp
@@ -261,12 +261,7 @@ void PollWizardDetailsPage::initializePage()
 
         // Only populate poll additional field entries if version >= 3.
         bool v3_enabled = false;
-
-        {
-            AssertLockHeld(cs_main);
-
-            v3_enabled = IsPollV3Enabled(nBestHeight);
-        }
+        v3_enabled = IsPollV3Enabled(nBestHeight);
 
         if (v3_enabled) {
             poll_item.m_additional_field_entries.push_back(

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -107,7 +107,10 @@ public:
 
         // Copy operator and constructor transfer the context
         UnlockContext(const UnlockContext& obj) { CopyFrom(obj); }
-        UnlockContext& operator=(const UnlockContext& rhs) { CopyFrom(rhs); return *this; }
+
+        // Commented out as we don't use the below form and it triggers an infinite recursion
+        // warning.
+        // UnlockContext& operator=(const UnlockContext& rhs) { CopyFrom(rhs); return *this; }
     private:
         WalletModel *wallet;
         bool valid;

--- a/src/random.h
+++ b/src/random.h
@@ -100,7 +100,7 @@ constexpr auto GetRandMillis = GetRandomDuration<std::chrono::milliseconds>;
  * is memoryless and should be used for repeated network events (e.g. sending a
  * certain type of message) to minimize leaking information to observers.
  *
- * The probability of an event occuring before time x is 1 - e^-(x/a) where a
+ * The probability of an event occurring before time x is 1 - e^-(x/a) where a
  * is the average interval between events.
  * */
 std::chrono::microseconds GetExponentialRand(std::chrono::microseconds now, std::chrono::seconds average_interval);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1750,7 +1750,7 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
         active.push_back(entry);
     }
 
-    for (auto beacon_ptr : beacons.FindPending(*cpid)) {
+    for (const auto& beacon_ptr : beacons.FindPending(*cpid)) {
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("cpid", cpid->ToString());
         entry.pushKV("active", false);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -352,8 +352,8 @@ int CommandLineRPC(int argc, char *argv[])
         const UniValue reply = CallRPC(strMethod, params);
 
         // Parse reply
-        const UniValue& result = find_value(reply, "result");
-        const UniValue& error  = find_value(reply, "error");
+        UniValue result = find_value(reply, "result");
+        UniValue error  = find_value(reply, "error");
 
         if (!error.isNull())
         {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1528,14 +1528,14 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
         const UniValue& input = inputs[idx];
         const UniValue& o = input.get_obj();
 
-        const UniValue& txid_v = find_value(o, "txid");
+        UniValue txid_v = find_value(o, "txid");
         if (!txid_v.isStr())
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing txid key");
         string txid = txid_v.get_str();
         if (!IsHex(txid))
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex txid");
 
-        const UniValue& vout_v = find_value(o, "vout");
+        UniValue vout_v = find_value(o, "vout");
         if (!vout_v.isNum())
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing vout key");
         int nOutput = vout_v.get_int();

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1102,7 +1102,7 @@ public:
         {
             // Evict a random entry. Random because that helps
             // foil would-be DoS attackers who might try to pre-generate
-            // and re-use a set of valid signatures just-slightly-greater
+            // and reuse a set of valid signatures just-slightly-greater
             // than our cache size.
             uint256 randomHash = GetRandHash();
             std::vector<unsigned char> unused;

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
             tx.vin[j].prevout.hash = txPrev.GetHash();
         }
         BOOST_CHECK(SignSignature(keystore, txPrev, tx, 0));
-        // Re-use same signature for other inputs
+        // Reuse same signature for other inputs
         // (they don't have to be valid for this test)
         for (unsigned int j = 1; j < tx.vin.size(); j++)
             tx.vin[j].scriptSig = tx.vin[0].scriptSig;

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -9,25 +9,6 @@
 #include <boost/test/unit_test.hpp>
 
 namespace {
-//!
-//! \brief Generate a mock project contract.
-//!
-//! \param key   A fake project name as it might appear in a contract.
-//! \param value A fake project URL as it might appear in a contract.
-//!
-//! \return A mock project contract.
-//!
-GRC::Contract contract(std::string key, std::string value)
-{
-    return GRC::MakeContract<GRC::Project>(
-        // Add or delete checked before passing to handler, so we don't need
-        // to give a specific value here:
-        GRC::ContractAction::UNKNOWN,
-        std::move(key),
-        std::move(value),
-        1234567); // timestamp
-}
-
 void AddProjectEntry(const uint32_t& payload_version, const std::string& name, const std::string& url,
                      const bool& gdpr_status, const int& height, const uint64_t time, const bool& reset_registry = false)
 {

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
     BOOST_CHECK(VerifyScript(goodsig3, scriptPubKey23, txTo23, 0, 0));
 
     keys.clear();
-    keys.push_back(key2); keys.push_back(key2); // Can't re-use sig
+    keys.push_back(key2); keys.push_back(key2); // Can't reuse sig
     CScript badsig1 = sign_multisig(scriptPubKey23, keys, txTo23);
     BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey23, txTo23, 0, 0));
 

--- a/src/test/xxd/xxd.c
+++ b/src/test/xxd/xxd.c
@@ -36,7 +36,7 @@
  *  7.06.96 -i printed 'int' instead of 'char'. *blush*
  *	    added Bram's OS2 ifdefs...
  * 18.07.96 gcc -Wall @ SunOS4 is now silent.
- *	    Added osver for MSDOS/DJGPP/WIN32.
+ *	    Added osver for MS-DOS/DJGPP/WIN32.
  * 29.08.96 Added size_t to strncmp() for Amiga.
  * 24.03.97 Windows NT support (Phil Hanna). Clean exit for Amiga WB (Bram)
  * 02.04.97 Added -E option, to have EBCDIC translation instead of ASCII

--- a/src/util.h
+++ b/src/util.h
@@ -168,7 +168,7 @@ inline int64_t abs64(int64_t n)
 //! implementations.
 //!
 //! In particular this class is used for sidestake allocations, both the allocation "percentage", and the CAmount allocations
-//! resulting from muliplying the allocation (fraction) times the CAmount rewards.
+//! resulting from multiplying the allocation (fraction) times the CAmount rewards.
 //!
 class Fraction {
 public:

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2188,11 +2188,10 @@ UniValue walletpassphrase(const UniValue& params, bool fHelp)
     strWalletPass.reserve(100);
     strWalletPass = std::string_view{params[0].get_str()};
 
-    if (strWalletPass.length() > 0)
-    {
+    if (strWalletPass.length() > 0) {
         LOCK2(cs_main, pwalletMain->cs_wallet);
 
-        if (!pwalletMain->Unlock(strWalletPass))
+        if (!pwalletMain->Unlock(strWalletPass)) {
             // Check if the passphrase has a null character
             if (strWalletPass.find('\0') == std::string::npos) {
                 throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
@@ -2204,11 +2203,12 @@ UniValue walletpassphrase(const UniValue& params, bool fHelp)
                                                                     "the first null character. If this is successful, please set a new "
                                                                     "passphrase to avoid this issue in the future.");
             }
-    }
-    else
+        }
+    } else {
         throw runtime_error(
             "walletpassphrase <passphrase> <timeout>\n"
             "Stores the wallet decryption key in memory for <timeout> seconds.");
+    }
 
     NewThread(ThreadTopUpKeyPool, nullptr);
     int64_t* pnSleepTime = new int64_t(nSleepTime);
@@ -2252,7 +2252,7 @@ UniValue walletpassphrasechange(const UniValue& params, bool fHelp)
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    if (!pwalletMain->ChangeWalletPassphrase(strOldWalletPass, strNewWalletPass))
+    if (!pwalletMain->ChangeWalletPassphrase(strOldWalletPass, strNewWalletPass)) {
         // Check if the old passphrase had a null character
         if (strOldWalletPass.find('\0') == std::string::npos) {
             throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
@@ -2263,12 +2263,13 @@ UniValue walletpassphrasechange(const UniValue& params, bool fHelp)
                                                                 "please try again with only the characters up to — but not including — "
                                                                 "the first null character.");
         }
+    }
 
     return NullUniValue;
 }
 
 /**
- * Run the walled diagnose checks
+ * Run the wallet diagnose checks
  */
 UniValue walletdiagnose(const UniValue& params, bool fHelp)
 {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -99,7 +99,8 @@ public:
 class CWalletDB : public CDB
 {
 public:
-    CWalletDB(const std::string& strFilename, const char* pszMode = "r+", bool fFlushOnClose = true) : CDB(strFilename, pszMode, fFlushOnClose)
+    CWalletDB(const std::string& strFilename, const char* pszMode = "r+", bool flush_on_close = true)
+        : CDB(strFilename, pszMode, flush_on_close)
     {
     }
 private:

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -27,3 +27,4 @@ smoe
 sur
 clen
 siz
+anull


### PR DESCRIPTION
Various minor fixes for compilation warnings with both gcc and clang. This is on top of https://github.com/gridcoin-community/Gridcoin-Research/pull/2731 and so will show those commits too until that PR is merged and this is rebased.

Some of these warnings are downright false positive boneheaded things from the compilers BTW.

Closes #2691.