### PR TITLE
wallet, qt: stop the transaction store losing rows, and cover the paths that hid it

### DIFF
--- a/src/qt/detailedtxmodel.cpp
+++ b/src/qt/detailedtxmodel.cpp
@@ -326,6 +326,25 @@ void DetailedTxModel::sinkDataChanged(int first, int count)
     emit dataChanged(index(first, 0), index(first + count - 1, lastCol));
 }
 
+void DetailedTxModel::noteRejected(const char* what, int first, int count,
+                                   GRC::ApplyResult result)
+{
+    // Applied is the normal case; AlreadyReflected is the routine PR4-fix B skip on
+    // a reset refetch. Rejected means the delta did not fit this replica's virtual
+    // table — the producer cursor and the consumer have diverged, and the row it
+    // carried is simply lost until the next Reset rebuilds the view. That used to
+    // be swallowed (every call site discarded the bool), so a divergence left no
+    // trace anywhere (#3257 review). It should be unreachable; if it ever fires,
+    // this line is the only evidence there will be.
+    if (result != GRC::ApplyResult::Rejected) {
+        return;
+    }
+    GUILogPrintf("WARNING: DetailedTxModel: rejected %s delta at %d count %d "
+                 "(rows=%d, cached [%d,%d)) — view diverged from the producer cursor",
+                 what, first, count, m_cache.total(), m_cache.cacheFirst(),
+                 m_cache.cacheFirst() + m_cache.cacheSize());
+}
+
 void DetailedTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& events)
 {
     interfaces::WalletTxSource& store = m_walletModel->txSource();
@@ -343,7 +362,8 @@ void DetailedTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 // raced this Reset (PR4-fix B, via RowsResult atomicity).
                 GRC::RowsResult r = store.getRows(GRC::VIEW_DETAILED, 0, kInitialWindow);
                 if (m_cache.applyReset(m_sink, seqno, std::move(r.records), 0,
-                                       r.total_accepted, r.epoch, r.high_water)) {
+                                       r.total_accepted, r.epoch, r.high_water)
+                        == GRC::ApplyResult::Applied) {
                     // The pre-Reset viewport range is meaningless against the rebuilt
                     // (possibly resized) table; reset it to the top — where a model
                     // reset scrolls the view — so the re-armed fetch targets a valid
@@ -361,17 +381,20 @@ void DetailedTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 // payload carries the inserted records; the cache gates on seqno,
                 // forwards begin/endInsertRows (before/after growing total) and either
                 // splices into the slice or shifts the cache base.
-                m_cache.applyInsert(m_sink, seqno, payload.position, payload.records);
+                noteRejected("insert", payload.position, static_cast<int>(payload.records.size()),
+                             m_cache.applyInsert(m_sink, seqno, payload.position, payload.records));
             } else if constexpr (std::is_same_v<P, GRC::RowsRemovedPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
-                m_cache.applyRemove(m_sink, seqno, payload.position, payload.count);
+                noteRejected("remove", payload.position, payload.count,
+                             m_cache.applyRemove(m_sink, seqno, payload.position, payload.count));
             } else if constexpr (std::is_same_v<P, GRC::RowsChangedPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
                 if (seqno <= m_cache.structuralSeqno()) return;   // skip the wasted getRows
                 // A Change carries no records (no reorder); refetch the changed slice.
                 const std::vector<TransactionRecord> fresh =
                     store.getRows(GRC::VIEW_DETAILED, payload.first, payload.count).records;
-                m_cache.applyChange(m_sink, seqno, payload.first, payload.count, fresh);
+                noteRejected("change", payload.first, payload.count,
+                             m_cache.applyChange(m_sink, seqno, payload.first, payload.count, fresh));
             }
             // RowCountChanged / ChainTipChanged / VIEW_FULL / VIEW_OVERVIEW are not
             // consumed here (the detailed view's cap stays unlimited).

--- a/src/qt/detailedtxmodel.h
+++ b/src/qt/detailedtxmodel.h
@@ -134,6 +134,12 @@ private:
     //! rejection — a worker push raced the read — re-arm a bounded retry.
     void fetchWindow(int first, int count);
 
+    //! Log a structural delta the cache REJECTED (as opposed to correctly skipping
+    //! as already-reflected). A rejection means this replica and the producer
+    //! cursor have diverged and the delta's row is lost until the next Reset; it
+    //! should be unreachable, and used to leave no trace at all.
+    void noteRejected(const char* what, int first, int count, GRC::ApplyResult result);
+
     //! Forwarders so the nested CacheSink drives our QAbstractItemModel row signals
     //! from within a DetailedTxModel member (avoids any protected-base access
     //! subtlety, and keeps the begin/end bracket ownership in the cache).

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -20,6 +20,14 @@ static const int MODEL_EVENT_DRAIN_INTERVAL = 500;
  * the Qt event loop between batches. */
 static const int MODEL_EVENT_DRAIN_MAX_BATCH = 1024;
 
+/* Consecutive non-disconnect failures of the wallet event drain before the
+ * periodic pump gives up. That pump is the sole feed for BOTH windowed
+ * transaction views and the balance refresh, and nothing in the tree restarts
+ * it, so a transient throw must not be fatal to it -- but a hard-looping fault
+ * must not spin forever either. A node-disconnect exception still stops it
+ * immediately; only other exceptions are counted here. */
+static const int MODEL_EVENT_DRAIN_MAX_FAILURES = 10;
+
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;
 

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -133,7 +133,15 @@ void OverviewTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 if (seqno <= m_applied_seqno) return;   // already reflected in a refetch
                 if (payload.records.empty()) return;  // empty insert → invalid beginInsertRows range
                 const int pos = payload.position;
-                if (pos < 0 || static_cast<std::size_t>(pos) > m_rows.size()) return;
+                if (pos < 0 || static_cast<std::size_t>(pos) > m_rows.size()) {
+                    // Divergence from the producer cursor: the row is lost until the
+                    // next Reset. Should be unreachable; say so rather than
+                    // swallowing it, as this used to (#3257 review).
+                    GUILogPrintf("WARNING: OverviewTxModel: rejected insert at %d "
+                                 "(have %d rows) — view diverged from the producer cursor",
+                                 pos, static_cast<int>(m_rows.size()));
+                    return;
+                }
                 beginInsertRows(QModelIndex(), pos,
                                 pos + static_cast<int>(payload.records.size()) - 1);
                 m_rows.insert(m_rows.begin() + pos,
@@ -146,7 +154,12 @@ void OverviewTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 const int pos = payload.position;
                 if (pos < 0 || payload.count <= 0
                         || static_cast<std::size_t>(pos) + static_cast<std::size_t>(payload.count)
-                               > m_rows.size()) return;
+                               > m_rows.size()) {
+                    GUILogPrintf("WARNING: OverviewTxModel: rejected remove at %d count %d "
+                                 "(have %d rows) — view diverged from the producer cursor",
+                                 pos, payload.count, static_cast<int>(m_rows.size()));
+                    return;
+                }
                 beginRemoveRows(QModelIndex(), pos, pos + payload.count - 1);
                 m_rows.erase(m_rows.begin() + pos, m_rows.begin() + pos + payload.count);
                 endRemoveRows();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -12,6 +12,7 @@
 #include <QTimer>
 
 #include <cassert>
+#include <string>
 
 WalletModel::WalletModel(interfaces::Wallet& wallet, interfaces::WalletTxSource& tx_source,
                          OptionsModel* optionsModel, QObject* parent)
@@ -248,12 +249,45 @@ void WalletModel::drainEventQueue()
         if (events.size() >= static_cast<std::size_t>(MODEL_EVENT_DRAIN_MAX_BATCH)) {
             QTimer::singleShot(0, this, &WalletModel::drainEventQueue);
         }
