### PR TITLE
polls, voting, staking: Enhance voting consensus rules to allow for changeable magnitude weight factor and enhance CBR

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -77,6 +77,7 @@ public:
         consensus.MRCZeroPaymentInterval = 14 * 24 * 60 * 60;
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
         consensus.DefaultMagnitudeUnit = Fraction(1, 4);
+        consensus.MaxMagnitudeUnit = Fraction(5, 1);
         consensus.DefaultMagnitudeWeightFactor = Fraction(100, 567);
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -192,6 +193,7 @@ public:
         consensus.MRCZeroPaymentInterval = 10 * 60;
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
         consensus.DefaultMagnitudeUnit = Fraction(1, 4);
+        consensus.MaxMagnitudeUnit = Fraction(5, 1);
         consensus.DefaultMagnitudeWeightFactor = Fraction(100, 567);
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -70,17 +70,15 @@ public:
         consensus.BlockV13Height = std::numeric_limits<int>::max();
         consensus.PollV3Height = 2671700;
         consensus.ProjectV2Height = 2671700;
-        // Immediately post zero payment interval fees 40% for mainnet
+        consensus.DefaultConstantBlockReward = 10 * COIN;
+        consensus.ConstantBlockRewardFloor = 0;
+        consensus.ConstantBlockRewardCeiling = 200 * COIN;
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
-        // Zero day interval is 14 days on mainnet
         consensus.MRCZeroPaymentInterval = 14 * 24 * 60 * 60;
-        // The maximum ratio of rewards that can be allocated to all of the mandatory sidestakes.
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
-        // The "standard" contract replay lookback for those contract types
-        // that do not have a registry db.
+        consensus.DefaultMagnitudeUnit = Fraction(1, 4);
+        consensus.DefaultMagnitudeWeightFactor = Fraction(100, 567);
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
-        // "standard" scrypt target limit for proof of work, results in 0,000244140625 proof-of-work difficulty.
-        // Equivalent to ~arith_uint256() >> 20 or 1e0fffff in compact notation.
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -187,16 +185,15 @@ public:
         consensus.BlockV13Height = std::numeric_limits<int>::max();
         consensus.PollV3Height = 1944820;
         consensus.ProjectV2Height = 1944820;
-        // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
+        consensus.DefaultConstantBlockReward = 10 * COIN;
+        consensus.ConstantBlockRewardFloor = 0;
+        consensus.ConstantBlockRewardCeiling = 100 * COIN;
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
-        // Zero day interval is 10 minutes on testnet. The very short interval facilitates testing.
         consensus.MRCZeroPaymentInterval = 10 * 60;
-        // The maximum ratio of rewards that can be allocated to all of the mandatory sidestakes.
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
-        // The "standard" contract replay lookback for those contract types
-        // that do not have a registry db.
+        consensus.DefaultMagnitudeUnit = Fraction(1, 4);
+        consensus.DefaultMagnitudeWeightFactor = Fraction(100, 567);
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
-        // Equivalent to ~arith_uint256() >> 16 or 1f00ffff in compact notation.
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         pchMessageStart[0] = 0xcd;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,7 +72,7 @@ public:
         consensus.ProjectV2Height = 2671700;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
-        consensus.ConstantBlockRewardCeiling = 200 * COIN;
+        consensus.ConstantBlockRewardCeiling = 500 * COIN;
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         consensus.MRCZeroPaymentInterval = 14 * 24 * 60 * 60;
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
@@ -188,7 +188,7 @@ public:
         consensus.ProjectV2Height = 1944820;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
-        consensus.ConstantBlockRewardCeiling = 100 * COIN;
+        consensus.ConstantBlockRewardCeiling = 500 * COIN;
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         consensus.MRCZeroPaymentInterval = 10 * 60;
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -78,7 +78,9 @@ public:
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
         consensus.DefaultMagnitudeUnit = Fraction(1, 4);
         consensus.MaxMagnitudeUnit = Fraction(5, 1);
+        consensus.MinMagnitudeWeightFactor = Fraction(1, 10);
         consensus.DefaultMagnitudeWeightFactor = Fraction(100, 567);
+        consensus.MaxMagnitudeWeightFactor = Fraction(1);
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         /**
@@ -194,7 +196,9 @@ public:
         consensus.MaxMandatorySideStakeTotalAlloc = Fraction(1, 4);
         consensus.DefaultMagnitudeUnit = Fraction(1, 4);
         consensus.MaxMagnitudeUnit = Fraction(5, 1);
+        consensus.MinMagnitudeWeightFactor = Fraction(1, 10);
         consensus.DefaultMagnitudeWeightFactor = Fraction(100, 567);
+        consensus.MaxMagnitudeWeightFactor = Fraction(1);
         consensus.StandardContractReplayLookback = 180 * 24 * 60 * 60;
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -41,6 +41,9 @@ struct Params {
     int ProjectV2Height;
     /**
       * @brief The default GRC paid for a constant block reward.
+      *
+      * Note that the GRC paid for CBR can be specified by an administrative protocol entry with the key name "blockreward1" for
+      * V13+ blocks. The value is specified in HALFORDS.
       */
     int64_t DefaultConstantBlockReward;
     /**
@@ -67,11 +70,21 @@ struct Params {
     Fraction MaxMandatorySideStakeTotalAlloc;
     /**
       * @brief The multiplier applied to network magnitude to determine the rate of accrual. Nominally 1/4 from Fern onwards.
+      *
+      * Note that the magnitude unit can be set by an administrative protocol entry with the key name "magnitudeunit" for
+      * V13+ blocks. The value is specified as a whole number or fraction. For example, 0.25 would be "1/4", 5 would be "5".
       */
     Fraction DefaultMagnitudeUnit;
     /**
+      * @brief The maximum magnitude unit allowed to be specified. This is an upper clamp that is set at 5.
+      */
+    Fraction MaxMagnitudeUnit;
+    /**
       * @brief The multiplier applied to (money supply / network magnitude) to scale the network magnitude into equivalent GRC
       * for purposes of computing voting weight. Nominally 1 / 5.67 from Fern onwards.
+      *
+      * The magnitude weight factor can be set by an administrative protocol entry with the key name "magnitudeweightfactor" for
+     * V13+ blocks. The value is specified as a whole number or fraction. For example, 1 / 5.67 would be "100/567", 2 would be "2".
       */
     Fraction DefaultMagnitudeWeightFactor;
     /** The "standard" contract replay lookback for those contract types that do not have a registry db.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -39,8 +39,22 @@ struct Params {
     int PollV3Height;
     /** Block height at which project v2 contracts are allowed */
     int ProjectV2Height;
+    /**
+      * @brief The default GRC paid for a constant block reward.
+      */
+    int64_t DefaultConstantBlockReward;
+    /**
+      * @brief The minimum GRC that can be set by administrative contract for a constant block reward (clamp floor). This is valid
+      * for block v13+. Note that this is typed as int64_t rather than CAmount to avoid the extra include.
+      */
+    int64_t ConstantBlockRewardFloor;
+    /**
+      * @brief The maximum GRC that can be set by administrative contract for a constant block reward (clamp ceiling). This is valid
+      * for block v13+. Note that this is typed as int64_t rather than CAmount to avoid the extra include.
+      */
+    int64_t ConstantBlockRewardCeiling;
     /** The fraction of rewards taken as fees in an MRC after the zero payment interval. Only consesnus critical
-      * at BlockV12Height or above.
+      * at BlockV12Height or above. Note that this is typed as int64_t rather than CAmount to avoid the extra include.
       */
     Fraction InitialMRCFeeFractionPostZeroInterval;
     /** The amount of time from the last reward payment to a researcher where submitting an MRC will resort in 100%
@@ -51,9 +65,22 @@ struct Params {
      * @brief The maximum allocation (as a Fraction) that can be used by all of the mandatory sidestakes
      */
     Fraction MaxMandatorySideStakeTotalAlloc;
