### PR TITLE
diagnose, rpc: fix compilation with boost 1.87

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ env:
 jobs:
     test-linux:
         name: ${{ matrix.name }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         strategy:
             matrix:
                 include:
-                  - name: ARM  [GOAL install]  [buster]
+                  - name: ARM  [GOAL install]  [bullseye]
                     script-id: arm
                   - name: Win32
                     script-id: win32
@@ -21,7 +21,7 @@ jobs:
                     script-id: linux_i386
                   - name: x86_64 Linux  [GOAL install]  [GUI]  [focal]  [no depends]
                     script-id: native
-                  - name: x86_64 Linux  [GOAL install]  [GUI]  [bionic]  [no depends]
+                  - name: x86_64 Linux  [GOAL install]  [GUI]  [noble]  [no depends]
                     script-id: native_old
                   - name: x86_64 Linux  [ASan]  [LSan]  [UBSan]  [integer]  [jammy]  [no depends]
                     script-id: native_asan

--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -150,7 +150,7 @@ jobs:
             - name: Install dependencies
               run: brew install --overwrite
                   ${{matrix.deps}}
-                  boost@1.85
+                  boost
                   ccache
                   libzip
                   ninja
@@ -168,7 +168,6 @@ jobs:
                   -DCMAKE_C_COMPILER_LAUNCHER=ccache
                   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
                   ${{matrix.options}}
-                  -DBOOST_ROOT=$(brew --prefix boost@1.85)
                   -DENABLE_TESTS=ON
             - name: Restore cache
               uses: actions/cache/restore@v4

--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -196,8 +196,6 @@ jobs:
                   retention-days: 7
 
     test-msys2:
-        # MSYS2 is rolling release, only latest Boost is available.
-        if: false
         runs-on: windows-latest
         defaults:
             run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,13 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
     # Allow to find old Boost (pre 1.70) with new CMake (3.30 and later).
     cmake_policy(SET CMP0167 OLD)
 endif()
-find_package(Boost ${BOOST_MINIMUM_VERSION}...<1.87.0 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+find_package(Boost ${BOOST_MINIMUM_VERSION} REQUIRED)
+if(Boost_VERSION VERSION_LESS 1.70.0)
+    find_package(Boost ${BOOST_MINIMUM_VERSION} COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+else()
+    # Better upstream-provided CMake config is available.
+    find_package(Boost ${BOOST_MINIMUM_VERSION} COMPONENTS ${BOOST_COMPONENTS} CONFIG REQUIRED)
+endif()
 
 if(BUNDLED_OPENSSL)
     hunter_add_package(OpenSSL)

--- a/cd/00_setup_env.sh
+++ b/cd/00_setup_env.sh
@@ -32,7 +32,7 @@ export HOST=${HOST:-$("$BASE_ROOT_DIR/depends/config.guess")}
 # Whether to prefer BusyBox over GNU utilities
 export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
 export CONTAINER_NAME=${CONTAINER_NAME:-ci_unnamed}
-export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:18.04}
+export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:20.04}
 # See man 7 debconf
 export DEBIAN_FRONTEND=noninteractive
 export CCACHE_SIZE=${CCACHE_SIZE:-300M}

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -37,7 +37,7 @@ export RUN_SECURITY_TESTS=${RUN_SECURITY_TESTS:-false}
 export TEST_RUNNER_ENV=${TEST_RUNNER_ENV:-}
 export RUN_FUZZ_TESTS=${RUN_FUZZ_TESTS:-false}
 export CONTAINER_NAME=${CONTAINER_NAME:-ci_unnamed}
-export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:18.04}
+export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:20.04}
 # Randomize test order.
 # See https://www.boost.org/doc/libs/1_71_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/random.html
 export BOOST_TEST_RANDOM=${BOOST_TEST_RANDOM:-1}

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -18,7 +18,7 @@ if [ -n "$QEMU_USER_CMD" ]; then
 fi
 export CONTAINER_NAME=ci_arm_linux
 # Use debian to avoid 404 apt errors when cross compiling
-export DOCKER_NAME_TAG="debian:buster"
+export DOCKER_NAME_TAG="debian:bullseye"
 export USE_BUSY_BOX=true
 export RUN_UNIT_TESTS=true
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/00_setup_env_native_old.sh
+++ b/ci/test/00_setup_env_native_old.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_old
-export DOCKER_NAME_TAG=ubuntu:18.04
+export DOCKER_NAME_TAG=ubuntu:20.04
 export PACKAGES="gcc-8 g++-8 libqt5gui5 libqt5core5a qtbase5-dev libqt5dbus5 qttools5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-iostreams-dev libboost-test-dev libboost-thread-dev libminiupnpc-dev libqrencode-dev libzip-dev zlib1g zlib1g-dev libcurl4-openssl-dev"
 export RUN_UNIT_TESTS=true
 # export RUN_FUNCTIONAL_TESTS=false

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -143,17 +143,18 @@ public:
     bool connect(const std::string& server, const std::string& port)
     {
         boost::asio::ip::tcp::resolver resolver(GetIOService(stream));
-        boost::asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(server, port);
-        boost::asio::ip::tcp::resolver::iterator end;
-        boost::system::error_code error = boost::asio::error::host_not_found;
-        while (error && endpoint_iterator != end)
-        {
+        boost::system::error_code error;
+
+        for (const auto& res : resolver.resolve(server, port)) {
             stream.lowest_layer().close();
-            stream.lowest_layer().connect(*endpoint_iterator++, error);
+            stream.lowest_layer().connect(res, error);
+
+            if (!error) {
+                return true;
+            }
         }
-        if (error)
-            return false;
-        return true;
+
+        return false;
     }
 
 private:

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -143,8 +143,7 @@ public:
     bool connect(const std::string& server, const std::string& port)
     {
         boost::asio::ip::tcp::resolver resolver(GetIOService(stream));
-        boost::asio::ip::tcp::resolver::query query(server.c_str(), port.c_str());
-        boost::asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+        boost::asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(server, port);
         boost::asio::ip::tcp::resolver::iterator end;
         boost::system::error_code error = boost::asio::error::host_not_found;
         while (error && endpoint_iterator != end)


### PR DESCRIPTION
- `boost::asio::ip::tcp::resolver::query` has been removed in 1.87 which causes compilation issues.
- `boost::asio::ip::tcp::resolver::iterator` has been removed in 1.87 which causes compilation issues.
- `boost::asio::ip::socket_base::max_connections` has been renamed to `max_listen_connections`.
- `boost::asio::ip::address_v6::to_v4()`, `boost::asio::ip::address_v6::is_v4_compatible()` and `boost::asio::ip::address_v4::to_ulong` has been removed.

This raises the minimum supported version of Boost to 1.66 which should be safe to do since near-EOL focal has 1.71. Ubuntu bionic CI is bumped to accommodate this.

Fixes the CI issue in #2781.