### PR TITLE
gui: add GRC::CoinViews, the grouped index core for coin selection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library(gridcoin_util STATIC
     util/tokenpipe.cpp
     validation.cpp
     validationinterface.cpp
+    wallet/coinviews.cpp
     wallet/cursor.cpp
     wallet/db.cpp
     wallet/diagnose.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -80,6 +80,13 @@ add_executable(test_gridcoin
     # into the GUI-OFF binary pins the Qt-freedom the node-side source needs.
     ${CMAKE_SOURCE_DIR}/src/wallet/transactionrecord.cpp
     qt_transactionrecord_tests.cpp
+    # Qt-free grouped index core (src/wallet/coinviews.cpp) of the windowed
+    # coin-control selection model (#3183) + its unit suite: flat/tree index
+    # maintenance, directory aggregate arithmetic, per-scope deltas, and the
+    # scope-local high-water + per-view floor contract exercised against the
+    # real WindowCache gate — tested GUI-OFF like the cursor.
+    ${CMAKE_SOURCE_DIR}/src/wallet/coinviews.cpp
+    qt_coinviews_tests.cpp
     # Qt-free wallet event queue (src/wallet/wallet_event_queue.h, a header-only
     # template shared by the tx and coin channels) unit suite: the MPSC intake
     # drain/ordering + multi-producer seqno-density contract (GUI-OFF).

--- a/src/test/qt_coinviews_tests.cpp
+++ b/src/test/qt_coinviews_tests.cpp
@@ -1,0 +1,543 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF unit coverage for the Qt-free grouped index core
+// (src/wallet/coinviews.{h,cpp}) of the windowed coin-control selection model
+// (issue #3183): flat/tree index maintenance, directory aggregate arithmetic,
+// per-scope delta emission, the scope-local high-water + per-view floor
+// contract (exercised against the real GRC::WindowCache gate — the design's
+// central novel invariant), and windowed reads within a pathological
+// single-address group. Driven from synthetic record tables, never a real
+// CWallet — the windowed tx-table risk-control discipline.
+
+#include <qt/windowcache.h>
+#include <wallet/coinviews.h>
+
+#include <arith_uint256.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <util/strencodings.h>
+
+#include <string>
+#include <vector>
+
+using GRC::CoinRecord;
+using GRC::CoinViewDelta;
+using GRC::CoinViewMode;
+using GRC::CoinViews;
+using GRC::WindowCache;
+using GRC::WindowCacheSink;
+
+namespace {
+
+constexpr int kView = GRC::VIEW_COIN_CONTROL;
+
+uint256 hashOf(int n)
+{
+    return ArithToUint256(arith_uint256(static_cast<uint64_t>(n) + 1));
+}
+
+CoinRecord makeCoin(int seed, int64_t amount, const std::string& group,
+                    bool is_change = false, int64_t time = 0, int height = 100)
+{
+    CoinRecord r;
+    r.outpoint = COutPoint(hashOf(seed), 0);
+    r.amount = amount;
+    r.address = is_change ? ("change" + ToString(seed)) : group;
+    r.group_address = group;
+    r.label = "";
+    r.time = time;
+    r.block_height = height;
+    r.is_change = is_change;
+    return r;
+}
+
+//! Synthetic backing table + the CoinViews under test, wired the way the
+//! store drives it: mutate the table first (append / compact), then call the
+//! matching apply* (applyRemove is called before the compaction).
+struct Harness {
+    std::vector<CoinRecord> table;
+    CoinViews cv;
+
+    Harness() : cv([this](std::size_t i) -> const CoinRecord& { return table[i]; }) {}
+
+    std::vector<CoinViewDelta> insert(const CoinRecord& r)
+    {
+        table.push_back(r);
+        return cv.applyInsert(table.size() - 1);
+    }
+
+    std::vector<CoinViewDelta> remove(std::size_t absidx, bool was_selected = false)
+    {
+        auto deltas = cv.applyRemove(absidx, was_selected);
+        table.erase(table.begin() + absidx);
+        return deltas;
+    }
+};
+
+//! No-op sink for WindowCache integration checks.
+struct NullSink : WindowCacheSink {
+    void beginReset() override {}
+    void endReset() override {}
+    void beginInsert(int, int) override {}
+    void endInsert() override {}
+    void beginRemove(int, int) override {}
+    void endRemove() override {}
+    void dataChanged(int, int) override {}
+};
+
+int countType(const std::vector<CoinViewDelta>& deltas, CoinViewDelta::Type type)
+{
+    int n = 0;
+    for (const auto& d : deltas) {
+        if (d.type == type) ++n;
+    }
+    return n;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(qt_coinviews_tests)
+
+BOOST_AUTO_TEST_CASE(flatViewSortsAndSlices)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 300, "A"));
+    h.table.push_back(makeCoin(2, 100, "A"));
+    h.table.push_back(makeCoin(3, 200, "B"));
+
+    // Amount descending — the dialog default.
+    auto deltas = h.cv.registerView(kView, CoinViewMode::Flat,
+                                    GRC::COINCOL_AMOUNT, /*desc*/ 1, h.table.size());
+    BOOST_REQUIRE_EQUAL(deltas.size(), 1u);
+    BOOST_CHECK(deltas[0].type == CoinViewDelta::Reset);
+
+    int total = 0;
+    auto slice = h.cv.flatSlice(kView, 0, -1, total);
+    BOOST_CHECK_EQUAL(total, 3);
+    BOOST_REQUIRE_EQUAL(slice.size(), 3u);
+    BOOST_CHECK_EQUAL(h.table[slice[0]].amount, 300);
+    BOOST_CHECK_EQUAL(h.table[slice[1]].amount, 200);
+    BOOST_CHECK_EQUAL(h.table[slice[2]].amount, 100);
+
+    // Windowed sub-slice.
+    auto mid = h.cv.flatSlice(kView, 1, 1, total);
+    BOOST_REQUIRE_EQUAL(mid.size(), 1u);
+    BOOST_CHECK_EQUAL(h.table[mid[0]].amount, 200);
+}
+
+BOOST_AUTO_TEST_CASE(treeViewDirectoryAndAggregates)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 300, "A"));
+    h.table.push_back(makeCoin(2, 100, "A", /*is_change*/ true));
+    h.table.push_back(makeCoin(3, 200, "B"));
+
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    int total = 0;
+    auto dir = h.cv.directorySlice(kView, 0, -1, total);
+    BOOST_CHECK_EQUAL(total, 2);
+    BOOST_REQUIRE_EQUAL(dir.size(), 2u);
+    // A totals 400, B totals 200 — amount-desc directory.
+    BOOST_CHECK_EQUAL(dir[0], "A");
+    BOOST_CHECK_EQUAL(dir[1], "B");
+
+    auto a = h.cv.groupInfo("A");
+    BOOST_CHECK_EQUAL(a.total_amount, 400);
+    BOOST_CHECK_EQUAL(a.output_count, 2);
+    BOOST_CHECK_EQUAL(a.direct_output_count, 1); // the change member doesn't count
+    BOOST_CHECK_EQUAL(a.selected_count, 0);
+
+    // Group scope slice, child order amount-desc.
+    auto members = h.cv.groupSlice(kView, "A", 0, -1, total);
+    BOOST_CHECK_EQUAL(total, 2);
+    BOOST_REQUIRE_EQUAL(members.size(), 2u);
+    BOOST_CHECK_EQUAL(h.table[members[0]].amount, 300);
+    BOOST_CHECK_EQUAL(h.table[members[1]].amount, 100);
+
+    // Unknown group: empty, total 0.
+    auto none = h.cv.groupSlice(kView, "Z", 0, -1, total);
+    BOOST_CHECK(none.empty());
+    BOOST_CHECK_EQUAL(total, 0);
+
+    // The address-ordered picker directory.
+    auto directory = h.cv.groupDirectory();
+    BOOST_REQUIRE_EQUAL(directory.size(), 2u);
+    BOOST_CHECK_EQUAL(directory[0].address, "A");
+    BOOST_CHECK_EQUAL(directory[1].address, "B");
+}
+
+BOOST_AUTO_TEST_CASE(insertEmitsMemberAndDirectoryDeltas)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 500, "A"));
+    h.table.push_back(makeCoin(2, 400, "B"));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    // New group C (amount 100): member insert + directory GroupInsert at the end.
+    auto deltas = h.insert(makeCoin(3, 100, "C"));
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::Insert), 1);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupInsert), 1);
+    for (const auto& d : deltas) {
+        if (d.type == CoinViewDelta::Insert) BOOST_CHECK_EQUAL(d.scope, "C");
+        if (d.type == CoinViewDelta::GroupInsert) BOOST_CHECK_EQUAL(d.first, 2);
+    }
+
+    // A big coin lands in B (total 400 -> 900 > A's 500): the directory row
+    // MOVES, which must go out as GroupRemove + GroupInsert — an in-place
+    // GroupChange would silently diverge the consumer's positional replica.
+    deltas = h.insert(makeCoin(4, 500, "B"));
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupRemove), 1);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupInsert), 1);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupChange), 0);
+
+    int total = 0;
+    auto dir = h.cv.directorySlice(kView, 0, -1, total);
+    BOOST_REQUIRE_EQUAL(dir.size(), 3u);
+    BOOST_CHECK_EQUAL(dir[0], "B");
+    BOOST_CHECK_EQUAL(dir[1], "A");
+
+    // A small coin into A (500 -> 600, still second): in place — GroupChange.
+    deltas = h.insert(makeCoin(5, 100, "A"));
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupChange), 1);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupRemove), 0);
+}
+
+BOOST_AUTO_TEST_CASE(removeCompactsAndKeepsMapping)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 300, "A"));
+    h.table.push_back(makeCoin(2, 200, "A"));
+    h.table.push_back(makeCoin(3, 100, "B"));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    // Remove the middle record (absidx 1): its group survives; the absolute
+    // index of the old record 2 shifts down and every index must keep
+    // resolving to the right records afterwards.
+    auto deltas = h.remove(1);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::Remove), 1);
+    for (const auto& d : deltas) {
+        if (d.type == CoinViewDelta::Remove) {
+            BOOST_CHECK_EQUAL(d.scope, "A");
+            BOOST_CHECK_EQUAL(d.first, 1); // second row of A's amount-desc children
+        }
+    }
+
+    auto a = h.cv.groupInfo("A");
+    BOOST_CHECK_EQUAL(a.output_count, 1);
+    BOOST_CHECK_EQUAL(a.total_amount, 300);
+
+    int total = 0;
+    auto members = h.cv.groupSlice(kView, "B", 0, -1, total);
+    BOOST_REQUIRE_EQUAL(members.size(), 1u);
+    BOOST_CHECK_EQUAL(h.table[members[0]].amount, 100); // shifted index still maps
+
+    // Removing B's last coin kills the group.
+    deltas = h.remove(members[0]);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupRemove), 1);
+    BOOST_CHECK(h.cv.groupInfo("B").address.empty());
+    auto dir = h.cv.directorySlice(kView, 0, -1, total);
+    BOOST_CHECK_EQUAL(total, 1);
+}
+
+BOOST_AUTO_TEST_CASE(updateReslotsAndRegroups)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 300, "A", false, 0, -1)); // unconfirmed
+    h.table.push_back(makeCoin(2, 200, "A", false, 0, 50));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_CONFS, 0, h.table.size());
+
+    // Ascending confirmations: unconfirmed first. Record 0 confirms at a low
+    // height (many confs) — it moves behind record 1: Remove + Insert.
+    h.table[0].block_height = 10;
+    auto deltas = h.cv.applyUpdate(0, "A", false, false);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::Remove), 1);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::Insert), 1);
+
+    int total = 0;
+    auto members = h.cv.groupSlice(kView, "A", 0, -1, total);
+    BOOST_REQUIRE_EQUAL(members.size(), 2u);
+    BOOST_CHECK_EQUAL(h.table[members[0]].block_height, 50); // fewer confs first
+    BOOST_CHECK_EQUAL(h.table[members[1]].block_height, 10);
+
+    // Regroup (the address-book change-walk flip): record 1 moves A -> B,
+    // selected. Member Remove from A, Insert into B, new-group GroupInsert,
+    // and the selection aggregate moves with it.
+    h.cv.applySelection(1, true);
+    h.table[1].group_address = "B";
+    h.table[1].is_change = false;
+    deltas = h.cv.applyUpdate(1, "A", false, /*was_selected*/ true);
+
+    bool removed_from_a = false, inserted_into_b = false;
+    for (const auto& d : deltas) {
+        if (d.type == CoinViewDelta::Remove && d.scope == "A") removed_from_a = true;
+        if (d.type == CoinViewDelta::Insert && d.scope == "B") inserted_into_b = true;
+    }
+    BOOST_CHECK(removed_from_a);
+    BOOST_CHECK(inserted_into_b);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupInsert), 1);
+
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("A").selected_count, 0);
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("B").selected_count, 1);
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("B").selected_amount, 200);
+}
+
+BOOST_AUTO_TEST_CASE(selectionAggregatesAndDeltas)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 300, "A"));
+    h.table.push_back(makeCoin(2, 200, "A"));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    auto deltas = h.cv.applySelection(0, true);
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupChange), 1);
+
+    auto a = h.cv.groupInfo("A");
+    BOOST_CHECK_EQUAL(a.selected_count, 1);
+    BOOST_CHECK_EQUAL(a.selected_amount, 300);
+
+    h.cv.applySelection(1, true);
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("A").selected_count, 2); // == output_count: parent checked
+
+    // Removing a selected coin pulls the aggregates down with it.
+    h.remove(0, /*was_selected*/ true);
+    a = h.cv.groupInfo("A");
+    BOOST_CHECK_EQUAL(a.selected_count, 1);
+    BOOST_CHECK_EQUAL(a.selected_amount, 200);
+}
+
+BOOST_AUTO_TEST_CASE(highWaterScopeAndFloorArithmetic)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 100, "A"));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    BOOST_CHECK_EQUAL(h.cv.highWater(kView, "A"), 0u);
+
+    h.cv.noteScopeEvent(kView, "A", 5);
+    BOOST_CHECK_EQUAL(h.cv.highWater(kView, "A"), 5u);
+    // Another scope's event does NOT advance A's high-water (the gap-tolerant
+    // per-scope stream).
+    h.cv.noteScopeEvent(kView, "B", 6);
+    BOOST_CHECK_EQUAL(h.cv.highWater(kView, "A"), 5u);
+
+    // A broadcast (Reset/resync) floors EVERY scope of the view — including
+    // scopes that have never seen an event of their own.
+    h.cv.noteBroadcast(kView, 9);
+    BOOST_CHECK_EQUAL(h.cv.highWater(kView, "A"), 9u);
+    BOOST_CHECK_EQUAL(h.cv.highWater(kView, "never-seen"), 9u);
+    BOOST_CHECK_EQUAL(h.cv.directoryHighWater(kView), 9u);
+
+    // Scope events past the floor take over again.
+    h.cv.noteScopeEvent(kView, "A", 12);
+    BOOST_CHECK_EQUAL(h.cv.highWater(kView, "A"), 12u);
+    h.cv.noteDirectoryEvent(kView, 13);
+    BOOST_CHECK_EQUAL(h.cv.directoryHighWater(kView), 13u);
+}
+
+BOOST_AUTO_TEST_CASE(broadcastFloorPreventsWindowCacheGateLivelock)
+{
+    // The adversarial-review livelock scenario, against the REAL WindowCache
+    // gate: a sort change arrives as one global-seqno Reset; a floorless
+    // high-water would leave every subsequent fetch permanently rejected on a
+    // quiescent wallet (fetch high_water < the cache's reseeded baseline).
+    Harness h;
+    for (int i = 0; i < 4; ++i) h.table.push_back(makeCoin(i, 100 * (i + 1), "A"));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    NullSink sink;
+    WindowCache<CoinRecord> cache;
+
+    // Steady state: scope A saw its last event at seqno 42.
+    h.cv.noteScopeEvent(kView, "A", 42);
+
+    // User flips the sort. The store emits CoinReset with queue seqno 60 and
+    // records it as a broadcast; the consumer destroys and reseeds the cache
+    // from a fresh fetch, whose high-water reflects the floor.
+    h.cv.setViewSort(kView, GRC::COINCOL_AMOUNT, 0, h.table.size());
+    h.cv.noteBroadcast(kView, 60);
+
+    int total = 0;
+    auto slice = h.cv.groupSlice(kView, "A", 0, -1, total);
+    std::vector<CoinRecord> rows;
+    for (auto idx : slice) rows.push_back(h.table[idx]);
+    cache.seedInitial(rows, 0, total, h.cv.epoch(kView), h.cv.highWater(kView, "A"));
+
+    // Quiescent wallet, user scrolls: the fetch carries the SAME high-water
+    // and must be adopted.
+    BOOST_CHECK(cache.fillContent(sink, 0, rows, h.cv.epoch(kView),
+                                  h.cv.highWater(kView, "A")));
+
+    // A floorless implementation would have returned the stale scope seqno
+    // (42) for the reseed-time and fetch-time high-water of a scope the Reset
+    // never touched... but the cache baseline would then have to come from
+    // the Reset event's own seqno (60, the tx-channel applyReset pattern),
+    // and 42 != 60 rejects EVERY fetch forever. Pin exactly that mismatch:
+    cache.seedInitial(rows, 0, total, h.cv.epoch(kView), /*applyReset baseline*/ 60);
+    BOOST_CHECK(!cache.fillContent(sink, 0, rows, h.cv.epoch(kView), /*stale scope*/ 42));
+
+    // With the floor, later scope events resume normally: an insert for A at
+    // seqno 61 advances the scope past the floor and the gate tracks it.
+    h.table.push_back(makeCoin(99, 50, "A"));
+    auto deltas = h.cv.applyInsert(h.table.size() - 1);
+    BOOST_REQUIRE(!deltas.empty());
+    h.cv.noteScopeEvent(kView, "A", 61);
+    BOOST_CHECK_EQUAL(h.cv.highWater(kView, "A"), 61u);
+}
+
+BOOST_AUTO_TEST_CASE(multiScopeInterleaveGateAcceptsAndRejects)
+{
+    // Two scope caches; an event for one scope must not invalidate the
+    // other's content fetches (the reason high-water is scope-local at all),
+    // and the affected scope's fetch is rejected until its cache applies the
+    // structural delta.
+    Harness h;
+    h.table.push_back(makeCoin(1, 300, "A"));
+    h.table.push_back(makeCoin(2, 200, "A"));
+    h.table.push_back(makeCoin(3, 100, "B"));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    NullSink sink;
+    WindowCache<CoinRecord> cacheA, cacheB;
+
+    auto seed = [&](WindowCache<CoinRecord>& cache, const std::string& scope) {
+        int total = 0;
+        auto slice = h.cv.groupSlice(kView, scope, 0, -1, total);
+        std::vector<CoinRecord> rows;
+        for (auto idx : slice) rows.push_back(h.table[idx]);
+        cache.seedInitial(std::move(rows), 0, total, h.cv.epoch(kView),
+                          h.cv.highWater(kView, scope));
+    };
+    seed(cacheA, "A");
+    seed(cacheB, "B");
+
+    // A coin arrives in B: global seqno 7, scope-B event.
+    h.table.push_back(makeCoin(4, 400, "B"));
+    auto deltas = h.cv.applyInsert(h.table.size() - 1);
+    h.cv.noteScopeEvent(kView, "B", 7);
+
+    // Scope A's fetch still gates against A's unchanged high-water: adopted.
+    {
+        int total = 0;
+        auto slice = h.cv.groupSlice(kView, "A", 0, -1, total);
+        std::vector<CoinRecord> rows;
+        for (auto idx : slice) rows.push_back(h.table[idx]);
+        BOOST_CHECK(cacheA.fillContent(sink, 0, std::move(rows), h.cv.epoch(kView),
+                                       h.cv.highWater(kView, "A")));
+    }
+
+    // Scope B's fetch now reports high-water 7, but the cache's structural
+    // seqno is still the seed value: rejected until the delta is applied.
+    {
+        int total = 0;
+        auto slice = h.cv.groupSlice(kView, "B", 0, -1, total);
+        std::vector<CoinRecord> rows;
+        for (auto idx : slice) rows.push_back(h.table[idx]);
+        BOOST_CHECK(!cacheB.fillContent(sink, 0, rows, h.cv.epoch(kView),
+                                        h.cv.highWater(kView, "B")));
+
+        // Apply the structural insert (the drained event), then the refetch
+        // is coherent and adopted.
+        int mpos = -1;
+        for (const auto& d : deltas) {
+            if (d.type == CoinViewDelta::Insert && d.scope == "B") mpos = d.first;
+        }
+        BOOST_REQUIRE(mpos >= 0);
+        BOOST_CHECK(cacheB.applyInsert(sink, 7, mpos,
+                                       {h.table[h.table.size() - 1]}));
+        BOOST_CHECK(cacheB.fillContent(sink, 0, std::move(rows), h.cv.epoch(kView),
+                                       h.cv.highWater(kView, "B")));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(pathologicalSingleGroupWindowedReads)
+{
+    // The #3183 pathology: one address with a very large child set. Bulk-load
+    // the table, register (one O(n log n) build), then windowed reads are
+    // slice copies.
+    constexpr int kCoins = 100000;
+
+    Harness h;
+    h.table.reserve(kCoins);
+    for (int i = 0; i < kCoins; ++i) {
+        h.table.push_back(makeCoin(i, (i * 7919) % 1000000 + 1, "whale"));
+    }
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    auto info = h.cv.groupInfo("whale");
+    BOOST_CHECK_EQUAL(info.output_count, kCoins);
+
+    int total = 0;
+    auto window = h.cv.groupSlice(kView, "whale", 50000, 200, total);
+    BOOST_CHECK_EQUAL(total, kCoins);
+    BOOST_REQUIRE_EQUAL(window.size(), 200u);
+    // Amount-desc order holds across the window boundary.
+    for (std::size_t i = 1; i < window.size(); ++i) {
+        BOOST_CHECK(h.table[window[i - 1]].amount >= h.table[window[i]].amount);
+    }
+
+    // Tail clamp.
+    auto tail = h.cv.groupSlice(kView, "whale", kCoins - 50, 200, total);
+    BOOST_CHECK_EQUAL(tail.size(), 50u);
+}
+
+BOOST_AUTO_TEST_CASE(rebuildResetsEpochAndSelection)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 100, "A"));
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+    h.cv.applySelection(0, true);
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("A").selected_count, 1);
+
+    const uint64_t epoch_before = h.cv.epoch(kView);
+    auto deltas = h.cv.rebuild(h.table.size());
+    BOOST_REQUIRE_EQUAL(deltas.size(), 1u);
+    BOOST_CHECK(deltas[0].type == CoinViewDelta::Reset);
+    BOOST_CHECK_EQUAL(h.cv.epoch(kView), epoch_before + 1);
+
+    // Selection aggregates are cleared on rebuild; the store re-applies its
+    // mirror afterwards (the reconcile contract).
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("A").selected_count, 0);
+}
+
+BOOST_AUTO_TEST_CASE(viewLifecycleAndModeSwitch)
+{
+    Harness h;
+    h.table.push_back(makeCoin(1, 100, "A"));
+    h.table.push_back(makeCoin(2, 200, "B"));
+
+    BOOST_CHECK(!h.cv.hasViews());
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+    BOOST_CHECK(h.cv.hasView(kView));
+
+    // Mode switch: epoch bump + Reset; flat slice becomes available.
+    const uint64_t epoch_before = h.cv.epoch(kView);
+    auto deltas = h.cv.setViewMode(kView, CoinViewMode::Flat, h.table.size());
+    BOOST_REQUIRE_EQUAL(deltas.size(), 1u);
+    BOOST_CHECK(deltas[0].type == CoinViewDelta::Reset);
+    BOOST_CHECK_EQUAL(h.cv.epoch(kView), epoch_before + 1);
+
+    int total = 0;
+    auto slice = h.cv.flatSlice(kView, 0, -1, total);
+    BOOST_CHECK_EQUAL(total, 2);
+
+    // Two views with different sorts coexist (the wizard flow).
+    h.cv.registerView(GRC::VIEW_COIN_WIZARD, CoinViewMode::Tree,
+                      GRC::COINCOL_ADDRESS, 0, h.table.size());
+    auto dir = h.cv.directorySlice(GRC::VIEW_COIN_WIZARD, 0, -1, total);
+    BOOST_REQUIRE_EQUAL(dir.size(), 2u);
+    BOOST_CHECK_EQUAL(dir[0], "A");
+
+    h.cv.unregisterView(kView);
+    BOOST_CHECK(!h.cv.hasView(kView));
+    BOOST_CHECK(h.cv.hasViews());
+    h.cv.unregisterView(GRC::VIEW_COIN_WIZARD);
+    BOOST_CHECK(!h.cv.hasViews());
+    h.cv.unregisterView(GRC::VIEW_COIN_WIZARD); // idempotent
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_coinviews_tests.cpp
+++ b/src/test/qt_coinviews_tests.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+using GRC::ApplyResult;
 using GRC::CoinRecord;
 using GRC::CoinViewDelta;
 using GRC::CoinViewMode;
@@ -448,7 +449,8 @@ BOOST_AUTO_TEST_CASE(multiScopeInterleaveGateAcceptsAndRejects)
         }
         BOOST_REQUIRE(mpos >= 0);
         BOOST_CHECK(cacheB.applyInsert(sink, 7, mpos,
-                                       {h.table[h.table.size() - 1]}));
+                                       {h.table[h.table.size() - 1]})
+                    == ApplyResult::Applied);
         BOOST_CHECK(cacheB.fillContent(sink, 0, std::move(rows), h.cv.epoch(kView),
                                        h.cv.highWater(kView, "B")));
     }