-
+    /**
+      * @brief The multiplier applied to network magnitude to determine the rate of accrual. Nominally 1/4 from Fern onwards.
+      */
+    Fraction DefaultMagnitudeUnit;
+    /**
+      * @brief The multiplier applied to (money supply / network magnitude) to scale the network magnitude into equivalent GRC
+      * for purposes of computing voting weight. Nominally 1 / 5.67 from Fern onwards.
+      */
+    Fraction DefaultMagnitudeWeightFactor;
+    /** The "standard" contract replay lookback for those contract types that do not have a registry db.
+      */
     int64_t StandardContractReplayLookback;
-
+    /**
+      * "standard" scrypt target limit for proof of work, results in 0,000244140625 proof-of-work difficulty.
+      * Equivalent to ~arith_uint256() >> 20 or 1e0fffff in compact notation.
+      */
     uint256 powLimit;
 };
 } // namespace Consensus

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -80,6 +80,10 @@ struct Params {
       */
     Fraction MaxMagnitudeUnit;
     /**
+     * @brief This is the minimum allowed magnitude weight factor as a fraction. Applicable for block v13+
+     */
+    Fraction MinMagnitudeWeightFactor;
+    /**
       * @brief The multiplier applied to (money supply / network magnitude) to scale the network magnitude into equivalent GRC
       * for purposes of computing voting weight. Nominally 1 / 5.67 from Fern onwards.
       *
@@ -87,6 +91,10 @@ struct Params {
      * V13+ blocks. The value is specified as a whole number or fraction. For example, 1 / 5.67 would be "100/567", 2 would be "2".
       */
     Fraction DefaultMagnitudeWeightFactor;
+    /**
+     * @brief This is the maximum allowed magnitude weight factor as a fraction. Applicable for block v13+.
+     */
+    Fraction MaxMagnitudeWeightFactor;
     /** The "standard" contract replay lookback for those contract types that do not have a registry db.
       */
     int64_t StandardContractReplayLookback;

--- a/src/gridcoin/protocol.cpp
+++ b/src/gridcoin/protocol.cpp
@@ -318,7 +318,7 @@ ProtocolEntryOption ProtocolRegistry::TryLastBeforeTimestamp(const std::string& 
 
     // Walk the revision history chain for the protocol entries with the provided key to find an active historical entry
     // with a timestamp that is equal to or less than the provided timestamp, if it exists.
-     HistoricalProtocolEntryMap::iterator hist_protocol_entry_iter = m_protocol_db.find(iter->second->m_previous_hash);
+    HistoricalProtocolEntryMap::iterator hist_protocol_entry_iter = m_protocol_db.find(iter->second->m_previous_hash);
 
     while (hist_protocol_entry_iter != m_protocol_db.end()
            && !hist_protocol_entry_iter->second->m_previous_hash.IsNull()
@@ -327,7 +327,12 @@ ProtocolEntryOption ProtocolRegistry::TryLastBeforeTimestamp(const std::string& 
         hist_protocol_entry_iter = m_protocol_db.find(hist_protocol_entry_iter->second->m_previous_hash);
     }
 
-    return hist_protocol_entry_iter->second;
+    // Check whether the final hist_protocol_entry_iter timestamp is before or equal to the timestamp.
+    if (hist_protocol_entry_iter->second->m_timestamp <= timestamp) {
+        return hist_protocol_entry_iter->second;
+    } else { // Last identified protocol entry in chainlet still has a timestamp greater than the input parameter so return nullptr
+        return nullptr;
+    }
 }
 
 void ProtocolRegistry::Reset()

--- a/src/gridcoin/protocol.h
+++ b/src/gridcoin/protocol.h
@@ -461,6 +461,17 @@ public:
     ProtocolEntryOption TryActive(const std::string& key) const;
 
     //!
+    //! \brief Get the last protocol entry for the specified key string at or before the specified timestamp
+    //!
+    //! \param key The key string of the protocol entry.
+    //! \param timestamp The desired timestamp to limit the find.
+    //!
+    //! \return An object that either contains a reference to some protocol entry if it exists
+    //! for the key at or before the provided timestamp or does not.
+    //!
+    ProtocolEntryOption TryLastBeforeTimestamp(const std::string& key, const int64_t& timestamp);
+
+    //!
     //! \brief Destroy the contract handler state in case of an error in loading
     //! the protocol entry registry state from LevelDB to prepare for reload from contract
     //! replay. This is not used for protocol entries, unless -clearprotocolentryhistory is specified

--- a/src/gridcoin/staking/difficulty.h
+++ b/src/gridcoin/staking/difficulty.h
@@ -6,6 +6,7 @@
 #ifndef GRIDCOIN_STAKING_DIFFICULTY_H
 #define GRIDCOIN_STAKING_DIFFICULTY_H
 
+#include <cstdint>
 class CBlockIndex;
 class CWallet;
 #include <cmath>
@@ -26,6 +27,40 @@ double GetSmoothedDifficulty(int64_t nStakeableBalance);
 
 uint64_t GetStakeWeight(const CWallet& wallet);
 double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40);
+
+//!
+//! \brief This returns the precise average network weight in units of Halfords as a 64 bit unsigned integer. This form takes
+//! two arguments: the number of blocks to lookback and include in the average, and the ending point CBlockIndex pointer. Note
+//! if the index pointer is not specified the lookback start is the current (best) block.
+//!
+//! Please refer to https://gridcoin.us/assets/docs/grc-bluepaper-section-1.pdf equations 1 and 16 and footnote 5.
+//! This method of computing net_weight is from first principles using the target from the nBits representation
+//! recorded in the index, rather than the GetEstimatedNetworkWeight() function, which uses double fp arithmetic.
+//!
+//! \param block_interval The number of blocks looking back from the index_start to include in the average.
+//! \param index_start The CBlockIndex pointer to the starting index with which to take the average.
+//!
+//! \return uint64_t of the average network weight in Halford units.
+//!
+uint64_t GetAvgNetworkWeight(const unsigned int& block_interval, CBlockIndex* index_start = nullptr);
+
+//!
+//! \brief This returns the precise average network weight in units of Halfords as a 64 bit unsigned integer. The starting index
+//! and the ending index are defaulted to nullptr if not provided. If neither is provided, the network weight for the current (best)
+//! block will be returned. If only the starting index pointer is provided, the network weight of that block will be returned.
+//! If both are provided, the network weight average will be returned over the interval of blocks inclusive of both start and end.
+//! Both indexes, if specified, must be in the main chain.
+//!
+//! Please refer to https://gridcoin.us/assets/docs/grc-bluepaper-section-1.pdf equations 1 and 16 and footnote 5.
+//! This method of computing net_weight is from first principles using the target from the nBits representation
+//! recorded in the index, rather than the GetEstimatedNetworkWeight() function, which uses double fp arithmetic.
+//!
+//! \param index_start The CBlockIndex pointer to the starting index with which to take the average. Note that this is inclusive.
+//! \param index_end The BClockIndex pointer to the ending index with which to take the average. Note that this is inclusive.
+//!
+//! \return uint64_t of the average network weight in Halford units.
+//!
+uint64_t GetAvgNetworkWeight(CBlockIndex* index_start = nullptr, CBlockIndex* index_end = nullptr);
 double GetEstimatedTimetoStake(bool ignore_staking_status = false, double dDiff = 0.0, double dConfidence = DEFAULT_ETTS_CONFIDENCE);
 } // namespace GRC
 

