### PR TITLE
packaging: build the Debian/OBS packages with multiprocess enabled

### DIFF
--- a/debian-testnet/control
+++ b/debian-testnet/control
@@ -25,6 +25,11 @@ Build-Depends:
  libboost-date-time-dev,
  libboost-test-dev,
  libminiupnpc-dev,
+# Multiprocess (IPC) build: the code generator and the runtime. The vendored
+# libmultiprocess subtree requires Cap'n Proto 0.9 or newer and fails configure
+# below that, so the floor is expressed here rather than discovered mid-build.
+ capnproto (>= 0.9),
+ libcapnp-dev (>= 0.9),
  libqrencode-dev,
  libzip-dev,
  libcurl4-openssl-dev,
@@ -70,6 +75,8 @@ Depends:
  qt6-svg-plugins | libqt6svg6
 Recommends:
  bash-completion
+Suggests:
+ gridcointestnetd
 Description: Gridcoin Research testnet Qt GUI
  Gridcoin is a proof-of-stake cryptocurrency that rewards BOINC
  (Berkeley Open Infrastructure for Network Computing) participants
@@ -77,3 +84,8 @@ Description: Gridcoin Research testnet Qt GUI
  .
  This package provides the Qt-based graphical user interface for the
  testnet (gridcointestnet).
+ .
+ The GUI runs the node in-process by default. To use the multiprocess
+ (GUI/node split) mode with -multiprocess, install gridcointestnetd as well:
+ in that mode the GUI attaches over IPC to a daemon that is already running,
+ and does not start one itself.

--- a/debian-testnet/rules
+++ b/debian-testnet/rules
@@ -53,6 +53,7 @@ override_dh_auto_configure:
 		-DENABLE_TESTS=ON \
 		-DENABLE_QRENCODE=ON \
 		-DENABLE_UPNP=ON \
+		-DENABLE_MULTIPROCESS=ON \
 		-DUSE_DBUS=ON \
 		-DENABLE_PIE=ON \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,11 @@ Build-Depends:
  libboost-date-time-dev,
  libboost-test-dev,
  libminiupnpc-dev,
+# Multiprocess (IPC) build: the code generator and the runtime. The vendored
+# libmultiprocess subtree requires Cap'n Proto 0.9 or newer and fails configure
+# below that, so the floor is expressed here rather than discovered mid-build.
+ capnproto (>= 0.9),
+ libcapnp-dev (>= 0.9),
  libqrencode-dev,
  libzip-dev,
  libcurl4-openssl-dev,
@@ -69,6 +74,8 @@ Depends:
  qt6-svg-plugins | libqt6svg6
 Recommends:
  bash-completion
+Suggests:
+ gridcoinresearchd
 Description: Gridcoin Research Qt GUI
  Gridcoin is a proof-of-stake cryptocurrency that rewards BOINC
  (Berkeley Open Infrastructure for Network Computing) participants
@@ -76,3 +83,8 @@ Description: Gridcoin Research Qt GUI
  .
  This package provides the Qt-based graphical user interface
  (gridcoinresearch).
+ .
+ The GUI runs the node in-process by default. To use the multiprocess
+ (GUI/node split) mode with -multiprocess, install gridcoinresearchd as well:
+ in that mode the GUI attaches over IPC to a daemon that is already running,
+ and does not start one itself.

--- a/debian/rules
+++ b/debian/rules
@@ -53,6 +53,7 @@ override_dh_auto_configure:
 		-DENABLE_TESTS=ON \
 		-DENABLE_QRENCODE=ON \
 		-DENABLE_UPNP=ON \
+		-DENABLE_MULTIPROCESS=ON \
 		-DUSE_DBUS=ON \
 		-DENABLE_PIE=ON \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
`ENABLE_MULTIPROCESS` defaults OFF and neither `debian/rules` nor `debian-testnet/rules` sets it, so **every package built through OBS is monolithic**.

With production CI now enabling multiprocess on all seven artifact jobs, the distribution packages are the only shipped Gridcoin binaries without the GUI/node split. A user installing from a distro repository gets a build whose `--help` advertises `-multiprocess` and which cannot do it.

## What changed

Both recipes pass `-DENABLE_MULTIPROCESS=ON`, and both control files gain the Cap'n Proto build dependencies:

```
 capnproto,
 libcapnp-dev (>= 0.9),
```

`capnproto` supplies the code generator, `libcapnp-dev` the runtime. **The `>= 0.9` floor is not arbitrary** — `src/ipc/libmultiprocess/CMakeLists.txt` calls `find_package(CapnProto 0.9)` and hard-fails below it:

```cmake
message(FATAL_ERROR "Cap'n Proto 0.9 or newer is required, but version ${CapnProto_VERSION} was found.")
```

Expressing the floor in `Build-Depends` means a distribution that cannot satisfy it reports the package **unresolvable**, rather than starting a build that dies part way through with a version-mismatch error.

libmultiprocess is a vendored subtree and needs no packaging. `${shlibs:Depends}` already covers the libcapnp runtime dependency for both binary packages, so no manual `Depends` entry is needed.

## The split packaging

The daemon and GUI are separate binary packages, so multiprocess needs **both** installed. That is now stated rather than left to be discovered — the GUI package `Suggests` the daemon, and its description explains that `-multiprocess` attaches over IPC to a daemon that is already running and does not start one itself.

The testnet recipe uses its own package names (`gridcointestnetd`, `gridcointestnet-qt`) and refers to those, not the mainnet ones.

## What is NOT verified — please check before merging

**No OBS build was run.** More importantly, **the distributions the OBS project targets are configured in OBS, not in this repository**, so I cannot determine from here what the `>= 0.9` floor does to the target list. A target shipping an older Cap'n Proto will go **unresolvable** rather than quietly producing a monolithic package — which is the right failure mode, but it means that distribution stops receiving packages until it is dropped or the floor is handled differently.

If any current target predates Cap'n Proto 0.9, that decision needs making before this lands. The alternative shape — probing `pkg-config --atleast-version=0.9 capnp` in `debian/rules` and degrading to a monolithic build — was deliberately **not** taken, because it makes package contents vary silently by distribution.

## Related

**Rebased onto `development` after #3264 merged.** The two did conflict as predicted — both `debian/rules` and `debian-testnet/rules`, since this PR inserted `-DENABLE_MULTIPROCESS=ON` directly above the `-DDEFAULT_UPNP=ON` line #3264 deletes.

Resolved the way both PR bodies said it should be: keep `-DENABLE_MULTIPROCESS=ON`, drop `-DDEFAULT_UPNP=ON`. `-DENABLE_UPNP=ON` is retained in both files, so UPnP support stays compiled in and only the start-enabled default is gone — #3264's intent preserved.

The diff is now purely additive (26 insertions, 0 deletions): one `-DENABLE_MULTIPROCESS=ON` line per rules file plus the Cap'n Proto build-deps and `Suggests:` in each control file.