+
+        m_drain_failures = 0;   // a clean pass clears the consecutive-failure budget
     } catch (const std::exception& e) {
-        // Almost always the node connection dropping mid-drain (multiprocess), but
-        // do not assert the cause in the message — any drain exception lands here.
-        GUILogPrintf("WalletModel: wallet event drain failed; stopping the periodic drain: %s", e.what());
-        if (eventDrainTimer) {
-            eventDrainTimer->stop();
+        const std::string msg{e.what()};
+        // The node process going away is the case this catch was written for, and
+        // the only one where stopping the pump is right: every later call would
+        // throw too, and the IPC disconnect hook (bitcoin.cpp) is already driving
+        // the quit. Detect it by libmultiprocess's raise text, the same two
+        // substrings GridcoinApplication::notify matches.
+        if (msg.find("interrupted by disconnect") != std::string::npos
+                || msg.find("called after disconnect") != std::string::npos) {
+            GUILogPrintf("WalletModel: node connection lost mid-drain; stopping the "
+                         "periodic wallet event drain: %s", e.what());
+            if (eventDrainTimer) {
+                eventDrainTimer->stop();
+            }
+            return;
+        }
+
+        // Anything else is a bug in an apply slot, not a dead node — and this is
+        // the ONLY periodic pump feeding both windowed transaction views and the
+        // balance refresh, with no restart path anywhere in the tree. Stopping it
+        // for a transient throw silenced the whole wallet UI for the rest of the
+        // session (#3257 review). Log and keep draining; give up only if the
+        // failures are persistent, so a hard loop cannot spin forever.
+        //
+        // Note the batch is already popped by drainEvents(), so the events being
+        // processed when the throw happened are lost to any view not yet notified.
+        // Those views recover on the next cursor Reset; the counter exists so a
+        // repeating fault is visible in the log rather than silently eating events.
+        ++m_drain_failures;
+        GUILogPrintf("WalletModel: wallet event drain failed (%d consecutive): %s",
+                     m_drain_failures, e.what());
+        if (m_drain_failures >= MODEL_EVENT_DRAIN_MAX_FAILURES) {
+            GUILogPrintf("WalletModel: %d consecutive wallet event drain failures; "
+                         "stopping the periodic drain", m_drain_failures);
+            if (eventDrainTimer) {
+                eventDrainTimer->stop();
+            }
         }
     }
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -233,6 +233,12 @@ private:
     //! never double-processed. Qt-thread only.
     bool m_draining = false;
 
+    //! Consecutive drain failures that were NOT a node disconnect. Any clean pass
+    //! resets it; the periodic pump gives up at MODEL_EVENT_DRAIN_MAX_FAILURES, so
+    //! a repeating fault stays bounded without a single transient throw silencing
+    //! both windowed views and the balance refresh for the session. Qt-thread only.
+    int m_drain_failures = 0;
+
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
     void checkBalanceChanged();

--- a/src/qt/windowcache.h
+++ b/src/qt/windowcache.h
@@ -80,6 +80,24 @@ struct WindowCacheSink {
     virtual void dataChanged(int first, int count) = 0;
 };
 
+//!
+//! \brief Outcome of applying one structural delta.
+//!
+//! The structural apply* methods used to return a bare bool, which conflated two
+//! completely different things: a delta correctly skipped because the cache
+//! already reflects it (the routine PR4-fix B seqno gate), and a delta REJECTED
+//! because its position does not fit the cache's virtual table. The first is
+//! normal and happens on every reset refetch; the second means the producer's
+//! cursor and this replica have diverged, which is a bug — and callers, having
+//! only a bool, discarded both silently. Distinguishing them lets the host log
+//! the divergence instead of swallowing it (#3257 review).
+//!
+enum class ApplyResult {
+    Applied,           //!< the delta was applied and the seqno advanced
+    AlreadyReflected,  //!< seqno <= the structural high-water; correctly skipped
+    Rejected,          //!< malformed or out-of-range: replica/producer divergence
+};
+
 template <class Record>
 class WindowCache
 {
@@ -134,10 +152,10 @@ public:
     //! structural baseline is max(high_water, seqno) — the fetch's high-water if
     //! it is ahead of the Reset event's own seqno (PR4-fix B). Brackets the swap
     //! in beginReset/endReset.
-    bool applyReset(WindowCacheSink& sink, uint64_t seqno, std::vector<Record> rows,
-                    int cache_first, int total, uint64_t epoch, uint64_t high_water)
+    ApplyResult applyReset(WindowCacheSink& sink, uint64_t seqno, std::vector<Record> rows,
+                           int cache_first, int total, uint64_t epoch, uint64_t high_water)
     {
-        if (seqno <= m_structural_seqno) return false;   // already reflected
+        if (seqno <= m_structural_seqno) return ApplyResult::AlreadyReflected;
         sink.beginReset();
         m_rows = std::move(rows);
         m_cache_first = cache_first;
@@ -145,19 +163,19 @@ public:
         m_epoch = epoch;
         sink.endReset();
         m_structural_seqno = high_water > seqno ? high_water : seqno;
-        return true;
+        return ApplyResult::Applied;
     }
 
     //! Structural Insert of `records.size()` rows at absolute `pos`. Shifts the
     //! cache base or splices into the slice as the position dictates (see below),
     //! grows m_total inside the begin/endInsert bracket, and advances the seqno.
-    bool applyInsert(WindowCacheSink& sink, uint64_t seqno, int pos,
-                     const std::vector<Record>& records)
+    ApplyResult applyInsert(WindowCacheSink& sink, uint64_t seqno, int pos,
+                            const std::vector<Record>& records)
     {
-        if (seqno <= m_structural_seqno) return false;   // already reflected
+        if (seqno <= m_structural_seqno) return ApplyResult::AlreadyReflected;
         const int count = static_cast<int>(records.size());
-        if (count <= 0) return false;                    // empty insert: nothing to do
-        if (pos < 0 || pos > m_total) return false;      // out of range: drop defensively
+        if (count <= 0) return ApplyResult::Rejected;    // empty insert: nothing to do
+        if (pos < 0 || pos > m_total) return ApplyResult::Rejected;
 
         const int base = m_cache_first;
         const int len = static_cast<int>(m_rows.size());
@@ -177,18 +195,18 @@ public:
         // pos > base + len: entirely after the window; only m_total changed.
         sink.endInsert();
         m_structural_seqno = seqno;
-        return true;
+        return ApplyResult::Applied;
     }
 
     //! Structural Remove of `count` rows at absolute `pos`. Erases the overlap
     //! with the slice and shifts the cache base down by however many removed rows
     //! were strictly before it; shrinks m_total inside the begin/endRemove bracket.
-    bool applyRemove(WindowCacheSink& sink, uint64_t seqno, int pos, int count)
+    ApplyResult applyRemove(WindowCacheSink& sink, uint64_t seqno, int pos, int count)
     {
-        if (seqno <= m_structural_seqno) return false;   // already reflected
+        if (seqno <= m_structural_seqno) return ApplyResult::AlreadyReflected;
         // Subtraction form, not pos+count > m_total: avoids int wrap on pathological
         // input (count > 0 holds by short-circuit when the comparison is reached).
-        if (count <= 0 || pos < 0 || pos > m_total - count) return false;
+        if (count <= 0 || pos < 0 || pos > m_total - count) return ApplyResult::Rejected;
 
         const int base = m_cache_first;
         const int len = static_cast<int>(m_rows.size());
@@ -209,7 +227,7 @@ public:
         m_cache_first = base - removed_before_cache;
         sink.endRemove();
         m_structural_seqno = seqno;
-        return true;
+        return ApplyResult::Applied;
     }
 
     //! Structural Change: `count` rows at absolute `pos` were refreshed in place
@@ -222,13 +240,13 @@ public:
     //! once. If `fresh` is shorter than `count` (a contract violation), the uncovered
     //! rows keep their cached values rather than reading out of bounds; the content
     //! channel refreshes them on the next fetch.
-    bool applyChange(WindowCacheSink& sink, uint64_t seqno, int pos, int count,
-                     const std::vector<Record>& fresh)
+    ApplyResult applyChange(WindowCacheSink& sink, uint64_t seqno, int pos, int count,
+                            const std::vector<Record>& fresh)
     {
-        if (seqno <= m_structural_seqno) return false;   // already reflected
+        if (seqno <= m_structural_seqno) return ApplyResult::AlreadyReflected;
         // Subtraction form, not pos+count > m_total: avoids int wrap on pathological
         // input (count > 0 holds by short-circuit when the comparison is reached).
-        if (count <= 0 || pos < 0 || pos > m_total - count) return false;
+        if (count <= 0 || pos < 0 || pos > m_total - count) return ApplyResult::Rejected;
 
         const int base = m_cache_first;
         const int len = static_cast<int>(m_rows.size());
@@ -249,7 +267,7 @@ public:
         if (updated_lo >= 0) {
             sink.dataChanged(updated_lo, updated_hi - updated_lo + 1);
         }
-        return true;
+        return ApplyResult::Applied;
     }
 
     // ---- content channel ---------------------------------------------------

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -89,6 +89,11 @@ add_executable(test_gridcoin
     # null-wallet-safe getRowDetail early-returns. Core lives in gridcoin_util,
     # so only the suite is listed here (GUI-OFF).
     qt_wallettxstore_tests.cpp
+    # The WALLET-BACKED half of the same store: applyChainTipRefresh() and prime()
+    # need a live CWallet plus a chain tip, so the null-wallet suite above cannot
+    # reach them at all. This one drives the real coinstake NotAccepted -> flip-in
+    # path against pwalletMain and a mock chain (#3257).
+    qt_wallettxstore_chain_tests.cpp
     # Multiprocess connect-handshake logic (src/ipc/handshake.cpp): identity-token
     # hashing, the ClientHandshake matching policy, and CheckIdentityBinding. The
     # TU has no Cap'n Proto / libmultiprocess dependency, so it compiles into the

--- a/src/test/qt_cursor_tests.cpp
+++ b/src/test/qt_cursor_tests.cpp
@@ -13,11 +13,14 @@
 
 #include <wallet/cursor.h>
 #include <interfaces/wallet_tx_filter.h>
+#include <tinyformat.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -76,6 +79,87 @@ Rec active(int64_t time, const std::string& ssort = "") { Rec r; r.time = time; 
 // Count deltas of a given type.
 int countType(const std::vector<CursorDelta>& d, CursorDelta::Type t) {
     int n = 0; for (const auto& x : d) if (x.type == t) ++n; return n;
+}
+
+//! A served-window replica driven ONLY by the emitted deltas, holding stable row
+//! identities (the addr field) rather than absolute indices — exactly what a real
+//! consumer holds, since absolute indices renumber under it invisibly.
+//!
+//! Comparing this against the cursor's own served window is the contract the
+//! whole delta protocol exists to satisfy, and it is what the position-only
+//! assertions elsewhere in this suite cannot check: they verify WHERE a delta
+//! points, never WHICH row it carries.
+struct ServedReplica {
+    std::vector<std::string> ids;
+    bool bad = false;
+
+    void apply(const std::vector<CursorDelta>& deltas, const Cursor& cur, const Table& t)
+    {
+        for (const CursorDelta& d : deltas) {
+            switch (d.type) {
+            case CursorDelta::Reset:
+                ids = servedIds(cur, t);
+                break;
+            case CursorDelta::Insert: {
+                if (d.first < 0 || static_cast<std::size_t>(d.first) > ids.size()
+                        || d.rows.size() != static_cast<std::size_t>(d.count)) {
+                    bad = true;
+                    break;
+                }
+                std::vector<std::string> add;
+                for (std::size_t absidx : d.rows) {
+                    if (absidx >= t.rows.size()) { bad = true; break; }
+                    add.push_back(t.rows[absidx].addr);
+                }
+                if (bad) break;
+                ids.insert(ids.begin() + d.first, add.begin(), add.end());
+                break;
+            }
+            case CursorDelta::Remove:
+                if (d.first < 0 || d.count <= 0
+                        || static_cast<std::size_t>(d.first) + static_cast<std::size_t>(d.count)
+                               > ids.size()) {
+                    bad = true;
+                    break;
+                }
+                ids.erase(ids.begin() + d.first, ids.begin() + d.first + d.count);
+                break;
+            case CursorDelta::Change:
+                break;   // content-only; no structural effect
+            }
+        }
+    }
+
+    static std::vector<std::string> servedIds(const Cursor& cur, const Table& t)
+    {
+        std::vector<std::string> out;
+        for (std::size_t i = 0; i < cur.servedCount(); ++i) {
+            const std::size_t absidx = cur.viewIndex()[i];
+            out.push_back(absidx < t.rows.size() ? t.rows[absidx].addr : std::string("<oob>"));
+        }
+        return out;
+    }
+};
+
+void checkServedMatches(const Cursor& cur, const Table& t, const ServedReplica& rep)
+{
+    BOOST_CHECK_MESSAGE(!rep.bad, "a delta was unusable: bad position, wrong row count, "
+                                  "or an out-of-range record index");
+    const std::vector<std::string> served = ServedReplica::servedIds(cur, t);
+    BOOST_CHECK_EQUAL_COLLECTIONS(rep.ids.begin(), rep.ids.end(), served.begin(), served.end());
+}
+
+//! `n` accepted rows in strict time-DESC order, so view order == absolute order
+//! and each row is identified by addr "rNN".
+Table descendingTable(int n)
+{
+    Table t;
+    for (int i = 0; i < n; ++i) {
+        Rec r = active(1000 + (n - i));
+        r.addr = strprintf("r%02d", i);
+        t.rows.push_back(r);
+    }
+    return t;
 }
 
 } // anonymous namespace
@@ -514,6 +598,120 @@ BOOST_AUTO_TEST_CASE(position_of_multipart_same_key_distinct_rows)
     // rowForKey(idx<0) takes the MIN accepted position across the parts -> abs0, row 1.
     BOOST_CHECK_EQUAL(std::min({c.positionOf(0), c.positionOf(1), c.positionOf(2)}), 1u);
     BOOST_CHECK(c.positionOf(7) == NPOS);
+}
+
+// ---- delta payloads must name the row they were emitted for -----------------
+
+BOOST_AUTO_TEST_CASE(multipart_remove_promotions_carry_the_promoted_row)
+{
+    // Removing a multi-part transaction from a CAPPED view emits its deltas
+    // against successive intermediate states: each erased part can promote an
+    // off-window row into the last visible slot, and the served window can end up
+    // SHORTER than the cap. So neither the coordinate nor the record of an earlier
+    // delta survives the batch, and the store must not re-derive either afterwards
+    // (#3257 review).
+    //
+    // Two shapes, both reachable when a coinstake is orphaned out of the Overview:
+    //   n = 10: the accepted set ends BELOW the cap, so the promotion coordinate
+    //           emitted while it was still above the cap now points past the end.
+    //   n = 11: the accepted set stays at the cap, but the surviving absolute
+    //           indices are renumbered by the store's erase, so a record index
+    //           captured mid-batch names the wrong row unless it is renumbered too.
+    for (const int n : {10, 11}) {
+        Table t = descendingTable(n);
+        FilterSpec spec;
+        spec.limit_rows = 9;
+        Cursor c(1, spec, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+
+        ServedReplica rep;
+        rep.apply(c.rebuild(t.rows.size()), c, t);
+        BOOST_REQUIRE_EQUAL(c.servedCount(), 9u);
+        checkServedMatches(c, t, rep);
+
+        // The store erases the transaction's parts from its record table BEFORE
+        // driving the cursors (WalletTxStore::removeLocked), so mirror that order.
+        t.rows.erase(t.rows.begin(), t.rows.begin() + 2);
+        rep.apply(c.applyStoreRemove(0, 2), c, t);
+
+        BOOST_CHECK_EQUAL(c.totalAccepted(), static_cast<std::size_t>(n - 2));
+        checkServedMatches(c, t, rep);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(multipart_remove_straddling_the_cap_names_no_doomed_row)
+{
+    // The nastiest shape: a transaction whose parts sit either side of the cap
+    // boundary — one served at the last visible slot, its sibling the first
+    // off-window row — AND at the end of the record table. Erasing the served part
+    // promotes the sibling into the window, and erasing the sibling then takes it
+    // straight back out; a delta naming that sibling names a record the store has
+    // already erased, which here is past the end of the shrunken table.
+    Table t = descendingTable(10);
+    FilterSpec spec;
+    spec.limit_rows = 9;
+    Cursor c(1, spec, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+
+    ServedReplica rep;
+    rep.apply(c.rebuild(t.rows.size()), c, t);
+    BOOST_REQUIRE_EQUAL(c.servedCount(), 9u);
+    // View order == absolute order, so absolute 8 is the last served row and
+    // absolute 9 is the first off-window one.
+    BOOST_REQUIRE_EQUAL(c.viewIndex()[8], 8u);
+
+    t.rows.erase(t.rows.begin() + 8, t.rows.begin() + 10);
+    const auto deltas = c.applyStoreRemove(8, 2);
+    rep.apply(deltas, c, t);
+
+    BOOST_CHECK_EQUAL(c.totalAccepted(), 8u);
+    checkServedMatches(c, t, rep);
+    // Every record an Insert names must exist in the post-erase table.
+    for (const CursorDelta& d : deltas) {
+        if (d.type != CursorDelta::Insert) continue;
+        BOOST_CHECK_EQUAL(d.rows.size(), static_cast<std::size_t>(d.count));
+        for (const std::size_t absidx : d.rows) {
+            BOOST_CHECK_MESSAGE(absidx < t.rows.size(),
+                                "Insert delta names record " << absidx << " of " << t.rows.size());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(multipart_insert_deltas_carry_distinct_rows_under_status_sort)
+{
+    // A two-part transaction whose parts sort in REVERSE absolute order: under a
+    // DESC status sort the trailing idx field of TransactionRecord's sortKey puts
+    // part idx 1 before part idx 0, so both Inserts land at the SAME slot. The two
+    // deltas must still carry different records — re-resolving the shared
+    // coordinate after the batch yielded the same row twice, duplicating one part
+    // and losing the other (the Overview half of #3101).
+    Table t;
+    t.rows = { active(900, "0000000300-0-0000000100-000") };
+    t.rows[0].addr = "seed";
+    FilterSpec spec;
+    Cursor c(1, spec, TXCOL_STATUS, TXSORT_DESC, t.fields(), t.keys());
+    ServedReplica rep;
+    rep.apply(c.rebuild(t.rows.size()), c, t);
+
+    // Two parts of one transaction at absolute [1, 3), same everything but idx.
+    Rec p0 = active(500, "0000000400-0-0000000200-000");
+    p0.addr = "part0";
+    Rec p1 = active(500, "0000000400-0-0000000200-001");
+    p1.addr = "part1";
+    t.rows.push_back(p0);
+    t.rows.push_back(p1);
+
+    const auto deltas = c.applyStoreInsert(1, 2);
+    rep.apply(deltas, c, t);
+
+    // Both parts are in the view, each named by exactly one delta.
+    BOOST_CHECK_EQUAL(c.totalAccepted(), 3u);
+    checkServedMatches(c, t, rep);
+    std::set<std::size_t> named;
+    for (const CursorDelta& d : deltas) {
+        if (d.type != CursorDelta::Insert) continue;
+        BOOST_CHECK_EQUAL(d.rows.size(), static_cast<std::size_t>(d.count));
+        for (std::size_t absidx : d.rows) named.insert(absidx);
+    }
+    BOOST_CHECK_EQUAL(named.size(), 2u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_wallettxstore_chain_tests.cpp
+++ b/src/test/qt_wallettxstore_chain_tests.cpp
@@ -229,6 +229,49 @@ std::size_t viewRowCount(WalletTxStore& store, int viewId)
     return store.getRows(viewId, 0, -1).records.size();
 }
 
+//! A wallet transaction that cannot be processed without throwing.
+//!
+//! Funds two MAX_MONEY outputs to `mine` in a mature block (each individually in
+//! range), then spends BOTH with one coinstake. CWallet::GetDebit sums per input
+//! and range-checks the running total, so the second input takes it past
+//! MAX_MONEY and it throws std::runtime_error. Both of the paths under test reach
+//! that: decomposeTransaction calls GetDebit() directly, and updateStatus reaches
+//! it via IsTrusted() -> IsFromMe() once the tx is at depth 1.
+//!
+//! \return the coinstake's hash. `funding_out` receives the funding tx hash so the
+//! caller can erase both.
+uint256 injectPoisonCoinstake(const CTxDestination& mine, const uint256& mature_block,
+                              const uint256& tip_block, uint256& funding_out)
+{
+    CMutableTransaction fund_mtx;
+    fund_mtx.vout.resize(2);
+    for (int i = 0; i < 2; ++i) {
+        fund_mtx.vout[i].nValue = MAX_MONEY;
+        fund_mtx.vout[i].scriptPubKey = P2PKH(mine);
+    }
+    const CTransaction fund(fund_mtx);
+    InjectConfirmedTx(fund, mature_block);
+    funding_out = fund.GetHash();
+
+    CMutableTransaction mtx;
+    mtx.vin.resize(2);
+    mtx.vin[0].prevout = COutPoint(fund.GetHash(), 0);
+    mtx.vin[1].prevout = COutPoint(fund.GetHash(), 1);
+    CTxOut empty;
+    empty.SetEmpty();
+    mtx.vout.push_back(empty);
+    CTxOut ret;
+    ret.nValue = 50 * COIN;
+    ret.scriptPubKey = P2PKH(mine);
+    mtx.vout.push_back(ret);
+    mtx.vout.push_back(ret);
+
+    const CTransaction poison(mtx);
+    BOOST_REQUIRE(poison.IsCoinStake());
+    InjectConfirmedTx(poison, tip_block);
+    return poison.GetHash();
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_SUITE(qt_wallettxstore_chain_tests)
@@ -338,34 +381,9 @@ BOOST_AUTO_TEST_CASE(oneUnrefreshableTxDoesNotFreezeTheRestOfTheWallet)
     OwnedKey mine;
     OwnedKey sidestake_dest;
 
-    // The poison transaction: a funding tx paying us two MAX_MONEY outputs (each
-    // individually in range), spent by a coinstake with two inputs — so GetDebit's
-    // running total leaves MoneyRange on the second input and throws.
-    CMutableTransaction fund_mtx;
-    fund_mtx.vout.resize(2);
-    for (int i = 0; i < 2; ++i) {
-        fund_mtx.vout[i].nValue = MAX_MONEY;
-        fund_mtx.vout[i].scriptPubKey = P2PKH(mine.dest);
-    }
-    const CTransaction fund(fund_mtx);
-    InjectConfirmedTx(fund, chain.hash_prev);   // deep/mature block
-
-    CMutableTransaction poison_mtx;
-    poison_mtx.vin.resize(2);
-    poison_mtx.vin[0].prevout = COutPoint(fund.GetHash(), 0);
-    poison_mtx.vin[1].prevout = COutPoint(fund.GetHash(), 1);
-    CTxOut empty;
-    empty.SetEmpty();
-    poison_mtx.vout.push_back(empty);
-    CTxOut ret;
-    ret.nValue = 50 * COIN;
-    ret.scriptPubKey = P2PKH(mine.dest);
-    poison_mtx.vout.push_back(ret);
-    poison_mtx.vout.push_back(ret);
-    const CTransaction poison(poison_mtx);
-    BOOST_REQUIRE(poison.IsCoinStake());
-    const uint256 poison_hash = poison.GetHash();
-    InjectConfirmedTx(poison, chain.hash_fresh);
+    uint256 fund_hash;
+    const uint256 poison_hash =
+        injectPoisonCoinstake(mine.dest, chain.hash_prev, chain.hash_fresh, fund_hash);
 
     WalletEventQueue q;
     WalletTxStore store(pwalletMain, q);
@@ -430,8 +448,65 @@ BOOST_AUTO_TEST_CASE(oneUnrefreshableTxDoesNotFreezeTheRestOfTheWallet)
     BOOST_CHECK_EQUAL(store.rowForKey(GRC::VIEW_DETAILED, poison_hash, 0), -1);
 
     EraseWalletTx(poison_hash);
-    EraseWalletTx(fund.GetHash());
+    EraseWalletTx(fund_hash);
     for (const uint256& h : good_hashes) EraseWalletTx(h);
+}
+
+//! prime()'s rescan can throw, and the intake worker must survive it.
+//!
+//! prime() quiesces the single intake worker (m_rebuilding = true) before
+//! rebuilding the store from mapWallet, and the worker's wait predicate is that
+//! flag. The rescan in between is not safe: decomposeTransaction calls GetCredit
+//! and GetDebit, which throw std::runtime_error outside MoneyRange, and
+//! updateStatus reaches GetGeneratedType, which hits the tx index and reads a
+//! block from disk.
+//!
+//! If the flag is cleared by falling off the end of the function, a throw leaves
+//! the worker parked FOREVER. Producers keep enqueuing successfully and m_intake
+//! grows without bound, while the inline applyChainTipRefresh keeps ripening rows
+//! already in the store — so the GUI shows existing transactions updating
+//! normally and never shows a new one again. Releasing the park from an RAII
+//! guard is what makes that unwind-safe, and this pins it (#3257).
+BOOST_AUTO_TEST_CASE(primeThatThrowsMidRescanStillReleasesTheIntakeWorker)
+{
+    PendingTipChain chain;
+    OwnedKey mine;
+    OwnedKey sidestake_dest;
+
+    uint256 fund_hash;
+    const uint256 poison_hash =
+        injectPoisonCoinstake(mine.dest, chain.hash_prev, chain.hash_fresh, fund_hash);
+    chain.connect();
+
+    WalletEventQueue q;
+    WalletTxStore store(pwalletMain, q);
+    registerProductionViews(store);
+    store.start();
+
+    // Premise: the rescan really does throw on this wallet. prime() has no
+    // try/catch by design — the guard exists to make the unwind safe, not to
+    // swallow it — so the exception is expected to reach the caller.
+    BOOST_CHECK_THROW(store.prime(false, 0), std::runtime_error);
+
+    // The worker must have been released on the way out. Drop the poison so the
+    // producer side is clean, then prove liveness the only way that counts: a new
+    // transaction enqueued AFTER the failed prime still has to reach the view.
+    EraseWalletTx(poison_hash);
+    EraseWalletTx(fund_hash);
+
+    const CTransaction good =
+        MakeCoinstake(mine.dest, 42 * COIN, sidestake_dest.dest, 1 * COIN);
+    const uint256 good_hash = good.GetHash();
+    InjectConfirmedTx(good, chain.hash_fresh);
+
+    store.enqueueInsert(producerRecordsFor(good_hash));
+    settle(q);
+
+    BOOST_CHECK_MESSAGE(store.rowForKey(GRC::VIEW_DETAILED, good_hash, 0) >= 0,
+                        "the intake worker never resumed after prime() threw — "
+                        "every later transaction would be invisible");
+
+    EraseWalletTx(good_hash);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_wallettxstore_chain_tests.cpp
+++ b/src/test/qt_wallettxstore_chain_tests.cpp
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF coverage for the WALLET-BACKED half of GRC::WalletTxStore — the half
+// qt_wallettxstore_tests.cpp cannot reach, because every case there constructs
+// the store with a nullptr wallet. That leaves applyChainTipRefresh() and
+// prime(), the two functions the entire coinstake lifecycle rests on, with no
+// coverage at all (#3257).
+//
+// Why that gap matters, and why simulating it is not good enough: with the
+// default filters a freshly staked coinstake is INVISIBLE at insert. The wallet
+// is notified of a block's transactions from inside ConnectBlock, before
+// SetBestChain advances pindexBest, so the block holding the coinstake is not
+// yet in the main chain and TransactionRecord::updateStatus takes the Generated
+// branch with !IsInMainChain() -> NotAccepted. GRC::Accepts masks
+// Conflicted/NotAccepted in BOTH production views. The row's only route onto the
+// screen is the later applyChainTipRefresh() -> Cursor::applyStatusUpdate()
+// flip-in. That single path carries every stake row in the GUI.
+//
+// The sibling suite approximates that flip with enqueueUpsert() and a re-stamped
+// record, which drives applyStatusUpdate() but bypasses applyChainTipRefresh()
+// entirely — so it passes whether or not the real path works. These cases build
+// a real CWallet transaction on a real (mock) chain and advance the tip, so the
+// refresh runs for real.
+//
+// Note also that no -regtest test can cover this: CMerkleTx::GetBlocksToMaturity()
+// short-circuits to 0 on a mockable chain (wallet.cpp), so a regtest stake is
+// stamped Confirmed on arrival and never enters the NotAccepted window.
+
+#include "key.h"
+#include "key_io.h"
+#include "main.h"
+#include "primitives/transaction.h"
+#include "rpc/blockchain.h"
+#include "test/test_gridcoin.h"
+#include "wallet/wallet.h"
+
+#include <interfaces/wallet_tx_filter.h>
+#include <interfaces/wallet_tx_record.h>
+#include <wallet/wallet_event_queue.h>
+#include <wallet/wallettxstore.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using GRC::WalletEventQueue;
+using GRC::WalletTxStore;
+
+extern CWallet* pwalletMain;
+
+namespace {
+
+//! Overview's cap: OverviewTxModel sets limit_rows = numItems * 3.
+constexpr int kOverviewCap = 9;
+
+//! Register the two cursors exactly as the Qt consumers do — DetailedTxModel a
+//! default FilterSpec (show_orphans=false, limit_rows=-1) sorted Date DESC,
+//! OverviewTxModel show_inactive=false plus a finite cap sorted Status DESC. Both
+//! therefore mask Conflicted/NotAccepted.
+void registerProductionViews(WalletTxStore& store)
+{
+    GRC::FilterSpec detail;
+    store.registerView(GRC::VIEW_DETAILED, detail, GRC::TXCOL_DATE, GRC::TXSORT_DESC);
+
+    GRC::FilterSpec overview;
+    overview.show_inactive = false;
+    overview.limit_rows = kOverviewCap;
+    store.registerView(GRC::VIEW_OVERVIEW, overview, GRC::TXCOL_STATUS, GRC::TXSORT_DESC);
+}
+
+//! Wait until the intake worker stops producing, so a test can assert on the
+//! ABSENCE of per-view events without racing it.
+void settle(WalletEventQueue& q)
+{
+    std::size_t last = q.size();
+    int stable = 0;
+    for (int i = 0; i < 400 && stable < 4; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        const std::size_t now = q.size();
+        stable = (now == last) ? stable + 1 : 0;
+        last = now;
+    }
+}
+
+//! A mock chain holding a block that is BUILT but not yet CONNECTED — exactly the
+//! window applyChainTipRefresh exists to close.
+//!
+//! `fresh->pprev == prev` and `pindexBest == prev`, but `prev->pnext` is left null,
+//! which is what CBlockIndex::IsInMainChain() tests. So a transaction confirmed in
+//! `fresh` reads as not-in-main-chain, precisely as it does inside ConnectBlock
+//! before SetBestChain runs. connect() then does what node/chainman.cpp does after
+//! ConnectBlock returns: links the block in and advances the tip.
+struct PendingTipChain
+{
+    CBlockIndex* saved_best;
+    uint256 hash_prev;
+    uint256 hash_fresh;
+    CBlockIndex* prev;
+    CBlockIndex* fresh;
+
+    PendingTipChain()
+    {
+        LOCK(cs_main);
+        saved_best = pindexBest;
+        hash_prev = InsecureRand256();
+        hash_fresh = InsecureRand256();
+        // InsertBlockIndex points phashBlock at the mapBlockIndex key, so teardown
+        // is a plain erase — the index comes from BlockIndexPool and is never deleted.
+        prev = GRC::MockBlockIndex::InsertBlockIndex(hash_prev);
+        fresh = GRC::MockBlockIndex::InsertBlockIndex(hash_fresh);
+        // High enough that a tx in `prev` is mature, so only `fresh` is immature.
+        prev->nHeight = nCoinbaseMaturity + 50;
+        fresh->nHeight = prev->nHeight + 1;
+        fresh->pprev = prev;
+        // prev->pnext deliberately NOT set yet: that is what makes `fresh` read as
+        // not-in-main-chain and stamps the coinstake NotAccepted.
+        pindexBest = prev;
+    }
+
+    void connect()
+    {
+        LOCK(cs_main);
+        prev->pnext = fresh;
+        pindexBest = fresh;
+    }
+
+    ~PendingTipChain()
+    {
+        LOCK(cs_main);
+        pindexBest = saved_best;
+        prev->pnext = nullptr;
+        fresh->pprev = nullptr;
+        mapBlockIndex.erase(hash_prev);
+        mapBlockIndex.erase(hash_fresh);
+    }
+};
+
+//! An owned key plus its destination — decomposeTransaction only emits a coinstake
+//! part when wallet->IsMine(vout[1]) != ISMINE_NO.
+struct OwnedKey
+{
+    CKey key;
+    CTxDestination dest;
+
+    OwnedKey()
+    {
+        key.MakeNewKey(false);
+        BOOST_REQUIRE(pwalletMain->AddKey(key));
+        dest = CTxDestination(key.GetPubKey().GetID());
+    }
+};
+
+CScript P2PKH(const CTxDestination& dest)
+{
+    CScript script;
+    script.SetDestination(dest);
+    return script;
+}
+
+//! A coinstake as CTransaction::IsCoinStake() defines it: a non-null prevout, an
+//! empty vout[0] marker, and at least two outputs. vout[1] is the stake return to
+//! `mine` (what decomposeTransaction keys the Generated part off); any further
+//! outputs are sidestakes.
+CTransaction MakeCoinstake(const CTxDestination& mine, int64_t stake_value,
+                           const CTxDestination& sidestake_to, int64_t sidestake_value)
+{
+    CMutableTransaction mtx;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(InsecureRand256(), 0);
+
+    CTxOut empty;
+    empty.SetEmpty();
+    mtx.vout.push_back(empty);
+
+    CTxOut stake_return;
+    stake_return.nValue = stake_value;
+    stake_return.scriptPubKey = P2PKH(mine);
+    mtx.vout.push_back(stake_return);
+
+    CTxOut sidestake;
+    sidestake.nValue = sidestake_value;
+    sidestake.scriptPubKey = P2PKH(sidestake_to);
+    mtx.vout.push_back(sidestake);
+
+    CTransaction tx(mtx);
+    BOOST_REQUIRE(tx.IsCoinStake());
+    return tx;
+}
+
+void InjectConfirmedTx(const CTransaction& tx, const uint256& block_hash)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    CWalletTx wtx(pwalletMain, tx);
+    wtx.SetTxState(TxStateConfirmed{block_hash, 0});
+    pwalletMain->mapWallet[tx.GetHash()] = wtx;
+}
+
+void EraseWalletTx(const uint256& hash)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    pwalletMain->mapWallet.erase(hash);
+}
+
+//! Reproduce exactly what WalletTxSourceImpl::onTransactionChanged does on CT_NEW:
+//! decompose under the core locks and stamp each part's status producer-side.
+std::vector<TransactionRecord> producerRecordsFor(const uint256& hash)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    auto it = pwalletMain->mapWallet.find(hash);
+    BOOST_REQUIRE(it != pwalletMain->mapWallet.end());
+    const CWalletTx& wtx = it->second;
+
+    std::vector<TransactionRecord> recs =
+        TransactionRecord::decomposeTransaction(pwalletMain, wtx);
+    for (TransactionRecord& rec : recs) {
+        rec.updateStatus(wtx);
+        rec.populateDisplayLabel(*pwalletMain);
+    }
+    return recs;
+}
+
+std::size_t viewRowCount(WalletTxStore& store, int viewId)
+{
+    return store.getRows(viewId, 0, -1).records.size();
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(qt_wallettxstore_chain_tests)
+
+//! THE #3257 CASE. A coinstake arrives in the pre-tip window (NotAccepted, masked
+//! in both views), the block is then connected, and the per-tip refresh must flip
+//! it into both views. This drives the REAL applyChainTipRefresh against a real
+//! CWallet — the path with no prior coverage — rather than simulating it with an
+//! upsert.
+BOOST_AUTO_TEST_CASE(coinstakeFlipsIntoBothViewsOnRealChainTipRefresh)
+{
+    PendingTipChain chain;
+    OwnedKey mine;
+    OwnedKey foreign_dest;   // a distinct destination for the sidestake part
+
+    const CTransaction cs = MakeCoinstake(mine.dest, 50 * COIN, foreign_dest.dest, 1 * COIN);
+    const uint256 cs_hash = cs.GetHash();
+    InjectConfirmedTx(cs, chain.hash_fresh);
+
+    WalletEventQueue q;
+    WalletTxStore store(pwalletMain, q);
+    registerProductionViews(store);
+    store.start();
+
+    const std::vector<TransactionRecord> recs = producerRecordsFor(cs_hash);
+    BOOST_REQUIRE(!recs.empty());
+
+    // Precondition — the pre-tip window really does stamp NotAccepted. If this
+    // ever stops holding, the rest of the case is vacuous, so assert it.
+    BOOST_CHECK_EQUAL(static_cast<int>(recs[0].status.status),
+                      static_cast<int>(TransactionStatus::NotAccepted));
+
+    store.enqueueInsert(recs);
+    settle(q);
+
+    // Masked in both production views while NotAccepted — the invariant that makes
+    // the flip-in load-bearing.
+    BOOST_CHECK_EQUAL(viewRowCount(store, GRC::VIEW_DETAILED), 0u);
+    BOOST_CHECK_EQUAL(viewRowCount(store, GRC::VIEW_OVERVIEW), 0u);
+
+    // Connect the block and drive the real per-tip refresh, as onBlocksChanged does.
+    chain.connect();
+    {
+        LOCK(cs_main);
+        store.applyChainTipRefresh();
+    }
+
+    // The whole point of the issue: the rows must now be visible in BOTH views.
+    BOOST_CHECK_EQUAL(viewRowCount(store, GRC::VIEW_DETAILED), recs.size());
+    BOOST_CHECK_EQUAL(viewRowCount(store, GRC::VIEW_OVERVIEW), recs.size());
+
+    EraseWalletTx(cs_hash);
+}
+
+//! prime() against a real wallet: the rebuild must pick the coinstake up and, once
+//! the block is connected, present it in both views. This is the path that has been
+//! masking the bug in the field — every stake a user sees may have arrived via a
+//! restart's prime() rather than a live flip-in — so pin it explicitly.
+BOOST_AUTO_TEST_CASE(primeRebuildsCoinstakeRowsFromTheWallet)
+{
+    PendingTipChain chain;
+    OwnedKey mine;
+    OwnedKey foreign_dest;
+
+    const CTransaction cs = MakeCoinstake(mine.dest, 50 * COIN, foreign_dest.dest, 1 * COIN);
+    const uint256 cs_hash = cs.GetHash();
+    InjectConfirmedTx(cs, chain.hash_fresh);
+
+    // Connect first, so the rescan sees a settled, in-main-chain coinstake.
+    chain.connect();
+
+    WalletEventQueue q;
+    WalletTxStore store(pwalletMain, q);
+    registerProductionViews(store);
+    store.start();
+
+    store.prime(false, 0);
+    settle(q);
+
+    const std::size_t parts = producerRecordsFor(cs_hash).size();
+    BOOST_REQUIRE(parts > 0);
+    BOOST_CHECK_EQUAL(viewRowCount(store, GRC::VIEW_DETAILED), parts);
+
+    EraseWalletTx(cs_hash);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_wallettxstore_chain_tests.cpp
+++ b/src/test/qt_wallettxstore_chain_tests.cpp
@@ -315,4 +315,123 @@ BOOST_AUTO_TEST_CASE(primeRebuildsCoinstakeRowsFromTheWallet)
     EraseWalletTx(cs_hash);
 }
 
+//! One transaction that cannot be refreshed must not stop the refresh of every
+//! other volatile transaction in the wallet.
+//!
+//! updateStatus() reaches IsTrusted() -> IsFromMe() -> GetDebit(), which throws
+//! std::runtime_error once the summed debit leaves MoneyRange. At depth 1 — which
+//! is exactly where a freshly staked block sits — that path is always taken, so a
+//! wallet holding such a transaction throws on every single chain-tip refresh.
+//!
+//! Unguarded, that exception unwinds the whole m_volatile loop, so every hash
+//! after it in iteration order is skipped. Those rows never leave NotAccepted,
+//! both production views mask inactive rows, and the staked blocks behind the
+//! poison record stay invisible until a prime() rebuilds the set — the #3257
+//! fingerprint. m_volatile is an unordered_set, so position is by bucket; this
+//! case seeds enough good transactions that some are guaranteed to sort behind
+//! the poison one whatever the bucket layout.
+BOOST_AUTO_TEST_CASE(oneUnrefreshableTxDoesNotFreezeTheRestOfTheWallet)
+{
+    constexpr int kGood = 20;
+
+    PendingTipChain chain;
+    OwnedKey mine;
+    OwnedKey sidestake_dest;
+
+    // The poison transaction: a funding tx paying us two MAX_MONEY outputs (each
+    // individually in range), spent by a coinstake with two inputs — so GetDebit's
+    // running total leaves MoneyRange on the second input and throws.
+    CMutableTransaction fund_mtx;
+    fund_mtx.vout.resize(2);
+    for (int i = 0; i < 2; ++i) {
+        fund_mtx.vout[i].nValue = MAX_MONEY;
+        fund_mtx.vout[i].scriptPubKey = P2PKH(mine.dest);
+    }
+    const CTransaction fund(fund_mtx);
+    InjectConfirmedTx(fund, chain.hash_prev);   // deep/mature block
+
+    CMutableTransaction poison_mtx;
+    poison_mtx.vin.resize(2);
+    poison_mtx.vin[0].prevout = COutPoint(fund.GetHash(), 0);
+    poison_mtx.vin[1].prevout = COutPoint(fund.GetHash(), 1);
+    CTxOut empty;
+    empty.SetEmpty();
+    poison_mtx.vout.push_back(empty);
+    CTxOut ret;
+    ret.nValue = 50 * COIN;
+    ret.scriptPubKey = P2PKH(mine.dest);
+    poison_mtx.vout.push_back(ret);
+    poison_mtx.vout.push_back(ret);
+    const CTransaction poison(poison_mtx);
+    BOOST_REQUIRE(poison.IsCoinStake());
+    const uint256 poison_hash = poison.GetHash();
+    InjectConfirmedTx(poison, chain.hash_fresh);
+
+    WalletEventQueue q;
+    WalletTxStore store(pwalletMain, q);
+    registerProductionViews(store);
+    store.start();
+
+    // The poison record goes in hand-built: decomposeTransaction would itself throw
+    // on this wallet tx, and what is under test is the REFRESH loop, not decompose.
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        TransactionRecord rec(poison_hash, pwalletMain->mapWallet[poison_hash].GetTxTime());
+        rec.type = TransactionRecord::Generated;
+        rec.idx = 0;
+        rec.vout = 1;
+        rec.status.status = TransactionStatus::NotAccepted;   // volatile, so it is refreshed
+        store.enqueueInsert({rec});
+    }
+
+    std::vector<uint256> good_hashes;
+    for (int i = 0; i < kGood; ++i) {
+        const CTransaction cs =
+            MakeCoinstake(mine.dest, (10 + i) * COIN, sidestake_dest.dest, 1 * COIN);
+        InjectConfirmedTx(cs, chain.hash_fresh);
+        good_hashes.push_back(cs.GetHash());
+        store.enqueueInsert(producerRecordsFor(cs.GetHash()));
+    }
+    settle(q);
+
+    // All masked while NotAccepted.
+    BOOST_CHECK_EQUAL(viewRowCount(store, GRC::VIEW_DETAILED), 0u);
+
+    chain.connect();
+
+    // Confirm the premise rather than assuming it: with the block connected the
+    // poison tx sits at depth 1, so IsTrusted() takes the IsFromMe() -> GetDebit()
+    // path and really does throw. Without this the whole case could pass vacuously.
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        const CWalletTx& pwtx = pwalletMain->mapWallet[poison_hash];
+        TransactionRecord probe(poison_hash, pwtx.GetTxTime());
+        probe.type = TransactionRecord::Generated;
+        probe.vout = 1;
+        BOOST_CHECK_THROW(probe.updateStatus(pwtx), std::runtime_error);
+    }
+
+    {
+        LOCK(cs_main);
+        store.applyChainTipRefresh();   // must not propagate
+    }
+
+    // Every good transaction must have flipped in, wherever the poison record
+    // landed in the bucket order. Two parts each (stake return + sidestake).
+    BOOST_CHECK_EQUAL(viewRowCount(store, GRC::VIEW_DETAILED),
+                      static_cast<std::size_t>(kGood) * 2u);
+    for (const uint256& h : good_hashes) {
+        BOOST_CHECK_MESSAGE(store.rowForKey(GRC::VIEW_DETAILED, h, 0) >= 0,
+                            "good coinstake " + h.GetHex() + " never reached the view");
+    }
+
+    // And the poison record is still masked — it threw, was skipped, and did not
+    // silently succeed. This is what keeps the assertions above meaningful.
+    BOOST_CHECK_EQUAL(store.rowForKey(GRC::VIEW_DETAILED, poison_hash, 0), -1);
+
+    EraseWalletTx(poison_hash);
+    EraseWalletTx(fund.GetHash());
+    for (const uint256& h : good_hashes) EraseWalletTx(h);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_wallettxstore_tests.cpp
+++ b/src/test/qt_wallettxstore_tests.cpp
@@ -13,15 +13,19 @@
 // validation, exactly as the PR2 store proper was.
 
 #include <arith_uint256.h>
+#include <interfaces/wallet_tx_filter.h>
 #include <interfaces/wallet_tx_record.h>
+#include <tinyformat.h>
 #include <wallet/wallet_event_queue.h>
 #include <wallet/wallettxstore.h>
 #include <uint256.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <set>
+#include <string>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -90,6 +94,206 @@ GRC::FilterSpec permissiveSpec()
     GRC::FilterSpec spec;
     spec.show_orphans = true;
     return spec;
+}
+
+//
+// ---- coinstake-lifecycle harness (issue #3257) -----------------------------
+//
+// The cases above use synthetic single-part records and a permissive filter. The
+// #3257 lifecycle needs the real thing: the PRODUCTION view configurations, and
+// records carrying the status and status.sortKey the producer actually stamps.
+//
+
+constexpr int     kSeedRows      = 40;
+constexpr int     kBlocks        = 25;
+constexpr int     kOverviewCap   = 9;          //!< OverviewTxModel's resize-derived cap
+constexpr int64_t kBaseTime      = 1700000000;
+constexpr int     kBaseHeight    = 3200000;
+constexpr int     kStakeHashBase = 100000;     //!< disjoint from the seed hashes
+
+//! TransactionRecord::updateStatus's sort key, byte for byte
+//! (transactionrecord.cpp): "%010d-%01d-%010u-%03d" over
+//! (height, isCoinBase, nTimeReceived, idx) — note idx is the LAST field, so
+//! under a DESC status sort the parts of one transaction come out in REVERSE
+//! decompose order.
+std::string statusSortKey(int height, unsigned int time_received, int idx)
+{
+    return strprintf("%010d-%01d-%010u-%03d", height, 0, time_received, idx);
+}
+
+//! The two records decomposeTransaction produces for a sidestaking coinstake:
+//! part idx 0 is the gross stake (vout 1, credit = every output, debit = the
+//! consumed input) and part idx 1 is the sidestake sent away (vout 2). Both are
+//! type Generated and share hash/time, differing only in idx — which is exactly
+//! what makes them a contiguous multi-part run in the store.
+std::vector<TransactionRecord> makeCoinstake(const uint256& hash, int64_t time, int height,
+                                             TransactionStatus::Status status)
+{
+    std::vector<TransactionRecord> parts;
+    for (int idx = 0; idx < 2; ++idx) {
+        TransactionRecord r(hash, time);
+        r.idx = idx;
+        r.vout = static_cast<unsigned int>(idx + 1);
+        r.type = TransactionRecord::Generated;
+        if (idx == 0) {
+            r.address = "mStakeReturnAddress";
+            r.credit  = 1000000000;   // gross: returned principal + reward
+            r.debit   = -900000000;   // the staked input
+        } else {
+            r.address = "mSideStakeAddress";
+            r.debit   = -10000000;
+        }
+        r.status.status = status;
+        r.status.generated_type = GRC::MinedType::POR;
+        r.status.sortKey = statusSortKey(height, static_cast<unsigned int>(time), idx);
+        parts.push_back(r);
+    }
+    return parts;
+}
+
+//! A settled single-part received payment, for seeding history.
+std::vector<TransactionRecord> makePayment(const uint256& hash, int64_t time, int height)
+{
+    TransactionRecord r(hash, time);
+    r.idx = 0;
+    r.type = TransactionRecord::RecvWithAddress;
+    r.address = "mSeedAddress";
+    r.credit = 100000000;
+    r.status.status = TransactionStatus::Confirmed;
+    r.status.sortKey = statusSortKey(height, static_cast<unsigned int>(time), 0);
+    return {r};
+}
+
+//! Register the two cursors exactly as the Qt consumers do: DetailedTxModel uses
+//! a default FilterSpec (show_orphans=false, show_inactive=true, limit_rows=-1)
+//! sorted Date DESC; OverviewTxModel sets show_inactive=false and a finite cap,
+//! sorted Status DESC. Both therefore mask Conflicted/NotAccepted rows.
+void registerProductionViews(WalletTxStore& store)
+{
+    GRC::FilterSpec detail;
+    store.registerView(GRC::VIEW_DETAILED, detail, GRC::TXCOL_DATE, GRC::TXSORT_DESC);
+
+    GRC::FilterSpec overview;
+    overview.show_inactive = false;
+    overview.limit_rows = kOverviewCap;
+    store.registerView(GRC::VIEW_OVERVIEW, overview, GRC::TXCOL_STATUS, GRC::TXSORT_DESC);
+}
+
+//! Wait until the worker stops producing: the queue depth must hold steady for
+//! several polls. Unlike waitForQueue this needs no expected count, so a test can
+//! assert on the ABSENCE of per-view events without racing the worker.
+void settle(WalletEventQueue& q)
+{
+    std::size_t last = q.size();
+    int stable = 0;
+    for (int i = 0; i < 400 && stable < 4; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        const std::size_t now = q.size();
+        stable = (now == last) ? stable + 1 : 0;
+        last = now;
+    }
+}
+
+//! Row identity: (hash, idx) is what uniquely names a decomposed part.
+using RowKey = std::pair<uint256, int>;
+
+std::vector<RowKey> keysOf(const std::vector<TransactionRecord>& recs)
+{
+    std::vector<RowKey> out;
+    out.reserve(recs.size());
+    for (const TransactionRecord& r : recs) out.emplace_back(r.hash, r.idx);
+    return out;
+}
+
+std::string describe(const RowKey& k)
+{
+    // Last 8 hex digits: uint256 prints big-endian-reversed, so the leading ones
+    // are all zeros for the small synthetic hashes these tests use.
+    const std::string hex = k.first.GetHex();
+    return hex.substr(hex.size() - 8) + "/" + strprintf("%d", k.second);
+}
+
+//! A consumer replica driven PURELY by the event stream, mirroring what
+//! OverviewTxModel and DetailedTxModel do: splice a RowsInserted payload's
+//! records in at the stamped position, erase a RowsRemoved range, refetch on
+//! Change/Reset. The contract every consumer depends on is that this replica
+//! equals the store's own served window at every quiescent point — so comparing
+//! the two catches both a lost insert (the #3257 shape) and a delta whose
+//! payload does not match the slot it names.
+struct Replica
+{
+    explicit Replica(int id) : viewId(id) {}
+
+    int viewId;
+    std::vector<RowKey> rows;
+    //! Set if a delta named a position outside the replica: the producer and the
+    //! consumer have diverged, which the real consumers silently swallow.
+    bool out_of_range = false;
+
+    void apply(const std::vector<GRC::WalletEvent>& batch, WalletTxStore& store)
+    {
+        for (const GRC::WalletEvent& ev : batch) {
+            if (const auto* p = std::get_if<GRC::RowsResetPayload>(&ev.payload)) {
+                if (p->viewId != viewId) continue;
+                rows = keysOf(store.getRows(viewId, 0, -1).records);
+            } else if (const auto* p = std::get_if<GRC::RowsInsertedPayload>(&ev.payload)) {
+                if (p->viewId != viewId) continue;
+                if (p->position < 0
+                        || static_cast<std::size_t>(p->position) > rows.size()) {
+                    out_of_range = true;
+                    continue;
+                }
+                const std::vector<RowKey> k = keysOf(p->records);
+                rows.insert(rows.begin() + p->position, k.begin(), k.end());
+            } else if (const auto* p = std::get_if<GRC::RowsRemovedPayload>(&ev.payload)) {
+                if (p->viewId != viewId) continue;
+                if (p->position < 0 || p->count <= 0
+                        || static_cast<std::size_t>(p->position) + static_cast<std::size_t>(p->count)
+                               > rows.size()) {
+                    out_of_range = true;
+                    continue;
+                }
+                rows.erase(rows.begin() + p->position, rows.begin() + p->position + p->count);
+            } else if (const auto* p = std::get_if<GRC::RowsChangedPayload>(&ev.payload)) {
+                if (p->viewId != viewId) continue;
+                // A Change carries no records; the consumers refetch the slice.
+                const std::vector<RowKey> fresh =
+                    keysOf(store.getRows(viewId, p->first, p->count).records);
+                for (std::size_t i = 0; i < fresh.size()
+                        && static_cast<std::size_t>(p->first) + i < rows.size(); ++i) {
+                    rows[static_cast<std::size_t>(p->first) + i] = fresh[i];
+                }
+            }
+        }
+    }
+};
+
+void applyBatch(const std::vector<GRC::WalletEvent>& batch, WalletTxStore& store,
+                Replica& a, Replica& b)
+{
+    a.apply(batch, store);
+    b.apply(batch, store);
+}
+
+//! The core invariant: a replica built only from the deltas must equal what the
+//! store serves for that view.
+void checkReplicaMatchesStore(WalletTxStore& store, const Replica& replica)
+{
+    BOOST_CHECK_MESSAGE(!replica.out_of_range,
+                        "view " << replica.viewId << ": a delta named an out-of-range position");
+
+    const std::vector<RowKey> served = keysOf(store.getRows(replica.viewId, 0, -1).records);
+    BOOST_CHECK_MESSAGE(replica.rows.size() == served.size(),
+                        "view " << replica.viewId << ": replica has " << replica.rows.size()
+                                << " rows, store serves " << served.size());
+
+    const std::size_t n = std::min(replica.rows.size(), served.size());
+    for (std::size_t i = 0; i < n; ++i) {
+        BOOST_CHECK_MESSAGE(replica.rows[i] == served[i],
+                            "view " << replica.viewId << " row " << i << ": replica has "
+                                    << describe(replica.rows[i]) << ", store serves "
+                                    << describe(served[i]));
+    }
 }
 
 } // anonymous namespace
@@ -291,6 +495,121 @@ BOOST_AUTO_TEST_CASE(unregisterViewIsIdempotent)
     q.drain();
     store.registerView(GRC::VIEW_DETAILED, permissiveSpec(), GRC::TXCOL_DATE, GRC::TXSORT_DESC);
     BOOST_CHECK(batchHasViewId(q.drain(), GRC::VIEW_DETAILED));
+}
+
+//
+// Coinstake lifecycle coverage (issue #3257).
+//
+// The cases below replay what actually happens to a staked block, which the
+// suite above never did: a live coinstake is stamped NotAccepted at CT_NEW
+// (the wallet is notified inside ConnectBlock, before pindexBest advances), both
+// production view filters mask inactive rows, and the row's ONLY route into
+// either view is the later applyChainTipRefresh -> applyStatusUpdate flip-in.
+// They use the production view configurations rather than permissiveSpec(),
+// because the masking IS the thing under test.
+//
+
+BOOST_AUTO_TEST_CASE(coinstakeNotAcceptedIsMaskedThenFlipsIntoBothViews)
+{
+    WalletEventQueue q;
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    registerProductionViews(store);
+    q.drain();   // the two registration Resets
+
+    Replica detail(GRC::VIEW_DETAILED);
+    Replica overview(GRC::VIEW_OVERVIEW);
+
+    // Seed history so the views are non-trivial and the Overview cap binds.
+    for (int i = 0; i < kSeedRows; ++i) {
+        store.enqueueInsert(makePayment(hashOf(i), kBaseTime + i, kBaseHeight + i));
+    }
+    settle(q);
+    applyBatch(q.drain(), store, detail, overview);
+    BOOST_CHECK_EQUAL(store.getRows(GRC::VIEW_DETAILED, 0, -1).total_accepted, kSeedRows);
+
+    // Replay blocks: each mines a two-part coinstake that arrives NotAccepted and
+    // is flipped to Immature by the next tip advance.
+    for (int b = 0; b < kBlocks; ++b) {
+        const uint256 h = hashOf(kStakeHashBase + b);
+        const int64_t t = kBaseTime + kSeedRows + b;
+        const int height = kBaseHeight + kSeedRows + b;
+        const int before = store.getRows(GRC::VIEW_DETAILED, 0, -1).total_accepted;
+
+        // (a) CT_NEW inside block connection: both parts NotAccepted.
+        store.enqueueInsert(makeCoinstake(h, t, height, TransactionStatus::NotAccepted));
+        settle(q);
+        auto masked = q.drain();
+
+        // The record enters m_records (native VIEW_FULL stream) but neither cursor
+        // accepts it: Accepts() rejects inactive rows under both production specs.
+        BOOST_CHECK(batchHasViewId(masked, GRC::VIEW_FULL));
+        BOOST_CHECK(!batchHasViewId(masked, GRC::VIEW_DETAILED));
+        BOOST_CHECK(!batchHasViewId(masked, GRC::VIEW_OVERVIEW));
+        BOOST_CHECK_EQUAL(store.getRows(GRC::VIEW_DETAILED, 0, -1).total_accepted, before);
+        applyBatch(masked, store, detail, overview);
+
+        // (b) The tip advanced and the block matured into the chain. This is the
+        // wallet-free stand-in for applyChainTipRefresh: updateTransaction's
+        // in-place path drives Cursor::applyStatusUpdate exactly as the per-tip
+        // refresh does, one part at a time.
+        store.enqueueUpsert(makeCoinstake(h, t, height, TransactionStatus::Immature));
+        settle(q);
+        applyBatch(q.drain(), store, detail, overview);
+
+        // Both views must now show the pair. A regression of the #3257 shape
+        // stalls this at the first iteration.
+        BOOST_CHECK_EQUAL(store.getRows(GRC::VIEW_DETAILED, 0, -1).total_accepted, before + 2);
+        checkReplicaMatchesStore(store, detail);
+        checkReplicaMatchesStore(store, overview);
+    }
+
+    BOOST_CHECK_EQUAL(store.getRows(GRC::VIEW_DETAILED, 0, -1).total_accepted,
+                      kSeedRows + 2 * kBlocks);
+    // The newest stake is resolvable by identity, i.e. it really is in the view.
+    BOOST_CHECK(store.rowForKey(GRC::VIEW_DETAILED, hashOf(kStakeHashBase + kBlocks - 1), 0) >= 0);
+}
+
+BOOST_AUTO_TEST_CASE(multiPartInsertDeltaPayloadsMatchServedSlots)
+{
+    WalletEventQueue q;
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    registerProductionViews(store);
+    q.drain();
+
+    Replica detail(GRC::VIEW_DETAILED);
+    Replica overview(GRC::VIEW_OVERVIEW);
+
+    for (int i = 0; i < kSeedRows; ++i) {
+        store.enqueueInsert(makePayment(hashOf(i), kBaseTime + i, kBaseHeight + i));
+    }
+    settle(q);
+    applyBatch(q.drain(), store, detail, overview);
+
+    // A coinstake that is already accepted when it reaches the store — the
+    // re-add half of updateTransaction's remove+insert fallback, and what a
+    // post-prime CT_UPDATED does. Both parts pass the filter in ONE
+    // insertLocked, so Cursor::applyStoreInsert emits two deltas in a single
+    // batch. Each delta's position is an intermediate-state coordinate, so the
+    // records the store attaches to them must be captured at emission time.
+    //
+    // Under the Overview's Status DESC sort this is not academic: the two parts'
+    // sort keys differ only in the trailing idx field, so part idx 1 sorts BEFORE
+    // part idx 0 and both deltas land at the SAME slot.
+    for (int b = 0; b < kBlocks; ++b) {
+        const uint256 h = hashOf(kStakeHashBase + b);
+        store.enqueueInsert(makeCoinstake(h, kBaseTime + kSeedRows + b,
+                                          kBaseHeight + kSeedRows + b,
+                                          TransactionStatus::Immature));
+        settle(q);
+        applyBatch(q.drain(), store, detail, overview);
+
+        checkReplicaMatchesStore(store, detail);
+        checkReplicaMatchesStore(store, overview);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_windowcache_tests.cpp
+++ b/src/test/qt_windowcache_tests.cpp
@@ -28,6 +28,13 @@
 
 using namespace GRC;
 
+// Shorthands for the structural apply* outcome. Named so the negative cases state
+// WHICH kind of non-application they expect: a routine seqno-gate skip, or a
+// rejection meaning the replica has diverged from the producer cursor.
+constexpr ApplyResult APPLIED   = ApplyResult::Applied;
+constexpr ApplyResult REFLECTED = ApplyResult::AlreadyReflected;
+constexpr ApplyResult REJECTED  = ApplyResult::Rejected;
+
 namespace {
 
 //! A synthetic record carrying just an identity, so a splice/shift bug shows up
@@ -127,7 +134,7 @@ BOOST_AUTO_TEST_CASE(insert_before_window_shifts_base_only)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(10, 10), 10, 30, 1, 5);
 
-    BOOST_CHECK(c.applyInsert(s, /*seqno*/6, /*pos*/3, recs({100, 101})));
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/6, /*pos*/3, recs({100, 101})) == APPLIED);
     BOOST_CHECK_EQUAL(c.total(), 32);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);
     // slice content unchanged, base shifted +2.
@@ -148,7 +155,7 @@ BOOST_AUTO_TEST_CASE(insert_inside_window_splices)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(10, 10), 10, 30, 1, 5);
 
-    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/13, recs({100, 101})));
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/13, recs({100, 101})) == APPLIED);
     BOOST_CHECK_EQUAL(c.total(), 32);
     check_slice(c, 10, {10, 11, 12, 100, 101, 13, 14, 15, 16, 17, 18, 19});
 }