--- a/src/test/qt_coinviews_tests.cpp
+++ b/src/test/qt_coinviews_tests.cpp
@@ -542,4 +542,41 @@ BOOST_AUTO_TEST_CASE(viewLifecycleAndModeSwitch)
     h.cv.unregisterView(GRC::VIEW_COIN_WIZARD); // idempotent
 }
 
+BOOST_AUTO_TEST_CASE(regroupKillsTheEmptiedOldGroup)
+{
+    // The regroup case updateReslotsAndRegroups does not reach: the record
+    // leaving is its old group's LAST member, so the old group must die in
+    // the same call that inserts into the new one. This is the only path to
+    // the deferred m_groups erase-by-key in applyUpdate, and it combines
+    // three teardowns (directory row, per-view member index, shared
+    // aggregates) with the new group's directory reslot still to come.
+    Harness h;
+    h.table.push_back(makeCoin(1, 300, "A"));
+    h.table.push_back(makeCoin(2, 200, "B")); // sole member of B
+    h.cv.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1, h.table.size());
+
+    int total = 0;
+    BOOST_REQUIRE_EQUAL(h.cv.directorySlice(kView, 0, -1, total).size(), 2u);
+
+    h.table[1].group_address = "A";
+    auto deltas = h.cv.applyUpdate(1, "B", false, /*was_selected*/ false);
+
+    BOOST_CHECK_EQUAL(countType(deltas, CoinViewDelta::GroupRemove), 1);
+
+    // The emptied group is gone from the directory, the shared aggregates
+    // and the view's member index alike.
+    auto dir = h.cv.directorySlice(kView, 0, -1, total);
+    BOOST_REQUIRE_EQUAL(dir.size(), 1u);
+    BOOST_CHECK_EQUAL(dir[0], "A");
+    BOOST_CHECK_EQUAL(total, 1);
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("B").address, "");
+    BOOST_CHECK_EQUAL(h.cv.groupSlice(kView, "B", 0, -1, total).size(), 0u);
+
+    // ...and the survivor absorbed the member and its amount.
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("A").output_count, 2);
+    BOOST_CHECK_EQUAL(h.cv.groupInfo("A").total_amount, 500);
+    BOOST_CHECK_EQUAL(h.cv.groupSlice(kView, "A", 0, -1, total).size(), 2u);
+    BOOST_CHECK_EQUAL(total, 2);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/coinviews.cpp
+++ b/src/wallet/coinviews.cpp
@@ -1,0 +1,799 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "wallet/coinviews.h"
+
+#include <algorithm>
+#include <cassert>
+#include <limits>
+#include <utility>
+
+namespace GRC {
+
+namespace {
+
+constexpr std::size_t npos = static_cast<std::size_t>(-1);
+
+//! Confirmations sort is height sort with unconfirmed (-1) ranking as the
+//! fewest confirmations: ascending confirmations == this key ascending.
+int64_t ConfKey(const CoinRecord& r)
+{
+    if (r.block_height < 0) return std::numeric_limits<int64_t>::min();
+    return -static_cast<int64_t>(r.block_height);
+}
+
+bool LessOutPoint(const COutPoint& a, const COutPoint& b)
+{
+    if (a.hash != b.hash) return a.hash < b.hash;
+    return a.n < b.n;
+}
+
+} // anonymous namespace
+
+CoinViews::CoinViews(RecordFn records)
+    : m_records(std::move(records))
+{
+}
+
+// ---- comparators --------------------------------------------------------
+
+bool CoinViews::lessRecord(const ViewState& v, std::size_t a, std::size_t b) const
+{
+    const CoinRecord& ra = m_records(a);
+    const CoinRecord& rb = m_records(b);
+
+    // Three-way per column, ascending; the outpoint is the deterministic
+    // tiebreak so re-sorts are reproducible (the cursor's native-index
+    // tiebreak transposed to the coin identity, which is stable across the
+    // table compaction shifts).
+    int cmp = 0;
+    switch (v.sort_column) {
+    case COINCOL_AMOUNT:
+        cmp = (ra.amount < rb.amount) ? -1 : (ra.amount > rb.amount) ? 1 : 0;
+        break;
+    case COINCOL_LABEL:
+        cmp = ra.label.compare(rb.label);
+        if (cmp == 0) cmp = ra.address.compare(rb.address);
+        break;
+    case COINCOL_ADDRESS:
+        cmp = ra.address.compare(rb.address);
+        break;
+    case COINCOL_DATE:
+        cmp = (ra.time < rb.time) ? -1 : (ra.time > rb.time) ? 1 : 0;
+        break;
+    case COINCOL_CONFS: {
+        const int64_t ka = ConfKey(ra), kb = ConfKey(rb);
+        cmp = (ka < kb) ? -1 : (ka > kb) ? 1 : 0;
+        break;
+    }
+    }
+
+    if (cmp != 0) {
+        return (v.sort_order == 0) ? (cmp < 0) : (cmp > 0);
+    }
+    return LessOutPoint(ra.outpoint, rb.outpoint);
+}
+
+bool CoinViews::lessGroup(const ViewState& v, const std::string& a, const std::string& b) const
+{
+    auto ita = m_groups.find(a);
+    auto itb = m_groups.find(b);
+    assert(ita != m_groups.end() && itb != m_groups.end());
+    const GroupData& ga = ita->second;
+    const GroupData& gb = itb->second;
+
+    // Parent rows have no date/confirmations; those columns fall back to the
+    // address so the directory order is defined (the legacy widget's order
+    // under these sorts was arbitrary — documented deviation).
+    int cmp = 0;
+    switch (v.sort_column) {
+    case COINCOL_AMOUNT:
+        cmp = (ga.total_amount < gb.total_amount) ? -1
+            : (ga.total_amount > gb.total_amount) ? 1 : 0;
+        break;
+    case COINCOL_LABEL:
+        cmp = ga.label.compare(gb.label);
+        break;
+    case COINCOL_ADDRESS:
+    case COINCOL_DATE:
+    case COINCOL_CONFS:
+        cmp = 0; // address tiebreak below decides
+        break;
+    }
+
+    if (cmp != 0) {
+        return (v.sort_order == 0) ? (cmp < 0) : (cmp > 0);
+    }
+    // Address tiebreak keeps equal-keyed groups in a stable, defined order.
+    // Applied in the view's direction for the fallback columns so an
+    // address-sorted directory actually toggles with the sort order.
+    const int addr_cmp = a.compare(b);
+    if (v.sort_column == COINCOL_ADDRESS || v.sort_column == COINCOL_DATE ||
+        v.sort_column == COINCOL_CONFS) {
+        return (v.sort_order == 0) ? (addr_cmp < 0) : (addr_cmp > 0);
+    }
+    return addr_cmp < 0;
+}
+
+bool CoinViews::lessAmount(std::size_t a, std::size_t b) const
+{
+    const CoinRecord& ra = m_records(a);
+    const CoinRecord& rb = m_records(b);
+    if (ra.amount != rb.amount) return ra.amount < rb.amount;
+    return LessOutPoint(ra.outpoint, rb.outpoint);
+}
+
+// ---- locate helpers -----------------------------------------------------
+
+std::size_t CoinViews::lowerBoundRecord(const ViewState& v,
+                                        const std::vector<std::size_t>& index,
+                                        std::size_t absidx) const
+{
+    auto it = std::lower_bound(index.begin(), index.end(), absidx,
+                               [&](std::size_t lhs, std::size_t rhs) {
+                                   return lessRecord(v, lhs, rhs);
+                               });
+    return static_cast<std::size_t>(it - index.begin());
+}
+
+std::size_t CoinViews::findValue(const std::vector<std::size_t>& index,
+                                 std::size_t absidx) const
+{
+    // Identity locate by VALUE, never by key (the cursor spec's Item 1): a
+    // record whose fields already changed cannot be found by key compare.
+    auto it = std::find(index.begin(), index.end(), absidx);
+    if (it == index.end()) return npos;
+    return static_cast<std::size_t>(it - index.begin());
+}
+
+std::size_t CoinViews::lowerBoundGroup(const ViewState& v, const std::string& address) const
+{
+    auto it = std::lower_bound(v.directory.begin(), v.directory.end(), address,
+                               [&](const std::string& lhs, const std::string& rhs) {
+                                   return lessGroup(v, lhs, rhs);
+                               });
+    return static_cast<std::size_t>(it - v.directory.begin());
+}
+
+std::size_t CoinViews::findGroup(const ViewState& v, const std::string& address) const
+{
+    auto it = std::find(v.directory.begin(), v.directory.end(), address);
+    if (it == v.directory.end()) return npos;
+    return static_cast<std::size_t>(it - v.directory.begin());
+}
+
+// ---- builds -------------------------------------------------------------
+
+void CoinViews::buildGroups(std::size_t n)
+{
+    m_groups.clear();
+    m_amount_order.clear();
+    m_amount_order.reserve(n);
+
+    for (std::size_t i = 0; i < n; ++i) {
+        const CoinRecord& r = m_records(i);
+        GroupData& g = m_groups[r.group_address];
+        g.label = r.label;
+        g.total_amount += r.amount;
+        g.output_count += 1;
+        if (!r.is_change) g.direct_output_count += 1;
+        g.members.push_back(i);
+        m_amount_order.push_back(i);
+    }
+
+    std::sort(m_amount_order.begin(), m_amount_order.end(),
+              [this](std::size_t a, std::size_t b) { return lessAmount(a, b); });
+
+    m_count = n;
+}
+
+void CoinViews::buildView(ViewState& v, std::size_t n)
+{
+    v.flat_index.clear();
+    v.directory.clear();
+    v.group_index.clear();
+
+    if (v.mode == CoinViewMode::Flat) {
+        v.flat_index.reserve(n);
+        for (std::size_t i = 0; i < n; ++i) v.flat_index.push_back(i);
+        std::sort(v.flat_index.begin(), v.flat_index.end(),
+                  [&](std::size_t a, std::size_t b) { return lessRecord(v, a, b); });
+        return;
+    }
+
+    v.directory.reserve(m_groups.size());
+    for (const auto& [address, group] : m_groups) {
+        v.directory.push_back(address);
+        auto& members = v.group_index[address];
+        members = group.members;
+        std::sort(members.begin(), members.end(),
+                  [&](std::size_t a, std::size_t b) { return lessRecord(v, a, b); });
+    }
+    std::sort(v.directory.begin(), v.directory.end(),
+              [&](const std::string& a, const std::string& b) {
+                  return lessGroup(v, a, b);
+              });
+}
+
+// ---- view lifecycle -----------------------------------------------------
+
+std::vector<CoinViewDelta> CoinViews::registerView(int view_id, CoinViewMode mode,
+                                                   int sort_column, int sort_order,
+                                                   std::size_t n)
+{
+    // Membership/aggregates are shared; build them on the first registration
+    // (or when the caller's table size moved under us via rebuild()).
+    if (m_views.empty()) {
+        buildGroups(n);
+    }
+    assert(n == m_count);
+
+    auto [it, inserted] = m_views.try_emplace(view_id);
+    ViewState& v = it->second;
+    if (!inserted) v.epoch += 1;
+    v.mode = mode;
+    v.sort_column = sort_column;
+    v.sort_order = sort_order;
+    v.scope_seqno.clear();
+    v.directory_seqno = 0;
+    buildView(v, n);
+
+    return {{view_id, CoinViewDelta::Reset, std::string(), 0, 0}};
+}
+
+void CoinViews::unregisterView(int view_id)
+{
+    m_views.erase(view_id);
+}
+
+std::vector<CoinViewDelta> CoinViews::setViewMode(int view_id, CoinViewMode mode,
+                                                  std::size_t n)
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return {};
+
+    ViewState& v = it->second;
+    v.mode = mode;
+    v.epoch += 1;
+    buildView(v, n);
+    return {{view_id, CoinViewDelta::Reset, std::string(), 0, 0}};
+}
+
+std::vector<CoinViewDelta> CoinViews::setViewSort(int view_id, int sort_column,
+                                                  int sort_order, std::size_t n)
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return {};
+
+    ViewState& v = it->second;
+    v.sort_column = sort_column;
+    v.sort_order = sort_order;
+    v.epoch += 1;
+    buildView(v, n);
+    return {{view_id, CoinViewDelta::Reset, std::string(), 0, 0}};
+}
+
+std::vector<CoinViewDelta> CoinViews::rebuild(std::size_t n)
+{
+    buildGroups(n);
+
+    std::vector<CoinViewDelta> out;
+    for (auto& [view_id, v] : m_views) {
+        v.epoch += 1;
+        buildView(v, n);
+        out.push_back({view_id, CoinViewDelta::Reset, std::string(), 0, 0});
+    }
+    return out;
+}
+
+// ---- directory reslot ---------------------------------------------------
+
+void CoinViews::reslotDirectory(ViewState& v, int view_id, const std::string& address,
+                                std::vector<CoinViewDelta>& out)
+{
+    const std::size_t old_pos = findGroup(v, address);
+    assert(old_pos != npos);
+
+    // Erase-then-lower_bound (the cursor spec's Item 2): the group's parent
+    // sort key already changed, so its slot must be recomputed against the
+    // directory WITHOUT it.
+    v.directory.erase(v.directory.begin() + old_pos);
+    const std::size_t new_pos = lowerBoundGroup(v, address);
+    v.directory.insert(v.directory.begin() + new_pos, address);
+
+    if (new_pos == old_pos) {
+        // In place: aggregates changed but the row did not move. An in-place
+        // Change is only correct when the position is unchanged — a MOVED
+        // group must go out as Remove+Insert or the consumer's positional
+        // coordinate system diverges from the store's.
+        out.push_back({view_id, CoinViewDelta::GroupChange, std::string(),
+                       static_cast<int>(old_pos), 1});
+    } else {
+        out.push_back({view_id, CoinViewDelta::GroupRemove, std::string(),
+                       static_cast<int>(old_pos), 1});
+        out.push_back({view_id, CoinViewDelta::GroupInsert, std::string(),
+                       static_cast<int>(new_pos), 1});
+    }
+}
+
+// ---- table mutations ----------------------------------------------------
+
+std::vector<CoinViewDelta> CoinViews::applyInsert(std::size_t absidx)
+{
+    assert(absidx == m_count);
+    const CoinRecord& r = m_records(absidx);
+
+    std::vector<CoinViewDelta> out;
+
+    // Shared membership/aggregates, once.
+    auto [git, group_is_new] = m_groups.try_emplace(r.group_address);
+    GroupData& g = git->second;
+    g.label = r.label;
+    g.total_amount += r.amount;
+    g.output_count += 1;
+    if (!r.is_change) g.direct_output_count += 1;
+    g.members.push_back(absidx);
+
+    const std::size_t amount_pos =
+        static_cast<std::size_t>(std::lower_bound(m_amount_order.begin(), m_amount_order.end(),
+                                                  absidx,
+                                                  [this](std::size_t a, std::size_t b) {
+                                                      return lessAmount(a, b);
+                                                  }) -
+                                 m_amount_order.begin());
+    m_amount_order.insert(m_amount_order.begin() + amount_pos, absidx);
+
+    // Per-view positional maintenance.
+    for (auto& [view_id, v] : m_views) {
+        if (v.mode == CoinViewMode::Flat) {
+            const std::size_t pos = lowerBoundRecord(v, v.flat_index, absidx);
+            v.flat_index.insert(v.flat_index.begin() + pos, absidx);
+            out.push_back({view_id, CoinViewDelta::Insert, std::string(),
+                           static_cast<int>(pos), 1});
+            continue;
+        }
+
+        auto& members = v.group_index[r.group_address];
+        const std::size_t mpos = lowerBoundRecord(v, members, absidx);
+        members.insert(members.begin() + mpos, absidx);
+        out.push_back({view_id, CoinViewDelta::Insert, r.group_address,
+                       static_cast<int>(mpos), 1});
+
+        if (group_is_new) {
+            const std::size_t gpos = lowerBoundGroup(v, r.group_address);
+            v.directory.insert(v.directory.begin() + gpos, r.group_address);
+            out.push_back({view_id, CoinViewDelta::GroupInsert, std::string(),
+                           static_cast<int>(gpos), 1});
+        } else {
+            reslotDirectory(v, view_id, r.group_address, out);
+        }
+    }
+
+    m_count += 1;
+    return out;
+}
+
+std::vector<CoinViewDelta> CoinViews::applyRemove(std::size_t absidx, bool was_selected)
+{
+    assert(absidx < m_count);
+    const CoinRecord& r = m_records(absidx);
+    const std::string group_address = r.group_address;
+
+    std::vector<CoinViewDelta> out;
+
+    auto git = m_groups.find(group_address);
+    assert(git != m_groups.end());
+    GroupData& g = git->second;
+    g.total_amount -= r.amount;
+    g.output_count -= 1;
+    if (!r.is_change) g.direct_output_count -= 1;
+    if (was_selected) {
+        g.selected_count -= 1;
+        g.selected_amount -= r.amount;
+    }
+    {
+        auto mit = std::find(g.members.begin(), g.members.end(), absidx);
+        assert(mit != g.members.end());
+        g.members.erase(mit);
+    }
+    const bool group_dead = (g.output_count == 0);
+
+    {
+        const std::size_t apos = findValue(m_amount_order, absidx);
+        assert(apos != npos);
+        m_amount_order.erase(m_amount_order.begin() + apos);
+    }
+
+    for (auto& [view_id, v] : m_views) {
+        if (v.mode == CoinViewMode::Flat) {
+            const std::size_t pos = findValue(v.flat_index, absidx);
+            assert(pos != npos);
+            v.flat_index.erase(v.flat_index.begin() + pos);
+            out.push_back({view_id, CoinViewDelta::Remove, std::string(),
+                           static_cast<int>(pos), 1});
+            continue;
+        }
+
+        auto& members = v.group_index[group_address];
+        const std::size_t mpos = findValue(members, absidx);
+        assert(mpos != npos);
+        members.erase(members.begin() + mpos);
+        out.push_back({view_id, CoinViewDelta::Remove, group_address,
+                       static_cast<int>(mpos), 1});
+
+        if (group_dead) {
+            const std::size_t gpos = findGroup(v, group_address);
+            assert(gpos != npos);
+            v.directory.erase(v.directory.begin() + gpos);
+            v.group_index.erase(group_address);
+            out.push_back({view_id, CoinViewDelta::GroupRemove, std::string(),
+                           static_cast<int>(gpos), 1});
+        } else {
+            reslotDirectory(v, view_id, group_address, out);
+        }
+    }
+
+    if (group_dead) {
+        m_groups.erase(git);
+    }
+
+    // The caller compacts the table after this returns; mirror the shift.
+    shiftDown(absidx);
+    m_count -= 1;
+    return out;
+}
+
+std::vector<CoinViewDelta> CoinViews::applyUpdate(std::size_t absidx,
+                                                  const std::string& old_group_address,
+                                                  bool old_is_change,
+                                                  bool was_selected)
+{
+    assert(absidx < m_count);
+    const CoinRecord& r = m_records(absidx);
+    const bool moved_group = (r.group_address != old_group_address);
+
+    std::vector<CoinViewDelta> out;
+
+    // Shared aggregates.
+    if (moved_group) {
+        auto oit = m_groups.find(old_group_address);
+        assert(oit != m_groups.end());
+        GroupData& og = oit->second;
+        og.total_amount -= r.amount;
+        og.output_count -= 1;
+        if (!old_is_change) og.direct_output_count -= 1;
+        if (was_selected) {
+            og.selected_count -= 1;
+            og.selected_amount -= r.amount;
+        }
+        {
+            auto mit = std::find(og.members.begin(), og.members.end(), absidx);
+            assert(mit != og.members.end());
+            og.members.erase(mit);
+        }
+        const bool old_dead = (og.output_count == 0);
+
+        auto [nit, group_is_new] = m_groups.try_emplace(r.group_address);
+        GroupData& ng = nit->second;
+        ng.label = r.label;
+        ng.total_amount += r.amount;
+        ng.output_count += 1;
+        if (!r.is_change) ng.direct_output_count += 1;
+        if (was_selected) {
+            ng.selected_count += 1;
+            ng.selected_amount += r.amount;
+        }
+        ng.members.push_back(absidx);
+
+        for (auto& [view_id, v] : m_views) {
+            if (v.mode == CoinViewMode::Flat) {
+                // Re-slot: the label/group key change may move the row.
+                const std::size_t old_pos = findValue(v.flat_index, absidx);
+                assert(old_pos != npos);
+                v.flat_index.erase(v.flat_index.begin() + old_pos);
+                const std::size_t new_pos = lowerBoundRecord(v, v.flat_index, absidx);
+                v.flat_index.insert(v.flat_index.begin() + new_pos, absidx);
+                if (new_pos == old_pos) {
+                    out.push_back({view_id, CoinViewDelta::Change, std::string(),
+                                   static_cast<int>(old_pos), 1});
+                } else {
+                    out.push_back({view_id, CoinViewDelta::Remove, std::string(),
+                                   static_cast<int>(old_pos), 1});
+                    out.push_back({view_id, CoinViewDelta::Insert, std::string(),
+                                   static_cast<int>(new_pos), 1});
+                }
+                continue;
+            }
+
+            // Out of the old group...
+            auto& old_members = v.group_index[old_group_address];
+            const std::size_t mpos = findValue(old_members, absidx);
+            assert(mpos != npos);
+            old_members.erase(old_members.begin() + mpos);
+            out.push_back({view_id, CoinViewDelta::Remove, old_group_address,
+                           static_cast<int>(mpos), 1});
+            if (old_dead) {
+                const std::size_t gpos = findGroup(v, old_group_address);
+                assert(gpos != npos);
+                v.directory.erase(v.directory.begin() + gpos);
+                v.group_index.erase(old_group_address);
+                out.push_back({view_id, CoinViewDelta::GroupRemove, std::string(),
+                               static_cast<int>(gpos), 1});
+            } else {
+                reslotDirectory(v, view_id, old_group_address, out);
+            }
+
+            // ...into the new one.
+            auto& new_members = v.group_index[r.group_address];
+            const std::size_t npos_new = lowerBoundRecord(v, new_members, absidx);
+            new_members.insert(new_members.begin() + npos_new, absidx);
+            out.push_back({view_id, CoinViewDelta::Insert, r.group_address,
+                           static_cast<int>(npos_new), 1});
+            if (group_is_new) {
+                const std::size_t gpos = lowerBoundGroup(v, r.group_address);
+                v.directory.insert(v.directory.begin() + gpos, r.group_address);
+                out.push_back({view_id, CoinViewDelta::GroupInsert, std::string(),
+                               static_cast<int>(gpos), 1});
+            } else {
+                reslotDirectory(v, view_id, r.group_address, out);
+            }
+        }
+
+        if (old_dead) {
+            m_groups.erase(old_group_address);
+        }
+        return out;
+    }
+
+    // Same group: refresh the label snapshot and re-slot within each index.
+    auto git = m_groups.find(r.group_address);
+    assert(git != m_groups.end());
+    git->second.label = r.label;
+
+    for (auto& [view_id, v] : m_views) {
+        if (v.mode == CoinViewMode::Flat) {
+            const std::size_t old_pos = findValue(v.flat_index, absidx);
+            assert(old_pos != npos);
+            v.flat_index.erase(v.flat_index.begin() + old_pos);
+            const std::size_t new_pos = lowerBoundRecord(v, v.flat_index, absidx);
+            v.flat_index.insert(v.flat_index.begin() + new_pos, absidx);
+            if (new_pos == old_pos) {
+                out.push_back({view_id, CoinViewDelta::Change, std::string(),
+                               static_cast<int>(old_pos), 1});
+            } else {
+                out.push_back({view_id, CoinViewDelta::Remove, std::string(),
+                               static_cast<int>(old_pos), 1});
+                out.push_back({view_id, CoinViewDelta::Insert, std::string(),
+                               static_cast<int>(new_pos), 1});
+            }
+            continue;
+        }
+
+        auto& members = v.group_index[r.group_address];
+        const std::size_t old_pos = findValue(members, absidx);
+        assert(old_pos != npos);
+        members.erase(members.begin() + old_pos);
+        const std::size_t new_pos = lowerBoundRecord(v, members, absidx);
+        members.insert(members.begin() + new_pos, absidx);
+        if (new_pos == old_pos) {
+            out.push_back({view_id, CoinViewDelta::Change, r.group_address,
+                           static_cast<int>(old_pos), 1});
+        } else {
+            out.push_back({view_id, CoinViewDelta::Remove, r.group_address,
+                           static_cast<int>(old_pos), 1});
+            out.push_back({view_id, CoinViewDelta::Insert, r.group_address,
+                           static_cast<int>(new_pos), 1});
+        }
+
+        // A label change re-keys a label-sorted directory (and refreshes the
+        // rendered parent row either way).
+        reslotDirectory(v, view_id, r.group_address, out);
+    }
+
+    return out;
+}
+
+std::vector<CoinViewDelta> CoinViews::applySelection(std::size_t absidx, bool selected)
+{
+    assert(absidx < m_count);
+    const CoinRecord& r = m_records(absidx);
+
+    auto git = m_groups.find(r.group_address);
+    assert(git != m_groups.end());
+    GroupData& g = git->second;
+    if (selected) {
+        g.selected_count += 1;
+        g.selected_amount += r.amount;
+    } else {
+        g.selected_count -= 1;
+        g.selected_amount -= r.amount;
+    }
+
+    // Selection never moves a directory row (selected_* are not parent sort
+    // keys) — an in-place GroupChange refreshes the tristate rendering.
+    std::vector<CoinViewDelta> out;
+    for (auto& [view_id, v] : m_views) {
+        if (v.mode != CoinViewMode::Tree) continue;
+        const std::size_t gpos = findGroup(v, r.group_address);
+        assert(gpos != npos);
+        out.push_back({view_id, CoinViewDelta::GroupChange, std::string(),
+                       static_cast<int>(gpos), 1});
+    }
+    return out;
+}
+
+void CoinViews::shiftDown(std::size_t absidx)
+{
+    auto shift = [absidx](std::vector<std::size_t>& index) {
+        for (std::size_t& v : index) {
+            if (v > absidx) v -= 1;
+        }
+    };
+
+    shift(m_amount_order);
+    for (auto& entry : m_groups) {
+        shift(entry.second.members);
+    }
+    for (auto& view_entry : m_views) {
+        ViewState& v = view_entry.second;
+        shift(v.flat_index);
+        for (auto& group_entry : v.group_index) {
+            shift(group_entry.second);
+        }
+    }
+}
+
+// ---- reads --------------------------------------------------------------
+
+namespace {
+
+//! Clamp [first, first+count) against a container's size; count < 0 = rest.
+std::pair<std::size_t, std::size_t> ClampRange(std::size_t size, int first, int count)
+{
+    if (first < 0) first = 0;
+    std::size_t lo = std::min(static_cast<std::size_t>(first), size);
+    std::size_t n = (count < 0) ? (size - lo)
+                                : std::min(static_cast<std::size_t>(count), size - lo);
+    return {lo, n};
+}
+
+} // anonymous namespace
+
+std::vector<std::size_t> CoinViews::flatSlice(int view_id, int first, int count,
+                                              int& total_out) const
+{
+    total_out = 0;
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return {};
+    const ViewState& v = it->second;
+
+    total_out = static_cast<int>(v.flat_index.size());
+    auto [lo, n] = ClampRange(v.flat_index.size(), first, count);
+    return std::vector<std::size_t>(v.flat_index.begin() + lo,
+                                    v.flat_index.begin() + lo + n);
+}
+
+std::vector<std::string> CoinViews::directorySlice(int view_id, int first, int count,
+                                                   int& total_out) const
+{
+    total_out = 0;
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return {};
+    const ViewState& v = it->second;
+
+    total_out = static_cast<int>(v.directory.size());
+    auto [lo, n] = ClampRange(v.directory.size(), first, count);
+    return std::vector<std::string>(v.directory.begin() + lo,
+                                    v.directory.begin() + lo + n);
+}
+
+std::vector<std::size_t> CoinViews::groupSlice(int view_id, const std::string& group_address,
+                                               int first, int count, int& total_out) const
+{
+    total_out = 0;
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return {};
+    const ViewState& v = it->second;
+
+    auto git = v.group_index.find(group_address);
+    if (git == v.group_index.end()) return {};
+    const auto& members = git->second;
+
+    total_out = static_cast<int>(members.size());
+    auto [lo, n] = ClampRange(members.size(), first, count);
+    return std::vector<std::size_t>(members.begin() + lo, members.begin() + lo + n);
+}
+
+CoinGroupInfo CoinViews::groupInfo(const std::string& group_address) const
+{
+    CoinGroupInfo info;
+    auto it = m_groups.find(group_address);
+    if (it == m_groups.end()) return info;
+
+    const GroupData& g = it->second;
+    info.address = group_address;
+    info.label = g.label;
+    info.total_amount = g.total_amount;
+    info.output_count = g.output_count;
+    info.direct_output_count = g.direct_output_count;
+    info.selected_count = g.selected_count;
+    info.selected_amount = g.selected_amount;
+    return info;
+}
+
+std::vector<CoinGroupInfo> CoinViews::groupDirectory() const
+{
+    std::vector<CoinGroupInfo> out;
+    out.reserve(m_groups.size());
+    // m_groups is an ordered map, so this is the address-sorted directory.
+    for (const auto& entry : m_groups) {
+        out.push_back(groupInfo(entry.first));
+    }
+    return out;
+}
+
+std::vector<std::size_t> CoinViews::groupMembers(const std::string& group_address) const
+{
+    auto it = m_groups.find(group_address);
+    if (it == m_groups.end()) return {};
+    return it->second.members;
+}
+
+// ---- event bookkeeping --------------------------------------------------
+
+void CoinViews::noteScopeEvent(int view_id, const std::string& scope, uint64_t seqno)
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return;
+    it->second.scope_seqno[scope] = seqno;
+}
+
+void CoinViews::noteDirectoryEvent(int view_id, uint64_t seqno)
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return;
+    it->second.directory_seqno = seqno;
+}
+
+void CoinViews::noteBroadcast(int view_id, uint64_t seqno)
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return;
+    it->second.floor_seqno = seqno;
+}
+
+uint64_t CoinViews::highWater(int view_id, const std::string& scope) const
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return 0;
+    const ViewState& v = it->second;
+
+    uint64_t scope_seqno = 0;
+    auto sit = v.scope_seqno.find(scope);
+    if (sit != v.scope_seqno.end()) scope_seqno = sit->second;
+    return std::max(scope_seqno, v.floor_seqno);
+}
+
+uint64_t CoinViews::directoryHighWater(int view_id) const
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return 0;
+    return std::max(it->second.directory_seqno, it->second.floor_seqno);
+}
+
+uint64_t CoinViews::epoch(int view_id) const
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return 0;
+    return it->second.epoch;
+}
+
+CoinViewMode CoinViews::mode(int view_id) const
+{
+    auto it = m_views.find(view_id);
+    if (it == m_views.end()) return CoinViewMode::Tree;
+    return it->second.mode;
+}
+
+} // namespace GRC

