### PR TITLE
scraper, project, superblock: Implement automated greylisting

### DIFF
--- a/doc/automated_greylisting_design_highlights.md
+++ b/doc/automated_greylisting_design_highlights.md
@@ -1,0 +1,270 @@
+# Automated Greylisting Design Highlights
+
+## Executive Summary
+
+This document provides the highlights for the functionality included in Gridcoin PR [scraper, project, superblock: Implement automated greylisting by jamescowens · Pull Request #2778 · gridcoin-community/Gridcoin-Research · GitHub](https://github.com/gridcoin-community/Gridcoin-Research/pull/2778), which implements both manual and automated greylisting. The Gridcoin network rules for project whitelisting and the conditions for greylisting are documented on the main Gridcoin website at [Whitelist Process](https://gridcoin.us/wiki/whitelist-process.html).
+
+When projects temporarily do not meet the requirements for whitelisting, the main two rules of which are a Work Availability Score (WAS) of less than 0.1, and/or a Zero Credit Days (ZCD) count of greater than 7, the project is "greylisted". Traditionally, from a network operations perspective, this has meant temporarily removing the project from the whitelist using the administrative protocol update procedures, and then re-adding the project when the two rules return to normal. This is a manual and labor intensive process that does not scale well as the number of whitelisted projects increase, and it depends on the administrator to take action in a timely manner.
+
+To address the scalability and administrative stablility, it was recognized several years ago that a form of automatic greylisting would be important functionality to implement. This PR addresses that functionality need.
+
+This PR implements *manual greylisting* via a new project entry status *MAN_GREYLISTED*. This is set by administrative contract just like whitelisting. The purpose of the manual listing is twofold: 1) Not all possible issues that could result in a need to greylist are covered by the WAS and ZCD rules, and 2) a long term low level availability of a project at a fairly consistent level for more than 40 days will cause the WAS to pass, because both the numerator and denominator forming WAS will see similar results. This project status is stored in the project registry.
+
+*Automatic greylisting* is implemented via a new AutoGreylist class. This class essentially records total credit data across the entire project (all CPIDs, whether they have an active beacon or not) collected from the scrapers via a pending, or existing (last) superblock for all whitelisted projects, and the history of 40 superblocks back from the pending or last superblock, and evaluates the WAS and ZCD rules. Because it operates at the granularity of the superblocks, technically the definition of these rules is *slightly* different than the documentation since the time between superblocks is **slightly** more than 24 hours. In practice this is essentially equivalent. Because the automatic greylisting status is aligned along superblock boundaries, the AutoGreylist class is implemented as a caching singleton, so that repeated calls to the class for the greylist simply report the cached state rather than doing the heavyweight walk of 40 superblocks to recompute the automatic greylist state from the superblock history as long as the referenced superblock hash for the cache has not changed.
+
+The AutoGreylist class *overrides* a project registry status of ACTIVE or MAN_GREYLISTED with the status of AUTO_GREYLISTED if it meets greylisting criteria. This is done directly in the Whitelist::Snapshot method, preserving the underlying project entries. Since the underlying registry entries are preserved, the project state returns to the underlying status as soon as the greylist entry for that project returns to normal. Conversely there is also the ability to set via addkey the project status AUTO_GREYLIST_OVERRIDE in the project registry, which takes precedence over the automatic greylisting. This allows an override to keep a project active even if the automated greylist rules would greylist it. A good example of this would be a project that had a one day correction of TC due to a database issue that distorts the WAS, causing a false failure. In that case it would be a good idea to override the automatic greylisting for that project temporarily after evaluation by the community.
+
+Note that the auto greylisting ruleset is entirely contained within the AutoGreylist class. While the rules are encapsulated in that class, no attempt to write a formal rules engine was done as that would be too heavyweight for just two rules. Additionally, WAS has been implemented using 64 bit integer arithmetic and the Gridcoin Fraction class to avoid consensus issues due to floating point. For ease of display, WAS values in reports are shown as floating point.
+
+The *excluded project* functionality of the scraper convergence and the associated superblocks formed still applies. This means that a project that does not export statistics at all in a 48 hour period will be excluded from superblocks until access to project statistics are restored. This is related to the 48 hour statistics retention rule for scraper statistics that has been in place since the scraper rewrite a number of years ago. When a project is *excluded* this is effectively an override of all project registry statuses and the operation of the automated greylisting.
+
+## Changes to the scraper
+
+The scraper was modified to collect total credit across the entire project for each project that does not have a status of deleted in the project registry. This was accomplished via the following changes (this is not all inclusive):
+
+1. Addition of two fields in the scraper file manifest registry, All_cpid_total_credit and No_records. All_cpid_total_credit captures the total credit summation across the entire project regardless of whether the cpid is active or not. No_records is a flag to record when a file has no active cpids. Formerly, a file and its corresponding entry would have been deleted, but now we must retain the file and entry to record the all_cpid_total_credit even if there are no current active cpids in that project.
+
+2. Implementation of an additional pseudo-project entry in the CScraperManifest with the name ProjectsAllCpidTotalCredits to allow convergence to be calculated by each node from the scraper data. This means the total credits data must also match just like other project data for a convergence to occur and insures integrity of the total credits data similar to other project data.
+
+3. Extension of the ScraperStatsVerifiedBeacons structure used in the convergence to include total credits, and renamed ScraperStatsVerifiedBeaconsTotalCredits. This is the primary method of transferrance of state to the superblock of the total credits for each project from a manifest convergence.
+
+4. Modification of the scraper machinery to assign zero magnitude to greylisted projects for purposes of magnitude calculation.
+
+5. Modification of the ProcessProjectRacFileByCPID function to accumulate total credit for a project from all CPIDs regardless of status.
+
+6. Reporting for CScraperManifest and the convergence report rpc functions were extended to provide information on the total credits across all projects.
+
+## Changes to the registry_db.h template
+
+The registry db template provides generic programming common code underlying the registry implementations for each of the contract types that require historized, revertable state maintenance of their corresponding objects. This implements versioned state storage of registered contract type objects via the defined key in leveldb. The AutoGreylist class needs to know when the first entry actually occurred for a project to properly apply the rules for projects whitelisted within the 40 superblock lookback scope. As a result, the registry db template had to be extended to include a generic type and code to accomodate this.
+
+Each of the corresponding contract type classes had to be modified to accomodate changes in the registry template, even if they did not actually use the first occurance functionality, i.e. trivial modifications to all other contract types besides project.
+
+## Changes to the superblock
+
+The superblock class version was incremented to v3 and was extended to include the m_projects_all_cpids_total_credits map which contains the total credits data for all projects, and which is from the ScraperStatsVerifiedBeaconsTotalCredits structure in the manifest convergence from the scraper. This data is serialized and is stored on the blockchain when the superblock is staked and in turn is used by the AutoGreylist class for greylist status calculations.
+
+The superblock also was extended to store projects that have been greylisted.
+
+## Implementation of the AutoGreylist class and changes to the project class and project registry (whitelist)
+
+### ProjectEntryStatus enum class changes
+
+The ProjectEntryStatus num class was extended and moved to fwd.h to avoid recursive include problems.
+
+```
+{
+//!
+//! \brief Enumeration of project entry status. Unlike beacons this is for both storage
+//! and memory.
+//!
+//! UNKNOWN status is only encountered in trivially constructed empty
+//! project entries and should never be seen on the blockchain.
+//!
+//! DELETED status corresponds to a removed entry.
+//!
+//! ACTIVE corresponds to an active entry.
+//!
+//! GREYLISTED means that the project temporarily does not meet the whitelist qualification criteria.
+//!
+//! OUT_OF_BOUND must go at the end and be retained for the EnumBytes wrapper.
+//!
+enum class ProjectEntryStatus
+{
+    UNKNOWN,
+    DELETED,
+    ACTIVE,
+    MAN_GREYLISTED,
+    AUTO_GREYLISTED,
+    AUTO_GREYLIST_OVERRIDE,
+    OUT_OF_BOUND
+};
+
+```
+
+MAN_GREYLISTED, AUTO_GREYLISTED, AUTO_GREYLIST_OVERRIDE are new states. The order of enum entries for the extending states was not changed to avoid serialization issues with older project entries.
+
+### Implementation of project filter for whitelist snapshots
+
+A ProjectFilterFlag was implemented to accomplish easy filtering of the whitelist snapshot depending on intended use.
+
+```
+    //!
+    //! \brief Project filter flag enumeration.
+    //!
+    //! This controls what project entries by status are in the project whitelist snapshot. Note that REG_ACTIVE
+    //! is the original "ACTIVE" and represents project entries with a status of "ACTIVE" in the registry. The
+    //! filter flag "ACTIVE" here includes both REG_ACTIVE and AUTO_GREYLIST_OVERRIDE project entry statuses from
+    //! the registry, since both mean the project is active assuming a convergence can be formed.
+    //!
+    enum ProjectFilterFlag : uint8_t {
+        NONE                   = 0b00000,
+        DELETED                = 0b00001,
+        MAN_GREYLISTED         = 0b00010,
+        AUTO_GREYLISTED        = 0b00100,
+        GREYLISTED             = MAN_GREYLISTED | AUTO_GREYLISTED,
+        REG_ACTIVE             = 0b01000,
+        AUTO_GREYLIST_OVERRIDE = 0b10000,
+        ACTIVE                 = REG_ACTIVE | AUTO_GREYLIST_OVERRIDE,
+        NOT_ACTIVE             = 0b00111,
+        ALL_BUT_DELETED        = 0b11110,
+        ALL                    = 0b11111
+    };
+
+```
+Note that the ACTIVE enum value is actually a combination of the original ACTIVE (now labled REG_ACTIVE, which is short for registry active) and AUTO_GREYLIST_OVERRIDE, since a project status of AUTO_GREYLIST_OVERRIDE means that the project is not only active, but overrides any determination by the automatic greylisting.
+
+### ProjectEntry class modifications
+
+The ProjectEntry class current version has been incremented to v4 and now includes a requires_ext_adapter boolean to replace the temporary protocol entry based approach to show this status in the GUI. This boolean is serialized and the serialization is conditioned on the version to ensure compatibility with older project records.
+
+### AutoGreylist class implementation
+
+#### GreylistCandidateEntry
+
+The GreylistCandidateEntry is a class implemented within the AutoGreylist class that formalizes the greylist state maintenance and state history for each project in the whitelist filtered by ALL_BUT_DELETED (i.e. all but deleted). This class uses a "reverse" bookmark based approach to effectively deal with a number of tricky situations involving lack of availability of project total credit data (drop-outs). In addition, each update is stored in the m_update_history vector to provide visibility of the historical evolution of the total credit data and greylist status according to the rules.
+
+The GreylistCandidateEntry contains an "empty" constructor and a parameterized constructor, the latter of which both creates the GreylistCandidateEntry and establishes the baseline for the measurements.
+
+##### uint8_t GetZCD()
+
+This method simply returns the m_zcd_20_SB_count member variable, which is a count of the number of zero credit days in the 20 superblock lookback from the baseline.
+
+##### Fraction GetWAS()
+
+The method computes the average total credit over a 7 superblock lookback and a 40  superblock lookback and then constructs a Fraction of the result. Note that if the lookback is less than 40, the number of superblocks in the average is reduced for the 40 superblock lookback and similarly if the lookback is less than 7, the number of superblocks in the average is reduced for the 7 superblock lookback. Given that when data is first being collected for a newly listed project, this can lead to odd behavior of WAS, there is a grace period implemented in the application of the rules for setting the m_meets_greylisting_crit flag in the GreylistCandidateEntry. This grace period is currently set at 7 superblocks.
+
+##### void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline)
+
+This method is used by the RefreshWithSuperblock method to update each GreylistCandidateEntry and add each update to the entry history.
+
+##### struct UpdateHistoryEntry
+
+This is the struct that stores the greylist state at the given update for the greylist candidate. *Note that this is the history viewed BACKWARDS as a lookback from the current state, not forwards looking, so this can be misleading if you do not understand that*. Each time the AutoGreylist class is updated due to the current superblock hash changing, the historical entries will be rebuilt from the current superblock backwards. This struct contains most of its member variables as std::optionals to accomodate the lack of information at a particular update.
+
+##### const std::vector<UpdateHistoryEntry> GetUpdateHistory() const
+
+This is a getter that returns a constant version of m_update_history.
+
+##### Public member variables
+
+```
+        const std::string m_project_name;
+
+        uint8_t m_zcd_20_SB_count;
+        uint64_t m_TC_7_SB_sum;
+        uint64_t m_TC_40_SB_sum;
+        bool m_meets_greylisting_crit;
+
+```
+
+The m_project_name contains the project name, which is the key to the greylist map. The next three contain the undertying state with which to compute the ZCD and WAS but since they are public, they can be independently accessed. The m_meets_greylisting_crit stores the current greylist qualification state for the entry. If it is true, the project currently meets automatic greylisting criteria.
+
+##### Private member variables
+
+```
+        std::optional<uint64_t> m_TC_initial_bookmark; //!< This is a "reverse" bookmark - we are going backwards in SB's.
+        std::optional<uint64_t> m_TC_bookmark;
+        uint8_t m_sb_from_baseline_processed;
+
+        std::vector<UpdateHistoryEntry> m_update_history;
+
+```
+
+These store the bookmarks (which are for internal use only) and the m_update_history vector, which is accessed via GetUpdateHistory().
+
+#### The Greylist map
+
+```
+    typedef std::map<std::string, GreylistCandidateEntry> Greylist;
+
+    //!
+    //! \brief Smart pointer around a collection of projects.
+    //!
+    typedef std::shared_ptr<Greylist> GreylistPtr;
+
+```
+
+The actual greylist entries are collected into a std::map keyed by project name. This in turn is wrapped by a shared_ptr.
+
+#### AutoGreylist iterator overloads
+
+Similar to other registry and registry like classes in Gridcoin, the AutoGreylist contains iterator overloads to allow accessing the AutoGreylist map using range loops and other iterator like uses.
+
+#### void Refresh()
+
+This refreshes the AutoGreylist object from the current superblock. The cached state is used if the superblock hash has not changed to reduce overhead.
+
+#### void RefreshWithSuperblock(SuperblockPtr superblock_ptr_in, std::shared_ptr<std::map<int, std::pair<CBlockIndex*, SuperblockPtr>>> unit_test_blocks = nullptr)
+
+This refreshes the AutoGreylist object from an input Superblock pointer. It contains a second parameter that provides an alternate way to input test superblocks for unit testing.
+
+#### void AutoGreylist::RefreshWithSuperblock(Superblock& superblock)
+
+This refreshes the AutoGreylist object from an input Superblock that is going to be associated with the current head of the chain (i.e. a stake). This mode is used in the scraper during the construction of the superblock contract as part of the call chain from the miner. The superblock object will be updated with the greylist status. This is critical distinction. The other two forms simply use the superblocks on the chain, while this form is freezing the state into the provided superblock object as well as doing the historical lookback.
+
+#### void Reset()
+
+Resets the AutoGreylist object. This is called from the Whitelist Reset().
+
+#### Private members
+
+```
+    mutable CCriticalSection autogreylist_lock;
+
+    GreylistPtr m_greylist_ptr;
+    QuorumHash m_superblock_hash;
+```
+
+The autogreylist_lock is an internal critical section to ensure thread safety, since the AutoGreylist singleton can be accessed by multiple threads. The m_greylist_ptr is the shared smart pointer to the actual greylist map, and the m_superblock_hash stores the hash of the superblock used for the last AutoGreylist update and is used to detect a state change, otherwise the cached information is used.
+
+### Changes to Whitelist (Project Registry) class
+
+#### Change to WhitelistSnapshot Snapshot method
+
+This method has been extended to take the Project Filter as an argument, defaulting to ACTIVE, and also the refresh_greylist boolean defautling to true, and the include_override boolean defaulting to true. This method implements the AUTO_GREYLISTED override of project status when the corresponding AutoGreylist greylist candidate entry meets greylisting criteria according to the rules.
+
+#### const ProjectEntryMap GetProjectsFirstActive() const
+
+This is a new method that provides a map of the first entry for each project in the registry. This is used by the AutoGreylist class to determine abbreviated lookbacks for projects that were whitelisted within the 40 superblock lookback window.
+
+#### std::shared_ptr<AutoGreylist> GetAutoGreylist()
+
+This is a new method that returns a shared smart pointer to the AutoGreylist object. This object is a singleton just like the Whitelist registry.
+
+#### New private members
+
+ProjectEntryMap m_project_first_actives stores the first (active) entry for each project keyed by project name, and is returned read-only by GetProjectsFirstActive(). This map is populated by the registry contract handlers and leveldb initialization method. The std::shared_ptr<AutoGreylist> m_auto_greylist is the smart shared pointer to the AutoGreylist object.
+
+### Change to the WhitelistSnapshot class
+
+The constructor of this class was changed to accept the project filter used as a parameter, which is stored for convenience in the WhitelistSnapshot object.
+
+## Quorum changes
+
+The QuorumHash ComputeQuorumHash() was extended (implicitly) to include the project all cpid total credit data as part of the superblock hash. The superblock version is validated to ensure that no superblocks less than v4 are accepted once the superblock v4 block height has been reached.
+
+## GUI - ResearcherModel and ProjectTableModel changes
+
+The researcher and project table models were extended to deal appropriately with auto greylisted status, following the order of precedence. In the project table displayed in the GUi, automatic greylisting status and manual greylisting status takes precedence over excluded, because if a project has those statuses, it has the same effect as exclusion, but is not a scraper directive.
+
+## RPC changes
+
+### UniValue SuperblockToJson(const GRC::Superblock& superblock)
+
+This helper function that provides JSON superblock outputs to several different RPC functions has been modified to include the project greylist status and the project all CPID total credits.
+
+### UniValue addkey(const UniValue& params, bool fHelp)
+
+This administrative function has been extended to handle manual greylisting and the automatic greylisting override.
+
+## Unit Tests
+
+### superblock_tests.cpp
+
+The superblock tests were modified to use version two in the superblock tests. A todo would be to change them for the new structures in v3 to fully test serialization and deserialization, but this has been covered in the isolated testnet live network test.
+
+### project_tests.cpp
+
+A unit test that uses the std::pair<CBlockIndex*, SuperblockPtr>>> unit_test_blocks parameter of the AutoGreylist::RefreshWithSuperblock method has been implemented with 47 superblocks of test data to test the operation of the greylisting rules. These superblocks exercise every real-world condition expected to be encountered that can be solved with automatic application of the implemented automatic greylisting rules, including no statistics on the first superblock after whitelisting, statistics "drop outs" with no data or no increase in total credit and/or both (i.e. a total credit number then no data then another total credit number that is the same), and a drastic drop in total credit change per superblock that results in WAS meeting greylisting criteria. More superblocks than the lookback limit was tested to ensure the lookback stopped at the appropriate place.
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -117,6 +117,7 @@ GRIDCOIN_CORE_H = \
     gridcoin/contract/registry.h \
     gridcoin/contract/registry_db.h \
     gridcoin/cpid.h \
+    gridcoin/fwd.h \
     gridcoin/gridcoin.h \
     gridcoin/magnitude.h \
     gridcoin/mrc.h \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2020 The Bitcoin Core developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -74,6 +74,7 @@ public:
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
+        consensus.ProjectV4Height = std::numeric_limits<int>::max();
         consensus.SuperblockV3Height = std::numeric_limits<int>::max();
         // Immediately post zero payment interval fees 40% for mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
@@ -194,6 +195,7 @@ public:
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
+        consensus.ProjectV4Height = std::numeric_limits<int>::max();
         consensus.SuperblockV3Height = std::numeric_limits<int>::max();
         // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -73,6 +73,8 @@ public:
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
+        consensus.SuperblockV3Height = std::numeric_limits<int>::max();
+        // Immediately post zero payment interval fees 40% for mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         consensus.MRCZeroPaymentInterval = 14 * 24 * 60 * 60;
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
@@ -191,6 +193,8 @@ public:
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
+        consensus.SuperblockV3Height = std::numeric_limits<int>::max();
+        // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         consensus.MRCZeroPaymentInterval = 10 * 60;
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2020 The Bitcoin Core developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -170,6 +170,13 @@ inline bool IsProjectV2Enabled(int nHeight)
     return nHeight >= Params().GetConsensus().ProjectV2Height;
 }
 
+inline bool IsSuperblockV3Enabled(int nHeight)
+{
+    // The argument driven override temporarily here to facilitate testing.
+
+    return nHeight >= gArgs.GetArg("-superblockv3height", Params().GetConsensus().SuperblockV3Height);
+}
+
 inline int GetSuperblockAgeSpacing(int nHeight)
 {
     return (fTestNet ? 86400 : (nHeight > 364500) ? 86400 : 43200);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -178,6 +178,13 @@ inline bool IsSuperblockV3Enabled(int nHeight)
     return nHeight >= gArgs.GetArg("-superblockv3height", Params().GetConsensus().SuperblockV3Height);
 }
 
