### PR TITLE
wallet: fix spurious wallet file version warning on load

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -567,11 +567,11 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 
     LogPrintf("nFileVersion = %d", wss.nFileVersion);
 
-    // Validate wallet file version is in expected range
-    if (wss.nFileVersion > wallet::FEATURE_LATEST) {
-        LogPrintf("WARNING: Wallet file version %d exceeds latest wallet feature version %d",
-                  wss.nFileVersion, wallet::FEATURE_LATEST);
-        LogPrintf("This may indicate version mismatch or corrupted wallet file");
+    // A wallet last written by a newer client is not corruption; genuine
+    // incompatibility is governed by the "minversion" check above.
+    if (wss.nFileVersion > CLIENT_VERSION) {
+        LogPrintf("Wallet file version %d was last written by a newer client (this client: %d)",
+                  wss.nFileVersion, CLIENT_VERSION);
     }
 
     LogPrintf("Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total",


### PR DESCRIPTION
Fixes #3190.

## Problem

Every wallet touched by a client newer than 5.4.1.1 logs a spurious corruption warning on every load — including brand-new wallets on their very first start:

```
2026-07-06T15:17:26Z nFileVersion = 5050101
2026-07-06T15:17:26Z WARNING: Wallet file version 5050101 exceeds latest wallet feature version 5040101
2026-07-06T15:17:26Z This may indicate version mismatch or corrupted wallet file
```

(from the 5.5.1.4 macOS debug.log that prompted the issue)

## Root cause

The check (added incidentally in f2b856abd) compares two values from different version spaces:

- `wss.nFileVersion` — the wallet's `"version"` record, stamped with the **client version** (`WriteVersion(CLIENT_VERSION)` in `CDB` creation and in the `nFileVersion < CLIENT_VERSION` upgrade path a few lines below the warning).
- `wallet::FEATURE_LATEST = FEATURE_HD = 5040101` — a **wallet feature** constant, which is just the 5.4.1.1 client version frozen in time.

So any client ≥ 5.4.1.2 stamps a `"version"` that "exceeds" `FEATURE_LATEST`, and the warning fires forever on exactly the wallets that are healthy.

## Fix

Compare within the client-version space and reword the message. A wallet last written by a newer client is not corruption — genuine incompatibility is already governed by the `"minversion"` check earlier in `LoadWallet` (`DB_TOO_NEW` → "Wallet requires newer version of Gridcoin"). This also matches the equivalent last-client check in Bitcoin Core (`last_client > CLIENT_VERSION`, informational only).

The remaining message covers the one case where the two values can legitimately differ upward: an older client opening a wallet stamped by a newer one.

## Verification

Built with `-DENABLE_TESTS=ON`; on a fresh regtest datadir (wallet.dat created and stamped `version = 5050104` at DB open, so `LoadWallet` reads it back the same startup):

- **Before** (development @ ee19963): `nFileVersion = 5050104` followed by the two WARNING lines in debug.log.
- **After**: `nFileVersion = 5050104` and no warning; the new informational line correctly does not fire (5050104 ≯ 5050104).
- `gridcoin_tests` unit suite passes.
