### PR TITLE
net: Correct -tor argument handling

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1158,7 +1158,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         }
 
         if (!addrOnion.IsValid()) {
-            return InitError(strprintf(_("Invalid -tor address: '%s'"), gArgs.GetArg("-tor", "")));
+            return InitError(strprintf(_("Invalid -tor address: '%s'"), gArgs.GetArg("-tor", gArgs.GetArg("-proxy", ""))));
         }
         SetProxy(NET_TOR, addrOnion);
         SetReachable(NET_TOR, true);


### PR DESCRIPTION
A review of -tor startup parameter handling given #2732 reveals that the logic was flawed. This PR attempts to fix that.

Closes #2732.