+inline bool IsProjectV4Enabled(int nHeight)
+{
+    // The argument driven override temporarily here to facilitate testing.
+
+    return nHeight >= gArgs.GetArg("-projectv4height", Params().GetConsensus().ProjectV4Height);
+}
+
 inline int GetSuperblockAgeSpacing(int nHeight)
 {
     return (fTestNet ? 86400 : (nHeight > 364500) ? 86400 : 43200);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -40,6 +40,8 @@ struct Params {
     int PollV3Height;
     /** Block height at which project v2 contracts are allowed */
     int ProjectV2Height;
+    /** Block height at which project v4 contracts are allowed */
+    int ProjectV4Height;
     /**
       * @brief The default GRC paid for a constant block reward.
       *

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -56,6 +56,10 @@ struct Params {
       * for block v13+. Note that this is typed as int64_t rather than CAmount to avoid the extra include.
       */
     int64_t ConstantBlockRewardCeiling;
+    /**
+      * @brief Block height at which superblock v3 contracts are allowed/required
+      */
+    int SuperblockV3Height;
     /** The fraction of rewards taken as fees in an MRC after the zero payment interval. Only consesnus critical
       * at BlockV12Height or above. Note that this is typed as int64_t rather than CAmount to avoid the extra include.
       */
@@ -88,7 +92,7 @@ struct Params {
       * for purposes of computing voting weight. Nominally 1 / 5.67 from Fern onwards.
       *
       * The magnitude weight factor can be set by an administrative protocol entry with the key name "magnitudeweightfactor" for
-     * V13+ blocks. The value is specified as a whole number or fraction. For example, 1 / 5.67 would be "100/567", 2 would be "2".
+      * V13+ blocks. The value is specified as a whole number or fraction. For example, 1 / 5.67 would be "100/567", 2 would be "2".
       */
     Fraction DefaultMagnitudeWeightFactor;
     /**

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -1239,14 +1239,16 @@ void BeaconRegistry::Deactivate(const uint256 superblock_hash)
 //! \param recnum
 //! \param key_type
 //!
-template<> void BeaconRegistry::BeaconDB::HandleCurrentHistoricalEntries(GRC::BeaconRegistry::BeaconMap& entries,
-                                               GRC::BeaconRegistry::PendingBeaconMap& pending_entries,
+ template<> void BeaconRegistry::BeaconDB::HandleCurrentHistoricalEntries(GRC::BeaconRegistry::BeaconMap& entries,
+                                                               GRC::BeaconRegistry::PendingBeaconMap& pending_entries,
                                                                std::set<Beacon_ptr>& expired_entries,
-                                               const Beacon& entry,
-                                               entry_ptr& historical_entry_ptr,
-                                               const uint64_t& recnum,
-                                               const std::string& key_type)
-{
+                                                               GRC::BeaconRegistry::BeaconMap& first_entries,
+                                                               const Beacon& entry,
+                                                               entry_ptr& historical_entry_ptr,
+                                                               const uint64_t& recnum,
+                                                               const std::string& key_type,
+                                                               const bool& populate_first_entries)
+ {
     // Note that in this specialization, entry.m_cpid and entry.GetId() are used for the map keys. In the general template,
     // entry.Key() is used (which here is the same as entry.m_cpid). No generalized method to implement entry.PendingKey()
     // has been implemented up to this point, because the pending map is actually only used here in the beacon
@@ -1366,7 +1368,7 @@ template<> void BeaconRegistry::BeaconDB::HandleCurrentHistoricalEntries(GRC::Be
 
 int BeaconRegistry::Initialize()
 {
-    int height = m_beacon_db.Initialize(m_beacons, m_pending, m_expired_pending);
+    int height = m_beacon_db.Initialize(m_beacons, m_pending, m_expired_pending, m_beacon_first_entries, false);
 
     LogPrint(LogFlags::BEACON, "INFO: %s: m_beacon_db size after load: %u", __func__, m_beacon_db.size());
     LogPrint(LogFlags::BEACON, "INFO: %s: m_beacons size after load: %u", __func__, m_beacons.size());

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -830,6 +830,8 @@ private:
     //!
     std::set<Beacon_ptr> m_expired_pending;
 
+    BeaconMap m_beacon_first_entries {}; //!< Not used here. Only to satisfy the template.
+
     //!
     //! \brief The member variable that is the instance of the beacon database. This is private to the
     //! beacon registry and is only accessible by beacon registry functions.

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/contract/registry_db.h
+++ b/src/gridcoin/contract/registry_db.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/contract/registry_db.h
+++ b/src/gridcoin/contract/registry_db.h
@@ -66,10 +66,14 @@ public:
     //! specialization.
     //! \param expired_entries. The map of expired pending entries. This is not used in the general template, only in the
     //! beacons specialization.
+    //! \param first_entries: The map of the first entry for the given key. This is only currently used for the whitelist
+    //! (projects).
+    //!
+    //! \param populate_first_entries. This is a boolean that controls whether the first entries map is populated.
     //!
     //! \return block height up to and including which the entry records were stored.
     //!
-    int Initialize(M& entries, P& pending_entries, X& expired_entries)
+    int Initialize(M& entries, P& pending_entries, X& expired_entries, M& first_entries, const bool& populate_first_entries)
     {
         bool status = true;
         int height = 0;
@@ -173,8 +177,8 @@ public:
             m_historical[iter.second.m_hash] = std::make_shared<E>(entry);
             entry_ptr& historical_entry_ptr = m_historical[iter.second.m_hash];
 
-            HandleCurrentHistoricalEntries(entries, pending_entries, expired_entries, entry,
-                                                historical_entry_ptr, recnum, key_type);
+            HandleCurrentHistoricalEntries(entries, pending_entries, expired_entries, first_entries, entry,
+                                                historical_entry_ptr, recnum, key_type, populate_first_entries);
 
             number_passivated += (uint64_t) HandlePreviousHistoricalEntries(historical_entry_ptr);
         } // storage_by_record_num iteration
@@ -198,14 +202,16 @@ public:
     //!
     //! \param entries
     //! \param pending_entries
+    //! \param expired_entries
+    //! \param first_entries
     //! \param entry
     //! \param historical_entry_ptr
     //! \param recnum
     //! \param key_type
     //!
-    void HandleCurrentHistoricalEntries(M& entries, P& pending_entries, X& expired_entries, const E& entry,
+    void HandleCurrentHistoricalEntries(M& entries, P& pending_entries, X& expired_entries, M& first_entries, const E& entry,
                                         entry_ptr& historical_entry_ptr, const uint64_t& recnum,
-                                        const std::string& key_type)
+                                        const std::string& key_type, const bool& populate_first_entries)
     {
         // The unknown or out of bound status conditions should have never made it into leveldb to begin with, since
         // the entry contract will fail validation, but to be thorough, include the filter condition anyway.
@@ -226,6 +232,10 @@ public:
 
             // Insert or replace the existing map entry with the latest.
             entries[entry.Key()] = historical_entry_ptr;
+
+            if (populate_first_entries && historical_entry_ptr->m_previous_hash.IsNull()) {
+                first_entries[entry.Key()] = historical_entry_ptr;
+            }
         }
     }
 

--- a/src/gridcoin/fwd.h
+++ b/src/gridcoin/fwd.h
@@ -29,6 +29,7 @@ enum class ProjectEntryStatus
     ACTIVE,
     MAN_GREYLISTED,
     AUTO_GREYLISTED,
+    AUTO_GREYLIST_OVERRIDE,
     OUT_OF_BOUND
 };
 } // namespace GRC

--- a/src/gridcoin/fwd.h
+++ b/src/gridcoin/fwd.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2014-2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_FWD_H
+#define GRIDCOIN_FWD_H
+
+namespace GRC
+{
+//!
+//! \brief Enumeration of project entry status. Unlike beacons this is for both storage
+//! and memory.
+//!
+//! UNKNOWN status is only encountered in trivially constructed empty
+//! project entries and should never be seen on the blockchain.
+//!
+//! DELETED status corresponds to a removed entry.
+//!
+//! ACTIVE corresponds to an active entry.
+//!
+//! GREYLISTED means that the project temporarily does not meet the whitelist qualification criteria.
+//!
+//! OUT_OF_BOUND must go at the end and be retained for the EnumBytes wrapper.
+//!
+enum class ProjectEntryStatus
+{
+    UNKNOWN,
+    DELETED,
+    ACTIVE,
+    MAN_GREYLISTED,
+    AUTO_GREYLISTED,
+    OUT_OF_BOUND
+};
+} // namespace GRC
+
+#endif // GRIDCOIN_FWD_H
+

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -648,7 +648,7 @@ WhitelistSnapshot Whitelist::Snapshot(const ProjectEntry::ProjectFilterFlag& fil
     // projects is relatively small.
     ProjectEntryMap project_entries = m_project_entries;
 
-    for (auto iter : project_entries) {
+    for (auto& iter : project_entries) {
         if (include_override) {
             // This is the actual override. The most important thing here is the greylist_ptr->Contains(iter.first) part. This
             // applies the current state of the greylist at the time of the construction of the whitelist snapshot, without

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -514,9 +514,6 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
         SuperblockPtr superblock_ptr;
 
         if (unit_test_blocks == nullptr) {
-            // For some reason this is not working.
-            //superblock_ptr.ReadFromDisk(index_ptr);
-
             CBlock block;
 
             if (!ReadBlockFromDisk(block, index_ptr, Params().GetConsensus())) {
@@ -1034,6 +1031,10 @@ void Whitelist::ResetInMemoryOnly()
     m_expired_project_entries.clear();
     m_project_first_actives.clear();
     m_project_db.clear_in_memory_only();
+
+    // If the whitelist registry is reset, the auto greylist cache should be reset as well.
+    m_auto_greylist->Reset();
+
 }
 
 uint64_t Whitelist::PassivateDB()

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -216,11 +216,28 @@ Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_
 {
 }
 
-Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_controls, bool manual_greylist)
+Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_controls, ProjectEntryStatus status)
     : ProjectEntry(version, name, url, gdpr_controls, ProjectEntryStatus::UNKNOWN, int64_t {0})
 {
-    if (manual_greylist) {
+    // The only two values that make sense for status using this constructor overload are MAN_GREYLISTED and
+    // AUTO_GREYLIST_OVERRIDE. The other are handled by the contract action context and the other overloads.
+    switch (status) {
+    case ProjectEntryStatus::MAN_GREYLISTED:
         m_status = ProjectEntryStatus::MAN_GREYLISTED;
+        break;
+    case ProjectEntryStatus::AUTO_GREYLIST_OVERRIDE:
+        m_status = ProjectEntryStatus::AUTO_GREYLIST_OVERRIDE;
+        break;
+    case ProjectEntryStatus::ACTIVE:
+        break;
+    case ProjectEntryStatus::DELETED:
+        break;
+    case ProjectEntryStatus::AUTO_GREYLISTED:
+        break;
+    case ProjectEntryStatus::UNKNOWN:
+        break;
+    case ProjectEntryStatus::OUT_OF_BOUND:
+        break;
     }
 }
 

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -1044,10 +1044,8 @@ uint64_t Whitelist::PassivateDB()
     return m_project_db.passivate_db();
 }
 
-const Whitelist::ProjectEntryMap Whitelist::GetProjectsFirstActive() const
+const Whitelist::ProjectEntryMap Whitelist::GetProjectsFirstActive() const EXCLUSIVE_LOCKS_REQUIRED(Whitelist::cs_lock)
 {
-    LOCK(cs_lock);
-
     return m_project_first_actives;
 }
 

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -308,7 +308,7 @@ AutoGreylist::AutoGreylist()
     : m_greylist_ptr(std::make_shared<Greylist>())
     , m_superblock_hash(uint256 {})
 {
-    Refresh();
+    //Refresh();
 }
 
 AutoGreylist::Greylist::const_iterator AutoGreylist::begin() const

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -49,23 +49,24 @@ ProjectEntry::ProjectEntry(uint32_t version)
     , m_hash()
     , m_previous_hash()
     , m_gdpr_controls(false)
+    , m_requires_ext_adapter(false)
     , m_public_key(CPubKey {})
     , m_status(ProjectEntryStatus::UNKNOWN)
 {
 }
 
 ProjectEntry::ProjectEntry(uint32_t version, std::string name, std::string url)
-    : ProjectEntry(version, name, url, false, ProjectEntryStatus::UNKNOWN, int64_t {0})
+    : ProjectEntry(version, name, url, false, false, ProjectEntryStatus::UNKNOWN, int64_t {0})
 {
 }
 
 ProjectEntry::ProjectEntry(uint32_t version, std::string name, std::string url, bool gdpr_controls)
-    : ProjectEntry(version, name, url, gdpr_controls, ProjectEntryStatus::UNKNOWN, int64_t {0})
+    : ProjectEntry(version, name, url, gdpr_controls, false, ProjectEntryStatus::UNKNOWN, int64_t {0})
 {
 }
 
 ProjectEntry::ProjectEntry(uint32_t version, std::string name, std::string url,
-                           bool gdpr_controls, Status status, int64_t timestamp)
+                           bool gdpr_controls, bool requires_ext_adapter, Status status, int64_t timestamp)
     : m_version(version)
     , m_name(name)
     , m_url(url)
@@ -73,6 +74,7 @@ ProjectEntry::ProjectEntry(uint32_t version, std::string name, std::string url,
     , m_hash()
     , m_previous_hash()
     , m_gdpr_controls(gdpr_controls)
+    , m_requires_ext_adapter(requires_ext_adapter)
     , m_public_key(CPubKey {})
     , m_status(status)
 {
@@ -181,6 +183,17 @@ std::optional<bool> ProjectEntry::HasGDPRControls() const
     return has_gdpr_controls;
 }
 
+std::optional<bool> ProjectEntry::RequiresExtAdapter() const
+{
+    std::optional<bool> requires_ext_adapter;
+
+    if (m_version >= 4) {
+        requires_ext_adapter = m_requires_ext_adapter;
+    }
+
+    return requires_ext_adapter;
+}
+
 // -----------------------------------------------------------------------------
 // Class: Project
 // -----------------------------------------------------------------------------
@@ -193,27 +206,28 @@ Project::Project(uint32_t version)
 }
 
 Project::Project(std::string name, std::string url)
-    : ProjectEntry(1, name, url, false, ProjectEntryStatus::UNKNOWN, int64_t {0})
+    : ProjectEntry(1, name, url, false, false, ProjectEntryStatus::UNKNOWN, int64_t {0})
 {
 }
 
 Project::Project(uint32_t version, std::string name, std::string url)
-    : ProjectEntry(version, name, url, false, ProjectEntryStatus::UNKNOWN, int64_t {0})
+    : ProjectEntry(version, name, url, false, false,ProjectEntryStatus::UNKNOWN, int64_t {0})
 {
 }
 
 Project::Project(std::string name, std::string url, int64_t timestamp, uint32_t version)
-    : ProjectEntry(version, name, url, false, ProjectEntryStatus::UNKNOWN, timestamp)
+    : ProjectEntry(version, name, url, false, false, ProjectEntryStatus::UNKNOWN, timestamp)
 {
 }
 
 Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_controls)
-    : ProjectEntry(version, name, url, gdpr_controls, ProjectEntryStatus::UNKNOWN, int64_t {0})
+    : ProjectEntry(version, name, url, gdpr_controls, false, ProjectEntryStatus::UNKNOWN, int64_t {0})
 {
 }
 
-Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_controls, ProjectEntryStatus status)
-    : ProjectEntry(version, name, url, gdpr_controls, ProjectEntryStatus::UNKNOWN, int64_t {0})
+Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_controls,
+                 bool requires_ext_adapter, ProjectEntryStatus status)
+    : ProjectEntry(version, name, url, gdpr_controls, requires_ext_adapter, ProjectEntryStatus::UNKNOWN, int64_t {0})
 {
     // The only two values that make sense for status using this constructor overload are MAN_GREYLISTED and
     // AUTO_GREYLIST_OVERRIDE. The other are handled by the contract action context and the other overloads.
@@ -238,12 +252,12 @@ Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_
 }
 
 Project::Project(uint32_t version, std::string name, std::string url, bool gdpr_controls, int64_t timestamp)
-    : ProjectEntry(version, name, url, gdpr_controls, ProjectEntryStatus::UNKNOWN, timestamp)
+    : ProjectEntry(version, name, url, gdpr_controls, false, ProjectEntryStatus::UNKNOWN, timestamp)
 {
 }
 
 Project::Project(std::string name, std::string url, int64_t timestamp, uint32_t version, bool gdpr_controls)
-    : ProjectEntry(version, name, url, gdpr_controls, ProjectEntryStatus::UNKNOWN, timestamp)
+    : ProjectEntry(version, name, url, gdpr_controls, false,  ProjectEntryStatus::UNKNOWN, timestamp)
 {
 }
 

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -11,7 +11,6 @@
 #include "node/ui_interface.h"
 
 #include <algorithm>
-#include <atomic>
 
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
@@ -565,6 +564,8 @@ void AutoGreylist::Reset()
 {
     if (m_greylist_ptr != nullptr) {
         m_greylist_ptr->clear();
+    } else {
+        m_greylist_ptr = std::make_shared<Greylist>();
     }
 
     m_superblock_hash = Superblock().GetHash(true);
@@ -586,7 +587,7 @@ WhitelistSnapshot Whitelist::Snapshot(const ProjectEntry::ProjectFilterFlag& fil
         return WhitelistSnapshot(std::make_shared<ProjectList>(projects), filter);
     }
 
-    if (refresh_greylist) {
+    if (refresh_greylist && m_auto_greylist != nullptr) {
         m_auto_greylist->Refresh();
     }
 
@@ -610,7 +611,7 @@ WhitelistSnapshot Whitelist::Snapshot(const ProjectEntry::ProjectFilterFlag& fil
             // applies the current state of the greylist at the time of the construction of the whitelist snapshot, without
             // disturbing the underlying projects registry.
 
-            bool in_greylist = m_auto_greylist->Contains(iter.first);
+            bool in_greylist = m_auto_greylist != nullptr ? m_auto_greylist->Contains(iter.first) : false;
 
             // If the project does NOT have a status of auto greylist override, and it is either active or already manually
             // greylisted, then if it is in the greylist, mark with the status auto greylisted.

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -295,9 +295,9 @@ public:
     //! \param name            Project name from contract message key.
     //! \param url             Project URL from contract message value.
     //! \param gdpr_controls   Boolean to indicate gdpr stats export controls enforced
-    //! \param manual_greylist Boolean to force manual greylisting of project
+    //! \param status          ProjectEntryStatus to force project status.
     //!
-    Project(uint32_t version, std::string name, std::string url, bool gdpr_controls, bool manual_greylist);
+    Project(uint32_t version, std::string name, std::string url, bool gdpr_controls, ProjectEntryStatus status);
 
     //!
     //! \brief Initialize a \c Project using data from the contract.

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -655,6 +655,11 @@ public:
             std::optional<bool> m_meets_greylisting_crit;
         };
 
+        const std::vector<UpdateHistoryEntry> GetUpdateHistory() const
+        {
+            return m_update_history;
+        }
+
         const std::string m_project_name;
 
         uint8_t m_zcd_20_SB_count;

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -40,15 +40,17 @@ public:
     //! This controls what project entries by status are in the project whitelist snapshot.
     //!
     enum ProjectFilterFlag : uint8_t {
-        NONE            = 0b0000,
-        DELETED         = 0b0001,
-        MAN_GREYLISTED  = 0b0010,
-        AUTO_GREYLISTED = 0b0100,
-        GREYLISTED      = MAN_GREYLISTED | AUTO_GREYLISTED,
-        ACTIVE          = 0b1000,
-        NOT_ACTIVE      = 0b0111,
-        ALL_BUT_DELETED = 0b1110,
-        ALL             = 0b1111
+        NONE                   = 0b00000,
+        DELETED                = 0b00001,
+        MAN_GREYLISTED         = 0b00010,
+        AUTO_GREYLISTED        = 0b00100,
+        GREYLISTED             = MAN_GREYLISTED | AUTO_GREYLISTED,
+        REG_ACTIVE             = 0b01000,
+        AUTO_GREYLIST_OVERRIDE = 0b10000,
+        ACTIVE                 = REG_ACTIVE | AUTO_GREYLIST_OVERRIDE,
+        NOT_ACTIVE             = 0b00111,
+        ALL_BUT_DELETED        = 0b11110,
+        ALL                    = 0b11111
     };
 
     //!

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -659,10 +659,13 @@ public:
     //!
     bool Contains(const std::string& name, const bool& only_auto_greylisted = true) const;
 
+    //!
+    //! \brief This refreshes the AutoGreylist object from the last superblock in the chain.
+    //!
     void Refresh();
 
     //!
-    //! \brief This refreshes a local instantiation of the AutoGreylist from an input Superblock pointer.
+    //! \brief This refreshes the AutoGreylist object from an input Superblock pointer.
     //!
     //! Note that the AutoGreylist object refreshed this way will also be used to update the referenced superblock
     //! object
@@ -674,7 +677,7 @@ public:
     void RefreshWithSuperblock(SuperblockPtr superblock_ptr_in);
 
     //!
-    //! \brief This refreshes a local instantiation of the AutoGreylist from an input Superblock that is going to be associated
+    //! \brief This refreshes the AutoGreylist object from an input Superblock that is going to be associated
     //! with the current head of the chain. This mode is used in the scraper during the construction of the superblock contract.
     //!
     //! Note that the AutoGreylist object refreshed this way will also be used to update the referenced superblock
@@ -686,13 +689,15 @@ public:
     //!
     void RefreshWithSuperblock(Superblock& superblock);
 
+    void Reset();
+
     static std::shared_ptr<AutoGreylist> GetAutoGreylistCache();
 
 private:
-    CCriticalSection lock;
+    mutable CCriticalSection autogreylist_lock;
 
     GreylistPtr m_greylist_ptr;
-    uint256 m_superblock_hash;
+    QuorumHash m_superblock_hash;
 };
 
 //!
@@ -837,6 +842,12 @@ public:
     uint64_t PassivateDB() override;
 
     //!
+    //! \brief This returns m_project_first_actives.
+    //! \return
+    //!
+    const ProjectEntryMap GetProjectsFirstActive() const;
+
+    //!
     //! \brief Specializes the template RegistryDB for the ScraperEntry class. Note that std::set<ProjectEntry> is not
     //! actually used.
     //!
@@ -872,7 +883,9 @@ private:
 
     std::set<ProjectEntry> m_expired_project_entries {}; //!< Not actually used. Only to satisfy the template.
 
-    ProjectEntryDB m_project_db; //!< The project db member
+    ProjectEntryMap m_project_first_actives;             //!< Tracks when projects were first activated for auto greylisting purposes.
+
+    ProjectEntryDB m_project_db;                         //!< The project db member
 public:
 
     ProjectEntryDB& GetProjectDB();

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -1001,8 +1001,10 @@ public:
     uint64_t PassivateDB() override;
 
     //!
-    //! \brief This returns m_project_first_actives.
-    //! \return
+    //! \brief This returns m_project_first_actives. Note that unlike other methods here, this does not take the cs_lock
+    //! internally but rather requires it. The reason for this is that this function is used by the AutoGreylist class update
+    //! where the cs_lock is already taken before, and the AutoGreylist class has its own lock. If cs_lock is then taken again,
+    //! a potential deadlock can result.
     //!
     const ProjectEntryMap GetProjectsFirstActive() const;
 

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -63,7 +63,7 @@ public:
     //! ensure that the serialization/deserialization routines also handle all
     //! of the previous versions.
     //!
-    static constexpr uint32_t CURRENT_VERSION = 3;
+    static constexpr uint32_t CURRENT_VERSION = 4;
 
     //!
     //! \brief Version number of the serialized project format.
@@ -78,6 +78,7 @@ public:
     uint256 m_hash;                      //!< The txid of the transaction that contains the project entry.
     uint256 m_previous_hash;             //!< The m_hash of the previous project entry with the same key.
     bool m_gdpr_controls;                //!< Boolean to indicate whether project has GDPR stats export controls.
+    bool m_requires_ext_adapter;         //!< Boolean to indicate whether project requires external adapter.
     CPubKey m_public_key;                //!< Project public key.
     Status m_status;                     //!< The status of the project entry. (Note serialization converts to/from int.)
 
@@ -113,10 +114,12 @@ public:
     //! \param name. The key of the project entry.
     //! \param url. The value of the project entry.
     //! \param gdpr_controls. The gdpr control flag of the project entry
+    //! \param requires_ext_adapter. The flag that indicates whether the project requires an external adapter for stats.
     //! \param status. the status of the project entry.
     //! \param timestamp. The timestamp of the project entry that comes from the containing transaction
     //!
-    ProjectEntry(uint32_t version, std::string name, std::string url, bool gdpr_controls, Status status, int64_t timestamp);
+    ProjectEntry(uint32_t version, std::string name, std::string url, bool gdpr_controls,
+                 bool requires_ext_adapter, Status status, int64_t timestamp);
 
     //!
     //! \brief Determine whether a project entry contains each of the required elements.
@@ -183,6 +186,11 @@ public:
     //! \brief Returns true if project has project stats GDPR export controls
     //!
     std::optional<bool> HasGDPRControls() const;
+
+    //!
+    //! \brief Returns true if project requires an externel adapter for statistics collection.
+    //!
+    std::optional<bool> RequiresExtAdapter() const;
 
     //!
     //! \brief Comparison operator overload used in the unit test harness.
@@ -300,7 +308,8 @@ public:
     //! \param gdpr_controls   Boolean to indicate gdpr stats export controls enforced
     //! \param status          ProjectEntryStatus to force project status.
     //!
-    Project(uint32_t version, std::string name, std::string url, bool gdpr_controls, ProjectEntryStatus status);
+    Project(uint32_t version, std::string name, std::string url, bool gdpr_controls,
+            bool requires_ext_adapter, ProjectEntryStatus status);
 
     //!
     //! \brief Initialize a \c Project using data from the contract.
@@ -415,6 +424,10 @@ public:
             READWRITE(m_hash);
             READWRITE(m_previous_hash);
             READWRITE(m_status);
+        }
+
+        if (m_version >= 4) {
+            READWRITE(m_requires_ext_adapter);
         }
     }
 }; // Project (entry payload)

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -13,6 +13,7 @@
 #include "serialize.h"
 #include "pubkey.h"
 #include "sync.h"
+#include "node/ui_interface.h"
 
 #include <memory>
 #include <vector>
@@ -666,6 +667,11 @@ public:
                        PendingProjectEntryMap,
                        std::set<ProjectEntry>,
                        HistoricalProjectEntryMap> ProjectEntryDB;
+
+    //!
+    //! \brief Core signal to indicate that a project status has changed.
+    //!
+    boost::signals2::signal<void (const ProjectEntry_ptr project, ChangeType status)> NotifyProjectChanged;
 
 private:
     //!

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -508,7 +508,7 @@ public:
             , m_zcd_20_SB_count(0)
             , m_TC_7_SB_sum(0)
             , m_TC_40_SB_sum(0)
-            , m_meets_greylisting_crit(0)
+            , m_meets_greylisting_crit(false)
             , m_TC_initial_bookmark(0)
             , m_TC_bookmark(0)
             , m_sb_from_baseline_processed(0)
@@ -520,7 +520,7 @@ public:
             , m_zcd_20_SB_count(0)
             , m_TC_7_SB_sum(0)
             , m_TC_40_SB_sum(0)
-            , m_meets_greylisting_crit(0)
+            , m_meets_greylisting_crit(false)
             , m_TC_initial_bookmark(TC_initial_bookmark)
             , m_TC_bookmark(0)
             , m_sb_from_baseline_processed(0)
@@ -739,7 +739,7 @@ public:
     //! the AutoGreylist as part of taking the snapshot.
     //!
     WhitelistSnapshot Snapshot(const ProjectEntry::ProjectFilterFlag& filter = ProjectEntry::ProjectFilterFlag::ACTIVE,
-                               const bool& refresh_greylist = false) const;
+                               const bool& refresh_greylist = true, const bool &include_override = true) const;
 
     //!
     //! \brief Destroy the contract handler state to prepare for historical

--- a/src/gridcoin/protocol.cpp
+++ b/src/gridcoin/protocol.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/protocol.cpp
+++ b/src/gridcoin/protocol.cpp
@@ -526,7 +526,11 @@ int ProtocolRegistry::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_protocol_db.Initialize(m_protocol_entries, m_pending_protocol_entries, m_expired_protocol_entries);
+    int height = m_protocol_db.Initialize(m_protocol_entries,
+                                          m_pending_protocol_entries,
+                                          m_expired_protocol_entries,
+                                          m_protocol_first_entries,
+                                          false);
 
     LogPrint(LogFlags::CONTRACT, "INFO: %s: m_protocol_db size after load: %u", __func__, m_protocol_db.size());
     LogPrint(LogFlags::CONTRACT, "INFO: %s: m_protocol_entries size after load: %u", __func__, m_protocol_entries.size());

--- a/src/gridcoin/protocol.h
+++ b/src/gridcoin/protocol.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/protocol.h
+++ b/src/gridcoin/protocol.h
@@ -603,6 +603,8 @@ private:
 
     std::set<ProtocolEntry> m_expired_protocol_entries {}; //!< Not used. Only to satisfy the template.
 
+    ProtocolEntryMap m_protocol_first_entries {};          //!< Not used. Only to satisfy the template.
+
     ProtocolEntryDB m_protocol_db;
 
 public:

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -20,8 +20,8 @@
 using namespace GRC;
 
 // TODO: use a header
-ScraperStatsAndVerifiedBeacons  GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
-ScraperStatsAndVerifiedBeacons  GetScraperStatsFromSingleManifest(CScraperManifest_shared_ptr& manifest);
+ScraperStatsVerifiedBeaconsTotalCredits  GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
+ScraperStatsVerifiedBeaconsTotalCredits  GetScraperStatsFromSingleManifest(CScraperManifest_shared_ptr& manifest);
 unsigned int NumScrapersForSupermajority(unsigned int nScraperCount);
 mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests();
 Superblock ScraperGetSuperblockContract(
@@ -822,7 +822,7 @@ private: // SuperblockValidator classes
         //!
         QuorumHash ComputeQuorumHash() const
         {
-            const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetScraperStatsByConvergedManifest(m_convergence);
+            const ScraperStatsVerifiedBeaconsTotalCredits stats_and_verified_beacons = GetScraperStatsByConvergedManifest(m_convergence);
 
             return QuorumHash::Hash(stats_and_verified_beacons);
         }
@@ -1392,7 +1392,7 @@ private: // SuperblockValidator methods
     //!
     bool TryManifest(CScraperManifest_shared_ptr& manifest) const
     {
-        const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetScraperStatsFromSingleManifest(manifest);
+        const ScraperStatsVerifiedBeaconsTotalCredits stats_and_verified_beacons = GetScraperStatsFromSingleManifest(manifest);
 
         return QuorumHash::Hash(stats_and_verified_beacons) == m_quorum_hash;
     }
@@ -1663,7 +1663,7 @@ std::vector<ExplainMagnitudeProject> Quorum::ExplainMagnitude(const Cpid cpid)
     // Although the map is ordered, the keys begin with project names, so we
     // cannot binary search for a block of CPID entries yet:
     //
-    for (const auto& entry : ConvergedScraperStatsCache.mScraperConvergedStats) {
+    for (const auto& entry : ConvergedScraperStatsCache.mScraperConvergedStats.mScraperStats) {
         if (entry.first.objecttype == statsobjecttype::byCPIDbyProject) {
             const Span<const char> project_name = try_item(entry.first.objectID);
 

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -159,6 +159,11 @@ struct ConvergedManifest
      */
     std::vector<std::string> vExcludedProjects;
 
+    //!
+    //! \brief The list of projects that have been greylisted.
+    //!
+    std::vector<std::string> vGreylistedProjects;
+
     /** Populates the part pointers map in the convergence */
     bool PopulateConvergedManifestPartPtrsMap();
 

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "gridcoin/fwd.h"
 #include "gridcoin/scraper/scraper_net.h"
 #include "util.h"
 #include "streams.h"
@@ -160,9 +161,10 @@ struct ConvergedManifest
     std::vector<std::string> vExcludedProjects;
 
     //!
-    //! \brief The list of projects that have been greylisted.
+    //! \brief The list of projects that have been greylisted, with the greylisting status, indicating whether they are
+    //! manually or automatically greylisted.
     //!
-    std::vector<std::string> vGreylistedProjects;
+    std::vector<std::pair<std::string, GRC::ProjectEntryStatus>> vGreylistedProjects;
 
     /** Populates the part pointers map in the convergence */
     bool PopulateConvergedManifestPartPtrsMap();

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -281,13 +281,32 @@ struct ScraperVerifiedBeacons
     }
 };
 
+/**
+ * @brief Used to hold total credits across ALL cpids for each project. This is to support auto greylisting.
+ */
+struct ScraperProjectsAllCpidTotalCredit
+{
+    int64_t m_timestamp = GetAdjustedTime();
+    std::map<std::string, double> m_all_cpid_total_credit_map;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(m_timestamp);
+        READWRITE(m_all_cpid_total_credit_map);
+    }
+};
+
 /** A combination of scraper stats and verified beacons. For convenience in the interface between the scraper and the
  * quorum/superblock code.
  */
