### PR TITLE
refactor: repoint the interfaces.cpp bridges off main.h (#3125 C9)

### DIFF
--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -36,7 +36,7 @@
 #include "gridcoin/voting/result.h"
 #include "interfaces/handler.h"
 #include "key_io.h"
-#include "main.h"
+#include "chain.h"
 #include "net_processing.h"
 #include "node/psgt_pool.h"
 #include "node/ui_interface.h"

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -22,7 +22,7 @@
 #include "interfaces/voting.h"
 #include "interfaces/wallet.h"
 #include "interfaces/wallet_tx_source.h"
-#include "main.h"
+#include "chain.h"
 #include "net.h"
 #include "netbase.h"
 #include "node/ui_interface.h"
@@ -31,6 +31,7 @@
 #include "sync.h"
 #include "util.h"
 #include "util/strencodings.h"
+#include "validation.h"
 #include "wallet/diagnose.h"
 
 #include <univalue.h>

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -9,7 +9,6 @@
 #include "hash.h"
 #include "interfaces/handler.h"
 #include "key_io.h"
-#include "main.h"
 #include "policy/fees.h"
 #include "policy/policy.h"
 #include "streams.h"


### PR DESCRIPTION
node/interfaces.cpp → chain.h + validation.h; gridcoin/interfaces.cpp → chain.h (validation.h/researcher.h already included); wallet/interfaces.cpp needs nothing beyond wallet/wallet.h. Kept deliberately tiny and rebased at open time — these files are in the active interfaces:: migration churn zone.

Stacked C9 series (#3125), in merge order: chain/extract-chain-globals (#3174) → validation/move-sync-state (#3175) → staking/move-settings-globals → wallet/move-settings-globals → interfaces/drop-mainh → gridcoin/extract-block-claims → init/rehome-lifecycle-flags → node/retire-main-cpp. Each PR's diff vs development includes its predecessors until they merge (the #3131–#3137 pattern).

Verification: full fork CI green on the stack tip (all 5 workflows; one known rpc_psgtpool funding-setup flake cleared on re-run — the #3165 domain). Per-commit syntax-only sweep of all non-qt TUs; include-guard + circular-dependency lints clean; zero src/qt changes (lint-qt-includes ratchet untouched).

Part of #3125 (C9). Pure code motion; no behavior change.
