### PR TITLE
net: subscribe PeerManager to validation signals; move tip inv relay behind UpdatedBlockTip (#3125 C8)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -289,6 +289,13 @@ void Shutdown(void* parg)
         // stake miner above too, so this is the first point at which no thread -- net,
         // RPC, or miner -- can still touch either. Reset the peer manager before the
         // connection manager it is associated with (PR 8a).
+        //
+        // Defensive/idiomatic unregister before destruction (issue #3125 C8; see
+        // the comment on the Unregister block further below): in the current
+        // teardown order this is a no-op -- UnregisterBackgroundSignalScheduler()
+        // earlier in Shutdown() already disconnected every subscriber -- and the
+        // operative safety invariant is the thread joins described above.
+        if (g_peerman) UnregisterValidationInterface(g_peerman.get());
         if (g_peerman) g_peerman.reset();
         if (g_connman) g_connman.reset();
 
@@ -2122,6 +2129,15 @@ bool AppInit2(ThreadHandlerPtr threads)
     // whose inputs get spent are evicted on mempool admission (fast) and on
     // block connection (authoritative).
     RegisterValidationInterface(&g_psgt_pool);
+
+    // Subscribe the peer manager so the new-tip inventory relay (moved out of
+    // AcceptBlock) hangs off UpdatedBlockTip like Bitcoin's net_processing --
+    // the PeerManager-as-subscriber half of workstream B3 (#3030), issue
+    // #3125 C8. g_peerman was constructed in Step 12 above; note StartNode is
+    // already running, so a block accepted from a live peer before this point
+    // no longer relays (the pre-move AcceptBlock loop did) -- a sub-second
+    // window, registration cannot precede the scheduler wiring above.
+    RegisterValidationInterface(g_peerman.get());
 
     // Three-layer PSGT pool notification (#2910), the -pollnotify pattern:
     // the pool fires this hook outside its lock for every mutation; it fans

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1663,11 +1663,12 @@ public:
         // per-node nStartingHeight heuristic below is the historical IBD
         // suppressor, so no fInitialDownload gate is added).
         //
-        // The best-chain gate is load-bearing, not redundant: SetBestChain's
-        // trust-regression path reorganizes back to the previous tip yet still
-        // emits UpdatedBlockTip with the losing block as pindexNew, and
-        // relaying that inv would advertise a non-best block. AcceptBlock's
-        // pre-move code suppressed exactly that case via the same comparison.
+        // Defensive best-chain guard. SetBestChain now emits UpdatedBlockTip only
+        // when the tip actually advanced -- it reports pindexBest and skips the
+        // emission on its trust-regression reorg-back path (issues #3145, #3125
+        // C8) -- so pindexNew is the best chain here. The guard stays as cheap
+        // insurance against a future emitter that fires on a non-advancing tip
+        // (relaying that inv would advertise a non-best block).
         if (pindexNew == nullptr || pindexNew->GetBlockHash() != hashBestChain) return;
 
         int nBlockEstimate = Params().Checkpoints().GetHeight();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1655,6 +1655,36 @@ public:
         // be consolidated onto PeerManager.
     }
 
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* /*pindexFork*/,
+                         bool /*fInitialDownload*/) override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    {
+        // Relay inventory, but don't relay old inventory during initial block
+        // download (moved verbatim from AcceptBlock, issue #3125 C8; the
+        // per-node nStartingHeight heuristic below is the historical IBD
+        // suppressor, so no fInitialDownload gate is added).
+        //
+        // The best-chain gate is load-bearing, not redundant: SetBestChain's
+        // trust-regression path reorganizes back to the previous tip yet still
+        // emits UpdatedBlockTip with the losing block as pindexNew, and
+        // relaying that inv would advertise a non-best block. AcceptBlock's
+        // pre-move code suppressed exactly that case via the same comparison.
+        if (pindexNew == nullptr || pindexNew->GetBlockHash() != hashBestChain) return;
+
+        int nBlockEstimate = Params().Checkpoints().GetHeight();
+
+        // Iterate under the already-held cs_main (issue #2558 PR 9c); read the
+        // cs_main-guarded height into a local so the callback stays lock-clean.
+        const int nBestHeightLocal = nBestHeight;
+        const CInv inv(MSG_BLOCK, pindexNew->GetBlockHash());
+        if (g_connman)
+        {
+            g_connman->ForEachNodeUnderLock([&](CNode* pnode) {
+                if (nBestHeightLocal > (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : nBlockEstimate))
+                    pnode->PushInventory(inv);
+            });
+        }
+    }
+
     bool Misbehaving(const CAddress& addr, int howmuch) override
     {
         if (addr.IsLocal())

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -6,6 +6,8 @@
 #define BITCOIN_NET_PROCESSING_H
 
 #include "net.h"
+#include "sync.h"
+#include "validationinterface.h"
 
 #include <memory>
 
@@ -13,6 +15,11 @@ class CTransaction;
 class CConnman;
 class CScheduler;
 class BanMan;
+
+//! Declared in chain.h; redeclared here for the UpdatedBlockTip lock
+//! annotation (the gridcoin/staking/chain_trust.h idiom) without pulling the
+//! chain-state header into the net layer.
+extern CCriticalSection cs_main;
 
 // Relay a transaction to peers, caching its serialized form in mapRelay so it
 // can be served from the getdata loop (moved from net.h, issue #2558 PR 2b).
@@ -34,8 +41,11 @@ void RelayPSGT(const uint256& revision_hash);
 //! peer-misbehavior tracking moved onto it in PR 8b (was the free
 //! GetMisbehaviorAddr/MisbehavingAddr/ClearMisbehaviorForSubnet of PR 2c).
 //! ThreadMessageHandler drives it through g_peerman; CConnman gains a
-//! NetEventsInterface* in PR 8c.
-class PeerManager : public NetEventsInterface
+//! NetEventsInterface* in PR 8c. It is additionally a CValidationInterface
+//! subscriber (registered in init.cpp) so relay work hangs off validation
+//! signals like Bitcoin's net_processing (issue #3125 C8, the
+//! PeerManager-as-subscriber half of #3030 workstream B3).
+class PeerManager : public NetEventsInterface, public CValidationInterface
 {
 public:
     static std::unique_ptr<PeerManager> make(CConnman& connman, BanMan* banman);
@@ -43,6 +53,13 @@ public:
 
     //! Start the recurring scheduled tasks (shell in PR 8a; populated later).
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;
+
+    //! CValidationInterface: relay the new best-block inventory to peers
+    //! (moved from AcceptBlock, issue #3125 C8). Redeclared public here --
+    //! the base declares it protected -- so tests can drive the handler
+    //! through g_peerman directly (the node/psgt_pool.h pattern).
+    virtual void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork,
+                                 bool fInitialDownload) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     //! Score misbehavior against an address; returns true if it triggered a ban.
     //! The per-address score, its linear decay, and the ban escalation moved

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -607,15 +607,13 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     // common ancestor for a multi-block reorg -- unlike origBestIndex, which
     // would be wrong for any non-trivial reorg. nullptr only when connecting the
     // genesis block. This resolves the #3080 stopgap so fork-point-dependent
-    // subscribers (e.g. the deferred PeerManager) receive correct semantics
-    // (issue #3104).
-    //
-    // The tip is reported as pindexBest rather than pindexNew: the
-    // trust-regression reorg-back above can leave the final tip at
-    // origBestIndex, and pindexNew would then name the abandoned block (issue
-    // #3145). On the normal path pindexBest == pindexNew after a successful
-    // reorganize, so this is equivalent.
-    GetMainSignals().UpdatedBlockTip(pindexBest, pfork, fIsInitialDownload);
+    // subscribers receive correct semantics (issue #3104). The PeerManager is
+    // now such a subscriber (issue #3125 C8): its UpdatedBlockTip handler
+    // relays the new-tip inventory (moved from AcceptBlock), gated on
+    // pindexNew still being the best chain -- load-bearing because the
+    // trust-regression path above reorganizes back to the previous tip yet
+    // still emits with the losing pindexNew.
+    GetMainSignals().UpdatedBlockTip(pindexNew, pfork, fIsInitialDownload);
 
     return GridcoinServices();
 }

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -525,15 +525,15 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     //
     // pfork captures the fork point of this forward reorg to pindexNew, threaded
     // out for the UpdatedBlockTip emission below (issue #3104). The reorg-back
