### PR TITLE
autogreylist: Removes zcd, was, and meets greylist criteria from getautogreylist history

### DIFF
--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -580,10 +580,7 @@ public:
         {
             // Populate the initial historical entry from the initial baseline.
             UpdateHistoryEntry entry = UpdateHistoryEntry(0,
-                                                          TC_initial_bookmark,
-                                                          std::optional<uint8_t>(),
-                                                          std::optional<Fraction>(),
-                                                          std::optional<bool>());
+                                                          TC_initial_bookmark);
 
             m_update_history.push_back(entry);
         }
@@ -703,7 +700,7 @@ public:
             m_meets_greylisting_crit = (sb_from_baseline >= 7 && (zcd > 7 || was < Fraction(1, 10)));
 
             // Insert historical entry.
-            UpdateHistoryEntry entry(sb_from_baseline, total_credit, zcd, was, m_meets_greylisting_crit);
+            UpdateHistoryEntry entry(sb_from_baseline, total_credit);
             m_update_history.push_back(entry);
         }
 
@@ -717,27 +714,15 @@ public:
             //!
             //! \param sb_from_baseline_processed
             //! \param total_credit
-            //! \param zcd
-            //! \param was
-            //! \param meets_greylisting_crit
             //!
             UpdateHistoryEntry(uint8_t sb_from_baseline_processed,
-                               std::optional<uint64_t>total_credit,
-                               std::optional<uint8_t> zcd,
-                               std::optional<Fraction> was,
-                               std::optional<bool> meets_greylisting_crit)
+                               std::optional<uint64_t>total_credit)
                 : m_sb_from_baseline_processed(sb_from_baseline_processed)
                 , m_total_credit(total_credit)
-                , m_zcd(zcd)
-                , m_was(was)
-                , m_meets_greylisting_crit(meets_greylisting_crit)
             {}
 
             uint8_t m_sb_from_baseline_processed;
             std::optional<uint64_t> m_total_credit;
-            std::optional<uint8_t> m_zcd;
-            std::optional<Fraction> m_was;
-            std::optional<bool> m_meets_greylisting_crit;
         };
 
         //!

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2824,24 +2824,6 @@ UniValue getautogreylist(const UniValue& params, bool fHelp)
                     historical_entry.pushKV("total_credit", "NA");
                 }
 
-                if (hist_entry.m_zcd) {
-                    historical_entry.pushKV("zcd", *hist_entry.m_zcd);
-                } else {
-                    historical_entry.pushKV("zcd", "NA");
-                }
-
-                if (hist_entry.m_was) {
-                    historical_entry.pushKV("was", hist_entry.m_was->ToDouble());
-                } else {
-                    historical_entry.pushKV("was", "NA");
-                }
-
-                if (hist_entry.m_meets_greylisting_crit) {
-                    historical_entry.pushKV("meets_greylisting_criteria", *hist_entry.m_meets_greylisting_crit);
-                } else {
-                    historical_entry.pushKV("meets_greylisting_criteria", "NA");
-                }
-
                 entry_history.push_back(historical_entry);
             }
 


### PR DESCRIPTION
This commit removes the reporting of zcd, was, and meets autogreylist criteria from the autogreylist history of each project. These are confusing because the historical records are reconstructed from the present SB backwards in time, and therefore the zcd, was and meets are NOT the same as what they would have been if one were standing on a particular historical superblock and computing the present status. Essentially the final value at the last history record (going backwards) IS correct and represents the current status.

The superblocks_from_baseline and total_credit remain as these are not misleading, and allows someone to script an audit based on the historical information.