@@ -161,7 +168,7 @@ BOOST_AUTO_TEST_CASE(insert_at_window_top_splices_no_flash)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(10, 10), 10, 30, 1, 5);
 
-    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/10, recs({100})));
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/10, recs({100})) == APPLIED);
     check_slice(c, 10, {100, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
     BOOST_CHECK_EQUAL(c.total(), 31);
 }
@@ -172,7 +179,7 @@ BOOST_AUTO_TEST_CASE(insert_at_window_end_appends)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(10, 10), 10, 30, 1, 5);   // slice covers abs [10,20)
 
-    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/20, recs({200})));   // pos == base+len
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/20, recs({200})) == APPLIED);   // pos == base+len
     check_slice(c, 10, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 200});
     BOOST_CHECK_EQUAL(c.total(), 31);
 }
@@ -183,7 +190,7 @@ BOOST_AUTO_TEST_CASE(insert_after_window_changes_total_only)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(10, 10), 10, 30, 1, 5);
 
-    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/25, recs({300})));   // pos > base+len
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/25, recs({300})) == APPLIED);   // pos > base+len
     check_slice(c, 10, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
     BOOST_CHECK_EQUAL(c.total(), 31);
     BOOST_CHECK_EQUAL(s.ops[0].kind, "beginInsert");
@@ -196,9 +203,9 @@ BOOST_AUTO_TEST_CASE(insert_empty_or_out_of_range_is_noop)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(10, 10), 10, 30, 1, 5);
 
