### PR TITLE
refactor: move chain-state and chain-trust globals out of main.cpp (#3125 C9)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,7 @@ add_library(gridcoin_util STATIC
     arith_uint256.cpp
     banman.cpp
     base58.cpp
+    chain.cpp
     chainparams.cpp
     chainparamsbase.cpp
     checkpoints.cpp
@@ -161,6 +162,7 @@ add_library(gridcoin_util STATIC
     gridcoin/scraper/scraper_net.cpp
     gridcoin/scraper/scraper_registry.cpp
     gridcoin/sidestake.cpp
+    gridcoin/staking/chain_trust.cpp
     gridcoin/staking/difficulty.cpp
     gridcoin/staking/exceptions.cpp
     gridcoin/staking/kernel.cpp

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "chain.h"
+
+#include "gridcoin/block_index.h"
+
+// Definitions for the active-chain state declared in chain.h, moved out of
+// main.cpp (issue #3125 C9).
+
+//! The chain-state lock. The canonical lock order is
+//! cs_main -> signals -> cs_wallet (see doc/developer-notes.md).
+CCriticalSection cs_main;
+
+namespace GRC {
+BlockIndexPool::Pool<CBlockIndex> BlockIndexPool::m_block_index_pool;
+BlockIndexPool::Pool<ResearcherContext> BlockIndexPool::m_researcher_context_pool;
+} // namespace GRC
+
+BlockMap mapBlockIndex;
+CBlockIndex* pindexGenesisBlock GUARDED_BY(cs_main) = nullptr;
+int nBestHeight GUARDED_BY(cs_main) = -1;
+uint256 hashBestChain GUARDED_BY(cs_main);
+CBlockIndex* pindexBest GUARDED_BY(cs_main) = nullptr;
+std::atomic<int64_t> g_previous_block_time;
+std::atomic<int64_t> g_nTimeBestReceived;
+std::atomic<bool> g_reorg_in_progress = false;
+
+arith_uint256 CBlockIndex::GetBlockTrust() const
+{
+    arith_uint256 bnTarget;
+    bool fNegative;
+    bool fOverflow;
+    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
+    if (fNegative || fOverflow || bnTarget == 0)
+        return 0;
+    // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256
+    // as it's too large for an arith_uint256. However, as 2**256 is at least as large
+    // as bnTarget+1, it is equal to ((2**256 - bnTarget - 1) / (bnTarget+1)) + 1,
+    // or ~bnTarget / (bnTarget+1) + 1.
+    return (~bnTarget / (bnTarget + 1)) + 1;
+}

--- a/src/chain.h
+++ b/src/chain.h
@@ -24,13 +24,14 @@ typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 //! The chain-state lock. Guards the active-chain globals below.
 extern CCriticalSection cs_main;
 
-//! Active chain state, extracted from main.h (issue #3030, workstream A6).
-//! These remain defined in main.cpp; only the declarations live here so
-//! consumers can depend on chain state without pulling in all of main.h.
+//! Active chain state, extracted from main.h (issue #3030, workstream A6) and
+//! defined in chain.cpp (issue #3125 C9). Note: a stale extern for a
+//! nBestChainTrust global was removed in the C9 move -- it had no definition
+//! anywhere; the chain-tip trust lives in g_chain_trust
+//! (gridcoin/staking/chain_trust.h).
 extern BlockMap mapBlockIndex GUARDED_BY(cs_main);
 extern CBlockIndex* pindexGenesisBlock GUARDED_BY(cs_main);
 extern int nBestHeight GUARDED_BY(cs_main);
-extern arith_uint256 nBestChainTrust GUARDED_BY(cs_main);
 extern uint256 hashBestChain GUARDED_BY(cs_main);
 extern CBlockIndex* pindexBest GUARDED_BY(cs_main);
 extern std::atomic<bool> g_reorg_in_progress;

--- a/src/gridcoin/staking/chain_trust.cpp
+++ b/src/gridcoin/staking/chain_trust.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// chain_trust.h and spam.h rely on their includer supplying a complete
+// CBlockIndex first (the ChainTrustCache constructor news one inline), so
+// primitives/block.h must precede them here.
+#include "primitives/block.h"
+
+#include "gridcoin/staking/chain_trust.h"
+#include "gridcoin/staking/spam.h"
+
+// Definitions moved out of main.cpp (issue #3125 C9). Declarations live in
+// the headers above; the many per-TU ad-hoc externs were removed in the same
+// change.
+
+GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
+GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
+
+//!
+//! \brief Re-exports chain trust values for reporting.
+//!
+arith_uint256 GetChainTrust(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    return g_chain_trust.GetTrust(pindex);
+}

--- a/src/gridcoin/staking/chain_trust.h
+++ b/src/gridcoin/staking/chain_trust.h
@@ -13,6 +13,8 @@
 
 extern CCriticalSection cs_main;
 
+class CBlockIndex;
+
 namespace GRC {
 //!
 //! \brief Calculates and stores chain trust values.
@@ -362,5 +364,14 @@ private:
     LongTrustCache m_long_cache;      //!< Caches chain trust at height intervals.
 }; // ChainTrustCache
 } // namespace GRC
+
+//! Chain trust cache for the active chain. Defined in chain_trust.cpp (moved
+//! from main.cpp, issue #3125 C9).
+extern GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
+
+//!
+//! \brief Re-exports chain trust values for reporting.
+//!
+arith_uint256 GetChainTrust(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif // GRIDCOIN_STAKING_CHAIN_TRUST_H

--- a/src/gridcoin/staking/spam.h
+++ b/src/gridcoin/staking/spam.h
@@ -235,4 +235,8 @@ private:
 }; // SeenStakes
 } // namespace GRC
 
