### PR TITLE
gui, util: Enhance verify checkpoints fail handling; use RegistryBookmarks for DB passivation

### DIFF
--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -1391,21 +1391,6 @@ BeaconRegistry::BeaconDB &BeaconRegistry::GetBeaconDB()
     return m_beacon_db;
 }
 
-// This is static and called by the scheduler.
-void BeaconRegistry::RunDBPassivation()
-{
-    TRY_LOCK(cs_main, locked_main);
-
-    if (!locked_main)
-    {
-        return;
-    }
-
-    BeaconRegistry& beacons = GetBeaconRegistry();
-
-    beacons.PassivateDB();
-}
-
 template<> const std::string BeaconRegistry::BeaconDB::KeyType()
 {
     return std::string("beacon");

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -768,7 +768,7 @@ public:
     //!
     //! \return The number of elements passivated.
     //!
-    uint64_t PassivateDB();
+    uint64_t PassivateDB() override;
 
     //!
     //! \brief This function walks the linked beacon entries back (using the m_previous_hash member) from a provided
@@ -794,11 +794,6 @@ public:
     //! \return
     //!
     bool SetNeedsIsContractCorrection(bool flag);
-
-    //!
-    //! \brief A static function that is called by the scheduler to run the beacon database passivation.
-    //!
-    static void RunDBPassivation();
 
     //!
     //! \brief Specializes the template RegistryDB for the ScraperEntry class

--- a/src/gridcoin/contract/handler.h
+++ b/src/gridcoin/contract/handler.h
@@ -5,6 +5,7 @@
 #ifndef GRIDCOIN_CONTRACT_HANDLER_H
 #define GRIDCOIN_CONTRACT_HANDLER_H
 
+#include <cstdint>
 #include <string>
 
 class CBlockIndex;
@@ -153,6 +154,20 @@ struct IContractHandler
     //! \param height
     //!
     virtual void SetDBHeight(int& height);
+
+    //!
+    //! \brief Passivates the elements in the underlying db, which means remove from memory elements in the
+    //! historical map that are not referenced by any of the in memory maps. The backing store of
+    //! the element removed from memory is retained and will be transparently restored if find()
+    //! is called on the hash key for the element.
+    //!
+    //! \return The number of elements passivated.
+    //!
+    virtual uint64_t PassivateDB()
+    {
+        // The default method here does nothing.
+        return uint64_t {0};
+    };
 };
 
 } // namespace GRC

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -484,11 +484,8 @@ void ScheduleRegistriesPassivation(CScheduler& scheduler)
 {
     // Run registry database passivation every 5 minutes. This is a very thin call most of the time.
     // Please see the PassivateDB function and passivate_db.
-    // TODO: Turn into a loop using extension of RegistryBookmarks
-    scheduler.scheduleEvery(BeaconRegistry::RunDBPassivation, std::chrono::minutes{5});
-    scheduler.scheduleEvery(ScraperRegistry::RunDBPassivation, std::chrono::minutes{5});
-    scheduler.scheduleEvery(ProtocolRegistry::RunDBPassivation, std::chrono::minutes{5});
-    scheduler.scheduleEvery(Whitelist::RunDBPassivation, std::chrono::minutes{5});
+
+    scheduler.scheduleEvery(RunDBPassivation, std::chrono::minutes{5});
 }
 } // Anonymous namespace
 
@@ -608,3 +605,13 @@ skip:;
     return true;
 }
 
+void GRC::RunDBPassivation()
+{
+    LOCK(cs_main);
+
+    for (const auto& contract_type : RegistryBookmarks::CONTRACT_TYPES_WITH_REG_DB) {
+        Registry& registry = RegistryBookmarks::GetRegistryWithDB(contract_type);
+
+        registry.PassivateDB();
+    }
+}

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -27,6 +27,7 @@ extern bool fExplorer;
 extern unsigned int nScraperSleep;
 extern unsigned int nActiveBeforeSB;
 extern bool fScraperActive;
+extern bool fQtActive;
 
 void Scraper(bool bSingleShot = false);
 void ScraperSubscriber();