-    BOOST_CHECK(!c.applyInsert(s, 6, 5, recs({})));     // empty
-    BOOST_CHECK(!c.applyInsert(s, 6, -1, recs({1})));   // pos < 0
-    BOOST_CHECK(!c.applyInsert(s, 6, 31, recs({1})));   // pos > total
+    BOOST_CHECK(c.applyInsert(s, 6, 5, recs({})) == REJECTED);     // empty
+    BOOST_CHECK(c.applyInsert(s, 6, -1, recs({1})) == REJECTED);   // pos < 0
+    BOOST_CHECK(c.applyInsert(s, 6, 31, recs({1})) == REJECTED);   // pos > total
     BOOST_CHECK_EQUAL(c.total(), 30);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 5u);
     BOOST_CHECK(s.ops.empty());
@@ -212,7 +219,7 @@ BOOST_AUTO_TEST_CASE(remove_before_window)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(10, 10), 10, 30, 1, 5);
 
-    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/3, /*count*/2));   // [3,5) entirely before
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/3, /*count*/2) == APPLIED);   // [3,5) entirely before
     BOOST_CHECK_EQUAL(c.total(), 28);
     check_slice(c, 8, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
     BOOST_CHECK_EQUAL(s.ops[0].kind, "beginRemove");
@@ -225,7 +232,7 @@ BOOST_AUTO_TEST_CASE(remove_front_overlap)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);   // abs [5,15) ids 5..14
 
