### PR TITLE
test: deterministic mock-time lockstep for the PSGT multi-node tests (fixes #3165)

### DIFF
--- a/test/functional/p2p_psgt_orphan.py
+++ b/test/functional/p2p_psgt_orphan.py
@@ -127,10 +127,19 @@ class P2PPsgtOrphanTest(GridcoinTestFramework):
         # longer knows the funding output -- exactly the relay-race condition.
         self.restart_node(0, self.extra_args[0])
         assert_equal(node0.getrawmempool(), [])
+        # The restart also reset the daemon's mock clock while the tip may sit
+        # ahead of real time (block times march in 16-second slots): re-pin the
+        # clock to the tip so the resubmitted funding transaction is not
+        # future-dated and the spaced connect below stays deterministic.
+        # (sync_blocks would do this, but node0 has no peers here.)
+        self.sync_clocks([node0])
 
         watcher = node0.add_p2p_connection(InvCollector())
-        time.sleep(6)  # inbound rate limit: 1 per 5s per IP (all 127.0.0.1)
-        sender = node0.add_p2p_connection(P2PInterface())
+        # Second connect through the spaced helper: the daemon's inbound rate
+        # limit (1 per 5s per IP, on mock-affected GetAdjustedTime) would
+        # otherwise drop it -- a real sleep no longer helps once the mock
+        # clock is pinned ahead of real time.
+        sender = self.add_p2p_connection_spaced(node0, P2PInterface())
 
         # --- inject the PSGT while the funding is unknown: held, not pooled ---
         sender.send_message(msg_psgt(wire))

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -31,6 +31,7 @@ message and we assert, in order:
 import time
 from decimal import Decimal
 
+from test_framework.authproxy import JSONRPCException
 from test_framework.messages import (
     CInv,
     MSG_PSGT,
@@ -76,29 +77,23 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
         self.extra_args = [["-staking=0", "-blockv15height=0"], ["-staking=0", "-blockv15height=0"]]
 
     def confirm_funding(self, txid):
-        """Confirm a just-sent funding transaction. PoS block timestamps are
-        masked down to 16-second boundaries (STAKE_TIMESTAMP_MASK) and the
-        miner excludes transactions with nTime > block.nTime, so wait for the
-        next boundary before mining the confirmation block. Returns False if
-        the transaction vanished instead (double-spent by the staker's own
-        coinstake -- the wallet does not track raw spends)."""
+        """Confirm a just-sent funding transaction. The miner excludes
+        transactions with nTime > block.nTime, so advance every node's mock
+        clock to the next 16-second STAKE_TIMESTAMP_MASK slot before mining
+        the confirmation block. Returns False if the funding lost a race with
+        the staker's own coinstake instead (the wallet does not track raw
+        spends, so CreateCoinStake can pick the funding's input): either the
+        coinstake confirmed AGAINST it (the funding vanishes as a double-spend
+        loser) or the miner built a self-conflicting block containing both --
+        rejected as "ConnectInputs(): prev tx already used" (#3165), which
+        surfaces here as an RPC error after the miner's retries."""
         node0 = self.nodes[0]
-        time.sleep(16 - (int(time.time()) % 16) + 1)
-        node0.generatetoaddress(1, node0.getnewaddress())
+        self.advance_to_next_stake_slot()
         try:
+            node0.generatetoaddress(1, node0.getnewaddress())
             return node0.getrawtransaction(txid, True).get("confirmations", 0) >= 1
-        except Exception:
+        except JSONRPCException:
             return False
-
-    def add_spaced_p2p(self, node, peer):
-        """add_p2p_connection with the daemon's inbound rate limit respected:
-        at most one inbound per 5 seconds per IP (net.cpp AcceptConnection),
-        and every scripted peer here is 127.0.0.1. The limit compares integer
-        second deltas from GetAdjustedTime(), so sleep a full 6 s -- sleeping
-        exactly 5 can land two connects in the same second boundary (delta 4)
-        and get the second one dropped / misbehavior-scored."""
-        time.sleep(6)
-        return node.add_p2p_connection(peer)
 
     def setup_network(self):
         # Bring the nodes up without the base-class createwallet path (the
@@ -131,10 +126,15 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
         for _ in range(5):
             # 1 confirmation: grow_utxo_universe's split outputs are ordinary
             # outputs, spendable immediately; confirm_funding + this retry loop
-            # still absorb the staker racing us for a chosen output.
-            candidates = [u for u in node0.listunspent(1)
-                          if (u["txid"], u["vout"]) not in tried
-                          and u["amount"] - 1 > Decimal("0.01")]
+            # still absorb the staker racing us for a chosen output. Prefer the
+            # SMALLEST candidate: the staker's kernel search is weight-driven,
+            # so funding from a small split output rather than a huge premine
+            # output keeps the funding input out of CreateCoinStake's likeliest
+            # picks and shrinks the race window to marginal.
+            candidates = sorted((u for u in node0.listunspent(1)
+                                 if (u["txid"], u["vout"]) not in tried
+                                 and u["amount"] - 1 > Decimal("0.01")),
+                                key=lambda u: u["amount"])
             assert candidates, "no mature UTXO left to fund the multisig"
             utxo = candidates[0]
             tried.add((utxo["txid"], utxo["vout"]))
@@ -182,9 +182,13 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
         wire = self.make_partially_signed_psgt()
         revision = uint256_from_str(hash256(wire))
 
-        sender = node1.add_p2p_connection(P2PInterface())
-        watcher = self.add_spaced_p2p(node1, InvCollector())
-        old_peer = self.add_spaced_p2p(node1, OldVersionInvCollector())
+        # All scripted peers connect through the spaced helper: it paces the
+        # daemon's inbound rate limit on the mock clocks and stamps each
+        # version handshake from the node's own clock (which runs ahead of the
+        # real time a plain connect would stamp).
+        sender = self.add_p2p_connection_spaced(node1, P2PInterface())
+        watcher = self.add_p2p_connection_spaced(node1, InvCollector())
+        old_peer = self.add_p2p_connection_spaced(node1, OldVersionInvCollector())
 
         # --- inject: node1 must validate, pool, and announce the revision ---
         sender.send_message(msg_psgt(wire))
@@ -199,7 +203,7 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
 
         # --- daemon-to-daemon relay + connect-time push: node0 fetched the
         # PSGT from node1, and advertises it to fresh v15 peers on connect ---
-        late_peer = self.add_spaced_p2p(node0, InvCollector())
+        late_peer = self.add_p2p_connection_spaced(node0, InvCollector())
         late_peer.wait_until(lambda: revision in late_peer.psgt_invs)
         self.log.info("node0 pooled the PSGT and pushed it to a connecting peer")
 
@@ -217,7 +221,7 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
         self.log.info("pre-PSGT protocol peer received no MSG_PSGT inventory")
 
         # --- invalid psgt messages: rejected without relay, node unfazed ---
-        bad_peer = self.add_spaced_p2p(node1, P2PInterface())
+        bad_peer = self.add_p2p_connection_spaced(node1, P2PInterface())
         announced_before = len(watcher.psgt_invs)
         bad_peer.send_message(msg_psgt(b"not a psgt"))
         corrupted = bytearray(wire)

--- a/test/functional/rpc_psgtpool.py
+++ b/test/functional/rpc_psgtpool.py
@@ -26,7 +26,6 @@ from test_framework.test_framework import GridcoinTestFramework
 from test_framework.util import assert_equal
 
 import os
-import time
 from decimal import Decimal
 
 
@@ -74,8 +73,11 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
         # 1 confirmation: the grow_utxo_universe split outputs are ordinary
         # outputs, spendable at 1 confirmation. The testmempoolaccept gate below
         # still guards spendability (and both-nodes agreement) for whatever
-        # listunspent(1) returns.
-        for cand in node0.listunspent(1):
+        # listunspent(1) returns. Smallest candidate first: the staker's kernel
+        # search is weight-driven, so funding from a small split output rather
+        # than a huge premine output keeps the funding input out of
+        # CreateCoinStake's likeliest picks.
+        for cand in sorted(node0.listunspent(1), key=lambda u: u["amount"]):
             amount = cand["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
             if amount <= 0:
                 continue  # too small to fund after fee (createrawtransaction rejects <= 0)
@@ -93,11 +95,12 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
         assert signed is not None, "no consensus-unspent mature UTXO to fund the multisig"
         txid = node0.sendrawtransaction(signed["hex"])
 
-        # Wait for the funding tx to reach node1's mempool, then for the next
-        # 16-second STAKE_TIMESTAMP_MASK boundary (the miner excludes
-        # transactions with nTime > block.nTime) before node1 mines it.
+        # Wait for the funding tx to reach node1's mempool, then advance every
+        # node's mock clock to the next 16-second STAKE_TIMESTAMP_MASK slot
+        # (the miner excludes transactions with nTime > block.nTime) before
+        # node1 mines it.
         self.wait_until(lambda: txid in node1.getrawmempool())
-        time.sleep(16 - (int(time.time()) % 16) + 1)
+        self.advance_to_next_stake_slot()
         node1.generatetoaddress(1, node1.getnewaddress())
         self.sync_blocks()
 

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -231,6 +231,14 @@ class P2PInterface(P2PConnection):
     def peer_connect_send_version(self):
         # Send a version message on connection.
         vt = msg_version()
+        # msg_version stamps nTime from the real clock; a test can pre-set
+        # `version_time` on the peer to stamp a specific time instead. The
+        # daemon disconnects any peer whose version.nTime is more than 480
+        # seconds from its adjusted time, and under mock-time lockstep the
+        # node's clock legitimately runs ahead of the real clock — so
+        # add_p2p_connection_spaced stamps the target node's own clock here.
+        if getattr(self, "version_time", None) is not None:
+            vt.nTime = self.version_time
         vt.nServices = NODE_NETWORK
         vt.addrTo.ip = self.dstaddr
         vt.addrTo.port = self.dstport

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -844,54 +844,104 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         if agree_with is not None:
             self.sync_blocks()
 
-        # Pick a mature source UTXO unspent in every consensus view.
-        src = None
-        for cand in funder.listunspent(11):
-            # Amount math stays in Decimal end to end (authproxy parses amounts
-            # as Decimal), exact at 1e-8 (satoshi) granularity, and is handed
-            # straight to createrawtransaction: a Decimal serializes to a JSON
-            # string, which AmountFromValue now parses exactly to the satoshi
-            # (issue #3148). No float() round-trip, so no double-rounding.
-            amount = cand["amount"] - Decimal("1.0")  # ~1 GRC fee
-            if amount <= 0:
+        # Lockstep removes the clock-skew failure modes but not the supply
+        # one: kernel selection is random per run, so the staker can have
+        # churned every mature output right when we scan (empty scan), and the
+        # confirm block's own coinstake can race the very source the split
+        # spends. Both are absorbed by a bounded retry; final failure keeps
+        # the original diagnostic (plus the last miner error, if any).
+        tried = set()
+        last_error = None
+        for _ in range(3):
+            # Pick a mature source UTXO unspent in every consensus view.
+            src = None
+            for cand in funder.listunspent(11):
+                if (cand["txid"], cand["vout"]) in tried:
+                    continue
+                # Amount math stays in Decimal end to end (authproxy parses
+                # amounts as Decimal), exact at 1e-8 (satoshi) granularity, and
+                # is handed straight to createrawtransaction: a Decimal
+                # serializes to a JSON string, which AmountFromValue now parses
+                # exactly to the satoshi (issue #3148). No float() round-trip,
+                # so no double-rounding.
+                amount = cand["amount"] - Decimal("1.0")  # ~1 GRC fee
+                if amount <= 0:
+                    continue
+                probe = funder.signrawtransactionwithwallet(
+                    funder.createrawtransaction(
+                        [{"txid": cand["txid"], "vout": cand["vout"]}],
+                        {funder.getnewaddress(): amount}))
+                if not probe.get("complete"):
+                    continue
+                if not funder.testmempoolaccept([probe["hex"]])[0]["allowed"]:
+                    continue
+                if agree_with is not None and not agree_with.testmempoolaccept([probe["hex"]])[0]["allowed"]:
+                    continue
+                src = cand
+                break
+
+            if src is None:
+                # Supply starved: mine one block on funder to mature another
+                # coinstake into listunspent(11) range, then rescan. The refill
+                # mine can itself fail while starved ("CreateCoinStake: no
+                # stake found") — treat that as a failed attempt, not a crash.
+                try:
+                    self.advance_to_next_stake_slot()
+                    funder.generatetoaddress(1, funder.getnewaddress())
+                    if agree_with is not None:
+                        self.sync_blocks()
+                except JSONRPCException as e:
+                    last_error = e
                 continue
-            probe = funder.signrawtransactionwithwallet(
+            tried.add((src["txid"], src["vout"]))
+
+            # ROUND_DOWN to the satoshi so count * per_out never exceeds the
+            # input (rounding up could make the outputs sum > the source,
+            # invalidating the tx). Decimal at 1e-8 is the exact int64_t
+            # CAmount in GRC units.
+            per_out = ((src["amount"] - Decimal("1.0")) / count).quantize(
+                Decimal("0.00000001"), rounding=ROUND_DOWN)  # ~1 GRC total fee
+            assert per_out > 0, "source UTXO too small to fan out into `count` outputs"
+            outputs = {funder.getnewaddress(): per_out for _ in range(count)}
+            signed = funder.signrawtransactionwithwallet(
                 funder.createrawtransaction(
-                    [{"txid": cand["txid"], "vout": cand["vout"]}],
-                    {funder.getnewaddress(): amount}))
-            if not probe.get("complete"):
-                continue
-            if not funder.testmempoolaccept([probe["hex"]])[0]["allowed"]:
-                continue
-            if agree_with is not None and not agree_with.testmempoolaccept([probe["hex"]])[0]["allowed"]:
-                continue
-            src = cand
-            break
-        assert src is not None, "no spendable consensus-unspent UTXO to seed the universe"
+                    [{"txid": src["txid"], "vout": src["vout"]}], outputs))
+            assert signed.get("complete"), "failed to sign the universe split transaction"
+            split_txid = funder.sendrawtransaction(signed["hex"])
 
-        # ROUND_DOWN to the satoshi so count * per_out never exceeds the input
-        # (rounding up could make the outputs sum > the source, invalidating the
-        # tx). Decimal at 1e-8 is the exact int64_t CAmount in GRC units.
-        per_out = ((src["amount"] - Decimal("1.0")) / count).quantize(
-            Decimal("0.00000001"), rounding=ROUND_DOWN)  # ~1 GRC total fee
-        assert per_out > 0, "source UTXO too small to fan out into `count` outputs"
-        outputs = {funder.getnewaddress(): per_out for _ in range(count)}
-        signed = funder.signrawtransactionwithwallet(
-            funder.createrawtransaction(
-                [{"txid": src["txid"], "vout": src["vout"]}], outputs))
-        assert signed.get("complete"), "failed to sign the universe split transaction"
-        split_txid = funder.sendrawtransaction(signed["hex"])
+            # Confirm in a single block. If confirming on a different node,
+            # wait for the split tx to propagate there first. Advance to the
+            # next 16-second STAKE_TIMESTAMP_MASK slot either way: the miner
+            # excludes txs with nTime > block.nTime, so mining too early would
+            # leave the split out.
+            if confirm_on is not funder:
+                self.wait_until(lambda: split_txid in confirm_on.getrawmempool())
+            self.advance_to_next_stake_slot()
+            try:
+                confirm_on.generatetoaddress(1, confirm_on.getnewaddress())
+            except JSONRPCException as e:
+                # The confirm block's coinstake can pick the very UTXO the
+                # pending split spends (the wallet does not track raw spends):
+                # the block then double-spends its own transaction and is
+                # rejected — "ConnectInputs(): prev tx already used" — which
+                # surfaces here as an RPC error after the miner's retries.
+                # Retry with a different source.
+                last_error = e
+                continue
+            if agree_with is not None:
+                self.sync_blocks()
 
-        # Confirm in a single block. If confirming on a different node, wait for
-        # the split tx to propagate there first. Advance to the next 16-second
-        # STAKE_TIMESTAMP_MASK slot either way: the miner excludes txs with
-        # nTime > block.nTime, so mining too early would leave the split out.
-        if confirm_on is not funder:
-            self.wait_until(lambda: split_txid in confirm_on.getrawmempool())
-        self.advance_to_next_stake_slot()
-        confirm_on.generatetoaddress(1, confirm_on.getnewaddress())
-        if agree_with is not None:
-            self.sync_blocks()
+            # The coinstake race can also confirm quietly AGAINST the split
+            # (the split simply vanishes as a double-spend loser), so declare
+            # success only once the split itself is buried.
+            try:
+                if funder.getrawtransaction(split_txid, True).get("confirmations", 0) >= 1:
+                    return
+            except JSONRPCException:
+                pass
+        raise AssertionError(
+            "no spendable consensus-unspent UTXO to seed the universe"
+            + (" (last mining error: %s)" % (last_error,) if last_error else ""))
 
     # Private helper methods. These should not be accessed by the subclass test scripts.
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -883,12 +883,12 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         split_txid = funder.sendrawtransaction(signed["hex"])
 
         # Confirm in a single block. If confirming on a different node, wait for
-        # the split tx to propagate there first. Wait for the next 16-second
-        # STAKE_TIMESTAMP_MASK boundary either way: the miner excludes txs with
+        # the split tx to propagate there first. Advance to the next 16-second
+        # STAKE_TIMESTAMP_MASK slot either way: the miner excludes txs with
         # nTime > block.nTime, so mining too early would leave the split out.
         if confirm_on is not funder:
             self.wait_until(lambda: split_txid in confirm_on.getrawmempool())
-        time.sleep(16 - (int(time.time()) % 16) + 1)
+        self.advance_to_next_stake_slot()
         confirm_on.generatetoaddress(1, confirm_on.getnewaddress())
         if agree_with is not None:
             self.sync_blocks()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -48,6 +48,13 @@ TEST_EXIT_SKIPPED = 77
 
 TMPDIR_PREFIX = "gridcoin_func_test_"
 
+# Mirrors STAKE_TIMESTAMP_MASK in src/gridcoin/staking/kernel.h: proof-of-stake
+# masks coinstake timestamps down to (mask+1)-second slots — 16 seconds — and
+# the miner excludes mempool transactions with nTime > block.nTime, so block
+# times march in 16-second steps and can legitimately run ahead of the wall
+# clock. See advance_to_next_stake_slot() / sync_clocks().
+STAKE_TIMESTAMP_MASK = 15
+
 
 class SkipTest(Exception):
     """This exception is raised to skip a test"""
@@ -671,6 +678,10 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         while time.time() <= stop_time:
             best_hash = [x.getbestblockhash() for x in rpc_connections]
             if best_hash.count(best_hash[0]) == len(rpc_connections):
+                # Everyone agrees on the tip; also bring every node's clock up
+                # to it, so nodes that merely synced the blocks do not stamp
+                # their next transactions behind the chain (issue #3165).
+                self.sync_clocks(rpc_connections)
                 return
             # Check that each peer has at least one connection
             assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
@@ -709,6 +720,93 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
 
     def wait_until(self, test_function, timeout=60):
         return wait_until_helper(test_function, timeout=timeout, timeout_factor=self.options.timeout_factor)
+
+    def sync_clocks(self, nodes=None):
+        """Advance every node's mock clock to its own chain tip's time.
+
+        Forward-only: a no-op for a node whose clock is not behind its tip,
+        and skipped for nodes that opted out via setmocktime(0). PR #3161's
+        generatetoaddress shadow keeps the MINING node's adjusted time in step
+        with the blocks it produces, but a node that merely syncs those blocks
+        over P2P keeps a lagging clock and stamps its next transactions behind
+        the chain, tripping the coinstake input-timestamp consensus rule
+        ("transaction timestamp earlier than input transaction") as an
+        intermittent -22 send failure (issue #3165). Called automatically from
+        sync_blocks once tips agree; also callable standalone — e.g. after
+        restart_node, which resets the daemon's mock clock while the tip may
+        still sit ahead of real time.
+
+        Nodes still at genesis are skipped: the genesis timestamp is in the
+        distant past (nothing to advance to), and getblock crashes the daemon
+        on the genesis block (blockToJSON; pre-existing bug, reported
+        separately)."""
+        for node in (nodes or self.nodes):
+            if node.getblockcount() == 0:
+                continue
+            node.advance_mocktime_to(node.getblock(node.getbestblockhash())['time'])
+
+    def advance_to_next_stake_slot(self, nodes=None):
+        """Advance every node's mock clock to the next 16-second coinstake slot
+        boundary and return that timestamp.
+
+        The miner excludes mempool transactions with nTime > block.nTime and
+        stamps blocks on STAKE_TIMESTAMP_MASK slot boundaries, so a transaction
+        sent mid-slot is only guaranteed into the next mined block once the
+        clock has crossed the next boundary. This replaces the old wall-clock
+        wait (time.sleep(16 - now % 16 + 1)), which stops working the moment
+        mock time engages. Every pending transaction was stamped <= now <
+        target, the target is itself slot-aligned, and the target is ahead of
+        every tip, so the next mined block — at the target slot or a later
+        miner retry slot — includes the pending transactions.
+
+        Lockstep assumption: a node that opted out via setmocktime(0) cannot
+        be advanced and is skipped with a warning; a block stamped more than
+        128 seconds past such a node's real clock would be rejected there."""
+        nodes = nodes or self.nodes
+        slot = STAKE_TIMESTAMP_MASK + 1
+        # Nodes at genesis contribute only their clock: the genesis timestamp
+        # is far in the past, and getblock crashes the daemon on the genesis
+        # block (blockToJSON; pre-existing bug, reported separately).
+        now = max(max(node.mock_now(),
+                      node.getblock(node.getbestblockhash())['time']
+                      if node.getblockcount() else 0)
+                  for node in nodes)
+        target = (now // slot + 1) * slot
+        for node in nodes:
+            if node._mocktime_off:
+                self.log.warning("advance_to_next_stake_slot: node%d opted out "
+                                 "of mock time; not advanced", node.index)
+                continue
+            node.advance_mocktime_to(target)
+        return target
+
+    def add_p2p_connection_spaced(self, node, peer, spacing=6):
+        """add_p2p_connection with the daemon's inbound rate limit respected:
+        at most one inbound connection per 5 seconds per IP (net.cpp
+        AcceptConnection), and every scripted peer is 127.0.0.1. The limit
+        compares integer-second deltas of GetAdjustedTime() — mock-affected —
+        so the spacing is applied to the mock clocks (of ALL nodes, keeping
+        lockstep); spacing must be >= 6 because advancing exactly 5 can land
+        two connects in the same second boundary (delta 4) and get the second
+        one dropped and misbehavior-scored.
+
+        The peer's version handshake is stamped from the node's own clock:
+        the daemon disconnects a peer whose version.nTime is more than 480
+        seconds from its adjusted time, and the mock clock legitimately runs
+        ahead of the real clock the default stamp uses.
+
+        Fallback when the target node opted out via setmocktime(0): sleep on
+        the REAL clock — but long enough for real time to clear the highest
+        mock time ever pinned (the daemon's rate-limit map may hold an accept
+        timestamp from when the clock ran ahead), not just `spacing` seconds."""
+        if node._mocktime_off:
+            time.sleep(max(spacing, node._mocktime_high + spacing - int(time.time())))
+        else:
+            target = max(n.mock_now() for n in self.nodes) + spacing
+            for n in self.nodes:
+                n.advance_mocktime_to(target)
+        peer.version_time = node.mock_now()
+        return node.add_p2p_connection(peer)
 
     def grow_utxo_universe(self, funder, count=48, *, agree_with=None, confirm_on=None):
         """Fan one mature premine UTXO on `funder` into `count` ordinary,

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -606,7 +606,26 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
     def connect_nodes(self, a, b):
         def connect_nodes_helper(from_connection, node_num):
             ip_port = "127.0.0.1:" + str(p2p_port(node_num))
-            from_connection.addnode(ip_port, "onetry")
+
+            # A "onetry" connect races the target node's P2P listener coming up:
+            # if that node's daemon is still binding its port when we get here,
+            # the connect is refused immediately and the daemon throws
+            # RPC_CLIENT_NODE_ALREADY_ADDED (-23) with "Node connection failed"
+            # (rpc/net.cpp). Under host saturation (seen intermittently on the
+            # Sanitizers CI job, where the SUT builds run slow) this is a
+            # transient startup race, not a real failure, so retry the onetry
+            # until it is accepted. A genuinely unreachable peer still surfaces:
+            # wait_until_helper raises once its timeout elapses.
+            def issue_onetry():
+                try:
+                    from_connection.addnode(ip_port, "onetry")
+                    return True
+                except JSONRPCException as e:
+                    if e.error['code'] == -23 and 'Node connection failed' in e.error['message']:
+                        return False
+                    raise
+            wait_until_helper(issue_onetry)
+
             # Poll until the version handshake has produced a peer with a
             # negotiated protocol version. Gridcoin's getpeerinfo does not
             # expose Bitcoin Core's per-message byte counters (bytesrecv_per_msg),
@@ -799,6 +818,11 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         the REAL clock — but long enough for real time to clear the highest
         mock time ever pinned (the daemon's rate-limit map may hold an accept
         timestamp from when the clock ran ahead), not just `spacing` seconds."""
+        # Enforce the >= 6 constraint the docstring relies on: a smaller spacing
+        # can leave two connects in the same integer-second boundary (delta 4),
+        # tripping the daemon's inbound rate limit and reintroducing the exact
+        # intermittent connect-drop this helper exists to prevent.
+        assert spacing >= 6, "add_p2p_connection_spaced spacing must be >= 6 (daemon 5s inbound rate limit)"
         if node._mocktime_off:
             time.sleep(max(spacing, node._mocktime_high + spacing - int(time.time())))
         else:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -141,6 +141,14 @@ class TestNode():
         # distinguishing "test wants the real clock" from "never set" so the
         # generatetoaddress auto-advance below leaves that choice alone.
         self._mocktime_off = False
+        # High-water mark of every mock time ever pinned on this process,
+        # retained across setmocktime(0): after an opt-out the daemon snaps
+        # back to the real clock, but daemon-side state stamped while the mock
+        # clock ran ahead (e.g. the inbound-connection rate-limit map) still
+        # holds the old, future timestamps. Consumers that must wait those
+        # out (add_p2p_connection_spaced's fallback) need to know how far
+        # ahead the clock ever was.
+        self._mocktime_high = 0
         self.log = logging.getLogger('TestFramework.node%d' % i)
         self.cleanup_on_exit = True # Whether to kill the node when this object goes away
         # Cache perf subprocesses here by their data output filename.
@@ -209,6 +217,7 @@ class TestNode():
         # against the fresh process's real clock.
         self._mocktime = None
         self._mocktime_off = False
+        self._mocktime_high = 0
 
         # Add a new stdout and stderr file each time gridcoinresearchd is started
         if stderr is None:
@@ -338,7 +347,26 @@ class TestNode():
         result = self._rpc().setmocktime(timestamp)
         self._mocktime = None if timestamp == 0 else timestamp
         self._mocktime_off = (timestamp == 0)
+        self._mocktime_high = max(self._mocktime_high, timestamp)
         return result
+
+    def mock_now(self):
+        """The node's adjusted time as tracked Python-side: the mock clock when
+        one is pinned, the real clock otherwise. Matches the daemon's
+        GetAdjustedTime() in functional tests -- the peer time offset stays 0
+        because AddTimeData needs five distinct peer addresses and every test
+        peer is 127.0.0.1."""
+        return self._mocktime if self._mocktime is not None else int(time.time())
+
+    def advance_mocktime_to(self, timestamp):
+        """Pin the node's mock clock to `timestamp` if that moves it FORWARD.
+        Never rewinds (a test may have deliberately set the clock ahead), and
+        is a no-op once a test has opted out of mock time via setmocktime(0).
+        Returns whether the clock moved."""
+        if self._mocktime_off or timestamp <= self.mock_now():
+            return False
+        self.setmocktime(timestamp)
+        return True
 
     def generatetoaddress(self, *args, **kwargs):
         """Shadow the RPC to keep the node's adjusted time in step with the
@@ -356,25 +384,23 @@ class TestNode():
         sanitizer CI job.
 
         After mining, advance the node's mock clock to the tip so its adjusted
-        time never lags the chain. Guarded: the clock only ever moves FORWARD
-        (never behind a mocktime a test has deliberately set ahead of the tip),
-        it is a no-op when the tip is not ahead of the current clock, and it is
-        skipped entirely once a test has explicitly disabled mock time
-        (setmocktime(0)) — so tests that manage their own time are unaffected.
+        time never lags the chain (advance_mocktime_to: forward-only, no-op
+        when the tip is not ahead, skipped entirely once a test has explicitly
+        disabled mock time with setmocktime(0) — so tests that manage their own
+        time are unaffected). This covers only the MINING node; nodes that sync
+        these blocks over P2P are caught up by the test framework's
+        sync_clocks(), called from sync_blocks (issue #3165).
 
         Limitation: mining through a raw wallet handle (get_wallet_rpc) calls
         the RPC directly and bypasses this shadow, so the clock is not advanced.
         No functional test mines that way; the direct node.generatetoaddress /
         node.generate paths are the covered ones."""
         hashes = self._rpc().generatetoaddress(*args, **kwargs)
-        if not self._mocktime_off and hashes:
+        if hashes:
             # The last returned hash is the block we just produced (the tip),
             # so no getbestblockhash round-trip is needed. getblock (not
             # getblockheader — Gridcoin has no such RPC) carries the time.
-            tip_time = self._rpc().getblock(hashes[-1])['time']
-            current = self._mocktime if self._mocktime is not None else int(time.time())
-            if tip_time > current:
-                self.setmocktime(tip_time)
+            self.advance_mocktime_to(self._rpc().getblock(hashes[-1])['time'])
         return hashes
 
     def get_wallet_rpc(self, wallet_name):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -150,6 +150,9 @@ BASE_SCRIPTS = [
     'feature_shutdown.py',
     'p2p_version_handshake.py',
     'p2p_block_tx_relay.py',
+    # The PSGT multi-node tests run under deterministic mock-time lockstep
+    # (sync_clocks/advance_to_next_stake_slot, #3165): no wall-clock sleeps on
+    # their critical paths.
     'p2p_psgt_relay.py',
     'p2p_psgt_orphan.py',
     'p2p_ping.py',


### PR DESCRIPTION

Closes #3165.

## Problem

The multi-node PoS functional tests (`p2p_psgt_relay.py`, `rpc_psgtpool.py`,
`p2p_psgt_orphan.py`) were chronically flaky from timing races the upstream
PoW-deterministic framework was never designed for. PR #3161 closed half the gap:
the **mining** node's mock clock now follows the blocks it produces. The remaining
half is #3165: a node that merely *syncs* those blocks keeps a lagging clock, so it
stamps its next transaction behind the chain and trips the coinstake
input-timestamp rule — surfacing as the intermittent `-22 "TX rejected"` from
`sendrawtransaction`. Worse, once mock time engages, every real-time sleep in the
tests (stake-slot boundary waits, the 6-second inbound rate-limit spacing) measures
the wrong clock entirely: the daemon reads `GetAdjustedTime()`, which is
mock-affected.

## Fix: framework-level clock lockstep

- `sync_clocks()` — advance every node's mock clock to its own tip; called
  automatically from `sync_blocks()` once tips agree (forward-only, no-op unless
  the tip is ahead, skips `setmocktime(0)` opt-outs and nodes at genesis, resets
  on restart). Tests whose block times never outrun real time see no change.
- `advance_to_next_stake_slot()` — the mock-clock replacement for the 16-second
  `STAKE_TIMESTAMP_MASK` boundary sleeps.
- `add_p2p_connection_spaced()` — spaces scripted-peer connects on the mock
  clocks (the inbound rate limit reads adjusted time) and stamps the version
  handshake from the node's own clock, keeping the ±480 s handshake drift gate
  closed no matter how far the pinned clocks run ahead of real time.
- `grow_utxo_universe` seeding hardened with a bounded retry against the supply
  races lockstep cannot remove (random kernel selection): empty source scan,
  "no stake found" on the refill mine, and the confirm block's coinstake racing
  the split's own source ("prev tx already used" — the other #3165 signature).
- The tests' funding candidate scans prefer the smallest output, keeping funding
  inputs out of `CreateCoinStake`'s dominant-weight kernel picks.

Deliberately **not** added: a retry that swallows `-22` from
`sendrawtransaction`. In these funding loops nothing mines between the candidate
rescan and the send, so a send-time `-22` is never a transient race — it is a
systemic clock bug (the #3165 class itself), and swallowing it would erase the
pinpointing traceback.

## Evidence (24-core WSL2, 32 copies per round at 16-way parallelism — far
harsher than CI)

**This branch — 800 runs per test:**

| Test | Failures | #3165-class |
|---|---|---|
| p2p_psgt_relay.py | 14 (1.75%) | **0** |
| rpc_psgtpool.py | 9 (1.1%) | **0** |
| p2p_psgt_orphan.py | 14 (1.75%) | **0** |

Every failure is the pre-existing daemon-startup/setup flake family (RPC-startup
ECONNREFUSED, `connect_nodes` -23, raw TCP connect timeouts under host
saturation) — none contains any #3165 signature.

**Baseline (unmodified tests @ a2894c006, same binary) — 320 runs per test:**

| Test | Failures | #3165-class | Infra |
|---|---|---|---|
| p2p_psgt_relay.py | 40 (12.5%) | **36 (11.25%)** — 31× rate-limit spaced connect, 5× `-22 TX rejected` | 4 (1.25%) |
| rpc_psgtpool.py | 10 (3.1%) | **7 (2.2%)** — all "funding transaction did not confirm" | 3 (0.9%) |
| p2p_psgt_orphan.py | 3 (0.9%) | 0 | 3 (0.9%) |

The infra background rate is statistically identical before and after
(baseline 10/960 ≈ 1.0%, branch 37/2400 ≈ 1.5%); the #3165-class rate drops
from 11.25% (relay) / 2.2% (pool) to **0 across 2,400 branch runs**.

Full functional suite (`test_runner.py -j16`, 29 tests): all pass — the
`sync_blocks` hook has no blast radius. `lint-all.sh` clean.

## Drive-by finding (separate issue to file)

`getblock` on the **genesis block** segfaults the daemon (`blockToJSON`,
`src/rpc/blockchain.cpp:192`). The new clock helpers guard `getblockcount() == 0`
to avoid it; the daemon bug itself deserves its own issue/fix.
