### PR TITLE
init, registry: Support -clearallregistryhistory startup parameter

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -170,7 +170,7 @@ void InitializeContracts(CBlockIndex* pindexBest)
         uiInterface.InitMessage(_("Loading history for contract type ") + tr_contract_type_string + "...");
 
         std::string history_arg = "-clear" + GRC::Contract::Type::ToString(contract_type) + "history";
-        if (gArgs.GetBoolArg(history_arg, false)) {
+        if (gArgs.GetBoolArg(history_arg, false) || gArgs.GetBoolArg("-clearallregistryhistory", false)) {
             registry.Reset();
         }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -627,12 +627,16 @@ void SetupServerArgs()
     hidden_args.emplace_back("-activebeforesb");
 
     // This puts hidden options in the form of -clear<type>history, where <type> is the contract types that have a
-    // registry with a backing db. This is currently beacon, project, protocol, and scraper.
+    // registry with a backing db. This is currently beacon, project, protocol, and scraper, with sidestakes starting
+    // at V13 height.
     for (const auto& contract_type : GRC::RegistryBookmarks::CONTRACT_TYPES_WITH_REG_DB) {
         std::string history_arg = "-clear" + GRC::Contract::Type::ToString(contract_type) + "history";
 
         hidden_args.emplace_back(history_arg);
     }
+
+    // Also allow the -clearallregistryhistory hidden argument to support clearing all of the registries.
+    hidden_args.emplace_back("-clearallregistryhistory");
 
     // -boinckey should now be removed entirely. It is put here to prevent the executable erroring out on
     // an invalid parameter for old clients that may have left the argument in.


### PR DESCRIPTION
This allows specifying -clearallregistryhistory as a startup parameter to clear all of the contract registries.

When I rewrote the registry replay code a while back in preparation for V13, I neglected to reimplement a "clear all" registry clear parameter. This restores that functionality. It is hidden, just like the registry type specific versions, because it will be rarely used, most likely for development and for troubleshooting wallet issues by a developer.