-    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/3, /*count*/4));   // [3,7) -> drops ids 5,6
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/3, /*count*/4) == APPLIED);   // [3,7) -> drops ids 5,6
     BOOST_CHECK_EQUAL(c.total(), 26);
     check_slice(c, 3, {7, 8, 9, 10, 11, 12, 13, 14});
 }
@@ -236,7 +243,7 @@ BOOST_AUTO_TEST_CASE(remove_strictly_inside)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/8, /*count*/3));   // [8,11) -> drops ids 8,9,10
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/8, /*count*/3) == APPLIED);   // [8,11) -> drops ids 8,9,10
     BOOST_CHECK_EQUAL(c.total(), 27);
     check_slice(c, 5, {5, 6, 7, 11, 12, 13, 14});
 }
@@ -247,7 +254,7 @@ BOOST_AUTO_TEST_CASE(remove_back_overlap)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/12, /*count*/5));   // [12,17) -> drops ids 12,13,14
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/12, /*count*/5) == APPLIED);   // [12,17) -> drops ids 12,13,14
     BOOST_CHECK_EQUAL(c.total(), 25);
     check_slice(c, 5, {5, 6, 7, 8, 9, 10, 11});
 }
@@ -258,7 +265,7 @@ BOOST_AUTO_TEST_CASE(remove_spans_whole_cache)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/2, /*count*/20));   // [2,22) -> drops all cached
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/2, /*count*/20) == APPLIED);   // [2,22) -> drops all cached
     BOOST_CHECK_EQUAL(c.total(), 10);
     BOOST_CHECK_EQUAL(c.cacheFirst(), 2);
     BOOST_CHECK_EQUAL(c.cacheSize(), 0);
@@ -271,7 +278,7 @@ BOOST_AUTO_TEST_CASE(remove_after_window)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/20, /*count*/3));   // entirely after
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/20, /*count*/3) == APPLIED);   // entirely after
     BOOST_CHECK_EQUAL(c.total(), 27);
     check_slice(c, 5, {5, 6, 7, 8, 9, 10, 11, 12, 13, 14});
 }
@@ -282,9 +289,9 @@ BOOST_AUTO_TEST_CASE(remove_out_of_range_is_noop)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(!c.applyRemove(s, 6, 0, 0));     // count 0
-    BOOST_CHECK(!c.applyRemove(s, 6, -1, 2));    // pos < 0
-    BOOST_CHECK(!c.applyRemove(s, 6, 29, 5));    // pos+count > total
+    BOOST_CHECK(c.applyRemove(s, 6, 0, 0) == REJECTED);     // count 0
+    BOOST_CHECK(c.applyRemove(s, 6, -1, 2) == REJECTED);    // pos < 0
+    BOOST_CHECK(c.applyRemove(s, 6, 29, 5) == REJECTED);    // pos+count > total
     BOOST_CHECK_EQUAL(c.total(), 30);
     BOOST_CHECK(s.ops.empty());
 }
@@ -297,7 +304,7 @@ BOOST_AUTO_TEST_CASE(change_refreshes_in_cache_overlap)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(c.applyChange(s, 6, /*pos*/7, /*count*/2, recs({77, 88})));
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/7, /*count*/2, recs({77, 88})) == APPLIED);
     check_slice(c, 5, {5, 6, 77, 88, 9, 10, 11, 12, 13, 14});
     BOOST_CHECK_EQUAL(c.total(), 30);   // no size change
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);
@@ -315,7 +322,7 @@ BOOST_AUTO_TEST_CASE(change_partial_overlap_clips_to_cache)
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
     // Change abs [3,8): only [5,8) is in cache -> rows 5,6,7 get fresh[2..4].
-    BOOST_CHECK(c.applyChange(s, 6, /*pos*/3, /*count*/5, recs({30, 40, 50, 60, 70})));
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/3, /*count*/5, recs({30, 40, 50, 60, 70})) == APPLIED);
     check_slice(c, 5, {50, 60, 70, 8, 9, 10, 11, 12, 13, 14});
     BOOST_REQUIRE_EQUAL(s.ops.size(), 1u);
     BOOST_CHECK_EQUAL(s.ops[0].first, 5);
@@ -328,7 +335,7 @@ BOOST_AUTO_TEST_CASE(change_fully_off_window_no_signal)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(c.applyChange(s, 6, /*pos*/20, /*count*/2, recs({1, 2})));
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/20, /*count*/2, recs({1, 2})) == APPLIED);
     check_slice(c, 5, {5, 6, 7, 8, 9, 10, 11, 12, 13, 14});
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);   // seqno still advances
     BOOST_CHECK(s.ops.empty());                   // but no dataChanged (nothing visible)
@@ -342,15 +349,15 @@ BOOST_AUTO_TEST_CASE(structural_seqno_gate_skips_already_reflected)
     RecSink s; s.cache = &c;
     c.seedInitial(seq(0, 5), 0, 5, 1, /*high_water*/10);
 
-    BOOST_CHECK(!c.applyInsert(s, /*seqno*/10, 0, recs({99})));   // == high-water: skip
-    BOOST_CHECK(!c.applyInsert(s, /*seqno*/9, 0, recs({99})));    // <  high-water: skip
-    BOOST_CHECK(!c.applyRemove(s, 10, 0, 1));
-    BOOST_CHECK(!c.applyChange(s, 10, 0, 1, recs({1})));
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/10, 0, recs({99})) == REFLECTED);   // == high-water: skip
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/9, 0, recs({99})) == REFLECTED);    // <  high-water: skip
+    BOOST_CHECK(c.applyRemove(s, 10, 0, 1) == REFLECTED);
+    BOOST_CHECK(c.applyChange(s, 10, 0, 1, recs({1})) == REFLECTED);
     BOOST_CHECK_EQUAL(c.total(), 5);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 10u);
     BOOST_CHECK(s.ops.empty());
 
-    BOOST_CHECK(c.applyInsert(s, /*seqno*/11, 0, recs({99})));    // > high-water: apply
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/11, 0, recs({99})) == APPLIED);    // > high-water: apply
     BOOST_CHECK_EQUAL(c.total(), 6);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 11u);
 }
@@ -362,11 +369,11 @@ BOOST_AUTO_TEST_CASE(reset_skips_stale_and_takes_max_baseline)
     c.seedInitial(seq(0, 5), 0, 5, 1, /*high_water*/10);
 
     // A Reset whose seqno is already reflected is skipped.
-    BOOST_CHECK(!c.applyReset(s, /*seqno*/10, seq(0, 3), 0, 3, /*epoch*/2, /*hw*/10));
+    BOOST_CHECK(c.applyReset(s, /*seqno*/10, seq(0, 3), 0, 3, /*epoch*/2, /*hw*/10) == REFLECTED);
     BOOST_CHECK_EQUAL(c.total(), 5);
 
     // A live Reset: new geometry; baseline = max(high_water, seqno).
-    BOOST_CHECK(c.applyReset(s, /*seqno*/12, seq(100, 4), 0, 20, /*epoch*/2, /*hw*/15));
+    BOOST_CHECK(c.applyReset(s, /*seqno*/12, seq(100, 4), 0, 20, /*epoch*/2, /*hw*/15) == APPLIED);
     BOOST_CHECK_EQUAL(c.total(), 20);
     BOOST_CHECK_EQUAL(c.epoch(), 2u);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 15u);   // hw(15) > seqno(12)
@@ -432,7 +439,7 @@ BOOST_AUTO_TEST_CASE(structural_delta_applies_after_a_content_fill)
     s.clear();
 
     // insert before the window: base shifts, total grows, seqno advances.
-    BOOST_CHECK(c.applyInsert(s, /*seqno*/11, /*pos*/40, recs({900, 901})));
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/11, /*pos*/40, recs({900, 901})) == APPLIED);
     BOOST_CHECK_EQUAL(c.total(), 102);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 11u);
     check_slice(c, 52, {50, 51, 52, 53, 54});
@@ -468,7 +475,7 @@ BOOST_AUTO_TEST_CASE(change_short_fresh_refreshes_what_it_has_and_advances_seqno
     RecSink s; s.cache = &c;
     c.seedInitial(seq(5, 10), 5, 30, 1, 5);
 
-    BOOST_CHECK(c.applyChange(s, 6, /*pos*/7, /*count*/3, recs({77})));   // only 1 of 3
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/7, /*count*/3, recs({77})) == APPLIED);   // only 1 of 3
     check_slice(c, 5, {5, 6, 77, 8, 9, 10, 11, 12, 13, 14});             // 8,9 unchanged
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);                          // advanced regardless
     BOOST_REQUIRE_EQUAL(s.ops.size(), 1u);
@@ -491,25 +498,25 @@ BOOST_AUTO_TEST_CASE(consumer_routing_scenario)
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 10u);
 
     // RowsInserted at the top (a fresh tx): payload carries the record.
-    BOOST_CHECK(c.applyInsert(s, 11, /*pos*/0, recs({100})));
+    BOOST_CHECK(c.applyInsert(s, 11, /*pos*/0, recs({100})) == APPLIED);
     BOOST_CHECK_EQUAL(c.total(), 51);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 11u);
     check_slice(c, 0, {100, 0, 1, 2, 3, 4});
 
     // RowsRemoved off-window (below the cache): total shrinks, window unchanged.
-    BOOST_CHECK(c.applyRemove(s, 12, /*pos*/40, /*count*/2));
+    BOOST_CHECK(c.applyRemove(s, 12, /*pos*/40, /*count*/2) == APPLIED);
     BOOST_CHECK_EQUAL(c.total(), 49);
     check_slice(c, 0, {100, 0, 1, 2, 3, 4});
 
     // RowsChanged in-window: the consumer fetched `fresh`; refresh row 2.
-    BOOST_CHECK(c.applyChange(s, 13, /*pos*/2, /*count*/1, recs({222})));
+    BOOST_CHECK(c.applyChange(s, 13, /*pos*/2, /*count*/1, recs({222})) == APPLIED);
     check_slice(c, 0, {100, 0, 222, 2, 3, 4});
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 13u);
 
     // Stale / duplicate deltas (seqno <= structural): skipped, no signals.
     s.clear();
