### PR TITLE
refactor: move wallet, miner, and researcher settings out of main.{h,cpp} (#3125 C9)

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -32,9 +32,12 @@ using namespace GRC;
 
 extern CCriticalSection cs_main;
 extern CCriticalSection cs_ScraperGlobals;
-extern CCriticalSection cs_msMiningErrors;
-extern std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
 extern unsigned int nActiveBeforeSB;
+
+// Mining status variables (moved from main.cpp, issue #3125 C9; declared in
+// researcher.h).
+CCriticalSection cs_msMiningErrors;
+std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
 
 std::vector<MiningPool> MiningPools::GetMiningPools()
 {

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -21,6 +21,16 @@ class uint256;
 extern CCriticalSection cs_main;
 extern CWallet* pwalletMain;
 
+//! \brief Guards \ref msMiningErrors. Written by Researcher::StoreResearcher
+//! on the GUI / timer thread, read by getmininginfo RPC and the researcher
+//! interface on their respective threads. std::string assignment / copy is
+//! not atomic, so the writer's release of internal buffer storage can race
+//! with a reader's traversal of the same buffer — undefined behaviour
+//! without serialization. Defined in researcher.cpp (moved from
+//! main.{h,cpp}, issue #3125 C9).
+extern CCriticalSection cs_msMiningErrors;
+extern std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
+
 namespace GRC {
 
 class Beacon;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,28 +83,16 @@ extern int64_t GetCoinYearReward(int64_t nTime);
 // Orphan block storage managed by g_orphan_blocks (node/orphan_blocks.h)
 
 
-// Constant stuff for coinbase transactions we create:
-CScript COINBASE_FLAGS;
-
-// Settings
-// This is changed to MIN_TX_FEE * 10 for block version 11 (CTransaction::CURRENT_VERSION 2).
-// Note that this is an early init value and will result in overpayment of the fee per kbyte
-// if this code is run on a wallet prior to the v11 mandatory switchover unless a manual value
-// of -paytxfee is specified as an argument.
-int64_t nTransactionFee = MIN_TX_FEE * 10;
-int64_t nReserveBalance = 0;
-int64_t nMinimumInputValue = 0;
+// COINBASE_FLAGS moved to miner.{h,cpp}; the wallet settings
+// (nTransactionFee, nReserveBalance, nMinimumInputValue) to
+// wallet/wallet.{h,cpp}; the mining status variables (cs_msMiningErrors,
+// msMiningErrors) to gridcoin/researcher.{h,cpp}; and fUseFastIndex to
+// primitives/block.{h,cpp} (issue #3125 C9).
 
 // Gridcoin - Rob Halford
 
 bool fQtActive = false;
 std::atomic<bool> bGridcoinCoreInitComplete{false};
-
-// Mining status variables
-CCriticalSection cs_msMiningErrors;
-std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
-
-bool fUseFastIndex = false;
 
 // End of Gridcoin Global vars
 

--- a/src/main.h
+++ b/src/main.h
@@ -63,36 +63,25 @@ typedef std::optional<Claim> ClaimOption;
 // fEnforceCanonical are declared in validation.h, included above
 // (issue #3125 C9).
 
-extern CScript COINBASE_FLAGS;
-
-// nNodeLifespan is declared in net.h and strMessageMagic in util.h, both
-// included above (issue #3125 C9).
+// nNodeLifespan is declared in net.h, strMessageMagic in util.h, and
+// fUseFastIndex in primitives/block.h, all included above. COINBASE_FLAGS
+// lives in miner.h and the mining status variables (cs_msMiningErrors,
+// msMiningErrors) in gridcoin/researcher.h; their consumers include those
+// directly (issue #3125 C9).
+// Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
 
 // -- Compatibility declarations: delete as the remaining main.h includers
 // -- are repointed (#3125 C9). Verbatim duplicates of the canonical
-// -- declarations in gridcoin/staking/kernel.h, which is NOT part of this
-// -- header's re-include set (kernel.h itself still includes main.h).
+// -- declarations in gridcoin/staking/kernel.h and wallet/wallet.h, which
+// -- are NOT part of this header's re-include set (both still include
+// -- main.h themselves).
 extern unsigned int nStakeMinAge;
 extern unsigned int nStakeMaxAge;
-// -- End compatibility declarations.
-// Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
-
-// Settings
 extern int64_t nTransactionFee;
 extern int64_t nReserveBalance;
 extern int64_t nMinimumInputValue;
-
-extern bool fUseFastIndex;
 extern unsigned int nDerivationMethodIndex;
-
-//! \brief Guards \ref msMiningErrors. Written by Researcher::StoreResearcher
-//! on the GUI / timer thread, read by getmininginfo RPC and the Qt researcher
-//! model on their respective threads. std::string assignment / copy is not
-//! atomic, so the writer's release of internal buffer storage can race with a
-//! reader's traversal of the same buffer — undefined behaviour without
-//! serialization.
-extern CCriticalSection cs_msMiningErrors;
-extern std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
+// -- End compatibility declarations.
 
 class CReserveKey;
 class CTxDB;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -51,6 +51,10 @@ static bool fDevbuildCripple = false;
 bool GetDevbuildCripple() { return fDevbuildCripple; }
 void SetDevbuildCripple(bool crippled) { fDevbuildCripple = crippled; }
 
+// Constant stuff for coinbase transactions we create (moved from main.cpp,
+// issue #3125 C9; declared in miner.h):
+CScript COINBASE_FLAGS;
+
 std::atomic<int> g_stakelimit_height{0};
 
 int32_t ComputeBlockVersion(int height)

--- a/src/miner.h
+++ b/src/miner.h
@@ -19,6 +19,10 @@ typedef std::vector<GRC::SideStake_ptr> SideStakeAlloc;
 
 extern unsigned int nMinerSleep;
 
+//! Extra data appended to the coinbase scriptSig of blocks we create.
+//! Defined in miner.cpp (moved from main.{h,cpp}, issue #3125 C9).
+extern CScript COINBASE_FLAGS;
+
 //! \brief Select the block header version the miner must stamp for a block at
 //! the given height. Mirrors Bitcoin Core's ComputeBlockVersion: a pure,
 //! side-effect-free function of \p height and the active chain parameters, so

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -8,11 +8,14 @@
 #include "main.h"
 
 // These methods are defined out-of-line (rather than inline in primitives/block.h)
-// because they reference chain-state globals declared in main.h — pindexBest,
-// mapBlockIndex, pindexGenesisBlock, fUseFastIndex, and the genesis-block hashes.
+// because they reference chain-state globals declared in chain.h — pindexBest,
+// mapBlockIndex, pindexGenesisBlock — and the genesis-block hashes.
 // Keeping them here lets primitives/block.h stay free of main.h. The
 // EXCLUSIVE_LOCKS_REQUIRED(cs_main) annotations live on the in-class declarations
 // in the header and are intentionally not repeated on these definitions.
+
+// -fastindex flag (moved from main.cpp, issue #3125 C9; declared in block.h).
+bool fUseFastIndex = false;
 
 bool CBlockIndex::IsInMainChain() const
 {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -32,8 +32,13 @@ class SuperblockPtr;
 
 // cs_main guards the chain-state globals named in the EXCLUSIVE_LOCKS_REQUIRED
 // annotations on the methods defined out-of-line in primitives/block.cpp.
-// Redeclared here (identical to main.h) so this header stays main.h-free.
+// Redeclared here (identical to chain.h) so this header stays main.h-free.
 extern CCriticalSection cs_main;
+
+//! -fastindex: skip some block-hash verification while loading the block
+//! index. Defined in primitives/block.cpp (moved from main.{h,cpp}, issue
+//! #3125 C9); its only core consumer is the hash caching in block.cpp.
+extern bool fUseFastIndex;
 
 /** Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp. */
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -40,6 +40,15 @@ bool fConfChange;
 unsigned int nDerivationMethodIndex;
 extern std::atomic<int64_t> g_nTimeBestReceived;
 
+// Moved from main.cpp (issue #3125 C9); declared in wallet.h.
+// This is changed to MIN_TX_FEE * 10 for block version 11 (CTransaction::CURRENT_VERSION 2).
+// Note that this is an early init value and will result in overpayment of the fee per kbyte
+// if this code is run on a wallet prior to the v11 mandatory switchover unless a manual value
+// of -paytxfee is specified as an argument.
+int64_t nTransactionFee = MIN_TX_FEE * 10;
+int64_t nReserveBalance = 0;
+int64_t nMinimumInputValue = 0;
+
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 
 namespace {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -37,6 +37,15 @@
 //! send paths and the GUI status rendering, on different threads.
 extern std::atomic<bool> fWalletUnlockStakingOnly;
 extern bool fConfChange;
+
+// Wallet settings, defined in wallet.cpp (moved from main.{h,cpp}, issue
+// #3125 C9). nTransactionFee is initialized to MIN_TX_FEE * 10 for block
+// version 11; -paytxfee overrides it in AppInit2.
+extern int64_t nTransactionFee;
+extern int64_t nReserveBalance;
+extern int64_t nMinimumInputValue;
+extern unsigned int nDerivationMethodIndex;
+
 class CAccountingEntry;
 class CWalletTx;
 class CReserveKey;


### PR DESCRIPTION
nTransactionFee/nReserveBalance/nMinimumInputValue (+ the nDerivationMethodIndex declaration) → wallet/wallet.{h,cpp} with fenced compatibility duplicates kept in main.h for the not-yet-migrated qt consumers; COINBASE_FLAGS → miner.{h,cpp} (single consumer, deleted from main.h); cs_msMiningErrors + msMiningErrors → gridcoin/researcher.{h,cpp} atomically with their GUARDED_BY documentation (both remaining readers already include researcher.h); fUseFastIndex → primitives/block.{h,cpp}.

Stacked C9 series (#3125), in merge order: chain/extract-chain-globals (#3174) → validation/move-sync-state (#3175) → staking/move-settings-globals → wallet/move-settings-globals → interfaces/drop-mainh → gridcoin/extract-block-claims → init/rehome-lifecycle-flags → node/retire-main-cpp. Each PR's diff vs development includes its predecessors until they merge (the #3131–#3137 pattern).

Verification: full fork CI green on the stack tip (all 5 workflows; one known rpc_psgtpool funding-setup flake cleared on re-run — the #3165 domain). Per-commit syntax-only sweep of all non-qt TUs; include-guard + circular-dependency lints clean; zero src/qt changes (lint-qt-includes ratchet untouched).

Part of #3125 (C9). Pure code motion; no behavior change.
