### PR TITLE
gui, util: Improve upgrade dialog

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -106,6 +106,7 @@ QT_FORMS_UI = \
   qt/forms/sendcoinsentry.ui \
   qt/forms/signverifymessagedialog.ui \
   qt/forms/transactiondescdialog.ui \
+  qt/forms/updatedialog.ui \
   qt/forms/voting/additionalfieldstableview.ui \
   qt/forms/voting/pollcard.ui \
   qt/forms/voting/pollcardview.ui \
@@ -171,6 +172,7 @@ QT_MOC_CPP = \
   qt/moc_transactionfilterproxy.cpp \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
+  qt/moc_updatedialog.cpp \
   qt/moc_walletmodel.cpp \
   qt/researcher/moc_projecttablemodel.cpp \
   qt/researcher/moc_researchermodel.cpp \
@@ -298,6 +300,7 @@ GRIDCOINRESEARCH_QT_H = \
   qt/transactionrecord.h \
   qt/transactiontablemodel.h \
   qt/transactionview.h \
+  qt/updatedialog.h \
   qt/upgradeqt.h \
   qt/voting/additionalfieldstableview.h \
   qt/voting/additionalfieldstablemodel.h \
@@ -388,6 +391,7 @@ GRIDCOINRESEARCH_QT_CPP = \
   qt/transactiontablemodel.cpp \
   qt/transactionview.cpp \
   qt/upgradeqt.cpp \
+  qt/updatedialog.cpp \
   qt/voting/additionalfieldstableview.cpp \
   qt/voting/additionalfieldstablemodel.cpp \
   qt/voting/poll_types.cpp \

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -32,12 +32,16 @@ Upgrade::Upgrade()
 
 void Upgrade::ScheduledUpdateCheck()
 {
-    std::string VersionResponse = "";
+    std::string VersionResponse;
+    std::string change_log;
 
-    CheckForLatestUpdate(VersionResponse);
+    Upgrade::UpgradeType upgrade_type {Upgrade::UpgradeType::Unknown};
+
+    CheckForLatestUpdate(VersionResponse, change_log, upgrade_type);
 }
 
-bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dialog, bool snapshotrequest)
+bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, std::string& change_log, Upgrade::UpgradeType& upgrade_type,
+                                   bool ui_dialog, bool snapshotrequest)
 {
     // If testnet skip this || If the user changes this to disable while wallet running just drop out of here now.
     // (Need a way to remove items from scheduler.)
@@ -46,8 +50,8 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     Http VersionPull;
 
-    std::string GithubResponse = "";
-    std::string VersionResponse = "";
+    std::string GithubResponse;
+    std::string VersionResponse;
 
     // We receive the response and it's in a json reply
     UniValue Response(UniValue::VOBJ);
@@ -64,15 +68,15 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     if (VersionResponse.empty())
     {
-        LogPrintf("WARNING %s: No Response from GitHub", __func__);
+        LogPrintf("WARNING: %s: No Response from GitHub", __func__);
 
         return false;
     }
 
-    std::string GithubReleaseData = "";
-    std::string GithubReleaseTypeData = "";
-    std::string GithubReleaseBody = "";
-    std::string GithubReleaseType = "";
+    std::string GithubReleaseData;
+    std::string GithubReleaseTypeData;
+    std::string GithubReleaseBody;
+    std::string GithubReleaseType;
 
     try
     {
@@ -95,14 +99,19 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
     }
 
     GithubReleaseTypeData = ToLower(GithubReleaseTypeData);
-    if (GithubReleaseTypeData.find("leisure") != std::string::npos)
+
+    if (GithubReleaseTypeData.find("leisure") != std::string::npos) {
         GithubReleaseType = _("leisure");
-
-    else if (GithubReleaseTypeData.find("mandatory") != std::string::npos)
+        upgrade_type = Upgrade::UpgradeType::Leisure;
+    } else if (GithubReleaseTypeData.find("mandatory") != std::string::npos) {
         GithubReleaseType = _("mandatory");
-
-    else
+        // This will be confirmed below by also checking the second position version. If not incremented, then it will
+        // be set to unknown.
+        upgrade_type = Upgrade::UpgradeType::Mandatory;
+    } else {
         GithubReleaseType = _("unknown");
+        upgrade_type = Upgrade::UpgradeType::Unknown;
+    }
 
     // Parse version data
     std::vector<std::string> GithubVersion;
@@ -113,6 +122,7 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
     LocalVersion.push_back(CLIENT_VERSION_MAJOR);
     LocalVersion.push_back(CLIENT_VERSION_MINOR);
     LocalVersion.push_back(CLIENT_VERSION_REVISION);
+    LocalVersion.push_back(CLIENT_VERSION_BUILD);
 
     if (GithubVersion.size() != 4)
     {
@@ -123,60 +133,79 @@ bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, bool ui_dial
 
     bool NewVersion = false;
     bool NewMandatory = false;
+    bool same_version = true;
 
     try {
         // Left to right version numbers.
-        // 3 numbers to check for production.
-        for (unsigned int x = 0; x < 3; x++)
-        {
+        // 4 numbers to check.
+        for (unsigned int x = 0; x <= 3; x++) {
             int github_version = 0;
 
-            if (!ParseInt32(GithubVersion[x], &github_version))
-            {
+            if (!ParseInt32(GithubVersion[x], &github_version)) {
                 throw std::invalid_argument("Failed to parse GitHub version from official GitHub project repo.");
             }
 
-            if (github_version > LocalVersion[x])
-            {
+            if (github_version > LocalVersion[x]) {
                 NewVersion = true;
-                if (x < 2)
-                {
+                same_version = false;
+
+                if (x < 2 && upgrade_type == Upgrade::UpgradeType::Mandatory) {
                     NewMandatory = true;
+                } else {
+                    upgrade_type = Upgrade::UpgradeType::Unknown;
                 }
-                break;
+            } else {
+                same_version &= (github_version == LocalVersion[x]);
             }
         }
-    }
-    catch (std::exception& ex)
-    {
+    } catch (std::exception& ex) {
         error("%s: Exception occurred checking client version against GitHub version (%s)",
                   __func__, ToString(ex.what()));
 
+        upgrade_type = Upgrade::UpgradeType::Unknown;
         return false;
     }
 
-    if (!NewVersion) return NewVersion;
-
-    // New version was found
+    // Populate client_message_out regardless of whether new version is found, because we are using this method for
+    // the version information button in the "About Gridcoin" dialog.
     client_message_out = _("Local version: ") + strprintf("%d.%d.%d.%d", CLIENT_VERSION_MAJOR, CLIENT_VERSION_MINOR,
                                                           CLIENT_VERSION_REVISION, CLIENT_VERSION_BUILD) + "\r\n";
     client_message_out.append(_("GitHub version: ") + GithubReleaseData + "\r\n");
-    client_message_out.append(_("This update is ") + GithubReleaseType + "\r\n\r\n");
 
-    // For snapshot requests we will handle things differently after this point
-    if (snapshotrequest && NewMandatory)
-        return NewVersion;
+    if (NewVersion) {
+        client_message_out.append(_("This update is ") + GithubReleaseType + "\r\n\r\n");
+    } else if (same_version) {
+        client_message_out.append(_("The latest release is ") + GithubReleaseType + "\r\n\r\n");
+        client_message_out.append(_("You are running the latest release.") + "\n");
+    } else {
+        client_message_out.append(_("The latest release is ") + GithubReleaseType + "\r\n\r\n");
 
-    if (NewMandatory)
+        // If not a new version available and the version is not the same, the only thing left is that we are running
+        // a version greater than the latest release version, so set the upgrade_type to Unsupported, which is used for a
+        // warning.
+        upgrade_type = Upgrade::UpgradeType::Unsupported;
+        client_message_out.append(_("WARNING: You are running a version that is higher than the latest release.") + "\n");
+    }
+
+    change_log = GithubReleaseBody;
+
+    if (!NewVersion) return false;
+
+    // For snapshot requests we will only return true if there is a new mandatory version AND the snapshotrequest boolean
+    // is set true. This is because the snapshot request context is looking for the presence of a new mandatory to block
+    // the snapshot download before upgrading to the new mandatory if there is one.
+    if (snapshotrequest && NewMandatory) return true;
+
+    if (NewMandatory) {
         client_message_out.append(_("WARNING: A mandatory release is available. Please upgrade as soon as possible.")
                                   + "\n");
+    }
 
-    std::string ChangeLog = GithubReleaseBody;
+    if (ui_dialog) {
+        uiInterface.UpdateMessageBox(client_message_out, static_cast<int>(upgrade_type), change_log);
+    }
 
-    if (ui_dialog)
-        uiInterface.UpdateMessageBox(client_message_out, ChangeLog);
-
-    return NewVersion;
+    return true;
 }
 
 void Upgrade::SnapshotMain()
@@ -188,8 +217,10 @@ void Upgrade::SnapshotMain()
 
     // Verify a mandatory release is not available before we continue to snapshot download.
     std::string VersionResponse = "";
+    std::string change_log;
+    Upgrade::UpgradeType upgrade_type {Upgrade::UpgradeType::Unknown};
 
-    if (CheckForLatestUpdate(VersionResponse, false, true))
+    if (CheckForLatestUpdate(VersionResponse, change_log, upgrade_type, false, true))
     {
         std::cout << this->ResetBlockchainMessages(UpdateAvailable) << std::endl;
         std::cout << this->ResetBlockchainMessages(GithubResponse) << std::endl;

--- a/src/gridcoin/upgrade.h
+++ b/src/gridcoin/upgrade.h
@@ -125,6 +125,13 @@ public:
         GithubResponse
     };
 
+    enum UpgradeType {
+        Unknown,
+        Leisure,
+        Mandatory,
+        Unsupported //! This is used for a running version that is greater than the current official release.
+    };
+
     //!
     //! \brief Scheduler call to CheckForLatestUpdate
     //!
@@ -133,7 +140,8 @@ public:
     //!
     //! \brief Check for latest updates on GitHub.
     //!
-    static bool CheckForLatestUpdate(std::string& client_message_out, bool ui_dialog = true, bool snapshotrequest = false);
+    static bool CheckForLatestUpdate(std::string& client_message_out, std::string& change_log, UpgradeType& upgrade_type,
+                                     bool ui_dialog = true, bool snapshotrequest = false);
 
     //!
     //! \brief Function that will be threaded to download snapshot

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -67,7 +67,7 @@ ADD_SIGNALS_IMPL_WRAPPER(UpdateMessageBox);
 ADD_SIGNALS_IMPL_WRAPPER(RwSettingsUpdated);
 
 void CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
-void CClientUIInterface::UpdateMessageBox(const std::string& version, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, message); }
+void CClientUIInterface::UpdateMessageBox(const std::string& version, const int& update_type, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, update_type, message); }
 bool CClientUIInterface::ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption) { return g_ui_signals.ThreadSafeAskFee(nFeeRequired, strCaption).value_or(false); }
 bool CClientUIInterface::ThreadSafeAskQuestion(std::string caption, std::string body) { return g_ui_signals.ThreadSafeAskQuestion(caption, body).value_or(false); }
 void CClientUIInterface::ThreadSafeHandleURI(const std::string& strURI) { return g_ui_signals.ThreadSafeHandleURI(strURI); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -88,7 +88,7 @@ public:
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, void, const std::string& message, const std::string& caption, int style);
 
     /** Update notification message box. */
-    ADD_SIGNALS_DECL_WRAPPER(UpdateMessageBox, void, const std::string& version, const std::string& message);
+    ADD_SIGNALS_DECL_WRAPPER(UpdateMessageBox, void, const std::string& version, const int& update_type, const std::string& message);
 
     /** Ask the user whether they want to pay a fee or not. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeAskFee, bool, int64_t nFeeRequired, const std::string& strCaption);

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -21,7 +21,7 @@ static bool noui_ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCa
     return true;
 }
 
-static int noui_UpdateMessageBox(const std::string& version, const std::string& message)
+static int noui_UpdateMessageBox(const std::string& version, const int& upgrade_type, const std::string& message)
 {
     std::string caption = _("Gridcoin Update Available");
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(gridcoinqt STATIC
     transactionrecord.cpp
     transactiontablemodel.cpp
     transactionview.cpp
+    updatedialog.cpp
     upgradeqt.cpp
     voting/additionalfieldstableview.cpp
     voting/additionalfieldstablemodel.cpp

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -17,7 +17,8 @@ AboutDialog::AboutDialog(QWidget *parent) :
     if (!fTestNet) {
         connect(ui->versionInfoButton, &QAbstractButton::pressed, this, [this]() { handlePressVersionInfoButton(); });
     } else {
-        ui->versionInfoButton->hide();
+        ui->versionInfoButton->setDisabled(true);
+        ui->versionInfoButton->setToolTip(tr("Version information is not available on testnet."));
     }
 }
 

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -14,8 +14,12 @@ AboutDialog::AboutDialog(QWidget *parent) :
 
     resize(GRC::ScaleSize(this, width(), height()));
 
-    if (!fTestNet) {
+    if (!fTestNet && !gArgs.GetBoolArg("-disableupdatecheck", false)) {
         connect(ui->versionInfoButton, &QAbstractButton::pressed, this, [this]() { handlePressVersionInfoButton(); });
+    } else if (gArgs.GetBoolArg("-disableupdatecheck", false)) {
+        ui->versionInfoButton->setDisabled(true);
+        ui->versionInfoButton->setToolTip(tr("Version information and update check has been disabled "
+                                             "by config or startup parameter."));
     } else {
         ui->versionInfoButton->setDisabled(true);
         ui->versionInfoButton->setToolTip(tr("Version information is not available on testnet."));

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -10,7 +10,23 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui(new Ui::AboutDialog)
 {
     ui->setupUi(this);
-    ui->copyrightLabel->setText("Copyright 2009-2024 The Bitcoin/Peercoin/Black-Coin/Gridcoin developers");
+
+    QString copyrightText = "Copyright 2009-";
+    std::variant<int, QString> copyright_year = COPYRIGHT_YEAR;
+
+    try {
+        copyrightText += QString::number(std::get<int>(copyright_year));
+    } catch (const std::bad_variant_access& e) {
+        try {
+            copyrightText += std::get<QString>(copyright_year);
+        } catch (const std::bad_variant_access& e) {
+            copyrightText += "Present";
+        }
+    }
+
+    copyrightText +=  " The Bitcoin/Peercoin/Black-Coin/Gridcoin developers";
+
+    ui->copyrightLabel->setText(copyrightText);
 
     resize(GRC::ScaleSize(this, width(), height()));
 

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -2,6 +2,8 @@
 #include "qt/decoration.h"
 #include "ui_aboutdialog.h"
 #include "clientmodel.h"
+#include "updatedialog.h"
+#include "util.h"
 
 AboutDialog::AboutDialog(QWidget *parent) :
     QDialog(parent),
@@ -11,6 +13,12 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui->copyrightLabel->setText("Copyright 2009-2024 The Bitcoin/Peercoin/Black-Coin/Gridcoin developers");
 
     resize(GRC::ScaleSize(this, width(), height()));
+
+    if (!fTestNet) {
+        connect(ui->versionInfoButton, &QAbstractButton::pressed, this, [this]() { handlePressVersionInfoButton(); });
+    } else {
+        ui->versionInfoButton->hide();
+    }
 }
 
 void AboutDialog::setModel(ClientModel *model)
@@ -29,4 +37,29 @@ AboutDialog::~AboutDialog()
 void AboutDialog::on_buttonBox_accepted()
 {
     close();
+}
+
+void AboutDialog::handlePressVersionInfoButton()
+{
+    std::string client_message_out;
+    std::string change_log;
+    GRC::Upgrade::UpgradeType upgrade_type = GRC::Upgrade::UpgradeType::Unknown;
+
+
+    GRC::Upgrade::CheckForLatestUpdate(client_message_out, change_log, upgrade_type, false, false);
+
+    if (client_message_out == std::string {}) {
+        client_message_out = "No response from GitHub - check network connectivity.";
+        change_log = " ";
+    }
+
+    UpdateDialog update_dialog;
+
+    update_dialog.setWindowTitle("Gridcoin Version Information");
+    update_dialog.setVersion(QString().fromStdString(client_message_out));
+    update_dialog.setUpgradeType(static_cast<GRC::Upgrade::UpgradeType>(upgrade_type));
+    update_dialog.setDetails(QString().fromStdString(change_log));
+    update_dialog.setModal(false);
+
+    update_dialog.exec();
 }

--- a/src/qt/aboutdialog.h
+++ b/src/qt/aboutdialog.h
@@ -23,6 +23,7 @@ private:
 
 private slots:
     void on_buttonBox_accepted();
+    void handlePressVersionInfoButton();
 };
 
 #endif // BITCOIN_QT_ABOUTDIALOG_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -192,16 +192,16 @@ static void InitMessage(const std::string &message)
     }
 }
 
-static void UpdateMessageBox(const std::string& version, const std::string& message)
+static void UpdateMessageBox(const std::string& version, const int& update_version, const std::string& message)
 {
     std::string caption = _("Gridcoin Update Available");
 
     if (guiref)
     {
-        std::string guiaddition = version + _("Click \"Show Details\" to view changes in latest update.");
         QMetaObject::invokeMethod(guiref, "update", Qt::QueuedConnection,
                                    Q_ARG(QString, QString::fromStdString(caption)),
-                                   Q_ARG(QString, QString::fromStdString(guiaddition)),
+                                   Q_ARG(QString, QString::fromStdString(version)),
+                                   Q_ARG(int, update_version),
                                    Q_ARG(QString, QString::fromStdString(message)));
     }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -45,6 +45,7 @@
 #include "upgradeqt.h"
 #include "voting/votingmodel.h"
 #include "voting/polltablemodel.h"
+#include "updatedialog.h"
 
 #ifdef Q_OS_MAC
 #include "macdockiconhandler.h"
@@ -1159,22 +1160,20 @@ void BitcoinGUI::error(const QString &title, const QString &message, bool modal)
     }
 }
 
-void BitcoinGUI::update(const QString &title, const QString& version, const QString &message)
+void BitcoinGUI::update(const QString &title, const QString& version, const int& upgrade_type, const QString &message)
 {
-    // Create our own message box; A dialog can go here in future for qt if we choose
-
-    updateMessageDialog.reset(new QMessageBox);
+    updateMessageDialog.reset(new UpdateDialog);
 
     updateMessageDialog->setWindowTitle(title);
-    updateMessageDialog->setText(version);
-    updateMessageDialog->setDetailedText(message);
-    updateMessageDialog->setIcon(QMessageBox::Information);
-    updateMessageDialog->setStandardButtons(QMessageBox::Ok);
+    updateMessageDialog->setVersion(version);
+    updateMessageDialog->setUpgradeType(static_cast<GRC::Upgrade::UpgradeType>(upgrade_type));
+    updateMessageDialog->setDetails(message);
     updateMessageDialog->setModal(false);
-    connect(updateMessageDialog.get(), &QMessageBox::finished, [this](int) { updateMessageDialog.reset(); });
+
+    connect(updateMessageDialog.get(), &QDialog::finished, this, [this]() { updateMessageDialog.reset(); });
+
     // Due to slight delay in gui load this could appear behind the gui ui
     // The only other option available would make the message box stay on top of all applications
-
     QTimer::singleShot(5000, updateMessageDialog.get(), [this]() { updateMessageDialog->show(); });
 }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -32,6 +32,7 @@ class Notificator;
 class RPCConsole;
 class DiagnosticsDialog;
 class ClickLabel;
+class UpdateDialog;
 
 QT_BEGIN_NAMESPACE
 class QLabel;
@@ -110,7 +111,7 @@ private:
     TransactionView *transactionView;
     VotingPage *votingPage;
     SignVerifyMessageDialog *signVerifyMessageDialog;
-    std::unique_ptr<QMessageBox> updateMessageDialog;
+    std::unique_ptr<UpdateDialog> updateMessageDialog;
 
     QLabel *statusbarAlertsLabel;
     QLabel *labelEncryptionIcon;
@@ -205,7 +206,7 @@ public slots:
     void setEncryptionStatus(int status);
 
     /** Notify the user if there is an update available */
-    void update(const QString& title, const QString& version, const QString& message);
+    void update(const QString& title, const QString& version, const int& upgrade_type, const QString& message);
 
     /** Notify the user of an error in the network or transaction handling code. */
     void error(const QString &title, const QString &message, bool modal);

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -137,6 +137,43 @@ This product includes software developed by the OpenSSL Project for use in the O
       </spacer>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="versionInfoButton">
+         <property name="text">
+          <string>Version Information</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/src/qt/forms/updatedialog.ui
+++ b/src/qt/forms/updatedialog.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UpdateDialog</class>
+ <widget class="QDialog" name="UpdateDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>609</width>
+    <height>430</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="infoIcon">
+       <property name="text">
+        <string>icon</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="versionData">
+       <property name="text">
+        <string>version</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="versionDetails">
+     <property name="undoRedoEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+     <property name="placeholderText">
+      <string>changelog</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>UpdateDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>UpdateDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/updatedialog.cpp
+++ b/src/qt/updatedialog.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2014-2024 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "updatedialog.h"
+#include "qicon.h"
+#include "qstyle.h"
+#include "qt/decoration.h"
+
+#include "ui_updatedialog.h"
+
+UpdateDialog::UpdateDialog(QWidget* parent)
+    : QDialog(parent)
+      , ui(new Ui::UpdateDialog)
+{
+    ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
+}
+
+UpdateDialog::~UpdateDialog()
+{
+    delete ui;
+}
+
+void UpdateDialog::setVersion(QString version)
+{
+    ui->versionData->setText(version);
+}
+
+void UpdateDialog::setDetails(QString message)
+{
+    ui->versionDetails->setText(message);
+}
+
+void UpdateDialog::setUpgradeType(GRC::Upgrade::UpgradeType upgrade_type)
+{
+    QIcon info_icon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation);
+    QIcon warning_icon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
+    QIcon unknown_icon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxQuestion);
+
+    switch (upgrade_type) {
+    case GRC::Upgrade::UpgradeType::Mandatory:
+        [[fallthrough]];
+    case GRC::Upgrade::UpgradeType::Unsupported:
+        ui->infoIcon->setPixmap(GRC::ScaleIcon(this, warning_icon, 48));
+        break;
+    case GRC::Upgrade::UpgradeType::Leisure:
+        ui->infoIcon->setPixmap(GRC::ScaleIcon(this, info_icon, 48));
+        break;
+    case GRC::Upgrade::Unknown:
+        ui->infoIcon->setPixmap(GRC::ScaleIcon(this, unknown_icon, 48));
+        break;
+    }
+}

