### PR TITLE
refactor: move staking, net, and util globals out of main.{h,cpp} (#3125 C9)

### DIFF
--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -17,6 +17,12 @@
 using namespace std;
 using namespace GRC;
 
+// Moved from main.cpp (issue #3125 C9); declared in kernel.h.
+
+//Gridcoin Minimum Stake Age (16 Hours)
+unsigned int nStakeMinAge = 16 * 60 * 60; // 16 hours
+unsigned int nStakeMaxAge = -1; // unlimited
+
 namespace {
 //!
 //! \brief Represents a candidate block for new stake modifier selection.

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -9,6 +9,11 @@
 #include "amount.h"
 #include "main.h"
 
+//! Gridcoin minimum/maximum stake age. Defined in
+//! gridcoin/staking/kernel.cpp (moved from main.cpp, issue #3125 C9).
+extern unsigned int nStakeMinAge;
+extern unsigned int nStakeMaxAge;
+
 namespace GRC {
 // To decrease granularity of timestamp
 // Supposed to be 2^n-1

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,7 +62,6 @@ extern bool fQtActive;
 extern std::atomic<bool> bGridcoinCoreInitComplete;
 extern bool fConfChange;
 extern bool fEnforceCanonical;
-extern unsigned int nNodeLifespan;
 extern unsigned int nDerivationMethodIndex;
 extern unsigned int nMinerSleep;
 extern bool fUseFastIndex;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,8 +52,6 @@
 #include <math.h>
 #include <util/string.h>
 
-unsigned int nNodeLifespan;
-
 using namespace std;
 using namespace boost;
 
@@ -75,9 +73,9 @@ using namespace boost;
 
 extern int64_t GetCoinYearReward(int64_t nTime);
 
-//Gridcoin Minimum Stake Age (16 Hours)
-unsigned int nStakeMinAge = 16 * 60 * 60; // 16 hours
-unsigned int nStakeMaxAge = -1; // unlimited
+// nStakeMinAge/nStakeMaxAge moved to gridcoin/staking/kernel.{h,cpp};
+// nNodeLifespan to net.{h,cpp}; strMessageMagic and CoinToDouble to
+// util.{h,cpp} (issue #3125 C9).
 
 
 
@@ -87,7 +85,6 @@ unsigned int nStakeMaxAge = -1; // unlimited
 
 // Constant stuff for coinbase transactions we create:
 CScript COINBASE_FLAGS;
-const string strMessageMagic = "Gridcoin Signed Message:\n";
 
 // Settings
 // This is changed to MIN_TX_FEE * 10 for block version 11 (CTransaction::CURRENT_VERSION 2).
@@ -120,14 +117,6 @@ bool fUseFastIndex = false;
 // rebroadcast self-schedules on g_scheduler, and the net-half request-count /
 // own-tx-trickle paths call pwalletMain directly. The canonical lock order is
 // now cs_main -> cs_wallet.
-
-
-double CoinToDouble(double surrogate)
-{
-    //Converts satoshis to a human double amount
-    double coin = (double)surrogate/(double)COIN;
-    return coin;
-}
 
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -64,10 +64,17 @@ typedef std::optional<Claim> ClaimOption;
 // (issue #3125 C9).
 
 extern CScript COINBASE_FLAGS;
+
+// nNodeLifespan is declared in net.h and strMessageMagic in util.h, both
+// included above (issue #3125 C9).
+
+// -- Compatibility declarations: delete as the remaining main.h includers
+// -- are repointed (#3125 C9). Verbatim duplicates of the canonical
+// -- declarations in gridcoin/staking/kernel.h, which is NOT part of this
+// -- header's re-include set (kernel.h itself still includes main.h).
 extern unsigned int nStakeMinAge;
 extern unsigned int nStakeMaxAge;
-extern unsigned int nNodeLifespan;
-extern const std::string strMessageMagic;
+// -- End compatibility declarations.
 // Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
 
 // Settings
@@ -98,7 +105,7 @@ class CTxIndex;
 // LoadExternalBlockFile) and LoadBlockIndex live in node/blockstorage.h,
 // included above (issue #3125, workstream C5).
 void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-double CoinToDouble(double surrogate);
+// CoinToDouble is declared in util.h, included above (issue #3125 C9).
 
 // ProcessMessages / SendMessages moved to net_processing.h (issue #2558 PR 2a).
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -46,6 +46,7 @@ using namespace std;
 extern int nMaxConnections;
 int MAX_OUTBOUND_CONNECTIONS = 8;
 int PEER_TIMEOUT = 45;
+unsigned int nNodeLifespan; // -addrlifespan, set in AppInit2 (moved from main.cpp, issue #3125 C9)
 
 #ifdef USE_UPNP
 void ThreadMapPort2(void* parg);

--- a/src/net.h
+++ b/src/net.h
@@ -39,6 +39,9 @@ static const int PING_INTERVAL = 2 * 60;
 static const int TIMEOUT_INTERVAL = 20 * 60;
 extern int MAX_OUTBOUND_CONNECTIONS;
 extern int PEER_TIMEOUT;
+//! Peer-address lifespan in days (-addrlifespan): addresses older than this
+//! are not relayed. Defined in net.cpp (moved from main.cpp, issue #3125 C9).
+extern unsigned int nNodeLifespan;
 
 typedef int64_t NodeId;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,6 +29,16 @@ using namespace std;
 
 CMedianFilter<int64_t> vTimeOffsets(200,0);
 
+// Moved from main.cpp (issue #3125 C9); declared in util.h.
+const std::string strMessageMagic = "Gridcoin Signed Message:\n";
+
+double CoinToDouble(double surrogate)
+{
+    //Converts satoshis to a human double amount
+    double coin = (double)surrogate/(double)COIN;
+    return coin;
+}
+
 /** A map that contains all the currently held directory locks. After
  * successful locking, these will be held here until the global destructor
  * cleans them up and thus automatically unlocks them, or ReleaseDirectoryLocks

--- a/src/util.h
+++ b/src/util.h
@@ -79,10 +79,19 @@
 
 extern int GetDayOfYear(int64_t timestamp);
 
+//! Prefix mixed into signed user messages so a message signature cannot be
+//! replayed as a transaction signature. Defined in util.cpp (moved from
+//! main.cpp, issue #3125 C9).
+extern const std::string strMessageMagic;
+
 void LogException(std::exception* pex, const char* pszThread);
 void PrintException(std::exception* pex, const char* pszThread);
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);
 std::string FormatMoney(int64_t n, bool fPlus=false);
+
+//! Convert satoshis to a human coin amount (moved from main.cpp, issue
+//! #3125 C9).
+double CoinToDouble(double surrogate);
 bool ParseMoney(const std::string& str, int64_t& nRet);
 bool ParseMoney(const char* pszIn, int64_t& nRet);
 bool WildcardMatch(const char* psz, const char* mask);


### PR DESCRIPTION
nStakeMinAge/nStakeMaxAge → gridcoin/staking/kernel.{h,cpp} (main.h keeps fenced verbatim compatibility duplicates: kernel.h is not in its re-include set and e.g. node/blockstorage.cpp still reaches the ages through main.h); nNodeLifespan → net.{h,cpp}; strMessageMagic and CoinToDouble → util.{h,cpp} (re-included → deleted from main.h outright).

Stacked C9 series (#3125), in merge order: chain/extract-chain-globals (#3174) → validation/move-sync-state (#3175) → staking/move-settings-globals → wallet/move-settings-globals → interfaces/drop-mainh → gridcoin/extract-block-claims → init/rehome-lifecycle-flags → node/retire-main-cpp. Each PR's diff vs development includes its predecessors until they merge (the #3131–#3137 pattern).

Verification: full fork CI green on the stack tip (all 5 workflows; one known rpc_psgtpool funding-setup flake cleared on re-run — the #3165 domain). Per-commit syntax-only sweep of all non-qt TUs; include-guard + circular-dependency lints clean; zero src/qt changes (lint-qt-includes ratchet untouched).

Part of #3125 (C9). Pure code motion; no behavior change.