--- a/src/wallet/coinviews.h
+++ b/src/wallet/coinviews.h
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_WALLET_COINVIEWS_H
+#define GRIDCOIN_WALLET_COINVIEWS_H
+
+#include "interfaces/wallet_coin_channel.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+//!
+//! \file coinviews.h
+//!
+//! Qt-free grouped index core for the windowed coin-control selection model
+//! (issue #3183) — the coin channel's analogue of the per-view GRC::Cursor,
+//! extended with the tree dimension: besides a flat sorted index it maintains
+//! the group DIRECTORY (address rows ordered by the parent sort) and a sorted
+//! member index per group, plus the server-side aggregates that let a consumer
+//! render parent rows — count, total, selection tristate — without
+//! materializing children.
+//!
+//! The class holds no records, no locks and no Qt types; the store-worker
+//! drives it under cs_store, and the same logic is unit-tested against
+//! synthetic record tables in the ENABLE_GUI=OFF configuration CI exercises
+//! (the windowed tx-table risk-control discipline). It is parameterized on a
+//! projector callable RecordFn(absidx) -> const CoinRecord& reading the
+//! backing table; callers MUST mutate the backing table BEFORE calling the
+//! corresponding apply* method (applyRemove is the one exception — see its
+//! comment).
+//!
+//! Views: up to a handful of consumers (the coin-control dialog and the
+//! consolidate wizard page) register independently, each with its own display
+//! mode, sort, epoch and floor. Ordered indices are per-view (two views can
+//! sort differently); group MEMBERSHIP and aggregates are view-independent
+//! and maintained once.
+//!
+//! Event bookkeeping: the deltas returned by the apply* methods are pushed as
+//! events by the store, which feeds the queue-assigned seqnos back through
+//! noteScopeEvent / noteDirectoryEvent / noteBroadcast. highWater() then
+//! answers the scope-local-with-floor contract documented on
+//! GRC::CoinRowsResult: max(last seqno emitted for the scope, the view's
+//! broadcast floor). Keeping this arithmetic here — not in the store — puts
+//! the design's central novel invariant in the Qt-free tested core.
+//!
+
+namespace GRC {
+
+//!
+//! \brief One structural change to a view's row universe, in positional
+//! coordinates of the affected scope.
+//!
+//! scope names the flat list ("") or a group's child list (the group
+//! address); the Group* types address the directory and carry no scope. The
+//! store translates each delta into the matching wallet_coin_channel.h event
+//! payload (fetching the inserted records / refreshed group info itself) and
+//! stamps it with the view's epoch.
+//!
+struct CoinViewDelta {
+    enum Type {
+        Reset,        //!< the view rebuilt wholesale; consumer drops every scope cache
+        Insert,       //!< scope rows [first, first+count) inserted
+        Remove,       //!< scope rows [first, first+count) removed
+        Change,       //!< scope rows [first, first+count) changed in place
+        GroupInsert,  //!< directory rows [first, first+count) inserted
+        GroupRemove,  //!< directory rows [first, first+count) removed
+        GroupChange,  //!< directory rows [first, first+count) changed in place
+    };
+
+    int view_id;
+    Type type;
+    std::string scope;
+    int first{0};
+    int count{0};
+};
+
+class CoinViews
+{
+public:
+    //! Return by const reference: the store owns the record table and holds
+    //! cs_store across every call into this class, so the reference cannot
+    //! dangle mid-operation. Record fields are the sort keys directly (raw
+    //! int64/string compares, locale-free) — no separate key cache is needed.
+    using RecordFn = std::function<const CoinRecord&(std::size_t)>;
+
+    explicit CoinViews(RecordFn records);
+
+    // ---- view lifecycle -------------------------------------------------
+
+    //! Register (or replace) a view over the n records [0, n). Builds the
+    //! mode's indices and returns one Reset. Bumps the epoch when replacing.
+    std::vector<CoinViewDelta> registerView(int view_id, CoinViewMode mode,
+                                            int sort_column, int sort_order,
+                                            std::size_t n);
+
+    //! Drop a view. Idempotent.
+    void unregisterView(int view_id);
+
+    bool hasViews() const { return !m_views.empty(); }
+    bool hasView(int view_id) const { return m_views.count(view_id) > 0; }
+
+    //! Switch display mode / change sort: epoch bump, index rebuild for the
+    //! new mode over the current n records, one Reset.
+    std::vector<CoinViewDelta> setViewMode(int view_id, CoinViewMode mode,
+                                           std::size_t n);
+    std::vector<CoinViewDelta> setViewSort(int view_id, int sort_column,
+                                           int sort_order, std::size_t n);
+
+    //! Rebuild every registered view over [0, n) (full resync). One Reset per
+    //! view. Group membership/aggregates are rebuilt from the table;
+    //! selection aggregates are cleared — the store re-applies its mirror via
+    //! applySelection afterwards.
+    std::vector<CoinViewDelta> rebuild(std::size_t n);
+
+    // ---- table mutations ------------------------------------------------
+
+    //! The table APPENDED a record at absidx (== previous n). Inserts it into
+    //! every view's indices, creates/updates its group and aggregates.
+    std::vector<CoinViewDelta> applyInsert(std::size_t absidx);
+
+    //! The table is ABOUT to remove the record at absidx and compact (later
+    //! absolute indices shift down by one). Unlike the other apply* methods
+    //! this is called BEFORE the table mutation — the record's fields are
+    //! needed to locate its group and adjust aggregates. \p was_selected
+    //! tells the aggregates whether the store's selection mirror held it.
+    std::vector<CoinViewDelta> applyRemove(std::size_t absidx, bool was_selected);
+
+    //! Record absidx changed in place (label re-snapshot, height fill-in on
+    //! confirmation, or a regroup when the change-walk result moved it to a
+    //! different group). \p old_group_address / \p old_is_change are the
+    //! values before the caller mutated the table (they drive the aggregate
+    //! move out of the old group); \p was_selected moves the selection
+    //! aggregates with the record when the group changed.
+    std::vector<CoinViewDelta> applyUpdate(std::size_t absidx,
+                                           const std::string& old_group_address,
+                                           bool old_is_change,
+                                           bool was_selected);
+
+    //! The store's selection mirror toggled absidx. Updates the group
+    //! aggregates and emits a directory Change for tree views (selection
+    //! never moves a directory row: selected_* are not parent sort keys).
+    std::vector<CoinViewDelta> applySelection(std::size_t absidx, bool selected);
+
+    // ---- reads (positional, absidx out) ---------------------------------
+
+    //! Flat-scope slice for a view: absolute indices [first, first+count) in
+    //! view order (count < 0 = to the end) plus the scope's total.
+    std::vector<std::size_t> flatSlice(int view_id, int first, int count,
+                                       int& total_out) const;
+
+    //! Directory slice for a view: group addresses in view order plus total.
+    std::vector<std::string> directorySlice(int view_id, int first, int count,
+                                            int& total_out) const;
+
+    //! Group-scope slice for a view: the group's member absolute indices in
+    //! view order plus the group's total. Unknown group => empty, total 0.
+    std::vector<std::size_t> groupSlice(int view_id, const std::string& group_address,
+                                        int first, int count, int& total_out) const;
+
+    //! Aggregates for one group (address/label/counts/amounts). Returns a
+    //! default-constructed info (empty address) for an unknown group.
+    CoinGroupInfo groupInfo(const std::string& group_address) const;
+
+    //! Every group's aggregates, address-ordered (view-independent — the
+    //! consolidation pickers' directory).
+    std::vector<CoinGroupInfo> groupDirectory() const;
+
+    //! Membership of one group (unsorted absolute indices) — selectGroup.
+    std::vector<std::size_t> groupMembers(const std::string& group_address) const;
+
+    //! All records sorted by (amount, outpoint) ascending — the persistent
+    //! index applyValueFilter walks so a 500k-coin filter is O(n) per call
+    //! with no per-call sort under cs_store (GUI-thread hold budget).
+    const std::vector<std::size_t>& amountOrder() const { return m_amount_order; }
+
+    // ---- event bookkeeping (the scope-local high-water contract) --------
+
+    //! Record the queue seqno of an event the store just pushed for a scope
+    //! ("" = flat) / the directory of \p view_id.
+    void noteScopeEvent(int view_id, const std::string& scope, uint64_t seqno);
+    void noteDirectoryEvent(int view_id, uint64_t seqno);
+
+    //! Record a broadcast event (CoinReset / resync): advances the view's
+    //! floor, which every scope's high-water reflects from then on. Never
+    //! touches any scope's own counter.
+    void noteBroadcast(int view_id, uint64_t seqno);
+
+    //! max(last scope event seqno, view floor) — what every read reports so
+    //! a consumer cache reseeded after a broadcast can always gate content
+    //! fetches against a reachable value (see CoinRowsResult).
+    uint64_t highWater(int view_id, const std::string& scope) const;
+    uint64_t directoryHighWater(int view_id) const;
+
+    uint64_t epoch(int view_id) const;
+    CoinViewMode mode(int view_id) const;
+
+private:
+    struct GroupData {
+        std::string label;
+        int64_t total_amount{0};
+        int output_count{0};
+        int direct_output_count{0};
+        int selected_count{0};
+        int64_t selected_amount{0};
+        std::vector<std::size_t> members; //!< unsorted absolute indices
+    };
+
+    struct ViewState {
+        CoinViewMode mode{CoinViewMode::Tree};
+        int sort_column{COINCOL_AMOUNT};
+        int sort_order{1}; // Qt::DescendingOrder — the dialog's default
+        uint64_t epoch{0};
+        uint64_t floor_seqno{0};
+
+        //! Flat mode: all records sorted by the child comparator.
+        std::vector<std::size_t> flat_index;
+        //! Tree mode: group addresses sorted by the parent comparator, and
+        //! per-group member indices sorted by the child comparator.
+        std::vector<std::string> directory;
+        std::unordered_map<std::string, std::vector<std::size_t>> group_index;
+
+        //! Last event seqno per scope ("" = flat, address = group children).
+        std::unordered_map<std::string, uint64_t> scope_seqno;
+        uint64_t directory_seqno{0};
+    };
+
+    //! Child (output-row) total order for a view's column/order, outpoint
+    //! tiebreak. Confirmations order is height order (depth is serve-time).
+    bool lessRecord(const ViewState& v, std::size_t a, std::size_t b) const;
+    //! Parent (group-row) total order: total_amount / (label, address) /
+    //! address fallback for DATE + CONFS, address tiebreak.
+    bool lessGroup(const ViewState& v, const std::string& a, const std::string& b) const;
+
+    //! Sorted insert slot via lower_bound (never used to locate an existing
+    //! entry). / Identity locate by value, npos when absent.
+    std::size_t lowerBoundRecord(const ViewState& v,
+                                 const std::vector<std::size_t>& index,
+                                 std::size_t absidx) const;
+    std::size_t findValue(const std::vector<std::size_t>& index,
+                          std::size_t absidx) const;
+    std::size_t lowerBoundGroup(const ViewState& v, const std::string& address) const;
+    std::size_t findGroup(const ViewState& v, const std::string& address) const;
+
+    //! Rebuild one view's indices for its current mode over [0, n).
+    void buildView(ViewState& v, std::size_t n);
+    //! Rebuild shared membership/aggregates over [0, n) (selection cleared).
+    void buildGroups(std::size_t n);
+    //! (amount, outpoint)-ascending comparator for m_amount_order.
+    bool lessAmount(std::size_t a, std::size_t b) const;
+
+    //! Directory maintenance after a group's parent sort key may have moved:
+    //! emits GroupChange in place or a GroupRemove+GroupInsert reposition.
+    void reslotDirectory(ViewState& v, int view_id, const std::string& address,
+                         std::vector<CoinViewDelta>& out);
+
+    //! Decrement every stored absolute index greater than absidx (the table
+    //! compaction shift) across all views, membership and the amount order.
+    void shiftDown(std::size_t absidx);
+
+    RecordFn m_records;
+    std::map<int, ViewState> m_views;
+    std::map<std::string, GroupData> m_groups; //!< ordered: address-sorted directory reads
+    std::vector<std::size_t> m_amount_order;
+    std::size_t m_count{0}; //!< records currently indexed
+};
+
+} // namespace GRC
+
+#endif // GRIDCOIN_WALLET_COINVIEWS_H