-    // call, if it runs, overwrites pfork so the emission describes the reorg
-    // that actually produced the final tip (issue #3145). On that path the
-    // externally visible tip is unchanged (the tip itself would be the minimal
-    // fork point); the back-leg common ancestor passed instead is always a
-    // non-null ancestor of the reported tip, so a fork-point-dependent
-    // subscriber at worst revisits blocks already on the main chain.
+    // call, if it runs, leaves pfork untouched: the tip did not advance on that
+    // path, so the UpdatedBlockTip emission below is skipped entirely (see there)
+    // and pfork is never read.
     const CBlockIndex* pfork = nullptr;
     success = ReorganizeChain(txdb, cnt_dis, cnt_con, blockNew, pindexNew, &pfork);
 
+    // Whether the forward reorg to pindexNew regressed chain trust and was rolled
+    // back to origBestIndex. On that path the externally visible tip is unchanged.
+    bool reorged_back = false;
     if (previous_chain_trust > g_chain_trust.Best()) {
         LogPrintf("INFO: %s: Reorganize caused lower chain trust than before. Reorganizing back.", __func__);
 
@@ -543,7 +543,8 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
             return error("%s: Fatal Error while reading original best block", __func__);
         }
 
-        success = ReorganizeChain(txdb, cnt_dis, cnt_con, origBlock, origBestIndex, &pfork);
+        success = ReorganizeChain(txdb, cnt_dis, cnt_con, origBlock, origBestIndex);
+        reorged_back = true;
     }
 
     if (!success) {
@@ -596,24 +597,30 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     }
     #endif
 
