### PR TITLE
rpc: include unbooked wallet addresses with received payments in listreceivedby*

### DIFF
--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -308,6 +308,70 @@ BOOST_AUTO_TEST_CASE(received_by_label_rpcs_work_flag_free)
     BOOST_CHECK(found);
 }
 
+namespace {
+//! Inject an unconfirmed wallet tx: mapWallet entry in the mempool state plus an actual
+//! mempool entry, so GetDepthInMainChain() reports 0 (visible at minconf=0 only).
+void InjectMempoolTx(const CTransaction& tx)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    CWalletTx wtx(pwalletMain, tx);
+    wtx.SetTxState(TxStateInMempool{});
+    pwalletMain->mapWallet[tx.GetHash()] = wtx;
+    // addUnchecked's contract requires the caller hold mempool.cs (it does no internal
+    // locking, unlike mempool.remove in RemoveMempoolTx below); acquire it after cs_wallet
+    // per the canonical lock order.
+    LOCK(mempool.cs);
+    mempool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(
+        tx, /*fee=*/0, /*time=*/0, /*height=*/0,
+        ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));
+}
+
+void RemoveMempoolTx(const CTransaction& tx)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    mempool.remove(tx);
+    pwalletMain->mapWallet.erase(tx.GetHash());
+}
+
+//! One-output tx paying `dest`; with no vins it debits nothing, so IsFromMe() is false --
+//! the shape of a payment arriving from outside the wallet.
+CTransaction ExternalPaymentTx(const CTxDestination& dest, int64_t nValue)
+{
+    CMutableTransaction mtx;
+    mtx.vout.resize(1);
+    mtx.vout[0].nValue = nValue;
+    mtx.vout[0].scriptPubKey.SetDestination(dest);
+    return CTransaction(mtx);
+}
+
+size_t CountRowsForAddress(const UniValue& rows, const std::string& addr)
+{
+    size_t count = 0;
+    for (size_t i = 0; i < rows.size(); ++i) {
+        if (rows[i]["address"].get_str() == addr) ++count;
+    }
+    return count;
+}
+
+//! Amount of the row for `addr` in listreceivedbyaddress output, or -1 if absent.
+double RowAmountForAddress(const UniValue& rows, const std::string& addr)
+{
+    for (size_t i = 0; i < rows.size(); ++i) {
+        if (rows[i]["address"].get_str() == addr) return rows[i]["amount"].get_real();
+    }
+    return -1.0;
+}
+
+//! Amount of the row for `label` in listreceivedbylabel output, or 0 if the label has no row.
+double LabelGroupAmount(const UniValue& rows, const std::string& label)
+{
+    for (size_t i = 0; i < rows.size(); ++i) {
+        if (rows[i]["label"].get_str() == label) return rows[i]["amount"].get_real();
+    }
+    return 0.0;
+}
+} // namespace
+
 // The label tally counts only outputs the wallet owns (a labeled send-to address that
 // receives coins must NOT be counted), honors minconf, and listreceivedbylabel rows carry
 // the "label" key LAST (Bitcoin's serialized order: amount, confirmations, label).
@@ -333,20 +397,7 @@ BOOST_AUTO_TEST_CASE(received_by_label_tallies_owned_outputs_only)
     mtx.vout[1].nValue = 7 * COIN;
     mtx.vout[1].scriptPubKey.SetDestination(otherDest);
     CTransaction tx(mtx);
-    const uint256 hash = tx.GetHash();
-    {
-        LOCK2(cs_main, pwalletMain->cs_wallet);
-        CWalletTx wtx(pwalletMain, tx);
-        wtx.SetTxState(TxStateInMempool{});
-        pwalletMain->mapWallet[hash] = wtx;
-        // addUnchecked's contract requires the caller hold mempool.cs (it does no
-        // internal locking, unlike mempool.remove below); acquire it after cs_wallet
-        // per the canonical lock order.
-        LOCK(mempool.cs);
-        mempool.addUnchecked(hash, CTxMemPoolEntry(
-            tx, /*fee=*/0, /*time=*/0, /*height=*/0,
-            ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));
-    }
+    InjectMempoolTx(tx);
 
     UniValue grArgs(UniValue::VARR);
     grArgs.push_back("fundedlabel");
