### PR TITLE
gui: add GRC::WalletCoinStore and the in-process WalletCoinSource

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,7 +268,9 @@ add_library(gridcoin_util STATIC
     wallet/txfilter.cpp
     wallet/txorder.cpp
     wallet/wallet.cpp
+    wallet/wallet_coin_source.cpp
     wallet/wallet_tx_source.cpp
+    wallet/walletcoinstore.cpp
     wallet/walletdb.cpp
     wallet/wallettxstore.cpp
     wallet/walletutil.cpp

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -12,6 +12,7 @@
 #include "interfaces/staking.h"
 #include "interfaces/voting.h"
 #include "interfaces/wallet.h"
+#include "interfaces/wallet_coin_source.h"
 #include "interfaces/wallet_tx_source.h"
 
 namespace interfaces {
@@ -55,5 +56,7 @@ std::unique_ptr<PSGTPoolContext> Init::makePSGTPoolContext() { return nullptr; }
 std::unique_ptr<Wallet> Init::makeWallet() { return nullptr; }
 
 std::shared_ptr<WalletTxSource> Init::makeWalletTxSource() { return nullptr; }
+
+std::shared_ptr<WalletCoinSource> Init::makeWalletCoinSource() { return nullptr; }
 
 } // namespace interfaces

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -23,6 +23,7 @@ class SideStakeManager;
 class StakingStatus;
 class VotingManager;
 class Wallet;
+class WalletCoinSource;
 class WalletTxSource;
 
 //! The node's compile-time build fingerprint. After authentication the GUI
@@ -162,6 +163,12 @@ public:
     //! never calls this pays nothing. Takes no wallet argument (see makeMRC).
     //! Returns nullptr before wallet startup completes.
     virtual std::shared_ptr<WalletTxSource> makeWalletTxSource();
+
+    //! Returns a coin-selection source over the node's single wallet (the
+    //! windowed coin-control store, its worker, and the producer subscriptions
+    //! — issue #3183). Same lifecycle contract as makeWalletTxSource, including
+    //! taking no wallet argument (see makeMRC).
+    virtual std::shared_ptr<WalletCoinSource> makeWalletCoinSource();
 };
 
 //! Return the monolithic-build Init implementation.

--- a/src/interfaces/wallet_coin_source.h
+++ b/src/interfaces/wallet_coin_source.h
@@ -48,9 +48,11 @@ class WalletCoinSource
 public:
     virtual ~WalletCoinSource() = default;
 
