### PR TITLE
CMake: Set maximum supported Boost version

### DIFF
--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -150,7 +150,7 @@ jobs:
             - name: Install dependencies
               run: brew install --overwrite
                   ${{matrix.deps}}
-                  boost
+                  boost@1.85
                   ccache
                   libzip
                   ninja
@@ -168,6 +168,7 @@ jobs:
                   -DCMAKE_C_COMPILER_LAUNCHER=ccache
                   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
                   ${{matrix.options}}
+                  -DBOOST_ROOT=$(brew --prefix boost@1.85)
                   -DENABLE_TESTS=ON
             - name: Restore cache
               uses: actions/cache/restore@v4
@@ -195,6 +196,8 @@ jobs:
                   retention-days: 7
 
     test-msys2:
+        # MSYS2 is rolling release, only latest Boost is available.
+        if: false
         runs-on: windows-latest
         defaults:
             run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,11 @@ endif()
 if(BUNDLED_BOOST)
     hunter_add_package(Boost COMPONENTS ${BOOST_HUNTER_COMPONENTS})
 endif()
-find_package(Boost ${BOOST_MINIMUM_VERSION} COMPONENTS ${BOOST_COMPONENTS} CONFIG REQUIRED)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
+    # Allow to find old Boost (pre 1.70) with new CMake (3.30 and later).
+    cmake_policy(SET CMP0167 OLD)
+endif()
+find_package(Boost ${BOOST_MINIMUM_VERSION} COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 
 if(BUNDLED_OPENSSL)
     hunter_add_package(OpenSSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ endif()
 
 set(BOOST_MINIMUM_VERSION 1.63.0)
 set(BOOST_COMPONENTS filesystem iostreams thread)
-set(BOOST_HUNTER_COMPONENTS ${BOOST_COMPONENTS})
+set(BOOST_HUNTER_COMPONENTS system atomic regex ${BOOST_COMPONENTS})
 if(ENABLE_TESTS)
     list(APPEND BOOST_COMPONENTS unit_test_framework)
     list(APPEND BOOST_HUNTER_COMPONENTS test)
@@ -169,7 +169,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
     # Allow to find old Boost (pre 1.70) with new CMake (3.30 and later).
     cmake_policy(SET CMP0167 OLD)
 endif()
-find_package(Boost ${BOOST_MINIMUM_VERSION} COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+find_package(Boost ${BOOST_MINIMUM_VERSION}...<1.87.0 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 
 if(BUNDLED_OPENSSL)
     hunter_add_package(OpenSSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/build-
 option(HUNTER_ENABLED "Enable Hunter package manager" OFF)
 include(HunterGate)
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/refs/tags/v0.25.3.tar.gz"
-    SHA1 "0dfbc2cb5c4cf7e83533733bdfd2125ff96680cb"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.25.8.tar.gz"
+    SHA1 "26c79d587883ec910bce168e25f6ac4595f97033"
     FILEPATH "${CMAKE_CURRENT_SOURCE_DIR}/build-aux/cmake/Hunter/config.cmake"
 )
 

--- a/build-aux/cmake/Hunter/config.cmake
+++ b/build-aux/cmake/Hunter/config.cmake
@@ -1,0 +1,3 @@
+include(hunter_user_error)
+
+#hunter_config(Boost VERSION 1.83.0)

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -97,21 +97,21 @@ Dependency Build Instructions: OpenSUSE
 Build requirements:
 
     sudo zypper install -t pattern devel_basis
-    sudo zypper install cmake libtool automake autoconf pkg-config libopenssl-devel libevent-devel
+    sudo zypper install cmake libtool automake autoconf pkg-config libcurl-devel libopenssl-devel libevent-devel libzip-devel libzip-tools
 
 Tumbleweed:
 
-    sudo zypper install libboost_system1_*_0-devel libboost_filesystem1_*_0-devel libboost_test1_*_0-devel libboost_thread1_*_0-devel
+    sudo zypper install libboost_system1*-devel libboost_filesystem1*-devel libboost_iostreams1*-devel libboost_test1*-devel libboost_thread1*-devel libboost_atomic1*-devel libboost_regex1*-devel
 
 Leap:
 
-    sudo zypper install libboost_system1_61_0-devel libboost_filesystem1_61_0-devel libboost_test1_61_0-devel libboost_thread1_61_0-devel
+    sudo zypper install libboost_system1_66_0-devel libboost_iostreams1_66_0-devel libboost_filesystem1_66_0-devel libboost_test1_66_0-devel libboost_thread1_66_0-devel libboost_atomic1_66_0-devel libboost_regex1_66_0-devel
 
 If that doesn't work, you can install all boost development packages with:
 
 Leap:
 
-    sudo zypper install boost_1_61-devel
+    sudo zypper install libboost_*1_66_0-devel
 
 Optional (see `ENABLE_UPNP / DEFAULT_UPNP` options for CMake and
 `--with-miniupnpc / --enable-upnp-default` for Autotools):


### PR DESCRIPTION
Update CMakeLists and CI to use only Boost 1.86.0 and older. Fix "find_package" call so it works with Boost versions older than 1.70.

Upper bound could be removed after https://github.com/gridcoin-community/Gridcoin-Research/pull/2786 is finished.