@@ -380,11 +431,166 @@ BOOST_AUTO_TEST_CASE(received_by_label_tallies_owned_outputs_only)
     BOOST_CHECK_EQUAL(others, 0.0);
 
     // Remove the injected tx so later cases (and suites) see the wallet they expect.
+    RemoveMempoolTx(tx);
+}
+
+// Regression for the reported bug: a wallet-owned address with NO address book entry that
+// received an external payment must appear in listreceivedbyaddress (with account ""), and
+// its amount must roll into the listreceivedbylabel "" group. Before the fix such an address
+// was invisible until the user set a label on it.
+BOOST_AUTO_TEST_CASE(listreceived_shows_unbooked_address_with_external_receipt)
+{
+    UniValue byAddrArgs(UniValue::VARR);
+    byAddrArgs.push_back(UniValue(0));
+    UniValue byLabelArgs(UniValue::VARR);
+    byLabelArgs.push_back(UniValue(0));
+    byLabelArgs.push_back(UniValue(true));
+
+    const double defaultGroupBefore = LabelGroupAmount(listreceivedbylabel(byLabelArgs), "");
+
+    // Owned key, deliberately NOT added to the address book.
+    CKey key;
+    key.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(key));
+    const CTxDestination dest = CTxDestination(key.GetPubKey().GetID());
+    const std::string addr = EncodeDestination(dest);
     {
-        LOCK2(cs_main, pwalletMain->cs_wallet);
-        mempool.remove(tx);
-        pwalletMain->mapWallet.erase(hash);
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE_EQUAL(pwalletMain->mapAddressBook.count(dest), 0u);
     }
