### PR TITLE
ci: use overwrite with brew install on MacOS CMake

### DIFF
--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -148,7 +148,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Install dependencies
-              run: brew install
+              run: brew install --overwrite
                   ${{matrix.deps}}
                   boost
                   ccache


### PR DESCRIPTION
Some version of pkg-config seems to be pre-installed on the CIs now.