### PR TITLE
refactor: move sync-state and validation globals into validation.{h,cpp} (#3125 C9)

### DIFF
--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -19,8 +19,6 @@
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
 
-extern int64_t g_v11_timestamp;
-
 namespace {
 BeaconRegistry g_beacons;
 

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -23,8 +23,6 @@
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
 
-extern int64_t g_v11_timestamp;
-
 namespace {
 /*
 //!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,10 @@ using namespace boost;
 // the sync clocks, g_reorg_in_progress) moved to chain.cpp (issue #3125 C9);
 // their declarations remain in chain.h.
 
-CCriticalSection cs_tx_val_commit_to_disk;
+// cs_tx_val_commit_to_disk, nCoinbaseMaturity, cPeerBlockCounts,
+// nGrandfather, fEnforceCanonical, g_v11_timestamp, and the sync-state
+// helpers (GetNumBlocksOfPeers, IsInitialBlockDownload, OutOfSyncByAge)
+// moved to validation.{h,cpp} (issue #3125 C9).
 
 ///////////////////////MINOR VERSION////////////////////////////////
 
@@ -75,10 +78,6 @@ extern int64_t GetCoinYearReward(int64_t nTime);
 //Gridcoin Minimum Stake Age (16 Hours)
 unsigned int nStakeMinAge = 16 * 60 * 60; // 16 hours
 unsigned int nStakeMaxAge = -1; // unlimited
-
-// Gridcoin:
-int nCoinbaseMaturity = 100;
-CMedianFilter<int> cPeerBlockCounts GUARDED_BY(cs_main) {5, 0}; // Amount of blocks that other nodes claim to have
 
 
 
@@ -108,14 +107,7 @@ std::atomic<bool> bGridcoinCoreInitComplete{false};
 CCriticalSection cs_msMiningErrors;
 std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
 
-//When syncing, we grandfather block rejection rules up to this block, as rules became stricter over time and fields changed
-int nGrandfather = 1034700;
-
-bool fEnforceCanonical = true;
 bool fUseFastIndex = false;
-
-// Temporary block version 11 transition helpers:
-int64_t g_v11_timestamp = 0;
 
 // End of Gridcoin Global vars
 
@@ -143,38 +135,6 @@ double CoinToDouble(double surrogate)
 //
 // CBlock and CBlockIndex
 //
-// Return maximum amount of blocks that other nodes claim to have
-int GetNumBlocksOfPeers()
-{
-    LOCK(cs_main);
-    return std::max(cPeerBlockCounts.median(), Params().Checkpoints().GetHeight());
-}
-
-bool IsInitialBlockDownload()
-{
-    LOCK(cs_main);
-    if ((pindexBest == nullptr || nBestHeight < GetNumBlocksOfPeers()) && nBestHeight < 1185000)
-        return true;
-    static int64_t nLastUpdate;
-    static CBlockIndex* pindexLastBest;
-    if (pindexBest != pindexLastBest)
-    {
-        pindexLastBest = pindexBest;
-        nLastUpdate =  GetAdjustedTime();
-    }
-    return ( GetAdjustedTime() - nLastUpdate < 15 &&
-            pindexBest->GetBlockTime() <  GetAdjustedTime() - 8 * 60 * 60);
-}
-
-bool OutOfSyncByAge()
-{
-    // Assume we are out of sync if the current block age is 10
-    // times older than the target spacing. This is the same
-    // rules that Bitcoin uses.
-    constexpr int64_t maxAge = 90 * 10;
-
-    return GetAdjustedTime() - g_previous_block_time >= maxAge;
-}
 
 const GRC::Claim& CBlock::GetClaim() const
 {

--- a/src/main.h
+++ b/src/main.h
@@ -59,12 +59,14 @@ typedef std::optional<Claim> ClaimOption;
 // chain.h, included above (issue #3030, workstream A6). FutureDrift and
 // GetTargetSpacing live in primitives/block.h (extracted in #3060).
 
+// cs_tx_val_commit_to_disk, nCoinbaseMaturity, nGrandfather, and
+// fEnforceCanonical are declared in validation.h, included above
+// (issue #3125 C9).
+
 extern CScript COINBASE_FLAGS;
-extern CCriticalSection cs_tx_val_commit_to_disk;
 extern unsigned int nStakeMinAge;
 extern unsigned int nStakeMaxAge;
 extern unsigned int nNodeLifespan;
-extern int nCoinbaseMaturity;
 extern const std::string strMessageMagic;
 // Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
 
@@ -76,8 +78,6 @@ extern int64_t nMinimumInputValue;
 extern bool fUseFastIndex;
 extern unsigned int nDerivationMethodIndex;
 
-extern bool fEnforceCanonical;
-
 //! \brief Guards \ref msMiningErrors. Written by Researcher::StoreResearcher
 //! on the GUI / timer thread, read by getmininginfo RPC and the Qt researcher
 //! model on their respective threads. std::string assignment / copy is not
@@ -86,8 +86,6 @@ extern bool fEnforceCanonical;
 //! serialization.
 extern CCriticalSection cs_msMiningErrors;
 extern std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
-
-extern int nGrandfather;
 
 class CReserveKey;
 class CTxDB;
@@ -109,12 +107,11 @@ double CoinToDouble(double surrogate);
 
 GRC::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-int GetNumBlocksOfPeers();
-bool IsInitialBlockDownload();
+// GetNumBlocksOfPeers, IsInitialBlockDownload, and OutOfSyncByAge live in
+// validation.h, included above (issue #3125 C9).
 // GetWarnings lives in alert.h (issue #3125, workstream C6). GetTransaction
 // lives in validation.h, included above, and CMerkleTx in wallet/wallet.h --
 // only the wallet derives from it (issue #3125, workstream C3).
-bool OutOfSyncByAge();
 
 // AcceptToMemoryPool lives in validation.h, included above (issue #3125,
 // workstream C2).

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -65,7 +65,8 @@ using namespace std;
 extern CCriticalSection cs_mapAlerts;
 extern std::map<uint256, CAlert> mapAlerts GUARDED_BY(cs_mapAlerts);
 
-// cPeerBlockCounts stays in main.cpp (read by GetNumBlocksOfPeers); the moved
+// cPeerBlockCounts stays in validation.cpp (read by GetNumBlocksOfPeers --
+// homing it here would mint a validation <-> net_processing cycle); the moved
 // VERSION handler feeds it peer-claimed heights, so declare it here.
 extern CMedianFilter<int> cPeerBlockCounts GUARDED_BY(cs_main);
 

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -40,12 +40,10 @@
 using namespace std;
 
 // Globals defined elsewhere that the chain-management functions reference.
-// g_chain_trust and g_seen_stakes now come from their canonical headers
-// (gridcoin/staking/chain_trust.h and spam.h, included above -- issue #3125
-// C9); the remaining ad-hoc externs cover:
-//   g_v11_timestamp -> defined in main.cpp
-//   pwalletMain     -> defined in init.cpp
-extern int64_t g_v11_timestamp;
+// g_chain_trust, g_seen_stakes, and g_v11_timestamp now come from their
+// canonical headers (gridcoin/staking/chain_trust.h, spam.h, validation.h,
+// included above -- issue #3125 C9); the remaining ad-hoc extern covers:
+//   pwalletMain -> defined in init.cpp
 extern CWallet* pwalletMain;
 
 void UpdateSyncTime(const CBlockIndex* const pindexBest)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -11,15 +11,6 @@
 #include "consensus/consensus.h"
 #include "consensus/tx_verify.h"
 
-// Defined in main.cpp; declared in main.h. The ad-hoc extern (the
-// node/chainman.cpp pattern) avoids re-including the main.h umbrella here.
-//
-// This is a bridge, and it has a definite end: #3125 C9 moves the global into
-// validation.{h,cpp}, and policy.h (repointed above) already includes
-// validation.h -- so once that lands this declaration is redundant and should
-// be deleted rather than relocated. It does not move to a policy header.
-extern bool fEnforceCanonical;
-
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
 {
     std::vector<valtype> vSolutions;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -38,6 +38,55 @@
 #include <set>
 #include <stdexcept>
 
+// Sync / chain-progress state moved out of main.cpp (issue #3125 C9);
+// declarations live in validation.h.
+
+CCriticalSection cs_tx_val_commit_to_disk;
+
+int nCoinbaseMaturity = 100;
+
+CMedianFilter<int> cPeerBlockCounts GUARDED_BY(cs_main) {5, 0}; // Amount of blocks that other nodes claim to have
+
+//When syncing, we grandfather block rejection rules up to this block, as rules became stricter over time and fields changed
+int nGrandfather = 1034700;
+
+bool fEnforceCanonical = true;
+
+// Temporary block version 11 transition helpers:
+int64_t g_v11_timestamp = 0;
+
+int GetNumBlocksOfPeers()
+{
+    LOCK(cs_main);
+    return std::max(cPeerBlockCounts.median(), Params().Checkpoints().GetHeight());
+}
+
+bool IsInitialBlockDownload()
+{
+    LOCK(cs_main);
+    if ((pindexBest == nullptr || nBestHeight < GetNumBlocksOfPeers()) && nBestHeight < 1185000)
+        return true;
+    static int64_t nLastUpdate;
+    static CBlockIndex* pindexLastBest;
+    if (pindexBest != pindexLastBest)
+    {
+        pindexLastBest = pindexBest;
+        nLastUpdate =  GetAdjustedTime();
+    }
+    return ( GetAdjustedTime() - nLastUpdate < 15 &&
+            pindexBest->GetBlockTime() <  GetAdjustedTime() - 8 * 60 * 60);
+}
+
+bool OutOfSyncByAge()
+{
+    // Assume we are out of sync if the current block age is 10
+    // times older than the target spacing. This is the same
+    // rules that Bitcoin uses.
+    constexpr int64_t maxAge = 90 * 10;
+
+    return GetAdjustedTime() - g_previous_block_time >= maxAge;
+}
+
 static constexpr CAmount nGenesisSupply = 340569880;
 bool fColdBoot = true;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -28,6 +28,37 @@ namespace GRC {
 
 typedef std::map<uint256, std::pair<CTxIndex, CTransaction>> MapPrevTx;
 
+//
+// Sync / chain-progress state, moved out of main.{h,cpp} (issue #3125 C9).
+//
+
+//! Serializes the transaction-validation commit-to-disk window (issue #2865).
+extern CCriticalSection cs_tx_val_commit_to_disk;
+
+//! Coinbase/coinstake maturity depth.
+extern int nCoinbaseMaturity;
+
+//! When syncing, block-rejection rules are grandfathered up to this height,
+//! as rules became stricter over time and fields changed.
+extern int nGrandfather;
+
+//! Enforce canonical script pushes for standardness.
+extern bool fEnforceCanonical;
+
+//! Temporary block-version-11 transition helper.
+extern int64_t g_v11_timestamp;
+
+//! Median of the block heights that connected peers claim to have, floored
+//! at the hardened-checkpoint height.
+int GetNumBlocksOfPeers();
+
+//! Heuristic: still syncing the historical chain (peer-height median and
+//! tip-age based).
+bool IsInitialBlockDownload();
+
+//! Heuristic: the tip is older than ten target block spacings.
+bool OutOfSyncByAge();
+
 bool ReadTxFromDisk(CTransaction& tx, CDiskTxPos pos, FILE** pfileRet = nullptr);
 bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout, CTxIndex& txindexRet);
 bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout);


### PR DESCRIPTION
Moves cs_tx_val_commit_to_disk, nCoinbaseMaturity, nGrandfather, fEnforceCanonical, g_v11_timestamp, cPeerBlockCounts, and the sync-state helpers (GetNumBlocksOfPeers, IsInitialBlockDownload with its function-local statics, OutOfSyncByAge) into validation.{h,cpp}. net_processing keeps its mirrored cPeerBlockCounts extern (homing it there would mint a validation ↔ net_processing cycle). main.h loses the declarations outright — validation.h is one of its re-includes.

Stacked C9 series (#3125), in merge order: chain/extract-chain-globals → validation/move-sync-state → staking/move-settings-globals → wallet/move-settings-globals → interfaces/drop-mainh → gridcoin/extract-block-claims → init/rehome-lifecycle-flags → node/retire-main-cpp. Each PR's diff vs development includes its predecessors until they merge (the #3131–#3137 pattern).

Verification: full fork CI green on the stack tip (all 5 workflows; one known rpc_psgtpool funding-setup flake cleared on re-run — the #3165 domain). Per-commit syntax-only sweep of all non-qt TUs; include-guard + circular-dependency lints clean; zero src/qt changes (lint-qt-includes ratchet untouched).

Part of #3125 (C9). Pure code motion; no behavior change.