+//! Proof-of-stake proofs seen near the chain tip. Defined in
+//! gridcoin/staking/chain_trust.cpp (moved from main.cpp, issue #3125 C9).
+extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
+
 #endif // GRIDCOIN_STAKING_SPAM_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,19 +61,16 @@ using namespace boost;
 // Global state
 //
 
-CCriticalSection cs_main;
+// cs_main, the block-index pools, and the active-chain globals
+// (mapBlockIndex, pindexGenesisBlock, nBestHeight, hashBestChain, pindexBest,
+// the sync clocks, g_reorg_in_progress) moved to chain.cpp (issue #3125 C9);
+// their declarations remain in chain.h.
+
 CCriticalSection cs_tx_val_commit_to_disk;
 
 ///////////////////////MINOR VERSION////////////////////////////////
 
 extern int64_t GetCoinYearReward(int64_t nTime);
-
-namespace GRC {
-BlockIndexPool::Pool<CBlockIndex> BlockIndexPool::m_block_index_pool;
-BlockIndexPool::Pool<ResearcherContext> BlockIndexPool::m_researcher_context_pool;
-}
-
-BlockMap mapBlockIndex;
 
 //Gridcoin Minimum Stake Age (16 Hours)
 unsigned int nStakeMinAge = 16 * 60 * 60; // 16 hours
@@ -81,14 +78,6 @@ unsigned int nStakeMaxAge = -1; // unlimited
 
 // Gridcoin:
 int nCoinbaseMaturity = 100;
-CBlockIndex* pindexGenesisBlock GUARDED_BY(cs_main) = nullptr;
-int nBestHeight GUARDED_BY(cs_main) = -1;
-
-uint256 hashBestChain GUARDED_BY(cs_main);
-CBlockIndex* pindexBest GUARDED_BY(cs_main) = nullptr;
-std::atomic<int64_t> g_previous_block_time;
-std::atomic<int64_t> g_nTimeBestReceived;
-std::atomic<bool> g_reorg_in_progress = false;
 CMedianFilter<int> cPeerBlockCounts GUARDED_BY(cs_main) {5, 0}; // Amount of blocks that other nodes claim to have
 
 
@@ -130,16 +119,9 @@ int64_t g_v11_timestamp = 0;
 
 // End of Gridcoin Global vars
 
-GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
-GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
-
-//!
-//! \brief Re-exports chain trust values for reporting.
-//!
-arith_uint256 GetChainTrust(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
-{
-    return g_chain_trust.GetTrust(pindex);
-}
+// g_seen_stakes, g_chain_trust, and GetChainTrust moved to
+// gridcoin/staking/chain_trust.cpp (issue #3125 C9); declarations live in
+// gridcoin/staking/spam.h and gridcoin/staking/chain_trust.h.
 
 // The setpwalletRegistered wallet registry has been fully retired (issues #3030
 // and #3108): wallet notifications flow through CMainSignals, the wallet
@@ -240,20 +222,7 @@ GRC::SuperblockPtr CBlock::GetSuperblock(const CBlockIndex* const pindex) const
     return superblock;
 }
 
-arith_uint256 CBlockIndex::GetBlockTrust() const
-{
-    arith_uint256 bnTarget;
-    bool fNegative;
-    bool fOverflow;
-    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
-    if (fNegative || fOverflow || bnTarget == 0)
-        return 0;
-    // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256
-    // as it's too large for an arith_uint256. However, as 2**256 is at least as large
-    // as bnTarget+1, it is equal to ((2**256 - bnTarget - 1) / (bnTarget+1)) + 1,
-    // or ~bnTarget / (bnTarget+1) + 1.
-    return (~bnTarget / (bnTarget + 1)) + 1;
-}
+// CBlockIndex::GetBlockTrust moved to chain.cpp (issue #3125 C9).
 
 void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -26,12 +26,6 @@
 #include <cerrno>
 #include <stdio.h>
 
