### PR TITLE
macos, ci: ship the daemon in the DMG, and stop the release job dropping assets

### DIFF
--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -474,6 +474,37 @@ jobs:
             echo "WARNING: Code signature verification failed (ad-hoc signing may not verify on CI)"
           fi
 
+          # The daemon must ship alongside the GUI: multiprocess is compiled into
+          # every macOS artifact and the IPC layer is connect-only, so a DMG without
+          # a node makes -multiprocess impossible to satisfy.
+          DAEMON="$APP/Contents/Helpers/gridcoinresearchd"
+          if [ ! -x "$DAEMON" ]; then
+            echo "FAIL: gridcoinresearchd missing from the bundle"
+            ls -la "$APP/Contents/Helpers/" "$APP/Contents/MacOS/" || true
+            hdiutil detach "$MOUNT_POINT" || true
+            exit 1
+          fi
+          echo "PASS: gridcoinresearchd present in the bundle"
+
+          # Neither binary may reference a build-machine library path. Homebrew is
+          # present on the runner and on most developer machines, so a missed
+          # relocation runs fine here and fails only on a clean install -- which is
+          # exactly the failure this check exists to catch, and why it asserts rather
+          # than reports.
+          leak=0
+          for b in "$BINARY" "$DAEMON"; do
+            if otool -L "$b" | tail -n +2 | grep -qE "^[[:space:]]*(/usr/local|/opt/homebrew)"; then
+              echo "FAIL: $(basename "$b") references build-machine libraries:"
+              otool -L "$b" | tail -n +2 | grep -E "^[[:space:]]*(/usr/local|/opt/homebrew)"
+              leak=1
+            fi
+          done
+          if [ "$leak" -ne 0 ]; then
+            hdiutil detach "$MOUNT_POINT" || true
+            exit 1
+          fi
+          echo "PASS: no build-machine library paths in either binary"
+
           # Verify binary is a valid Mach-O executable (no runtime execution
           # since the GUI binary pops up dialogs that hang in headless CI)
           if file "$BINARY" | grep -q "Mach-O"; then
@@ -683,6 +714,37 @@ jobs:
           else
             echo "WARNING: Code signature verification failed (ad-hoc signing may not verify on CI)"
           fi
+
+          # The daemon must ship alongside the GUI: multiprocess is compiled into
+          # every macOS artifact and the IPC layer is connect-only, so a DMG without
+          # a node makes -multiprocess impossible to satisfy.
+          DAEMON="$APP/Contents/Helpers/gridcoinresearchd"
+          if [ ! -x "$DAEMON" ]; then
+            echo "FAIL: gridcoinresearchd missing from the bundle"
+            ls -la "$APP/Contents/Helpers/" "$APP/Contents/MacOS/" || true
+            hdiutil detach "$MOUNT_POINT" || true
+            exit 1
+          fi
+          echo "PASS: gridcoinresearchd present in the bundle"
+
+          # Neither binary may reference a build-machine library path. Homebrew is
+          # present on the runner and on most developer machines, so a missed
+          # relocation runs fine here and fails only on a clean install -- which is
+          # exactly the failure this check exists to catch, and why it asserts rather
+          # than reports.
+          leak=0
+          for b in "$BINARY" "$DAEMON"; do
+            if otool -L "$b" | tail -n +2 | grep -qE "^[[:space:]]*(/usr/local|/opt/homebrew)"; then
+              echo "FAIL: $(basename "$b") references build-machine libraries:"
+              otool -L "$b" | tail -n +2 | grep -E "^[[:space:]]*(/usr/local|/opt/homebrew)"
+              leak=1
+            fi
+          done
+          if [ "$leak" -ne 0 ]; then
+            hdiutil detach "$MOUNT_POINT" || true
+            exit 1
+          fi
+          echo "PASS: no build-machine library paths in either binary"
 
           # Verify binary is a valid Mach-O executable (no runtime execution
           # since the GUI binary pops up dialogs that hang in headless CI)

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -1130,7 +1130,16 @@ jobs:
   # ----------------------------------------------------------------------
   deploy:
     name: Create Release
