### PR TITLE
packaging: stop forcing UPnP on at startup in the Debian builds

### DIFF
--- a/debian-testnet/rules
+++ b/debian-testnet/rules
@@ -53,7 +53,6 @@ override_dh_auto_configure:
 		-DENABLE_TESTS=ON \
 		-DENABLE_QRENCODE=ON \
 		-DENABLE_UPNP=ON \
-		-DDEFAULT_UPNP=ON \
 		-DUSE_DBUS=ON \
 		-DENABLE_PIE=ON \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/debian/rules
+++ b/debian/rules
@@ -53,7 +53,6 @@ override_dh_auto_configure:
 		-DENABLE_TESTS=ON \
 		-DENABLE_QRENCODE=ON \
 		-DENABLE_UPNP=ON \
-		-DDEFAULT_UPNP=ON \
 		-DUSE_DBUS=ON \
 		-DENABLE_PIE=ON \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
`debian/rules:56` and `debian-testnet/rules:56` both pass `-DDEFAULT_UPNP=ON`, so packages built through them **start with port mapping already enabled**.

That is the exact state the UPnP work removed everywhere else. The intended split is: UPnP **compiled in** whenever the library is present, so the GUI setting is operative — and **off at runtime** until the operator asks for it. Eleven `-DDEFAULT_UPNP=ON` overrides were dropped from the CI workflows at the time; these two were missed.

## Why it survived

OBS builds through `debian/rules`, not through any workflow this repository's CI exercises. Nothing in the pipeline that validated the original change ever configures this path, so the override was invisible to it. `DEFAULT_UPNP` is still a live option — `CMakeLists.txt:130`, consumed at `src/CMakeLists.txt:339` and `src/qt/CMakeLists.txt:206` — so this was not a stale no-op flag; it was doing exactly what it says.

## Scope of the effect

Confined to **listening** nodes. `AppInit2` already declined to map a port when not listening, and the runtime path now applies the same rule. The stock configuration makes eight outbound connections and has no inbound port to map, so there is nothing for the default to be useful for.

`ENABLE_UPNP=ON` is deliberately retained. The capability stays compiled in; only the start-enabled default goes.

## Behaviour change

After upgrading a distribution package, a **listening** node that relied on the package default will no longer map a port until UPnP is enabled — via the GUI toggle or `-upnp`. Non-listening nodes are unaffected, which is the overwhelming majority.

## Testing

Not built through OBS here — this changes only the arguments `dh_auto_configure` passes, and `-DDEFAULT_UPNP=ON` was the only removal, with `ENABLE_UPNP=ON` left in place. `grep` confirms no `DEFAULT_UPNP` reference remains under `debian/` or `debian-testnet/`. Worth a confirmation on the first OBS build that the resulting package starts with UPnP off.


## Related

**This conflicts with #3265 — verified, not assumed.** A `git merge-tree` of the two branches reports a content conflict in **both** `debian/rules` and `debian-testnet/rules`. The changes land on immediately adjacent lines: #3265 inserts `-DENABLE_MULTIPROCESS=ON` directly above the `-DDEFAULT_UPNP=ON` line this PR deletes, and git will not auto-resolve that.

Whichever merges second needs a rebase, and the resolution is unambiguous — the final flag list keeps `-DENABLE_MULTIPROCESS=ON` and drops `-DDEFAULT_UPNP=ON`, in both files. There is no ordering preference between them otherwise; they are independent changes.