--- a/src/gridcoin/support/block_finder.cpp
+++ b/src/gridcoin/support/block_finder.cpp
@@ -57,16 +57,38 @@ CBlockIndex* BlockFinder::FindByMinTime(int64_t time)
 }
 
 // The arguments are passed by value on purpose.
-CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* index)
+CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in)
 {
+    CBlockIndex* index = index_in;
+
     // If no starting index is provided (i.e. second parameter is omitted or nullptr is passed in,
     // then start at the Genesis Block. This is in general expensive and should be avoided.
-    if (!index) {
+    if (index == nullptr) {
         index = pindexGenesisBlock;
     }
 
     while (index && index->pnext && index->nTime < time) {
         index = index->pnext;
+    }
+
+    return index;
+}
+
+CBlockIndex* BlockFinder::FindLatestSuperblock(CBlockIndex* const index_in)
+{
+    CBlockIndex* index = index_in;
+
+    // If no input index is provided, start at the head of the chain.
+    if (index == nullptr) {
+        index = pindexBest;
+    }
+
+    while (index && index->pprev) {
+        if (index->IsSuperblock()) {
+            break;
+        }
+
+        index = index->pprev;
     }
 
     return index;

--- a/src/gridcoin/support/block_finder.h
+++ b/src/gridcoin/support/block_finder.h
@@ -48,7 +48,14 @@ public:
     //! \return CBlockIndex pointing to the youngest block which is not older than \p time, or
     //! the head of the chain if it is older than \p time.
     //!
-    static CBlockIndex* FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* index = nullptr);
+    static CBlockIndex* FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in = nullptr);
+
+    //!
+    //! \brief Find the last superblock at or before the provided index.
+    //! \param CBlockIndex from where to start.
+    //! \return CBlockIndex pointing to the block containing the last superblock contract.
+    //!
+    static CBlockIndex* FindLatestSuperblock(CBlockIndex * const index_in = nullptr);
 };
 } // namespace GRC
 

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -99,7 +99,7 @@ public:
     //!
     //! \return Current magnitude unit adjusted for the specified block.
     //!
-    static double GetMagnitudeUnit(const CBlockIndex* const pindex);
+    static double GetMagnitudeUnit(CBlockIndex * const pindex);
 
     //!
     //! \brief Get a traversable object for the research accounts stored in

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -217,6 +217,10 @@ int64_t Poll::Expiration() const
 
 Fraction Poll::ResolveMagnitudeWeightFactor(CBlockIndex *index) const
 {
+    if (index == nullptr) {
+        return Fraction();
+    }
+
     Fraction magnitude_weight_factor = Params().GetConsensus().DefaultMagnitudeWeightFactor;
 
     // Before V13 magnitude weight factor is 1 / 5.67.

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -237,6 +237,11 @@ Fraction Poll::ResolveMagnitudeWeightFactor(CBlockIndex *index) const
         magnitude_weight_factor = Fraction().FromString(protocol_entry->m_value);
     }
 
+    // Clamp to allowed MagnitudeWeightFactor interval.
+    magnitude_weight_factor = std::clamp<Fraction>(magnitude_weight_factor,
+                                                   Params().GetConsensus().MinMagnitudeWeightFactor,
+                                                   Params().GetConsensus().MaxMagnitudeWeightFactor);
+
     return magnitude_weight_factor;
 }
 

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -512,9 +512,11 @@ public:
     //! \brief Fetch the applicable magnitude factor for the poll. This is the magnitude factor of the last entry in the
     //! protocol registry database that has a timestamp at or before the poll start timestamp.
     //!
+    //! \param index CBlockIndex of block containing poll transaction (poll start).
+    //!
     //! \return Fraction Magnitude factor expressed as a Fraction.
     //!
-    Fraction ResolveMagnitudeWeightFactor() const;
+    Fraction ResolveMagnitudeWeightFactor(CBlockIndex* index) const;
 
     //!
     //! \brief Get the set of possible answers to the poll.

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -9,6 +9,7 @@
 #include "gridcoin/voting/fwd.h"
 #include "serialize.h"
 #include "uint256.h"
+#include "util.h"
 
 #include <string>
 #include <vector>
@@ -398,7 +399,8 @@ public:
     AdditionalFieldList m_additional_fields; //!< The set of additional fields for the poll.
 
     // Memory only:
-    int64_t m_timestamp;          //!< Time of the poll's containing transaction.
+    int64_t m_timestamp;                     //!< Time of the poll's containing transaction.
+    Fraction m_magnitude_weight_factor;      //!< Magnitude weight factor for the poll (defined at poll start).
 
     //!
     //! \brief Initialize an empty, invalid poll instance.
@@ -408,26 +410,27 @@ public:
     //!
     //! \brief Initialize a poll instance with data from a contract.
     //!
-    //! \param type          Type of the poll.
-    //! \param weight_type   Method used to weigh votes.
-    //! \param response_type Method for choosing poll answers.
-    //! \param duration_days Number of days the poll remains active.
-    //! \param title         UTF-8 title of the poll.
-    //! \param url           UTF-8 URL of the poll discussion webpage.
-    //! \param question      UTF-8 prompt that voters shall answer.
-    //! \param choices       The set of possible answers to the poll.
-    //! \param timestamp     Timestamp of the poll's containing transaction.
+    //! \param type                    Type of the poll.
+    //! \param weight_type             Method used to weigh votes.
+    //! \param response_type           Method for choosing poll answers.
+    //! \param duration_days           Number of days the poll remains active.
+    //! \param title                   UTF-8 title of the poll.
+    //! \param url                     UTF-8 URL of the poll discussion webpage.
+    //! \param question                UTF-8 prompt that voters shall answer.
+    //! \param choices                 The set of possible answers to the poll.
+    //! \param timestamp               Timestamp of the poll's containing transaction.
+    //! \param magnitude_weight_factor The magnitude weight factor for the poll, valid at poll start.
     //!
-    Poll(
-        PollType type,
-        PollWeightType weight_type,
-        PollResponseType response_type,
-        uint32_t duration_days,
-        std::string title,
-        std::string url,
-        std::string question,
-        ChoiceList choices,
-        int64_t timestamp);
+    Poll(PollType type,
+         PollWeightType weight_type,
+         PollResponseType response_type,
+         uint32_t duration_days,
+         std::string title,
+         std::string url,
+         std::string question,
+         ChoiceList choices,
+         int64_t timestamp,
+         Fraction magnitude_weight_factor);
 
     //!
     //! \brief Initialize a poll instance from a contract that contains poll
@@ -504,6 +507,14 @@ public:
     //! \return Expiration time as the number of seconds since the UNIX epoch.
     //!
     int64_t Expiration() const;