-    needs: [depends-builds, flatpak-build]
+    # EVERY job that uploads a gridcoin-* artifact must be listed here.
+    # download-artifact takes whatever exists at the moment it runs, so a producer
+    # missing from this list is a race, not a dependency detail: if it finishes after
+    # this job, its asset is silently absent from the release and the job still
+    # reports success. That is exactly how 5.5.1.5-testnet shipped without the macOS
+    # Intel DMG -- the Intel build completed 4m48s AFTER the release was assembled,
+    # while the ARM64 build happened to finish 17 minutes before it and was included.
+    # The docker-* artifacts are deliberately NOT needed: they feed docker-publish and
+    # are excluded from the release by the gridcoin-* glob below.
+    needs: [depends-builds, flatpak-build, macos-native-arm64, macos-native-intel]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -1143,17 +1152,25 @@ jobs:
 
       - name: Assemble Release Assets
         run: |
+          set -euo pipefail
           mkdir -p release_assets
 
-          # Copy all artifacts into release_assets
-          for dir in artifacts/gridcoin-*/; do
-            cp "$dir"* release_assets/ 2>/dev/null || true
+          # Copy all artifacts into release_assets. A failure here used to be
+          # swallowed by "2>/dev/null || true", which made a missing or unreadable
+          # artifact indistinguishable from a present one; the release then shipped
+          # short and still went green.
+          shopt -s nullglob
+          dirs=(artifacts/gridcoin-*/)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "No gridcoin-* artifacts were downloaded; nothing to release." >&2
+            exit 1
+          fi
+          for dir in "${dirs[@]}"; do
+            cp "$dir"* release_assets/
           done
 
           cd release_assets
           ls -la
-          sha256sum * > SHA256SUMS.txt
-          cat SHA256SUMS.txt
 
       - name: Publish Release
         uses: softprops/action-gh-release@v2

--- a/clinerules/05-common-tasks.md
+++ b/clinerules/05-common-tasks.md
@@ -1307,11 +1307,14 @@ cmake_production.yml
 
 When a tag is pushed (e.g., `v5.4.9.99`):
 
-1. All Production builds complete
+1. All Production builds complete -- every artifact-producing job must be in the `deploy`
+   job's `needs:` list, or it races the release and its asset is silently dropped
 2. `deploy` job activates
 3. Downloads all artifacts (Linux `.tar.gz`, Windows `.exe`, macOS `.dmg`)
-4. Generates `SHA256SUMS.txt`
-5. Creates **Draft Release** on GitHub with binaries attached
+4. Creates **Draft Release** on GitHub with binaries attached
+
+Checksums are not generated: the GitHub release page already publishes a SHA-256 digest for
+every attached asset.
 
 **Manual steps** (maintainer only):
 - Review draft release

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -783,7 +783,7 @@ if config.sign is not None and platform.system() == "Darwin":
     # 5. Sign the top-level app bundle (with entitlements)
     codesignItem(target, identity, entitlements_path, hardened, verbose)
 