-// Chain-state globals defined in main.cpp that LoadBlockIndex references;
-// same ad-hoc extern pattern as node/chainman.cpp and node/coherence.cpp.
-extern GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
-extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
-
-
 bool WriteBlockToDisk(const CBlock& block, unsigned int& nFileRet, unsigned int& nBlockPosRet,
                       const CMessageHeader::MessageStartChars& messageStart)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -39,15 +39,12 @@
 
 using namespace std;
 
-// Chain-state globals defined elsewhere that the chain-management functions
-// reference. Kept where they are to limit churn (issue #3030, A4):
-//   g_chain_trust       -> defined in main.cpp (also extern'd in validation.cpp)
-//   g_seen_stakes / g_v11_timestamp -> defined in main.cpp (same ad-hoc extern
-//                          pattern as node/orphan_blocks.cpp / node/coherence.cpp)
-//   g_previous_block_time / g_nTimeBestReceived -> defined in main.cpp, declared in main.h
-//   pwalletMain         -> defined in init.cpp
-extern GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
-extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
+// Globals defined elsewhere that the chain-management functions reference.
+// g_chain_trust and g_seen_stakes now come from their canonical headers
+// (gridcoin/staking/chain_trust.h and spam.h, included above -- issue #3125
+// C9); the remaining ad-hoc externs cover:
+//   g_v11_timestamp -> defined in main.cpp
+//   pwalletMain     -> defined in init.cpp
 extern int64_t g_v11_timestamp;
 extern CWallet* pwalletMain;
 

--- a/src/node/coherence.cpp
+++ b/src/node/coherence.cpp
@@ -17,9 +17,6 @@
 
 #include <limits>
 
-extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
-extern GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
-
 namespace GRC {
 
 CoherenceResult VerifyChainCoherence(int max_walkback)

--- a/src/node/orphan_blocks.cpp
+++ b/src/node/orphan_blocks.cpp
@@ -9,8 +9,6 @@
 #include "gridcoin/staking/spam.h"
 #include "util.h"
 
-extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
-
 OrphanBlockManager g_orphan_blocks GUARDED_BY(cs_main);
 
 bool OrphanBlockManager::Add(const uint256& hash, const CBlock& block, int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -18,6 +18,7 @@
 #include <util/string.h>
 #include <util/time.h>
 #include "gridcoin/mrc.h"
+#include "gridcoin/staking/chain_trust.h"
 #include "gridcoin/support/block_finder.h"
 #include "gridcoin/support/xml.h"
 #include <rpc/util.h>
@@ -38,7 +39,6 @@ extern GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = 
 extern ScraperPendingBeaconMap GetPendingBeaconsForReport();
 extern ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = false);
 extern UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-arith_uint256 GetChainTrust(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 double CoinToDouble(double surrogate);
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 UniValue ContractToJson(const GRC::Contract& contract);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -38,9 +38,6 @@
 #include <set>
 #include <stdexcept>
 
-extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
-extern GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
-
 static constexpr CAmount nGenesisSupply = 340569880;
 bool fColdBoot = true;
 


### PR DESCRIPTION
Creates src/chain.cpp (cs_main, the BlockIndexPool statics, mapBlockIndex and the active-chain globals, CBlockIndex::GetBlockTrust) and src/gridcoin/staking/chain_trust.cpp (g_chain_trust, g_seen_stakes, GetChainTrust), replacing six per-TU ad-hoc externs with canonical declarations in chain_trust.h/spam.h. Also deletes the stale definition-less nBestChainTrust extern from chain.h.

Stacked C9 series (#3125), in merge order: chain/extract-chain-globals → validation/move-sync-state → staking/move-settings-globals → wallet/move-settings-globals → interfaces/drop-mainh → gridcoin/extract-block-claims → init/rehome-lifecycle-flags → node/retire-main-cpp. Each PR's diff vs development includes its predecessors until they merge (the #3131–#3137 pattern).

Verification: full fork CI green on the stack tip (all 5 workflows; one known rpc_psgtpool funding-setup flake cleared on re-run — the #3165 domain). Per-commit syntax-only sweep of all non-qt TUs; include-guard + circular-dependency lints clean; zero src/qt changes (lint-qt-includes ratchet untouched).

Part of #3125 (C9). Pure code motion; no behavior change.
