### PR TITLE
util, gui, init: don't abort on an inaccessible data directory

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1391,6 +1391,16 @@ bool AppInit2(ThreadHandlerPtr threads)
     LogPrintf("POOL pending/open retention configured at %d blocks", GetPendingPoolRetention());
 
     fs::path datadir = GetDataDir();
+
+    // GetDataDirPath returns an empty path when the data directory cannot be accessed or
+    // created (e.g. wrong permissions, or a -datadir this user cannot read). It no longer
+    // throws, so guard here rather than proceed with an empty path -- DirIsWritable("")
+    // and LockDirectory("") would otherwise silently operate in the current working
+    // directory, seeding a fresh datadir/wallet in the wrong place.
+    if (datadir.empty()) {
+        return InitError(_("Cannot access the data directory; check that it exists and that you have permission to read and write it."));
+    }
+
     fs::path walletFileName = gArgs.GetArg("-wallet", "wallet.dat");
 
     LogPrintf("INFO %s: DataDir = %s.", __func__, fsbridge::LongPathString(datadir));

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -753,7 +753,15 @@ int main(int argc, char *argv[])
     // at another user's datadir). GetDataDirPath now returns an empty path on such
     // failures instead of throwing; without this check the process would abort silently
     // in the config read below, before any window or dialog exists.