-    BOOST_CHECK(!c.applyInsert(s, 13, 0, recs({999})));
-    BOOST_CHECK(!c.applyRemove(s, 5, 0, 1));
+    BOOST_CHECK(c.applyInsert(s, 13, 0, recs({999})) == REFLECTED);
+    BOOST_CHECK(c.applyRemove(s, 5, 0, 1) == REFLECTED);
     BOOST_CHECK_EQUAL(c.total(), 49);
     BOOST_CHECK(s.ops.empty());
 
@@ -527,7 +534,7 @@ BOOST_AUTO_TEST_CASE(consumer_routing_scenario)
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 13u); // content never advances the seqno
 
     // A structural Reset (sort/filter) with a fresh epoch: rebuild + new baseline.
-    BOOST_CHECK(c.applyReset(s, /*seqno*/14, seq(0, 5), 0, /*total*/49, /*epoch*/2, /*hw*/14));
+    BOOST_CHECK(c.applyReset(s, /*seqno*/14, seq(0, 5), 0, /*total*/49, /*epoch*/2, /*hw*/14) == APPLIED);
     BOOST_CHECK_EQUAL(c.epoch(), 2u);
     BOOST_CHECK_EQUAL(c.structuralSeqno(), 14u);
     check_slice(c, 0, {0, 1, 2, 3, 4});

--- a/src/wallet/cursor.cpp
+++ b/src/wallet/cursor.cpp
@@ -283,7 +283,15 @@ std::vector<CursorDelta> Cursor::setSort(int sort_column, int sort_order)
 
 std::vector<CursorDelta> Cursor::setFilter(const FilterSpec& filter, std::size_t n)
 {
+    // Preserve the served-window cap. limit_rows rides along in FilterSpec, but it
+    // is owned by setLimit (the view's own resize), not by the caller's filter —
+    // and a caller building a FilterSpec from the UI's filter controls leaves it at
+    // the -1 default, which would silently uncap the view. Latent today, since no
+    // view both filters and caps, but the two are independent knobs and the wire
+    // type should not couple them.
+    const int32_t cap_kept = m_filter.limit_rows;
     m_filter = filter;
+    m_filter.limit_rows = cap_kept;
     return rebuild(n);
 }
 

--- a/src/wallet/cursor.cpp
+++ b/src/wallet/cursor.cpp
@@ -68,31 +68,54 @@ std::vector<CursorDelta> Cursor::rebuild(std::size_t n)
     return {{CursorDelta::Reset, 0, static_cast<int>(servedCount())}};
 }
 
+std::vector<std::size_t> Cursor::rowsAt(std::size_t first, std::size_t count) const
+{
+    std::vector<std::size_t> out;
+    if (first >= m_view_index.size()) {
+        return out;
+    }
+    const std::size_t end = std::min(m_view_index.size(), first + count);
+    out.reserve(end - first);
+    for (std::size_t i = first; i < end; ++i) {
+        out.push_back(m_view_index[i]);
+    }
+    return out;
+}
+
 // Served-window translation for a single-row INSERT that already happened at
 // `slot` (m_view_index has grown by 1). Eviction when the window was full.
-static void emitInsertAt(std::size_t slot, std::size_t size_after, std::size_t cap_v,
-                         std::vector<CursorDelta>& out)
+void Cursor::emitInsertAt(std::size_t slot, std::size_t absidx, std::size_t cap_v,
+                          std::vector<CursorDelta>& out) const
 {
+    const std::size_t size_after    = m_view_index.size();
     const std::size_t served_before = std::min(size_after - 1, cap_v);
     const std::size_t served_after  = std::min(size_after, cap_v);
     if (slot < served_after) {
-        out.push_back({CursorDelta::Insert, static_cast<int>(slot), 1});
+        // Stamp the record now: `slot` is only meaningful against the view_index
+        // as it stands at this instant (CursorDelta::rows).
+        out.push_back({CursorDelta::Insert, static_cast<int>(slot), 1, {absidx}});
         if (served_before == cap_v) {  // window was full → last visible row evicted
-            out.push_back({CursorDelta::Remove, static_cast<int>(cap_v), 1});
+            out.push_back({CursorDelta::Remove, static_cast<int>(cap_v), 1, {}});
         }
     }
 }
 
 // Served-window translation for a single-row REMOVE that already happened at
 // `pos` (size_before = size before the erase). Promotion when an off-window row exists.
-static void emitRemoveAt(std::size_t pos, std::size_t size_before, std::size_t cap_v,
-                         std::vector<CursorDelta>& out)
+void Cursor::emitRemoveAt(std::size_t pos, std::size_t size_before, std::size_t cap_v,
+                          std::vector<CursorDelta>& out) const
 {
     const std::size_t served_before = std::min(size_before, cap_v);
     if (pos < served_before) {
-        out.push_back({CursorDelta::Remove, static_cast<int>(pos), 1});
+        out.push_back({CursorDelta::Remove, static_cast<int>(pos), 1, {}});
         if (size_before > cap_v) {  // an off-window row promotes into the last visible slot
-            out.push_back({CursorDelta::Insert, static_cast<int>(cap_v - 1), 1});
+            // Capture the promoted record HERE. The erase has happened, so
+            // view_index holds size_before-1 >= cap_v entries and cap_v-1 is in
+            // range — but a later erase in the same batch can shrink it below
+            // cap_v, which is exactly what made resolving this coordinate after
+            // the batch an out-of-bounds read (#3257 review).
+            out.push_back({CursorDelta::Insert, static_cast<int>(cap_v - 1), 1,
+                           rowsAt(cap_v - 1, 1)});
         }
     }
 }
@@ -110,7 +133,7 @@ std::vector<CursorDelta> Cursor::applyStoreInsert(std::size_t P, std::size_t cou
         if (Accepts(m_fields(i), m_filter)) {
             const std::size_t slot = lowerBoundSlot(i);
             m_view_index.insert(m_view_index.begin() + slot, i);
-            emitInsertAt(slot, m_view_index.size(), cap_v, out);
+            emitInsertAt(slot, i, cap_v, out);
         }
     }
     return out;
@@ -120,18 +143,58 @@ std::vector<CursorDelta> Cursor::applyStoreRemove(std::size_t P, std::size_t cou
 {
     std::vector<CursorDelta> out;
     const std::size_t cap_v = cap();
-    // (a) erase the entries whose absolute value is in [P, P+count), by identity.
+    const std::size_t size_before = m_view_index.size();
+
+    // Erase EVERY target entry before emitting anything, then translate against the
+    // final index. Emitting per-erase (interleaved, as this used to) promotes a row
+    // into the window as each part goes; when a transaction's parts straddle the
+    // cap — one served, its sibling the first off-window row — the promotion picks
+    // up that sibling, which the very next erase then removes. The delta would
+    // carry a record the store has ALREADY erased from m_records (removeLocked
+    // erases before driving the cursors), so the payload named a foreign row, or
+    // ran off the end when the removed run sat at the table end (#3257 review).
+    // Deferring the translation makes every emitted record come from the final,
+    // fully-renumbered index, so a doomed row can never be named.
+
+    // (a) locate the entries whose absolute value is in [P, P+count), by identity.
+    std::vector<std::size_t> positions;
     for (std::size_t v = P; v < P + count; ++v) {
         const std::size_t pos = findSlot(v);
-        if (pos != NPOS) {
-            const std::size_t size_before = m_view_index.size();
-            m_view_index.erase(m_view_index.begin() + pos);
-            emitRemoveAt(pos, size_before, cap_v, out);
-        }
+        if (pos != NPOS) positions.push_back(pos);
     }
+    if (positions.empty()) {
+        return out;   // none of the removed records was in this view
+    }
+    std::sort(positions.begin(), positions.end());
+    for (std::size_t i = positions.size(); i-- > 0;) {
+        m_view_index.erase(m_view_index.begin() + positions[i]);   // high to low
+    }
+
     // (b) the table shrank by `count` at P → later survivors shift -count.
     for (auto& e : m_view_index) {
         if (e >= P + count) e -= count;
+    }
+
+    // (c) served-window translation. One Remove per erased row that WAS visible,
+    // in ascending order — each already-emitted Remove has shifted the consumer's
+    // later rows down by one, hence the running adjustment.
+    const std::size_t served_before = std::min(size_before, cap_v);
+    const std::size_t served_after  = std::min(m_view_index.size(), cap_v);
+    std::size_t removed_in_window = 0;
+    for (const std::size_t pos : positions) {
+        if (pos >= served_before) continue;   // off-window: the consumer never had it
+        out.push_back({CursorDelta::Remove,
+                       static_cast<int>(pos - removed_in_window), 1, {}});
+        ++removed_in_window;
+    }
+
+    // Off-window rows promoting into the freed slots, appended in one batch. Their
+    // records come from the final index, so they are correct by construction.
+    const std::size_t visible_now = served_before - removed_in_window;
+    if (served_after > visible_now) {
+        const std::size_t promoted = served_after - visible_now;
+        out.push_back({CursorDelta::Insert, static_cast<int>(visible_now),
+                       static_cast<int>(promoted), rowsAt(visible_now, promoted)});
     }
     return out;
 }
@@ -150,7 +213,7 @@ std::vector<CursorDelta> Cursor::applyStatusUpdate(std::size_t P)
     if (!old_in && new_in) {                          // membership flip-in
         const std::size_t slot = lowerBoundSlot(P);
         m_view_index.insert(m_view_index.begin() + slot, P);
-        emitInsertAt(slot, m_view_index.size(), cap_v, out);
+        emitInsertAt(slot, P, cap_v, out);
         return out;
     }
     if (old_in && !new_in) {                          // membership flip-out
@@ -170,20 +233,22 @@ std::vector<CursorDelta> Cursor::applyStatusUpdate(std::size_t P)
 
     const std::size_t served_full = std::min(size_full, cap_v);
     if (new_slot == old_pos) {                        // unchanged slot → just re-read
-        if (old_pos < served_full) out.push_back({CursorDelta::Change, static_cast<int>(old_pos), 1});
+        if (old_pos < served_full) out.push_back({CursorDelta::Change, static_cast<int>(old_pos), 1, {}});
         return out;
     }
     const bool old_vis = old_pos < served_full;
     const bool new_vis = new_slot < served_full;
     if (old_vis && new_vis) {                          // reorder within the window
-        out.push_back({CursorDelta::Remove, static_cast<int>(old_pos), 1});
-        out.push_back({CursorDelta::Insert, static_cast<int>(new_slot), 1});
+        out.push_back({CursorDelta::Remove, static_cast<int>(old_pos), 1, {}});
+        out.push_back({CursorDelta::Insert, static_cast<int>(new_slot), 1, {P}});
     } else if (old_vis && !new_vis) {                  // moved out of the window
-        out.push_back({CursorDelta::Remove, static_cast<int>(old_pos), 1});
-        if (size_full > cap_v) out.push_back({CursorDelta::Insert, static_cast<int>(served_full - 1), 1});
+        out.push_back({CursorDelta::Remove, static_cast<int>(old_pos), 1, {}});
+        // The row that promotes into the last visible slot, captured now.
+        if (size_full > cap_v) out.push_back({CursorDelta::Insert, static_cast<int>(served_full - 1), 1,
+                                              rowsAt(served_full - 1, 1)});
     } else if (!old_vis && new_vis) {                  // moved into the window
-        out.push_back({CursorDelta::Insert, static_cast<int>(new_slot), 1});
-        if (size_full > cap_v) out.push_back({CursorDelta::Remove, static_cast<int>(served_full), 1});
+        out.push_back({CursorDelta::Insert, static_cast<int>(new_slot), 1, {P}});
+        if (size_full > cap_v) out.push_back({CursorDelta::Remove, static_cast<int>(served_full), 1, {}});
     }
     // !old_vis && !new_vis: off-window move, no emission (view_index still maintained).
     return out;
@@ -196,9 +261,12 @@ std::vector<CursorDelta> Cursor::setLimit(int new_limit)
     m_filter.limit_rows = new_limit;
     const std::size_t served_new = servedCount();
     if (served_new > served_old) {
-        out.push_back({CursorDelta::Insert, static_cast<int>(served_old), static_cast<int>(served_new - served_old)});
+        out.push_back({CursorDelta::Insert, static_cast<int>(served_old),
+                       static_cast<int>(served_new - served_old),
+                       rowsAt(served_old, served_new - served_old)});
     } else if (served_new < served_old) {
-        out.push_back({CursorDelta::Remove, static_cast<int>(served_new), static_cast<int>(served_old - served_new)});
+        out.push_back({CursorDelta::Remove, static_cast<int>(served_new),
+                       static_cast<int>(served_old - served_new), {}});
     }
     return out;
 }

--- a/src/wallet/cursor.h
+++ b/src/wallet/cursor.h
@@ -50,6 +50,20 @@ struct CursorDelta {
     enum Type { Reset, Insert, Remove, Change } type;
     int first;
     int count;
+    //! Insert only: the ABSOLUTE record indices of the inserted rows, captured at
+    //! the moment this delta was emitted.
+    //!
+    //! A single apply* call can emit several deltas, each against a different
+    //! intermediate state of view_index (a two-part coinstake inserts one part at
+    //! a time; a multi-row remove promotes off-window rows one at a time). `first`
+    //! is therefore an intermediate-state coordinate, and re-resolving it against
+    //! the FINAL view_index after the batch — which WalletTxStore::emitCursorDeltas
+    //! used to do — attaches the wrong record to the delta, or reads out of bounds
+    //! when a later delta shrank the served window past this coordinate (#3257
+    //! review; the Overview half of #3101). Capturing here makes the delta
+    //! self-describing, so nothing downstream has to re-derive a stale position.
+    //! Empty for Reset/Remove/Change, none of which carry records.
+    std::vector<std::size_t> rows;
 };
 
 class Cursor
@@ -100,8 +114,16 @@ public:
     std::size_t servedCount() const;
     //! Total accepted rows (the full sorted index size).
     std::size_t totalAccepted() const { return m_view_index.size(); }
-    //! Absolute record index at served position `served_pos` (for getRows).
-    std::size_t rowAt(std::size_t served_pos) const { return m_view_index[served_pos]; }
+    //! Absolute record index at served position `served_pos` (for getRows), or
+    //! npos if `served_pos` is out of range. Bounds-checked rather than a raw
+    //! operator[]: the callers derive `served_pos` from separately-sampled state,
+    //! and a stale coordinate must degrade to a skipped row, not a heap read past
+    //! the end of view_index (#3257 review).
+    std::size_t rowAt(std::size_t served_pos) const
+    {
+        return served_pos < m_view_index.size() ? m_view_index[served_pos]
+                                                : static_cast<std::size_t>(-1);
+    }
 
     //! Accepted-row position of absolute record index `absidx` in the sorted
     //! view, or npos (== static_cast<std::size_t>(-1)) if `absidx` is not
@@ -132,6 +154,24 @@ private:
     std::size_t findSlot(std::size_t absidx) const;
     //! Cap as a size_t (SIZE_MAX when unlimited).
     std::size_t cap() const;
+
+    //! Absolute record indices of served rows [first, first+count), read from the
+    //! CURRENT view_index. Used to stamp CursorDelta::rows at emission time;
+    //! clamps to the live size, so a short result means the caller asked for rows
+    //! that do not exist.
+    std::vector<std::size_t> rowsAt(std::size_t first, std::size_t count) const;
+
+    //! Served-window translation for a single-row insert that already happened at
+    //! `slot` (view_index has already grown by 1); `absidx` is the record that
+    //! landed there, stamped onto the emitted Insert.
+    void emitInsertAt(std::size_t slot, std::size_t absidx, std::size_t cap_v,
+                      std::vector<CursorDelta>& out) const;
+
+    //! Served-window translation for a single-row remove that already happened at
+    //! `pos` (`size_before` is the size before the erase). Any promotion Insert is
+    //! stamped from the post-erase view_index.
+    void emitRemoveAt(std::size_t pos, std::size_t size_before, std::size_t cap_v,
+                      std::vector<CursorDelta>& out) const;
 
     int m_view_id;
     FilterSpec m_filter;

--- a/src/wallet/wallettxstore.cpp
+++ b/src/wallet/wallettxstore.cpp
@@ -126,11 +126,25 @@ void WalletTxStore::start()
     m_worker = std::thread([this] { workerLoop(); });
 }
 