-    // Notify the validation-signal layer that the chain tip advanced. The UI
-    // bridge registered in init.cpp re-emits uiInterface.NotifyBlocksChanged()
-    // for the Qt models, so GUI block notifications now flow through the
-    // validation interface (issue #3030, workstream B3).
+    // Notify the validation-signal layer that the chain tip advanced, but only
+    // when it actually did. Two subscribers consume this (issue #3030 B3): the UI
+    // bridge in init.cpp, which re-emits uiInterface.NotifyBlocksChanged() from
+    // the reported index's height/time for the Qt models; and the PeerManager
+    // (issue #3125 C8), which relays the new-tip inventory moved out of
+    // AcceptBlock.
     //
-    // pindexFork is the true reorg fork point: the last common ancestor
-    // (pcommon) computed in ReorganizeChain and threaded up here via pfork. It
-    // is the previous tip for a trivial single-block extension and the deeper
-    // common ancestor for a multi-block reorg -- unlike origBestIndex, which
-    // would be wrong for any non-trivial reorg. nullptr only when connecting the
-    // genesis block. This resolves the #3080 stopgap so fork-point-dependent
-    // subscribers receive correct semantics (issue #3104). The PeerManager is
-    // now such a subscriber (issue #3125 C8): its UpdatedBlockTip handler
-    // relays the new-tip inventory (moved from AcceptBlock), gated on
-    // pindexNew still being the best chain -- load-bearing because the
-    // trust-regression path above reorganizes back to the previous tip yet
-    // still emits with the losing pindexNew.
-    GetMainSignals().UpdatedBlockTip(pindexNew, pfork, fIsInitialDownload);
+    // Report pindexBest, not pindexNew: after a trust-regression reorg-back the
+    // final tip is origBestIndex, and pindexNew would name the abandoned block --
+    // mis-reporting the GUI height and advertising a non-best block (issues #3145,
+    // #3125 C8). On the advance path pindexBest == pindexNew.
+    //
+    // Emit only when the tip advanced. On the reorg-back path the tip is
+    // unchanged, so there is no update to report: skipping the emission is what
+    // suppresses the PeerManager relay there (the behavior AcceptBlock's old
+    // best-chain gate provided) and spares the GUI a redundant notification.
+    //
+    // pfork is the true reorg fork point (the last common ancestor computed in
+    // ReorganizeChain, issue #3104): the previous tip for a trivial extension, the
+    // deeper common ancestor for a multi-block reorg. nullptr only when connecting
+    // the genesis block.
+    if (!reorged_back) {
+        GetMainSignals().UpdatedBlockTip(pindexBest, pfork, fIsInitialDownload);
+    }
 
     return GridcoinServices();
 }

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -525,9 +525,12 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     //
     // pfork captures the fork point of this forward reorg to pindexNew, threaded
     // out for the UpdatedBlockTip emission below (issue #3104). The reorg-back
