### PR TITLE
scraper: Protect access to ConvergedStats.csv.gz with a lock

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -65,6 +65,10 @@ CCriticalSection cs_ScraperGlobals;
  */
 CCriticalSection cs_StructScraperFileManifest;
 /**
+ * @brief Protects access to the ConvergedStats.csv.gz compressed statistics map output file.
+ */
+CCriticalSection cs_ConvergedStats;
+/**
  * @brief Protects the global converged scraper stats cache, which is populated by periodic runs of the scraper and/or
  * subscriber loop, and is used to validate superblocks.
  */
@@ -3452,6 +3456,8 @@ bool StoreScraperFileManifest(const fs::path& file)
 
 bool StoreStats(const fs::path& file, const ScraperStats& mScraperStats)
 {
+    LOCK(cs_ConvergedStats);
+
     if (fs::exists(file))
         fs::remove(file);
 
@@ -6069,13 +6075,13 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
     {
         LOCK(cs_ConvergedScraperStatsCache);
 
-		if (!ConvergedScraperStatsCache.NewFormatSuperblock.WellFormed())
-		{
-		    UniValue error(UniValue::VOBJ);
-		    error.pushKV("Error:", "Wait until a convergence is formed.");
+        if (!ConvergedScraperStatsCache.NewFormatSuperblock.WellFormed())
+        {
+            UniValue error(UniValue::VOBJ);
+            error.pushKV("Error:", "Wait until a convergence is formed.");
 
-		    return error;
-		}
+            return error;
+        }
 
         _log(logattribute::INFO, "testnewsb",
              "Size of the PastConvergences map = " + ToString(ConvergedScraperStatsCache.PastConvergences.size()));

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -27,6 +27,7 @@
 extern CCriticalSection cs_Scraper;
 extern CCriticalSection cs_ScraperGlobals;
 extern CCriticalSection cs_StructScraperFileManifest;
+extern CCriticalSection cs_ConvergedStats;
 extern CCriticalSection cs_ConvergedScraperStatsCache;
 extern CCriticalSection cs_TeamIDMap;
 extern CCriticalSection cs_VerifiedBeacons;


### PR DESCRIPTION
StoreStats in the scraper, which rewrites ConvergedStats.csv.gz, can be called from at least two different threads. The file access should be protected by a lock.