### PR TITLE
beacon: Change beacon renewal job interval

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -547,7 +547,7 @@ void GRC::ScheduleBackgroundJobs(CScheduler& scheduler)
         LogInstance().archive(false, plogfile_out);
     }, std::chrono::seconds{300});
 
-    scheduler.scheduleEvery(Researcher::RunRenewBeaconJob, std::chrono::hours{4});
+    scheduler.scheduleEvery(Researcher::RunRenewBeaconJob, std::chrono::hours{1});
 
     ScheduleBackups(scheduler);
     ScheduleUpdateChecks(scheduler);

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1114,6 +1114,8 @@ void Researcher::RunRenewBeaconJob()
         return;
     }
 
+    LogPrintf("INFO: %s: Running renew beacon job for %s", __func__, researcher->Id().ToString());
+
     TRY_LOCK(cs_main, locked_main);
 
     if (!locked_main) {
@@ -1137,6 +1139,10 @@ void Researcher::RunRenewBeaconJob()
         }
 
         researcher->AdvertiseBeacon();
+    } else {
+        LogPrint(BCLog::LogFlags::BEACON,
+                 "INFO: %s: Skipping beacon renewal while within scraper beacon consensus window.",
+                 __func__);
     }
 }
 


### PR DESCRIPTION
This PR changes the renewal job interval to 1 hour from 4 hours and adds additional logging.

The original interval, 4 hours, is not often enough given the additional restriction with respect to the scraper activation window (beacon consensus window). This has no effect on wallet resource use as the call is effectively a no-op unless a renewal can be actually performed.