### PR TITLE
scraper: Change scraper_net unserialize check to include ALL_BUT_DELETED projects

### DIFF
--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -501,13 +501,15 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
     // is set to below 0.5, both to prevent a divide by zero exception, and also prevent unreasonably lose limits. So this
     // means the loosest limit that is allowed is essentially 2 * whitelist + 2.
 
+    // Note that the whitelist size is taken from the snapshot including all projects but deleted.
     unsigned int nMaxProjects = 0;
 
     {
         LOCK(cs_ScraperGlobals);
 
-        nMaxProjects = static_cast<unsigned int>(std::ceil(static_cast<double>(GRC::GetWhitelist().Snapshot().size()) /
-                                                                    std::max(0.5, CONVERGENCE_BY_PROJECT_RATIO)) + 2);
+        nMaxProjects = static_cast<unsigned int>(
+            std::ceil(static_cast<double>(GRC::GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED).size()) /
+                      std::max(0.5, CONVERGENCE_BY_PROJECT_RATIO)) + 2);
     }
 
     if (!OutOfSyncByAge() && projects.size() > nMaxProjects)


### PR DESCRIPTION
This should fix a validation error that is occurring on testnet post mandatory. The implementation of autogreylisting means that the greylisted projects should be included in the whitelist project list used for the determination of max projects in a manifest, rather than just the active projects (which is the default).