### PR TITLE
Fix man page installation path for cmake builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -266,7 +266,7 @@ if(ENABLE_DAEMON)
             DESTINATION "${CMAKE_INSTALL_BINDIR}"
         )
         install(FILES "${CMAKE_SOURCE_DIR}/doc/gridcoinresearchd.1"
-            DESTINATION "${CMAKE_INSTALL_MANDIR}"
+            DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
         )
         install(FILES "${CMAKE_SOURCE_DIR}/contrib/init/gridcoinresearchd.service"
             DESTINATION /lib/systemd/system

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -194,7 +194,7 @@ if(UNIX AND NOT APPLE)
         DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
     )
     install(FILES "${CMAKE_SOURCE_DIR}/doc/gridcoinresearch.1"
-        DESTINATION "${CMAKE_INSTALL_MANDIR}"
+        DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
     )
 endif()
 


### PR DESCRIPTION
The standard layout for man pages is for them to be stored in subdirectories based on the section they belong to.