@@ -40,17 +41,29 @@ namespace {
 //!
 void ShowChainCorruptedMessage()
 {
-    uiInterface.ThreadSafeMessageBox(
-        _("WARNING: Blockchain data may be corrupted.\n\n"
-            "Gridcoin detected bad index entries. This may occur because of an "
-            "unexpected exit, a power failure, or a late software upgrade.\n\n"
-            "Please exit Gridcoin, open the data directory, and delete:\n"
-            " - the blk****.dat files\n"
-            " - the txleveldb folder\n\n"
-            "Your wallet will re-download the blockchain. Your balance may "
-            "appear incorrect until the synchronization finishes.\n" ),
-        "Gridcoin",
-        CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+    fResetBlockchainRequest = true;
+
+    if (fQtActive) {
+        uiInterface.ThreadSafeMessageBox(
+            _("ERROR: Checkpoint mismatch: Blockchain data may be corrupted.\n\n"
+              "Gridcoin detected bad index entries. This may occur because of a "
+              "late software upgrade, unexpected exit, or a power failure. "
+              "Your blockchain data is being reset and your wallet will resync "
+              "from genesis when you restart. Your balance may appear incorrect "
+              "until the synchronization finishes."),
+            "Gridcoin",
+            CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+    } else {
+        uiInterface.ThreadSafeMessageBox(
+            _("ERROR: Checkpoint mismatch: Blockchain data may be corrupted.\n\n"
+              "Gridcoin detected bad index entries. This may occur because of a "
+              "late software upgrade, unexpected exit, or a power failure. "
+              "Please run gridcoinresearchd with the -resetblockchaindata "
+              "parameter. Your wallet will re-download the blockchain. Your "
+              "balance may appear incorrect until the synchronization finishes." ),
+            "Gridcoin",
+            CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+    }
 }
 
 //!

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -40,6 +40,12 @@ void ScheduleBackgroundJobs(CScheduler& scheduler);
 //! \return \c true if no errors occurred.
 //!
 bool CleanConfig();
+
+//!
+//! \brief Function to allow cycling through DB passivation for all contract types backed
+//! with registry db.
+//!
+void RunDBPassivation();
 } // namespace GRC
 
 #endif // GRIDCOIN_GRIDCOIN_H

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -541,21 +541,6 @@ Whitelist::ProjectEntryDB &Whitelist::GetProjectDB()
     return m_project_db;
 }
 
-// This is static and called by the scheduler.
-void Whitelist::RunDBPassivation()
-{
-    TRY_LOCK(cs_main, locked_main);
-
-    if (!locked_main)
-    {
-        return;
-    }
-
-    Whitelist& project_entries = GetWhitelist();
-
-    project_entries.PassivateDB();
-}
-
 template<> const std::string Whitelist::ProjectEntryDB::KeyType()
 {
     return std::string("project");

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -603,19 +603,14 @@ public:
     void ResetInMemoryOnly();
 
     //!
-    //! \brief Passivates the elements in the scraper db, which means remove from memory elements in the
+    //! \brief Passivates the elements in the project db, which means remove from memory elements in the
     //! historical map that are not referenced by m_projects. The backing store of the element removed
     //! from memory is retained and will be transparently restored if find() is called on the hash key
     //! for the element.
     //!
     //! \return The number of elements passivated.
     //!
-    uint64_t PassivateDB();
-
-    //!
-    //! \brief A static function that is called by the scheduler to run the project entry database passivation.
-    //!
-    static void RunDBPassivation();
+    uint64_t PassivateDB() override;
 
     //!
     //! \brief Specializes the template RegistryDB for the ScraperEntry class. Note that std::set<ProjectEntry> is not

--- a/src/gridcoin/protocol.cpp
+++ b/src/gridcoin/protocol.cpp
@@ -528,21 +528,6 @@ ProtocolRegistry::ProtocolEntryDB &ProtocolRegistry::GetProtocolEntryDB()
     return m_protocol_db;
 }
 
-// This is static and called by the scheduler.
-void ProtocolRegistry::RunDBPassivation()
-{
-    TRY_LOCK(cs_main, locked_main);
-
-    if (!locked_main)
-    {
-        return;
-    }
-
-    ProtocolRegistry& protocol_entries = GetProtocolRegistry();
-
-    protocol_entries.PassivateDB();
-}
-
 template<> const std::string ProtocolRegistry::ProtocolEntryDB::KeyType()
 {
     return std::string("protocol");

--- a/src/gridcoin/protocol.h
+++ b/src/gridcoin/protocol.h
@@ -559,12 +559,7 @@ public:
     //!
     //! \return The number of elements passivated.
     //!
-    uint64_t PassivateDB();
-
-    //!
-    //! \brief A static function that is called by the scheduler to run the protocol entry database passivation.
-    //!
-    static void RunDBPassivation();
+    uint64_t PassivateDB() override;
 
     //!
     //! \brief Specializes the template RegistryDB for the ProtocolEntry class. Note that std::set<ProtocolEntry>

--- a/src/gridcoin/scraper/scraper_registry.cpp
+++ b/src/gridcoin/scraper/scraper_registry.cpp
@@ -573,21 +573,6 @@ ScraperRegistry::ScraperEntryDB &ScraperRegistry::GetScraperDB()
     return m_scraper_db;
 }
 
-// This is static and called by the scheduler.
-void ScraperRegistry::RunDBPassivation()
-{
-    TRY_LOCK(cs_main, locked_main);
-
-    if (!locked_main)
-    {
-        return;
-    }
-
-    ScraperRegistry& scraper_entries = GetScraperRegistry();
-
-    scraper_entries.PassivateDB();
-}
-
 template<> const std::string ScraperRegistry::ScraperEntryDB::KeyType()
 {
     return std::string("scraper");

--- a/src/gridcoin/scraper/scraper_registry.h
+++ b/src/gridcoin/scraper/scraper_registry.h
@@ -598,12 +598,7 @@ public:
     //!
     //! \return The number of elements passivated.
     //!
-    uint64_t PassivateDB();
-
-    //!
-    //! \brief A static function that is called by the scheduler to run the scraper entry database passivation.
-    //!
-    static void RunDBPassivation();
+    uint64_t PassivateDB() override;
 
     //!
     //! \brief Specializes the template RegistryDB for the ScraperEntry class. Note that std::set<ScraperEntry> is

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -1164,21 +1164,6 @@ SideStakeRegistry::SideStakeDB &SideStakeRegistry::GetSideStakeDB()
     return m_sidestake_db;
 }
 
-// This is static and called by the scheduler.
-void SideStakeRegistry::RunDBPassivation()
-{
-    TRY_LOCK(cs_main, locked_main);
-
-    if (!locked_main)
-    {
-        return;
-    }
-
-    SideStakeRegistry& SideStake_entries = GetSideStakeRegistry();
-
-    SideStake_entries.PassivateDB();
-}
-
 template<> const std::string SideStakeRegistry::SideStakeDB::KeyType()
 {
     return std::string("SideStake");

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -830,18 +830,13 @@ public:
     //!
     //! \return The number of elements passivated.
     //!
-    uint64_t PassivateDB();
+    uint64_t PassivateDB() override;
 
     //!
     //! \brief This method parses the config file for local sidestakes. It is based on the original GetSideStakingStatusAndAlloc()
     //! that was in miner.cpp prior to the implementation of the SideStake class.
     //!
     void LoadLocalSideStakesFromConfig();
-
-    //!
-    //! \brief A static function that is called by the scheduler to run the sidestake entry database passivation.
-    //!
-    static void RunDBPassivation();
 
     //!
     //! \brief Specializes the template RegistryDB for the SideStake class. Note that std::set<MandatorySideStake>


### PR DESCRIPTION
This changes the verify checkpoints fail handling to use the GUI reset blockchain facility if in the GUI, or direct the user to use the -resetblockchaindata option if using the daemon, rather than instructing the user to manually delete the blockchain data files.