+
+    //!
+    //! \brief Fetch the applicable magnitude factor for the poll. This is the magnitude factor of the last entry in the
+    //! protocol registry database that has a timestamp at or before the poll start timestamp.
+    //!
+    //! \return Fraction Magnitude factor expressed as a Fraction.
+    //!
+    Fraction ResolveMagnitudeWeightFactor() const;
 
     //!
     //! \brief Get the set of possible answers to the poll.

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -657,13 +657,7 @@ std::optional<CAmount> PollReference::GetActiveVoteWeight(const PollResultOption
             }
         }
 
-        // Please refer to https://gridcoin.us/assets/docs/grc-bluepaper-section-1.pdf equations 1 and 16 and footnote 5.
-        // This method of computing net_weight is from first principles using the target from the nBits representation
-        // recorded in the index, rather than the GetEstimatedNetworkWeight() function, which uses double fp arithmetic.
-        arith_uint256 target;
-        target.SetCompact(pindex->nBits);
-
-        arith_uint256 net_weight = ~arith_uint256() / arith_uint256(450) / target * arith_uint256(COIN);
+        arith_uint256 net_weight = GetAvgNetworkWeight(pindex);
 
         arith_uint256 money_supply = pindex->nMoneySupply;
 

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -353,7 +353,7 @@ PollOption PollReference::TryReadFromDisk(CTxDB& txdb) const
 
             // This is a critical initialization, because the magnitude weight factor is only stored
             // in memory and is not serialized.
-            payload.m_poll.m_magnitude_weight_factor = payload.m_poll.ResolveMagnitudeWeightFactor();
+            payload.m_poll.m_magnitude_weight_factor = payload.m_poll.ResolveMagnitudeWeightFactor(GetStartingBlockIndexPtr());
             m_magnitude_weight_factor = payload.m_poll.m_magnitude_weight_factor;
 
             LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: reference.m_timestamp = %" PRId64 " , poll.m_timestamp = %" PRId64 " , "
@@ -1033,12 +1033,13 @@ void PollRegistry::AddPoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(
         poll_ref.m_type = payload->m_poll.m_type.Value();
         poll_ref.m_timestamp = ctx.m_tx.nTime;
         poll_ref.m_duration_days = payload->m_poll.m_duration_days;
-        poll_ref.m_magnitude_weight_factor = payload->m_poll.ResolveMagnitudeWeightFactor();
 
         m_latest_poll = &poll_ref;
 
         auto result_pair = m_polls_by_txid.emplace(ctx.m_tx.GetHash(), &poll_ref);
         poll_ref.m_txid = result_pair.first->first;
+
+        poll_ref.m_magnitude_weight_factor = payload->m_poll.ResolveMagnitudeWeightFactor(poll_ref.GetStartingBlockIndexPtr());
 
         if (fQtActive && !poll_ref.Expired(GetAdjustedTime())) {
             uiInterface.NewPollReceived(poll_ref.Time());

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -568,6 +568,11 @@ std::optional<CAmount> PollReference::GetActiveVoteWeight(const PollResultOption
             const arith_uint256 scaled_pool_magnitude,
             const arith_uint256 scaled_network_magnitude)
     {
+        // Unlike the complementary calculation in EnableMagnitudeWeight for vote weights, this calculation is not
+        // subject to overflow because it uses 256 bit integers. In the end it the RESULT is cast to a 64 bit integer, but
+        // by then all of the multiplication and division are done. m_magnitude_weight_factor as a fraction something that is
+        // not expected to stray any farther than the interval [1/10, 1/1], where the current default value of 100 / 567 is
+        // in that interval. So we should never have an overflow problem here.
         active_vote_weight_tally += net_weight + money_supply * (scaled_network_magnitude - scaled_pool_magnitude)
                                                               * arith_uint256(m_magnitude_weight_factor.GetNumerator())
                                                               / arith_uint256(m_magnitude_weight_factor.GetDenominator())

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -10,6 +10,7 @@
 #include "gridcoin/voting/fwd.h"
 #include "sync.h"
 #include "uint256.h"
+#include "util.h"
 #include <atomic>
 #include <map>
 
@@ -175,14 +176,15 @@ public:
     void UnlinkVote(const uint256 txid);
 
 private:
-    uint256 m_txid;               //!< Hash of the poll transaction.
-    uint32_t m_payload_version;   //!< Version of the poll (payload).
-    PollType m_type;              //!< Type of the poll.
-    const std::string* m_ptitle;  //!< Title of the poll for indexing/mapping purposes.
-    std::string m_title;          //!< Original title of the poll for display purposes.
-    int64_t m_timestamp;          //!< Timestamp of the poll transaction.
-    uint32_t m_duration_days;     //!< Number of days the poll remains active.
-    std::vector<uint256> m_votes; //!< Hashes of the linked vote transactions.
+    uint256 m_txid;                     //!< Hash of the poll transaction.
+    uint32_t m_payload_version;         //!< Version of the poll (payload).
+    PollType m_type;                    //!< Type of the poll.
+    const std::string* m_ptitle;        //!< Title of the poll for indexing/mapping purposes.
+    std::string m_title;                //!< Original title of the poll for display purposes.
+    int64_t m_timestamp;                //!< Timestamp of the poll transaction.
+    uint32_t m_duration_days;           //!< Number of days the poll remains active.
+    std::vector<uint256> m_votes;       //!< Hashes of the linked vote transactions.
+    Fraction m_magnitude_weight_factor; //!< Magnitude weight factor for the poll (defined at poll start).
 }; // PollReference
 
 //!

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -186,6 +186,7 @@ private:
     uint256 m_txid;                             //!< Hash of the poll transaction.
     uint32_t m_payload_version;                 //!< Version of the poll (payload).
     PollType m_type;                            //!< Type of the poll.
+    mutable PollWeightType m_weight_type;       //!< Weight type of the poll.
     const std::string* m_ptitle;                //!< Title of the poll for indexing/mapping purposes.
     std::string m_title;                        //!< Original title of the poll for display purposes.
     mutable int64_t m_timestamp;                //!< Timestamp of the poll transaction.

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -154,6 +154,13 @@ public:
     std::optional<int> GetEndingHeight() const;
 
     //!
+    //! \brief Get the magnitude weight factor at the poll start.
+    //!
+    //! \return Fraction representing magnitude weight factor.
+    //!
+    Fraction GetMagnitudeWeightFactor() const;
+
+    //!
     //! \brief Computes the Active Vote Weight for the poll, which is used to determine whether the poll is validated.
     //! \param result: The actual tabulated votes (poll result)
     //! \return ActiveVoteWeight
@@ -176,15 +183,15 @@ public:
     void UnlinkVote(const uint256 txid);
 
 private:
-    uint256 m_txid;                     //!< Hash of the poll transaction.
-    uint32_t m_payload_version;         //!< Version of the poll (payload).
-    PollType m_type;                    //!< Type of the poll.
-    const std::string* m_ptitle;        //!< Title of the poll for indexing/mapping purposes.
-    std::string m_title;                //!< Original title of the poll for display purposes.
-    int64_t m_timestamp;                //!< Timestamp of the poll transaction.
-    uint32_t m_duration_days;           //!< Number of days the poll remains active.
-    std::vector<uint256> m_votes;       //!< Hashes of the linked vote transactions.
-    Fraction m_magnitude_weight_factor; //!< Magnitude weight factor for the poll (defined at poll start).
+    uint256 m_txid;                             //!< Hash of the poll transaction.
+    uint32_t m_payload_version;                 //!< Version of the poll (payload).
+    PollType m_type;                            //!< Type of the poll.
+    const std::string* m_ptitle;                //!< Title of the poll for indexing/mapping purposes.
+    std::string m_title;                        //!< Original title of the poll for display purposes.
+    mutable int64_t m_timestamp;                //!< Timestamp of the poll transaction.
+    uint32_t m_duration_days;                   //!< Number of days the poll remains active.
+    std::vector<uint256> m_votes;               //!< Hashes of the linked vote transactions.
+    mutable Fraction m_magnitude_weight_factor; //!< Magnitude weight factor for the poll (defined at poll start).
 }; // PollReference
 
 //!

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -1198,6 +1198,11 @@ PollResultOption PollResult::BuildFor(const PollReference& poll_ref)
 
         counter.CountVotes(result, poll_ref.Votes());
 
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: poll_ref.Time() = %" PRId64 " poll.GetMagnitudeWeightFactor() = %s",
+                 __func__,
+                 poll_ref.Time(),
+                 poll_ref.GetMagnitudeWeightFactor().ToString());
+
         if (auto active_vote_weight = poll_ref.GetActiveVoteWeight(result)) {
             result.m_active_vote_weight = active_vote_weight;
 

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -797,6 +797,19 @@ public:
         }
 
         // Use integer arithmetic to avoid floating-point discrepancies:
+
+        // Overflow analysis:
+        //
+        // Current supply as of block 3404576 = 493424753.
+        // network magnitude = 115000
+        // max value for uint64_t = 2^64 - 1
+        //
+        // 2^64 - 1 >= (493424753 / 115000) * mwf numerator
+        //
+        // This means mwf numerator <= (2^64 - 1) * (115000 / 493424753)
+        //                         ~<= 4.3E15
+        // Even if money supply is approximately doubled we can safely handle 2E15, which means 15 decimal
+        // places in the fraction numerator
         m_magnitude_factor = supply / total_mag
                              * (uint64_t) m_poll.m_magnitude_weight_factor.GetNumerator()
                              / (uint64_t) m_poll.m_magnitude_weight_factor.GetDenominator();

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "gridcoin/protocol.h"
 #include "main.h"
 #include "gridcoin/beacon.h"
 #include "gridcoin/quorum.h"
@@ -787,7 +788,7 @@ public:
     //! \param supply     The total network money supply as of the latest
     //! block in the poll window in units of 1/100000000 GRC.
     //!
-    void EnableMagnitudeWeight(SuperblockPtr superblock, const uint64_t supply)
+    void EnableMagnitudeWeight(SuperblockPtr superblock, const uint64_t supply, const Fraction magnitude_weight_factor)
     {
         const uint64_t total_mag = superblock->m_cpids.TotalMagnitude();
 
@@ -796,7 +797,9 @@ public:
         }
 
         // Use integer arithmetic to avoid floating-point discrepancies:
-        m_magnitude_factor = supply / total_mag * 100 / 567;
+        m_magnitude_factor = supply / total_mag
+                             * (uint64_t) magnitude_weight_factor.GetNumerator()
+                             / (uint64_t) magnitude_weight_factor.GetDenominator();
         m_resolver.SetSuperblock(std::move(superblock));
     }
 
@@ -1133,6 +1136,30 @@ CAmount ResolveMoneySupplyForPoll(const Poll& poll)
 
     return pindex->nMoneySupply;
 }
+
+//!
+//! \brief Fetch the applicable magnitude factor for the poll. This is the magnitude factor of the last entry in the
+//! protocol registry database that has a timestamp at or before the poll start timestamp.
+//!
+//! \param poll Poll for which to fetch the Magnitude Weight Factor.
+//! \return Fraction Magnitude factor expressed as a Fraction.
+//!
+Fraction ResolveMagnitudeWeightFactorForPoll(const Poll& poll)
+{
+    Fraction magnitude_weight_factor = Params().GetConsensus().DefaultMagnitudeWeightFactor;
+
+    // Find the current protocol entry value for Magnitude Weight Factor, if it exists.
+    ProtocolEntryOption protocol_entry = GetProtocolRegistry().TryLastBeforeTimestamp("magnitudeweightfactor", poll.m_timestamp);
+
+    // If their is an entry prior or equal in timestemp to the start of the poll and it is active then set the magnitude weight
+    // factor to that value. If the last entry is not active (i.e. deleted), then leave at the default.
+    if (protocol_entry != nullptr && protocol_entry->m_status == ProtocolEntryStatus::ACTIVE) {
+        magnitude_weight_factor = Fraction().FromString(protocol_entry->m_value);
+    }
+
+    return magnitude_weight_factor;
+}
+
 } // Anonymous namespace
 
 // -----------------------------------------------------------------------------
@@ -1186,7 +1213,8 @@ PollResultOption PollResult::BuildFor(const PollReference& poll_ref)
         if (result.m_poll.IncludesMagnitudeWeight()) {
             counter.EnableMagnitudeWeight(
                 ResolveSuperblockForPoll(result.m_poll),
-                ResolveMoneySupplyForPoll(result.m_poll));
+                ResolveMoneySupplyForPoll(result.m_poll),
+                ResolveMagnitudeWeightFactorForPoll(result.m_poll));
         }
 
         LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: number of votes = %u for poll %s",

--- a/src/main.h
+++ b/src/main.h
@@ -47,8 +47,6 @@ class MRC;
 typedef std::optional<Claim> ClaimOption;
 }
 
-static const int64_t DEFAULT_CBR = 10 * COIN;
-
 /** Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp. */
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -878,7 +878,7 @@
                    </size>
                   </property>
                   <property name="toolTip">
-                   <string>You are approaching the accrual limit of 16384 GRC. If you have a relatively low balance, you should request payment via MRC so that you do not lose earned rewards.</string>
+                   <string>You are approaching the accrual limit. If you have a relatively low balance, you should request payment via MRC so that you do not lose earned rewards.</string>
                   </property>
                   <property name="text">
                    <string/>

--- a/src/qt/voting/polltab.cpp
+++ b/src/qt/voting/polltab.cpp
@@ -25,14 +25,14 @@ QString RefreshMessage()
     return QCoreApplication::translate("PollTab", "Press \"Refresh\" to update the list.");
 }
 
-QString WaitMessage()
+QString PollWaitMessage()
 {
     return QCoreApplication::translate("PollTab", "This may take several minutes.");
 }
 
 QString FullRefreshMessage()
 {
-    return QStringLiteral("%1 %2").arg(RefreshMessage()).arg(WaitMessage());
+    return QStringLiteral("%1 %2").arg(RefreshMessage()).arg(PollWaitMessage());
 }
 } // Anonymous namespace
 
@@ -188,7 +188,7 @@ void PollTab::refresh()
 {
     if (m_polltable_model->empty()) {
         m_no_result->showDefaultLoadingTitle();
-        m_no_result->contentWidgetAs<QLabel>()->setText(WaitMessage());
+        m_no_result->contentWidgetAs<QLabel>()->setText(PollWaitMessage());
     }
 
     m_loading->start();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2432,14 +2432,32 @@ UniValue addkey(const UniValue& params, bool fHelp)
         break;
     }
     case GRC::ContractType::PROTOCOL:
