### PR TITLE
rpc/server: fix removing deprecated commands from command list

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -932,7 +932,7 @@ std::vector<std::string> CRPCTable::listCommands() const
                     boost::bind(&commandMap::value_type::first,boost::placeholders::_1) );
     // remove deprecated commands from autocomplete
     for(auto &command: DEPRECATED_RPCS) {
-        std::remove(commandList.begin(), commandList.end(), command);
+        commandList.erase(std::remove(commandList.begin(), commandList.end(), command), commandList.end());
     }
     return commandList;
 }


### PR DESCRIPTION
The call to std::remove also requires using std::vector::erase

see: https://en.cppreference.com/w/cpp/algorithm/remove

This fixes the following warning:

```
/home/lukas/Documents/git/Gridcoin-Research/src/rpc/server.cpp:935:20: warning: ignoring return value of ‘_FIter std::remove(_FIter, _FIter, const _Tp&) [with _FIter = __gnu_cxx::__normal_iterator<__cxx11::basic_string<char>*, vector<__cxx11::basic_string<char> > >; _Tp = const char*]’, declared with attribute ‘nodiscard’ [-Wunused-result]
  935 |         std::remove(commandList.begin(), commandList.end(), command);
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/algorithm:61,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/span.h:10,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/uint256.h:10,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/consensus/params.h:9,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/chainparams.h:10,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/main.h:10,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/consensus/tx_verify.h:8,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/wallet/wallet.h:16,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/init.h:9,
                 from /home/lukas/Documents/git/Gridcoin-Research/src/rpc/server.cpp:7:
/usr/include/c++/14/bits/stl_algo.h:788:5: note: declared here
  788 |     remove(_ForwardIterator __first, _ForwardIterator __last,
      |     ^~~~~~
```