### PR TITLE
validation: signal the reverted tip on trust-regression reorg-back (#3145)

### DIFF
--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -525,9 +525,12 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     //
     // pfork captures the fork point of this forward reorg to pindexNew, threaded
     // out for the UpdatedBlockTip emission below (issue #3104). The reorg-back
-    // call, if it runs, intentionally leaves pfork untouched: the emission
-    // reports pindexNew, so its matching fork point is this forward common
-    // ancestor.
+    // call, if it runs, overwrites pfork so the emission describes the reorg
+    // that actually produced the final tip (issue #3145). On that path the
+    // externally visible tip is unchanged (the tip itself would be the minimal
+    // fork point); the back-leg common ancestor passed instead is always a
+    // non-null ancestor of the reported tip, so a fork-point-dependent
+    // subscriber at worst revisits blocks already on the main chain.
     const CBlockIndex* pfork = nullptr;
     success = ReorganizeChain(txdb, cnt_dis, cnt_con, blockNew, pindexNew, &pfork);
 
@@ -540,7 +543,7 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
             return error("%s: Fatal Error while reading original best block", __func__);
         }
 
-        success = ReorganizeChain(txdb, cnt_dis, cnt_con, origBlock, origBestIndex);
+        success = ReorganizeChain(txdb, cnt_dis, cnt_con, origBlock, origBestIndex, &pfork);
     }
 
     if (!success) {
@@ -557,7 +560,12 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     bool fIsInitialDownload = IsInitialBlockDownload();
 
     if (!fIsInitialDownload) {
-        const CBlockLocator locator(pindexNew);
+        // Build the locator from pindexBest, not pindexNew: after a
+        // trust-regression reorg-back the final tip is origBestIndex, and a
+        // locator built from the abandoned pindexNew would lead with
+        // off-main-chain hashes (issue #3145). On the normal path
+        // pindexBest == pindexNew, so this is equivalent.
+        const CBlockLocator locator(pindexBest);
         // Persist the wallet best-block locator. Emitted synchronously under
         // cs_main (held by SetBestChain), so the CValidationInterface subscriber
         // (CWallet::ChainStateFlushed) runs in the canonical cs_main -> signals
@@ -601,7 +609,13 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     // genesis block. This resolves the #3080 stopgap so fork-point-dependent
     // subscribers (e.g. the deferred PeerManager) receive correct semantics
     // (issue #3104).
-    GetMainSignals().UpdatedBlockTip(pindexNew, pfork, fIsInitialDownload);
+    //
+    // The tip is reported as pindexBest rather than pindexNew: the
+    // trust-regression reorg-back above can leave the final tip at
+    // origBestIndex, and pindexNew would then name the abandoned block (issue
+    // #3145). On the normal path pindexBest == pindexNew after a successful
+    // reorganize, so this is equivalent.
+    GetMainSignals().UpdatedBlockTip(pindexBest, pfork, fIsInitialDownload);
 
     return GridcoinServices();
 }


### PR DESCRIPTION
Fixes #3145.

When a forward reorg yields lower chain trust than before (or fails during the connect phase), `SetBestChain` reorganizes back to the original tip, but the end-of-function signals were still emitted against the abandoned `pindexNew`:

- `ChainStateFlushed(locator(pindexNew))` — `CWallet::ChainStateFlushed` persists this locator verbatim via `WriteBestBlock`, so the wallet would record a best-block locator whose leading hashes are off-main-chain (wrong rescan position on a restore).
- `UpdatedBlockTip(pindexNew, pfork, ...)` — the UI bridge would report the abandoned block's height/time/bits.

This PR emits both signals against `pindexBest` (the actual final tip — the same source the adjacent log lines and `-blocknotify` already use) and threads the fork point out of the reorg-back `ReorganizeChain` call so `pfork` describes the reorg that actually produced that tip. The invariant becomes: every successful `SetBestChain` ends with signals describing the real tip.

## Scope

- **Behavior-neutral on the normal path**: after a successful forward reorganize, `pindexBest == pindexNew`, so the `g_chain_trust.Favors`-gated caller in `validation.cpp` sees identical emissions. Only paths where the revert fires change — intentionally, to the correct tip.
- The `LoadBlockIndex` corruption-repair caller (`dbwrapper.cpp`) always triggers the revert leg (rewinding to an ancestor always lowers trust), so its emissions are corrected by this change; there `fIsInitialDownload` is typically true, so the wallet locator write is IBD-gated off anyway.
- **Fork-point choice on the revert leg**: the externally visible tip is unchanged, so the minimal fork point would be the tip itself; the back-leg common ancestor passed instead is always a non-null ancestor of the reported tip, so a fork-point-dependent subscriber (e.g. the deferred PeerManager) at worst revisits blocks already on the main chain. No current subscriber reads `pindexFork`.

## Pre-existing issues noticed nearby (out of scope, can file separately)

- `g_reorg_in_progress` is left `true` on the failure returns in `SetBestChain` (ReadBlockFromDisk failure / revert failure), freezing GUI/poll-registry consumers of the flag.
- The `dbwrapper.cpp` LoadBlockIndex repair rewind appears to be silently undone by the trust-regression revert (the revert restores the corrupt-chain tip).

## Testing

- Full unit suite passes; lint clean.
- `test/functional/feature_reorg.py` (extended) A/B-tested against clean development over repeated runs: its known intermittent sync-timeout failures occur at a similar rate on both, with an identical symptom, and node debug logs from every failing run confirm the trust-regression revert path never executed (the test exercises only the neutral path).
- The revert path itself is not currently exercisable from the test harnesses (the `reorganize` RPC uses `ForceReorganizeToHash`, which bypasses `SetBestChain`); per the issue, coverage is deferred until it is.
- All CI workflows green on the fork branch (one OpenSUSE Tumbleweed `p2p_psgt_relay.py` failure was an environment flake — passed on rerun, locally, and on all other distros).