-    //! Register a per-view cursor with a display mode and sort. The first
-    //! registration on a cold source triggers the initial wallet scan (see
-    //! reloadAndSnapshot). Re-registering an existing view_id replaces it and
+    //! Register a per-view cursor with a display mode and sort. Registration
+    //! over a not-yet-loaded store is valid and yields empty scopes until
+    //! reloadAndSnapshot's Reset arrives — consumers run the initial scan off
+    //! the paint path (typically a one-shot load thread) and render a loading
+    //! state meanwhile. Re-registering an existing view_id replaces it and
     //! pushes a CoinReset. \p view_id is one of the GRC::VIEW_COIN_*
     //! identifiers; \p sort_column is a GRC::CoinSortColumn.
     virtual void registerView(int view_id, GRC::CoinViewMode mode,
@@ -135,6 +137,11 @@ public:
     //! Pull up to \p max_batch pending events in seqno order. Destructive;
     //! called ONLY by the single WalletModel drain point (see class comment).
     virtual std::vector<GRC::WalletCoinEvent> drainEvents(std::size_t max_batch) = 0;
+
+    //! True (once) after a bulk wallet mutation pass (rescan / reaccept)
+    //! bypassed per-tx notifications. The drain point polls this and
+    //! schedules reloadAndSnapshot off the paint path.
+    virtual bool consumeNeedsResync() = 0;
 
     //! GUI up-channel: an address-book entry changed. Labeling an own address
     //! flips IsChange for its outputs, so beyond re-snapshotting labels this

--- a/src/ipc/serve_init.cpp
+++ b/src/ipc/serve_init.cpp
@@ -15,6 +15,7 @@
 #include "interfaces/staking.h"
 #include "interfaces/voting.h"
 #include "interfaces/wallet.h"
+#include "interfaces/wallet_coin_source.h"
 #include "interfaces/wallet_tx_source.h"
 
 #include "logging.h"
@@ -143,6 +144,12 @@ public:
     {
         RequireAuth();
         return m_inner->makeWalletTxSource();
+    }
+
+    std::shared_ptr<interfaces::WalletCoinSource> makeWalletCoinSource() override
+    {
+        RequireAuth();
+        return m_inner->makeWalletCoinSource();
     }
 
     std::unique_ptr<interfaces::MRC> makeMRC() override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -21,6 +21,7 @@
 #include "interfaces/staking.h"
 #include "interfaces/voting.h"
 #include "interfaces/wallet.h"
+#include "interfaces/wallet_coin_source.h"
 #include "interfaces/wallet_tx_source.h"
 #include "chain.h"
 #include "net.h"
@@ -521,6 +522,11 @@ public:
     std::shared_ptr<WalletTxSource> makeWalletTxSource() override
     {
         return pwalletMain ? MakeWalletTxSource(pwalletMain) : nullptr;
+    }
+
+    std::shared_ptr<WalletCoinSource> makeWalletCoinSource() override
+    {
+        return pwalletMain ? MakeWalletCoinSource(pwalletMain) : nullptr;
     }
 };
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -101,6 +101,11 @@ add_executable(test_gridcoin
     # reach them at all. This one drives the real coinstake NotAccepted -> flip-in
     # path against pwalletMain and a mock chain (#3257).
     qt_wallettxstore_chain_tests.cpp
+    # Coin-store worker / double-queue (src/wallet/walletcoinstore.cpp) unit
+    # suite (#3183): upsert diffing, suppress-when-unwatched, the validated
+    # selection mirror, and the value-filter parity semantics. Core lives in
+    # gridcoin_util, so only the suite is listed here (GUI-OFF).
+    qt_walletcoinstore_tests.cpp
     # Transport helpers (src/ipc/process.cpp). Also Cap'n Proto-free. Needed here
     # because on WIN32 handshake.cpp's WriteFileAtomic calls MakeOwnerOnlyDacl /
     # ApplyOwnerOnlyDacl (defined at process.cpp:587,607) to create the cookie with

--- a/src/test/qt_walletcoinstore_tests.cpp
+++ b/src/test/qt_walletcoinstore_tests.cpp
@@ -1,0 +1,376 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF unit coverage for the coin-store worker / double-queue
+// (src/wallet/walletcoinstore.{h,cpp}, #3183), driven with a NULL wallet and
+// synthetic CoinRecords — the qt_wallettxstore_tests discipline. The park
+// protocol and lock ordering are structurally identical to WalletTxStore
+// (covered by its suite); this suite pins the coin-specific behavior: upsert
+// diffing, suppress-when-unwatched, the validated selection mirror (the
+// phantom-selection race), and the server-side value filter's parity
+// semantics including the tie-break and both legacy call shapes.
+
+#include <wallet/walletcoinstore.h>
+#include <wallet/wallet_event_queue.h>
+
+#include <arith_uint256.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <climits>
+#include <string>
+#include <thread>
+#include <vector>
+
+using GRC::CoinRecord;
+using GRC::CoinViewMode;
+using GRC::WalletCoinEventQueue;
+using GRC::WalletCoinStore;
+
+namespace {
+
+constexpr int kView = GRC::VIEW_COIN_CONTROL;
+
+uint256 hashOf(int n)
+{
+    return ArithToUint256(arith_uint256(static_cast<uint64_t>(n) + 1));
+}
+
+CoinRecord makeCoin(const uint256& hash, unsigned int vout, int64_t amount,
+                    const std::string& group, int height = 100)
+{
+    CoinRecord r;
+    r.outpoint = COutPoint(hash, vout);
+    r.amount = amount;
+    r.address = group;
+    r.group_address = group;
+    r.time = 0;
+    r.block_height = height;
+    r.is_change = false;
+    return r;
+}
+
+//! Null-wallet store + queue; helpers to wait for the worker to drain.
+struct Harness {
+    WalletCoinEventQueue queue;
+    WalletCoinStore store{nullptr, queue};
+
+    Harness() { store.start(); }
+
+    //! Wait until the flat total for kView reaches \p expected (bounded).
+    bool waitForTotal(int expected)
+    {
+        for (int i = 0; i < 5000; ++i) {
+            if (store.getRows(kView, 0, 0).total_accepted == expected) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return false;
+    }
+
+    //! Wait until the group's member total reaches \p expected (bounded).
+    bool waitForGroupTotal(const std::string& group, int expected)
+    {
+        for (int i = 0; i < 5000; ++i) {
+            if (store.getGroupRows(kView, group, 0, 0).total_accepted == expected) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return false;
+    }
+
+    //! Wait until the shared (view-independent) group directory holds
+    //! \p expected groups — the only observable while no view is registered.
+    bool waitForDirectorySize(std::size_t expected)
+    {
+        for (int i = 0; i < 5000; ++i) {
+            if (store.getGroupDirectory().size() == expected) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return false;
+    }
+};
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(qt_walletcoinstore_tests)
+
+BOOST_AUTO_TEST_CASE(workerDrainsUpsertsInOrder)
+{
+    Harness h;
+    h.store.registerView(kView, CoinViewMode::Flat, GRC::COINCOL_AMOUNT, 1);
+    h.queue.drain(); // discard the registration Reset
+
+    const uint256 h1 = hashOf(1), h2 = hashOf(2);
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A"), makeCoin(h1, 1, 100, "A")}, false);
+    h.store.enqueueUpsert(h2, {makeCoin(h2, 0, 200, "B")}, false);
+
+    BOOST_REQUIRE(h.waitForTotal(3));
+    auto rows = h.store.getRows(kView, 0, -1);
+    BOOST_REQUIRE_EQUAL(rows.records.size(), 3u);
+    BOOST_CHECK_EQUAL(rows.records[0].amount, 300);
+    BOOST_CHECK_EQUAL(rows.records[1].amount, 200);
+    BOOST_CHECK_EQUAL(rows.records[2].amount, 100);
+
+    // Events arrived in mutation order with monotonic seqnos.
+    auto events = h.queue.drain();
+    BOOST_REQUIRE(!events.empty());
+    for (std::size_t i = 1; i < events.size(); ++i) {
+        BOOST_CHECK(events[i].seqno > events[i - 1].seqno);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(upsertDiffsSpendConfirmAndRestore)
+{
+    Harness h;
+    h.store.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1);
+
+    const uint256 h1 = hashOf(1);
+    // Two coins; one unconfirmed (height -1).
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A"),
+                               makeCoin(h1, 1, 100, "A", /*height*/ -1)}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 2));
+
+    // "Confirm" output 1 (height fill-in) and "spend" output 0 (absent from
+    // the fresh decomposition) in one upsert — the single diff path.
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 1, 100, "A", /*height*/ 200)}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 1));
+
+    auto rows = h.store.getGroupRows(kView, "A", 0, -1);
+    BOOST_REQUIRE_EQUAL(rows.records.size(), 1u);
+    BOOST_CHECK(rows.records[0].outpoint == COutPoint(h1, 1));
+    BOOST_CHECK_EQUAL(rows.records[0].block_height, 200);
+
+    // "Restore" output 0 (reorg unspend arrives as a re-decomposition that
+    // includes it again).
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A"),
+                               makeCoin(h1, 1, 100, "A", 200)}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 2));
+
+    // Empty upsert removes everything for the hash (a fully-spent tx).
+    h.store.enqueueUpsert(h1, {}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 0));
+    BOOST_CHECK_EQUAL(h.store.getGroups(kView, 0, -1).total_groups, 0);
+}
+
+BOOST_AUTO_TEST_CASE(suppressWhenUnwatchedAndClearOnLastUnregister)
+{
+    Harness h;
+
+    // No view registered: mutations maintain the store but push no events.
+    // Wait for the worker to absorb the upsert BEFORE registering, so the
+    // event-count assertion below cannot race the intake drain.
+    const uint256 h1 = hashOf(1);
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A")}, false);
+    BOOST_REQUIRE(h.waitForDirectorySize(1));
+    BOOST_CHECK_EQUAL(h.queue.size(), static_cast<std::size_t>(0));
+
+    // Register and verify the records were kept warm.
+    h.store.registerView(kView, CoinViewMode::Flat, GRC::COINCOL_AMOUNT, 1);
+    BOOST_REQUIRE(h.waitForTotal(1));
+    BOOST_CHECK_EQUAL(h.queue.size(), static_cast<std::size_t>(1)); // the Reset only
+
+    // Live events flow while watched...
+    h.queue.drain();
+    const uint256 h2 = hashOf(2);
+    h.store.enqueueUpsert(h2, {makeCoin(h2, 0, 200, "B")}, false);
+    BOOST_REQUIRE(h.waitForTotal(2));
+    BOOST_CHECK(h.queue.size() > 0);
+
+    // ...and the last unregister discards the backlog.
+    h.store.unregisterView(kView);
+    BOOST_CHECK_EQUAL(h.queue.size(), static_cast<std::size_t>(0));
+
+    // Unwatched mutations stay silent; seqnos remain monotonic across the
+    // clear (pinned by re-registering and draining the fresh Reset).
+    const uint256 h3 = hashOf(3);
+    h.store.enqueueUpsert(h3, {makeCoin(h3, 0, 100, "C")}, false);
+    h.store.registerView(kView, CoinViewMode::Flat, GRC::COINCOL_AMOUNT, 1);
+    BOOST_REQUIRE(h.waitForTotal(3));
+    auto events = h.queue.drain();
+    BOOST_REQUIRE(!events.empty());
+}
+
+BOOST_AUTO_TEST_CASE(phantomSelectionIsRefused)
+{
+    Harness h;
+    h.store.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1);
+
+    const uint256 h1 = hashOf(1);
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A")}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 1));
+
+    // Select while present: applied, aggregates update synchronously.
+    auto update = h.store.setSelected(COutPoint(h1, 0), true);
+    BOOST_CHECK(update.applied);
+    BOOST_CHECK_EQUAL(update.group.selected_count, 1);
+
+    // The coin is spent (worker removal) before the user's next click lands:
+    // the toggle must be REFUSED — accepting it would plant a mirror entry
+    // whose removal event was emitted before the phantom insert, so no
+    // future event could repair the divergence.
+    h.store.enqueueUpsert(h1, {}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 0));
+
+    update = h.store.setSelected(COutPoint(h1, 0), true);
+    BOOST_CHECK(!update.applied);
+
+    // And the earlier selection was pruned with the removal.
+    auto reconciled = h.store.reconcileSelection({COutPoint(h1, 0)});
+    BOOST_CHECK(reconciled.empty());
+}
+
+BOOST_AUTO_TEST_CASE(selectGroupAndSelectAllReturnExactDeltas)
+{
+    Harness h;
+    h.store.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1);
+
+    const uint256 h1 = hashOf(1), h2 = hashOf(2);
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A"), makeCoin(h1, 1, 100, "A")}, false);
+    h.store.enqueueUpsert(h2, {makeCoin(h2, 0, 200, "B")}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 2));
+    BOOST_REQUIRE(h.waitForGroupTotal("B", 1));
+
+    auto result = h.store.selectGroup("A", true);
+    BOOST_CHECK_EQUAL(result.added.size(), 2u);
+    BOOST_CHECK_EQUAL(result.removed.size(), 0u);
+
+    // Selecting an already-selected member is not re-reported.
+    result = h.store.selectAll(true);
+    BOOST_CHECK_EQUAL(result.added.size(), 1u); // only B's coin
+    BOOST_CHECK(result.added[0] == COutPoint(h2, 0));
+
+    // Group aggregates drive the tristate.
+    auto groups = h.store.getGroups(kView, 0, -1);
+    for (const auto& g : groups.groups) {
+        BOOST_CHECK_EQUAL(g.selected_count, g.output_count);
+    }
+
+    result = h.store.selectAll(false);
+    BOOST_CHECK_EQUAL(result.removed.size(), 3u);
+}
+
+BOOST_AUTO_TEST_CASE(valueFilterParityAndTieBreak)
+{
+    Harness h;
+    h.store.registerView(kView, CoinViewMode::Flat, GRC::COINCOL_AMOUNT, 1);
+
+    // Amounts: 50, 100, 100, 100, 200 — the three 100s tie.
+    const uint256 h1 = hashOf(1), h2 = hashOf(2), h3 = hashOf(3);
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 50, "A"), makeCoin(h1, 1, 100, "A")}, false);
+    h.store.enqueueUpsert(h2, {makeCoin(h2, 0, 100, "B"), makeCoin(h2, 1, 200, "B")}, false);
+    h.store.enqueueUpsert(h3, {makeCoin(h3, 0, 100, "C")}, false);
+    BOOST_REQUIRE(h.waitForTotal(5));
+
+    h.store.selectAll(true);
+
+    // Filter-button shape: predicate only, no cap (UINT_MAX). less_or_equal
+    // 100 deselects the 200.
+    auto result = h.store.applyValueFilter(true, 100, UINT_MAX);
+    BOOST_CHECK_EQUAL(result.removed.size(), 1u);
+    BOOST_CHECK(result.removed[0] == COutPoint(h2, 1));
+    BOOST_CHECK(!result.culled);
+
+    // Consolidation shape: always-true predicate + cap 3. Prune-only keeps
+    // the 3 SMALLEST; the 100s tie-break by outpoint (hash asc, then n), so
+    // the survivor set is deterministic: 50, then the two lowest-outpoint
+    // 100s (h1:1 and h2:0), culling h3:0.
+    result = h.store.applyValueFilter(true, INT64_MAX, 3);
+    BOOST_CHECK(result.culled);
+    BOOST_REQUIRE_EQUAL(result.removed.size(), 1u);
+    BOOST_CHECK(result.removed[0] == COutPoint(h3, 0));
+
+    // The filter never SELECTS: re-running with a permissive predicate and a
+    // generous cap adds nothing.
+    result = h.store.applyValueFilter(true, INT64_MAX, UINT_MAX);
+    BOOST_CHECK_EQUAL(result.added.size(), 0u);
+    BOOST_CHECK_EQUAL(result.removed.size(), 0u);
+
+    // Greater-or-equal shape keeps the LARGEST under the cap.
+    h.store.selectAll(true);
+    result = h.store.applyValueFilter(false, 100, 2);
+    // Predicate drops the 50; the cap keeps the two largest survivors
+    // (200 and the highest-outpoint 100 = h3:0).
+    bool removed_50 = false;
+    for (const auto& op : result.removed) {
+        if (op == COutPoint(h1, 0)) removed_50 = true;
+    }
+    BOOST_CHECK(removed_50);
+    BOOST_CHECK(result.culled);
+}
+
+BOOST_AUTO_TEST_CASE(reconcilePrunesAndRestoresAggregates)
+{
+    Harness h;
+    h.store.registerView(kView, CoinViewMode::Tree, GRC::COINCOL_AMOUNT, 1);
+
+    const uint256 h1 = hashOf(1), h2 = hashOf(2);
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A")}, false);
+    BOOST_REQUIRE(h.waitForGroupTotal("A", 1));
+
+    // The GUI hands over a set containing one live and one stale outpoint.
+    auto pruned = h.store.reconcileSelection({COutPoint(h1, 0), COutPoint(h2, 5)});
+    BOOST_REQUIRE_EQUAL(pruned.size(), 1u);
+    BOOST_CHECK(pruned.count(COutPoint(h1, 0)) == 1);
+
+    auto groups = h.store.getGroups(kView, 0, -1);
+    BOOST_REQUIRE_EQUAL(groups.groups.size(), 1u);
+    BOOST_CHECK_EQUAL(groups.groups[0].selected_count, 1);
+    BOOST_CHECK_EQUAL(groups.groups[0].selected_amount, 300);
+
+    // A second reconcile with an empty set clears the aggregates.
+    pruned = h.store.reconcileSelection({});
+    BOOST_CHECK(pruned.empty());
+    groups = h.store.getGroups(kView, 0, -1);
+    BOOST_CHECK_EQUAL(groups.groups[0].selected_count, 0);
+}
+
+BOOST_AUTO_TEST_CASE(depthIsServeTimeFromTip)
+{
+    Harness h;
+    h.store.registerView(kView, CoinViewMode::Flat, GRC::COINCOL_AMOUNT, 1);
+
+    const uint256 h1 = hashOf(1);
+    h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A", /*height*/ 100),
+                               makeCoin(h1, 1, 100, "A", /*height*/ -1)}, false);
+    BOOST_REQUIRE(h.waitForTotal(2));
+
+    // Null-wallet applyChainTipRefresh updates the serve-time base and (with
+    // a view registered) pushes the depth-refresh marker. cs_main is not
+    // actually needed by the null-wallet path, but the annotation demands the
+    // caller hold it in production; the test drives the store directly.
+    {
+        LOCK(cs_main);
+        h.queue.drain();
+        h.store.applyChainTipRefresh(149);
+    }
+
+    auto rows = h.store.getRows(kView, 0, -1);
+    BOOST_REQUIRE_EQUAL(rows.records.size(), 2u);
+    BOOST_CHECK_EQUAL(rows.records[0].depth, 50); // 149 - 100 + 1
+    BOOST_CHECK_EQUAL(rows.records[1].depth, 0);  // unconfirmed
+
+    // The marker arrived.
+    bool saw_refresh = false;
+    for (const auto& ev : h.queue.drain()) {
+        if (std::holds_alternative<GRC::CoinDepthRefreshPayload>(ev.payload)) {
+            saw_refresh = true;
+        }
+    }
+    BOOST_CHECK(saw_refresh);
+}
+
+BOOST_AUTO_TEST_CASE(cleanShutdownWithPendingIntake)
+{
+    // Destruction with queued intake must not hang or crash (the tx-store
+    // dtor contract).
+    Harness h;
+    const uint256 h1 = hashOf(1);
+    for (int i = 0; i < 100; ++i) {
+        h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A")}, false);
+    }
+    // ~Harness runs ~WalletCoinStore with a possibly non-empty intake.
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet_coin_source.cpp
+++ b/src/wallet/wallet_coin_source.cpp
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "interfaces/wallet_coin_source.h"
+
+#include "main.h"
+#include "node/ui_interface.h"
+#include "wallet/wallet.h"
+#include "wallet/wallet_event_queue.h"
+#include "wallet/walletcoinstore.h"
+
+#include <boost/signals2/connection.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace interfaces {
+namespace {
+
+//! In-process WalletCoinSource: owns the node-side coin store and its event
+//! queue, and subscribes the producer handlers that feed them from CWallet's
+//! signals. Constructing is the attach (worker started, producers wired);
+//! destroying is the detach — the WalletTxSourceImpl lifecycle, including the
+//! weak_ptr-per-callback teardown discipline (see wallet_tx_source.cpp for
+//! the full rationale; this class copies it verbatim).
+class WalletCoinSourceImpl : public WalletCoinSource,
+                             public std::enable_shared_from_this<WalletCoinSourceImpl>
+{
+public:
+    explicit WalletCoinSourceImpl(CWallet* wallet)
+        : m_wallet(wallet)
+        , m_store(wallet, m_queue)
+    {
+        m_store.start();
+    }
+
+    //! Wire the producer subscriptions; called by MakeWalletCoinSource right
+    //! after make_shared (weak_from_this() is only valid then).
+    void subscribe();
+
+    ~WalletCoinSourceImpl() override
+    {
+        m_handlers.clear();
+    }
+
+    WalletCoinSourceImpl(const WalletCoinSourceImpl&) = delete;
+    WalletCoinSourceImpl& operator=(const WalletCoinSourceImpl&) = delete;
+
+    void registerView(int view_id, GRC::CoinViewMode mode,
+                      int sort_column, int sort_order) override
+    {
+        m_store.registerView(view_id, mode, sort_column, sort_order);
+    }
+
+    void unregisterView(int view_id) override { m_store.unregisterView(view_id); }
+
+    void setViewMode(int view_id, GRC::CoinViewMode mode) override
+    {
+        m_store.setViewMode(view_id, mode);
+    }
+
+    void setViewSort(int view_id, int sort_column, int sort_order) override
+    {
+        m_store.setViewSort(view_id, sort_column, sort_order);
+    }
+
+    GRC::CoinRowsResult getRows(int view_id, int first, int count) override
+    {
+        return m_store.getRows(view_id, first, count);
+    }
+
+    GRC::CoinGroupsResult getGroups(int view_id, int first, int count) override
+    {
+        return m_store.getGroups(view_id, first, count);
+    }
+
+    GRC::CoinRowsResult getGroupRows(int view_id, const std::string& group_address,
+                                     int first, int count) override
+    {
+        return m_store.getGroupRows(view_id, group_address, first, count);
+    }
+
+    std::vector<GRC::CoinGroupInfo> getGroupDirectory() override
+    {
+        return m_store.getGroupDirectory();
+    }
+
+    std::set<COutPoint> reconcileSelection(std::set<COutPoint> selection) override
+    {
+        return m_store.reconcileSelection(std::move(selection));
+    }
+
+    GRC::CoinSelectionUpdate setSelected(const COutPoint& outpoint, bool selected) override
+    {
+        return m_store.setSelected(outpoint, selected);
+    }
+
+    GRC::CoinBulkSelectionResult selectGroup(const std::string& group_address,
+                                             bool selected) override
+    {
+        return m_store.selectGroup(group_address, selected);
+    }
+
+    GRC::CoinBulkSelectionResult selectAll(bool selected) override
+    {
+        return m_store.selectAll(selected);
+    }
+
+    GRC::CoinBulkSelectionResult applyValueFilter(bool less_or_equal, int64_t value,
+                                                  uint32_t max_inputs) override
+    {
+        return m_store.applyValueFilter(less_or_equal, value, max_inputs);
+    }
+
+    GRC::CoinGroupsResult reloadAndSnapshot() override
+    {
+        return m_store.reloadAndSnapshot();
+    }
+
+    std::vector<GRC::WalletCoinEvent> drainEvents(std::size_t max_batch) override
+    {
+        return m_queue.drain(max_batch);
+    }
+
+    bool consumeNeedsResync() override { return m_store.consumeNeedsResync(); }
+
+    void noteAddressBookChanged(const std::string& address, const std::string& label) override
+    {
+        // Labeling an own address flips IsChange for its outputs, which can
+        // regroup coins across the whole store (a change chain re-walks to a
+        // different ancestor). Recompute producer-side on this (GUI) thread —
+        // the worker never takes wallet locks — by re-decomposing every
+        // wallet tx that currently contributes coins grouped under the
+        // address, plus the label snapshot pass for the cheap common case.
+        m_store.enqueueAddressBookChange(address, label);
+
+        LOCK2(cs_main, m_wallet->cs_wallet);
+        for (const auto& entry : m_wallet->mapWallet) {
+            bool pending = false;
+            std::vector<GRC::CoinRecord> recs =
+                GRC::WalletCoinStore::DecomposeCoins(m_wallet, entry.second, pending);
+            bool touches = false;
+            for (const GRC::CoinRecord& r : recs) {
+                if (r.group_address == address || r.address == address) {
+                    touches = true;
+                    break;
+                }
+            }
+            if (touches) {
+                m_store.enqueueUpsert(entry.first, std::move(recs), pending);
+            }
+        }
+    }
+
+private:
+    //! Producer: a wallet transaction appeared / changed / was deleted. Runs
+    //! on the emitting core thread under the locks it already holds
+    //! (CT_NEW/CT_UPDATED sites hold cs_main + cs_wallet; CT_DELETED sites
+    //! hold neither and only the hash is touched). NO_THREAD_SAFETY_ANALYSIS
+    //! for the signals2 dispatch, with AssertLockHeld enforcing at runtime —
+    //! the WalletTxSourceImpl::onTransactionChanged discipline.
+    void onTransactionChanged(CWallet* wallet, const uint256& hash, ChangeType status)
+        NO_THREAD_SAFETY_ANALYSIS;
+
+    //! Producer: the chain tip advanced. Runs the bounded pending-availability
+    //! recheck inline under the emitter's cs_main and pushes the depth-refresh
+    //! marker.
+    void onBlocksChanged(bool syncing, int height, int64_t best_time, uint32_t target_bits)
+        NO_THREAD_SAFETY_ANALYSIS;
+
+    CWallet* const m_wallet;
+
+    //! m_queue before m_store: the store binds a queue reference at
+    //! construction (member init order == declaration order).
+    GRC::WalletCoinEventQueue m_queue;
+    GRC::WalletCoinStore m_store;
+
+    std::vector<boost::signals2::scoped_connection> m_handlers;
+};
+
+void WalletCoinSourceImpl::subscribe()
+{
+    std::weak_ptr<WalletCoinSourceImpl> weak_self = weak_from_this();
+
+    m_handlers.emplace_back(m_wallet->NotifyTransactionChanged.connect(
+        [weak_self](CWallet* wallet, const uint256& hash, ChangeType status) {
+            if (auto self = weak_self.lock()) {
+                self->onTransactionChanged(wallet, hash, status);
+            }
+        }));
+    m_handlers.emplace_back(m_wallet->NotifyTransactionsBulkChanged.connect(
+        [weak_self]() {
+            // Rescan / reaccept mutated wallet-tx state with no per-tx
+            // signals; lock state at emission varies, so only flag — the GUI
+            // drain path polls consumeNeedsResync() and schedules the reload
+            // off the paint path.
+            if (auto self = weak_self.lock()) {
+                self->m_store.markNeedsResync();
+            }
+        }));
+    m_handlers.emplace_back(uiInterface.NotifyBlocksChanged_connect(
+        [weak_self](bool syncing, int height, int64_t best_time, uint32_t target_bits) {
+            if (auto self = weak_self.lock()) {
+                self->onBlocksChanged(syncing, height, best_time, target_bits);
+            }
+        }));
+}
+
+void WalletCoinSourceImpl::onTransactionChanged(CWallet* wallet, const uint256& hash,
+                                                ChangeType status)
+    NO_THREAD_SAFETY_ANALYSIS
+{
+    switch (status) {
+    case CT_NEW:
+    case CT_UPDATED:
+    case CT_UPDATING: {
+        AssertLockHeld(cs_main);
+        AssertLockHeld(wallet->cs_wallet);
+        auto it = wallet->mapWallet.find(hash);
+        if (it == wallet->mapWallet.end()) {
+            // Raced an erasure — drop whatever the store holds for the hash.
+            m_store.enqueueRemove(hash);
+            break;
+        }
+        // Decompose the tx's CURRENTLY available outputs under the held
+        // locks; the worker diffs against the stored outpoints, covering
+        // receive, spend (WalletUpdateSpent fires CT_UPDATED for the funding
+        // tx), confirmation, and reorg-restore (the parent CT_UPDATED added
+        // by the notify-gap patch). An empty set removes every stored coin
+        // of the hash.
+        bool pending = false;
+        std::vector<GRC::CoinRecord> recs =
+            GRC::WalletCoinStore::DecomposeCoins(wallet, it->second, pending);
+        m_store.enqueueUpsert(hash, std::move(recs), pending);
+        break;
+    }
+    case CT_DELETED:
+        m_store.enqueueRemove(hash);
+        break;
+    }
+}
+
+void WalletCoinSourceImpl::onBlocksChanged(bool /*syncing*/, int height, int64_t /*best_time*/,
+                                           uint32_t /*target_bits*/)
+    NO_THREAD_SAFETY_ANALYSIS
+{
+    // Fired under cs_main after every tip advance (the synchronous
+    // SetBestChain -> UpdatedBlockTip -> uiInterface bridge). The store
+    // updates its serve-time depth base, rechecks the bounded
+    // pending-availability set inline (cs_wallet under the held cs_main,
+    // then cs_store — never the worker), and pushes one CoinDepthRefresh.
+    m_store.applyChainTipRefresh(height);
+}
+
+} // namespace
+
+std::shared_ptr<WalletCoinSource> MakeWalletCoinSource(CWallet* wallet)
+{
+    // Two-phase like MakeWalletTxSource: shared ownership first, then
+    // subscribe() (weak_from_this() validity).
+    auto source = std::make_shared<WalletCoinSourceImpl>(wallet);
+    source->subscribe();
+    return source;
+}
+
+} // namespace interfaces

