### PR TITLE
consensus, mrc, sidestake: add mrc fees to staker to rewards to be allocated via sidestaking

### DIFF
--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -453,6 +453,33 @@ std::string SideStake::GetDescription() const
     return std::string {};
 }
 
+int64_t SideStake::GetTimeStamp() const
+{
+    if (m_type == Type::MANDATORY && m_mandatory_sidestake_ptr != nullptr) {
+        return m_mandatory_sidestake_ptr->m_timestamp;
+    }
+
+    return int64_t {0};
+}
+
+uint256 SideStake::GetHash() const
+{
+    if (m_type == Type::MANDATORY && m_mandatory_sidestake_ptr != nullptr) {
+        return m_mandatory_sidestake_ptr->m_hash;
+    }
+
+    return uint256 {};
+}
+
+uint256 SideStake::GetPreviousHash() const
+{
+    if (m_type == Type::MANDATORY && m_mandatory_sidestake_ptr != nullptr) {
+        return m_mandatory_sidestake_ptr->m_previous_hash;
+    }
+
+    return uint256 {};
+}
+
 SideStake::Status SideStake::GetStatus() const
 {
     // For trivial initializer case

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -428,6 +428,21 @@ public:
     //!
     std::string GetDescription() const;
     //!
+    //! \brief Gets the timestamp of the transaction that contains the mandatory sidestake contract (now entry)
+    //! \return
+    //!
+    int64_t GetTimeStamp() const;
+    //!
+    //! \brief Gets the hash of the transaction that contains the mandatory sidestake contract (now entry)
+    //! \return uint256 hash
+    //!
+    uint256 GetHash() const;
+    //!
+    //! \brief Gets the hash of the transaction that contains the previous mandatory sidestake contract for the same key (address)
+    //! \return uint256 hash
+    //!
+    uint256 GetPreviousHash() const;
+    //!
     //! \brief Gets a variant containing either the mandatory sidestake status or local sidestake status, whichever
     //! is applicable.
     //! \return std::variant of the applicable sidestake status

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -150,7 +150,7 @@ bool TrySignClaim(
 
 // This is in anonymous namespace because it is only to be used by miner code here in this file.
 bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, GRC::MRC>>& mrc_map,
-                      std::map<GRC::Cpid, uint256>& mrc_tx_map, uint32_t& claim_contract_version,
+                      std::map<GRC::Cpid, uint256>& mrc_tx_map, CAmount& reward, uint32_t& claim_contract_version,
                       GRC::Claim& claim, CWallet* pwallet) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // For convenience
@@ -160,7 +160,7 @@ bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, G
     // coinstake.vout size should be 2 at this point. If not something is really wrong so assert immediately.
     assert(coinstake.vout.size() == 2);
 
-    CAmount rewards = 0;
+    CAmount mrc_rewards = 0;
     CAmount staker_fees = 0;
     CAmount foundation_fees = 0;
 
@@ -202,7 +202,7 @@ bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, G
 
                 if (reward) {
                     mrc_outputs.push_back(CTxOut(reward, script_beacon_key));
-                    rewards += reward;
+                    mrc_rewards += reward;
                 }
 
                 if (foundation_fee_fraction.IsNonZero()) {
@@ -236,7 +236,7 @@ bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, G
                          FormatMoney(mrc.m_research_subsidy),
                          mrc.m_version,
                          FormatMoney(reward),
-                         FormatMoney(rewards),
+                         FormatMoney(mrc_rewards),
                          FormatMoney(staker_fees + foundation_fees),
                          FormatMoney(staker_fees),
                          FormatMoney(foundation_fees));
@@ -246,6 +246,9 @@ bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, G
 
         // Now that the MRC outputs are created, add the fees to the staker to the coinstake output 1 value.
         coinstake.vout[1].nValue += staker_fees;
+
+        // Increment the reward parameter to include the staker_fees. This is important for mandatory sidestakes later.
+        reward += staker_fees;
 
         if (foundation_fees > 0) {
             // TODO: Make foundation address a defaulted but protocol overridable parameter.
@@ -287,7 +290,7 @@ bool CreateMRCRewards(CBlock &blocknew, std::map<GRC::Cpid, std::pair<uint256, G
              FormatMoney(claim.m_block_subsidy),
              FormatMoney(staker_fees),
              FormatMoney(foundation_fees),
-             FormatMoney(rewards));
+             FormatMoney(mrc_rewards));
 
     // Now the claim is complete. Put on the coinbase.
     blocknew.vtx[0].vContracts.emplace_back(GRC::MakeContract<GRC::Claim>(
@@ -1439,7 +1442,8 @@ void StakeMiner(CWallet *pwallet)
 
         // * Add MRC outputs to coinstake. This has to be done before the coinstake splitting/sidestaking, because
         // Some of the MRC fees go to the miner as part of the reward, and this affects the SplitCoinStakeOutput calculation.
-        if (!CreateMRCRewards(StakeBlock, mrc_map, mrc_tx_map, claim_contract_version, claim, pwallet)) continue;
+        // Note that nReward here now includes the mrc fees to the staker.
+        if (!CreateMRCRewards(StakeBlock, mrc_map, mrc_tx_map, nReward, claim_contract_version, claim, pwallet)) continue;
 
         g_timer.GetTimes(function + "CreateMRC", "miner");
 
@@ -1466,6 +1470,28 @@ void StakeMiner(CWallet *pwallet)
         LogPrintf("INFO: %s: signed boinchash, coinstake, wholeblock", __func__);
 
         g_miner_status.IncrementBlocksCreated();
+
+        if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) {
+            COutPoint stake_prevout = StakeBlock.vtx[1].vin[0].prevout;
+            CTransaction stake_input;
+            ReadTxFromDisk(stake_input, stake_prevout);
+
+            LogPrintf("INFO: %s: stake input = %s",
+                      __func__,
+                      FormatMoney(stake_input.vout[stake_prevout.n].nValue));
+
+            for (unsigned int i = 1; i < StakeBlock.vtx[1].vout.size(); ++i) {
+                CTxDestination destination;
+
+                ExtractDestination(StakeBlock.vtx[1].vout[i].scriptPubKey, destination);
+
+                LogPrintf("INFO: %s: stake output[%u] = %s, destination = %s",
+                          __func__,
+                          i,
+                          FormatMoney(StakeBlock.vtx[1].vout[i].nValue),
+                          CBitcoinAddress(destination).ToString());
+            }
+        }
 
         // * delegate to ProcessBlock
         if (!ProcessBlock(nullptr, &StakeBlock, true)) {

--- a/src/miner.h
+++ b/src/miner.h
@@ -31,6 +31,7 @@ bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficie
 bool CreateMRCRewards(CBlock &blocknew,
                       std::map<GRC::Cpid, std::pair<uint256, GRC::MRC>>& mrc_map,
                       std::map<GRC::Cpid, uint256>& mrc_tx_map,
+                      CAmount& reward,
                       uint32_t& claim_contract_version,
                       GRC::Claim& claim,
                       CWallet* pwallet) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2700,6 +2700,41 @@ UniValue listprotocolentries(const UniValue& params, bool fHelp)
     return res;
 }
 
+UniValue listmandatorysidestakes(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "listprotocolentries\n"
+            "\n"
+            "Displays the mandatory sidestakes on the network.\n");
+
+    UniValue res(UniValue::VOBJ);
+    UniValue scraper_entries(UniValue::VARR);
+
+    for (const auto& sidestake : GRC::GetSideStakeRegistry().ActiveSideStakeEntries(GRC::SideStake::FilterFlag::MANDATORY, false)) {
+        UniValue entry(UniValue::VOBJ);
+
+        entry.pushKV("mandatory_sidestake_entry_address", CBitcoinAddress(sidestake->GetDestination()).ToString());
+        entry.pushKV("mandatory_sidestake_entry_allocation", sidestake->GetAllocation().ToPercent());
+        entry.pushKV("mandatory_sidestake_entry_tx_hash", sidestake->GetHash().ToString());
+        if (sidestake->GetPreviousHash().IsNull()) {
+            entry.pushKV("previous_mandatory_sidestake_entry_tx_hash", "null");
+        } else {
+            entry.pushKV("previous_mandatory_sidestake_entry_tx_hash", sidestake->GetPreviousHash().ToString());
+        }
+
+        entry.pushKV("mandatory_sidestake_entry_timestamp", sidestake->GetTimeStamp());
+        entry.pushKV("mandatory_sidestake_entry_time", DateTimeStrFormat(sidestake->GetTimeStamp()));
+        entry.pushKV("mandatory_sidestake_entry_status", sidestake->StatusToString());
+
+        scraper_entries.push_back(entry);
+    }
+
+    res.pushKV("current_mandatory_sidestake_entries", scraper_entries);
+
+    return res;
+}
+
 UniValue network(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -388,6 +388,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listprotocolentries",     &listprotocolentries,     cat_developer     },
     { "listresearcheraccounts",  &listresearcheraccounts,  cat_developer     },
     { "listscrapers",            &listscrapers,            cat_developer     },
+    { "listmandatorysidestakes", &listmandatorysidestakes, cat_developer     },
     { "listsettings",            &listsettings,            cat_developer     },
     { "logging",                 &logging,                 cat_developer     },
     { "network",                 &network,                 cat_developer     },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -199,6 +199,7 @@ extern UniValue listprojects(const UniValue& params, bool fHelp);
 extern UniValue listprotocolentries(const UniValue& params, bool fHelp);
 extern UniValue listresearcheraccounts(const UniValue& params, bool fHelp);
 extern UniValue listscrapers(const UniValue& params, bool fHelp);
+extern UniValue listmandatorysidestakes(const UniValue& params, bool fHelp);
 extern UniValue listsettings(const UniValue& params, bool fHelp);
 extern UniValue logging(const UniValue& params, bool fHelp);
 extern UniValue network(const UniValue& params, bool fHelp);

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(it_creates_valid_mrc_claims)
 
     BOOST_CHECK(CreateGridcoinReward(block, pindex->pprev, reward, claim));
 
-    BOOST_CHECK(CreateMRCRewards(block, mrc_map, mrc_tx_map, claim_contract_version, claim, wallet));
+    BOOST_CHECK(CreateMRCRewards(block, mrc_map, mrc_tx_map, reward, claim_contract_version, claim, wallet));
 
     // TODO(div72): Separate this test into pieces and actually have it do
     // some useful testing by testing the validation logic against it.


### PR DESCRIPTION
In V13 testing with simultaneous mrcs and mandatory sidestakes, stakes were being rejected by the reward validation because the calculated total reward to the staker used in SplitCoinStakeOutput did not include mrc fees. This apparently has been an existing omission, but since sidestakes were not validated it went undetected. Now that mandatory sidestakes are validated in terms of both destination and amount, they were being rejected by the validator as being too low. 

Adding the mrc fees due to the staker to the staker's reward parameter passed to SplitCoinStakeOutput fixes the problem.

This bug is only relevant for blocks v13 and above, since mandatory sidestakes are not present in v12 and below.

Also listmandatorysidestakes has been added since the older listdata rpc call has been retired with the removal of the remainder of the appcache.
