### PR TITLE
[cmake] bdb53: disable error for implicit-int with gcc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1418,7 +1418,7 @@ esac
 AC_CONFIG_SUBDIRS([src/univalue])
 AC_CONFIG_SUBDIRS([src/secp256k1])
 if test "$enable_embedded_bdb" = "yes"; then
-  AX_SUBDIRS_CONFIGURE([src/bdb53], [[CFLAGS="-Wno-error=implicit-function-declaration"], [CXXFLAGS="-Wno-error=implicit-function-declaration"], [--disable-java], [--disable-jdbc], [--disable-replication], [--enable-cxx], [$ADDITIONAL_BDB_FLAGS]], [], [], [])
+  AX_SUBDIRS_CONFIGURE([src/bdb53], [[CFLAGS=-Wno-error=implicit-function-declaration -Wno-error=implicit-int], [CXXFLAGS=-Wno-error=implicit-function-declaration -Wno-error=implicit-int], [--disable-java], [--disable-jdbc], [--disable-replication], [--enable-cxx], [$ADDITIONAL_BDB_FLAGS]], [], [], [])
 fi
 
 AC_OUTPUT

--- a/src/bdb53/CMakeLists.txt
+++ b/src/bdb53/CMakeLists.txt
@@ -34,7 +34,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         CFLAGS=-Wno-implicit-function-declaration
     )
 endif()
-
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    list(APPEND BDB_FLAGS
+        CFLAGS=-Wno-error=implicit-int
+    )
+endif()
 
 # Make flags
 # ==========


### PR DESCRIPTION
Hello!

I noticed that on fedora 40 (using gcc 14), `gridcoinresearchd` fails to compile to an implicit-int conversion.

This happens in the bdb53 dependency build. I didn't want to change the source code there so I just disabled the error so it would only be a warning. I also only made this change for GNU compiler, I'm not sure if it effects others.

The actual error is in the config.log of bdb53:
```
configure:20682: cc -o conftest -O3   -D_GNU_SOURCE -D_REENTRANT  conftest.c  -lpthread >&5
conftest.c:46:1: error: return type defaults to 'int' [-Wimplicit-int]
   46 | main() {
      | ^~~~
configure:20682: 0 = 1
configure: program exited with status 1
```

This cause the mutex detection to fail and ultimately fail the build. In the actual build log this looks like:
```
[   72s] checking for mutexes... UNIX/fcntl
[   72s] 
[   72s] -- stderr output is:
[   72s] configure: error: Support for FCNTL mutexes was removed in BDB 4.8.
```

This can be seen in the aarch64 build here -> https://build.opensuse.org/package/live_build_log/home:theMarix/gridcoin/Fedora_40/aarch64


This comes down to the fact that implicit-int was promoted to an error by default in gcc 14
see: https://gcc.gnu.org/gcc-14/porting_to.html