+
+    CTransaction tx = ExternalPaymentTx(dest, 9 * COIN);
+    InjectMempoolTx(tx);
+
+    UniValue rows = listreceivedbyaddress(byAddrArgs);
+    BOOST_REQUIRE(rows.isArray());
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addr), 1u);
+    BOOST_CHECK_EQUAL(RowAmountForAddress(rows, addr), 9.0);
+    for (size_t i = 0; i < rows.size(); ++i) {
+        if (rows[i]["address"].get_str() == addr) {
+            BOOST_CHECK_EQUAL(rows[i]["account"].get_str(), "");
+        }
+    }
+
+    // The listed amount agrees with getreceivedbyaddress (P2PKH receipt).
+    UniValue grArgs(UniValue::VARR);
+    grArgs.push_back(addr);
+    grArgs.push_back(UniValue(0));
+    BOOST_CHECK_EQUAL(getreceivedbyaddress(grArgs).get_real(), 9.0);
+
+    // The grouped variant counts the unbooked receipt under the default "" label.
+    const double defaultGroupAfter = LabelGroupAmount(listreceivedbylabel(byLabelArgs), "");
+    BOOST_CHECK_EQUAL(defaultGroupAfter, defaultGroupBefore + 9.0);
+
+    RemoveMempoolTx(tx);
+}
+
+// An unbooked owned address that only ever received change from the wallet's own spend stays
+// hidden (it is what CWallet::IsChange means by change); one external receipt then surfaces
+// it with its FULL tally, change included. Also pins the booked-address skip of the new
+// emission loop: the booked address A must appear exactly once (no duplicate row from the
+// mapTally pass) and its externally received amount must stay under its own label rather
+// than leak into the "" group.
+BOOST_AUTO_TEST_CASE(listreceived_hides_pure_change_until_external_receipt)
+{
+    UniValue byAddrArgs(UniValue::VARR);
+    byAddrArgs.push_back(UniValue(0));
+    UniValue byLabelArgs(UniValue::VARR);
+    byLabelArgs.push_back(UniValue(0));
+    byLabelArgs.push_back(UniValue(true));
+
+    const double defaultGroupBefore = LabelGroupAmount(listreceivedbylabel(byLabelArgs), "");
+
+    // A: owned AND labeled (booked). Receives externally, so its tally is flagged external --
+    // exactly the shape that would double-emit if the new loop's booked-skip were missing.
+    CKey keyA;
+    keyA.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(keyA));
+    const CTxDestination destA = CTxDestination(keyA.GetPubKey().GetID());
+    const std::string addrA = EncodeDestination(destA);
+    setlabel(ArgArray({addrA, "changetest-ext"}));
+
+    // C: owned, unbooked.
+    CKey keyC;
+    keyC.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(keyC));
+    const CTxDestination destC = CTxDestination(keyC.GetPubKey().GetID());
+    const std::string addrC = EncodeDestination(destC);
+
+    // tx1: external payment to A.
+    CTransaction tx1 = ExternalPaymentTx(destA, 10 * COIN);
+    InjectMempoolTx(tx1);
+
+    // tx2: the wallet spends tx1's output, paying C -- C's receipt is change. GetDebit only
+    // reads the prevout from mapWallet and IsMine on it, so no signature is needed.
+    CMutableTransaction mtx2;
+    mtx2.vin.resize(1);
+    mtx2.vin[0].prevout = COutPoint(tx1.GetHash(), 0);
+    mtx2.vout.resize(1);
+    mtx2.vout[0].nValue = 4 * COIN;
+    mtx2.vout[0].scriptPubKey.SetDestination(destC);
+    CTransaction tx2(mtx2);
+    InjectMempoolTx(tx2);
+
+    UniValue rows = listreceivedbyaddress(byAddrArgs);
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addrC), 0u);   // pure change: hidden
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addrA), 1u);   // booked: exactly once
+
+    // tx3: external payment to C -- C now qualifies and shows its full tally (change 4 + 6).
+    CTransaction tx3 = ExternalPaymentTx(destC, 6 * COIN);
+    InjectMempoolTx(tx3);
+
+    rows = listreceivedbyaddress(byAddrArgs);
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addrC), 1u);
+    BOOST_CHECK_EQUAL(RowAmountForAddress(rows, addrC), 10.0);
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addrA), 1u);   // still exactly once
+    BOOST_CHECK_EQUAL(RowAmountForAddress(rows, addrA), 10.0);
+
+    // Full tally agrees with getreceivedbyaddress.
+    UniValue grArgs(UniValue::VARR);
+    grArgs.push_back(addrC);
+    grArgs.push_back(UniValue(0));
+    BOOST_CHECK_EQUAL(getreceivedbyaddress(grArgs).get_real(), 10.0);
+
+    // Grouped: only C's tally lands in ""; A's external receipt stays under its own label.
+    UniValue labelRows = listreceivedbylabel(byLabelArgs);
+    BOOST_CHECK_EQUAL(LabelGroupAmount(labelRows, ""), defaultGroupBefore + 10.0);
+    BOOST_CHECK_EQUAL(LabelGroupAmount(labelRows, "changetest-ext"), 10.0);
+
+    RemoveMempoolTx(tx3);
+    RemoveMempoolTx(tx2);
+    RemoveMempoolTx(tx1);
+}
+
+// includeempty must not dump the keypool: an owned, unbooked key with no receipts stays
+// absent even with includeempty=true, while a booked empty address still needs
+// includeempty=true to get a row (unchanged behavior).
+BOOST_AUTO_TEST_CASE(listreceived_includeempty_ignores_unbooked_keys_without_receipts)
+{
+    // Owned, unbooked, no receipts.
+    CKey keyD;
+    keyD.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(keyD));
+    const std::string addrD = EncodeDestination(CTxDestination(keyD.GetPubKey().GetID()));
+
+    // Owned, booked, no receipts.
+    CKey keyE;
+    keyE.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(keyE));
+    const std::string addrE = EncodeDestination(CTxDestination(keyE.GetPubKey().GetID()));
+    setlabel(ArgArray({addrE, "emptylabel"}));
+
+    UniValue withEmpty(UniValue::VARR);
+    withEmpty.push_back(UniValue(0));
+    withEmpty.push_back(UniValue(true));
+    UniValue rows = listreceivedbyaddress(withEmpty);
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addrD), 0u);
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addrE), 1u);
+
+    UniValue withoutEmpty(UniValue::VARR);
+    withoutEmpty.push_back(UniValue(0));
+    rows = listreceivedbyaddress(withoutEmpty);
+    BOOST_CHECK_EQUAL(CountRowsForAddress(rows, addrE), 0u);
 }
 
 // migratelabels backfills purpose on entries that loaded as "unknown" (owned -> "receive"),

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1001,7 +1001,11 @@ static const RPCHelpMan getreceivedbyaccount_help{
     "Use getreceivedbylabel instead.\n"
     "\n"
     "Returns the total amount received by addresses with <account> in transactions with at least\n"
-    "[minconf] confirmations.",
+    "[minconf] confirmations.\n"
+    "\n"
+    "Only addresses carrying <account> in the address book are tallied; payments to wallet\n"
+    "addresses without an address book entry are not included even for the default \"\"\n"
+    "account (listreceivedbyaccount counts those under \"\").",
     {
         {"account", RPCArg::Type::STR, RPCArg::Optional::NO, "The account name."},
         {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
@@ -1063,7 +1067,11 @@ UniValue getreceivedbyaccount(const UniValue& params)
 static const RPCHelpMan getreceivedbylabel_help{
     "getreceivedbylabel",
     "Returns the total amount received by addresses with <label> in transactions with at least\n"
-    "[minconf] confirmations.",
+    "[minconf] confirmations.\n"
+    "\n"
+    "Only addresses carrying <label> in the address book are tallied; payments to wallet\n"
+    "addresses without an address book entry are not included even for the default \"\"\n"
+    "label (listreceivedbylabel counts those under \"\").",
     {
         {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The selected label, may be the default label using \"\"."},
         {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
@@ -1782,12 +1790,14 @@ struct tallyitem
     int nConf;
     vector<uint256> txids;
     bool fIsWatchonly;
+    bool fIsExternal;
 
     tallyitem()
     {
         nAmount = 0;
         nConf = std::numeric_limits<int>::max();
         fIsWatchonly = false;
+        fIsExternal = false;
     }
 };
 
@@ -1823,6 +1833,11 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts, const string& st
         int nDepth = wtx.GetDepthInMainChain();
         if (nDepth < nMinDepth)
             continue;
+
+        // A tx the wallet did not fund is an external receipt for every owned output it
+        // pays; one the wallet funded only produces change (see CWallet::IsChange).
+        const bool fTxFromMe = wtx.IsFromMe(filter);
+
         for (auto const& txout : wtx.vout)
         {
             CTxDestination address;
@@ -1839,7 +1854,8 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts, const string& st
             item.txids.push_back(wtx.GetHash());
             if (mine & ISMINE_WATCH_ONLY)
               item.fIsWatchonly = true;
-
+            if (!fTxFromMe)
+                item.fIsExternal = true;
         }
     }
 
@@ -1896,6 +1912,47 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts, const string& st
         }
     }
 
+    // Wallet addresses with tallied receipts that have no address book entry. Only list
+    // addresses paid at least once from outside the wallet: an unbooked address whose every
+    // tallied output came from wallet-funded transactions is treated as change (see
+    // CWallet::IsChange; receipts inside wallet-cofunded transactions share this fate) and
+    // stays hidden, matching upstream. Qualifying rows carry the default ("") name.
+    for (auto const& tally : mapTally)
+    {
+        const CTxDestination& address = tally.first;
+        const tallyitem& tallied = tally.second;
+
+        if (!tallied.fIsExternal || pwalletMain->mapAddressBook.count(address))
+            continue;
+
+        if (fByAccounts)
+        {
+            tallyitem& item = mapAccountTally[""];
+            item.nAmount += tallied.nAmount;
+            item.nConf = min(item.nConf, tallied.nConf);
+            if (tallied.fIsWatchonly)
+                item.fIsWatchonly = true;
+        }
+        else
+        {
+            UniValue obj(UniValue::VOBJ);
+            if (tallied.fIsWatchonly) {
+                obj.pushKV("involvesWatchonly", true);
+            }
+            obj.pushKV("address",       EncodeDestination(address));
+            obj.pushKV("account",       "");
+            obj.pushKV("amount",        ValueFromAmount(tallied.nAmount));
+            obj.pushKV("confirmations", (tallied.nConf == std::numeric_limits<int>::max() ? 0 : tallied.nConf));
+
+            UniValue transactions(UniValue::VARR);
+            for (const uint256& txid : tallied.txids) {
+                transactions.push_back(txid.GetHex());
+            }
+            obj.pushKV("txids", transactions);
+            ret.push_back(obj);
+        }
+    }
+
     if (fByAccounts)
     {
         for (const auto& it : mapAccountTally)
@@ -1922,12 +1979,19 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts, const string& st
 
 static const RPCHelpMan listreceivedbyaddress_help{
     "listreceivedbyaddress",
-    "List balances by receiving address.",
+    "List balances by receiving address.\n"
+    "\n"
+    "Wallet addresses with received payments are listed even when they have no address book\n"
+    "entry (shown with account \"\"). An included address reports its full received total,\n"
+    "change included, matching getreceivedbyaddress. Addresses whose payments all arrived in\n"
+    "transactions funded by this wallet (change, or receipts inside wallet-cofunded\n"
+    "transactions) are omitted until given an address book entry; qualification is evaluated\n"
+    "within the same minconf filter.",
     {
         {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
             "The minimum number of confirmations before payments are included (default: 1)."},
         {"includeempty", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-            "Whether to include addresses that haven't received any payments (default: false)."},
+            "Whether to include address book addresses that haven't received any payments (default: false)."},
         {"includeWatchonly", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
             "Whether to include watchonly addresses (see 'importaddress'). Default: false."},
     },
@@ -1962,7 +2026,11 @@ static const RPCHelpMan listreceivedbyaccount_help{
     "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
     "Use listreceivedbylabel instead.\n"
     "\n"
-    "List balances by account.",
+    "List balances by account. Payments to wallet addresses without an address book entry\n"
+    "are counted under the default \"\" account at their full received total (change\n"
+    "included). Addresses whose payments all arrived in transactions funded by this wallet\n"
+    "are not counted. Note that getreceivedbyaccount \"\" reads only the address book, so it\n"
+    "does not include these amounts.",
     {
         {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
             "Minimum confirmations before payments are included. Default: 1."},
@@ -1999,7 +2067,13 @@ UniValue listreceivedbyaccount(const UniValue& params)
 
 static const RPCHelpMan listreceivedbylabel_help{
     "listreceivedbylabel",
-    "List received transactions by label.",
+    "List received transactions by label.\n"
+    "\n"
+    "Payments to wallet addresses without an address book entry are counted under the\n"
+    "default \"\" label at their full received total (change included). Addresses whose\n"
+    "payments all arrived in transactions funded by this wallet are not counted. Note that\n"
+    "getreceivedbylabel \"\" reads only the address book, so it does not include these\n"
+    "amounts.",
     {
         {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
             "Minimum confirmations before payments are included. Default: 1."},


### PR DESCRIPTION
## Problem

Reported by QuaXeros on testnet (Discord, 7/6–7/8): `listreceivedbyaddress 0 true` omitted a
wallet-owned address holding ~370k GRC of received payments, while `getreceivedbyaddress`
returned the full amount for the same address. Setting a label made the address appear — and it
stayed visible even after re-labeling to `""`. Reproduced identically via GUI debug console and
curl RPC on 5.5.1.3/5.5.1.4.

Root cause: `ListReceived` builds its reply exclusively from `mapAddressBook`. A wallet-owned
address with no address book entry has no code path that emits it, regardless of how much it
received; `includeempty` only surfaces *booked* addresses with empty tallies. This is not a
regression — the logic is byte-identical on every version the reporter ran (verified against
tags `5.5.1.0` and `5.5.1.3-testnet`); their 5.5.1.0 wallet simply already had labels on those
addresses. Upstream Bitcoin Core has the same address-book-driven reply loop; it is less visible
there because Core books every address `getnewaddress` returns, whereas Gridcoin wallets commonly
hold unbooked receive addresses (restored keypools, addresses handed out via RPC).

## Fix

Tag each tallied destination with whether at least one tallied output arrived in a transaction
the wallet did not fund (`!wtx.IsFromMe(filter)`, using the tally's own isminefilter). After the
address-book pass, emit qualifying unbooked addresses:

- `listreceivedbyaddress`: per-address rows carrying the default `account ""`.
- `listreceivedbylabel` / `listreceivedbyaccount`: amounts roll into the `""` group, preserving
  the invariant that the grouped `""` total equals the sum of by-address rows with `account ""`.

An unbooked address whose *every* tallied output came from the wallet's own transactions is
change (this is precisely `CWallet::IsChange`'s definition) and stays hidden, matching upstream's
observable behavior. Once an address qualifies, its full tally is emitted so the amount agrees
with `getreceivedbyaddress`.

No result-schema change: new rows reuse the existing key set, so the heritage fingerprints for
`listreceivedbyaddress`/`listreceivedbylabel` are unchanged (`test/lint/lint-rpc-heritage.py`
passes, 208 RPCs current).

## Deliberate limitations

- The gate is transaction-level: a receive inside a wallet-cofunded transaction, or an RPC/raw
  self-send to an unbooked owned address, stays hidden until labeled. GUI sends always book the
  destination (`WalletImpl::sendCoins` → `SetAddressBookName`), so only RPC paths can hit this.
- A pure-change address still reports its total via `getreceivedbyaddress` (which ignores the
  address book) while staying absent from the list — mirrors upstream.
- Bare P2PK outputs to a key count in `ListReceived` (destination-based) but not in
  `getreceivedbyaddress` (exact-script match) — pre-existing divergence, unchanged.
- The GUI "Add Existing" list (`unbookedReceiveAddresses`) is balance-based and may offer a
  pure-change address this RPC will not list until booked — different criteria by design.
- `includeempty` still applies only to booked addresses: unbooked keys with no receipts are never
  listed, so the keypool is not dumped.
- The gate is evaluated within the requested `minconf` view: an unbooked address whose first
  external receipt is still unconfirmed is listed at `minconf 0` but absent (not partially
  listed) at `minconf 1` until that receipt confirms. Each view depends only on transactions
  meeting its own depth bound; the alternative (qualifying a confirmed view via an unconfirmed
  transaction) would flicker with mempool churn instead.
- **Open design question for review:** `getreceivedbylabel ""` / `getreceivedbyaccount ""`
  still read only the address book, so they do not include the amounts the list variants now
  place in the `""` group. This divergence is documented in both help texts. If twin parity is
  preferred, the same qualifying-unbooked tally can be added to `TallyReceivedByAddresses`
  callers for the `""` label in a follow-up — or the grouped rollup can be dropped, leaving
  only per-address rows. Maintainer preference welcome.
- Coinstake-embedded receipts (sidestakes and MRC payouts inside others' coinstakes, net stake
  rewards) remain excluded from all `receivedby*` tallies, as before — that larger semantic gap
  (it explains the remainder of the reporter's 150k-listed vs 170k-actual discrepancy) is
  tracked separately.
- A deeper convergence idea, deliberately left out: extending `migratelabels` to book owned
  addresses that have at least one external receipt (name `""`, purpose `receive`) would make
  the GUI address table, `IsChange`, and the `getreceivedby*` twins agree with this RPC by
  construction. That expands `migratelabels`' documented contract, so it belongs in the
  follow-up discussion, not here.

## Tests

Three new cases in `addressbook_tests` (built on the suite's existing mempool-injection
pattern):

- `listreceived_shows_unbooked_address_with_external_receipt` — the reported regression:
  unbooked owned address with an external receipt appears with `account ""`, amount agreeing
  with `getreceivedbyaddress`, and rolls into the `""` label group.
- `listreceived_hides_pure_change_until_external_receipt` — change to an unbooked address stays
  hidden; one external receipt surfaces it with the full tally (change included). Also pins the
  booked-address skip: a booked address with external receipts appears exactly once (no
  duplicate row) and its amount stays under its own label rather than leaking into `""`.
- `listreceived_includeempty_ignores_unbooked_keys_without_receipts` — `includeempty=true`
  never lists unbooked keys without receipts; booked empty addresses still require it.

Full `test_gridcoin` suite passes; `lint-rpc-heritage.py` and `lint-whitespace.sh` clean.