--- a/src/qt/updatedialog.h
+++ b/src/qt/updatedialog.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2014-2024 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_UPDATEDIALOG_H
+#define BITCOIN_QT_UPDATEDIALOG_H
+
+#include "gridcoin/upgrade.h"
+#include <QDialog>
+
+namespace Ui {
+class UpdateDialog;
+}
+
+class UpdateDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit UpdateDialog(QWidget* parent = nullptr);
+    ~UpdateDialog();
+
+    void setVersion(QString version);
+    void setDetails(QString message);
+    void setUpgradeType(GRC::Upgrade::UpgradeType upgrade_type);
+
+private:
+    Ui::UpdateDialog *ui;
+
+};
+
+#endif // BITCOIN_QT_UPDATEDIALOG_H

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -41,8 +41,10 @@ bool UpgradeQt::SnapshotMain(QApplication& SnapshotApp)
 
     // Verify a mandatory release is not available before we continue to snapshot download.
     std::string VersionResponse = "";
+    std::string change_log;
+    Upgrade::UpgradeType upgrade_type {Upgrade::UpgradeType::Unknown};
 
-    if (UpgradeMain.CheckForLatestUpdate(VersionResponse, false, true))
+    if (UpgradeMain.CheckForLatestUpdate(VersionResponse, change_log, upgrade_type, false, true))
     {
         ErrorMsg(UpgradeMain.ResetBlockchainMessages(Upgrade::UpdateAvailable),
                  UpgradeMain.ResetBlockchainMessages(Upgrade::GithubResponse) + "\r\n" + VersionResponse);

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -403,14 +403,16 @@ public:
         m_results_tip_arg.clear();
 
         std::string client_message;
+        std::string change_log;
+        GRC::Upgrade::UpgradeType upgrade_type {GRC::Upgrade::UpgradeType::Unknown};
 
-        if (g_UpdateChecker->CheckForLatestUpdate(client_message, false)
+        if (g_UpdateChecker->CheckForLatestUpdate(client_message, change_log, upgrade_type, false)
                 && client_message.find("mandatory") != std::string::npos) {
             m_results_tip = _("There is a new mandatory version available and you should upgrade as soon as possible to "
                               "ensure your wallet remains in consensus with the network.");
             m_results = Diagnose::FAIL;
 
-        } else if (g_UpdateChecker->CheckForLatestUpdate(client_message, false)
+        } else if (g_UpdateChecker->CheckForLatestUpdate(client_message, change_log, upgrade_type, false)
                    && client_message.find("mandatory") == std::string::npos) {
             m_results_tip = _("There is a new leisure version available and you should upgrade as soon as practical.");
             m_results = Diagnose::WARNING;


### PR DESCRIPTION
This changes the upgrade message box to a subclassed dialog box that is bigger in size and allows for further refinement in the future, plus makes other minor improvements.

Closes #2666.

A "version information" button has been added to the About Gridcoin dialog box, which brings up the same dialog as the upgrade check. This button only appears if the wallet is on mainnet.

![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/8ab74c28-b726-4966-8ee0-e87a8e0eba0d)

The new version information/upgrade dialog box now includes the GitHub release information by default, and also displays an appropriate icon based on the nature of the version, mandatory or leisure. It also is larger by default and can be resized.

![image](https://github.com/gridcoin-community/Gridcoin-Research/assets/7529186/d3c39a95-b55d-45fe-8368-40d473cbe508)

If you happen to be running a release that is actually greater than the official release (as this case with a test node on mainnet for testing), it will warn you about this too.