### PR TITLE
wallet: notify on the silent coin-availability mutation paths

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1319,7 +1319,14 @@ void CWallet::TransactionReplacedInMempool(const CTransactionRef& tx)
     // mempool. Preserve the legacy EraseFromWallets behavior: drop the defunct
     // copy entirely (EraseFromWallet takes cs_wallet internally). This replaces
     // the setpwalletRegistered EraseFromWallets wrapper (issue #3030).
-    EraseFromWallet(tx->GetHash());
+    const uint256 hash = tx->GetHash();
+
+    if (EraseFromWallet(hash)) {
+        // Without this the erased tx lingers in derived views (tx tables,
+        // coin lists) until restart. CT_DELETED handlers touch only the hash
+        // and expect no wallet locks held.
+        NotifyTransactionChanged(this, hash, CT_DELETED);
+    }
 }
 
 void CWallet::BlockConnected(const CBlock& block, int height)
@@ -1449,6 +1456,10 @@ void CWallet::BlockDisconnected(const CBlock& block, int height)
         pwalletdb = std::make_unique<CWalletDB>(strWalletFile);
     }
 
+    // Parents whose outputs are unmarked spent below; notified once each after
+    // the loop so subscribers see the restored coins.
+    std::set<uint256> parents_unspent;
+
     for (const auto& tx : block.vtx) {
         const uint256& hash = tx.GetHash();
         auto it = mapWallet.find(hash);
@@ -1513,12 +1524,24 @@ void CWallet::BlockDisconnected(const CBlock& block, int height)
 
                     // Persist the change to disk using shared database session
                     parent_wtx.WriteToDisk(pwalletdb.get());
+
+                    parents_unspent.insert(txin.prevout.hash);
                 }
             }
         }
 
         wtx.MarkDirty();
         wtx.WriteToDisk(pwalletdb.get());
+    }
+
+    // Notify once per parent whose outputs were unmarked above. Deduplicated
+    // across the whole block: a disconnected consolidation tx can consume
+    // hundreds of outputs of the same parent, and per-input signals would fan
+    // out to subscribers as repeated synchronous re-decompositions mid-reorg.
+    // cs_main (held by caller) and cs_wallet (held above) satisfy the
+    // CT_UPDATED handler contract.
+    for (const uint256& parent_hash : parents_unspent) {
+        NotifyTransactionChanged(this, parent_hash, CT_UPDATED);
     }
 
     // Update last block processed marker
@@ -2216,6 +2239,14 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
             pindex = pindex->pnext;
         }
     }
+
+    if (ret > 0) {
+        // AddToWalletIfInvolvingMe was called directly (not via the
+        // SyncTransaction path), so no per-tx NotifyTransactionChanged fired
+        // for anything found here. Let derived views resynchronize once.
+        NotifyTransactionsBulkChanged();
+    }
+
     return ret;
 }
 
@@ -2275,6 +2306,7 @@ void CWallet::ReacceptWalletTransactions()
 {
     CTxDB txdb("r");
     bool fRepeat = true;
+    bool fAnyUpdated = false;
     while (fRepeat)
     {
         LOCK2(cs_main, cs_wallet);
@@ -2306,6 +2338,7 @@ void CWallet::ReacceptWalletTransactions()
                     wtx.MarkDirty();
                     CWalletDB walletdb(strWalletFile);
                     wtx.WriteToDisk(&walletdb);
+                    fAnyUpdated = true;
                 }
                 continue;
             }
@@ -2352,6 +2385,7 @@ void CWallet::ReacceptWalletTransactions()
                 wtx.MarkDirty();
                 CWalletDB walletdb(strWalletFile);
                 wtx.WriteToDisk(&walletdb);
+                fAnyUpdated = true;
             }
         }
         if (!vMissingTx.empty()) {
@@ -2359,6 +2393,12 @@ void CWallet::ReacceptWalletTransactions()
             if (ScanForWalletTransactions(pindexGenesisBlock))
                 fRepeat = true;  // Found missing transactions: re-do re-accept.
         }
+    }
+
+    if (fAnyUpdated) {
+        // The state migrations and MarkSpent calls above bypass the per-tx
+        // notification path; let derived views resynchronize once.
+        NotifyTransactionsBulkChanged();
     }
 }
 
@@ -4419,7 +4459,11 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
     nMismatchFound = 0;
     nBalanceInQuestion = 0;
 
-    LOCK(cs_wallet);
+    // cs_main is required by the CT_UPDATED notification contract below (and
+    // guards the txindex reads). Callers either already hold it
+    // (ReorganizeChain) or hold neither lock (init, checkwallet/repairwallet
+    // RPCs), so taking both here is safe in the canonical order.
+    LOCK2(cs_main, cs_wallet);
     vector<CWalletTx*> vCoins;
     vCoins.reserve(mapWallet.size());
     for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
@@ -4427,6 +4471,12 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
     }
 
     CWalletDB walletdb(strWalletFile);