-    // call, if it runs, intentionally leaves pfork untouched: the emission
-    // reports pindexNew, so its matching fork point is this forward common
-    // ancestor.
+    // call, if it runs, overwrites pfork so the emission describes the reorg
+    // that actually produced the final tip (issue #3145). On that path the
+    // externally visible tip is unchanged (the tip itself would be the minimal
+    // fork point); the back-leg common ancestor passed instead is always a
+    // non-null ancestor of the reported tip, so a fork-point-dependent
+    // subscriber at worst revisits blocks already on the main chain.
     const CBlockIndex* pfork = nullptr;
     success = ReorganizeChain(txdb, cnt_dis, cnt_con, blockNew, pindexNew, &pfork);
 
@@ -540,7 +543,7 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
             return error("%s: Fatal Error while reading original best block", __func__);
         }
 
-        success = ReorganizeChain(txdb, cnt_dis, cnt_con, origBlock, origBestIndex);
+        success = ReorganizeChain(txdb, cnt_dis, cnt_con, origBlock, origBestIndex, &pfork);
     }
 
     if (!success) {
@@ -557,7 +560,12 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     bool fIsInitialDownload = IsInitialBlockDownload();
 
     if (!fIsInitialDownload) {
-        const CBlockLocator locator(pindexNew);
+        // Build the locator from pindexBest, not pindexNew: after a
+        // trust-regression reorg-back the final tip is origBestIndex, and a
+        // locator built from the abandoned pindexNew would lead with
+        // off-main-chain hashes (issue #3145). On the normal path
+        // pindexBest == pindexNew, so this is equivalent.
+        const CBlockLocator locator(pindexBest);
         // Persist the wallet best-block locator. Emitted synchronously under
         // cs_main (held by SetBestChain), so the CValidationInterface subscriber
         // (CWallet::ChainStateFlushed) runs in the canonical cs_main -> signals
@@ -601,7 +609,13 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     // genesis block. This resolves the #3080 stopgap so fork-point-dependent
     // subscribers (e.g. the deferred PeerManager) receive correct semantics
     // (issue #3104).
-    GetMainSignals().UpdatedBlockTip(pindexNew, pfork, fIsInitialDownload);
+    //
+    // The tip is reported as pindexBest rather than pindexNew: the
+    // trust-regression reorg-back above can leave the final tip at
+    // origBestIndex, and pindexNew would then name the abandoned block (issue
+    // #3145). On the normal path pindexBest == pindexNew after a successful
+    // reorganize, so this is equivalent.
+    GetMainSignals().UpdatedBlockTip(pindexBest, pfork, fIsInitialDownload);
 
     return GridcoinServices();
 }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -9,10 +9,13 @@
 #include "serialize.h"
 #include "streams.h"
 #include "net.h"
+#include "net_processing.h"
 #include "netbase.h"
 #include "addrdb.h"
+#include "chain.h"
 #include "chainparams.h"
 #include "clientversion.h"
+#include "primitives/block.h"
 
 using namespace std;
 
@@ -133,6 +136,29 @@ BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
     BOOST_CHECK(addrman2.size() == 0);
     adb.Read(addrman2, ssPeers2);
     BOOST_CHECK(addrman2.size() == 0);
+}
+
+// The PeerManager tip-relay handler (issue #3125 C8) must no-op safely on a
+// quiescent node: a null tip (defensive guard) and a non-best tip -- the
+// best-chain gate that suppresses relay when SetBestChain's trust-regression
+// path reorganizes back to the previous tip yet still emits UpdatedBlockTip
+// with the losing block. The fixture's g_connman has zero nodes, so a passing
+// gate would also no-op; what this exercises is the gate/guard path itself
+// under the handler's cs_main lock annotation.
+BOOST_AUTO_TEST_CASE(peerman_updatedblocktip_relay_gates)
+{
+    BOOST_REQUIRE(g_peerman);
+
+    LOCK(cs_main);
+
+    g_peerman->UpdatedBlockTip(nullptr, nullptr, false);
+
+    const uint256 not_best_hash = uint256S("0xdeadbeef");
+    CBlockIndex index;
+    index.phashBlock = &not_best_hash;
+    BOOST_REQUIRE(index.GetBlockHash() != hashBestChain);
+
+    g_peerman->UpdatedBlockTip(&index, nullptr, false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1512,22 +1512,11 @@ bool AcceptBlock(CBlock& block, CValidationState& state, bool generated_by_me) E
     if (!AddToBlockIndex(block, nFile, nBlockPos, hashProof))
         return error("%s: AddToBlockIndex failed", __func__);
 
-    // Relay inventory, but don't relay old inventory during initial block download
-    int nBlockEstimate = Params().Checkpoints().GetHeight();
-    if (hashBestChain == hash)
-    {
-        // Iterate under the already-held cs_main (issue #2558 PR 9c); read the
-        // cs_main-guarded height into a local so the callback stays lock-clean.
-        const int nBestHeightLocal = nBestHeight;
-        const CInv inv(MSG_BLOCK, hash);
-        if (g_connman)
-        {
-            g_connman->ForEachNodeUnderLock([&](CNode* pnode) {
-                if (nBestHeightLocal > (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : nBlockEstimate))
-                    pnode->PushInventory(inv);
-            });
-        }
-    }
+    // The new-tip inventory relay that lived here moved to
+    // PeerManagerImpl::UpdatedBlockTip, driven by the signal SetBestChain
+    // emits under the same cs_main hold (issue #3125 C8) -- including its
+    // best-chain gate, which suppressed relay when SetBestChain reorganized
+    // back to the previous tip.
 
     return true;
 }


### PR DESCRIPTION
Implements **C8 of #3125** — the PeerManager-as-subscriber half of #3030 workstream B3, carried over from the `CValidationInterface` work: register `g_peerman` as a validation-signal subscriber so post-#2558 relay work hangs off signals like Bitcoin's `net_processing`, and move `AcceptBlock`'s new-tip inventory relay into `PeerManagerImpl::UpdatedBlockTip`.

### What moves

- `PeerManager` (net_processing.h) additionally inherits `CValidationInterface`, with `UpdatedBlockTip` redeclared **public pure-virtual** (the base declares it protected; same pattern as `PSGTPool`'s public overrides in node/psgt_pool.h) so the handler is testable through `g_peerman`.
- The relay loop moves verbatim from `AcceptBlock` (validation.cpp) into `PeerManagerImpl::UpdatedBlockTip` (net_processing.cpp), driven by the emission `SetBestChain` already performs under the same `cs_main` hold on the same thread. Lock chain is unchanged: `cs_main -> signals -> cs_vNodes -> cs_inventory`.
- **The best-chain gate is kept**, rewritten against the signal parameter (`pindexNew->GetBlockHash() != hashBestChain -> return`). It is load-bearing, not redundant: `SetBestChain`'s trust-regression path reorganizes *back* to the previous tip, still returns success, and still emits `UpdatedBlockTip` with the losing block as `pindexNew` — the pre-move code suppressed relay in exactly that case, and this keeps doing so.
- Registration in `AppInit2` after `RegisterBackgroundSignalScheduler` (earlier registration is a documented silent no-op); a defensive `UnregisterValidationInterface` precedes `g_peerman.reset()` in `Shutdown` (a no-op in the current teardown order, same as the existing unregister block — the operative invariant is that all emitter threads are joined by that point).
- The `pindexFork` the handler receives is already the true fork point thanks to #3104; the handler doesn't need it yet, and the SetBestChain comment is updated accordingly.
- Unit test (`net_tests.cpp`): drives the null-tip guard and the non-best-tip gate paths through the public override on the quiescent fixture (the fixture never wires the signal scheduler, so a direct call is the only route).

### Behavior deltas (intentional, called out for review)

The move is wire-identical on the normal path (`PushInventory` only queues; sending happens later on the SendMessages thread), with three edge-window differences:

1. The relay enqueue now happens inside `SetBestChain` *before* `GridcoinServices()` runs, so a block whose GridcoinServices processing fails is relayed where it previously was not — arguably more correct, since the block did become the persisted on-disk tip.
2. A block accepted from a live peer between `StartNode`'s launch and the signal registration in `AppInit2` no longer relays (sub-second window; registration cannot precede the scheduler wiring).
3. Blocks accepted during shutdown after the signal-scheduler unregister no longer relay (the node is quitting).

For completeness: `ForceReorganizeToHash` does not go through `SetBestChain` and is unaffected, and the legacy startup-rewind `SetBestChain` call in dbwrapper.cpp cannot relay (pre-registration, and gated).

### Verification

- Full fork CI green (all 5 workflows) before opening: build matrix incl. qt, unit + functional tests, sanitizers, lints.
- `lint-include-guards.sh`, `lint-circular-dependencies.sh` clean (the new `net_processing -> validationinterface` edge introduces no cycle).

Part of #3125 (C8). Related: #3030 (workstream B3), #3104 (fork-point plumbing, already landed), #2558 (PeerManager scaffold).