-        // There will be no legacy payload contracts past version 2. This will need to be changed before the
-        // block v13 mandatory (which also means contract v3).
-        contract = GRC::MakeLegacyContract(
-                    type.Value(),
-                    action,
-                    params[2].get_str(),   // key
-                    params[3].get_str());  // value
+    {
+        if (block_v13_enabled) {
+            GRC::ProtocolEntryStatus status = GRC::ProtocolEntryStatus::UNKNOWN;
+
+            if (action == GRC::ContractAction::ADD) {
+                status = GRC::ProtocolEntryStatus::ACTIVE;
+            } else if (action == GRC::ContractAction::REMOVE) {
+                status = GRC::ProtocolEntryStatus::DELETED;
+            }
+
+            contract = GRC::MakeContract<GRC::ProtocolEntryPayload>(
+                        contract_version,
+                        action,
+                        uint32_t {2},         // Contract payload version number
+                        params[2].get_str(),  // key
+                        params[3].get_str(),  // value
+                        status);
+        } else {
+            contract = GRC::MakeLegacyContract(
+                type.Value(),
+                action,
+                params[2].get_str(),   // key
+                params[3].get_str());  // value
+        }
         break;
+    }
     case GRC::ContractType::SIDESTAKE:
     {
         if (block_v13_enabled) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -57,7 +57,7 @@ UniValue MRCToJson(const GRC::MRC& mrc) {
     return json;
 }
 
-UniValue ClaimToJson(const GRC::Claim& claim, const CBlockIndex* const pindex)
+UniValue ClaimToJson(const GRC::Claim& claim, CBlockIndex* pindex)
 {
     UniValue json(UniValue::VOBJ);
 
@@ -155,7 +155,7 @@ UniValue SuperblockToJson(const GRC::SuperblockPtr& superblock)
     return SuperblockToJson(*superblock);
 }
 
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPrintTransactionDetail)
+UniValue blockToJSON(const CBlock& block, CBlockIndex* blockindex, bool fPrintTransactionDetail)
 {
     UniValue result(UniValue::VOBJ);
 

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -18,53 +18,53 @@ extern bool fTestNet;
 extern leveldb::DB *txdb;
 
 namespace {
-   // Arbitrary random characters generated with Python UUID.
-   const std::string TEST_CPID("17c65330c0924259b2f93c31d25b03ac");
+// Arbitrary random characters generated with Python UUID.
+const std::string TEST_CPID("17c65330c0924259b2f93c31d25b03ac");
 
-   struct GridcoinTestsConfig
-   {
-      GridcoinTestsConfig()
-      {
-      }
+struct GridcoinTestsConfig
+{
+    GridcoinTestsConfig()
+    {
+    }
 
-      ~GridcoinTestsConfig()
-      {
-      }
-   };
+    ~GridcoinTestsConfig()
+    {
+    }
+};
 
-   void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, const std::string& value,
-                         const CBlockIndex index, const bool& reset_registry = false)
-   {
-       GRC::ProtocolRegistry& registry = GRC::GetProtocolRegistry();
+void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, const std::string& value,
+                      const CBlockIndex index, const bool& reset_registry = false)
+{
+    GRC::ProtocolRegistry& registry = GRC::GetProtocolRegistry();
 
-       // Make sure the registry is reset.
-       if (reset_registry) registry.Reset();
+           // Make sure the registry is reset.
+    if (reset_registry) registry.Reset();
 
-       CTransaction dummy_tx;
-       dummy_tx.nTime = index.nTime;
+    CTransaction dummy_tx;
+    dummy_tx.nTime = index.nTime;
 
-       GRC::Contract contract;
+    GRC::Contract contract;
 
-       if (payload_version < 2) {
-           contract = GRC::MakeContract<GRC::ProtocolEntryPayload>(
-                       uint32_t {2}, // Contract version (pre v13)
-                       GRC::ContractAction::ADD,
-                       key,
-                       value);
-       } else {
-           contract = GRC::MakeContract<GRC::ProtocolEntryPayload>(
-                       uint32_t {3}, // Contract version (post v13)
-                       GRC::ContractAction::ADD,
-                       payload_version, // Protocol payload version (post v13)
-                       key,
-                       value,
-                       GRC::ProtocolEntryStatus::ACTIVE);
-       }
+    if (payload_version < 2) {
+        contract = GRC::MakeContract<GRC::ProtocolEntryPayload>(
+            uint32_t {2}, // Contract version (pre v13)
+            GRC::ContractAction::ADD,
+            key,
+            value);
+    } else {
+        contract = GRC::MakeContract<GRC::ProtocolEntryPayload>(
+            uint32_t {3}, // Contract version (post v13)
+            GRC::ContractAction::ADD,
+            payload_version, // Protocol payload version (post v13)
+            key,
+            value,
+            GRC::ProtocolEntryStatus::ACTIVE);
+    }
 
-       dummy_tx.vContracts.push_back(contract);
+    dummy_tx.vContracts.push_back(contract);
 
-       registry.Add({contract, dummy_tx, &index});
-   }
+    registry.Add({contract, dummy_tx, &index});
+}
 
 } // anonymous namespace
 
@@ -105,13 +105,29 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(gridcoin_cbr_tests)
 
-BOOST_AUTO_TEST_CASE(gridcoin_DefaultCBRShouldBe10)
+BOOST_AUTO_TEST_CASE(gridcoin_DefaultCBRShouldBe10PreV13)
 {
     CBlockIndex index;
     index.nTime = 1538066417;
 
-    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), DEFAULT_CBR);
+    auto& registry = GRC::GetProtocolRegistry();
+    registry.Reset();
+
+    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), 10 * COIN);
 }
+
+BOOST_AUTO_TEST_CASE(gridcoin_DefaultCBRShouldBeDefaultConstantBlockRewardForV13)
+{
+    CBlockIndex index;
+    index.nTime = 1538066417;
+    index.nHeight = Params().GetConsensus().BlockV13Height;
+
+    auto& registry = GRC::GetProtocolRegistry();
+    registry.Reset();
+
+    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), Params().GetConsensus().DefaultConstantBlockReward);
+}
+
 
 // Note that payload versions 1 and 2 alternate here. This is to test the constructors and
 // the machinery to add to the registry. This alternating approach is not what would
@@ -154,7 +170,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldOverrideDefault)
     CBlockIndex index_2;
     index_2.nVersion = 13;
     index_2.nTime = time + 1;
-    index_2.nHeight = 2;
+    index_2.nHeight = Params().GetConsensus().BlockV13Height;
 
     // Protocol payload version 2
 
@@ -176,16 +192,16 @@ BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldOverrideDefault)
     BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index_2), cbr);
 }
 
-BOOST_AUTO_TEST_CASE(gridcoin_NegativeCBRShouldClampTo0)
+BOOST_AUTO_TEST_CASE(gridcoin_NegativeCBRShouldClampTo0PreV13)
 {
     const int64_t time = 123456;
     CBlockIndex index;
-    index.nTime = time + 2;
+    index.nTime = time;
     index.nHeight = 3;
 
     auto& registry = GRC::GetProtocolRegistry();
 
-    AddProtocolEntry(1, "blockreward1", ToString(-1 * COIN), index, false);
+    AddProtocolEntry(1, "blockreward1", ToString(-1 * COIN), index, true);
 
     if (GRC::ProtocolEntryOption entry = registry.TryActive("blockreward1")) {
         LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: Protocol entry: m_key %s, m_value %s, m_hash %s, m_previous_hash %s, "
@@ -203,16 +219,16 @@ BOOST_AUTO_TEST_CASE(gridcoin_NegativeCBRShouldClampTo0)
     BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), 0);
 }
 
-BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldClampTo2xDefault)
+BOOST_AUTO_TEST_CASE(gridcoin_NegativeCBRShouldClampToConstantBlockRewardFloorForV13)
 {
     const int64_t time = 123456;
     CBlockIndex index;
-    index.nTime = time + 3;
-    index.nHeight = 4;
+    index.nTime = time;
+    index.nHeight = Params().GetConsensus().BlockV13Height;
 
     auto& registry = GRC::GetProtocolRegistry();
 
-    AddProtocolEntry(2, "blockreward1", ToString(DEFAULT_CBR * 3), index, false);
+    AddProtocolEntry(2, "blockreward1", ToString(-1 * COIN), index, true);
 
     if (GRC::ProtocolEntryOption entry = registry.TryActive("blockreward1")) {
         LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: Protocol entry: m_key %s, m_value %s, m_hash %s, m_previous_hash %s, "
@@ -227,12 +243,64 @@ BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldClampTo2xDefault)
                  );
     }
 
-    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), DEFAULT_CBR * 2);
+    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), Params().GetConsensus().ConstantBlockRewardFloor);
 }
 
-// TODO: when the 180 day lookback is removed, this should be removed as a test as it will
-// be irrelevant and invalid.
-BOOST_AUTO_TEST_CASE(gridcoin_ObsoleteConfigurableCBRShouldResortToDefault)
+BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldClampTo2xDefaultPreV13)
+{
+    const int64_t time = 123456;
+    CBlockIndex index;
+    index.nTime = time;
+    index.nHeight = 4;
+
+    auto& registry = GRC::GetProtocolRegistry();
+
+    AddProtocolEntry(2, "blockreward1", ToString(Params().GetConsensus().DefaultConstantBlockReward * 3), index, true);
+
+    if (GRC::ProtocolEntryOption entry = registry.TryActive("blockreward1")) {
+        LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: Protocol entry: m_key %s, m_value %s, m_hash %s, m_previous_hash %s, "
+                                            "m_timestamp %" PRId64 ", m_status string %s",
+                 __func__,
+                 entry->m_key,
+                 entry->m_value,
+                 entry->m_hash.ToString(),
+                 entry->m_previous_hash.ToString(),
+                 entry->m_timestamp,
+                 entry->StatusToString()
+                 );
+    }
+
+    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), Params().GetConsensus().DefaultConstantBlockReward * 2);
+}
+
+BOOST_AUTO_TEST_CASE(gridcoin_ConfigurableCBRShouldClampToConstantBlockRewardCeilingForV13)
+{
+    const int64_t time = 123456;
+    CBlockIndex index;
+    index.nTime = time;
+    index.nHeight = Params().GetConsensus().BlockV13Height;
+
+    auto& registry = GRC::GetProtocolRegistry();
+
+    AddProtocolEntry(2, "blockreward1", ToString(Params().GetConsensus().ConstantBlockRewardCeiling * 2), index, true);
+
+    if (GRC::ProtocolEntryOption entry = registry.TryActive("blockreward1")) {
+        LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: Protocol entry: m_key %s, m_value %s, m_hash %s, m_previous_hash %s, "
+                                            "m_timestamp %" PRId64 ", m_status string %s",
+                 __func__,
+                 entry->m_key,
+                 entry->m_value,
+                 entry->m_hash.ToString(),
+                 entry->m_previous_hash.ToString(),
+                 entry->m_timestamp,
+                 entry->StatusToString()
+                 );
+    }
+
+    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index), Params().GetConsensus().ConstantBlockRewardCeiling);
+}
+
+BOOST_AUTO_TEST_CASE(gridcoin_ObsoleteConfigurableCBRShouldResortToDefaultPreV13)
 {
     CBlockIndex index_check;
     index_check.nTime = 1538066417;
@@ -245,7 +313,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_ObsoleteConfigurableCBRShouldResortToDefault)
 
     auto& registry = GRC::GetProtocolRegistry();
 
-    AddProtocolEntry(2, "blockreward1", ToString(3 * COIN), index_add, false);
+    AddProtocolEntry(1, "blockreward1", ToString(3 * COIN), index_add, true);
 
     if (GRC::ProtocolEntryOption entry = registry.TryActive("blockreward1")) {
         LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: Protocol entry: m_key %s, m_value %s, m_hash %s, m_previous_hash %s, "
@@ -260,7 +328,39 @@ BOOST_AUTO_TEST_CASE(gridcoin_ObsoleteConfigurableCBRShouldResortToDefault)
                  );
     }
 
-    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index_check), DEFAULT_CBR);
+    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index_check), Params().GetConsensus().DefaultConstantBlockReward);
 }
+
+BOOST_AUTO_TEST_CASE(gridcoin_PriorObsoleteConfigurableCBRShouldNotResortToDefaultforV13)
+{
+    CBlockIndex index_check;
+    index_check.nTime = 1538066417;
+    index_check.nHeight = Params().GetConsensus().BlockV13Height;
+    const int64_t max_message_age = 60 * 60 * 24 * 180;
+
+    CBlockIndex index_add;
+    index_add.nTime = index_check.nTime - max_message_age - 1;
+    index_add.nHeight = 5;
+
+    auto& registry = GRC::GetProtocolRegistry();
+
+    AddProtocolEntry(2, "blockreward1", ToString(3 * COIN), index_add, true);
+
+    if (GRC::ProtocolEntryOption entry = registry.TryActive("blockreward1")) {
+        LogPrint(BCLog::LogFlags::CONTRACT, "INFO: %s: Protocol entry: m_key %s, m_value %s, m_hash %s, m_previous_hash %s, "
+                                            "m_timestamp %" PRId64 ", m_status string %s",
+                 __func__,
+                 entry->m_key,
+                 entry->m_value,
+                 entry->m_hash.ToString(),
+                 entry->m_previous_hash.ToString(),
+                 entry->m_timestamp,
+                 entry->StatusToString()
+                 );
+    }
+
+    BOOST_CHECK_EQUAL(GRC::GetConstantBlockReward(&index_check), 3 * COIN);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1326,6 +1326,18 @@ BOOST_AUTO_TEST_CASE(util_Fraction_Initialization_from_int64_t)
     BOOST_CHECK_EQUAL(fraction.IsNonNegative(), false);
 }
 