+
+    // Transactions whose vfSpent was repaired below; notified once each after
+    // the loop so derived views hear about the availability changes (this runs
+    // from ReorganizeChain's otherwise-silent cleanup as well as the
+    // repairwallet RPC).
+    std::set<uint256> repaired;
 
     CTxDB txdb("r");
     for (auto const& pcoin : vCoins)
@@ -4448,6 +4498,7 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
                 {
                     pcoin->MarkUnspent(n);
                     pcoin->WriteToDisk(&walletdb);
+                    repaired.insert(pcoin->GetHash());
                 }
             }
             else if ((IsMine(pcoin->vout[n]) != ISMINE_NO) && !pcoin->IsSpent(n) && (txindex.vSpent.size() > n && !txindex.vSpent[n].IsNull()))
@@ -4460,9 +4511,14 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
                 {
                     pcoin->MarkSpent(n);
                     pcoin->WriteToDisk(&walletdb);
+                    repaired.insert(pcoin->GetHash());
                 }
             }
         }
+    }
+
+    for (const uint256& hash : repaired) {
+        NotifyTransactionChanged(this, hash, CT_UPDATED);
     }
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -630,6 +630,18 @@ public:
      */
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx, ChangeType status)> NotifyTransactionChanged;
 
+    /** A bulk wallet-transaction mutation pass (rescan / reaccept) completed
+     *  without emitting per-transaction NotifyTransactionChanged signals.
+     *  Subscribers that maintain derived transaction or coin state should
+     *  fully resynchronize from the wallet.
+     *  @note Lock state at emission varies by path (a rescan nested inside
+     *        ReacceptWalletTransactions fires under cs_main + cs_wallet; the
+     *        top-level emissions fire with neither held). Subscribers must not
+     *        assume either and should defer heavy resync work rather than
+     *        perform it inline.
+     */
+    boost::signals2::signal<void ()> NotifyTransactionsBulkChanged;
+
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() { return hdChain; }


### PR DESCRIPTION
First PR of the #3183 series (windowed/virtualized coin-control model — see the tracking comment there for the full series plan). This is the standalone wallet-side patch: it closes four verified paths where coin availability (`vfSpent` / `mapWallet` membership) mutates **without any `NotifyTransactionChanged` emission**, leaving event-driven consumers (today the windowed tx-table store, next the #3183 coin store) silently stale until restart.

## The four gaps

1. **`BlockDisconnected`** — when a block is disconnected, the parent outputs consumed by its transactions are `MarkUnspent`-ed with no notification for the parent tx, so coins restored by a reorg were invisible to the event stream. Now fires `CT_UPDATED` once per affected parent, **deduplicated across the block**: a disconnected consolidation transaction can consume hundreds of outputs of the same few parents, and per-input signals would fan out as repeated synchronous re-decompositions mid-reorg. Fires under `cs_main` (caller) + `cs_wallet` (held), satisfying the CT_UPDATED handler contract in `wallet_tx_source.cpp`.

2. **`TransactionReplacedInMempool`** — erased the defunct wallet tx with no notification (contrast: the stale-tx cleanup in `node/chainman.cpp:456` already does erase + `CT_DELETED`). This was a live windowed-tx-table bug: a replaced tx's row lingered until restart. Now mirrors the chainman pattern. CT_DELETED handlers touch only the hash and expect no wallet locks, matching the other CT_DELETED sites.

3. **`FixSpentCoins`** — flips `vfSpent` both directions with no notification, and it is not just the `checkwallet`/`repairwallet` RPCs: `ReorganizeChain` calls it during reorg housekeeping (its own comment says "this is silent"). Now fires `CT_UPDATED` once per actually-repaired tx. The lock is upgraded `LOCK(cs_wallet)` → `LOCK2(cs_main, cs_wallet)` for the notification contract (and it guards the txindex reads); callers either already hold `cs_main` (ReorganizeChain) or hold neither lock (init, the RPCs), so the canonical order is preserved everywhere.

4. **Rescan / reaccept** — `ScanForWalletTransactions` inserts via `AddToWalletIfInvolvingMe` directly (no notification), and `ReacceptWalletTransactions` does silent state migrations and `MarkSpent`; both are runtime-reachable via `importprivkey` / `importaddress`. Per-tx signals here would be a flood (a rescan can touch tens of thousands of txs), so this adds a new **`NotifyTransactionsBulkChanged`** signal — "a bulk pass completed; resynchronize" — fired once when either function actually changed something. The subscriber lands with the #3183 coin store (PR-D of the series); wiring the existing tx-table store to it is a natural follow-up.

## Not patched, deliberately

- `DisableTransaction` also `MarkUnspent`s silently, but it has **zero callers** (dead code) — patching it would be noise.
- Mempool ejection flipping depth 0 → −1 has no wallet signal anywhere (`TransactionRemovedFromMempool` has no emission site in the tree) — pre-existing blind spot, out of scope here.

## Testing

- Built `ENABLE_GUI=OFF -DENABLE_TESTS=ON`; full `ctest` suite passes.
- `test/lint/lint-all.sh` clean.

Part of #3183.