-    if (GetDataDir(/*fNetSpecific=*/true).empty()) {
+    //
+    // Exception: an ABSOLUTE -conf is read independently of the default datadir and may
+    // itself set an accessible datadir=, so an inaccessible default must not pre-empt it
+    // here. In that case defer to the post-config checks below (CheckDataDirOption and the
+    // empty-path guard before LockDirectory), which run once the config -- and thus the
+    // effective datadir -- is known and still fail cleanly.
+    const std::string conf_arg = gArgs.GetArg("-conf", "");
+    const bool conf_is_absolute = !conf_arg.empty() && fs::path(conf_arg).is_absolute();
+    if (!conf_is_absolute && GetDataDir(/*fNetSpecific=*/true).empty()) {
         const std::string dd = gArgs.GetArg("-datadir", "");
         ThreadSafeMessageBox(strprintf("Error: cannot access the data directory %s.\n",
                                        dd.empty() ? std::string("(default location)") : dd),

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -748,6 +748,22 @@ int main(int argc, char *argv[])
         return EXIT_SUCCESS;
     }
 
+    // Fail with a clear message if the data directory cannot be accessed or created
+    // (wrong permissions, or a -datadir this user cannot read -- e.g. pointing the GUI
+    // at another user's datadir). GetDataDirPath now returns an empty path on such
+    // failures instead of throwing; without this check the process would abort silently
+    // in the config read below, before any window or dialog exists.
+    if (GetDataDir(/*fNetSpecific=*/true).empty()) {
+        const std::string dd = gArgs.GetArg("-datadir", "");
+        ThreadSafeMessageBox(strprintf("Error: cannot access the data directory %s.\n",
+                                       dd.empty() ? std::string("(default location)") : dd),
+                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+        QMessageBox::critical(nullptr, PACKAGE_NAME,
+                QObject::tr("Error: Cannot access the data directory. Check that it exists and that you "
+                            "have permission to read and write it."));
+        return EXIT_FAILURE;
+    }
+
     // Not currently useful.
     std::string error_msg;
 
@@ -778,6 +794,19 @@ int main(int argc, char *argv[])
     // instance writing into an already running Gridcoin instance's logs. This is checked in init too,
     // but that is too late.
     fs::path dataDir = GetDataDir();
+
+    // Now that the actual chain is selected, re-verify the (network-specific) datadir is
+    // usable -- the earlier check ran under mainnet. An empty path means it could not be
+    // accessed/created; bail cleanly rather than LockDirectory("") in the CWD below.
+    if (dataDir.empty()) {
+        ThreadSafeMessageBox(strprintf("Error: cannot access the data directory %s.\n",
+                                       gArgs.GetArg("-datadir", "").empty() ? std::string("(default location)") : gArgs.GetArg("-datadir", "")),
+                "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+        QMessageBox::critical(nullptr, PACKAGE_NAME,
+                QObject::tr("Error: Cannot access the data directory. Check that it exists and that you "
+                            "have permission to read and write it."));
+        return EXIT_FAILURE;
+    }
 
     // In multiprocess mode the core runs in a separate gridcoinresearchd, which
     // owns the datadir and already holds this lock; the GUI runs no core, so it

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -330,10 +330,16 @@ const fs::path& ArgsManager::GetDataDirPath(bool net_specific) const
     // this function
     if (!path.empty()) return path;
 
+    // Filesystem access here must NOT throw. This runs during early startup (config
+    // reading), where a permission-denied or otherwise unusable data directory would
+    // otherwise escape as a filesystem_error and abort the process before any error can
+    // be shown to the user. Use the non-throwing (error_code) overloads and leave the
+    // cached path empty on failure so callers can report it cleanly.
+    boost::system::error_code ec;
     std::string datadir = GetArg("-datadir", "");
     if (!datadir.empty()) {
-        path = fs::system_complete(datadir);
-        if (!fs::is_directory(path)) {
+        path = fs::system_complete(datadir, ec);
+        if (ec || !fs::is_directory(path, ec)) {
             path = "";
             return path;
         }
@@ -343,10 +349,14 @@ const fs::path& ArgsManager::GetDataDirPath(bool net_specific) const
     if (net_specific)
         path /= BaseParams().DataDir();
 
-    if (fs::create_directories(path)) {
-        // This is the first run, create wallets subdirectory too
-        // Reserved for when we move wallets to a subdir like Bitcoin
-        //fs::create_directories(path / "wallets");
+    // On the first run this creates the datadir (and parents); a permission failure
+    // sets ec instead of throwing. (A wallets/ subdir was reserved here for a future
+    // Bitcoin-style move.)
+    fs::create_directories(path, ec);
+    if (ec && !fs::is_directory(path, ec)) {
+        // Could neither create nor find the data directory (e.g. no permission).
+        path = "";
+        return path;
     }
 
     path = StripRedundantLastElementsOfPath(path);
@@ -804,7 +814,11 @@ const fs::path &GetDataDir(bool fNetSpecific)
 bool CheckDataDirOption()
 {
     std::string datadir = gArgs.GetArg("-datadir", "");
-    return datadir.empty() || fs::is_directory(fs::system_complete(datadir));
+    if (datadir.empty()) return true;
+    // Non-throwing: a permission-denied -datadir must return false (invalid), not throw
+    // a filesystem_error out of startup.
+    boost::system::error_code ec;
+    return fs::is_directory(fs::system_complete(datadir, ec), ec);
 }
 
 fs::path GetConfigFile(const std::string& confPath)


### PR DESCRIPTION
## Problem
A Windows GUI crash dump (`gridcoinresearch.exe`, unhandled `c0000409` → `abort()`) symbolized to:

```
__cxa_throw                              (uncaught)
ArgsManager::GetDataDirPath(bool) const  src/util/system.cpp
… ReadConfigFiles …
main                                     src/qt/bitcoin.cpp
→ std::terminate → abort()
```

`GetDataDirPath` runs throwing `boost::filesystem` ops (`system_complete` / `is_directory` / `create_directories`) on the datadir. When the data directory is **permission-denied**, one throws `filesystem_error`, which is **uncaught** through `ReadConfigFiles` → `main` → `std::terminate` → `abort()`. The GUI dies **silently** — before any window or dialog exists.

Surfaced while testing the multiprocess GUI pointed at a datadir the running user can't access (a different Windows user), but the fault is generic: any inaccessible/uncreatable datadir aborts startup.

## Fix
- **`GetDataDirPath` / `CheckDataDirOption`** use the non-throwing `error_code` filesystem overloads and return an **empty path / false** on failure — matching the existing "return empty when `-datadir` isn't a directory" behavior, so no new empty-path contract.
- **Guard the consumers** so an empty path fails cleanly instead of proceeding:
  - **`AppInit2`** (covers the **daemon**/core and the monolithic GUI): returns `InitError`. Without this, `DirIsWritable("")` / `LockDirectory("")` silently operate in the **current working directory**, seeding a fresh datadir/wallet in the wrong place.
  - **Qt startup** (`bitcoin.cpp`): shows a clear *"Cannot access the data directory…"* dialog and `EXIT_FAILURE` instead of aborting — both before `ReadConfigFiles` (early, common case) and at the GUI's own `LockDirectory` site (post-`SelectParams`, network-specific).

## Validation
- All three TUs compile clean with the real build flags.
- Root cause established from the symbolized crash dump (not guessed).
- **Adversarially reviewed** before push; the `AppInit2` and GUI lock-site guards close the two regressions the review surfaced (daemon silently running in CWD; GUI `LockDirectory("")`). Core `GetDataDirPath`/`CheckDataDirOption` rewrite verified correct (success path unchanged, already-exists dir not wrongly emptied, permission-denied → empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)