+void WalletTxStore::warnIfIntakeBacklogged()
+{
+    if (m_intake.size() < m_intake_warn_at) {
+        return;
+    }
+    LogPrintf("WARNING: %s: transaction-store intake backlog is %u items "
+              "(worker parked=%d, rebuild in progress=%d) — new transactions are "
+              "not reaching the GUI transaction views",
+              __func__, static_cast<unsigned int>(m_intake.size()),
+              static_cast<int>(m_worker_parked), static_cast<int>(m_rebuilding));
+    m_intake_warn_at *= 2;
+}
+
 void WalletTxStore::enqueueInsert(std::vector<TransactionRecord> records)
 {
     {
         LOCK(cs_intake);
         m_intake.push_back(IntakeItem{IntakeItem::Insert, std::move(records), uint256()});
+        warnIfIntakeBacklogged();
     }
     m_intake_cv.notify_one();
 }
@@ -140,6 +154,7 @@ void WalletTxStore::enqueueRemove(const uint256& hash)
     {
         LOCK(cs_intake);
         m_intake.push_back(IntakeItem{IntakeItem::Remove, {}, hash});
+        warnIfIntakeBacklogged();
     }
     m_intake_cv.notify_one();
 }
@@ -153,6 +168,7 @@ void WalletTxStore::enqueueUpsert(std::vector<TransactionRecord> records)
     {
         LOCK(cs_intake);
         m_intake.push_back(IntakeItem{IntakeItem::Update, std::move(records), hash, {}, {}});
+        warnIfIntakeBacklogged();
     }
     m_intake_cv.notify_one();
 }
@@ -162,6 +178,7 @@ void WalletTxStore::enqueueAddressBookChange(const std::string& address, const s
     {
         LOCK(cs_intake);
         m_intake.push_back(IntakeItem{IntakeItem::AddressBook, {}, uint256(), address, label});
+        warnIfIntakeBacklogged();
     }
     m_intake_cv.notify_one();
 }
@@ -405,6 +422,28 @@ void WalletTxStore::prime(bool limit_enabled, int64_t limit_time)
     // (insert/removeTransaction take only cs_store), so waiting for it here while
     // we hold both cannot deadlock. m_started guards the pre-start() first reload
     // (no worker yet → nothing to wait for).
+    //
+    // The park is released by an RAII guard, NOT by falling off the end of this
+    // function. m_rebuilding is the worker's wait predicate, so if anything below
+    // throws — and plenty can: decomposeTransaction calls GetCredit/GetDebit,
+    // which throw std::runtime_error outside MoneyRange, and updateStatus reaches
+    // GetGeneratedType, which hits the tx index and reads a block from disk — the
+    // worker would stay parked FOREVER. Producers would keep enqueuing
+    // successfully and m_intake would grow without bound, while the inline
+    // applyChainTipRefresh kept refreshing already-stored rows: the GUI would show
+    // existing transactions ripening normally and never show a new one again
+    // (#3257).
+    struct RebuildPark {
+        WalletTxStore& s;
+        ~RebuildPark()
+        {
+            LOCK(s.cs_intake);
+            s.m_rebuilding = false;
+            s.m_worker_parked = false;
+            s.m_intake_cv.notify_all();
+        }
+    } park_guard{*this};
+
     {
         WAIT_LOCK(cs_intake, ilock);
         m_rebuilding = true;
@@ -489,15 +528,10 @@ void WalletTxStore::prime(bool limit_enabled, int64_t limit_time)
         }
     }
 
-    // Release the store-worker (PR2.5): the rebuilt index is live, so resume
-    // draining. Producers remain blocked on cs_wallet until we return, so the
-    // worker has nothing to apply until the snapshot is installed.
-    {
-        LOCK(cs_intake);
-        m_rebuilding = false;
-        m_worker_parked = false;
-        m_intake_cv.notify_all();
-    }
+    // The store-worker is released by park_guard's destructor as this function
+    // returns (PR2.5): the rebuilt index is live, so it resumes draining.
+    // Producers remain blocked on cs_wallet until we return, so the worker has
+    // nothing to apply until the snapshot is installed.
 }
 
 void WalletTxStore::updateTransaction(std::vector<TransactionRecord> records)

--- a/src/wallet/wallettxstore.cpp
+++ b/src/wallet/wallettxstore.cpp
@@ -341,46 +341,70 @@ void WalletTxStore::removeTransaction(const uint256& hash)
     removeLocked(hash);
 }
 
-void WalletTxStore::removeLocked(const uint256& hash)
+bool WalletTxStore::locateHashRange(const uint256& hash, std::size_t& minPos,
+                                    std::size_t& maxPos, std::size_t& count) const
 {
+    // Same-hash keys are contiguous under TxOrderLess (the hash tiebreaker
+    // clusters them), so min/max bound a single range. The erase in removeLocked
+    // depends on that; validate it at runtime rather than with an assert, since the
+    // deployed build is -DNDEBUG and a de-clustered index would erase a wider
+    // [minPos, maxPos] range that swallows foreign rows. The bounds check is
+    // ordered first and short-circuits, so the m_records[] subscripts below it
+    // never run out of range.
     auto range = m_by_hash.equal_range(hash);
     if (range.first == range.second) {
-        // Not present — filtered out at insert time, or never inserted. No-op,
-        // no event.
-        return;
+        return false;
     }
-
-    // Same-hash keys are contiguous under TxOrderLess (the hash tiebreaker
-    // clusters them), so min/max bound a single range.
-    std::size_t minPos = std::numeric_limits<std::size_t>::max();
-    std::size_t maxPos = 0;
+    minPos = std::numeric_limits<std::size_t>::max();
+    maxPos = 0;
     for (auto it = range.first; it != range.second; ++it) {
         if (it->second < minPos) minPos = it->second;
         if (it->second > maxPos) maxPos = it->second;
     }
-    const std::size_t count = maxPos - minPos + 1;
-    const std::size_t distance = static_cast<std::size_t>(std::distance(range.first, range.second));
+    count = maxPos - minPos + 1;
+    const std::size_t distance =
+        static_cast<std::size_t>(std::distance(range.first, range.second));
+    return maxPos < m_records.size()
+        && count == distance
+        && m_records[minPos].hash == hash
+        && m_records[maxPos].hash == hash;
+}
 
-    // The erase below relies on same-hash keys being a single contiguous run
-    // (guaranteed by TxOrderLess's hash tiebreaker). Validate at runtime, not
-    // via assert: the deployed build is -DNDEBUG, so an assert would vanish and
-    // a de-clustered index would erase a wider [minPos, maxPos] range that
-    // swallows foreign rows (heap/structure corruption). The bounds check is
-    // ordered first and short-circuits, so the m_records[] subscripts below it
-    // never run out of range. If the invariant is ever violated, bail without
-    // erasing or emitting — a stale row is a safe degradation; a wrong erase is
-    // not.
-    if (maxPos >= m_records.size()
-            || count != distance
-            || m_records[minPos].hash != hash
-            || m_records[maxPos].hash != hash) {
+bool WalletTxStore::removeLocked(const uint256& hash)
+{
+    std::size_t minPos = 0;
+    std::size_t maxPos = 0;
+    std::size_t count = 0;
+
+    if (!locateHashRange(hash, minPos, maxPos, count)) {
+        if (m_by_hash.find(hash) == m_by_hash.end()) {
+            // Not present — filtered out at insert time, or never inserted. No-op,
+            // no event. Report success: the caller's goal (this hash is gone) holds.
+            return true;
+        }
+        // The index disagrees with m_records. m_by_hash is derived purely from
+        // m_records, and m_records is kept in RecordOrder (which clusters a
+        // transaction's parts), so rebuilding it from the records restores the
+        // invariant by construction. Recover rather than bail: the old code
+        // returned here, and updateTransaction's remove+insert fallback then hit
+        // insertLocked's hash dedup on the still-present stale entries and
+        // returned too, so the transaction became permanently un-updatable,
+        // un-removable and un-reinsertable (#3257 review).
         LogPrintf("ERROR: %s: hash %s index non-contiguous/out-of-range "
-                  "(minPos=%u maxPos=%u count=%u distance=%u keys=%u) — skipping remove",
+                  "(minPos=%u maxPos=%u count=%u records=%u) — rebuilding the hash index",
                   __func__, hash.GetHex(),
                   static_cast<unsigned int>(minPos), static_cast<unsigned int>(maxPos),
-                  static_cast<unsigned int>(count), static_cast<unsigned int>(distance),
+                  static_cast<unsigned int>(count),
                   static_cast<unsigned int>(m_records.size()));
-        return;
+        rebuildIndex();
+        if (!locateHashRange(hash, minPos, maxPos, count)) {
+            if (m_by_hash.find(hash) == m_by_hash.end()) {
+                return true;   // the rebuild showed it was never really there
+            }
+            LogPrintf("ERROR: %s: hash %s still inconsistent after an index rebuild "
+                      "— skipping remove", __func__, hash.GetHex());
+            return false;
+        }
     }
 
     m_records.erase(m_records.begin() + minPos, m_records.begin() + maxPos + 1);
@@ -398,6 +422,7 @@ void WalletTxStore::removeLocked(const uint256& hash)
     for (auto& [viewId, cursor] : m_cursors) {
         emitCursorDeltas(viewId, cursor.epoch(), cursor.applyStoreRemove(minPos, count));
     }
+    return true;
 }
 
 void WalletTxStore::prime(bool limit_enabled, int64_t limit_time)
@@ -585,7 +610,15 @@ void WalletTxStore::updateTransaction(std::vector<TransactionRecord> records)
             || static_cast<std::size_t>(std::distance(range.first, range.second)) != stored
             || m_records[minPos].hash != hash
             || m_records[maxPos].hash != hash) {
-        removeLocked(hash);
+        if (!removeLocked(hash)) {
+            // The index could not be reconciled even after a rebuild. Do NOT fall
+            // through to insertLocked: its hash dedup would see the stale entries
+            // and return silently, dropping the update with no event and no
+            // volatility refresh — permanently, for this hash (#3257 review).
+            LogPrintf("ERROR: %s: hash %s could not be removed for the re-insert "
+                      "fallback — dropping this update", __func__, hash.GetHex());
+            return;
+        }
         insertLocked(std::move(records));
         return;
     }
@@ -682,6 +715,18 @@ void WalletTxStore::applyChainTipRefresh()
         // A tx's parts are contiguous in m_records; collect + sort their positions.
         std::vector<std::size_t> positions;
         for (auto it = range.first; it != range.second; ++it) {
+            // Bounds-check, as every other m_by_hash consumer in this file does.
+            // This one runs inline on the core thread for every volatile record on
+            // every block, and recomputeCacheAt below WRITES three parallel
+            // vectors at the same index — an unvalidated position here is a heap
+            // write, not just a bad read (#3257 review).
+            if (it->second >= m_records.size()) {
+                LogPrintf("ERROR: %s: hash %s maps to record %u of %u — skipping "
+                          "this part's refresh", __func__, hash.GetHex(),
+                          static_cast<unsigned int>(it->second),
+                          static_cast<unsigned int>(m_records.size()));
+                continue;
+            }
             positions.push_back(it->second);
         }
         std::sort(positions.begin(), positions.end());
