### PR TITLE
autogreylist: Fix stack-use-after-return in AutoGreylist

### DIFF
--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -574,7 +574,7 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
     m_superblock_hash = superblock_ptr_in->GetHash();
 }
 
-void AutoGreylist::RefreshWithSuperblock(Superblock& superblock) EXCLUSIVE_LOCKS_REQUIRED (cs_main)
+void AutoGreylist::RefreshWithAndUpdateSuperblock(Superblock& superblock) EXCLUSIVE_LOCKS_REQUIRED (cs_main)
 {
     SuperblockPtr superblock_ptr;
 
@@ -582,6 +582,8 @@ void AutoGreylist::RefreshWithSuperblock(Superblock& superblock) EXCLUSIVE_LOCKS
     // form a superblock ptr referencing the current head of the chain. The actual superblock will be the next block if it
     // is added to the chain, for for the purposes here, this is what we want, because it is simply used to feed the
     // overloaded version which takes the superblock_ptr and follows the chain backwards to do the greylist calculations.
+    //
+    // Replace copies the superblock object.
     superblock_ptr.Replace(superblock);
 
     superblock_ptr.Rebind(pindexBest);

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -839,7 +839,7 @@ public:
     //! from a scraper convergence, and is used in the call chain from the miner loop. The superblock object project status
     //! will be updated.
     //!
-    void RefreshWithSuperblock(Superblock& superblock);
+    void RefreshWithAndUpdateSuperblock(Superblock& superblock);
 
     //!
     //! \brief Resets the AutoGreylist object. This is called by the Whitelist Reset().

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -627,7 +627,7 @@ Superblock Superblock::FromConvergence(
         // Refresh the auto greylist and refresh this superblock with the greylist status.
         std::shared_ptr<GRC::AutoGreylist> greylist_ptr = GRC::GetAutoGreylistCache();
 
-        greylist_ptr->RefreshWithSuperblock(superblock);
+        greylist_ptr->RefreshWithAndUpdateSuperblock(superblock);
     }
 
     return superblock;

--- a/src/gridcoin/superblock.cpp
+++ b/src/gridcoin/superblock.cpp
@@ -621,7 +621,7 @@ Superblock Superblock::FromConvergence(
 
     if (version > 2) {
         // Populate the total credits into the superblock object from the convergence. This must be done BEFORE
-        // the auto greylist RefreshWithSuperblock is called.
+        // the auto greylist RefreshWithAndUpdateSuperblock is called.
         superblock.m_projects_all_cpids_total_credits.Reset(stats.mScraperConvergedStats.m_total_credit_map);
 
         // Refresh the auto greylist and refresh this superblock with the greylist status.

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -756,6 +756,15 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
     // cannot have a pindex with random data.
     pindexBest = new CBlockIndex;
+    pindexGenesisBlock = new CBlockIndex;
+
+    pindexGenesisBlock->nHeight = 0;
+    pindexGenesisBlock->nTime = 0;
+    pindexBest->nHeight = 1;
+    pindexBest->nTime = 1;
+    pindexBest->pprev = pindexGenesisBlock;
+    pindexGenesisBlock->pnext = pindexBest;
+    nBestHeight = 1;
 
     const ScraperStatsMeta meta(3);
     GRC::Superblock superblock = GRC::Superblock::FromConvergence(GetTestConvergence(meta), 3);
@@ -819,6 +828,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
     }
 
     delete pindexBest;
+    delete pindexGenesisBlock;
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence)
@@ -887,6 +897,15 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
     // cannot have a pindex with random data.
     pindexBest = new CBlockIndex;
+    pindexGenesisBlock = new CBlockIndex;
+
+    pindexGenesisBlock->nHeight = 0;
+    pindexGenesisBlock->nTime = 0;
+    pindexBest->nHeight = 1;
+    pindexBest->nTime = 1;
+    pindexBest->pprev = pindexGenesisBlock;
+    pindexGenesisBlock->pnext = pindexBest;
+    nBestHeight = 1;
 
     const ScraperStatsMeta meta(3);
     GRC::Superblock superblock = GRC::Superblock::FromConvergence(
@@ -965,6 +984,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
     }
 
     delete pindexBest;
+    delete pindexGenesisBlock;
 }
 
 BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_binary_contract)


### PR DESCRIPTION
The address sanitizer in CI caught a subtle stack use after return in AutoGreylist::RefreshWithSuperblock(Superblock& superblock).

The AutoGreylist::RefreshWithSuperblock(Superblock& superblock) overload has been renamed RefreshWithAndUpdateSuperblock for clarity.

The culprit was the lack of initialization of the the pindexGenesisBlock block index pointer and pprev/pnext in both pindexGenesis and pindexBest in a trivial two block formation, given the test in question utilizes blockfinder.

See #2801 for the original stack trace of this problem.

NOTE: Given that this really only affects the unit test and is not an actual problem in the running wallet, the current testnet 5.4.9.3 build does not have to be updated.