### PR TITLE
mandatory: Testnet v13 mandatory

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -189,14 +189,14 @@ public:
         consensus.BlockV10Height = 629409;
         consensus.BlockV11Height = 1301500;
         consensus.BlockV12Height = 1871830;
-        consensus.BlockV13Height = std::numeric_limits<int>::max();
+        consensus.BlockV13Height = 2870000;
         consensus.PollV3Height = 1944820;
         consensus.ProjectV2Height = 1944820;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
-        consensus.ProjectV4Height = std::numeric_limits<int>::max();
-        consensus.SuperblockV3Height = std::numeric_limits<int>::max();
+        consensus.ProjectV4Height = 2870000;
+        consensus.SuperblockV3Height = 2870000;
         // Immediately post zero payment interval fees 40% for testnet, the same as mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         consensus.MRCZeroPaymentInterval = 10 * 60;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -234,6 +234,7 @@ public:
             {
                 {0,       uint256S("0x00006e037d7b84104208ecf2a8638d23149d712ea810da604ee2f2cb39bae713")},
                 {2400000, uint256S("0x962b7607f8ffceb5c77951d242caed3f94f465f8529d924338700895ff8ed458")},
+                {2800000, uint256S("0x038f6a3bdea036e11f6793e5ec0d66434c7889c1fdb340e32136ec0d5bc4cd18")}
             }
         };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2051,8 +2051,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION
             || (DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD
                 && pfrom->nVersion < PROTOCOL_VERSION
-                && pindexBest->nHeight > std::max(Params().GetConsensus().BlockV12Height,
-                                                  Params().GetConsensus().BlockV12Height + DISCONNECT_GRACE_PERIOD)
+                && pindexBest->nHeight > std::max(Params().GetConsensus().BlockV13Height,
+                                                  Params().GetConsensus().BlockV13Height + DISCONNECT_GRACE_PERIOD)
                 )
             ) {
             // disconnect from peers older than this proto version

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
 // network protocol versioning
 //
 //! The current protocol version
-static const int PROTOCOL_VERSION = 180327;
+static const int PROTOCOL_VERSION = 180328;
 
 //! Note that there may be special logic implemented for
 //! a hard fork that actually disconnects nodes less than
@@ -24,7 +24,7 @@ static const bool DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD = true;
 static const int DISCONNECT_GRACE_PERIOD = 900 * 7;
 
 //! Disconnect from peers older than this proto version. This is absolute.
-static const int MIN_PEER_PROTO_VERSION = 180326;
+static const int MIN_PEER_PROTO_VERSION = 180327;
 
 //! initial proto version, to be increased after version/verack negotiation.
 static const int INIT_PROTO_VERSION = 180275;


### PR DESCRIPTION
This PR increments the PROTOCOL_VERSION and also sets the testnet v13 mandatory height (and related project and superblock version heights) to 2870000. A checkpoint was also added at 2800000.

Note that this height is (2870000 - 2837180) = 32830 blocks from 2025-04-21T19:00Z.


Current Time | 2025-04-21 19:00:00
-- | --
Blocks to Mandatory | 32,830
Blocks/Day | 878.2956
Days | 37.3792149249068
Estimated Mandatory Date/Time | 05/29/25 04:06 AM


</body>

</html>

Note that the config overrides have been left in place for me to continue to run the long running isolated v13 fork for testing. They will be removed by the mainnet v13 and/or v14 mandatory PR.