@@ -722,6 +767,17 @@ void WalletTxStore::makeCursorProjectors(Cursor::FieldsFn& fields, Cursor::KeysF
 
 void WalletTxStore::recomputeCacheAt(std::size_t i)
 {
+    // The three vectors are maintained in lockstep, so this should be
+    // unreachable — but it WRITES, and every caller derives `i` from m_by_hash or
+    // from a cursor position, so validate rather than trust (#3257 review).
+    if (i >= m_records.size() || i >= m_fields_cache.size() || i >= m_keys_cache.size()) {
+        LogPrintf("ERROR: %s: index %u out of range (records=%u fields=%u keys=%u)",
+                  __func__, static_cast<unsigned int>(i),
+                  static_cast<unsigned int>(m_records.size()),
+                  static_cast<unsigned int>(m_fields_cache.size()),
+                  static_cast<unsigned int>(m_keys_cache.size()));
+        return;
+    }
     m_fields_cache[i] = projectFields(m_records[i]);
     m_keys_cache[i] = projectKeys(m_records[i]);
 }
@@ -736,6 +792,9 @@ void WalletTxStore::updateVolatileForHash(const uint256& hash)
     auto range = m_by_hash.equal_range(hash);
     bool volatile_now = false;
     for (auto it = range.first; it != range.second; ++it) {
+        if (it->second >= m_records.size()) {
+            continue;   // stale index entry; removeLocked logs and repairs it
+        }
         if (isVolatile(m_records[it->second])) {
             volatile_now = true;
             break;

--- a/src/wallet/wallettxstore.cpp
+++ b/src/wallet/wallettxstore.cpp
@@ -811,7 +811,15 @@ RowsResult WalletTxStore::getRows(int viewId, int first, int count)
         : std::min(served, begin + static_cast<std::size_t>(count));
     res.records.reserve(end - begin);
     for (std::size_t i = begin; i < end; ++i) {
-        res.records.push_back(m_records[cur.rowAt(i)]);
+        const std::size_t absidx = cur.rowAt(i);
+        if (absidx >= m_records.size()) {
+            LogPrintf("ERROR: %s: view %d served row %u maps to record %u of %u — skipping",
+                      __func__, viewId, static_cast<unsigned int>(i),
+                      static_cast<unsigned int>(absidx),
+                      static_cast<unsigned int>(m_records.size()));
+            continue;
+        }
+        res.records.push_back(m_records[absidx]);
     }
     return res;
 }
@@ -840,7 +848,15 @@ RowsResult WalletTxStore::getAllRows(int viewId)
     const std::size_t n = static_cast<std::size_t>(res.total_accepted);
     res.records.reserve(n);
     for (std::size_t i = 0; i < n; ++i) {
-        res.records.push_back(m_records[cur.rowAt(i)]);
+        const std::size_t absidx = cur.rowAt(i);
+        if (absidx >= m_records.size()) {
+            LogPrintf("ERROR: %s: view %d accepted row %u maps to record %u of %u — skipping",
+                      __func__, viewId, static_cast<unsigned int>(i),
+                      static_cast<unsigned int>(absidx),
+                      static_cast<unsigned int>(m_records.size()));
+            continue;
+        }
+        res.records.push_back(m_records[absidx]);
     }
     return res;
 }
@@ -921,7 +937,6 @@ WalletTxDetail WalletTxStore::getRowDetail(const uint256& hash, int idx)
 void WalletTxStore::emitCursorDeltas(int viewId, uint64_t epoch,
                                      const std::vector<CursorDelta>& deltas)
 {
-    auto it = m_cursors.find(viewId);
     for (const CursorDelta& d : deltas) {
         // Record the seqno of every emitted event as the view's high-water (the
         // last one wins) so getRows can tell a consumer exactly what its refetch
@@ -932,12 +947,37 @@ void WalletTxStore::emitCursorDeltas(int viewId, uint64_t epoch,
             m_view_seqno[viewId] = m_queue.push(GRC::RowsResetPayload{viewId, epoch, d.count});
             break;
         case CursorDelta::Insert: {
+            // Read the records the CURSOR stamped on the delta, NOT a re-resolution
+            // of d.first against the cursor's current view_index. A single apply*
+            // call emits its deltas against successive intermediate states, so by
+            // the time we get here d.first can name a different row — or none at
+            // all, when a later delta shrank the served window past it. That was a
+            // wrong-record payload on capped Status-sorted views and an
+            // out-of-bounds read on the promotion path (#3257 review, and the
+            // Overview half of #3101).
             std::vector<TransactionRecord> recs;
-            if (it != m_cursors.end()) {
-                recs.reserve(static_cast<std::size_t>(d.count));
-                for (int j = 0; j < d.count; ++j) {
-                    recs.push_back(m_records[it->second.rowAt(static_cast<std::size_t>(d.first + j))]);
+            recs.reserve(d.rows.size());
+            for (const std::size_t absidx : d.rows) {
+                if (absidx >= m_records.size()) {
+                    // Unreachable by construction: rows are captured from a live
+                    // view_index under the same cs_store hold that mutated
+                    // m_records. Log rather than assert — the deployed build is
+                    // -DNDEBUG — and skip, so a stale index degrades to a missing
+                    // row instead of a heap read.
+                    LogPrintf("ERROR: %s: view %d Insert delta at %d references record "
+                              "%u of %u — skipping",
+                              __func__, viewId, d.first,
+                              static_cast<unsigned int>(absidx),
+                              static_cast<unsigned int>(m_records.size()));
+                    continue;
                 }
+                recs.push_back(m_records[absidx]);
+            }
+            if (recs.size() != static_cast<std::size_t>(d.count)) {
+                LogPrintf("ERROR: %s: view %d Insert delta at %d carries %u of %d records "
+                          "— consumer replicas will diverge until the next reset",
+                          __func__, viewId, d.first,
+                          static_cast<unsigned int>(recs.size()), d.count);
             }
             m_view_seqno[viewId] = m_queue.push(GRC::RowsInsertedPayload{d.first, std::move(recs), viewId, epoch});
             break;

--- a/src/wallet/wallettxstore.cpp
+++ b/src/wallet/wallettxstore.cpp
@@ -698,6 +698,10 @@ void WalletTxStore::applyChainTipRefresh()
     // Copy the set: updateVolatileForHash() mutates m_volatile as matured txs drop
     // out, and we must not iterate it while erasing.
     const std::vector<uint256> hashes(m_volatile.begin(), m_volatile.end());
+    LogPrint(BCLog::LogFlags::VERBOSE,
+             "applyChainTipRefresh: refreshing %u volatile transactions over %u records",
+             static_cast<unsigned int>(hashes.size()),
+             static_cast<unsigned int>(m_records.size()));
     for (const uint256& hash : hashes) {
         auto range = m_by_hash.equal_range(hash);
         if (range.first == range.second) {
@@ -736,14 +740,59 @@ void WalletTxStore::applyChainTipRefresh()
         // their old slots and break that precondition under a Status sort. Interleaving
         // keeps every untouched part at its consistent prior key/slot. Positions in
         // m_records are stable across the loop (status is not part of RecordOrder).
-        for (std::size_t p : positions) {
-            m_records[p].updateStatus(wtx);
-            recomputeCacheAt(p);
-            for (auto& [viewId, cursor] : m_cursors) {
-                emitCursorDeltas(viewId, cursor.epoch(), cursor.applyStatusUpdate(p));
+        //
+        // Guarded per hash. updateStatus() reaches a long way for something running
+        // inline on the core thread: IsTrusted() and GetBlocksToMaturity() walk the
+        // wallet, and GetGeneratedType() goes to the tx index and reads a block from
+        // disk. Any of that can throw — GetCredit/GetDebit raise std::runtime_error
+        // outside MoneyRange, and the disk paths raise their own. Unguarded, one bad
+        // record aborts the whole loop, so every hash AFTER it in the iteration order
+        // is skipped — and not just once. m_volatile is an unordered_set, so a given
+        // hash's position is fixed by its bucket for as long as the bucket count
+        // holds: the same records get skipped block after block, and only a rehash
+        // or a prime() reshuffles which ones.
+        // Those rows would then never leave NotAccepted/Immature, and since both
+        // production views mask inactive rows, every staked block behind the poison
+        // record would stay invisible until a prime() rebuilt the volatile set.
+        // One unrefreshable transaction must not freeze status refresh for the rest
+        // of the wallet (#3257).
+        try {
+            for (std::size_t p : positions) {
+                // Status transition + per-view delta count. Together these split the
+                // "a staked block never appears" failure three ways in one line:
+                //   before == after == NotAccepted  -> updateStatus is not clearing it
+                //   status flips but 0 deltas       -> the cursor is not flipping it in
+                //   status flips and a delta fires  -> the loss is downstream (queue,
+                //                                      drain pump or the Qt consumer)
+                // VERBOSE, so it costs nothing unless a user is chasing this (#3257).
+                const int before = static_cast<int>(m_records[p].status.status);
+                m_records[p].updateStatus(wtx);
+                const int after = static_cast<int>(m_records[p].status.status);
+                recomputeCacheAt(p);
+                for (auto& [viewId, cursor] : m_cursors) {
+                    const std::vector<CursorDelta> deltas = cursor.applyStatusUpdate(p);
+                    LogPrint(BCLog::LogFlags::VERBOSE,
+                             "applyChainTipRefresh: %s part %d record %u status %d->%d "
+                             "view %d emitted %u deltas",
+                             hash.GetHex(), m_records[p].idx,
+                             static_cast<unsigned int>(p), before, after, viewId,
+                             static_cast<unsigned int>(deltas.size()));
+                    emitCursorDeltas(viewId, cursor.epoch(), deltas);
+                }
             }
+            updateVolatileForHash(hash);   // drops the hash once every part is terminal
+        } catch (const std::exception& e) {
+            // Default log level, not VERBOSE: this is the line that names the
+            // offending transaction, and it must be present in a user's ordinary
+            // debug.log without them having to reproduce under -debug=verbose.
+            LogPrintf("ERROR: %s: refreshing hash %s threw (%s) — skipping it this "
+                      "tip; the remaining %u volatile transactions still refresh",
+                      __func__, hash.GetHex(), e.what(),
+                      static_cast<unsigned int>(m_volatile.size()));
+        } catch (...) {
+            LogPrintf("ERROR: %s: refreshing hash %s threw a non-standard exception "
+                      "— skipping it this tip", __func__, hash.GetHex());
         }
-        updateVolatileForHash(hash);   // drops the hash once every part is terminal
     }
 }
 

--- a/src/wallet/wallettxstore.h
+++ b/src/wallet/wallettxstore.h
@@ -235,6 +235,22 @@ private:
         std::string ab_label;                   //!< AddressBook: its new label ("" if removed).
     };
 
+    //! Intake depth at which to start warning that the worker is not keeping up.
+    //! Far above any legitimate burst (a reorg or an IBD catch-up drains in
+    //! well under this), so a crossing means the worker is wedged or starved.
+    static constexpr std::size_t kIntakeBacklogWarn = 2000;
+
+    //! Warn (at doubling thresholds, so it cannot spam) when the intake queue is
+    //! growing without being drained. Caller holds cs_intake.
+    //!
+    //! The worker is the SOLE path by which a new transaction reaches m_records,
+    //! and its health is otherwise invisible: if it stops draining, producers keep
+    //! enqueuing successfully and the inline applyChainTipRefresh keeps refreshing
+    //! already-stored rows, so the only symptom is that no new row ever appears
+    //! again — with nothing in the log to say why (#3257). A backlog that keeps
+    //! growing is the one observable signature, so say it out loud.
+    void warnIfIntakeBacklogged() EXCLUSIVE_LOCKS_REQUIRED(cs_intake);
+
     //! Worker entry point: drain the intake queue and apply each item. Parks
     //! while m_rebuilding is set (acknowledging via m_worker_parked); exits on
     //! m_stop. Holds cs_intake only while waiting/dequeuing — never with cs_store.
@@ -351,6 +367,8 @@ private:
     bool m_stop GUARDED_BY(cs_intake){false};          //!< shutdown request (dtor)
     bool m_rebuilding GUARDED_BY(cs_intake){false};    //!< prime wants the worker parked
     bool m_worker_parked GUARDED_BY(cs_intake){false}; //!< worker has acknowledged the pause
+    //! Next intake depth at which to warn, doubled after each warning.
+    std::size_t m_intake_warn_at GUARDED_BY(cs_intake){kIntakeBacklogWarn};
     CConditionVariable m_intake_cv;  //!< worker waits for work / stop / resume
     CConditionVariable m_idle_cv;    //!< prime waits for m_worker_parked
     std::thread m_worker;

--- a/src/wallet/wallettxstore.h
+++ b/src/wallet/wallettxstore.h
@@ -278,7 +278,25 @@ private:
     //! updateTransaction composes these directly for its not-present /
     //! part-count-changed fallback without re-entering the non-recursive cs_store.
     void insertLocked(std::vector<TransactionRecord> records) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
-    void removeLocked(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+    //! \return false only if the hash is present but its index entries could not
+    //! be reconciled with m_records even after an index rebuild. A caller that
+    //! intends to re-insert afterwards MUST check this: insertLocked's hash dedup
+    //! would otherwise see the stale entries and silently drop the re-insert.
+    bool removeLocked(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! Resolve \p hash to the contiguous record range [\p minPos, \p maxPos] that
+    //! m_by_hash claims for it, and validate that claim against m_records:
+    //! in range, entry count matching the span, and both endpoints actually
+    //! carrying \p hash. \return false if the hash is absent OR the index
+    //! disagrees with the records — removeLocked distinguishes the two and repairs
+    //! the second. Out-params are only meaningful when the hash was found (they
+    //! are set even on a validation failure, for the diagnostic).
+    //!
+    //! A member rather than a local lambda in removeLocked: Clang's thread-safety
+    //! analysis does not propagate the caller's held-lock state into a lambda body,
+    //! so reading the GUARDED_BY members there is a -Wthread-safety-analysis error.
+    bool locateHashRange(const uint256& hash, std::size_t& minPos, std::size_t& maxPos,
+                         std::size_t& count) const EXCLUSIVE_LOCKS_REQUIRED(cs_store);
 
     void shiftIndex(std::size_t from, std::ptrdiff_t delta) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
     void rebuildIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_store);
@@ -307,10 +325,19 @@ private:
     //! vectors are kept exactly the same size and order as m_records under cs_store.
     void recomputeCacheAt(std::size_t i) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
 
-    //! True if record r's displayed status is still height-dependent (it will
-    //! change as blocks advance: Unconfirmed / Confirming / Immature / Open* /
-    //! MaturesWarning). Terminal states (Confirmed / Conflicted / NotAccepted /
-    //! Offline) are excluded — applyChainTipRefresh skips them.
+    //! True if record r's displayed status is still height-dependent, so it must
+    //! stay in the per-block refresh set: Unconfirmed / Confirming / Immature /
+    //! Open* / MaturesWarning, AND Conflicted / NotAccepted.
+    //!
+    //! Conflicted and NotAccepted are deliberately included even though they look
+    //! terminal. A record can land in one of them transiently — a coinstake is
+    //! stamped NotAccepted at CT_NEW, because the wallet is notified inside block
+    //! connection before pindexBest advances — and the default view filters mask
+    //! inactive rows, so such a record is invisible while in that state. If it
+    //! were also excluded from the refresh set, nothing would ever re-evaluate it
+    //! and it could never appear (#3100; the same invariant #3257 depends on).
+    //! See the rationale on recordStatusIsVolatile in wallettxstore.cpp; do not
+    //! "simplify" either to match the other without reading it.
     static bool isVolatile(const TransactionRecord& r);
 
     //! Re-evaluate whether `hash` belongs in m_volatile from its records' current


### PR DESCRIPTION
Six commits against the windowed transaction model (merged 2026-07-24, c0382e421): one confirmed defect with a failing-before/passing-after test, two unwind-safety fixes on paths that had no protection at all, and the test coverage that should have caught them.

**On #3257 specifically: this does not claim to close it.** The root cause there is still unproven — see the analysis in the issue. Two of the fixes here are strong candidates and one matches the reported fingerprint closely, but I would rather land them on their own merits than mark an issue fixed on a fingerprint match. #3101's Overview half *is* fixed, and that one is demonstrated.

## What is actually broken

**1. `emitCursorDeltas` resolved Insert payloads against the post-batch cursor.** Each `CursorDelta` is computed against a successively different `m_view_index`, but the records were fetched afterwards by re-reading `rowAt(d.first)`. Under the Overview's Status DESC sort the two parts of a coinstake differ only in the trailing `idx` of `status.sortKey`, so both Inserts land at the same slot and both payloads resolved to the sidestake — duplicating it and losing the Mined row. **This is the Overview half of #3101.** The same re-resolution reads out of bounds on the capped-view promotion path when a multi-part remove straddles the cap. Deltas now carry the absolute record index stamped at emission time.

**2. One unrefreshable transaction froze status refresh for the whole wallet.** `applyChainTipRefresh` calls `updateStatus` on every part of every height-volatile transaction on every block. That reaches `IsTrusted() → IsFromMe() → GetDebit()`, which throws outside `MoneyRange`, and `GetGeneratedType()`, which hits the tx index and reads a block from disk. At depth 1 — where a freshly staked block sits — the `GetDebit()` path is always taken, and none of it was guarded. One throwing record unwound the entire `m_volatile` loop, skipping every hash after it in iteration order. `m_volatile` is an `unordered_set`, so a hash's position is fixed by its bucket for as long as the bucket count holds: the same records get skipped block after block, and only a rehash or a `prime()` reshuffles them.

That matters more than it sounds, because of the masking invariant below: the rows behind it never leave `NotAccepted`/`Immature`, so every staked block behind the poison record stays invisible until a restart. Now guarded per hash, with the failure logged at the **default** level rather than VERBOSE — the line names the offending txid and needs to be in an ordinary user's debug.log without them first reproducing under `-debug=verbose`.

**3. `prime()` could park the intake worker forever.** It sets the worker's wait predicate (`m_rebuilding`) and used to clear it by falling off the end of the function, ~80 lines later, across a rescan that calls `decomposeTransaction` (→ `GetCredit`/`GetDebit`) and `updateStatus`. Any throw in between left the single intake worker parked permanently while producers kept enqueuing successfully and the inline refresh kept ripening rows already in the store — the GUI would show existing transactions updating normally and never show a new one again. Released from an RAII guard now, plus a warning when the intake backlog grows past any legitimate burst.

**4. `removeLocked` bailing on an inconsistent index stranded a hash permanently.** `updateTransaction`'s remove+insert fallback then hit `insertLocked`'s hash dedup and dropped the update, forever, for that transaction. It now rebuilds the index and retries, and the fallback checks the result.

**5. `drainEventQueue`'s catch-all stopped the only periodic pump** for any exception, with no restart path anywhere. Narrowed to the IPC-disconnect case it was written for, with a bounded consecutive-failure cutoff otherwise.

**6. Bounds checks** on the `m_by_hash` → `m_records` subscripts in `applyChainTipRefresh`, `recomputeCacheAt` (which *writes* three parallel vectors) and `updateVolatileForHash`.

**7. A comment that would have caused the next bug.** `wallettxstore.h` claimed Conflicted/NotAccepted are terminal and skipped by `applyChainTipRefresh`. The implementation has deliberately done the opposite since #3100 — anyone "simplifying" the .cpp to match would reintroduce #3100 and hide every staked block.

## Why this cluster hid for so long

With the default filters a freshly staked coinstake is **invisible at insert**. The wallet is notified from inside `ConnectBlock`, before `SetBestChain` advances `pindexBest`, so its block is not yet in the main chain; `updateStatus` takes the Generated branch with `!IsInMainChain()` and stamps `NotAccepted`; and `GRC::Accepts` masks Conflicted/NotAccepted in **both** production views. A stake's only route onto the screen is the later `applyChainTipRefresh → Cursor::applyStatusUpdate` flip-in. One path carries every stake row in the GUI.

Nothing tested it. Every case in `qt_wallettxstore_tests.cpp` constructs the store with a **nullptr wallet**, which leaves `applyChainTipRefresh()` and `prime()` — the two functions that whole lifecycle rests on — with no coverage at all.

## Coverage added

A new wallet-backed suite (`qt_wallettxstore_chain_tests.cpp`) builds real coinstakes in `pwalletMain` on a mock chain whose newest block is deliberately left unlinked (`pprev` set, `pnext` not, which is what `IsInMainChain()` tests), asserts the record really is stamped `NotAccepted` and masked in both views, then connects the block and advances the tip as `node/chainman.cpp` does and drives `applyChainTipRefresh` for real.

Both new guards are pinned by tests I verified are load-bearing by deliberately breaking the fix:

| Guard | Neutered how | Failure observed |
|---|---|---|
| `applyChainTipRefresh` try/catch | re-throw in the catch | `CWallet::GetDebit() : value out of range` escaping the refresh |
| `prime()` RAII park | skip release during unwinding | *"the intake worker never resumed after prime() threw"* |

Both use the same deterministic throw — a coinstake spending two `MAX_MONEY` inputs, so `GetDebit`'s running total leaves `MoneyRange` on the second. Each case asserts the throw actually happens, so neither can pass vacuously.

Note that **no `-regtest` test can cover any of this**: `GetBlocksToMaturity()` short-circuits to 0 on a mockable chain, so a regtest stake is stamped Confirmed on arrival and never enters the `NotAccepted` window.

Also adds a `-debug=verbose` trace to the refresh that makes the remaining failure modes distinguishable in one line — status transition plus per-view delta count. For a stake that never appears: `9->9` means `updateStatus` is not clearing NotAccepted; `9->7 emitted 0 deltas` means the cursor is not flipping it in; `9->7 emitted 1 deltas` means the store did its job and the loss is downstream; no line at all means it never reached the volatile set. Mutually exclusive, each decisive.

## Testing

- GUI-OFF windowed suites: 71 cases green
- ASan + UBSan (instrumentation verified linked): 71 cases, no reports
- GUI-ON `ctest` including `functional_tests`: 3/3
- `test/lint/lint-all.sh`: clean
- Both guards verified to fail without their fix

Not covered locally: a live staking run. A wallet with no magnitude never produces a coinstake, so `m_volatile` stays empty and the refresh early-returns; regtest cannot substitute for the reason above. That validation needs a staking testnet wallet.

Refs #3257, #3100. Fixes the Overview half of #3101.