-struct ScraperStatsAndVerifiedBeacons
+struct ScraperStatsVerifiedBeaconsTotalCredits
 {
     ScraperStats mScraperStats;
     ScraperPendingBeaconMap mVerifiedMap;
+    std::map<std::string, double> m_total_credit_map;
 };
 
 #endif // GRIDCOIN_SCRAPER_FWD_H

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3472,7 +3472,7 @@ bool StoreScraperFileManifest(const fs::path& file)
                     + entry.first + ","
                     + ToString(entry.second.excludefromcsmanifest) + ","
                     + entry.second.filetype + ","
-                    + ToString(entry.second.all_cpid_total_credit) + ","
+                    + FromDoubleToString(entry.second.all_cpid_total_credit, 12) + ","
                     + ToString((uint32_t) entry.second.no_records)
                     + "\n";
             stream << sScraperFileManifestEntry;

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -169,7 +169,8 @@ unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE GUARDED_BY(cs_ScraperGlobals) = 0
 bool REQUIRE_TEAM_WHITELIST_MEMBERSHIP GUARDED_BY(cs_ScraperGlobals) = false;
 /** Default team whitelist. Remember this will be overridden by appcache entries. */
 std::string TEAM_WHITELIST GUARDED_BY(cs_ScraperGlobals) = "Gridcoin";
-/** This is a short term place to hold projects that require an external adapter for the scrapers.*/
+/** This is a short term place to hold projects that require an external adapter for the scrapers. This will be retired after
+  the block v13/superblock v3/project v4 mandatory */
 std::string EXTERNAL_ADAPTER_PROJECTS GUARDED_BY(cs_ScraperGlobals) = std::string{};
 /** This is the period after the deauthorizing of a scraper in seconds before the nodes will start
  * to assign banscore to nodes sending unauthorized manifests.
@@ -6228,7 +6229,7 @@ UniValue convergencereport(const UniValue& params, bool fHelp)
         for (const auto& entry : ConvergedScraperStatsCache.Convergence.vGreylistedProjects) {
             ProjectEntry::Status status = GRC::EnumByte<GRC::ProjectEntryStatus>(entry.second);
 
-            ProjectEntry dummy_project(3, entry.first, "foo", false, status, 0);
+            ProjectEntry dummy_project(3, entry.first, "foo", false, false, status, 0);
 
             UniValue greylisted_project_entry(UniValue::VOBJ);
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3792,7 +3792,7 @@ bool ProcessNetworkWideFromProjectStats(ScraperStats& mScraperStats)
     unsigned int nCPIDProjectCount = 0;
 
     //Also track the network wide rollup.
-    ScraperObjectStats NetworkWideStatsEntry;
+    ScraperObjectStats NetworkWideStatsEntry {};
 
     NetworkWideStatsEntry.statskey.objecttype = statsobjecttype::NetworkWide;
     // ObjectID is blank string for network-wide.

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 #ifndef GRIDCOIN_SCRAPER_SCRAPER_H

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -80,6 +80,8 @@ struct ScraperFileManifestEntry
     bool current = true;
     bool excludefromcsmanifest = true;
     std::string filetype;
+    double all_cpid_total_credit = 0;
+    bool no_records = true;
 };
 
 /**

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -124,9 +124,9 @@ uint256 GetFileHash(const fs::path& inputfile);
 /**
  * @brief Provides the computed scraper stats and verified beacons from the input converged manifest
  * @param StructConvergedManifest
- * @return ScraperStatsAndVerifiedBeacons
+ * @return ScraperStatsVerifiedBeaconsTotalCredits
  */
-ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
+ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
 /**
  * @brief Gets a copy of the extended scrapers cache global. This global is an extension of the appcache in that it
  * retains deleted entries with a deleted flag.
@@ -203,9 +203,9 @@ std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& Verifie
 /**
  * @brief Returns the scraper stats and verified beacons in one structure from the input ConvergedScraperStats
  * @param stats
- * @return ScraperStatsAndVerifiedBeacons
+ * @return ScraperStatsVerifiedBeaconsTotalCredits
  */
-ScraperStatsAndVerifiedBeacons GetScraperStatsAndVerifiedBeacons(const ConvergedScraperStats &stats);
+ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsVerifiedBeaconsTotalCredits(const ConvergedScraperStats &stats);
 /**
  * @brief Returns a map of pending beacons
  * @return ScraperPendingBeaconMap of pending beacons

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -881,17 +881,16 @@ UniValue CScraperManifest::ToJson() const EXCLUSIVE_LOCKS_REQUIRED(CSplitBlob::c
         if (part.project != "ProjectsAllCpidTotalCredits") {
             projects.push_back(part.ToJson());
 
-        } else {
-            CDataStream ss(SER_NETWORK, 1);
-
-            ss << vParts[part.part1]->data;
+        } else if (!vParts[part.part1]->data.empty()) {
+            CDataStream ss(vParts[part.part1]->data, SER_NETWORK, 1);
 
             ss >> total_credit_map;
 
             for (const auto& iter : total_credit_map) {
                 UniValue tc_entry(UniValue::VOBJ);
 
-                tc_entry.pushKV("project", iter.second);
+                tc_entry.pushKV("project", iter.first);
+                tc_entry.pushKV("all_cpid_total_credit", iter.second);
 
                 project_all_cpid_total_credits.push_back(tc_entry);
             }

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -870,12 +870,36 @@ UniValue CScraperManifest::ToJson() const EXCLUSIVE_LOCKS_REQUIRED(CSplitBlob::c
     r.pushKV("BeaconList_c", (int64_t) BeaconList_c);
 
     UniValue projects(UniValue::VARR);
+    UniValue project_all_cpid_total_credits(UniValue::VARR);
+
+    std::map<std::string, double> total_credit_map;
+
     for (const dentry& part : this->projects)
     {
-        projects.push_back(part.ToJson());
+        UniValue project(UniValue::VOBJ);
+
+        if (part.project != "ProjectsAllCpidTotalCredits") {
+            projects.push_back(part.ToJson());
+
+        } else {
+            CDataStream ss(SER_NETWORK, 1);
+
+            ss << vParts[part.part1]->data;
+
+            ss >> total_credit_map;
+
+            for (const auto& iter : total_credit_map) {
+                UniValue tc_entry(UniValue::VOBJ);
+
+                tc_entry.pushKV("project", iter.second);
+
+                project_all_cpid_total_credits.push_back(tc_entry);
+            }
+        }
     }
 
     r.pushKV("projects", projects);
+    r.pushKV("project_all_cpid_total_credits", project_all_cpid_total_credits);
 
     UniValue parts(UniValue::VARR);
     for (const CPart* part : this->vParts)

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/scraper/scraper_registry.cpp
+++ b/src/gridcoin/scraper/scraper_registry.cpp
@@ -521,7 +521,7 @@ int ScraperRegistry::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_scraper_db.Initialize(m_scrapers, m_pending_scrapers, m_expired_scraper_entries);
+    int height = m_scraper_db.Initialize(m_scrapers, m_pending_scrapers, m_expired_scraper_entries, m_first_scraper_entries, false);
 
     LogPrint(LogFlags::SCRAPER, "INFO: %s: m_scraper_db size after load: %u", __func__, m_scraper_db.size());
     LogPrint(LogFlags::SCRAPER, "INFO: %s: m_scrapers size after load: %u", __func__, m_scrapers.size());

--- a/src/gridcoin/scraper/scraper_registry.cpp
+++ b/src/gridcoin/scraper/scraper_registry.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2023 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/scraper/scraper_registry.h
+++ b/src/gridcoin/scraper/scraper_registry.h
@@ -627,6 +627,8 @@ private:
 
     std::set<ScraperEntry> m_expired_scraper_entries {}; //!< Not actually used for scrapers. To satisfy the template only.
 
+    ScraperMap m_first_scraper_entries {};   //!< Not used here. To satisfy the template only.
+
     ScraperEntryDB m_scraper_db;
 
 public:

--- a/src/gridcoin/scraper/scraper_registry.h
+++ b/src/gridcoin/scraper/scraper_registry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2023 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -887,7 +887,11 @@ int SideStakeRegistry::Initialize()
 {
     LOCK(cs_lock);
 
-    int height = m_sidestake_db.Initialize(m_mandatory_sidestake_entries, m_pending_sidestake_entries, m_expired_sidestake_entries);
+    int height = m_sidestake_db.Initialize(m_mandatory_sidestake_entries,
+                                           m_pending_sidestake_entries,
+                                           m_expired_sidestake_entries,
+                                           m_sidestake_first_entries,
+                                           false);
 
     SubscribeToCoreSignals();
 

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -887,6 +887,8 @@ private:
 
     std::set<SideStake> m_expired_sidestake_entries {};   //!< Not used. Only to satisfy the template.
 
+    MandatorySideStakeMap m_sidestake_first_entries {};   //!< Not used. Only to satisfy the template.
+
     SideStakeDB m_sidestake_db;                           //!< The internal sidestake db object for leveldb persistence.
 
     bool m_local_entry_already_saved_to_config = false;   //!< Flag to prevent reload on signal if individual entry saved already.

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -103,12 +103,9 @@ public:
     end_build_from_stats_loop:
         m_superblock.m_verified_beacons.Reset(stats_verified_beacons_tc.mVerifiedMap);
 
-        {
-            LOCK(cs_main);
-
-            if (IsSuperblockV3Enabled(nBestHeight)) {
-                m_superblock.m_projects_all_cpids_total_credits.Reset(stats_verified_beacons_tc.m_total_credit_map);
-            }
+        // This is equivalent to superblock v3+ and doesn't require a lock on cs_main.
+        if (!stats_verified_beacons_tc.m_total_credit_map.empty()) {
+            m_superblock.m_projects_all_cpids_total_credits.Reset(stats_verified_beacons_tc.m_total_credit_map);
         }
     }
 private:
@@ -1110,7 +1107,7 @@ QuorumHash::QuorumHash(const std::vector<unsigned char>& bytes) : QuorumHash()
 QuorumHash QuorumHash::Hash(const Superblock& superblock)
 {
     if (superblock.m_version > 1) {
-        return QuorumHash(SerializeHash(superblock));
+        return QuorumHash(SerializeHash(SuperblockForHash(superblock)));
     }
 
     std::string input;

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -628,7 +628,7 @@ Superblock Superblock::FromConvergence(
         superblock.m_projects_all_cpids_total_credits.Reset(stats.mScraperConvergedStats.m_total_credit_map);
 
         // Refresh the auto greylist and refresh this superblock with the greylist status.
-        std::shared_ptr<GRC::AutoGreylist> greylist_ptr = GRC::AutoGreylist::GetAutoGreylistCache();
+        std::shared_ptr<GRC::AutoGreylist> greylist_ptr = GRC::GetAutoGreylistCache();
 
         greylist_ptr->RefreshWithSuperblock(superblock);
     }

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -5,6 +5,7 @@
 #ifndef GRIDCOIN_SUPERBLOCK_H
 #define GRIDCOIN_SUPERBLOCK_H
 
+#include "gridcoin/project.h"
 #include "gridcoin/cpid.h"
 #include "gridcoin/magnitude.h"
 #include "gridcoin/scraper/fwd.h"
@@ -258,7 +259,7 @@ public:
     //! ensure that the serialization/deserialization routines also handle all
     //! of the previous versions.
     //!
-    static constexpr uint32_t CURRENT_VERSION = 2;
+    static constexpr uint32_t CURRENT_VERSION = 3;
 
     //!
     //! \brief The maximum allowed size of a serialized superblock in bytes.
@@ -1186,6 +1187,21 @@ public:
         uint64_t m_total_rac;
     }; // ProjectIndex
 
+    struct ProjectStatus
+    {
+        ProjectStatus() {};
+
+        std::vector<ProjectEntry::Status> m_project_status;
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
+        {
+            READWRITE(m_project_status);
+        }
+    };
+
     struct VerifiedBeacons
     {
         //!
@@ -1239,6 +1255,7 @@ public:
     CpidIndex m_cpids;       //!< Maps superblock CPIDs to magnitudes.
     ProjectIndex m_projects; //!< Whitelisted projects statistics.
     VerifiedBeacons m_verified_beacons; //!< Wrapped verified beacons vector
+    ProjectStatus m_project_status; //!< Wrapped project_status vector
 
     ADD_SERIALIZE_METHODS;
 
@@ -1254,6 +1271,10 @@ public:
         READWRITE(m_cpids);
         READWRITE(m_projects);
         READWRITE(m_verified_beacons);
+
+        if (m_version > 2) {
+            READWRITE(m_project_status);
+        }
     }
 
     //!

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -5,10 +5,11 @@
 #ifndef GRIDCOIN_SUPERBLOCK_H
 #define GRIDCOIN_SUPERBLOCK_H
 
-#include "gridcoin/project.h"
+#include "gridcoin/fwd.h"
 #include "gridcoin/cpid.h"
 #include "gridcoin/magnitude.h"
 #include "gridcoin/scraper/fwd.h"
+#include "gridcoin/support/enumbytes.h"
 #include "serialize.h"
 #include "uint256.h"
 
@@ -1187,11 +1188,15 @@ public:
         uint64_t m_total_rac;
     }; // ProjectIndex
 
+    //!
+    //! \brief This is a wrapper around m_project_status. To conserve space, project status entries with a status
+    //! of ACTIVE are omitted.
+    //!
     struct ProjectStatus
     {
         ProjectStatus() {};
 
-        std::vector<ProjectEntry::Status> m_project_status;
+        std::vector<std::pair<std::string, EnumByte<ProjectEntryStatus>>> m_project_status;
 
         ADD_SERIALIZE_METHODS;
 
@@ -1482,6 +1487,15 @@ public:
     int64_t Age(const int64_t now) const
     {
         return now - m_timestamp;
+    }
+
+    bool IsEmpty()
+    {
+        if (m_superblock == nullptr && m_height == 0 && m_timestamp == 0) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     ADD_SERIALIZE_METHODS;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -621,6 +621,9 @@ void SetupServerArgs()
     // Temporary hidden option for block v13 height override to facilitate testing.
     hidden_args.emplace_back("-blockv13height");
 
+    // Temporary hidden option for superblock v3 height override to facilitate testing.
+    hidden_args.emplace_back("-superblockv3height");
+
     // Additional hidden options
     hidden_args.emplace_back("-devbuild");
     hidden_args.emplace_back("-scrapersleep");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -622,6 +622,9 @@ void SetupServerArgs()
     // Temporary hidden option for block v13 height override to facilitate testing.
     hidden_args.emplace_back("-blockv13height");
 
+    // Temporary hidden option for project v4 height override to facilitate testing.
+    hidden_args.emplace_back("-projectv4height");
+
     // Temporary hidden option for superblock v3 height override to facilitate testing.
     hidden_args.emplace_back("-superblockv3height");
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -905,7 +906,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     //6-10-2014: R Halford: Updating Boost version to 1.5.5 to prevent sync issues; print the boost version to verify:
-	//5-04-2018: J Owens: Boost now needs to be 1.65 or higher to avoid thread sleep problems with system clock resets.
+    //5-04-2018: J Owens: Boost now needs to be 1.65 or higher to avoid thread sleep problems with system clock resets.
     std::string boost_version = "";
     std::ostringstream s;
     s << boost_version  << "Using Boost "

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -200,7 +200,11 @@ QVariant ProjectTableModel::data(const QModelIndex &index, int role) const
                 case Whitelisted:
                     if (row->m_whitelisted == ProjectRow::WhiteListStatus::True) {
                         return QIcon(":/icons/round_green_check");
-                    } else if (row->m_whitelisted == ProjectRow::WhiteListStatus::Greylisted) {
+                    } else if (row->m_whitelisted == ProjectRow::WhiteListStatus::Excluded) {
+                        return QIcon(":/icons/warning");
+                    } else if (row->m_whitelisted == ProjectRow::WhiteListStatus::Manually_Greylisted) {
+                        return QIcon(":/icons/warning");
+                    } else if (row->m_whitelisted == ProjectRow::WhiteListStatus::Automatically_Greylisted) {
                         return QIcon(":/icons/warning");
                     } else if (row->m_whitelisted == ProjectRow::WhiteListStatus::False) {
                         return QIcon(":/icons/white_and_red_x");

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -593,7 +593,9 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
         row.m_name = QString::fromStdString(project.DisplayName()).toLower();
         row.m_magnitude = 0.0;
 
-        if (std::find(external_adapter_projects.begin(),
+        // the external adapter code below only appears here because if the project is in BOINC it does not need
+        // an external adapter.
+        if (!project.RequiresExtAdapter() && std::find(external_adapter_projects.begin(),
                       external_adapter_projects.end(),
                       project.m_name) == external_adapter_projects.end()) {
             row.m_error = tr("Not attached");

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -589,7 +589,7 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
         } else {
             row.m_error = tr("Uses external adapter");
         }
-        
+
         if (std::find(excluded_projects.begin(), excluded_projects.end(), project.m_name)
             != excluded_projects.end()) {
             row.m_whitelisted = ProjectRow::WhiteListStatus::Excluded;

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -486,7 +486,7 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
     // projects behave in the network.
     //
 
-    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot();
+    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED);
     std::vector<std::string> excluded_projects;
 
     {
@@ -531,8 +531,14 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
         if (const ProjectEntry* whitelist_project = project.TryWhitelist(whitelist)) {
             if (std::find(excluded_projects.begin(), excluded_projects.end(), whitelist_project->m_name)
                 != excluded_projects.end()) {
-                row.m_whitelisted = ProjectRow::WhiteListStatus::Greylisted;
-                row.m_error = tr("Greylisted");
+                row.m_whitelisted = ProjectRow::WhiteListStatus::Excluded;
+                row.m_error = tr("Excluded");
+            } else if (whitelist_project->m_status == ProjectEntryStatus::MAN_GREYLISTED) {
+                row.m_whitelisted = ProjectRow::WhiteListStatus::Manually_Greylisted;
+                row.m_error = tr("Manually Greylisted");
+            } else if (whitelist_project->m_status == ProjectEntryStatus::AUTO_GREYLISTED) {
+                row.m_whitelisted = ProjectRow::WhiteListStatus::Automatically_Greylisted;
+                row.m_error = tr("Automatically Greylisted");
             } else {
                 row.m_whitelisted = ProjectRow::WhiteListStatus::True;
             }
@@ -565,7 +571,7 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
 
     // Add any whitelisted projects not detected from the local BOINC client:
     //
-    for (const auto& project : GetWhitelist().Snapshot()) {
+    for (const auto& project : GetWhitelist().Snapshot(ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED)) {
         if (rows.find(project.m_name) != rows.end()) {
             continue;
         }
@@ -583,11 +589,17 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
         } else {
             row.m_error = tr("Uses external adapter");
         }
-
+        
         if (std::find(excluded_projects.begin(), excluded_projects.end(), project.m_name)
             != excluded_projects.end()) {
-            row.m_whitelisted = ProjectRow::WhiteListStatus::Greylisted;
-            row.m_error = tr("Greylisted");
+            row.m_whitelisted = ProjectRow::WhiteListStatus::Excluded;
+            row.m_error = tr("Excluded");
+        } else if (project.m_status == ProjectEntryStatus::MAN_GREYLISTED) {
+            row.m_whitelisted = ProjectRow::WhiteListStatus::Manually_Greylisted;
+            row.m_error = tr("Manually Greylisted");
+        } else if (project.m_status == ProjectEntryStatus::AUTO_GREYLISTED) {
+            row.m_whitelisted = ProjectRow::WhiteListStatus::Automatically_Greylisted;
+            row.m_error = tr("Automatically Greylisted");
         } else {
             row.m_whitelisted = ProjectRow::WhiteListStatus::True;
         }

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -713,11 +713,15 @@ void ResearcherModel::updateBeacon()
 
     if (!cpid) {
         commitBeacon(BeaconStatus::NO_CPID);
+        emit beaconChanged();
+        emit researcherChanged();
         return;
     }
 
     if (outOfSync()) {
         commitBeacon(BeaconStatus::UNKNOWN);
+        emit beaconChanged();
+        emit researcherChanged();
         return;
     }
 
@@ -762,6 +766,9 @@ void ResearcherModel::updateBeacon()
             commitBeacon(BeaconStatus::ACTIVE, beacon, pending_beacon);
         }
     }
+
+    emit beaconChanged();
+    emit researcherChanged();
 }
 
 BeaconStatus ResearcherModel::advertiseBeacon()
@@ -815,5 +822,6 @@ void ResearcherModel::commitBeacon(
 
     if (changed) {
         emit beaconChanged();
+        emit researcherChanged();
     }
 }

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -63,7 +63,9 @@ public:
     enum WhiteListStatus
     {
         False,
-        Greylisted,
+        Excluded,
+        Manually_Greylisted,
+        Automatically_Greylisted,
         True
     };
 

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -114,38 +114,38 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
         // Update support for Side Stake and correctly show POS/POR as well
         strHTML += "<b>" + tr("Source") + ":</b> ";
 
-        MinedType gentype = GetGeneratedType(wallet, wtx.GetHash(), vout);
+        GRC::MinedType gentype = GetGeneratedType(wallet, wtx.GetHash(), vout);
 
         switch (gentype)
         {
-        case MinedType::POS:
+        case GRC::MinedType::POS:
             strHTML += tr("Mined - PoS");
             break;
-        case MinedType::POR:
+        case GRC::MinedType::POR:
             strHTML += tr("Mined - PoS+RR");
             break;
-        case MinedType::ORPHANED:
+        case GRC::MinedType::ORPHANED:
             strHTML += tr("Mined - Orphaned");
             break;
-        case MinedType::POS_SIDE_STAKE_RCV:
+        case GRC::MinedType::POS_SIDE_STAKE_RCV:
             strHTML += tr("PoS Side Stake Received");
             break;
-        case MinedType::POR_SIDE_STAKE_RCV:
+        case GRC::MinedType::POR_SIDE_STAKE_RCV:
             strHTML += tr("PoS+RR Side Stake Received");
             break;
-        case MinedType::POS_SIDE_STAKE_SEND:
+        case GRC::MinedType::POS_SIDE_STAKE_SEND:
             strHTML += tr("PoS Side Stake Sent");
             break;
-        case MinedType::POR_SIDE_STAKE_SEND:
+        case GRC::MinedType::POR_SIDE_STAKE_SEND:
             strHTML += tr("PoS+RR Side Stake Sent");
             break;
-        case MinedType::MRC_RCV:
+        case GRC::MinedType::MRC_RCV:
             strHTML += tr("MRC Payment Received");
             break;
-        case MinedType::MRC_SEND:
+        case GRC::MinedType::MRC_SEND:
             strHTML += tr("MRC Payment Sent");
             break;
-        case MinedType::SUPERBLOCK:
+        case GRC::MinedType::SUPERBLOCK:
             strHTML += tr("Mined - Superblock");
             break;
         default:

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -20,7 +20,7 @@ public:
         , sortKey("")
         , matures_in(0)
         , status(Offline)
-        , generated_type(MinedType::UNKNOWN)
+        , generated_type(GRC::MinedType::UNKNOWN)
         , depth(0)
         , open_for(0)
         , cur_num_blocks(-1)
@@ -54,7 +54,7 @@ public:
     /** @name Reported status
        @{*/
     Status status;
