### PR TITLE
node: fix build with GCC 15

### DIFF
--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -1,12 +1,13 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2012-2020 The Bitcoin developers
-// Copyright (c) 2014-2022 The Gridcoin developers
+// Copyright (c) 2014-2024 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_NODE_UI_INTERFACE_H
 #define BITCOIN_NODE_UI_INTERFACE_H
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Add a missing include for the uint32_t type

Bug: https://bugs.gentoo.org/945705