--- a/src/wallet/walletcoinstore.cpp
+++ b/src/wallet/walletcoinstore.cpp
@@ -1,0 +1,845 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "wallet/walletcoinstore.h"
+
+#include "chain.h"
+#include "consensus/tx_verify.h"
+#include "key_io.h"
+#include "main.h"
+#include "wallet/wallet.h"
+
+#include <algorithm>
+#include <cassert>
+#include <utility>
+
+namespace GRC {
+
+WalletCoinStore::WalletCoinStore(CWallet* wallet, GRC::WalletCoinEventQueue& queue)
+    : m_wallet(wallet)
+    , m_queue(queue)
+    , m_views([this](std::size_t i) -> const CoinRecord& { return recordAt(i); })
+{
+}
+
+const CoinRecord& WalletCoinStore::recordAt(std::size_t i) const
+{
+    return m_records[i];
+}
+
+WalletCoinStore::~WalletCoinStore()
+{
+    {
+        LOCK(cs_intake);
+        m_stop = true;
+    }
+    m_intake_cv.notify_all();
+    if (m_worker.joinable()) {
+        m_worker.join();
+    }
+}
+
+void WalletCoinStore::start()
+{
+    if (m_started) {
+        return;
+    }
+    m_started = true;
+    m_worker = std::thread([this] { workerLoop(); });
+}
+
+// ---- producers ----------------------------------------------------------
+
+void WalletCoinStore::enqueueUpsert(const uint256& hash, std::vector<CoinRecord> records,
+                                    bool pending)
+{
+    {
+        LOCK(cs_intake);
+        m_intake.push_back(IntakeItem{IntakeItem::Upsert, hash, std::move(records), pending});
+    }
+    m_intake_cv.notify_one();
+}
+
+void WalletCoinStore::enqueueRemove(const uint256& hash)
+{
+    {
+        LOCK(cs_intake);
+        m_intake.push_back(IntakeItem{IntakeItem::Remove, hash});
+    }
+    m_intake_cv.notify_one();
+}
+
+void WalletCoinStore::enqueueAddressBookChange(const std::string& address, const std::string& label)
+{
+    {
+        LOCK(cs_intake);
+        m_intake.push_back(IntakeItem{IntakeItem::AddressBook, uint256(), {}, false,
+                                      address, label});
+    }
+    m_intake_cv.notify_one();
+}
+
+// ---- worker (the WalletTxStore park/drain loop, verbatim shape) ---------
+
+void WalletCoinStore::workerLoop()
+{
+    WAIT_LOCK(cs_intake, lock);
+    while (true) {
+        // Explicit while-condition form (not a wait() predicate lambda) so the
+        // thread-safety analyzer keeps seeing the held lock over the guarded
+        // reads — the WalletTxStore::workerLoop discipline.
+        while (!m_stop && (m_rebuilding || m_intake.empty())) {
+            if (m_rebuilding && !m_worker_parked) {
+                m_worker_parked = true;
+                m_idle_cv.notify_all();
+            }
+            m_intake_cv.wait(lock);
+        }
+        if (m_stop) {
+            return;
+        }
+        m_worker_parked = false;
+
+        IntakeItem item = std::move(m_intake.front());
+        m_intake.pop_front();
+
+        // Drop cs_intake for the O(N) maintenance (which takes cs_store); the
+        // two leaves are never held together.
+        {
+            REVERSE_LOCK(lock);
+            applyIntake(std::move(item));
+        }
+    }
+}
+
+void WalletCoinStore::applyIntake(IntakeItem item)
+{
+    if (item.kind == IntakeItem::Upsert) {
+        upsertCoins(item.hash, std::move(item.records), item.pending);
+    } else if (item.kind == IntakeItem::AddressBook) {
+        applyAddressBookChange(item.ab_address, item.ab_label);
+    } else {
+        removeCoins(item.hash);
+    }
+}
+
+// ---- decomposition ------------------------------------------------------
+
+namespace {
+
+//! The change-walk from the retired listCoins(): a change output groups under
+//! the address of the ancestor output that funded its chain. Returns the
+//! walked destination's encoded address, or "" when none is extractable.
+//! \p walk_memo caches the from-tx walk result by txid (the walk from any
+//! change output of one tx follows vin[0] identically).
+std::string WalkChangeGroup(CWallet* wallet, const CWalletTx& wtx, unsigned int i,
+                            std::map<uint256, std::string>* walk_memo)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet)
+{
+    const CWalletTx* ptx = &wtx;
+    unsigned int idx = i;
+
+    if (walk_memo) {
+        auto mit = walk_memo->find(wtx.GetHash());
+        if (mit != walk_memo->end()) return mit->second;
+    }
+
+    while (wallet->IsChange(ptx->vout[idx]) && ptx->vin.size() > 0
+           && wallet->IsMine(ptx->vin[0]) != ISMINE_NO)
+    {
+        auto it = wallet->mapWallet.find(ptx->vin[0].prevout.hash);
+        if (it == wallet->mapWallet.end()) break;
+        idx = ptx->vin[0].prevout.n;
+        ptx = &it->second;
+        if (idx >= ptx->vout.size()) return std::string(); // corrupt walk target
+    }
+
+    CTxDestination dest;
+    std::string group;
+    if (ExtractDestination(ptx->vout[idx].scriptPubKey, dest)) {
+        group = EncodeDestination(dest);
+    }
+    if (walk_memo) {
+        (*walk_memo)[wtx.GetHash()] = group;
+    }
+    return group;
+}
+
+} // anonymous namespace
+
+std::vector<CoinRecord> WalletCoinStore::DecomposeCoins(
+    CWallet* wallet, const CWalletTx& wtx, bool& pending_out,
+    std::map<uint256, std::string>* walk_memo)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet)
+{
+    // Reproduces the CWallet::AvailableCoins(fOnlyConfirmed=true,
+    // coinControl=nullptr, fIncludeStakedCoins=false) conditions the retired
+    // listCoins() applied, per transaction. Exclusions that depend on global
+    // chain state (finality, the IsTrusted confirmation gate, generation
+    // maturity) flag pending_out: no notification fires for THIS hash when
+    // the chain advances past them, so applyChainTipRefresh re-decomposes
+    // the flagged set each tip.
+    AssertLockHeld(cs_main);
+    AssertLockHeld(wallet->cs_wallet);
+
+    pending_out = false;
+    std::vector<CoinRecord> records;
+
+    const int depth = wtx.GetDepthInMainChain();
+
+    if (!IsFinalTx(wtx)) {
+        pending_out = true;
+        return records;
+    }
+    if (!wtx.IsTrusted()) {
+        // Untrusted-below-3-conf becomes trusted with depth alone; a
+        // conflicted tx (depth < 0) instead changes via its own or its
+        // parents' notifications, but the flag is a bounded recheck either way.
+        pending_out = (depth >= 0);
+        return records;
+    }
+    if ((wtx.IsCoinBase() || wtx.IsCoinStake()) && wtx.GetBlocksToMaturity() > 0) {
+        pending_out = true;
+        return records;
+    }
+    if (depth < 0) {
+        return records;
+    }
+
+    int block_height = -1;
+    if (!wtx.hashBlock.IsNull()) {
+        auto bi = mapBlockIndex.find(wtx.hashBlock);
+        if (bi != mapBlockIndex.end() && bi->second != nullptr) {
+            block_height = bi->second->nHeight;
+        }
+    }
+
+    for (unsigned int i = 0; i < wtx.vout.size(); ++i) {
+        if (wallet->IsMine(wtx.vout[i]) == ISMINE_NO) continue;
+        if (wtx.IsSpent(i)) continue;
+        if (wtx.vout[i].nValue < nMinimumInputValue) continue;
+
+        CTxDestination dest;
+        std::string address;
+        if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
+            address = EncodeDestination(dest);
+        }
+
+        std::string group = address;
+        bool is_change = false;
+        if (wallet->IsChange(wtx.vout[i]) && wtx.vin.size() > 0
+            && wallet->IsMine(wtx.vin[0]) != ISMINE_NO) {
+            group = WalkChangeGroup(wallet, wtx, i, walk_memo);
+            is_change = (group != address);
+        }
+        // The retired listCoins() dropped outputs with no extractable group
+        // key; preserve that.
+        if (group.empty()) continue;
+
+        std::string label;
+        {
+            CTxDestination group_dest = DecodeDestination(group);
+            auto abit = wallet->mapAddressBook.find(group_dest);
+            if (abit != wallet->mapAddressBook.end()) {
+                label = abit->second.name;
+            }
+        }
+
+        CoinRecord r;
+        r.outpoint = COutPoint(wtx.GetHash(), i);
+        r.amount = wtx.vout[i].nValue;
+        r.address = address;
+        r.group_address = group;
+        r.label = label;
+        r.time = wtx.GetTxTime();
+        r.block_height = block_height;
+        r.is_change = is_change;
+        records.push_back(std::move(r));
+    }
+
+    return records;
+}
+
+// ---- store maintenance --------------------------------------------------
+
+void WalletCoinStore::removeRecordAt(std::size_t absidx)
+{
+    AssertLockHeld(cs_store);
+
+    const COutPoint outpoint = m_records[absidx].outpoint;
+    const bool was_selected = (m_selected.count(outpoint) > 0);
+
+    // CoinViews first (it reads the record and mirrors the compaction shift
+    // internally), then compact the table and this class's identity maps.
+    const auto deltas = m_views.applyRemove(absidx, was_selected);
+    m_selected.erase(outpoint);
+    emitDeltas(deltas, &outpoint);
+
+    m_records.erase(m_records.begin() + absidx);
+    m_by_outpoint.erase(outpoint);
+    {
+        auto range = m_by_hash.equal_range(outpoint.hash);
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second == absidx) {
+                m_by_hash.erase(it);
+                break;
+            }
+        }
+    }
+    for (auto& kv : m_by_outpoint) {
+        if (kv.second > absidx) kv.second -= 1;
+    }
+    for (auto& kv : m_by_hash) {
+        if (kv.second > absidx) kv.second -= 1;
+    }
+}
+
+void WalletCoinStore::upsertCoins(const uint256& hash, std::vector<CoinRecord> records,
+                                  bool pending)
+{
+    LOCK(cs_store);
+
+    if (pending) {
+        m_pending.insert(hash);
+    } else {
+        m_pending.erase(hash);
+    }
+
+    // Index the incoming set by outpoint.
+    std::map<COutPoint, const CoinRecord*> incoming;
+    for (const CoinRecord& r : records) {
+        incoming.emplace(r.outpoint, &r);
+    }
+
+    // Snapshot the stored (absidx, outpoint) pairs for this hash.
+    std::vector<std::pair<std::size_t, COutPoint>> stored;
+    {
+        auto range = m_by_hash.equal_range(hash);
+        for (auto it = range.first; it != range.second; ++it) {
+            stored.emplace_back(it->second, m_records[it->second].outpoint);
+        }
+    }
+
+    // Removals first, in DESCENDING absidx order so the compaction shifts
+    // cannot invalidate the indices still queued for removal.
+    std::sort(stored.begin(), stored.end(),
+              [](const auto& a, const auto& b) { return a.first > b.first; });
+    for (const auto& [absidx, outpoint] : stored) {
+        if (incoming.count(outpoint) == 0) {
+            removeRecordAt(absidx);
+        }
+    }
+
+    // In-place updates for surviving outpoints whose fields changed.
+    for (const CoinRecord& r : records) {
+        auto it = m_by_outpoint.find(r.outpoint);
+        if (it == m_by_outpoint.end()) continue;
+        CoinRecord& stored_rec = m_records[it->second];
+        if (stored_rec.block_height == r.block_height
+            && stored_rec.label == r.label
+            && stored_rec.group_address == r.group_address
+            && stored_rec.is_change == r.is_change
+            && stored_rec.amount == r.amount) {
+            continue;
+        }
+        const std::string old_group = stored_rec.group_address;
+        const bool old_is_change = stored_rec.is_change;
+        const bool was_selected = (m_selected.count(r.outpoint) > 0);
+        stored_rec = r;
+        emitDeltas(m_views.applyUpdate(it->second, old_group, old_is_change, was_selected));
+    }
+
+    // Fresh inserts (append + index).
+    for (const CoinRecord& r : records) {
+        if (m_by_outpoint.count(r.outpoint) > 0) continue;
+        const std::size_t absidx = m_records.size();
+        m_records.push_back(r);
+        m_by_outpoint.emplace(r.outpoint, absidx);
+        m_by_hash.emplace(r.outpoint.hash, absidx);
+        emitDeltas(m_views.applyInsert(absidx));
+    }
+}
+
+void WalletCoinStore::removeCoins(const uint256& hash)
+{
+    LOCK(cs_store);
+
+    m_pending.erase(hash);
+
+    std::vector<std::size_t> indices;
+    {
+        auto range = m_by_hash.equal_range(hash);
+        for (auto it = range.first; it != range.second; ++it) {
+            indices.push_back(it->second);
+        }
+    }
+    std::sort(indices.rbegin(), indices.rend());
+    for (std::size_t absidx : indices) {
+        removeRecordAt(absidx);
+    }
+}
+
+void WalletCoinStore::applyAddressBookChange(const std::string& address, const std::string& label)
+{
+    LOCK(cs_store);
+
+    // Refresh the label snapshot on records grouped under the address. The
+    // IsChange regroup consequences arrive as producer-side upserts (the
+    // worker never takes wallet locks); this pass keeps the rendered labels
+    // and the label sort key current.
+    for (std::size_t i = 0; i < m_records.size(); ++i) {
+        if (m_records[i].group_address != address) continue;
+        if (m_records[i].label == label) continue;
+        const std::string old_group = m_records[i].group_address;
+        const bool old_is_change = m_records[i].is_change;
+        const bool was_selected = (m_selected.count(m_records[i].outpoint) > 0);
+        m_records[i].label = label;
+        emitDeltas(m_views.applyUpdate(i, old_group, old_is_change, was_selected));
+    }
+}
+
+void WalletCoinStore::applyChainTipRefresh(int height)
+{
+    AssertLockHeld(cs_main);
+    m_tip_height.store(height, std::memory_order_relaxed);
+
+    if (m_wallet) {
+        // Re-decompose the bounded pending-availability set: coins whose
+        // exclusion was depth/time-dependent (trust gate, maturity, finality)
+        // flip with the chain alone, with no notification for their hash.
+        // cs_wallet under the caller's cs_main, then cs_store inside
+        // upsertCoins — canonical order; the worker is never involved.
+        LOCK(m_wallet->cs_wallet);
+
+        std::vector<uint256> pending;
+        {
+            LOCK(cs_store);
+            pending.assign(m_pending.begin(), m_pending.end());
+        }
+        for (const uint256& hash : pending) {
+            auto it = m_wallet->mapWallet.find(hash);
+            if (it == m_wallet->mapWallet.end()) {
+                removeCoins(hash);
+                continue;
+            }
+            bool still_pending = false;
+            std::vector<CoinRecord> recs = DecomposeCoins(m_wallet, it->second, still_pending);
+            upsertCoins(hash, std::move(recs), still_pending);
+        }
+    }
+
+    LOCK(cs_store);
+    if (m_views.hasViews()) {
+        m_queue.push(CoinDepthRefreshPayload{height});
+    }
+}
+
+// ---- event emission -----------------------------------------------------
+
+void WalletCoinStore::emitDeltas(const std::vector<CoinViewDelta>& deltas,
+                                 const COutPoint* removed_outpoint)
+{
+    AssertLockHeld(cs_store);
+
+    for (const CoinViewDelta& d : deltas) {
+        const uint64_t epoch = m_views.epoch(d.view_id);
+        switch (d.type) {
+        case CoinViewDelta::Insert: {
+            int total = 0;
+            std::vector<std::size_t> idxs =
+                d.scope.empty() ? m_views.flatSlice(d.view_id, d.first, d.count, total)
+                                : m_views.groupSlice(d.view_id, d.scope, d.first, d.count, total);
+            std::vector<CoinRecord> recs;
+            recs.reserve(idxs.size());
+            for (std::size_t idx : idxs) recs.push_back(m_records[idx]);
+            fillDepth(recs);
+            const uint64_t seqno = m_queue.push(CoinRowsInsertedPayload{
+                d.view_id, epoch, d.scope, d.first, std::move(recs)});
+            m_views.noteScopeEvent(d.view_id, d.scope, seqno);
+            break;
+        }
+        case CoinViewDelta::Remove: {
+            std::vector<COutPoint> outs;
+            if (removed_outpoint) outs.push_back(*removed_outpoint);
+            const uint64_t seqno = m_queue.push(CoinRowsRemovedPayload{
+                d.view_id, epoch, d.scope, d.first, d.count, std::move(outs)});
+            m_views.noteScopeEvent(d.view_id, d.scope, seqno);
+            break;
+        }
+        case CoinViewDelta::Change: {
+            const uint64_t seqno = m_queue.push(CoinRowsChangedPayload{
+                d.view_id, epoch, d.scope, d.first, d.count});
+            m_views.noteScopeEvent(d.view_id, d.scope, seqno);
+            break;
+        }
+        case CoinViewDelta::GroupInsert: {
+            int total = 0;
+            std::vector<std::string> addrs =
+                m_views.directorySlice(d.view_id, d.first, d.count, total);
+            std::vector<CoinGroupInfo> groups;
+            groups.reserve(addrs.size());
+            for (const std::string& a : addrs) groups.push_back(m_views.groupInfo(a));
+            const uint64_t seqno = m_queue.push(CoinGroupsInsertedPayload{
+                d.view_id, epoch, d.first, std::move(groups)});
+            m_views.noteDirectoryEvent(d.view_id, seqno);
+            break;
+        }
+        case CoinViewDelta::GroupRemove: {
+            const uint64_t seqno = m_queue.push(CoinGroupsRemovedPayload{
+                d.view_id, epoch, d.first, d.count});
+            m_views.noteDirectoryEvent(d.view_id, seqno);
+            break;
+        }
+        case CoinViewDelta::GroupChange: {
+            const uint64_t seqno = m_queue.push(CoinGroupsChangedPayload{
+                d.view_id, epoch, d.first, d.count});
+            m_views.noteDirectoryEvent(d.view_id, seqno);
+            break;
+        }
+        case CoinViewDelta::Reset: {
+            const uint64_t seqno = m_queue.push(CoinResetPayload{d.view_id, epoch});
+            m_views.noteBroadcast(d.view_id, seqno);
+            break;
+        }
+        }
+    }
+}
+
+void WalletCoinStore::fillDepth(std::vector<CoinRecord>& records) const
+{
+    const int tip = m_tip_height.load(std::memory_order_relaxed);
+    for (CoinRecord& r : records) {
+        r.depth = (r.block_height >= 0 && tip >= r.block_height)
+                      ? tip - r.block_height + 1
+                      : 0;
+    }
+}
+
+// ---- view lifecycle -----------------------------------------------------
+
+void WalletCoinStore::registerView(int view_id, CoinViewMode mode,
+                                   int sort_column, int sort_order)
+{
+    LOCK(cs_store);
+    const bool first = !m_views.hasViews();
+    const auto deltas = m_views.registerView(view_id, mode, sort_column, sort_order,
+                                             m_records.size());
+    if (first) {
+        // The first registration (re)built the shared aggregates, which
+        // cleared the selection counters; restore them from the mirror.
+        reapplyMirrorAggregates();
+    }
+    emitDeltas(deltas);
+}
+
+void WalletCoinStore::unregisterView(int view_id)
+{
+    LOCK(cs_store);
+    m_views.unregisterView(view_id);
+    if (!m_views.hasViews()) {
+        // Nothing watches: discard pending events (seqnos stay monotonic) so
+        // an idle GUI node accumulates nothing between dialog opens.
+        m_queue.clear();
+    }
+}
+
+void WalletCoinStore::setViewMode(int view_id, CoinViewMode mode)
+{
+    LOCK(cs_store);
+    emitDeltas(m_views.setViewMode(view_id, mode, m_records.size()));
+}
+
+void WalletCoinStore::setViewSort(int view_id, int sort_column, int sort_order)
+{
+    LOCK(cs_store);
+    emitDeltas(m_views.setViewSort(view_id, sort_column, sort_order, m_records.size()));
+}
+
+// ---- reads --------------------------------------------------------------
+
+CoinRowsResult WalletCoinStore::getRows(int view_id, int first, int count)
+{
+    LOCK(cs_store);
+    CoinRowsResult result;
+    std::vector<std::size_t> idxs =
+        m_views.flatSlice(view_id, first, count, result.total_accepted);
+    result.records.reserve(idxs.size());
+    for (std::size_t idx : idxs) result.records.push_back(m_records[idx]);
+    fillDepth(result.records);
+    result.epoch = m_views.epoch(view_id);
+    result.high_water = m_views.highWater(view_id, std::string());
+    return result;
+}
+
+CoinGroupsResult WalletCoinStore::getGroups(int view_id, int first, int count)
+{
+    LOCK(cs_store);
+    CoinGroupsResult result;
+    std::vector<std::string> addrs =
+        m_views.directorySlice(view_id, first, count, result.total_groups);
+    result.groups.reserve(addrs.size());
+    for (const std::string& a : addrs) result.groups.push_back(m_views.groupInfo(a));
+    result.epoch = m_views.epoch(view_id);
+    result.high_water = m_views.directoryHighWater(view_id);
+    return result;
+}
+
+CoinRowsResult WalletCoinStore::getGroupRows(int view_id, const std::string& group_address,
+                                             int first, int count)
+{
+    LOCK(cs_store);
+    CoinRowsResult result;
+    std::vector<std::size_t> idxs =
+        m_views.groupSlice(view_id, group_address, first, count, result.total_accepted);
+    result.records.reserve(idxs.size());
+    for (std::size_t idx : idxs) result.records.push_back(m_records[idx]);
+    fillDepth(result.records);
+    result.epoch = m_views.epoch(view_id);
+    result.high_water = m_views.highWater(view_id, group_address);
+    return result;
+}
+
+std::vector<CoinGroupInfo> WalletCoinStore::getGroupDirectory()
+{
+    LOCK(cs_store);
+    return m_views.groupDirectory();
+}
+
+// ---- selection ----------------------------------------------------------
+
+void WalletCoinStore::reapplyMirrorAggregates()
+{
+    AssertLockHeld(cs_store);
+    for (const COutPoint& outpoint : m_selected) {
+        auto it = m_by_outpoint.find(outpoint);
+        if (it == m_by_outpoint.end()) continue;
+        (void)m_views.applySelection(it->second, true);
+    }
+}
+
+std::set<COutPoint> WalletCoinStore::reconcileSelection(std::set<COutPoint> selection)
+{
+    LOCK(cs_store);
+
+    // Clear the current mirror's aggregates, then install the pruned set.
+    // No events: the consumer reconciles immediately before seeding its
+    // caches, so it reads the refreshed aggregates directly.
+    for (const COutPoint& outpoint : m_selected) {
+        auto it = m_by_outpoint.find(outpoint);
+        if (it == m_by_outpoint.end()) continue;
+        (void)m_views.applySelection(it->second, false);
+    }
+
+    std::set<COutPoint> pruned;
+    for (const COutPoint& outpoint : selection) {
+        if (m_by_outpoint.count(outpoint) > 0) {
+            pruned.insert(outpoint);
+        }
+    }
+    m_selected = pruned;
+    reapplyMirrorAggregates();
+    return pruned;
+}
+
+CoinSelectionUpdate WalletCoinStore::setSelected(const COutPoint& outpoint, bool selected)
+{
+    LOCK(cs_store);
+    CoinSelectionUpdate update;
+
+    auto it = m_by_outpoint.find(outpoint);
+    if (it == m_by_outpoint.end()) {
+        // Unknown (e.g. spent and removed between render and click): refuse.
+        // The caller must NOT mutate its own selection set — accepting it
+        // would plant a phantom mirror entry no future event repairs (the
+        // outpoint's removal event predates this call).
+        return update;
+    }
+
+    update.applied = true;
+    const bool currently = (m_selected.count(outpoint) > 0);
+    if (currently != selected) {
+        if (selected) {
+            m_selected.insert(outpoint);
+        } else {
+            m_selected.erase(outpoint);
+        }
+        emitDeltas(m_views.applySelection(it->second, selected));
+    }
+    update.group = m_views.groupInfo(m_records[it->second].group_address);
+    return update;
+}
+
+void WalletCoinStore::toggleLocked(std::size_t absidx, bool selected,
+                                   CoinBulkSelectionResult& result)
+{
+    const COutPoint& outpoint = m_records[absidx].outpoint;
+    const bool currently = (m_selected.count(outpoint) > 0);
+    if (currently == selected) return;
+
+    if (selected) {
+        m_selected.insert(outpoint);
+        result.added.push_back(outpoint);
+    } else {
+        m_selected.erase(outpoint);
+        result.removed.push_back(outpoint);
+    }
+    emitDeltas(m_views.applySelection(absidx, selected));
+}
+
+CoinBulkSelectionResult WalletCoinStore::selectGroup(const std::string& group_address,
+                                                     bool selected)
+{
+    LOCK(cs_store);
+    CoinBulkSelectionResult result;
+    for (std::size_t absidx : m_views.groupMembers(group_address)) {
+        toggleLocked(absidx, selected, result);
+    }
+    return result;
+}
+
+CoinBulkSelectionResult WalletCoinStore::selectAll(bool selected)
+{
+    LOCK(cs_store);
+    CoinBulkSelectionResult result;
+    for (std::size_t absidx = 0; absidx < m_records.size(); ++absidx) {
+        toggleLocked(absidx, selected, result);
+    }
+    return result;
+}
+
+CoinBulkSelectionResult WalletCoinStore::applyValueFilter(bool less_or_equal, int64_t value,
+                                                          uint32_t max_inputs)
+{
+    LOCK(cs_store);
+    CoinBulkSelectionResult result;
+
+    // Phase 1 — predicate prune over the current selection (never selects):
+    // deselect members on the wrong side of the value threshold.
+    const std::vector<std::size_t>& order = m_views.amountOrder();
+    for (std::size_t absidx : order) {
+        const CoinRecord& r = m_records[absidx];
+        if (m_selected.count(r.outpoint) == 0) continue;
+        const bool fails = less_or_equal ? (r.amount > value) : (r.amount < value);
+        if (fails) toggleLocked(absidx, false, result);
+    }
+
+    // Phase 2 — the input cap: keep the max_inputs smallest (less_or_equal)
+    // or largest survivors, walking the persistent (amount, outpoint) order
+    // so ties at the boundary break deterministically and the pass is O(n)
+    // with no per-call sort inside this GUI-thread cs_store hold.
+    uint32_t kept = 0;
+    if (less_or_equal) {
+        for (auto it = order.begin(); it != order.end(); ++it) {
+            capPassLocked(*it, max_inputs, kept, result);
+        }
+    } else {
+        for (auto it = order.rbegin(); it != order.rend(); ++it) {
+            capPassLocked(*it, max_inputs, kept, result);
+        }
+    }
+
+    return result;
+}
+
+void WalletCoinStore::capPassLocked(std::size_t absidx, uint32_t max_inputs, uint32_t& kept,
+                                    CoinBulkSelectionResult& result)
+{
+    const CoinRecord& r = m_records[absidx];
+    if (m_selected.count(r.outpoint) == 0) return;
+    if (kept < max_inputs) {
+        ++kept;
+    } else {
+        toggleLocked(absidx, false, result);
+        result.culled = true;
+    }
+}
+
+// ---- load / resync ------------------------------------------------------
+
+CoinGroupsResult WalletCoinStore::reloadAndSnapshot()
+{
+    CoinGroupsResult result;
+    if (!m_wallet) {
+        return result;
+    }
+
+    // Hold cs_main + cs_wallet across the scan AND the queue discard, with
+    // the store-worker parked — the WalletTxStore::reloadAndSnapshot
+    // protocol, verbatim: producers are excluded by the wallet locks, the
+    // worker by the park, so the swapped index, the emptied queue, and the
+    // published Resets are mutually consistent.
+    LOCK2(cs_main, m_wallet->cs_wallet);
+
+    {
+        WAIT_LOCK(cs_intake, ilock);
+        m_rebuilding = true;
+        m_intake_cv.notify_all();
+        while (m_started && !m_worker_parked) {
+            m_idle_cv.wait(ilock);
+        }
+        m_intake.clear();
+    }
+
+    std::vector<CoinRecord> built;
+    std::unordered_set<uint256, CoinTxHashHasher> pending_set;
+    std::map<uint256, std::string> walk_memo;
+    built.reserve(m_wallet->mapWallet.size());
+    for (const auto& entry : m_wallet->mapWallet) {
+        bool pending = false;
+        std::vector<CoinRecord> recs =
+            DecomposeCoins(m_wallet, entry.second, pending, &walk_memo);
+        if (pending) pending_set.insert(entry.first);
+        for (CoinRecord& r : recs) built.push_back(std::move(r));
+    }
+
+    m_tip_height.store(nBestHeight, std::memory_order_relaxed);
+
+    std::vector<CoinViewDelta> resets;
+    {
+        LOCK(cs_store);
+        m_records = std::move(built);
+        m_by_outpoint.clear();
+        m_by_hash.clear();
+        for (std::size_t i = 0; i < m_records.size(); ++i) {
+            m_by_outpoint.emplace(m_records[i].outpoint, i);
+            m_by_hash.emplace(m_records[i].outpoint.hash, i);
+        }
+        m_pending = std::move(pending_set);
+
+        // Prune the mirror to surviving coins, then rebuild the views (which
+        // clears aggregates) and restore the mirror's aggregates.
+        for (auto it = m_selected.begin(); it != m_selected.end();) {
+            if (m_by_outpoint.count(*it) == 0) {
+                it = m_selected.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        resets = m_views.rebuild(m_records.size());
+        reapplyMirrorAggregates();
+    }
+
+    // Events computed against the old index are superseded; discard them
+    // (producers still blocked on the wallet locks, worker parked).
+    m_queue.drain();
+
+    {
+        LOCK(cs_store);
+        // Publish each view's Reset AFTER the discard so it survives, and
+        // record it as the view's broadcast floor.
+        emitDeltas(resets);
+        result.groups = m_views.groupDirectory();
+        result.total_groups = static_cast<int>(result.groups.size());
+    }
+
+    {
+        LOCK(cs_intake);
+        m_rebuilding = false;
+    }
+    m_intake_cv.notify_all();
+
+    return result;
+}
+
+} // namespace GRC

--- a/src/wallet/walletcoinstore.h
+++ b/src/wallet/walletcoinstore.h
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_WALLET_WALLETCOINSTORE_H
+#define GRIDCOIN_WALLET_WALLETCOINSTORE_H
+
+#include "interfaces/wallet_coin_channel.h"
+#include "wallet/coinviews.h"
+#include "wallet/wallet_event_queue.h"
+#include "sync.h"
+#include "uint256.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <set>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+class CWallet;
+class CWalletTx;
+
+//! Forward declaration so applyChainTipRefresh() can carry an
+//! EXCLUSIVE_LOCKS_REQUIRED(cs_main) annotation without pulling in the heavy
+//! main.h here (the WalletTxStore precedent). CCriticalSection comes from
+//! sync.h, included above.
+extern CCriticalSection cs_main;
+
+namespace GRC {
+
+//!
+//! \brief Qt-free hasher for uint256-keyed store indices (the wallettxstore.h
+//! TxHashHasher pattern, redeclared under its own name so this header does
+//! not pull in the tx store).
+//!
+struct CoinTxHashHasher {
+    std::size_t operator()(const uint256& h) const { return static_cast<std::size_t>(h.GetUint64(0)); }
+};
+
+//!
+//! \brief Producer-owned authoritative store for the windowed coin-control
+//! selection model (issue #3183) — the coin channel's sibling of
+//! GRC::WalletTxStore, with the same threading shape: producers (core
+//! threads, under the locks they already hold) enqueue O(1) intake items;
+//! a store-worker thread drains them and performs the O(N) maintenance off
+//! the core locks; the Qt thread reads windowed slices and drives selection
+//! operations. GRC::CoinViews (the grouped index core) does the positional
+//! arithmetic; this class owns the record table, the wallet interaction, the
+//! selection mirror, and the event emission.
+//!
+//! Lock discipline (identical to WalletTxStore): cs_intake and cs_store are
+//! independent leaves, never held together; canonical order is
+//! cs_main -> cs_wallet -> cs_store; cs_store is NEVER held while acquiring
+//! cs_main / cs_wallet; the worker never takes cs_main / cs_wallet (the
+//! reloadAndSnapshot park protocol depends on it). Events are pushed while
+//! cs_store is held, so queue seqno order equals store mutation order.
+//!
+//! Coin-specific responsibilities beyond the tx store's shape:
+//!
+//!  - UPSERT DIFFING: a producer hands the store the FULL set of currently
+//!    available outputs of one transaction; the worker diffs it against the
+//!    stored outpoints of that hash into removals (spent/conflicted),
+//!    inserts (new/confirmed/restored) and in-place updates. One path covers
+//!    receive, spend, confirmation, maturity and reorg-restore.
+//!
+//!  - PENDING AVAILABILITY: a coin's availability depends on global chain
+//!    state (IsTrusted's confirmation gate, coinbase/coinstake maturity,
+//!    finality) — a received coin becomes spendable at depth 3 with no
+//!    notification for its own hash. Producers flag any tx excluded for such
+//!    a depth/time-dependent reason; applyChainTipRefresh() re-decomposes
+//!    the flagged set inline under the emitter's cs_main each tip advance.
+//!
+//!  - SELECTION MIRROR: the GUI-side interfaces::WalletCoinControl set stays
+//!    authoritative; the store mirrors it (validated against the outpoint
+//!    index — a toggle racing a worker removal must not plant a phantom
+//!    entry) so per-group tristate aggregates and the bulk operations
+//!    (selectGroup / selectAll / applyValueFilter) run server-side without
+//!    materializing children. Removal events carry outpoints so the drain
+//!    path prunes the GUI set unconditionally.
+//!
+//!  - SUPPRESS WHEN UNWATCHED: with no view registered the store still
+//!    maintains its records (reopen stays warm) but pushes no events; the
+//!    last unregisterView clears the queue, and a register triggers the
+//!    consumer's reseed via its Reset.
+//!
+class WalletCoinStore
+{
+public:
+    WalletCoinStore(CWallet* wallet, GRC::WalletCoinEventQueue& queue);
+    ~WalletCoinStore();
+
+    WalletCoinStore(const WalletCoinStore&) = delete;
+    WalletCoinStore& operator=(const WalletCoinStore&) = delete;
+
+    //! Start the store-worker thread. Idempotent; called once at attach.
+    void start();
+
+    // ---- producers (any core thread; leaf cs_intake only) ---------------
+
+    //! The full currently-available output set of one transaction (possibly
+    //! empty — an empty set removes every stored coin of the hash).
+    //! \p pending flags a depth/time-dependent exclusion (see class comment).
+    void enqueueUpsert(const uint256& hash, std::vector<CoinRecord> records,
+                       bool pending);
+
+    //! Remove every stored coin of \p hash (CT_DELETED — no wallet locks held).
+    void enqueueRemove(const uint256& hash);
+
+    //! An address-book entry changed. The worker re-labels affected records;
+    //! the regroup re-walk (IsChange flips) is performed by the producer side
+    //! before enqueueing (the worker never takes wallet locks), arriving here
+    //! as ordinary upserts — this intake item only refreshes label snapshots.
+    void enqueueAddressBookChange(const std::string& address, const std::string& label);
+
+    //! Core thread, cs_main held (the tip-advance emitter): update the cached
+    //! tip height, re-decompose the pending-availability set (takes cs_wallet
+    //! under the caller's cs_main, then cs_store — canonical order; runs
+    //! INLINE, never on the worker), and push one CoinDepthRefresh marker.
+    //! Null-wallet stores (unit tests) update the tip and marker only.
+    void applyChainTipRefresh(int height) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    //! A bulk wallet mutation pass (rescan/reaccept) bypassed per-tx
+    //! notifications: flag that a full resync is needed. The GUI drain path
+    //! polls consumeNeedsResync() and schedules reloadAndSnapshot off the
+    //! paint path (never inline in the signal — its lock state varies).
+    void markNeedsResync() { m_needs_resync = true; }
+    bool consumeNeedsResync() { return m_needs_resync.exchange(false); }
+
+    // ---- view lifecycle (Qt thread) -------------------------------------
+
+    void registerView(int view_id, CoinViewMode mode, int sort_column, int sort_order);
+    void unregisterView(int view_id);
+    void setViewMode(int view_id, CoinViewMode mode);
+    void setViewSort(int view_id, int sort_column, int sort_order);
+
+    // ---- reads (Qt thread; each atomic under one cs_store hold) ---------
+
+    CoinRowsResult getRows(int view_id, int first, int count);
+    CoinGroupsResult getGroups(int view_id, int first, int count);
+    CoinRowsResult getGroupRows(int view_id, const std::string& group_address,
+                                int first, int count);
+    std::vector<CoinGroupInfo> getGroupDirectory();
+
+    // ---- selection (Qt thread; synchronous, validated) ------------------
+
+    std::set<COutPoint> reconcileSelection(std::set<COutPoint> selection);
+    CoinSelectionUpdate setSelected(const COutPoint& outpoint, bool selected);
+    CoinBulkSelectionResult selectGroup(const std::string& group_address, bool selected);
+    CoinBulkSelectionResult selectAll(bool selected);
+    CoinBulkSelectionResult applyValueFilter(bool less_or_equal, int64_t value,
+                                             uint32_t max_inputs);
+
+    // ---- load / resync (Qt thread or a one-shot load thread) ------------
+
+    //! Rebuild the store from the wallet: AvailableCoins conditions +
+    //! change-walk grouping (memoized). Holds cs_main + cs_wallet across the
+    //! scan with the worker parked (the WalletTxStore park protocol); swaps
+    //! under cs_store; prunes the selection mirror to surviving outpoints;
+    //! discards the queue and publishes each view's Reset. O(wallet) — run it
+    //! off the paint path. Returns the address-ordered group directory.
+    CoinGroupsResult reloadAndSnapshot();
+
+    //! Decompose one wallet transaction into its currently-available coin
+    //! records, reproducing CWallet::AvailableCoins's listCoins conditions
+    //! (final, trusted, mature, depth >= 0, unspent, mine, above the minimum
+    //! input value) plus the change-walk group key and label snapshot.
+    //! \p pending_out reports a depth/time-dependent exclusion.
+    //! \p walk_memo optionally memoizes the change-walk across a bulk scan
+    //! (txid -> group address). Requires cs_main + wallet->cs_wallet — the
+    //! lock annotation lives on the definition, where CWallet is complete.
+    static std::vector<CoinRecord> DecomposeCoins(
+        CWallet* wallet, const CWalletTx& wtx, bool& pending_out,
+        std::map<uint256, std::string>* walk_memo = nullptr);
+
+private:
+    //! One unit of deferred maintenance handed from a producer to the worker.
+    struct IntakeItem {
+        enum Kind { Upsert, Remove, AddressBook } kind;
+        uint256 hash;
+        std::vector<CoinRecord> records;
+        bool pending{false};
+        std::string ab_address;
+        std::string ab_label;
+    };
+
+    //! Worker entry point: the WalletTxStore park/drain loop, verbatim shape.
+    void workerLoop();
+    void applyIntake(IntakeItem item);
+
+    //! Worker / tip-refresh core: diff \p records against the stored
+    //! outpoints of \p hash and apply removals / inserts / in-place updates.
+    //! Takes cs_store.
+    void upsertCoins(const uint256& hash, std::vector<CoinRecord> records,
+                     bool pending);
+    void removeCoins(const uint256& hash);
+    void applyAddressBookChange(const std::string& address, const std::string& label);
+
+    //! Remove the record at \p absidx: CoinViews first (positional deltas +
+    //! its shift), then compact m_records and shift this class's maps.
+    //! Caller holds cs_store.
+    void removeRecordAt(std::size_t absidx) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! Translate CoinViews deltas into channel events, push them (only while
+    //! a view is registered) and record their seqnos in the per-scope /
+    //! floor bookkeeping. \p removed_outpoint rides on Remove deltas so the
+    //! payload carries the outpoint for the GUI-side selection prune.
+    //! Caller holds cs_store.
+    void emitDeltas(const std::vector<CoinViewDelta>& deltas,
+                    const COutPoint* removed_outpoint = nullptr)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! Serve-time depth fill on a copied slice (from the atomic tip height).
+    void fillDepth(std::vector<CoinRecord>& records) const;
+
+    //! Re-apply the selection mirror's aggregates into CoinViews after a
+    //! rebuild cleared them. Caller holds cs_store.
+    void reapplyMirrorAggregates() EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! Mirror mutation core shared by the bulk operations: toggle \p absidx
+    //! and record the outpoint delta. Caller holds cs_store.
+    void toggleLocked(std::size_t absidx, bool selected,
+                      CoinBulkSelectionResult& result) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! One step of applyValueFilter's cap pass (a member rather than a lambda
+    //! so the thread-safety analyzer can see the held lock — it does not
+    //! propagate capabilities into lambda bodies).
+    void capPassLocked(std::size_t absidx, uint32_t max_inputs, uint32_t& kept,
+                       CoinBulkSelectionResult& result) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! CoinViews projector over m_records[i]. Invoked through the core's
+    //! std::function indirection, which the thread-safety analyzer cannot see
+    //! the lock through (the WalletTxStore projectFieldsAt precedent); every
+    //! call path holds cs_store.
+    const CoinRecord& recordAt(std::size_t i) const NO_THREAD_SAFETY_ANALYSIS;
+
+    CWallet* const m_wallet;
+    GRC::WalletCoinEventQueue& m_queue;
+
+    mutable Mutex cs_store;
+
+    //! The record table (append + compact-on-remove; CoinViews mirrors the
+    //! compaction shifts) and its identity indices.
+    std::vector<CoinRecord> m_records GUARDED_BY(cs_store);
+    std::unordered_map<COutPoint, std::size_t, OutPointHasher> m_by_outpoint GUARDED_BY(cs_store);
+    std::unordered_multimap<uint256, std::size_t, CoinTxHashHasher> m_by_hash GUARDED_BY(cs_store);
+
+    //! The grouped index core (flat/tree/direcory positional arithmetic,
+    //! aggregates, scope high-waters).
+    CoinViews m_views GUARDED_BY(cs_store);
+
+    //! The validated selection mirror (see class comment).
+    std::set<COutPoint> m_selected GUARDED_BY(cs_store);
+
+    //! Tx hashes excluded for a depth/time-dependent reason, re-decomposed
+    //! at each tip advance.
+    std::unordered_set<uint256, CoinTxHashHasher> m_pending GUARDED_BY(cs_store);
+
+    //! Cached tip height for serve-time depth fill (atomic: written under
+    //! cs_main by applyChainTipRefresh, read on the Qt thread without locks).
+    std::atomic<int> m_tip_height{0};
+
+    std::atomic<bool> m_needs_resync{false};
+
+    //! Intake queue + worker lifecycle: the WalletTxStore double-queue,
+    //! verbatim (cs_intake is an independent leaf, never held with cs_store).
+    mutable Mutex cs_intake;
+    std::deque<IntakeItem> m_intake GUARDED_BY(cs_intake);
+    bool m_stop GUARDED_BY(cs_intake){false};
+    bool m_rebuilding GUARDED_BY(cs_intake){false};
+    bool m_worker_parked GUARDED_BY(cs_intake){false};
+    CConditionVariable m_intake_cv;
+    CConditionVariable m_idle_cv;
+    std::thread m_worker;
+    bool m_started{false};
+};
+
+} // namespace GRC
+
+#endif // GRIDCOIN_WALLET_WALLETCOINSTORE_H


### PR DESCRIPTION
Fourth PR of the #3183 series (windowed/virtualized coin-control model). **Stacked on #3222** — review the last commit only.

`GRC::WalletCoinStore` is the producer-side store behind `interfaces::WalletCoinSource`, mirroring `WalletTxStore`'s threading shape **verbatim** — double intake queue (`cs_intake` leaf), store-worker thread, the reload park protocol, `cs_main → cs_wallet → cs_store` with `cs_store` a strict leaf the worker never escalates from — plus the coin-specific machinery the adversarial design review demanded:

- **Upsert diffing.** Producers decompose a transaction's *currently available* outputs under the emitter's held locks (reproducing the retired `listCoins()`'s `AvailableCoins` conditions exactly, plus the memoizable change-walk group key); the worker diffs against the stored outpoints of that hash. One path covers receive, spend (`WalletUpdateSpent` fires `CT_UPDATED` for the funding tx), confirmation, maturity, and reorg-restore (via #3220's parent notifications).

- **Pending availability.** A received coin becomes spendable when `IsTrusted()` flips at depth 3 — with **no notification for its own hash**. Any tx excluded for a depth/time-dependent reason (trust gate, generation maturity, finality) is flagged, and `applyChainTipRefresh` re-decomposes the bounded flagged set inline under the emitter's `cs_main` each tip advance. Depth itself is serve-time (cached tip height), so a tip advance reorders nothing and costs one `CoinDepthRefresh` marker.

- **Validated selection mirror.** The GUI-side `WalletCoinControl` set stays authoritative; the store's mirror refuses toggles for unknown outpoints — a click racing a worker removal would otherwise plant a phantom entry whose removal event *predates* it, unrepairable by any future event (the review's poisoned-tristate scenario, pinned by a test). Bulk ops (`selectGroup` / `selectAll` / the relocated `filterInputsByValue`) run server-side and return exact outpoint deltas; the value filter walks the persistent `(amount, outpoint)` index — O(n) per call inside the GUI-thread `cs_store` hold, deterministic tie-break at the cap boundary, both legacy call shapes (filter button: predicate + no cap; consolidation: always-true predicate + input cap).

- **Suppress-when-unwatched.** No view registered → records stay warm (instant reopen) but nothing is enqueued; the last `unregisterView` clears the queue; seqnos stay monotonic across the clear (the reseed-from-high-water contract).

The in-process source (`wallet_coin_source.cpp`) wires producers with the `weak_ptr`-per-callback teardown discipline from `wallet_tx_source.cpp`, subscribes the `NotifyTransactionsBulkChanged` resync flag from #3220 (flag-only — lock state at emission varies; the drain point polls `consumeNeedsResync()` and schedules the reload off the paint path), and lands `Init::makeWalletCoinSource`. The interface header gains `consumeNeedsResync()` and the registration-before-load contract note (consumers run the initial scan on a one-shot load thread with a loading state — the scan holds `cs_main + cs_wallet` and is O(wallet), and putting it on the GUI thread at first open would re-create the very hang this series removes).

## Testing

- `qt_walletcoinstore_tests` (GUI-OFF, null-wallet, synthetic records): upsert diff transitions (spend / confirm / restore / empty-set removal), suppress-when-unwatched + queue clear + seqno monotonicity, the phantom-selection refusal, bulk-op exact deltas, value-filter parity + tie-break + `culled`, reconcile pruning/aggregate restore, serve-time depth, clean shutdown with pending intake. The park protocol and lock ordering are structurally identical to `WalletTxStore` and covered by its suite.
- `qt_coinviews_tests` / `qt_wallet_event_queue_tests` still green; full build clean; whitespace/include-guard/locale lints clean.

No GUI consumer yet — the `CoinSelectionModel` + `CoinControlDialog` conversion is next in the series.

Part of #3183.
