### PR TITLE
build: Fix Systemd unit install location

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -269,7 +269,7 @@ if(ENABLE_DAEMON)
             DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
         )
         install(FILES "${CMAKE_SOURCE_DIR}/contrib/init/gridcoinresearchd.service"
-            DESTINATION /lib/systemd/system
+            DESTINATION "lib/systemd/system"
         )
     endif()
 endif()


### PR DESCRIPTION
The Systemd unit file should be installed relative to the install prefix, not at an absolute path.