-    # 5. Verify
+    # 6. Verify
     print("+ Verifying code signature +")
     subprocess.check_call(["codesign", "--verify", "--strict", "--verbose=2", target])
 

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -439,6 +439,52 @@ def deployFrameworks(frameworks: List[FrameworkInfo], bundlePath: str, binaryPat
 
     return deploymentInfo
 
+def helperBinaries(applicationBundle: ApplicationBundleInfo) -> List[str]:
+    """Executables shipped in Contents/Helpers, in a stable order.
+
+    Contents/MacOS is for the bundle's MAIN executable. Auxiliary executables belong
+    in Contents/Helpers: codesign treats a stray Mach-O in Contents/MacOS as a
+    subcomponent that must be independently valid, and an unsigned one there makes the
+    whole bundle fail verification with "code object is not signed at all".
+    """
+    helpersDir = os.path.join(applicationBundle.path, "Contents", "Helpers")
+    if not os.path.isdir(helpersDir):
+        return []
+    out = []
+    for name in sorted(os.listdir(helpersDir)):
+        path = os.path.join(helpersDir, name)
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            out.append(path)
+    return out
+
+
+def deployFrameworksForHelpers(applicationBundle: ApplicationBundleInfo, deploymentInfo: DeploymentInfo, strip: bool, verbose: int):
+    """Relocate library references for the helper executables.
+
+    The bundle ships gridcoinresearchd so the multiprocess (GUI/node split) build is
+    usable from the DMG. ApplicationBundleInfo.binaryPath names only the GUI, so
+    without this pass the daemon keeps whatever absolute install names it linked
+    against -- typically Homebrew paths under /usr/local or /opt/homebrew. It would run
+    on the build machine and on any developer box with the same brew packages, and fail
+    on a clean install with a dyld error naming a library the user has never heard of.
+
+    Contents/Helpers is a sibling of Contents/Frameworks, exactly as Contents/MacOS is,
+    so the @executable_path/../Frameworks/... install names deployFrameworks() writes
+    resolve from a helper unchanged.
+
+    deployFrameworks() is safe to call again here: it rewrites the passed binary's
+    install names first, and copyFramework() returns None for anything already in the
+    bundle, so shared libraries are relocated rather than duplicated. Libraries a helper
+    needs and the GUI does not are copied in on this pass.
+    """
+    for binaryPath in helperBinaries(applicationBundle):
+        print(f"+ Deploying frameworks for {os.path.basename(binaryPath)} +")
+        frameworks = getFrameworks(binaryPath, verbose)
+        if not frameworks:
+            continue
+        deployFrameworks(frameworks, applicationBundle.path, binaryPath, strip, verbose, deploymentInfo)
+
+
 def deployFrameworksForAppBundle(applicationBundle: ApplicationBundleInfo, strip: bool, verbose: int) -> DeploymentInfo:
     frameworks = getFrameworks(applicationBundle.binaryPath, verbose)
     if len(frameworks) == 0:
@@ -572,6 +618,7 @@ print("+ Deploying frameworks +")
 
 try:
     deploymentInfo = deployFrameworksForAppBundle(applicationBundle, config.strip, verbose)
+    deployFrameworksForHelpers(applicationBundle, deploymentInfo, config.strip, verbose)
     if deploymentInfo.qtPath is None:
         deploymentInfo.qtPath = os.getenv("QTDIR", None)
         if deploymentInfo.qtPath is None:
@@ -715,11 +762,25 @@ if config.sign is not None and platform.system() == "Darwin":
                     codesignItem(os.path.join(dirpath, filename),
                                  identity, None, hardened, verbose)
 
-    # 3. Sign the main executable (with entitlements)
+    # 3. Sign helper executables in Contents/Helpers, BEFORE the main binary and the
+    #    bundle. Inside-out order is not a style choice here: codesign validates a
+    #    bundle's subcomponents, so an unsigned helper makes signing the bundle fail
+    #    with "code object is not signed at all" naming the helper as the subcomponent.
+    #    Helpers get the same entitlements as the main binary -- gridcoinresearchd does
+    #    the same networking and file access the GUI does when it runs core in-process,
+    #    so under a hardened runtime it needs the same grants.
+    helpers_dir = os.path.join(target, "Contents", "Helpers")
+    if os.path.exists(helpers_dir):
+        for item in sorted(os.listdir(helpers_dir)):
+            item_path = os.path.join(helpers_dir, item)
+            if os.path.isfile(item_path) and os.access(item_path, os.X_OK):
+                codesignItem(item_path, identity, entitlements_path, hardened, verbose)
+
+    # 4. Sign the main executable (with entitlements)
     main_binary = os.path.join(target, "Contents", "MacOS", "gridcoinresearch")
     codesignItem(main_binary, identity, entitlements_path, hardened, verbose)
 
-    # 4. Sign the top-level app bundle (with entitlements)
+    # 5. Sign the top-level app bundle (with entitlements)
     codesignItem(target, identity, entitlements_path, hardened, verbose)
 
     # 5. Verify

--- a/doc/ci_cd.md
+++ b/doc/ci_cd.md
@@ -100,11 +100,17 @@ The `deploy` job in `cmake_production.yml` automates the release process.
 
   * **Trigger:** Pushing a tag (e.g., `git tag v5.4.9.99 && git push --tags`).
   * **Process:**
-    1.  Waits for Linux, Windows, and macOS builds to succeed.
+    1.  Waits for Linux, Windows, and macOS builds to succeed. Every job that uploads a
+        `gridcoin-*` artifact must appear in the `deploy` job's `needs:` list --
+        `download-artifact` collects whatever exists when it runs, so a producer left out
+        of `needs:` races the release and its asset is silently dropped.
     2.  Downloads all artifacts.
     3.  **Flattens** them (moves files from subfolders to root).
-    4.  Generates `SHA256SUMS.txt`.
-    5.  Creates a **Draft Release** on GitHub with all binaries attached.
+    4.  Creates a **Draft Release** on GitHub with all binaries attached.
+
+Checksums are not generated. The GitHub release page publishes a SHA-256 digest for every
+attached asset, so a separate `SHA256SUMS.txt` duplicated information the platform already
+provides.
 
 -----
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -479,15 +479,36 @@ if(APPLE)
     # in the inside-out order -- see deployFrameworksForHelpers() and step 3 of the
     # signing sequence there. Copying it afterwards would leave the daemon pointing at
     # Homebrew paths that do not exist on a user's machine, and unsigned.
+    # gridcoinresearchd is only a target when ENABLE_DAEMON is ON (src/CMakeLists.txt).
+    # Naming it unconditionally makes CMake fail at generate time with an "Unknown target"
+    # error that says nothing about the option that caused it, so the copy is conditional.
+    # Its absence is reported rather than silent: a bundle whose GUI advertises
+    # -multiprocess with no daemon beside it is the exact defect this target exists to
+    # prevent, and that combination is worth a warning rather than a note.
+    set(_deploy_helper_commands)
+    set(_deploy_helper_depends)
+    if(TARGET gridcoinresearchd)
+        set(_deploy_helper_commands
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${_app_bundle}/Contents/Helpers"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "$<TARGET_FILE:gridcoinresearchd>"
+                    "${_app_bundle}/Contents/Helpers/")
+        set(_deploy_helper_depends gridcoinresearchd)
+    elseif(ENABLE_MULTIPROCESS)
+        message(WARNING
+            "ENABLE_DAEMON is OFF but ENABLE_MULTIPROCESS is ON: the DMG will contain a GUI "
+            "that advertises -multiprocess with no gridcoinresearchd beside it to connect to.")
+    else()
+        message(STATUS
+            "Deploy: ENABLE_DAEMON is OFF, so the DMG will not contain gridcoinresearchd")
+    endif()
+
     add_custom_target(deploy
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${_app_bundle}/Contents/Helpers"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "$<TARGET_FILE:gridcoinresearchd>"
-                "${_app_bundle}/Contents/Helpers/"
+        ${_deploy_helper_commands}
         COMMAND ${CMAKE_COMMAND} -E env "QTDIR=${_qt_prefix_dir}" ${_deploy_cmd}
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         COMMENT "Deploying ${_dmg_name}.dmg via macdeployqtplus"
-        DEPENDS gridcoinresearch gridcoinresearchd
+        DEPENDS gridcoinresearch ${_deploy_helper_depends}
     )
 endif()
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -457,11 +457,37 @@ if(APPLE)
         endif()
     endif()
 
+    # Ship the daemon inside the bundle.
+    #
+    # Without this the DMG contains the GUI only, so -multiprocess is unusable from a
+    # macOS install: the IPC layer is connect-only (it attaches to a node already
+    # listening on node.sock and never spawns one), and there is no node to attach to.
+    # Every macOS artifact has multiprocess compiled in and advertises -multiprocess in
+    # --help, so shipping without the daemon leaves the option present and impossible to
+    # satisfy. The Windows installer already ships both.
+    #
+    # It goes in Contents/Helpers, not Contents/MacOS. Contents/MacOS is for the
+    # bundle's MAIN executable; codesign treats any other Mach-O there as a
+    # subcomponent that must be independently valid, and an auxiliary binary placed
+    # there fails bundle verification with "code object is not signed at all".
+    # Contents/Helpers is Apple's location for auxiliary executables, and it is a
+    # sibling of Contents/Frameworks exactly as Contents/MacOS is, so the
+    # @executable_path/../Frameworks/... install names resolve from it unchanged.
+    #
+    # It is copied in BEFORE macdeployqtplus runs, so the same pass that relocates the
+    # GUI's library references also relocates the daemon's, and so the daemon is signed
+    # in the inside-out order -- see deployFrameworksForHelpers() and step 3 of the
+    # signing sequence there. Copying it afterwards would leave the daemon pointing at
+    # Homebrew paths that do not exist on a user's machine, and unsigned.
     add_custom_target(deploy
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${_app_bundle}/Contents/Helpers"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_FILE:gridcoinresearchd>"
+                "${_app_bundle}/Contents/Helpers/"
         COMMAND ${CMAKE_COMMAND} -E env "QTDIR=${_qt_prefix_dir}" ${_deploy_cmd}
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         COMMENT "Deploying ${_dmg_name}.dmg via macdeployqtplus"
-        DEPENDS gridcoinresearch
+        DEPENDS gridcoinresearch gridcoinresearchd
     )
 endif()
 


### PR DESCRIPTION
Two defects in macOS/release packaging. They are together because the second one is how the first would have shipped broken without anyone noticing.

---

# 1. The macOS DMG ships no daemon

The DMG contains `Gridcoin.app` and nothing else — `gridcoinresearchd` appears nowhere in the image. Verified by extracting the `5.5.1.5-testnet` artifact:

```
Gridcoin.app/Contents/MacOS/
  gridcoinresearch          69 MB      <- only this
```

Multiprocess is compiled into every macOS artifact and `-multiprocess` is advertised in `--help`, but the IPC layer is **connect-only**: `ipc/interfaces.cpp` calls `m_process->connect(GetDataDir(), address)` and never spawns a node. So from a macOS install there is nothing to attach to, and the option cannot be satisfied. The Windows installer already ships both binaries, so the two platforms disagree about what a packaged artifact can do.

## Where it goes, and why not `Contents/MacOS`

The daemon is installed to **`Contents/Helpers`**, not `Contents/MacOS`. `Contents/MacOS` is for the bundle's *main* executable; `codesign` treats any other Mach-O placed there as a subcomponent that must be independently valid, and an auxiliary binary there fails bundle verification with `code object is not signed at all`. `Contents/Helpers` is Apple's location for auxiliary executables, and it is a sibling of `Contents/Frameworks` exactly as `Contents/MacOS` is — so `@executable_path/../Frameworks/...` install names resolve from it unchanged.

## Ordering is the substance of the change

**The daemon is copied in before `macdeployqtplus` runs.** `ApplicationBundleInfo.binaryPath` names the GUI only, so a daemon copied in *afterwards* keeps the absolute install names it linked against — Homebrew paths under `/usr/local` or `/opt/homebrew`, since the macOS jobs build against brew Cap'n Proto and Qt. That binary runs on the build machine and on any developer box with the same packages, and fails on a clean install with a `dyld` error naming a library the user has never installed.

Three pieces make that work:

- **`helperBinaries()`** enumerates executables in `Contents/Helpers` in a stable order.
- **`deployFrameworksForHelpers()`** relocates each one's install names. Reusing `deployFrameworks()` is safe: it rewrites the passed binary's references first, and `copyFramework()` returns `None` for anything already in the bundle — so shared libraries are re-pointed rather than duplicated, and libraries the daemon needs but the GUI does not are copied in on that pass. This mirrors what plugin deployment already does.
- **Signing step 3** signs helpers with the same entitlements as the main binary, *before* the main binary and the bundle, preserving inside-out order.

## Verification

The DMG check **asserts** both properties on the arm64 and Intel jobs, rather than assuming them:

- `gridcoinresearchd` is present and executable at `Contents/Helpers/`
- neither binary references `/usr/local` or `/opt/homebrew`

The second is the important one. Homebrew is present on the CI runner and on most developer machines, so a missed relocation passes every test anyone is likely to run and fails only for users. That has to fail the build, not print a warning.

For context on why it is worth asserting rather than trusting — the GUI's Cap'n Proto references in the current `5.5.1.5-testnet` DMG *are* correctly relocated:

```
@executable_path/../Frameworks/libcapnp.1.5.0.dylib
@executable_path/../Frameworks/libcapnp-rpc.1.5.0.dylib
@executable_path/../Frameworks/libkj.1.5.0.dylib
@executable_path/../Frameworks/libkj-async.1.5.0.dylib
```

`macdeployqtplus` does the right thing for the binary it knows about. The daemon is simply not a binary it knew about, and nothing today would have noticed.

## `ENABLE_DAEMON=OFF` no longer breaks configure

The `deploy` target named `gridcoinresearchd` unconditionally, but that target only exists inside `if(ENABLE_DAEMON)`. Configuring with `-DENABLE_DAEMON=OFF` failed at generate time with an `Unknown target` error naming the target rather than the option. The copy is now guarded on `if(TARGET gridcoinresearchd)`, and its absence is reported rather than silent: `ENABLE_DAEMON=OFF` combined with `ENABLE_MULTIPROCESS=ON` gets a warning, because a bundle advertising `-multiprocess` with no daemon beside it is the exact defect this target exists to prevent.

---

# 2. The release job races the macOS builds, and loses silently

**This is why `5.5.1.5-testnet` shipped with no Intel DMG.** The job did not fail — it was never waited for:

```
macOS ARM64      14:50:46 -> 15:04:21    finished 17 min early    -> included
Create Release   15:21:36 -> 15:21:49    ran here
macOS Intel      14:47:18 -> 15:26:37    finished 4m48s LATER     -> dropped
```

`deploy` needed only `[depends-builds, flatpak-build]`, but six jobs upload artifacts, and `download-artifact` collects whatever exists at the moment it runs. A producer missing from `needs:` is not a dependency detail — it is a race whose losing outcome is an incomplete release that still reports success. The Intel artifact exists on the run and the job is green; it simply was not published yet when the release was assembled.

**Both macOS jobs were unguarded.** The ARM64 DMG was present only because that build happened to finish seventeen minutes ahead. Either could have been dropped on a busier runner pool.

`needs:` now lists every job that uploads a `gridcoin-*` artifact. The two `docker-*` producers stay out deliberately — they feed `docker-publish` and are excluded from the release by the `gridcoin-*` glob, so waiting on them would only slow the release down.

## The assemble step no longer hides its own failures

`cp "$dir"* release_assets/ 2>/dev/null || true` made a missing or unreadable artifact indistinguishable from a present one — the same fail-open shape as the race itself. It now runs under `set -euo pipefail` and exits non-zero when no `gridcoin-*` artifact was downloaded at all.

## `SHA256SUMS.txt` is no longer generated

The GitHub release page publishes a SHA-256 digest for every attached asset, so the file duplicated what the platform already provides. It was also actively misleading: assembled from whatever survived the race, it documented the incomplete asset set as though it were complete.

## Docs corrected

`doc/ci_cd.md` already claimed the deploy job *"waits for Linux, Windows, and macOS builds to succeed."* That was the intent, not the behaviour. Both it and `clinerules/05-common-tasks.md` now state the `needs:` requirement explicitly and drop the checksum step.

---

# What I could not verify

**There is no Apple hardware in my environment.** The macOS packaging is verified by construction and by the CI assertions it adds; I have not built a DMG or launched the result. The added assertions are the gate — if the daemon is missing, or either binary still points at build-machine libraries, both macOS jobs fail rather than producing an artifact that breaks on a clean install.

Worth a maintainer smoke test on a machine **without** Homebrew, or with the relevant formulae unlinked, since that is the condition the assertion stands in for.

The CI changes were validated locally: the workflow parses and all four `needs:` entries resolve to real job ids; the assemble script copies `gridcoin-*` while excluding `docker-*`, and exits 1 when nothing matches. The race fix itself can only be confirmed by a tag build.

# Not addressed here

The GUI still does not spawn a node, so using multiprocess on macOS means starting `gridcoinresearchd` by hand from inside the bundle. Shipping it is the prerequisite; whether the GUI should launch it, or a launchd job should, is a separate decision.