### PR TITLE
build: explicitly include FindPkgConfig for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ include(CheckSymbolExists)
 
 include(CheckSSE)
 include(CheckStrerrorR)
+include(FindPkgConfig)
 include(HunterGate)
 include(VersionFromGit)
 


### PR DESCRIPTION
Should fix the `Unknown CMake command "pkg_check_modules".` error on the CI.