+BOOST_AUTO_TEST_CASE(util_Fraction_Initialization_from_string)
+{
+    Fraction fraction = Fraction().FromString("100/-567");
+
+    BOOST_CHECK_EQUAL(fraction.GetNumerator(), -100);
+    BOOST_CHECK_EQUAL(fraction.GetDenominator(), 567);
+    BOOST_CHECK_EQUAL(fraction.IsSimplified(), true);
+    BOOST_CHECK_EQUAL(fraction.IsZero(), false);
+    BOOST_CHECK_EQUAL(fraction.IsPositive(), false);
+    BOOST_CHECK_EQUAL(fraction.IsNonNegative(), false);
+}
+
 BOOST_AUTO_TEST_CASE(util_Fraction_Simplify)
 {
     Fraction fraction(-4, -6);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1744,7 +1744,65 @@ BOOST_AUTO_TEST_CASE(util_Fraction_ToString)
     Fraction fraction(123, 10000);
 
     BOOST_CHECK_EQUAL(fraction.IsSimplified(), true);
-    BOOST_CHECK_EQUAL(fraction.ToString(),"123/10000");
+    BOOST_CHECK_EQUAL(fraction.ToString(), "123/10000");
+}
+
+BOOST_AUTO_TEST_CASE(util_Fraction_FromString)
+{
+    Fraction fraction = Fraction().FromString("100/567");
+
+    BOOST_CHECK_EQUAL(fraction.IsSimplified(), true);
+    BOOST_CHECK(fraction == Fraction(100, 567, true));
+
+    fraction = Fraction().FromString("-100/567");
+
+    BOOST_CHECK_EQUAL(fraction.IsSimplified(), true);
+    BOOST_CHECK(fraction == Fraction(-100, 567, true));
+
+    fraction = Fraction().FromString("100/-567");
+
+    BOOST_CHECK_EQUAL(fraction.IsSimplified(), true);
+    BOOST_CHECK(fraction == Fraction(-100, 567, true));
+
+    fraction = Fraction().FromString("5");
+
+    BOOST_CHECK_EQUAL(fraction.IsSimplified(), true);
+    BOOST_CHECK(fraction == Fraction(5, 1, true));
+
+    std::string err;
+    std::string valid_err_message {"fraction input string cannot be parsed to fraction"};
+
+    try {
+        Fraction fraction = Fraction().FromString("100/567/300");
+    } catch (std::out_of_range& e) {
+        err = e.what();
+    }
+
+    BOOST_CHECK_EQUAL(err, valid_err_message);
+
+    try {
+        Fraction fraction = Fraction().FromString("100 / 567");
+    } catch (std::out_of_range& e) {
+        err = e.what();
+    }
+
+    BOOST_CHECK_EQUAL(err, valid_err_message);
+
+    try {
+        Fraction fraction = Fraction().FromString("100.1");
+    } catch (std::out_of_range& e) {
+        err = e.what();
+    }
+
+    BOOST_CHECK_EQUAL(err, valid_err_message);
+
+    try {
+        Fraction fraction = Fraction().FromString("");
+    } catch (std::out_of_range& e) {
+        err = e.what();
+    }
+
+    BOOST_CHECK_EQUAL(err, valid_err_message);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.h
+++ b/src/util.h
@@ -344,13 +344,25 @@ public:
     {
         std::vector<std::string> string_fraction = split(string, "/");
 
+        if (string_fraction.size() > 2 || string_fraction.size() < 1) {
+            throw std::out_of_range("fraction input string cannot be parsed to fraction");
+        }
+
         int64_t numerator;
         int64_t denominator;
 
-        if (string_fraction.size() != 2
-            || !ParseInt64(string_fraction[0], &numerator)
-            || !ParseInt64(string_fraction[1], &denominator)) {
-            throw std::out_of_range("Fraction input string cannot be parsed to fraction.");
+        if (string_fraction.size() == 1) {
+            if (!ParseInt64(string_fraction[0], &numerator)) {
+                throw std::out_of_range("fraction input string cannot be parsed to fraction");
+            }
+
+            denominator = 1;
+        } else {
+            // There must be two elements to the string fraction if we are here.
+            if (!ParseInt64(string_fraction[0], &numerator)
+                || !ParseInt64(string_fraction[1], &denominator)) {
+                throw std::out_of_range("fraction input string cannot be parsed to fraction");
+            }
         }
 
         return Fraction(numerator, denominator, true);

--- a/src/util.h
+++ b/src/util.h
@@ -340,6 +340,22 @@ public:
         return strprintf("%" PRId64 "/" "%" PRId64, m_numerator, m_denominator);
     }
 
+    Fraction FromString(const std::string& string) const
+    {
+        std::vector<std::string> string_fraction = split(string, "/");
+
+        int64_t numerator;
+        int64_t denominator;
+
+        if (string_fraction.size() != 2
+            || !ParseInt64(string_fraction[0], &numerator)
+            || !ParseInt64(string_fraction[1], &denominator)) {
+            throw std::out_of_range("Fraction input string cannot be parsed to fraction.");
+        }
+
+        return Fraction(numerator, denominator, true);
+    }
+
     bool operator!()
     {
         return IsZero();


### PR DESCRIPTION
This is the PR for the work to enhance the polls/voting consensus rules:
- To allow for a different magnitude unit to change the emitted coins for the network magnitude.
- To allow for different magnitude weight factor that assigns weight to magnitude for the purposes of vote weight of individual votes and AVW.
- Refactors the GetBlockReward function to properly work with revised CBR values in the protocol registry and expands the clamp to anticipate a larger upper end value for CBR in the future.

This implements https://github.com/gridcoin-community/Gridcoin-Tasks/issues/268.

For documentation purposes I am going to describe the changes introduced here. Note that all of these changes have been implemented in such a way as to be completely consensus compatible with the existing network rules prior to the V13 mandatory, which means that this PR can be merged prior to the setting of the mandatory height for V13.

### Implementation of changeable magnitude unit and magnitude weight factor
Prior to this PR, the magnitude unit has been hard-coded to 1/4 and the magnitude weight factor has been hard-coded to 100/567. This has been true since the Fern mandatory rules went into effect. We needed a way to both increase the amount of paid crunching rewards (the research emission), and also change the weight ratio used to convert magnitude of a voter into weight units for the voting in balance + magnitude polls. This PR provides both:

- The magnitude unit can be changed by a protocol entry (administrative contract) with key name "magnitudeunit" and a value specified as a whole number or rational fraction, such as 1/4 (the current value) or 5/4, for example. The maximum accrual has now been changed from a fixed value of 16384 to be (magnitude unit) * 32768 * 2, which represents the accrual that would occur for a CPID at the maximum magnitude (rounded up by 1 to 32768 from 32767) after two days with the network magnitude unit in effect. This reduces to the current value of 16384 with the magnitude unit at its current (default) value of 1/4.
- The magnitude weight factor can be changed similarly with key name "magnitudeweightfactor". The current value is 1/5.67 (i.e. 100/567). The magnitude weight factor proposed in 268, for example, is 5702887/3524578, which is a good rational approximation of 2 / (1 + sqrt(5)) without risking overflow in integer arithmetic.

### Enhanced CBR
The CBR code has been enhanced for V13+ to more reliably allow for changing the constant block reward via protocol entry (administrative contract) with the key name "blockreward1". The current value is 10 GRC.

### New blockchain consensus parameters to support/control the above
The following blockchain consensus parameters have been implemented and are active as of the V13 mandatory. the floor and ceiling parameters act as clamps.

        consensus.DefaultConstantBlockReward = 10 * COIN;
        consensus.ConstantBlockRewardFloor = 0;
        consensus.ConstantBlockRewardCeiling = 200 * COIN;
        consensus.DefaultMagnitudeUnit = Fraction(1, 4);
        consensus.MaxMagnitudeUnit = Fraction(5, 1);
        consensus.DefaultMagnitudeWeightFactor = Fraction(100, 567);

### Other corrections/additions
- GetActiveNetworkWeight did not correctly compute AVW for balance only polls/votes, which should not include any magnitude component to the AVW. It should simply be the sum of balance attestations in the votes divided by the average network weight. This has been corrected in this PR.
- The contract version for protocol contracts was never advanced, and the contract was still using the legacy format. This has been updated, although there is no hard enforcement of the older legacy contract in V13+ currently.

This PR has been tested on testnet and then mainnet for consensus compatibility prior to V13 mandatory, and comprehensively tested in a three node isolated testnet network post V13 mandatory, with several changes in the above protocols. Sync from genesis has also been conducted in all three cases.
