### PR TITLE
refactor: drop main.h from headers that no longer need it (#3125 C9)

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -7,7 +7,10 @@
 #define BITCOIN_DBWRAPPER_H
 
 #include "clientversion.h"
-#include "main.h"
+#include "index/disktxpos.h"
+#include "index/txindex.h"
+#include "primitives/block.h"
+#include "primitives/transaction.h"
 #include "streams.h"
 
 #include <cstdint>

--- a/src/gridcoin/account.h
+++ b/src/gridcoin/account.h
@@ -6,6 +6,8 @@
 #define GRIDCOIN_ACCOUNT_H
 
 #include "amount.h"
+#include "consensus/consensus.h"
+
 #include <optional>
 #include <unordered_map>
 

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -17,6 +17,8 @@
 #include "sync.h"
 #include "node/ui_interface.h"
 
+#include <boost/signals2/signal.hpp>
+
 #include <memory>
 #include <vector>
 #include <string>

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_MERKLEBLOCK_H
 #define BITCOIN_MERKLEBLOCK_H
 
-#include "main.h"
+#include "primitives/block.h"
 #include "serialize.h"
 #include "uint256.h"
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -12,8 +12,12 @@
 #include "consensus/tx_verify.h"
 
 // Defined in main.cpp; declared in main.h. The ad-hoc extern (the
-// node/chainman.cpp pattern) avoids re-including the main.h umbrella here
-// until the global moves to its policy home (#3125 C9).
+// node/chainman.cpp pattern) avoids re-including the main.h umbrella here.
+//
+// This is a bridge, and it has a definite end: #3125 C9 moves the global into
+// validation.{h,cpp}, and policy.h (repointed above) already includes
+// validation.h -- so once that lands this declaration is redundant and should
+// be deleted rather than relocated. It does not move to a policy header.
 extern bool fEnforceCanonical;
 
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -7,7 +7,14 @@
 
 #include <policy/policy.h>
 
+#include "chain.h"
+#include "consensus/consensus.h"
 #include "consensus/tx_verify.h"
+
+// Defined in main.cpp; declared in main.h. The ad-hoc extern (the
+// node/chainman.cpp pattern) avoids re-including the main.h umbrella here
+// until the global moves to its policy home (#3125 C9).
+extern bool fEnforceCanonical;
 
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
 {

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -6,7 +6,8 @@
 #ifndef BITCOIN_POLICY_POLICY_H
 #define BITCOIN_POLICY_POLICY_H
 
-#include "main.h"
+#include "script.h"
+#include "validation.h"
 
 /**
  * Mandatory script verification flags that all new transactions must comply with for

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -7,7 +7,6 @@
 #include "node/shutdown.h"
 #include "dbwrapper.h"
 #include "net.h"
-#include "main.h"
 #include "node/ui_interface.h"
 #include "util.h"
 


### PR DESCRIPTION
First umbrella-narrowing PR of **#3125 C9**: drop the `main.h` include from the four headers/TUs that do not actually need it, repointing them at their real dependencies. Every remaining `main.h` includer keeps compiling (the umbrella's re-includes are unchanged); files that consumed symbols *transitively* through these headers gained the direct includes they always should have had.

One commit per header for bisectability:

- **wallet/db.cpp** — include deleted outright; the TU uses nothing from the umbrella.
- **merkleblock.h** → `primitives/block.h` (CBlock/CBlockHeader are all it needs).
- **policy/policy.h** → `script.h` + `validation.h` (CScript/txnouttype/SCRIPT_VERIFY_*, CTransaction, `MapPrevTx`, and the `cs_main` declaration for the `IsStandardTx` annotation).
- **dbwrapper.h** → `index/disktxpos.h`, `index/txindex.h` (ordered as in validation.h — txindex.h has no includes of its own), `primitives/block.h`, `primitives/transaction.h`.
- Final commit: direct includes revealed by the umbrella loss — `gridcoin/account.h` uses `BLOCKS_PER_DAY` (→ `consensus/consensus.h`), `gridcoin/project.h` uses `boost::signals2::signal` (→ its header), `policy/policy.cpp` uses `nBestHeight` (→ `chain.h`), `MAX_STANDARD_TX_SIZE` (→ `consensus/consensus.h`), and `fEnforceCanonical` (ad-hoc extern, the node/chainman.cpp pattern, until the global moves to its policy home).

Found via an include-graph diff (14 TUs lost `main.h` reachability; all verified) plus a syntax-only sweep of every non-qt TU before/after. **Zero `src/qt` files are affected** (verified by the same graph diff over qt) — no `lint-qt-includes.sh` allowlist changes.

Verification: full fork CI green (all 5 workflows); include-guard and circular-dependency lints clean.

Part of #3125 (C9). Independent of the C9 symbol-move stack.
