### PR TITLE
doc: cmake is required for Windows depends

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -31,7 +31,7 @@ First, install the general dependencies:
 
     sudo apt update
     sudo apt upgrade
-    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git cmake
 
 A host toolchain (`build-essential`) is necessary because some dependency
 packages need to build host utilities that are used in the build process.


### PR DESCRIPTION
I think this was missed when cmake was added to the builds.