### PR TITLE
refactor: move the node-lifecycle flags into init.{h,cpp} (#3125 C9)

### DIFF
--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -28,7 +28,6 @@ extern bool fExplorer;
 extern unsigned int nScraperSleep;
 extern unsigned int nActiveBeforeSB;
 extern std::atomic<bool> fScraperActive;
-extern bool fQtActive;
 
 void Scraper(bool bSingleShot = false);
 void ScraperSubscriber();
@@ -666,9 +665,8 @@ void SchedulePollNotifications(CScheduler& scheduler)
 std::unique_ptr<Upgrade> g_UpdateChecker;
 bool fResetBlockchainRequest = false;
 
-// fQtActive lives in main.cpp; declared extern here so RebuildBeaconRegistry
-// can suppress the GUI popup in daemon mode.
-extern bool fQtActive;
+// fQtActive (init.h, included above) lets RebuildBeaconRegistry suppress the
+// GUI popup in daemon mode.
 
 // -----------------------------------------------------------------------------
 // Functions

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -40,13 +40,6 @@
 #include <stdio.h>
 #include <stdexcept>
 
-extern bool fQtActive;
-// Set true at the end of core init. The GUI sets it via ThreadAppInit2; the
-// daemon runs AppInit2 directly, so it sets it here (below) -- otherwise a
-// multiprocess GUI's isCoreReady() poll, served from this process, never
-// returns true and the GUI hangs on the splash.
-extern std::atomic<bool> bGridcoinCoreInitComplete;
-
 #if HAVE_DECL_FORK
 
 /** Custom implementation of daemon(). This implements the same order of operations as glibc.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -58,8 +58,12 @@ extern void ThreadAppInit2(void* parg);
 
 using namespace std;
 CWallet* pwalletMain;
-extern bool fQtActive;
-extern std::atomic<bool> bGridcoinCoreInitComplete;
+
+// Node-lifecycle flags (moved from main.cpp, issue #3125 C9; declared in
+// init.h).
+bool fQtActive = false;
+std::atomic<bool> bGridcoinCoreInitComplete{false};
+
 extern bool fConfChange;
 extern bool fEnforceCanonical;
 extern unsigned int nDerivationMethodIndex;

--- a/src/init.h
+++ b/src/init.h
@@ -9,6 +9,7 @@
 #include "wallet/wallet.h"
 #include <boost/thread.hpp>
 
+#include <atomic>
 #include <string>
 #include <utility>
 #include <vector>
@@ -68,4 +69,13 @@ bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& sett
                     std::string& error_out);
 
 extern bool fResetBlockchainRequest;
+
+//! Node-lifecycle flags, defined in init.cpp (moved from main.cpp, issue
+//! #3125 C9): fQtActive is set by the Qt entry point before core init so
+//! shutdown paths know a GUI owns the event loop;
+//! bGridcoinCoreInitComplete flips once AppInit2 finishes and gates
+//! interfaces::Init::isCoreReady (#3170) plus the GUI splash handoff.
+extern bool fQtActive;
+extern std::atomic<bool> bGridcoinCoreInitComplete;
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,10 +89,8 @@ extern int64_t GetCoinYearReward(int64_t nTime);
 // msMiningErrors) to gridcoin/researcher.{h,cpp}; and fUseFastIndex to
 // primitives/block.{h,cpp} (issue #3125 C9).
 
-// Gridcoin - Rob Halford
-
-bool fQtActive = false;
-std::atomic<bool> bGridcoinCoreInitComplete{false};
+// The node-lifecycle flags (fQtActive, bGridcoinCoreInitComplete) moved to
+// init.{h,cpp} (issue #3125 C9).
 
 // End of Gridcoin Global vars
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -43,8 +43,9 @@
 
 // The converged scraper stats cache has no header declaration; every consumer
 // declares the extern locally (quorum.cpp, scraper_net.cpp, rpc/blockchain.cpp).
+// bGridcoinCoreInitComplete comes from init.h (included above) since its move
+// out of main.cpp (issue #3125 C9).
 extern ConvergedScraperStats ConvergedScraperStatsCache;
-extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 namespace interfaces {
 namespace {


### PR DESCRIPTION
fQtActive and bGridcoinCoreInitComplete were defined in main.cpp and reached via ad-hoc per-TU externs (never declared in main.h). They move to init.{h,cpp} — AppInit2 is what flips bGridcoinCoreInitComplete, now read by interfaces::Init::isCoreReady since #3170. Redundant local externs dropped only from TUs already including init.h, keeping this out of the qt migration churn zone.

Stacked C9 series (#3125), in merge order: chain/extract-chain-globals (#3174) → validation/move-sync-state (#3175) → staking/move-settings-globals → wallet/move-settings-globals → interfaces/drop-mainh → gridcoin/extract-block-claims → init/rehome-lifecycle-flags → node/retire-main-cpp. Each PR's diff vs development includes its predecessors until they merge (the #3131–#3137 pattern).

Verification: full fork CI green on the stack tip (all 5 workflows; one known rpc_psgtpool funding-setup flake cleared on re-run — the #3165 domain). Per-commit syntax-only sweep of all non-qt TUs; include-guard + circular-dependency lints clean; zero src/qt changes (lint-qt-includes ratchet untouched).

Part of #3125 (C9). Pure code motion; no behavior change.
