### PR TITLE
fix build on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To build, run:
 
 * With CMake:
 
-  `mkdir build && cmake build && cmake .. && cmake --build .`
+  `mkdir -p build && cd build && cmake .. && cmake --build .`
 
 * With Autotools:
 

--- a/src/pbkdf2.cpp
+++ b/src/pbkdf2.cpp
@@ -16,6 +16,7 @@ be32dec(const void *pp)
 }
 */
 
+#ifndef __FreeBSD__
 static inline void
 be32enc(void *pp, uint32_t x)
 {
@@ -26,7 +27,7 @@ be32enc(void *pp, uint32_t x)
     p[1] = (x >> 16) & 0xff;
     p[0] = (x >> 24) & 0xff;
 }
-
+#endif
 
 /**
  * PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, c, buf, dkLen):

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -29,14 +29,10 @@
 #include <sys/time.h>
 #endif
 
-#ifdef HAVE_SYS_GETRANDOM
-#include <sys/syscall.h>
-#include <linux/random.h>
-#endif
-#if defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
-#include <unistd.h>
+#if defined(HAVE_GETRANDOM) || (defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX))
 #include <sys/random.h>
 #endif
+
 #ifdef HAVE_SYSCTL_ARND
 #include <sys/sysctl.h>
 #endif
@@ -286,23 +282,14 @@ void GetOSRand(unsigned char *ent32)
         RandFailure();
     }
     CryptReleaseContext(hProvider, 0);
-#elif defined(HAVE_SYS_GETRANDOM)
+#elif defined(HAVE_GETRANDOM)
     /* Linux. From the getrandom(2) man page:
      * "If the urandom source has been initialized, reads of up to 256 bytes
      * will always return as many bytes as requested and will not be
      * interrupted by signals."
      */
-    int rv = syscall(SYS_getrandom, ent32, NUM_OS_RANDOM_BYTES, 0);
-    if (rv != NUM_OS_RANDOM_BYTES) {
-        if (rv < 0 && errno == ENOSYS) {
-            /* Fallback for kernel <3.17: the return value will be -1 and errno
-             * ENOSYS if the syscall is not available, in that case fall back
-             * to /dev/urandom.
-             */
-            GetDevURandom(ent32);
-        } else {
-            RandFailure();
-        }
+    if (getrandom(ent32, NUM_OS_RANDOM_BYTES, 0) != NUM_OS_RANDOM_BYTES) {
+        RandFailure();
     }
 #elif defined(__OpenBSD__)
     /* OpenBSD. From the arc4random(3) man page:


### PR DESCRIPTION
Fix building on FreeBSD.

```
[ 73%] Building CXX object src/CMakeFiles/gridcoin_util.dir/pbkdf2.cpp.o
/home/wilkart/Gridcoin-Research/src/pbkdf2.cpp:20:1: error: redefinition of 'be32enc'
be32enc(void *pp, uint32_t x)
^
/usr/include/sys/endian.h:128:1: note: previous definition is here
be32enc(void *pp, uint32_t u)
^
1 error generated.
gmake[2]: *** [src/CMakeFiles/gridcoin_util.dir/build.make:972: src/CMakeFiles/gridcoin_util.dir/pbkdf2.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:249: src/CMakeFiles/gridcoin_util.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

Additionally remove #include <linux/random.h> according to upstream.

```
This requires a linux kernel of 3.17.0+, which seems entirely
reasonable. 3.17 went EOL in 2015, and the last supported 3.x kernel
(3.16) went EOL > 4 years ago, in 2020. For reference, the current
oldest maintained kernel is 4.14 (released 2017, EOL Jan 2024).
Support for getrandom() (and getentropy()) was added to
glibc 2.25, https://sourceware.org/legacy-ml/libc-alpha/2017-02/msg00079.html,
and we already require 2.27+.
All that being said, I don't think you would encounter a current day
system, running with kernel headers older than 3.17 (released 2014) but
also having a glibc of 2.27+ (released 2018).

```

