### PR TITLE
util: Adjust Fraction class addition overload overflow tests

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1648,8 +1648,8 @@ BOOST_AUTO_TEST_CASE(util_Fraction_addition_overflow_2)
 
 BOOST_AUTO_TEST_CASE(util_Fraction_addition_overflow_3)
 {
-    Fraction lhs(-(std::numeric_limits<int64_t>::max() / 2 + 1), 1);
-    Fraction rhs(-(std::numeric_limits<int64_t>::max() / 2 + 1), 1);
+    Fraction lhs(std::numeric_limits<int64_t>::min() / 2 + 1, 1);
+    Fraction rhs(std::numeric_limits<int64_t>::min() / 2, 1);
 
     std::string err;
 
@@ -1664,8 +1664,8 @@ BOOST_AUTO_TEST_CASE(util_Fraction_addition_overflow_3)
 
 BOOST_AUTO_TEST_CASE(util_Fraction_addition_overflow_4)
 {
-    Fraction lhs(-(std::numeric_limits<int64_t>::max() / 2 + 1), 1);
-    Fraction rhs(-(std::numeric_limits<int64_t>::max() / 2 + 2), 1);
+    Fraction lhs(std::numeric_limits<int64_t>::min() / 2, 1);
+    Fraction rhs(std::numeric_limits<int64_t>::min() / 2, 1);
 
     std::string err;
 

--- a/src/util.h
+++ b/src/util.h
@@ -684,7 +684,14 @@ private:
 
         if (a < 0 && b < 0) {
             // Remember b is negative here, so the difference below is GREATER than std::numeric_limits<int64_t>::min().
-            if (a >= std::numeric_limits<int64_t>::min() - b) {
+            //
+            // The reason for the + 1 below is that the first case handled in the addition overflow operator method above,
+            // the fraction addition with a common denominator, also specifies simplification of the resultant fraction.
+            // This will call std::gcd on the numerator and denominator, which then calls std::abs. If std::abs is called on
+            // std::numeric_limits<int64_t>::min(), and -D_GLIBCXX_ASSERTIONS is set, then the program will abort on a glibc
+            // assertion, because the abs will overflow. To prevent this, we increase (make less negative) by 1, which will
+            // ensure the call to std::abs will succeed at the extreme case.
+            if (a >= std::numeric_limits<int64_t>::min() + 1 - b) {
                 return a + b;
             } else {
                 throw std::overflow_error("fraction addition of a + b where a < 0 and b < 0 results in an overflow");


### PR DESCRIPTION
@Tahvok, the arch maintainer, caught a subtle error in the extreme overflow tests for the newly augmented Fraction class in the 5.4.6.0 release. Arch, unlike other distributions, uses  the C++ compiler flag -D_GLIBCXX_ASSERTIONS, and this caught the  error.

Essentially the problem is in the fraction addition overflow tests at the extreme negative case. When the fraction addition overload operator goes to add fractions of the same denominator, where both addends are std::numeric_limits<int64_t>::min()  / 2, the result on the numerator will be std::numeric_limits<int64_t>::min(). When simplification is called, it will call std::gcd, which calls std::abs. The std::abs of std::numeric_limits<int64_t>::min() is an overflow, because it would be std::numeric_limits<int64_t>::max() + 1, but this is handled as an assert in glibc. So to prevent this, we tightened the negative side overflow constraint in overflow_add by 1 to ensure the numerator will never be less than std::numeric_limits<int64_t>::min() +1, so that the std::abs of that will succeed (i.e. will be std::numeric_limits<int64_t>::max()).

This is really esoteric and will not be reached by any actual wallet operation, but it is being treated as a hotfix to get Arch compiles to work.

Thanks to @div72 for helping me troubleshoot this.