### PR DESCRIPTION
Third PR of the #3183 series (windowed/virtualized coin-control model). **Stacked on #3221** — review the last commit only.

`GRC::CoinViews` is the Qt-free grouped index core the coin store (next PR) drives under `cs_store`: the coin channel's analogue of the per-view `GRC::Cursor`, extended with the tree dimension. No consumer yet; the core compiles into `gridcoin_util` beside the cursor and lands with its GUI-OFF Boost suite, per the windowed tx-table risk-control discipline (the tricky logic is tested in the configuration CI actually exercises).

## What it maintains

Per registered view (the dialog and the wizard page register independently — each has its own display mode, sort, epoch, and broadcast floor):

- a **flat sorted index** (list mode);
- the **group directory** — address rows ordered by the parent sort (total amount / label / address, with a *defined* address fallback for the date/confirmations columns, where the legacy widget's parent order was arbitrary);
- a **sorted member index per group** (tree mode).

View-independent: group membership and the server-side aggregates (`total_amount`, `output_count`, `direct_output_count`, `selected_count/amount`) that let a consumer render parent rows — selection tristate included — **without materializing children**, plus a persistent `(amount, outpoint)` index so the store's `applyValueFilter` is an O(n) walk with no per-call sort inside its GUI-thread lock hold.

## The two rules the suite pins hardest

1. **A directory row that moves goes out as `GroupRemove` + `GroupInsert`, never an in-place change.** Under the default amount sort, any coin arrival can re-rank its group; an in-place event would silently diverge the consumer's positional replica.

2. **Scope-local high-water + per-view floor** (the contract from `wallet_coin_channel.h`): per-scope seqnos advance on scope events; a view-wide *floor* advances only on broadcast events (sort/mode reset, resync); every read reports `max(scope, floor)`. The suite exercises this against the **real `GRC::WindowCache` gate**, including:
   - the broadcast-livelock scenario — a sort flip on a quiescent wallet must not leave any scope's content fetches permanently rejected (the test also pins the failure shape a floorless implementation would produce), and
   - the multi-scope interleave — an event for one group must not invalidate another group's fetches, while the affected group's fetch is rejected exactly until its cache applies the structural delta.

Structural maintenance follows the cursor's published discipline: identity-locate by value, erase-then-`lower_bound` reslots, and index shifts mirroring the table compaction. A 100k-member single-group case covers the windowed-read pathology from the issue.

## Testing

- `qt_coinviews_tests` — 12 cases, all passing (`ENABLE_GUI=OFF`); full build clean.
- Whitespace + include-guard lints clean.

Part of #3183.