-    MinedType generated_type;
+    GRC::MinedType generated_type;
     int64_t depth;
     int64_t open_for; /**< Timestamp if status==OpenUntilDate, otherwise number
                        of additional blocks that need to be mined before

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -406,25 +406,25 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         {
             switch (wtx->status.generated_type)
             {
-            case MinedType::POS:
+            case GRC::MinedType::POS:
                 return tr("Mined - PoS");
-            case MinedType::POR:
+            case GRC::MinedType::POR:
                 return tr("Mined - PoS+RR");
-            case MinedType::ORPHANED:
+            case GRC::MinedType::ORPHANED:
                 return tr("Mined - Orphaned");
-            case MinedType::POS_SIDE_STAKE_RCV:
+            case GRC::MinedType::POS_SIDE_STAKE_RCV:
                 return tr("PoS Side Stake Received");
-            case MinedType::POR_SIDE_STAKE_RCV:
+            case GRC::MinedType::POR_SIDE_STAKE_RCV:
                 return tr("PoS+RR Side Stake Received");
-            case MinedType::POS_SIDE_STAKE_SEND:
+            case GRC::MinedType::POS_SIDE_STAKE_SEND:
                 return tr("PoS Side Stake Sent");
-            case MinedType::POR_SIDE_STAKE_SEND:
+            case GRC::MinedType::POR_SIDE_STAKE_SEND:
                 return tr("PoS+RR Side Stake Sent");
-            case MinedType::MRC_RCV:
+            case GRC::MinedType::MRC_RCV:
                 return tr("MRC Payment Received");
-            case MinedType::MRC_SEND:
+            case GRC::MinedType::MRC_SEND:
                 return tr("MRC Payment Sent");
-            case MinedType::SUPERBLOCK:
+            case GRC::MinedType::SUPERBLOCK:
                 return tr("Mined - Superblock");
             default:
                 return tr("Mined - Unknown");
@@ -454,25 +454,25 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     {
         switch (wtx->status.generated_type)
         {
-        case MinedType::POS:
+        case GRC::MinedType::POS:
             return QIcon(":/icons/tx_pos");
-        case MinedType::POR:
+        case GRC::MinedType::POR:
             return QIcon(":/icons/tx_por");
-        case MinedType::ORPHANED:
+        case GRC::MinedType::ORPHANED:
             return QIcon(":/icons/transaction_conflicted");
-        case MinedType::POS_SIDE_STAKE_RCV:
+        case GRC::MinedType::POS_SIDE_STAKE_RCV:
             return QIcon(":/icons/tx_pos_ss");
-        case MinedType::POR_SIDE_STAKE_RCV:
+        case GRC::MinedType::POR_SIDE_STAKE_RCV:
             return QIcon(":/icons/tx_por_ss");
-        case MinedType::POS_SIDE_STAKE_SEND:
+        case GRC::MinedType::POS_SIDE_STAKE_SEND:
             return QIcon(":/icons/tx_pos_ss_sent");
-        case MinedType::POR_SIDE_STAKE_SEND:
+        case GRC::MinedType::POR_SIDE_STAKE_SEND:
             return QIcon(":/icons/tx_por_ss_sent");
-        case MinedType::MRC_RCV:
+        case GRC::MinedType::MRC_RCV:
             return QIcon(":/icons/tx_por_ss");
-        case MinedType::MRC_SEND:
+        case GRC::MinedType::MRC_SEND:
             return QIcon(":/icons/tx_por_ss_sent");
-        case MinedType::SUPERBLOCK:
+        case GRC::MinedType::SUPERBLOCK:
             return QIcon(":/icons/superblock");
         default:
             return QIcon(":/icons/transaction_0");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -141,12 +141,39 @@ UniValue SuperblockToJson(const GRC::Superblock& superblock)
         beacons.push_back(key_id.ToString());
     }
 
+    UniValue project_greylist_status(UniValue::VARR);
+
+    for (const auto& project : superblock.m_project_status.m_project_status) {
+        UniValue status(UniValue::VOBJ);
+
+        // construct a dummy project entry to use the status to string.
+        auto dummy = GRC::ProjectEntry(GRC::ProjectEntry::CURRENT_VERSION, project.first, "foo", false, project.second, 0);
+
+        status.pushKV("project", project.first);
+        status.pushKV("status", dummy.StatusToString());
+
+        project_greylist_status.push_back(status);
+    }
+
+    UniValue project_all_cpid_total_credits(UniValue::VARR);
+
+    for (const auto& project : superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits) {
+        UniValue entry(UniValue::VOBJ);
+
+        entry.pushKV("project", project.first);
+        entry.pushKV("all_cpid_total_credit", project.second);
+
+        project_all_cpid_total_credits.push_back(entry);
+    }
+
     UniValue json(UniValue::VOBJ);
 
     json.pushKV("version", (int)superblock.m_version);
-    json.pushKV("magnitudes", std::move(magnitudes));
-    json.pushKV("projects", std::move(projects));
-    json.pushKV("beacons", std::move(beacons));
+    json.pushKV("magnitudes", magnitudes);
+    json.pushKV("projects", projects);
+    json.pushKV("beacons", beacons);
+    json.pushKV("project_greylist_status", project_greylist_status);
+    json.pushKV("project_all_cpid_total_credits", project_all_cpid_total_credits);
 
     return json;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1142,7 +1142,7 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
         LOCK(cs_ConvergedScraperStatsCache);
 
         // Make a local copy of the cached stats in the convergence and release the lock.
-        mScraperConvergedStats = ConvergedScraperStatsCache.mScraperConvergedStats;
+        mScraperConvergedStats = ConvergedScraperStatsCache.mScraperConvergedStats.mScraperStats;
     }
 
     LogPrint(BCLog::LogFlags::VERBOSE, "rainbymagnitude: mScraperConvergedStats size = %u", mScraperConvergedStats.size());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2711,7 +2711,7 @@ UniValue getautogreylist(const UniValue& params, bool fHelp)
 
         entry.pushKV("project:", iter.first);
         entry.pushKV("zcd", iter.second.GetZCD());
-        entry.pushKV("WAS", iter.second.GetWAS().ToDouble());
+        entry.pushKV("was", iter.second.GetWAS().ToDouble());
         entry.pushKV("meets_greylist_criteria", iter.second.m_meets_greylisting_crit);
 
         autogreylist.push_back(entry);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -148,7 +148,7 @@ UniValue SuperblockToJson(const GRC::Superblock& superblock)
         UniValue status(UniValue::VOBJ);
 
         // construct a dummy project entry to use the status to string.
-        auto dummy = GRC::ProjectEntry(GRC::ProjectEntry::CURRENT_VERSION, project.first, "foo", false, project.second, 0);
+        auto dummy = GRC::ProjectEntry(GRC::ProjectEntry::CURRENT_VERSION, project.first, "foo", false, false, project.second, 0);
 
         status.pushKV("project", project.first);
         status.pushKV("status", dummy.StatusToString());
@@ -2232,6 +2232,7 @@ UniValue superblocks(const UniValue& params, bool fHelp)
 UniValue addkey(const UniValue& params, bool fHelp)
 {
     bool project_v2_enabled = false;
+    bool project_v4_enabled = false;
     bool block_v13_enabled = false;
     uint32_t contract_version = 0;
 
@@ -2239,6 +2240,7 @@ UniValue addkey(const UniValue& params, bool fHelp)
         LOCK(cs_main);
 
         project_v2_enabled = IsProjectV2Enabled(nBestHeight);
+        project_v4_enabled = IsProjectV4Enabled(nBestHeight);
 
         block_v13_enabled = IsV13Enabled(nBestHeight);
         contract_version = block_v13_enabled ? 3 : 2;
@@ -2269,7 +2271,16 @@ UniValue addkey(const UniValue& params, bool fHelp)
             && type == GRC::ContractType::PROJECT) {
         required_param_count = 5;
 
-        block_v13_enabled ? param_count_max = 6 : param_count_max = 5;
+        if (block_v13_enabled) {
+            param_count_max = 6;
+
+            if (project_v4_enabled) {
+                required_param_count = 6;
+                param_count_max = 7;
+            }
+        } else {
+            param_count_max = 5;
+        }
     }
 
     if ((type == GRC::ContractType::PROJECT || type == GRC::ContractType::SCRAPER)
@@ -2299,6 +2310,22 @@ UniValue addkey(const UniValue& params, bool fHelp)
         std::string error_string;
 
         if (block_v13_enabled) {
+            if (project_v4_enabled) {
+                error_string = "addkey <action> <keytype> <keyname> <keyvalue> <gdpr_protection_bool> "
+                               "<requires_external_adapter> <status> \n"
+                               "\n"
+                               "<action> ---> Specify add or delete of key\n"
+                               "<keytype> --> Specify keytype ex: project\n"
+                               "<keyname> --> Specify keyname ex: milky\n"
+                               "<keyvalue> -> Specify keyvalue ex: 1\n"
+                               "\n"
+                               "For project keytype only\n"
+                               "<gdpr_protection_bool> -> true if GDPR stats export protection is enforced for project\n"
+                               "<requires_external_adapter> true if project requires an external adapter to collect stats\n"
+                               "<status> -> auto_greylist_override or man_greylist. Defaults to blank."
+                               "\n"
+                               "Add a key to the network";
+            } else {
             error_string = "addkey <action> <keytype> <keyname> <keyvalue> <gdpr_protection_bool> <status> \n"
                            "\n"
                            "<action> ---> Specify add or delete of key\n"
@@ -2311,6 +2338,7 @@ UniValue addkey(const UniValue& params, bool fHelp)
                            "<status> -> auto_greylist_override or man_greylist. Defaults to blank."
                            "\n"
                            "Add a key to the network";
+            }
         } else if (project_v2_enabled) {
             error_string = "addkey <action> <keytype> <keyname> <keyvalue> <gdpr_protection_bool>\n"
                            "\n"
@@ -2360,10 +2388,12 @@ UniValue addkey(const UniValue& params, bool fHelp)
     {
         if (action == GRC::ContractAction::ADD) {
             bool gdpr_export_control = false;
-            //bool manually_greylist = false;
             GRC::ProjectEntryStatus status = GRC::ProjectEntryStatus::UNKNOWN;
 
             if (block_v13_enabled) {
+                bool requires_ext_adapter = false;
+                uint32_t payload_version = 3;
+
                 // We must do our own conversion to boolean here, because the 5th parameter can either be
                 // a boolean for project or a string for sidestake, which means the client.cpp entry cannot contain a
                 // unicode type specifier for the 5th parameter.
@@ -2374,24 +2404,52 @@ UniValue addkey(const UniValue& params, bool fHelp)
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "GDPR export parameter invalid. Must be true or false.");
                 }
 
-                if (params.size() == 6) {
-                    if (ToLower(params[5].get_str()) == "man_greylist") {
-                        status = GRC::ProjectEntryStatus::MAN_GREYLISTED;
-                    } else if (ToLower(params[5].get_str()) == "auto_greylist_override") {
-                        status = GRC::ProjectEntryStatus::AUTO_GREYLIST_OVERRIDE;
-                    } else {
-                        throw JSONRPCError(RPC_INVALID_PARAMETER, "project status specifier, if provided, must be either man_greylist "
-                                                                  "or auto_greylist_override");
+                if (project_v4_enabled) {
+                    payload_version = 4;
+
+                    if (params.size() == 6) {
+                        if (ToLower(params[5].get_str()) == "true"){
+                            requires_ext_adapter = true;
+                        }
+                    } else if (ToLower(params[5].get_str()) != "false") {
+                        // Neither true or false - throw an exception.
+                        throw JSONRPCError(RPC_INVALID_PARAMETER, "Requires external adapter parameter invalid. "
+                                                                  "Must be true or false.");
+                    }
+
+                    if (params.size() == 7) {
+                        if (ToLower(params[6].get_str()) == "man_greylist") {
+                            status = GRC::ProjectEntryStatus::MAN_GREYLISTED;
+                        } else if (ToLower(params[5].get_str()) == "auto_greylist_override") {
+                            status = GRC::ProjectEntryStatus::AUTO_GREYLIST_OVERRIDE;
+                        } else {
+                            throw JSONRPCError(RPC_INVALID_PARAMETER, "project status specifier, if provided, "
+                                                                      "must be either man_greylist "
+                                                                      "or auto_greylist_override");
+                        }
+                    }
+                } else {
+                    if (params.size() == 6) {
+                        if (ToLower(params[5].get_str()) == "man_greylist") {
+                            status = GRC::ProjectEntryStatus::MAN_GREYLISTED;
+                        } else if (ToLower(params[5].get_str()) == "auto_greylist_override") {
+                            status = GRC::ProjectEntryStatus::AUTO_GREYLIST_OVERRIDE;
+                        } else {
+                            throw JSONRPCError(RPC_INVALID_PARAMETER, "project status specifier, if provided, must "
+                                                                      "be either man_greylist "
+                                                                      "or auto_greylist_override");
+                        }
                     }
                 }
 
                 contract = GRC::MakeContract<GRC::Project>(
                             contract_version,
                             action,
-                            uint32_t{3},          // Contract payload version number, 3
+                            payload_version,      // Contract payload version number, 3 or 4
                             params[2].get_str(),  // Name
                             params[3].get_str(),  // URL
                             gdpr_export_control,  // GDPR stats export protection enforced boolean
+                            requires_ext_adapter, // Requires external adapter flag
                             status);   // manual greylist flag
 
             } else if (project_v2_enabled) {
@@ -2422,13 +2480,20 @@ UniValue addkey(const UniValue& params, bool fHelp)
             }
         } else if (action == GRC::ContractAction::REMOVE) {
             if (block_v13_enabled) {
+                uint32_t payload_version = 3;
+
+                if (project_v4_enabled) {
+                    payload_version = 4;
+                }
+
                 contract = GRC::MakeContract<GRC::Project>(
                             contract_version,
                             action,
-                            uint32_t{3},                       // Contract payload version number, 3
+                            payload_version,                   // Contract payload version number, 3 or 4
                             params[2].get_str(),               // Name
                             std::string{},                     // URL ignored
                             false,                             // GDPR status irrelevant
+                            false,                             // Requires external adapter flag irrelevant
                             GRC::ProjectEntryStatus::UNKNOWN); // manual greylisting or auto greylist override irrelevant
 
             } else if (project_v2_enabled) {
@@ -2686,6 +2751,10 @@ UniValue listprojects(const UniValue& params, bool fHelp)
 
         if (project.HasGDPRControls()) {
             entry.pushKV("gdpr_controls", *project.HasGDPRControls());
+        }
+
+        if (project.RequiresExtAdapter()) {
+            entry.pushKV("requires_external_adapter", *project.RequiresExtAdapter());
         }
 
         entry.pushKV("time", DateTimeStrFormat(project.m_timestamp));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2610,15 +2610,23 @@ UniValue debug(const UniValue& params, bool fHelp)
 
 UniValue listprojects(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
+    if (fHelp || params.size() > 1)
         throw runtime_error(
-                "listprojects\n"
+                "listprojects <bool>\n"
+                "\n"
+                "<bool> -> true to show all projects, including greylisted and deleted. Defaults to false.\n"
                 "\n"
                 "Displays information about whitelisted projects.\n");
 
     UniValue res(UniValue::VOBJ);
 
-    for (const auto& project : GRC::GetWhitelist().Snapshot().Sorted()) {
+    GRC::Project::ProjectFilterFlag filter = GRC::Project::ProjectFilterFlag::ACTIVE;
+
+    if (params.size() && params[0].get_bool() == true) {
+        filter = GRC::Project::ProjectFilterFlag::ALL;
+    }
+
+    for (const auto& project : GRC::GetWhitelist().Snapshot(filter).Sorted()) {
         UniValue entry(UniValue::VOBJ);
 
         entry.pushKV("version", (int)project.m_version);
@@ -2633,6 +2641,7 @@ UniValue listprojects(const UniValue& params, bool fHelp)
         }
 
         entry.pushKV("time", DateTimeStrFormat(project.m_timestamp));
+        entry.pushKV("status", project.StatusToString());
 
         res.pushKV(project.m_name, entry);
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2722,7 +2722,7 @@ UniValue getautogreylist(const UniValue& params, bool fHelp)
 
     UniValue res(UniValue::VOBJ);
 
-    std::shared_ptr<GRC::AutoGreylist> greylist_ptr = GRC::AutoGreylist::GetAutoGreylistCache();
+    std::shared_ptr<GRC::AutoGreylist> greylist_ptr = GRC::GetAutoGreylistCache();
 
     greylist_ptr->Refresh();
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2652,11 +2652,19 @@ UniValue listprojects(const UniValue& params, bool fHelp)
 
 UniValue getautogreylist(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 0) {
+    if (fHelp || params.size() > 1) {
         throw runtime_error(
-            "getautogreylist \n"
+            "getautogreylist <bool> \n"
+            "\n"
+            "<bool> -> true to show all projects, including those that do not meet greylisting criteria. Defaults to false. \n"
             "\n"
             "Displays information about projects that meet auto greylisting criteria.");
+    }
+
+    bool show_all_projects = false;
+
+    if (params.size()) {
+        show_all_projects = params[0].get_bool();
     }
 
     UniValue res(UniValue::VOBJ);
@@ -2668,11 +2676,16 @@ UniValue getautogreylist(const UniValue& params, bool fHelp)
     UniValue autogreylist(UniValue::VARR);
 
     for (auto iter : *greylist_ptr) {
+        if (!show_all_projects && !iter.second.m_meets_greylisting_crit) {
+            continue;
+        }
+
         UniValue entry(UniValue::VOBJ);
 
         entry.pushKV("project:", iter.first);
         entry.pushKV("zcd", iter.second.GetZCD());
         entry.pushKV("WAS", iter.second.GetWAS().ToDouble());
+        entry.pushKV("meets_greylist_criteria", iter.second.m_meets_greylisting_crit);
 
         autogreylist.push_back(entry);
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2698,19 +2698,26 @@ UniValue listprojects(const UniValue& params, bool fHelp)
 
 UniValue getautogreylist(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1) {
+    if (fHelp || params.size() > 2) {
         throw runtime_error(
-            "getautogreylist <bool> \n"
+            "getautogreylist <bool> <bool> \n"
             "\n"
             "<bool> -> true to show all projects, including those that do not meet greylisting criteria. Defaults to false. \n"
+            "\n"
+            "<bool> -> true to show greylist history for each project. Defaults to false. \n"
             "\n"
             "Displays information about projects that meet auto greylisting criteria.");
     }
 
     bool show_all_projects = false;
+    bool show_history = false;
 
     if (params.size()) {
         show_all_projects = params[0].get_bool();
+    }
+
+    if (params.size() >= 2) {
+        show_history = params[1].get_bool();
     }
 
     UniValue res(UniValue::VOBJ);
@@ -2732,6 +2739,44 @@ UniValue getautogreylist(const UniValue& params, bool fHelp)
         entry.pushKV("zcd", iter.second.GetZCD());
         entry.pushKV("was", iter.second.GetWAS().ToDouble());
         entry.pushKV("meets_greylist_criteria", iter.second.m_meets_greylisting_crit);
+
+        if (show_history) {
+            UniValue entry_history(UniValue::VARR);
+
+            for (const auto& hist_entry : iter.second.GetUpdateHistory()) {
+                UniValue historical_entry(UniValue::VOBJ);
+
+                historical_entry.pushKV("superblocks_from_baseline", hist_entry.m_sb_from_baseline_processed);
+
+                if (hist_entry.m_total_credit) {
+                    historical_entry.pushKV("total_credit", *hist_entry.m_total_credit);
+                } else {
+                    historical_entry.pushKV("total_credit", "NA");
+                }
+
+                if (hist_entry.m_zcd) {
+                    historical_entry.pushKV("zcd", *hist_entry.m_zcd);
+                } else {
+                    historical_entry.pushKV("zcd", "NA");
+                }
+
+                if (hist_entry.m_was) {
+                    historical_entry.pushKV("was", hist_entry.m_was->ToDouble());
+                } else {
+                    historical_entry.pushKV("was", "NA");
+                }
+
+                if (hist_entry.m_meets_greylisting_crit) {
+                    historical_entry.pushKV("meets_greylisting_criteria", *hist_entry.m_meets_greylisting_crit);
+                } else {
+                    historical_entry.pushKV("meets_greylisting_criteria", "NA");
+                }
+
+                entry_history.push_back(historical_entry);
+            }
+
+            entry.pushKV("history", entry_history);
+        }
 
         autogreylist.push_back(entry);
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -6,6 +6,7 @@
 #include "chainparams.h"
 #include "blockchain.h"
 #include "gridcoin/protocol.h"
+#include "gridcoin/project.h"
 #include "gridcoin/scraper/scraper_registry.h"
 #include "gridcoin/sidestake.h"
 #include "node/blockstorage.h"
@@ -2645,6 +2646,38 @@ UniValue listprojects(const UniValue& params, bool fHelp)
 
         res.pushKV(project.m_name, entry);
     }
+
+    return res;
+}
+
+UniValue getautogreylist(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 0) {
+        throw runtime_error(
+            "getautogreylist \n"
+            "\n"
+            "Displays information about projects that meet auto greylisting criteria.");
+    }
+
+    UniValue res(UniValue::VOBJ);
+
+    std::shared_ptr<GRC::AutoGreylist> greylist_ptr = GRC::AutoGreylist::GetAutoGreylistCache();
+
+    greylist_ptr->Refresh();
+
+    UniValue autogreylist(UniValue::VARR);
+
+    for (auto iter : *greylist_ptr) {
+        UniValue entry(UniValue::VOBJ);
+
+        entry.pushKV("project:", iter.first);
+        entry.pushKV("zcd", iter.second.GetZCD());
+        entry.pushKV("WAS", iter.second.GetWAS().ToDouble());
+
+        autogreylist.push_back(entry);
+    }
+
+    res.pushKV("auto_greylist_projects", autogreylist);
 
     return res;
 }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -216,6 +216,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listmanifests"          , 0 },
     { "listprojects"           , 0 },
     { "getautogreylist"        , 0 },
+    { "getautogreylist"        , 1 },
     { "sendalert"              , 2 },
     { "sendalert"              , 3 },
     { "sendalert"              , 4 },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -214,6 +214,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblockstats"          , 2 },
     { "inspectaccrualsnapshot" , 0 },
     { "listmanifests"          , 0 },
+    { "listprojects"           , 0 },
     { "sendalert"              , 2 },
     { "sendalert"              , 3 },
     { "sendalert"              , 4 },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -215,6 +215,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "inspectaccrualsnapshot" , 0 },
     { "listmanifests"          , 0 },
     { "listprojects"           , 0 },
+    { "getautogreylist"        , 0 },
     { "sendalert"              , 2 },
     { "sendalert"              , 3 },
     { "sendalert"              , 4 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -385,6 +385,7 @@ static const CRPCCommand vRPCCommands[] =
     { "inspectaccrualsnapshot",  &inspectaccrualsnapshot,  cat_developer     },
     { "listalerts",              &listalerts,              cat_developer     },
     { "listprojects",            &listprojects,            cat_developer     },
+    { "getautogreylist",         &getautogreylist,         cat_developer     },
     { "listprotocolentries",     &listprotocolentries,     cat_developer     },
     { "listresearcheraccounts",  &listresearcheraccounts,  cat_developer     },
     { "listscrapers",            &listscrapers,            cat_developer     },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -221,9 +222,9 @@ UniValue help(const UniValue& params, bool fHelp)
             "developer -----> Returns help for developer commands\n"
             "network -------> Returns help for network related commands\n"
             "voting --------> Returns help for voting related commands\n"
-	    "\n"
-	    "You can support the development of Gridcoin by donating GRC to the\n"
-	    "Gridcoin Foundation at this address: bc3NA8e8E3EoTL1qhRmeprbjWcmuoZ26A2\n";
+            "\n"
+            "You can support the development of Gridcoin by donating GRC to the\n"
+            "Gridcoin Foundation at this address: bc3NA8e8E3EoTL1qhRmeprbjWcmuoZ26A2\n";
 
     // Allow to process through if params size is > 0
     string strCommand;

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -195,6 +195,7 @@ extern UniValue rpc_getblockstats(const UniValue& params, bool fHelp);
 extern UniValue inspectaccrualsnapshot(const UniValue& params, bool fHelp);
 extern UniValue listalerts(const UniValue& params, bool fHelp);
 extern UniValue listprojects(const UniValue& params, bool fHelp);
+extern UniValue getautogreylist(const UniValue& params, bool fHelp);
 extern UniValue listprotocolentries(const UniValue& params, bool fHelp);
 extern UniValue listresearcheraccounts(const UniValue& params, bool fHelp);
 extern UniValue listscrapers(const UniValue& params, bool fHelp);

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(it_adds_whitelisted_projects_from_contract_data)
     BOOST_CHECK(whitelist.Snapshot().size() == 0);
     BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == false);
 
-    AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, true);
+    AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, false);
 
     BOOST_CHECK(whitelist.Snapshot().size() == 1);
     BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == true);

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -479,19 +479,19 @@ BOOST_AUTO_TEST_CASE(it_adds_whitelisted_projects_from_contract_data)
     int height = 0;
     int64_t time = 0;
 
-    BOOST_CHECK(whitelist.Snapshot().size() == 0);
-    BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == false);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 0);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == false);
 
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, false);
 
-    BOOST_CHECK(whitelist.Snapshot().size() == 1);
-    BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 1);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == true);
 
     AddProjectEntry(2, "Foo", "http://foo.test", false, height++, time++, false);
 
-    BOOST_CHECK(whitelist.Snapshot().size() == 2);
-    BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == true);
-    BOOST_CHECK(whitelist.Snapshot().Contains("Foo") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 2);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Foo") == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_removes_whitelisted_projects_from_contract_data)
@@ -503,13 +503,13 @@ BOOST_AUTO_TEST_CASE(it_removes_whitelisted_projects_from_contract_data)
 
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, true);
 
-    BOOST_CHECK(whitelist.Snapshot().size() == 1);
-    BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 1);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == true);
 
     DeleteProjectEntry(1, "Enigma", height++, time++, false);
 
-    BOOST_CHECK(whitelist.Snapshot().size() == 0);
-    BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == false);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 0);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == false);
 }
 
 BOOST_AUTO_TEST_CASE(it_does_not_mutate_existing_snapshots)
@@ -522,14 +522,14 @@ BOOST_AUTO_TEST_CASE(it_does_not_mutate_existing_snapshots)
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, true);
     AddProjectEntry(2, "Foo", "http://foo.test", true, height++, time++, false);
 
-    auto snapshot = whitelist.Snapshot();
+    auto snapshot = whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false);
 
     DeleteProjectEntry(1, "Enigma", height, time, false);
 
     BOOST_CHECK(snapshot.Contains("Enigma") == true);
 
-    BOOST_CHECK(whitelist.Snapshot().Contains("Enigma") == false);
-    BOOST_CHECK(whitelist.Snapshot().Contains("Foo") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == false);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Foo") == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, true);
     AddProjectEntry(2, "Enigma", "http://new.enigma.test", true, height++, time++, false);
 
-    auto snapshot = whitelist.Snapshot();
+    auto snapshot = whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false);
     BOOST_CHECK(snapshot.size() == 1);
 
     for (const auto& project : snapshot) {

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -5,6 +5,7 @@
 #include "main.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/project.h"
+#include "wallet/generated_type.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -97,6 +98,45 @@ void DeleteProjectEntry(const uint32_t& payload_version, const std::string& name
 
     registry.Add({contract, dummy_tx, &dummy_index});
 }
+
+struct AutoGreylistEntryState
+{
+    AutoGreylistEntryState(uint8_t zcd_20_SB_count,
+                           uint64_t TC_7_SB_sum,
+                           uint64_t TC_40_SB_sum,
+                           Fraction was,
+                           bool meets_greylisting_crit)
+        : m_zcd_20_SB_count(zcd_20_SB_count)
+        , m_TC_7_SB_sum(TC_7_SB_sum)
+        , m_TC_40_SB_sum(TC_40_SB_sum)
+        , m_was(was)
+        ,m_meets_greylisting_crit(meets_greylisting_crit)
+    {}
+
+    uint8_t m_zcd_20_SB_count;
+    uint64_t m_TC_7_SB_sum;
+    uint64_t m_TC_40_SB_sum;
+    Fraction m_was;
+    bool m_meets_greylisting_crit;
+
+    bool operator==(const AutoGreylistEntryState& rhs)
+    {
+        bool equal = (
+            (m_zcd_20_SB_count == rhs.m_zcd_20_SB_count)
+            && (m_TC_7_SB_sum == rhs.m_TC_7_SB_sum)
+            && (m_TC_40_SB_sum == rhs.m_TC_40_SB_sum)
+            && (m_was == rhs.m_was)
+            && (m_meets_greylisting_crit == rhs.m_meets_greylisting_crit)
+            );
+
+        return equal;
+    }
+
+    bool operator!=(const AutoGreylistEntryState& rhs)
+    {
+        return !(*this == rhs);
+    }
+};
 
 //!
 //! \brief Dummy transaction for contract handler API.
@@ -548,6 +588,793 @@ BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
     for (const auto& project : snapshot) {
         BOOST_CHECK(project.m_url == "http://new.enigma.test");
     }
+}
+
+BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
+{
+    std::vector<std::tuple<std::optional<uint64_t>,
+                           AutoGreylistEntryState>> input_expected_result_proj_tc_history;
+
+    /**
+     * This is the input data for a HORRIBLE whitelisted project. This series of total credit
+     * is designed to break every rule in the book. It starts out with no data collection at the
+     * first superblock after whitelisting, and then proceeds to have lots of dropouts and zero
+     * credit deltas to test the auto greylisting algorithm. Along the way the total credit deltas
+     * are reduced to a level low enough to verify the triggering of the WAS rule. We go
+     * enough superblocks to ensure the lookback is properly scoped once we are past 40 SB's from
+     * baseline.
+     *
+     * No project is expected to be this bad, but we need to test out the algorithm here.
+     **/
+
+    // superblock 0 - baseline after whitelisting, but no stats due to problem with project.
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            std::optional<uint64_t>(),
+            AutoGreylistEntryState(
+                0, // zcd_20_SB_count
+                0, // TC_7_SB_sum
+                0, // TC_40_SB_sum
+                0, // was
+                false // meets_greylist_crit
+                )
+            )
+        );
+
+    // superblock 1 - first stats collection from project, TC = 1000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            1000,
+            AutoGreylistEntryState(
+                1,
+                0,
+                0,
+                0,
+                false
+                )
+            )
+        );
+
+    // superblock 2 - no stats again due to problem with project
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            std::optional<uint64_t>(),
+            AutoGreylistEntryState(
+                2,
+                0,
+                0,
+                0,
+                false
+                )
+            )
+        );
+
+    // superblock 3 - no status again due to continuing problem with project
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            std::optional<uint64_t>(),
+            AutoGreylistEntryState(
+                3,
+                0,
+                0,
+                0,
+                false
+                )
+            )
+        );
+
+    // superblock 4 - successful stats collection, but TC = 1000 still
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            1000,
+            AutoGreylistEntryState(
+                4,
+                0,
+                0,
+                0,
+                false
+                )
+            )
+        );
+
+    // superblock 5 - successful stats collection, TC = 2000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            2000,
+            AutoGreylistEntryState(
+                4,
+                1000,
+                1000,
+                Fraction(2000/5,2000/5),
+                false
+                )
+            )
+        );
+
+    // superblock 6 - successful stats collection, TC = 3000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            3000,
+            AutoGreylistEntryState(
+                4,
+                2000,
+                2000,
+                Fraction(2000/6,2000/6),
+                false
+                )
+            )
+        );
+
+    // superblock 7 - problem with stats collection
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            std::optional<uint64_t>(),
+            AutoGreylistEntryState(
+                5,
+                2000,
+                2000,
+                Fraction(2000/7,2000/7),
+                false
+                )
+            )
+        );
+
+    // superblock 8 - successful stats collection, TC = 3000 still
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            3000,
+            AutoGreylistEntryState(
+                6,
+                2000,
+                2000,
+                Fraction(2000/7,2000/8),
+                false
+                )
+            )
+        );
+
+    // superblock 9 - successful stats collection, TC = 4000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            4000,
+            AutoGreylistEntryState(
+                6,
+                3000,
+                3000,
+                Fraction(3000/7,3000/9),
+                false
+                )
+            )
+        );
+
+    // superblock 10 - successful stats collection, TC = 5000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5000,
+            AutoGreylistEntryState(
+                6,
+                4000,
+                4000,
+                Fraction(4000/7,4000/10),
+                false
+                )
+            )
+        );
+
+    // superblock 11 - successful stats collection, TC = 5000 still
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5000,
+            AutoGreylistEntryState(
+                7,
+                4000,
+                4000,
+                Fraction(4000/7,4000/11),
+                false
+                )
+            )
+        );
+
+    // superblock 12 - problem with stats collection
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            std::optional<uint64_t>(),
+            AutoGreylistEntryState(
+                8,
+                3000,
+                4000,
+                Fraction(3000/7,4000/12),
+                true
+                )
+            )
+        );
+
+    // superblock 13 - successful stats collection, reduced output TC = 5001
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5001,
+            AutoGreylistEntryState(
+                8,
+                2001,
+                4001,
+                Fraction(2001/7,4001/13),
+                true
+                )
+            )
+        );
+
+    // superblock 14 - successful stats collection, reduced output TC = 5002
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5002,
+            AutoGreylistEntryState(
+                8,
+                2002,
+                4002,
+                Fraction(2002/7,4002/14),
+                true
+                )
+            )
+        );
+
+    // superblock 15 - successful stats collection, reduced output TC = 5003
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5003,
+            AutoGreylistEntryState(
+                8,
+                2003,
+                4003,
+                Fraction(2003/7,4003/15),
+                true
+                )
+            )
+        );
+
+    // superblock 16 - successful stats collection, reduced output TC = 5004
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5004,
+            AutoGreylistEntryState(
+                8,
+                1004,
+                4004,
+                Fraction(1004/7,4004/16),
+                true
+                )
+            )
+        );
+
+    // superblock 17 - successful stats collection, slightly improved output TC = 5200
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5200,
+            AutoGreylistEntryState(
+                8,
+                200,
+                4200,
+                Fraction(200/7,4200/17),
+                true
+                )
+            )
+        );
+
+    // superblock 18 - successful stats collection, degraded output TC = 5225
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5225,
+            AutoGreylistEntryState(
+                8,
+                225,
+                4225,
+                Fraction(225/7,4225/18),
+                true
+                )
+            )
+        );
+
+    // superblock 19 - successful stats collection, degraded output TC = 5230
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5230,
+            AutoGreylistEntryState(
+                8,
+                229,
+                4230,
+                Fraction(230/7,4230/19),
+                true
+                )
+            )
+        );
+
+    // superblock 20 - successful stats collection, further degraded output TC = 5231
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5231,
+            AutoGreylistEntryState(
+                8,
+                230,
+                4231,
+                Fraction(230/7,4231/20),
+                true
+                )
+            )
+        );
+
+    // superblock 21 - successful stats collection, further degraded output TC = 5232
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5232,
+            AutoGreylistEntryState(
+                7,
+                230,
+                4232,
+                Fraction(230/7,4232/21),
+                false
+                )
+            )
+        );
+
+    // superblock 22 - successful stats collection, further degraded output TC = 5233
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5233,
+            AutoGreylistEntryState(
+                6,
+                230,
+                4233,
+                Fraction(230/7,4233/22),
+                false
+                )
+            )
+        );
+
+    // superblock 23 - successful stats collection, further degraded output TC = 5234
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5234,
+            AutoGreylistEntryState(
+                5,
+                230,
+                4234,
+                Fraction(230/7,4234/23),
+                false
+                )
+            )
+        );
+
+    // superblock 24 - successful stats collection, further degraded output TC = 5235
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5235,
+            AutoGreylistEntryState(
+                4,
+                35,
+                4235,
+                Fraction(35/7,4235/24),
+                true
+                )
+            )
+        );
+
+    // superblock 25 - successful stats collection, degraded output TC = 5250
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            5250,
+            AutoGreylistEntryState(
+                4,
+                25,
+                4250,
+                Fraction(25/7,4250/25),
+                true
+                )
+            )
+        );
+
+    // superblock 26 - successful stats collection, resume "normal" output TC = 6250
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            6250,
+            AutoGreylistEntryState(
+                4,
+                1020,
+                5250,
+                Fraction(1020/7,5250/26),
+                false
+                )
+            )
+        );
+
+    // superblock 27 - successful stats collection, TC = 7000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            7000,
+            AutoGreylistEntryState(
+                3,
+                1769,
+                6000,
+                Fraction(1769/7,6000/27),
+                false
+                )
+            )
+        );
+
+    // superblock 28 - successful stats collection, TC = 8000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            8000,
+            AutoGreylistEntryState(
+                2,
+                2768,
+                7000,
+                Fraction(2768/7,7000/28),
+                false
+                )
+            )
+        );
+
+    // superblock 29 - successful stats collection, TC = 9000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            9000,
+            AutoGreylistEntryState(
+                2,
+                3767,
+                8000,
+                Fraction(3767/7,8000/29),
+                false
+                )
+            )
+        );
+
+    // superblock 30 - successful stats collection, TC = 10000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            10000,
+            AutoGreylistEntryState(
+                2,
+                4766,
+                9000,
+                Fraction(4766/7,9000/30),
+                false
+                )
+            )
+        );
+
+    // superblock 31 - successful stats collection, TC = 11000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            11000,
+            AutoGreylistEntryState(
+                1,
+                5765,
+                10000,
+                Fraction(5765/7,10000/31),
+                false
+                )
+            )
+        );
+
+    // superblock 32 - successful stats collection, TC = 12000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            12000,
+            AutoGreylistEntryState(
+                1,
+                6750,
+                11000,
+                Fraction(6750/7,11000/32),
+                false
+                )
+            )
+        );
+
+    // superblock 33 - successful stats collection, TC = 13000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            13000,
+            AutoGreylistEntryState(
+                0,
+                6750,
+                12000,
+                Fraction(6750/7,12000/33),
+                false
+                )
+            )
+        );
+
+    // superblock 34 - successful stats collection, TC = 14000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            14000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                13000,
+                Fraction(7000/7,13000/34),
+                false
+                )
+            )
+        );
+
+    // superblock 35 - successful stats collection, TC = 15000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            15000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                14000,
+                Fraction(7000/7,14000/35),
+                false
+                )
+            )
+        );
+
+     // superblock 36 - successful stats collection, TC = 16000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            16000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                15000,
+                Fraction(7000/7,15000/36),
+                false
+                )
+            )
+        );
+
+     // superblock 37 - successful stats collection, TC = 17000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            17000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                16000,
+                Fraction(7000/7,16000/37),
+                false
+                )
+            )
+        );
+
+     // superblock 38 - successful stats collection, TC = 18000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            18000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                17000,
+                Fraction(7000/7,17000/38),
+                false
+                )
+            )
+        );
+
+     // superblock 39 - successful stats collection, TC = 19000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            19000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                18000,
+                Fraction(7000/7,18000/39),
+                false
+                )
+            )
+        );
+
+     // superblock 40 - successful stats collection, TC = 20000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            20000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                19000,
+                Fraction(7000/7,19000/40),
+                false
+                )
+            )
+        );
+
+    // superblock 41 - successful stats collection, TC = 21000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            21000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                20000,
+                Fraction(7000/7, 20000/40),
+                false
+                )
+            )
+        );
+
+    // superblock 42 - successful stats collection, TC = 22000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            22000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                21000,
+                Fraction(7000/7, 21000/40),
+                false
+                )
+            )
+        );
+
+    // superblock 43 - successful stats collection, TC = 23000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            23000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                22000,
+                Fraction(7000/7, 22000/40),
+                false
+                )
+            )
+        );
+
+    // superblock 44 - successful stats collection, TC = 24000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            24000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                23000,
+                Fraction(7000/7, 23000/40),
+                false
+                )
+            )
+        );
+
+    // superblock 45 - successful stats collection, TC = 25000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            25000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                23000,
+                Fraction(7000/7, 23000/40),
+                false
+                )
+            )
+        );
+
+    // superblock 46 - successful stats collection, TC = 26000
+    input_expected_result_proj_tc_history.push_back(
+        std::make_tuple(
+            26000,
+            AutoGreylistEntryState(
+                0,
+                7000,
+                23000,
+                Fraction(7000/7, 23000/40),
+                false
+                )
+            )
+        );
+
+    /**
+     * The point of this unit test is to exercise the rules in the AutoGreylist class to ensure they work correctly.
+     * A set of "unit_test_blocks" is made which are fixed up superblocks using the above test data, which is then
+     * injected into the RefreshWithSuperblock via the special unit test parameter.
+     *
+     * The results are compared with a lhs vs rhs comparison, using the == operator overload in the anonymous namespace
+     * AutoGreylistEntryState put here specifically for this purpose.
+     */
+
+    GRC::Whitelist& whitelist = GRC::GetWhitelist();
+
+    std::shared_ptr<GRC::AutoGreylist> auto_greylist = GRC::GetAutoGreylistCache();
+
+    whitelist.Reset();
+
+    int height = 0;
+    int64_t time = 0;
+
+    auto unit_test_blocks = std::make_shared<std::map<int, std::pair<CBlockIndex*, GRC::SuperblockPtr>>>();
+
+    // Add a project for testing.
+    AddProjectEntry(3, "autogreylist_test", "http://autogreylist.test", false, height, time, true);
+
+    // Create dummy CBlockIndex for the whitelist entry.
+    CBlockIndex* whitelist_index_entry = new CBlockIndex;
+
+    ++height;
+    ++time;
+
+//    CBlockIndex* index_ptr = new CBlockIndex;
+    CBlockIndex* index_ptr = whitelist_index_entry;
+    CBlockIndex* index_ptr_prev = nullptr;
+
+    for (auto iter : input_expected_result_proj_tc_history) {
+        // Reset the auto greylist
+        auto_greylist->Reset();
+
+        // Build a fake superblock ptr for the test.
+        index_ptr_prev = index_ptr;
+
+        index_ptr = new CBlockIndex;
+
+        index_ptr->nHeight = height;
+        index_ptr->nTime = time;
+        index_ptr->MarkAsSuperblock();
+        index_ptr->pprev = index_ptr_prev;
+
+        GRC::Superblock superblock = GRC::Superblock();
+
+        // If the optional is nullopt, then don't insert into the superblock.
+        if (std::get<0>(iter)) {
+            superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits
+                .insert(std::make_pair("autogreylist_test", *std::get<0>(iter)));
+        }
+
+        GRC::SuperblockPtr superblock_ptr = GRC::SuperblockPtr();
+        superblock_ptr.Replace(superblock);
+        superblock_ptr.Rebind(index_ptr);
+
+        unit_test_blocks->insert(std::make_pair(height, std::make_pair(index_ptr, superblock_ptr)));
+
+        auto_greylist->RefreshWithSuperblock(superblock_ptr, unit_test_blocks);
+
+        // Only one project in the test.
+        auto greylist_candidate = auto_greylist->begin()->second;
+        auto last_history_entry = greylist_candidate.GetUpdateHistory().back();
+
+        AutoGreylistEntryState entry_state_lhs(greylist_candidate.m_zcd_20_SB_count,
+                                               greylist_candidate.m_TC_7_SB_sum,
+                                               greylist_candidate.m_TC_40_SB_sum,
+                                               greylist_candidate.GetWAS(),
+                                               greylist_candidate.m_meets_greylisting_crit);
+
+        AutoGreylistEntryState entry_state_rhs = std::get<1>(iter);
+
+        LogPrintf("info: %s, height %i, sb %i", "it_auto_greylists_correctly", height, height - 1);
+
+        if (entry_state_lhs != entry_state_rhs) {
+            error("%s:\n"
+                  "lhs: zcd_20_SB_count = %u, TC_7_SB_sum = %" PRId64 ", TC_40_SB_sum = %" PRId64
+                  ", was = %s, meets_greylisting_crit = %u \n"
+                  "rhs: zcd_20_SB_count = %u, TC_7_SB_sum = %" PRId64 ", TC_40_SB_sum = %" PRId64
+                  ", was = %s, meets_greylisting_crit = %u",
+                  "it_auto_greylists_correctly",
+                  entry_state_lhs.m_zcd_20_SB_count,
+                  entry_state_lhs.m_TC_7_SB_sum,
+                  entry_state_lhs.m_TC_40_SB_sum,
+                  entry_state_lhs.m_was.ToString(),
+                  entry_state_lhs.m_meets_greylisting_crit,
+                  entry_state_rhs.m_zcd_20_SB_count,
+                  entry_state_rhs.m_TC_7_SB_sum,
+                  entry_state_rhs.m_TC_40_SB_sum,
+                  entry_state_rhs.m_was.ToString(),
+                  entry_state_rhs.m_meets_greylisting_crit
+                  );
+        }
+
+        BOOST_CHECK(entry_state_lhs == entry_state_rhs);
+
+        ++height;
+    }
+
+    // delete CBlockIndex pointers and clear map to prevent leaking memory.
+    for (auto iter : *unit_test_blocks) {
+        delete iter.second.first;
+    }
+
+    unit_test_blocks->clear();
+
+    delete whitelist_index_entry;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
 BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
 {
     std::vector<std::tuple<std::optional<uint64_t>,
-                           AutoGreylistEntryState>> input_expected_result_proj_tc_history;
+                           AutoGreylistEntryState>> input_expected_result;
 
     /**
      * This is the input data for a HORRIBLE whitelisted project. This series of total credit
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
      **/
 
     // superblock 0 - baseline after whitelisting, but no stats due to problem with project.
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             std::optional<uint64_t>(),
             AutoGreylistEntryState(
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 1 - first stats collection from project, TC = 1000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             1000,
             AutoGreylistEntryState(
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 2 - no stats again due to problem with project
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             std::optional<uint64_t>(),
             AutoGreylistEntryState(
@@ -650,7 +650,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 3 - no status again due to continuing problem with project
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             std::optional<uint64_t>(),
             AutoGreylistEntryState(
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 4 - successful stats collection, but TC = 1000 still
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             1000,
             AutoGreylistEntryState(
@@ -678,7 +678,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 5 - successful stats collection, TC = 2000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             2000,
             AutoGreylistEntryState(
@@ -692,7 +692,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 6 - successful stats collection, TC = 3000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             3000,
             AutoGreylistEntryState(
@@ -706,7 +706,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 7 - problem with stats collection
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             std::optional<uint64_t>(),
             AutoGreylistEntryState(
@@ -720,7 +720,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 8 - successful stats collection, TC = 3000 still
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             3000,
             AutoGreylistEntryState(
@@ -734,7 +734,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 9 - successful stats collection, TC = 4000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             4000,
             AutoGreylistEntryState(
@@ -748,7 +748,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 10 - successful stats collection, TC = 5000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5000,
             AutoGreylistEntryState(
@@ -762,7 +762,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 11 - successful stats collection, TC = 5000 still
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5000,
             AutoGreylistEntryState(
@@ -776,7 +776,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 12 - problem with stats collection
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             std::optional<uint64_t>(),
             AutoGreylistEntryState(
@@ -790,7 +790,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 13 - successful stats collection, reduced output TC = 5001
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5001,
             AutoGreylistEntryState(
@@ -804,7 +804,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 14 - successful stats collection, reduced output TC = 5002
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5002,
             AutoGreylistEntryState(
@@ -818,7 +818,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 15 - successful stats collection, reduced output TC = 5003
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5003,
             AutoGreylistEntryState(
@@ -832,7 +832,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 16 - successful stats collection, reduced output TC = 5004
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5004,
             AutoGreylistEntryState(
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 17 - successful stats collection, slightly improved output TC = 5200
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5200,
             AutoGreylistEntryState(
@@ -860,7 +860,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 18 - successful stats collection, degraded output TC = 5225
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5225,
             AutoGreylistEntryState(
@@ -874,7 +874,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 19 - successful stats collection, degraded output TC = 5230
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5230,
             AutoGreylistEntryState(
@@ -888,7 +888,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 20 - successful stats collection, further degraded output TC = 5231
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5231,
             AutoGreylistEntryState(
@@ -902,7 +902,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 21 - successful stats collection, further degraded output TC = 5232
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5232,
             AutoGreylistEntryState(
@@ -916,7 +916,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 22 - successful stats collection, further degraded output TC = 5233
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5233,
             AutoGreylistEntryState(
@@ -930,7 +930,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 23 - successful stats collection, further degraded output TC = 5234
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5234,
             AutoGreylistEntryState(
@@ -944,7 +944,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 24 - successful stats collection, further degraded output TC = 5235
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5235,
             AutoGreylistEntryState(
@@ -958,7 +958,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 25 - successful stats collection, degraded output TC = 5250
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             5250,
             AutoGreylistEntryState(
@@ -972,7 +972,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 26 - successful stats collection, resume "normal" output TC = 6250
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             6250,
             AutoGreylistEntryState(
@@ -986,7 +986,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 27 - successful stats collection, TC = 7000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             7000,
             AutoGreylistEntryState(
@@ -1000,7 +1000,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 28 - successful stats collection, TC = 8000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             8000,
             AutoGreylistEntryState(
@@ -1014,7 +1014,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 29 - successful stats collection, TC = 9000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             9000,
             AutoGreylistEntryState(
@@ -1028,7 +1028,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 30 - successful stats collection, TC = 10000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             10000,
             AutoGreylistEntryState(
@@ -1042,7 +1042,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 31 - successful stats collection, TC = 11000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             11000,
             AutoGreylistEntryState(
@@ -1056,7 +1056,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 32 - successful stats collection, TC = 12000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             12000,
             AutoGreylistEntryState(
@@ -1070,7 +1070,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 33 - successful stats collection, TC = 13000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             13000,
             AutoGreylistEntryState(
@@ -1084,7 +1084,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 34 - successful stats collection, TC = 14000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             14000,
             AutoGreylistEntryState(
@@ -1098,7 +1098,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 35 - successful stats collection, TC = 15000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             15000,
             AutoGreylistEntryState(
@@ -1112,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
      // superblock 36 - successful stats collection, TC = 16000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             16000,
             AutoGreylistEntryState(
@@ -1126,7 +1126,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
      // superblock 37 - successful stats collection, TC = 17000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             17000,
             AutoGreylistEntryState(
@@ -1140,7 +1140,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
      // superblock 38 - successful stats collection, TC = 18000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             18000,
             AutoGreylistEntryState(
@@ -1154,7 +1154,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
      // superblock 39 - successful stats collection, TC = 19000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             19000,
             AutoGreylistEntryState(
@@ -1168,7 +1168,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
      // superblock 40 - successful stats collection, TC = 20000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             20000,
             AutoGreylistEntryState(
@@ -1182,7 +1182,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 41 - successful stats collection, TC = 21000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             21000,
             AutoGreylistEntryState(
@@ -1196,7 +1196,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 42 - successful stats collection, TC = 22000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             22000,
             AutoGreylistEntryState(
@@ -1210,7 +1210,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 43 - successful stats collection, TC = 23000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             23000,
             AutoGreylistEntryState(
@@ -1224,7 +1224,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 44 - successful stats collection, TC = 24000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             24000,
             AutoGreylistEntryState(
@@ -1238,7 +1238,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 45 - successful stats collection, TC = 25000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             25000,
             AutoGreylistEntryState(
@@ -1252,7 +1252,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
         );
 
     // superblock 46 - successful stats collection, TC = 26000
-    input_expected_result_proj_tc_history.push_back(
+    input_expected_result.push_back(
         std::make_tuple(
             26000,
             AutoGreylistEntryState(
@@ -1298,7 +1298,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
     CBlockIndex* index_ptr = whitelist_index_entry;
     CBlockIndex* index_ptr_prev = nullptr;
 
-    for (auto iter : input_expected_result_proj_tc_history) {
+    for (auto iter : input_expected_result) {
         // Reset the auto greylist
         auto_greylist->Reset();
 
@@ -1368,7 +1368,7 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
     }
 
     // delete CBlockIndex pointers and clear map to prevent leaking memory.
-    for (auto iter : *unit_test_blocks) {
+    for (auto& iter : *unit_test_blocks) {
         delete iter.second.first;
     }
 

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2021 The Gridcoin developers
+// Copyright (c) 2014-2025 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -9,6 +9,7 @@
 #include "gridcoin/superblock.h"
 #include "gridcoin/support/xml.h"
 #include <key_io.h>
+#include "main.h"
 #include "streams.h"
 
 #include <array>
@@ -200,8 +201,13 @@ struct Legacy
 //!
 struct ScraperStatsMeta
 {
-    // Make clang happy
     ScraperStatsMeta()
+        : m_version(2)
+    {
+    }
+
+    ScraperStatsMeta(uint32_t version)
+        : m_version(version)
     {
     }
 
@@ -290,7 +296,13 @@ struct ScraperStatsMeta
 
     uint160 beacon_id_1 = uint160(std::vector<uint8_t>(sizeof(uint160), 0x01));
     uint160 beacon_id_2 = uint160(std::vector<uint8_t>(sizeof(uint160), 0x02));
+
+    double p1_all_cpid_tc = 10000;
+    double p2_all_cpid_tc = 13000;
+
+    uint32_t m_version;
 };
+
 
 //!
 //! \brief Build a mock scraper statistics data object.
@@ -417,6 +429,11 @@ const ScraperStatsVerifiedBeaconsTotalCredits GetTestScraperStats(const ScraperS
         EncodeBase58(meta.beacon_id_2.begin(), meta.beacon_id_2.end()),
         pendingBeaconEntry2);
 
+    if (meta.m_version > 2) {
+        stats_and_verified_beacons.m_total_credit_map.emplace(meta.project1, meta.p1_all_cpid_tc);
+        stats_and_verified_beacons.m_total_credit_map.emplace(meta.project2, meta.p2_all_cpid_tc);
+    }
+
     return stats_and_verified_beacons;
 }
 
@@ -504,6 +521,28 @@ ConvergedScraperStats GetTestConvergence(
 
     convergence.Convergence.ConvergedManifestPartPtrsMap.emplace("project_2",
                                                                  CScraperConvergedManifest_ptr->vParts[2]);
+
+    std::map<std::string, double> total_credit_map;
+
+    total_credit_map.emplace(meta.project1, meta.p1_all_cpid_tc);
+    total_credit_map.emplace(meta.project2, meta.p2_all_cpid_tc);
+
+    CDataStream projects_all_cpid_tc_part_data(SER_NETWORK, PROTOCOL_VERSION);
+    projects_all_cpid_tc_part_data
+        << total_credit_map;
+
+    ProjectEntry.project = "ProjectsAllCpidTotalCredits";
+    ProjectEntry.current = true;
+    ProjectEntry.part1 = 3;
+    ProjectEntry.partc = 0;
+    ProjectEntry.last = 1;
+
+    CScraperConvergedManifest_ptr->projects.push_back(ProjectEntry);
+
+    CScraperConvergedManifest_ptr->addPartData(std::move(projects_all_cpid_tc_part_data));
+
+    convergence.Convergence.ConvergedManifestPartPtrsMap.emplace("ProjectsAllCpidTotalCredits",
+                                                                 CScraperConvergedManifest_ptr->vParts[3]);
 
     // Inject underlying manifest into CScraperManifest::mapManifest without signing, this is part of the
     // normal CScraperManifest::addManifest call.
@@ -606,6 +645,66 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
     }
 }
 
+BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics_v3)
+{
+    const ScraperStatsMeta meta(3);
+    GRC::Superblock superblock = GRC::Superblock::FromStats(GetTestScraperStats(meta), 3);
+
+    BOOST_CHECK(superblock.m_version == 3);
+    BOOST_CHECK(superblock.m_convergence_hint == 0);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0);
+
+    auto& cpids = superblock.m_cpids;
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
+    BOOST_CHECK_EQUAL(cpids.TotalMagnitude(), meta.cpid_total_mag);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
+
+    auto& projects = superblock.m_projects;
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
+
+    if (const auto project_1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project_1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project_1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project_1->m_rac == meta.p1_rac);
+        BOOST_CHECK(project_1->m_convergence_hint == 0);
+    } else {
+        BOOST_FAIL("Project 1 not found in superblock.");
+    }
+
+    if (const auto project_2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project_2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project_2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project_2->m_rac == meta.p2_rac);
+        BOOST_CHECK(project_2->m_convergence_hint == 0);
+    } else {
+        BOOST_FAIL("Project 2 not found in superblock.");
+    }
+
+    auto& tcs = superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits;
+
+    auto project_1_tc = tcs.find(meta.project1);
+
+    if (project_1_tc == tcs.end()) {
+        BOOST_FAIL("Project 1 tc not found in superblock");
+    } else {
+        BOOST_CHECK(project_1_tc->second == meta.p1_all_cpid_tc);
+    }
+
+    auto project_2_tc = tcs.find(meta.project2);
+
+    if (project_2_tc == tcs.end()) {
+        BOOST_FAIL("Project 2 tc not found in superblock");
+    } else {
+        BOOST_CHECK(project_2_tc->second == meta.p2_all_cpid_tc);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
 {
     const ScraperStatsMeta meta;
@@ -650,6 +749,76 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
     } else {
         BOOST_FAIL("Project 2 not found in superblock.");
     }
+}
+
+BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
+{
+    // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
+    // cannot have a pindex with random data.
+    pindexBest = new CBlockIndex;
+
+    const ScraperStatsMeta meta(3);
+    GRC::Superblock superblock = GRC::Superblock::FromConvergence(GetTestConvergence(meta), 3);
+
+    BOOST_CHECK(superblock.m_version == 3);
+
+           // This initialization mode must set the convergence hint derived from
+           // the content hash of the convergence:
+    BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0x22222222);
+
+    auto& cpids = superblock.m_cpids;
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
+    BOOST_CHECK_EQUAL(cpids.TotalMagnitude(), meta.cpid_total_mag);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
+
+    auto& projects = superblock.m_projects;
+    BOOST_CHECK(projects.m_converged_by_project == false);
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
+
+    if (const auto project_1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project_1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project_1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project_1->m_rac == meta.p1_rac);
+        BOOST_CHECK(project_1->m_convergence_hint == 0);
+    } else {
+        BOOST_FAIL("Project 1 not found in superblock.");
+    }
+
+    if (const auto project_2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project_2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project_2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project_2->m_rac == meta.p2_rac);
+        BOOST_CHECK(project_2->m_convergence_hint == 0);
+    } else {
+        BOOST_FAIL("Project 2 not found in superblock.");
+    }
+
+    auto& tcs = superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits;
+
+    auto project_1_tc = tcs.find(meta.project1);
+
+    if (project_1_tc == tcs.end()) {
+        BOOST_FAIL("Project 1 tc not found in superblock");
+    } else {
+        BOOST_CHECK(project_1_tc->second == meta.p1_all_cpid_tc);
+    }
+
+    auto project_2_tc = tcs.find(meta.project2);
+
+    if (project_2_tc == tcs.end()) {
+        BOOST_FAIL("Project 2 tc not found in superblock");
+    } else {
+        BOOST_CHECK(project_2_tc->second == meta.p2_all_cpid_tc);
+    }
+
+    delete pindexBest;
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence)
@@ -711,6 +880,91 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
     } else {
         BOOST_FAIL("Project 2 not found in superblock.");
     }
+}
+
+BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence_v3)
+{
+    // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
+    // cannot have a pindex with random data.
+    pindexBest = new CBlockIndex;
+
+    const ScraperStatsMeta meta(3);
+    GRC::Superblock superblock = GRC::Superblock::FromConvergence(
+        GetTestConvergence(meta, true), 3); // Set fallback by project flag
+
+    BOOST_CHECK(superblock.m_version == 3);
+    BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
+    // Manifest content hint not set for fallback convergence:
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0x00000000);
+
+    auto& cpids = superblock.m_cpids;
+    BOOST_CHECK(cpids.size() == meta.cpid_count);
+    BOOST_CHECK_EQUAL(cpids.TotalMagnitude(), meta.cpid_total_mag);
+    BOOST_CHECK_CLOSE(cpids.AverageMagnitude(), meta.cpid_average_mag, 0.00000001);
+
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid1) == meta.c1_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid2) == meta.c2_mag_obj);
+    BOOST_CHECK(cpids.MagnitudeOf(meta.cpid3) == meta.c3_mag_obj);
+
+    auto& projects = superblock.m_projects;
+
+           // By project flag must be true in a fallback-to-project convergence:
+    BOOST_CHECK(projects.m_converged_by_project == true);
+    BOOST_CHECK(projects.size() == meta.project_count);
+    BOOST_CHECK(projects.TotalRac() == meta.project_total_rac);
+    BOOST_CHECK(projects.AverageRac() == meta.project_average_rac);
+
+    if (const auto project_1 = projects.Try(meta.project1)) {
+        BOOST_CHECK(project_1->m_total_credit == meta.p1_tc);
+        BOOST_CHECK(project_1->m_average_rac == meta.p1_avg_rac_rounded);
+        BOOST_CHECK(project_1->m_rac == meta.p1_rac);
+
+        CDataStream project_1_part_data(SER_NETWORK, PROTOCOL_VERSION);
+        project_1_part_data << "foo";
+
+        uint32_t calc_convergence_hint = Hash(project_1_part_data).GetUint64(0) >> 32;
+
+               // The convergence hint must be set in fallback-to-project convergence.
+        BOOST_CHECK(project_1->m_convergence_hint == calc_convergence_hint);
+    } else {
+        BOOST_FAIL("Project 1 not found in superblock.");
+    }
+
+    if (const auto project_2 = projects.Try(meta.project2)) {
+        BOOST_CHECK(project_2->m_total_credit == meta.p2_tc);
+        BOOST_CHECK(project_2->m_average_rac == meta.p2_avg_rac_rounded);
+        BOOST_CHECK(project_2->m_rac == meta.p2_rac);
+
+        CDataStream project_2_part_data(SER_NETWORK, PROTOCOL_VERSION);
+        project_2_part_data << "fi";
+
+        uint32_t calc_convergence_hint = Hash(project_2_part_data).GetUint64(0) >> 32;
+
+               // The convergence hint must be set in fallback-to-project convergence.
+        BOOST_CHECK(project_2->m_convergence_hint == calc_convergence_hint);
+    } else {
+        BOOST_FAIL("Project 2 not found in superblock.");
+    }
+
+    auto& tcs = superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits;
+
+    auto project_1_tc = tcs.find(meta.project1);
+
+    if (project_1_tc == tcs.end()) {
+        BOOST_FAIL("Project 1 tc not found in superblock");
+    } else {
+        BOOST_CHECK(project_1_tc->second == meta.p1_all_cpid_tc);
+    }
+
+    auto project_2_tc = tcs.find(meta.project2);
+
+    if (project_2_tc == tcs.end()) {
+        BOOST_FAIL("Project 2 tc not found in superblock");
+    } else {
+        BOOST_CHECK(project_2_tc->second == meta.p2_all_cpid_tc);
+    }
+
+    delete pindexBest;
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_binary_contract)
@@ -2119,6 +2373,63 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
 
     const GRC::QuorumHash hash = GRC::QuorumHash::Hash(
         GRC::Superblock::FromStats(GetTestScraperStats(meta), 2));
+
+    BOOST_CHECK(hash.Valid() == true);
+    BOOST_CHECK(hash.Which() == GRC::QuorumHash::Kind::SHA256);
+    BOOST_CHECK(hash == expected);
+    BOOST_CHECK(hash.ToString() == expected.ToString());
+}
+
+BOOST_AUTO_TEST_CASE(it_hashes_a_superblock_v3)
+{
+    const ScraperStatsMeta meta(3);
+    CHashWriter expected_hasher(SER_GETHASH, PROTOCOL_VERSION);
+
+           // Note: convergence hints embedded in a superblock are NOT considered
+           // when generating the superblock hash, and the container sizes aren't
+           // either:
+           //
+
+    std::map<std::string, uint64_t> expected_project_tcs;
+    expected_project_tcs.emplace(meta.project1, std::nearbyint<uint64_t>(meta.p1_all_cpid_tc));
+    expected_project_tcs.emplace(meta.project2, std::nearbyint<uint64_t>(meta.p2_all_cpid_tc));
+
+    expected_hasher
+                    // To allow for direct hashing of scraper stats data without
+                    // allocating a superblock, we generate an intermediate hash
+                    // of the segments of CPID-to-magnitude mappings:
+                    //
+        << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+            << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+                << meta.cpid3
+                << static_cast<uint8_t>(meta.c3_mag_obj.Compact()))
+                   .GetHash()
+            << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+                << meta.cpid2
+                << static_cast<uint8_t>(meta.c2_mag_obj.Compact()))
+                   .GetHash()
+            << (CHashWriter(SER_GETHASH, PROTOCOL_VERSION)
+                << meta.cpid1
+                << COMPACTSIZE(uint64_t{meta.c1_mag_obj.Compact()}))
+                   .GetHash())
+               .GetHash()
+        << VARINT(uint32_t{0}) // Zero-mag count
+        << meta.project1
+        << VARINT((uint64_t)std::nearbyint(meta.p1_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p1_rac))
+        << meta.project2
+        << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << std::vector<uint160> { meta.beacon_id_1, meta.beacon_id_2 }
+        // Notice that the project status map is NOT serialized. This is on purpose.
+        << expected_project_tcs;
+
+    const uint256 expected = expected_hasher.GetHash();
+
+    const GRC::QuorumHash hash = GRC::QuorumHash::Hash(
+        GRC::Superblock::FromStats(GetTestScraperStats(meta), 3));
 
     BOOST_CHECK(hash.Valid() == true);
     BOOST_CHECK(hash.Which() == GRC::QuorumHash::Kind::SHA256);

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -567,9 +567,9 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_the_specified_version)
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
 {
     const ScraperStatsMeta meta;
-    GRC::Superblock superblock = GRC::Superblock::FromStats(GetTestScraperStats(meta));
+    GRC::Superblock superblock = GRC::Superblock::FromStats(GetTestScraperStats(meta), 2);
 
-    BOOST_CHECK(superblock.m_version == GRC::Superblock::CURRENT_VERSION);
+    BOOST_CHECK(superblock.m_version == 2);
     BOOST_CHECK(superblock.m_convergence_hint == 0);
     BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
@@ -609,9 +609,9 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
 {
     const ScraperStatsMeta meta;
-    GRC::Superblock superblock = GRC::Superblock::FromConvergence(GetTestConvergence(meta));
+    GRC::Superblock superblock = GRC::Superblock::FromConvergence(GetTestConvergence(meta), 2);
 
-    BOOST_CHECK(superblock.m_version == GRC::Superblock::CURRENT_VERSION);
+    BOOST_CHECK(superblock.m_version == 2);
 
     // This initialization mode must set the convergence hint derived from
     // the content hash of the convergence:
@@ -1002,7 +1002,7 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
         << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
         << std::vector<uint160> { meta.beacon_id_1, meta.beacon_id_2 };
 
-    GRC::Superblock superblock = GRC::Superblock::FromConvergence(GetTestConvergence(meta));
+    GRC::Superblock superblock = GRC::Superblock::FromConvergence(GetTestConvergence(meta), 2);
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 
@@ -1142,7 +1142,7 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_fallback_convergences)
         << std::vector<uint160> { meta.beacon_id_1, meta.beacon_id_2 };
 
     GRC::Superblock superblock = GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta, true)); // Set fallback by project flag
+        GetTestConvergence(meta, true), 2); // Set fallback by project flag
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 
@@ -2118,7 +2118,7 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
     const uint256 expected = expected_hasher.GetHash();
 
     const GRC::QuorumHash hash = GRC::QuorumHash::Hash(
-        GRC::Superblock::FromStats(GetTestScraperStats(meta)));
+        GRC::Superblock::FromStats(GetTestScraperStats(meta), 2));
 
     BOOST_CHECK(hash.Valid() == true);
     BOOST_CHECK(hash.Which() == GRC::QuorumHash::Kind::SHA256);
@@ -2131,7 +2131,7 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_set_of_scraper_statistics_like_a_superblock)
     const ScraperStatsMeta meta;
     const ScraperStatsVerifiedBeaconsTotalCredits stats_and_verified_beacons = GetTestScraperStats(meta);
 
-    GRC::Superblock superblock = GRC::Superblock::FromStats(stats_and_verified_beacons);
+    GRC::Superblock superblock = GRC::Superblock::FromStats(stats_and_verified_beacons, 2);
     GRC::QuorumHash quorum_hash = GRC::QuorumHash::Hash(stats_and_verified_beacons);
 
     BOOST_CHECK(quorum_hash == superblock.GetHash());
@@ -2263,7 +2263,7 @@ BOOST_AUTO_TEST_CASE(it_compares_another_quorum_hash_for_equality)
 
 BOOST_AUTO_TEST_CASE(it_compares_a_sha256_hash_for_equality)
 {
-    const GRC::Superblock superblock;
+    const GRC::Superblock superblock(2);
     CHashWriter expected_hasher(SER_GETHASH, PROTOCOL_VERSION);
 
     expected_hasher
@@ -2288,7 +2288,7 @@ BOOST_AUTO_TEST_CASE(it_compares_a_sha256_hash_for_equality)
 
 BOOST_AUTO_TEST_CASE(it_compares_a_string_for_equality)
 {
-    const GRC::Superblock superblock;
+    const GRC::Superblock superblock(2);
     GRC::QuorumHash hash = GRC::QuorumHash::Hash(superblock);
 
     CHashWriter expected_hasher(SER_GETHASH, PROTOCOL_VERSION);

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -656,9 +656,9 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
 {
     const ScraperStatsMeta meta;
     GRC::Superblock superblock = GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta, true)); // Set fallback by project flag
+        GetTestConvergence(meta, true), 2); // Set fallback by project flag
 
-    BOOST_CHECK(superblock.m_version == GRC::Superblock::CURRENT_VERSION);
+    BOOST_CHECK(superblock.m_version == 2);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
     // Manifest content hint not set for fallback convergence:
     BOOST_CHECK(superblock.m_manifest_content_hint == 0x00000000);

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -297,9 +297,9 @@ struct ScraperStatsMeta
 //!
 //! \param meta Contains the values to initialize the scraper stats object with.
 //!
-const ScraperStatsAndVerifiedBeacons GetTestScraperStats(const ScraperStatsMeta& meta)
+const ScraperStatsVerifiedBeaconsTotalCredits GetTestScraperStats(const ScraperStatsMeta& meta)
 {
-    ScraperStatsAndVerifiedBeacons stats_and_verified_beacons;
+    ScraperStatsVerifiedBeaconsTotalCredits stats_and_verified_beacons;
 
     ScraperObjectStats p1c1;
     p1c1.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -432,14 +432,14 @@ ConvergedScraperStats GetTestConvergence(
 {
     LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
 
-    const ScraperStatsAndVerifiedBeacons stats = GetTestScraperStats(meta);
+    const ScraperStatsVerifiedBeaconsTotalCredits stats = GetTestScraperStats(meta);
     ConvergedScraperStats convergence;
 
     auto CScraperConvergedManifest_ptr = std::shared_ptr<CScraperManifest>(new CScraperManifest());
 
     LOCK(CScraperConvergedManifest_ptr->cs_manifest);
 
-    convergence.mScraperConvergedStats = stats.mScraperStats;
+    convergence.mScraperConvergedStats = stats;
 
     convergence.Convergence.bByParts = by_parts;
     convergence.Convergence.nContentHash
@@ -1950,7 +1950,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_collection)
 BOOST_AUTO_TEST_CASE(it_replaces_the_collection_from_scraper_statistics)
 {
     const ScraperStatsMeta meta;
-    const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetTestScraperStats(meta);
+    const ScraperStatsVerifiedBeaconsTotalCredits stats_and_verified_beacons = GetTestScraperStats(meta);
 
     GRC::Superblock::VerifiedBeacons beacon_ids;
 
@@ -2129,7 +2129,7 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
 BOOST_AUTO_TEST_CASE(it_hashes_a_set_of_scraper_statistics_like_a_superblock)
 {
     const ScraperStatsMeta meta;
-    const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetTestScraperStats(meta);
+    const ScraperStatsVerifiedBeaconsTotalCredits stats_and_verified_beacons = GetTestScraperStats(meta);
 
     GRC::Superblock superblock = GRC::Superblock::FromStats(stats_and_verified_beacons);
     GRC::QuorumHash quorum_hash = GRC::QuorumHash::Hash(stats_and_verified_beacons);

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
 #define BOOST_TEST_MODULE Gridcoin Test Suite
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -13,6 +13,7 @@
 #include "main.h"
 #include "random.h"
 #include "wallet/wallet.h"
+#include "gridcoin/project.h"
 
 leveldb::Env* txdb_env;
 

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -17,7 +17,6 @@
 #include "main.h"
 #include "random.h"
 #include "wallet/wallet.h"
-#include "gridcoin/project.h"
 
 leveldb::Env* txdb_env;
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2019 The Bitcoin Core developers
+// Copyright (c) 2025 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -24,3 +24,11 @@ void ParseString(const string& str, char c, vector<string>& v)
         i1 = i2+1;
     }
 }
+
+std::string FromDoubleToString(const double& t, const int& precision)
+{
+    std::ostringstream oss;
+    oss.imbue(std::locale::classic());
+    oss << std::scientific << std::setprecision(precision) << t;
+    return oss.str();
+}

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -11,6 +11,7 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <iomanip>
 #include <locale>
 #include <sstream>
 #include <string>
@@ -86,6 +87,16 @@ std::string ToString(const T& t)
     oss << t;
     return oss.str();
 }
+
+/**
+ * @brief Locale-independent version of ToString specifically for doubles with
+ * the ability to specificy the precision.
+ *
+ * @param t Input double floating point
+ * @param precision
+ * @return string
+ */
+std::string FromDoubleToString(const double& t, const int& precision);
 
 /**
  * Check whether a container begins with the given prefix.

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -1,4 +1,8 @@
 // Copyright (c) 2019-2020 The Bitcoin Core developers
+// Copyright (c) 2025 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/generated_type.h
+++ b/src/wallet/generated_type.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_GENERATED_TYPE_H
 
 /** (POS/POR) enums for CoinStake Transactions -- We should never get unknown but just in case!*/
+namespace GRC {
 enum MinedType
 {
     UNKNOWN = 0,
@@ -20,5 +21,6 @@ enum MinedType
     MRC_RCV = 9,
     MRC_SEND = 10
 };
+}
 
 #endif // BITCOIN_WALLET_GENERATED_TYPE_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1430,18 +1430,18 @@ UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
                 else
                     entry.pushKV("category", "generate");
 
-                MinedType gentype = GetGeneratedType(pwalletMain, wtx.GetHash(), s.vout);
+                GRC::MinedType gentype = GetGeneratedType(pwalletMain, wtx.GetHash(), s.vout);
 
                 switch (gentype)
                 {
-                    case MinedType::POR                 :    entry.pushKV("type", "POR");                     break;
-                    case MinedType::POS                 :    entry.pushKV("type", "POS");                     break;
-                    case MinedType::ORPHANED            :    entry.pushKV("type", "ORPHANED");                break;
-                    case MinedType::POS_SIDE_STAKE_RCV  :    entry.pushKV("type", "POS SIDE STAKE RECEIVED"); break;
-                    case MinedType::POR_SIDE_STAKE_RCV  :    entry.pushKV("type", "POR SIDE STAKE RECEIVED"); break;
-                    case MinedType::POS_SIDE_STAKE_SEND :    entry.pushKV("type", "POS SIDE STAKE SENT");     break;
-                    case MinedType::POR_SIDE_STAKE_SEND :    entry.pushKV("type", "POR SIDE STAKE SENT");     break;
-                    case MinedType::MRC_SEND            :    entry.pushKV("type", "MRC PAYMENT SENT");        break;
+                    case GRC::MinedType::POR                 :    entry.pushKV("type", "POR");                     break;
+                    case GRC::MinedType::POS                 :    entry.pushKV("type", "POS");                     break;
+                    case GRC::MinedType::ORPHANED            :    entry.pushKV("type", "ORPHANED");                break;
+                    case GRC::MinedType::POS_SIDE_STAKE_RCV  :    entry.pushKV("type", "POS SIDE STAKE RECEIVED"); break;
+                    case GRC::MinedType::POR_SIDE_STAKE_RCV  :    entry.pushKV("type", "POR SIDE STAKE RECEIVED"); break;
+                    case GRC::MinedType::POS_SIDE_STAKE_SEND :    entry.pushKV("type", "POS SIDE STAKE SENT");     break;
+                    case GRC::MinedType::POR_SIDE_STAKE_SEND :    entry.pushKV("type", "POR SIDE STAKE SENT");     break;
+                    case GRC::MinedType::MRC_SEND            :    entry.pushKV("type", "MRC PAYMENT SENT");        break;
                     default                             :    entry.pushKV("type", "UNKNOWN");                 break;
                 }
             }
@@ -1490,24 +1490,24 @@ UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
                     else
                         entry.pushKV("category", "generate");
 
-                    MinedType gentype = GetGeneratedType(pwalletMain, wtx.GetHash(), r.vout);
+                    GRC::MinedType gentype = GetGeneratedType(pwalletMain, wtx.GetHash(), r.vout);
 
                     switch (gentype)
                     {
-                        case MinedType::POR                 :    entry.pushKV("Type", "POR");                     break;
-                        case MinedType::POS                 :    entry.pushKV("Type", "POS");                     break;
-                        case MinedType::ORPHANED            :    entry.pushKV("Type", "ORPHANED");                break;
-                        case MinedType::POS_SIDE_STAKE_RCV  :    entry.pushKV("Type", "POS SIDE STAKE RECEIVED"); break;
-                        case MinedType::POR_SIDE_STAKE_RCV  :    entry.pushKV("Type", "POR SIDE STAKE RECEIVED"); break;
-                        case MinedType::POS_SIDE_STAKE_SEND :    entry.pushKV("Type", "POS SIDE STAKE SENT");     break;
-                        case MinedType::POR_SIDE_STAKE_SEND :    entry.pushKV("Type", "POR SIDE STAKE SENT");     break;
-                        case MinedType::MRC_RCV             :    entry.pushKV("Type", "MRC PAYMENT RECEIVED");    break;
-                        case MinedType::MRC_SEND            :    entry.pushKV("Type", "MRC PAYMENT SENT");        break;
+                        case GRC::MinedType::POR                 :    entry.pushKV("Type", "POR");                     break;
+                        case GRC::MinedType::POS                 :    entry.pushKV("Type", "POS");                     break;
+                        case GRC::MinedType::ORPHANED            :    entry.pushKV("Type", "ORPHANED");                break;
+                        case GRC::MinedType::POS_SIDE_STAKE_RCV  :    entry.pushKV("Type", "POS SIDE STAKE RECEIVED"); break;
+                        case GRC::MinedType::POR_SIDE_STAKE_RCV  :    entry.pushKV("Type", "POR SIDE STAKE RECEIVED"); break;
+                        case GRC::MinedType::POS_SIDE_STAKE_SEND :    entry.pushKV("Type", "POS SIDE STAKE SENT");     break;
+                        case GRC::MinedType::POR_SIDE_STAKE_SEND :    entry.pushKV("Type", "POR SIDE STAKE SENT");     break;
+                        case GRC::MinedType::MRC_RCV             :    entry.pushKV("Type", "MRC PAYMENT RECEIVED");    break;
+                        case GRC::MinedType::MRC_SEND            :    entry.pushKV("Type", "MRC PAYMENT SENT");        break;
                         default                             :    entry.pushKV("Type", "UNKNOWN");                 break;
                     }
 
                     // Skip posting this entry if stakes only is desired and not an actual stake.
-                    if (stakes_only && gentype != MinedType::POR && gentype != MinedType::POS) continue;
+                    if (stakes_only && gentype != GRC::MinedType::POR && gentype != GRC::MinedType::POS) continue;
                 }
                 else
                 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3040,39 +3040,39 @@ void CWallet::StoreLastBackupTime(const int64_t backup_time)
     CWalletDB(strWalletFile).WriteBackupTime(backup_time);
 }
 
-MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout)
+GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout)
 {
     CWalletTx wallettx;
     uint256 hashblock;
 
     if (!GetTransaction(tx, wallettx, hashblock))
-        return MinedType::ORPHANED;
+        return GRC::MinedType::ORPHANED;
 
     BlockMap::iterator mi = mapBlockIndex.find(hashblock);
 
     if (mi == mapBlockIndex.end()) {
-        return MinedType::UNKNOWN;
+        return GRC::MinedType::UNKNOWN;
     }
 
     CBlockIndex* blkindex = mi->second;
 
     // If we are calling GetGeneratedType, this is a transaction
     // that corresponds (is integral to) the block. We check whether
-    // the block is a superblock, and if so we set the MinedType to
+    // the block is a superblock, and if so we set the GRC::MinedType to
     // SUPERBLOCK if vout is 1 as that should override the others here.
     if (vout == 1 && blkindex->IsSuperblock())
     {
-        return MinedType::SUPERBLOCK;
+        return GRC::MinedType::SUPERBLOCK;
     }
 
     // Basic CoinStake Support
     if (wallettx.vout.size() == 2)
     {
         if (blkindex->ResearchSubsidy() == 0)
-            return MinedType::POS;
+            return GRC::MinedType::POS;
 
         else
-            return MinedType::POR;
+            return GRC::MinedType::POR;
     }
 
     // Side/Split Stake Support
@@ -3091,10 +3091,10 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
         if (fIsCoinStakeMine && wallettx.vout[vout].scriptPubKey == wallettx.vout[1].scriptPubKey)
         {
             if (blkindex->ResearchSubsidy() == 0)
-                return MinedType::POS;
+                return GRC::MinedType::POS;
 
             else
-                return MinedType::POR;
+                return GRC::MinedType::POR;
         }
         else
         {
@@ -3105,20 +3105,20 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
                 if (fIsOutputMine)
                 {
                     if (blkindex->ResearchSubsidy() == 0)
-                        return MinedType::POS_SIDE_STAKE_RCV;
+                        return GRC::MinedType::POS_SIDE_STAKE_RCV;
                     else
-                        return MinedType::POR_SIDE_STAKE_RCV;
+                        return GRC::MinedType::POR_SIDE_STAKE_RCV;
                 }
                 // ... or the output is not mine, then this must be a
                 // sidestake sent to someone else or an MRC payment.
                 else
                 {
                     if (blkindex->ResearchSubsidy() == 0 && vout < mrc_index_start) {
-                        return MinedType::POS_SIDE_STAKE_SEND;
+                        return GRC::MinedType::POS_SIDE_STAKE_SEND;
                     } else if (vout >= mrc_index_start) {
-                        return MinedType::MRC_SEND;
+                        return GRC::MinedType::MRC_SEND;
                     } else {
-                        return MinedType::POR_SIDE_STAKE_SEND;
+                        return GRC::MinedType::POR_SIDE_STAKE_SEND;
                     }
                 }
             }
@@ -3130,11 +3130,11 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
                 if (fIsOutputMine)
                 {
                     if (blkindex->ResearchSubsidy() == 0 && vout < mrc_index_start) {
-                        return MinedType::POS_SIDE_STAKE_RCV;
+                        return GRC::MinedType::POS_SIDE_STAKE_RCV;
                     } else if (vout >= mrc_index_start) {
-                        return MinedType::MRC_RCV;
+                        return GRC::MinedType::MRC_RCV;
                     } else {
-                        return MinedType::POR_SIDE_STAKE_RCV;
+                        return GRC::MinedType::POR_SIDE_STAKE_RCV;
                     }
                 }
 
@@ -3144,7 +3144,7 @@ MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned in
         }
     }
 
-    return MinedType::UNKNOWN;
+    return GRC::MinedType::UNKNOWN;
 }
 
 bool CWallet::UpgradeWallet(int version, std::string& error)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -35,7 +35,7 @@ class CReserveKey;
 class COutput;
 class CCoinControl;
 
-MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout);
+GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout);
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 static const unsigned int DEFAULT_KEYPOOL_SIZE_PRE_HD = 1000;
@@ -887,7 +887,7 @@ public:
 
     bool RevalidateTransaction(CTxDB& txdb);
 
-    MinedType GetGeneratedType(uint32_t vout_offset) const
+    GRC::MinedType GetGeneratedType(uint32_t vout_offset) const
     {
         return ::GetGeneratedType(pwallet, GetHash(), vout_offset);
     }


### PR DESCRIPTION
# Automated Greylisting Design Highlights

## Executive Summary

This document provides the highlights for the functionality included in this PR, which implements both manual and automated greylisting. The Gridcoin network rules for project whitelisting and the conditions for greylisting are documented on the main Gridcoin website at [Whitelist Process](https://gridcoin.us/wiki/whitelist-process.html).

When projects temporarily do not meet the requirements for whitelisting, the main two rules of which are a Work Availability Score (WAS) of less than 0.1, and/or a Zero Credit Days (ZCD) count of greater than 7, the project is "greylisted". Traditionally, from a network operations perspective, this has meant temporarily removing the project from the whitelist using the administrative protocol update procedures, and then re-adding the project when the two rules return to normal. This is a manual and labor intensive process that does not scale well as the number of whitelisted projects increase, and it depends on the administrator to take action in a timely manner.

To address the scalability and administrative stablility, it was recognized several years ago that a form of automatic greylisting would be important functionality to implement. This PR addresses that functionality need.

This PR implements *manual greylisting* via a new project entry status *MAN_GREYLISTED*. This is set by administrative contract just like whitelisting. The purpose of the manual listing is twofold: 1) Not all possible issues that could result in a need to greylist are covered by the WAS and ZCD rules, and 2) a long term low level availability of a project at a fairly consistent level for more than 40 days will cause the WAS to pass, because both the numerator and denominator forming WAS will see similar results. This project status is stored in the project registry.

*Automatic greylisting* is implemented via a new AutoGreylist class. This class essentially records total credit data across the entire project (all CPIDs, whether they have an active beacon or not) collected from the scrapers via a pending, or existing (last) superblock for all whitelisted projects, and the history of 40 superblocks back from the pending or last superblock, and evaluates the WAS and ZCD rules. Because it operates at the granularity of the superblocks, technically the definition of these rules is *slightly* different than the documentation since the time between superblocks is **slightly** more than 24 hours. In practice this is essentially equivalent. Because the automatic greylisting status is aligned along superblock boundaries, the AutoGreylist class is implemented as a caching singleton, so that repeated calls to the class for the greylist simply report the cached state rather than doing the heavyweight walk of 40 superblocks to recompute the automatic greylist state from the superblock history as long as the referenced superblock hash for the cache has not changed.

The AutoGreylist class *overrides* a project registry status of ACTIVE or MAN_GREYLISTED with the status of AUTO_GREYLISTED if it meets greylisting criteria. This is done directly in the Whitelist::Snapshot method, preserving the underlying project entries. Since the underlying registry entries are preserved, the project state returns to the underlying status as soon as the greylist entry for that project returns to normal. Conversely there is also the ability to set via addkey the project status AUTO_GREYLIST_OVERRIDE in the project registry, which takes precedence over the automatic greylisting. This allows an override to keep a project active even if the automated greylist rules would greylist it. A good example of this would be a project that had a one day correction of TC due to a database issue that distorts the WAS, causing a false failure. In that case it would be a good idea to override the automatic greylisting for that project temporarily after evaluation by the community.

Note that the auto greylisting ruleset is entirely contained within the AutoGreylist class. While the rules are encapsulated in that class, no attempt to write a formal rules engine was done as that would be too heavyweight for just two rules. Additionally, WAS has been implemented using 64 bit integer arithmetic and the Gridcoin Fraction class to avoid consensus issues due to floating point. For ease of display, WAS values in reports are shown as floating point.

The *excluded project* functionality of the scraper convergence and the associated superblocks formed still applies. This means that a project that does not export statistics at all in a 48 hour period will be excluded from superblocks until access to project statistics are restored. This is related to the 48 hour statistics retention rule for scraper statistics that has been in place since the scraper rewrite a number of years ago. When a project is *excluded* this is effectively an override of all project registry statuses and the operation of the automated greylisting.

## Changes to the scraper

The scraper was modified to collect total credit across the entire project for each project that does not have a status of deleted in the project registry. This was accomplished via the following changes (this is not all inclusive):

1. Addition of two fields in the scraper file manifest registry, All_cpid_total_credit and No_records. All_cpid_total_credit captures the total credit summation across the entire project regardless of whether the cpid is active or not. No_records is a flag to record when a file has no active cpids. Formerly, a file and its corresponding entry would have been deleted, but now we must retain the file and entry to record the all_cpid_total_credit even if there are no current active cpids in that project.

2. Implementation of an additional pseudo-project entry in the CScraperManifest with the name ProjectsAllCpidTotalCredits to allow convergence to be calculated by each node from the scraper data. This means the total credits data must also match just like other project data for a convergence to occur and insures integrity of the total credits data similar to other project data.

3. Extension of the ScraperStatsVerifiedBeacons structure used in the convergence to include total credits, and renamed ScraperStatsVerifiedBeaconsTotalCredits. This is the primary method of transferrance of state to the superblock of the total credits for each project from a manifest convergence.

4. Modification of the scraper machinery to assign zero magnitude to greylisted projects for purposes of magnitude calculation.

5. Modification of the ProcessProjectRacFileByCPID function to accumulate total credit for a project from all CPIDs regardless of status.

6. Reporting for CScraperManifest and the convergence report rpc functions were extended to provide information on the total credits across all projects.

## Changes to the registry_db.h template

The registry db template provides generic programming common code underlying the registry implementations for each of the contract types that require historized, revertable state maintenance of their corresponding objects. This implements versioned state storage of registered contract type objects via the defined key in leveldb. The AutoGreylist class needs to know when the first entry actually occurred for a project to properly apply the rules for projects whitelisted within the 40 superblock lookback scope. As a result, the registry db template had to be extended to include a generic type and code to accomodate this.

Each of the corresponding contract type classes had to be modified to accomodate changes in the registry template, even if they did not actually use the first occurance functionality, i.e. trivial modifications to all other contract types besides project.

## Changes to the superblock

The superblock class version was incremented to v3 and was extended to include the m_projects_all_cpids_total_credits map which contains the total credits data for all projects, and which is from the ScraperStatsVerifiedBeaconsTotalCredits structure in the manifest convergence from the scraper. This data is serialized and is stored on the blockchain when the superblock is staked and in turn is used by the AutoGreylist class for greylist status calculations.

The superblock also was extended to store projects that have been greylisted.

## Implementation of the AutoGreylist class and changes to the project class and project registry (whitelist)

### ProjectEntryStatus enum class changes

The ProjectEntryStatus num class was extended and moved to fwd.h to avoid recursive include problems.

```
{
//!
//! \brief Enumeration of project entry status. Unlike beacons this is for both storage
//! and memory.
//!
//! UNKNOWN status is only encountered in trivially constructed empty
//! project entries and should never be seen on the blockchain.
//!
//! DELETED status corresponds to a removed entry.
//!
//! ACTIVE corresponds to an active entry.
//!
//! GREYLISTED means that the project temporarily does not meet the whitelist qualification criteria.
//!
//! OUT_OF_BOUND must go at the end and be retained for the EnumBytes wrapper.
//!
enum class ProjectEntryStatus
{
    UNKNOWN,
    DELETED,
    ACTIVE,
    MAN_GREYLISTED,
    AUTO_GREYLISTED,
    AUTO_GREYLIST_OVERRIDE,
    OUT_OF_BOUND
};

```

MAN_GREYLISTED, AUTO_GREYLISTED, AUTO_GREYLIST_OVERRIDE are new states. The order of enum entries for the extending states was not changed to avoid serialization issues with older project entries.

### Implementation of project filter for whitelist snapshots

A ProjectFilterFlag was implemented to accomplish easy filtering of the whitelist snapshot depending on intended use.

```
    //!
    //! \brief Project filter flag enumeration.
    //!
    //! This controls what project entries by status are in the project whitelist snapshot. Note that REG_ACTIVE
    //! is the original "ACTIVE" and represents project entries with a status of "ACTIVE" in the registry. The
    //! filter flag "ACTIVE" here includes both REG_ACTIVE and AUTO_GREYLIST_OVERRIDE project entry statuses from
    //! the registry, since both mean the project is active assuming a convergence can be formed.
    //!
    enum ProjectFilterFlag : uint8_t {
        NONE                   = 0b00000,
        DELETED                = 0b00001,
        MAN_GREYLISTED         = 0b00010,
        AUTO_GREYLISTED        = 0b00100,
        GREYLISTED             = MAN_GREYLISTED | AUTO_GREYLISTED,
        REG_ACTIVE             = 0b01000,
        AUTO_GREYLIST_OVERRIDE = 0b10000,
        ACTIVE                 = REG_ACTIVE | AUTO_GREYLIST_OVERRIDE,
        NOT_ACTIVE             = 0b00111,
        ALL_BUT_DELETED        = 0b11110,
        ALL                    = 0b11111
    };

```
Note that the ACTIVE enum value is actually a combination of the original ACTIVE (now labled REG_ACTIVE, which is short for registry active) and AUTO_GREYLIST_OVERRIDE, since a project status of AUTO_GREYLIST_OVERRIDE means that the project is not only active, but overrides any determination by the automatic greylisting.

### ProjectEntry class modifications

The ProjectEntry class current version has been incremented to v4 and now includes a requires_ext_adapter boolean to replace the temporary protocol entry based approach to show this status in the GUI. This boolean is serialized and the serialization is conditioned on the version to ensure compatibility with older project records.

### AutoGreylist class implementation

#### GreylistCandidateEntry

The GreylistCandidateEntry is a class implemented within the AutoGreylist class that formalizes the greylist state maintenance and state history for each project in the whitelist filtered by ALL_BUT_DELETED (i.e. all but deleted). This class uses a "reverse" bookmark based approach to effectively deal with a number of tricky situations involving lack of availability of project total credit data (drop-outs). In addition, each update is stored in the m_update_history vector to provide visibility of the historical evolution of the total credit data and greylist status according to the rules.

The GreylistCandidateEntry contains an "empty" constructor and a parameterized constructor, the latter of which both creates the GreylistCandidateEntry and establishes the baseline for the measurements.

##### uint8_t GetZCD()

This method simply returns the m_zcd_20_SB_count member variable, which is a count of the number of zero credit days in the 20 superblock lookback from the baseline.

##### Fraction GetWAS()

The method computes the average total credit over a 7 superblock lookback and a 40  superblock lookback and then constructs a Fraction of the result. Note that if the lookback is less than 40, the number of superblocks in the average is reduced for the 40 superblock lookback and similarly if the lookback is less than 7, the number of superblocks in the average is reduced for the 7 superblock lookback. Given that when data is first being collected for a newly listed project, this can lead to odd behavior of WAS, there is a grace period implemented in the application of the rules for setting the m_meets_greylisting_crit flag in the GreylistCandidateEntry. This grace period is currently set at 7 superblocks.

##### void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline)

This method is used by the RefreshWithSuperblock method to update each GreylistCandidateEntry and add each update to the entry history.

##### struct UpdateHistoryEntry

This is the struct that stores the greylist state at the given update for the greylist candidate. *Note that this is the history viewed BACKWARDS as a lookback from the current state, not forwards looking, so this can be misleading if you do not understand that*. Each time the AutoGreylist class is updated due to the current superblock hash changing, the historical entries will be rebuilt from the current superblock backwards. This struct contains most of its member variables as std::optionals to accomodate the lack of information at a particular update.

##### const std::vector<UpdateHistoryEntry> GetUpdateHistory() const

This is a getter that returns a constant version of m_update_history.

##### Public member variables

```
        const std::string m_project_name;

        uint8_t m_zcd_20_SB_count;
        uint64_t m_TC_7_SB_sum;
        uint64_t m_TC_40_SB_sum;
        bool m_meets_greylisting_crit;

```

The m_project_name contains the project name, which is the key to the greylist map. The next three contain the undertying state with which to compute the ZCD and WAS but since they are public, they can be independently accessed. The m_meets_greylisting_crit stores the current greylist qualification state for the entry. If it is true, the project currently meets automatic greylisting criteria.

##### Private member variables

```
        std::optional<uint64_t> m_TC_initial_bookmark; //!< This is a "reverse" bookmark - we are going backwards in SB's.
        std::optional<uint64_t> m_TC_bookmark;
        uint8_t m_sb_from_baseline_processed;

        std::vector<UpdateHistoryEntry> m_update_history;

```

These store the bookmarks (which are for internal use only) and the m_update_history vector, which is accessed via GetUpdateHistory().

#### The Greylist map

```
    typedef std::map<std::string, GreylistCandidateEntry> Greylist;

    //!
    //! \brief Smart pointer around a collection of projects.
    //!
    typedef std::shared_ptr<Greylist> GreylistPtr;

```

The actual greylist entries are collected into a std::map keyed by project name. This in turn is wrapped by a shared_ptr.

#### AutoGreylist iterator overloads

Similar to other registry and registry like classes in Gridcoin, the AutoGreylist contains iterator overloads to allow accessing the AutoGreylist map using range loops and other iterator like uses.

#### void Refresh()

This refreshes the AutoGreylist object from the current superblock. The cached state is used if the superblock hash has not changed to reduce overhead.

#### void RefreshWithSuperblock(SuperblockPtr superblock_ptr_in, std::shared_ptr<std::map<int, std::pair<CBlockIndex*, SuperblockPtr>>> unit_test_blocks = nullptr)

This refreshes the AutoGreylist object from an input Superblock pointer. It contains a second parameter that provides an alternate way to input test superblocks for unit testing.

#### void AutoGreylist::RefreshWithSuperblock(Superblock& superblock)

This refreshes the AutoGreylist object from an input Superblock that is going to be associated with the current head of the chain (i.e. a stake). This mode is used in the scraper during the construction of the superblock contract as part of the call chain from the miner. The superblock object will be updated with the greylist status. This is critical distinction. The other two forms simply use the superblocks on the chain, while this form is freezing the state into the provided superblock object as well as doing the historical lookback.

#### void Reset()

Resets the AutoGreylist object. This is called from the Whitelist Reset().

#### Private members

```
    mutable CCriticalSection autogreylist_lock;

    GreylistPtr m_greylist_ptr;
    QuorumHash m_superblock_hash;
```

The autogreylist_lock is an internal critical section to ensure thread safety, since the AutoGreylist singleton can be accessed by multiple threads. The m_greylist_ptr is the shared smart pointer to the actual greylist map, and the m_superblock_hash stores the hash of the superblock used for the last AutoGreylist update and is used to detect a state change, otherwise the cached information is used.

### Changes to Whitelist (Project Registry) class

#### Change to WhitelistSnapshot Snapshot method

This method has been extended to take the Project Filter as an argument, defaulting to ACTIVE, and also the refresh_greylist boolean defautling to true, and the include_override boolean defaulting to true. This method implements the AUTO_GREYLISTED override of project status when the corresponding AutoGreylist greylist candidate entry meets greylisting criteria according to the rules.

#### const ProjectEntryMap GetProjectsFirstActive() const

This is a new method that provides a map of the first entry for each project in the registry. This is used by the AutoGreylist class to determine abbreviated lookbacks for projects that were whitelisted within the 40 superblock lookback window.

#### std::shared_ptr<AutoGreylist> GetAutoGreylist()

This is a new method that returns a shared smart pointer to the AutoGreylist object. This object is a singleton just like the Whitelist registry.

#### New private members

ProjectEntryMap m_project_first_actives stores the first (active) entry for each project keyed by project name, and is returned read-only by GetProjectsFirstActive(). This map is populated by the registry contract handlers and leveldb initialization method. The std::shared_ptr<AutoGreylist> m_auto_greylist is the smart shared pointer to the AutoGreylist object.

### Change to the WhitelistSnapshot class

The constructor of this class was changed to accept the project filter used as a parameter, which is stored for convenience in the WhitelistSnapshot object.

## Quorum changes

The QuorumHash ComputeQuorumHash() was extended (implicitly) to include the project all cpid total credit data as part of the superblock hash. The superblock version is validated to ensure that no superblocks less than v4 are accepted once the superblock v4 block height has been reached.

## GUI - ResearcherModel and ProjectTableModel changes

The researcher and project table models were extended to deal appropriately with auto greylisted status, following the order of precedence. In the project table displayed in the GUi, automatic greylisting status and manual greylisting status takes precedence over excluded, because if a project has those statuses, it has the same effect as exclusion, but is not a scraper directive.

## RPC changes

### UniValue SuperblockToJson(const GRC::Superblock& superblock)

This helper function that provides JSON superblock outputs to several different RPC functions has been modified to include the project greylist status and the project all CPID total credits.

### UniValue addkey(const UniValue& params, bool fHelp)

This administrative function has been extended to handle manual greylisting and the automatic greylisting override.

## Unit Tests

### superblock_tests.cpp

The superblock tests were modified to use version two in the superblock tests. A todo would be to change them for the new structures in v3 to fully test serialization and deserialization, but this has been covered in the isolated testnet live network test.

### project_tests.cpp

A unit test that uses the std::pair<CBlockIndex*, SuperblockPtr>>> unit_test_blocks parameter of the AutoGreylist::RefreshWithSuperblock method has been implemented with 47 superblocks of test data to test the operation of the greylisting rules. These superblocks exercise every real-world condition expected to be encountered that can be solved with automatic application of the implemented automatic greylisting rules, including no statistics on the first superblock after whitelisting, statistics "drop outs" with no data or no increase in total credit and/or both (i.e. a total credit number then no data then another total credit number that is the same), and a drastic drop in total credit change per superblock that results in WAS meeting greylisting criteria. More superblocks than the lookback limit was tested to ensure the lookback stopped at the appropriate place.

---

The original notes from the PR in the middle of development for historical purposes:

This PR is for tracking the progress of implementing automated greylisting.

Please see the following set of notes for design considerations that need to be discussed.

- Basic manual greylisting and scraper machinery for determining automatic greylisting complete
  - - Manual greylisting is an administrative contract type that rides normal transactions
      - Scrapers will now collect statistics on projects that have a greylisted status of either AUTO_GREYLISTED or MANUAL_GREYLISTED. Credits and average credits will be recorded in the project payloads, but the project magnitude will be zero, and they will not contribute to CPID magnitude
      - The Scraper code does not deal DIRECTLY with greylisting rules as this is an individual node responsibility
      - The convergence rules in terms of required number of projects use ACTIVE projects and do not include greylisted projects even though the stats are being collected for greylisted projects. This is because a project may be greylisted and available or literally not available at all, so convergences cannot be always expected at the project level for greylisted projects.
- TODO
  - Wire up automatic greylisting
    - These exist along superblock boundaries, like superblocks themselves (claims with a valid superblock contract) and beacon activation
    - Need to compute ZCD and WAS
    - ZCD rule is &lt;= 7 zero credit days out of 40, WAS rule is last 7 days average project credits / 40 days average project credits &gt;= 0.1
    - Since this needs to be on superblock boundaries, we can slightly change the rules for implementation to be in superblocks rather than days. Since almost all of the time superblocks are very close to one day, this is almost the same.
    - Implies an algorithm that operates over 40 days of superblock history
    - No stats for a whitelisted project in a superblock (i.e. because the project is hard down) needs to be counted in ZCD, with zero entry for WAS averaging, even though last project convergence may be from the 48 hour stats carryover. This may require a tweak to the scraper convergence code
    - Choice of
      - stateless methods that repeatedly iterate over 40 superblock history to apply rules
      - methods over a cache structure that stores a subset of information from up to 40 superblocks relevant to the rule computation
      - Advantage of stateless is simplicity
      - Disadvantage is that it is fairly expensive, as the superblock registry has to be iterated over and processed – this involves disk I/0.
      - Advantage of caching is speed
      - Disadvantage of caching is complexity
      - Once client is synced this is only called when the superblock is staked and processed by the client, ~1 per 24 hours.
      - During sync will be approx 1 per 960 blocks
    - Need to define order of precedence of manual greylist versus automatic. Status of manual greylist must always override automatic as the whole point to manual greylisting once this is put into place is to deal with corner case issues that are not handled by the ZCD and WAS rules.
      - Manual greylisting is granular to each block (i.e. an administrative contract of type project)
      - Automatic greylisting is granular to the superblock (valid staked superblock claim)
      - Walking this through…
        - Example 1

block → MAN_GREYLISTED

superblock → AUTO_GREYLISTED → status still MAN_GREYLISTED

superblock → removed from AUTO_GREYLISTED → status still MAN_GREYLISTED

block → removal from MAN_GREYLISTED → ACTIVE

- - - - - Example 2

block → MAN_GREYLISTED

superblock → AUTO_GREYLISTED → status still MAN_GREYLISTED

block → removed from MAN_GREYLISTED → AUTO_GREYLISTED

superblock → removed from AUTO_GREYLISTED → ACTIVE

- - - - I think this means we have to do the cache. The most convenient way to deal with this order of precedence is to store the underlying AUTO_GREYLIST status in the cache and have methods to utilize this information
                - Have status in cache of something like AUTO_GREYLIST_QUAL which means project has met the conditions for AUTO_GREYLIST by the rules, but was already MAN_GREYLISTED
                - This would be checked for each contract injection to change MAN_GREYLIST status, to decide whether new status is either AUTO_GREYLIST or ACTIVE
                - The AUTO_GREYLIST_QUAL is a flag on the project at the current (head) state
                - Maybe this really belongs in the in memory superblock structure? This does not need to be in the on-disk (chain) superblock structure at the cost of some computations.
            - There is an existing superblock cache (SuperblockIndex g_superblock_index) that currently stores the last three superblocks and could be expanded to 40 superblocks as an easy way to do the cache. This means more computation on top of the cache but much faster because it operates on in memory structures rather than reading from the superblock registry (disk I/O). It also means more memory usage.
            - Maybe best to modify the cache to be a hybrid and store more limited information for superblocks 4 – 40. But this makes the cache updating more complicated.
            - The memory usage of the additional superblocks is minimal compared to the current size of other data structures with the current active beacon count and chain length; however, when the benefactor contracts are implemented, this will no longer be true.
    - Create more detailed automated greylist reporting
      - - Simple listing status on project not sufficient, because users will want to know the details of why a project is greylisted (this is ZCD/WAS reporting)
          - Probably should be something that operates on the project grid in the GUI and allows “clicking” the project whitelisting status and then having a pop-up window that displays the details of ZCD/WAS.