### PR TITLE
build, ipc, doc: fix the OpenBSD and FreeBSD builds, including multiprocess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,31 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
     cmake_policy(SET CMP0167 OLD)
 endif()
 
+# CMake's FindBoost defaults Boost_USE_DEBUG_RUNTIME to TRUE when the caller has not
+# set it. That is an MSVC-only concept -- it selects the /MDd runtime -- but Boost's own
+# CMake config files honour it on every platform: each variant file begins with
+#
+#     if(Boost_USE_DEBUG_RUNTIME)
+#       _BOOST_SKIPPED("libboost_foo.so" "release runtime, ...")
+#
+# so on a distribution that ships only release-runtime variants EVERY variant is rejected
+# and Boost is reported as not found ("No suitable build variant has been found").
+# FreeBSD's boost packages are built that way.
+#
+# This only bites when FindBoost actually runs its module search: FindBoost first delegates
+# to find_package(Boost NO_MODULE) and returns early if a BoostConfig.cmake is found, in
+# which case the default is never assigned. So the failure appears on systems whose Boost
+# lacks the CMake config package, and not on those that have it -- which is why it is not
+# reproducible everywhere.
+#
+# Set it OFF up front rather than unsetting it afterwards: FindBoost only assigns the
+# default under if(NOT DEFINED ...), so a value defined here is preserved, it covers the
+# pre-1.70 module-mode branch below as well, and it does not discard a value a user or
+# toolchain file set deliberately.
+if(NOT DEFINED Boost_USE_DEBUG_RUNTIME)
+    set(Boost_USE_DEBUG_RUNTIME OFF)
+endif()
+
 find_package(Boost ${BOOST_MINIMUM_VERSION} REQUIRED)
 
 if(Boost_VERSION VERSION_LESS 1.69.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,13 +504,43 @@ if(ENABLE_HARDENING)
         message(STATUS "Hardening: branch-protection and stack-clash skipped (Mach-O target)")
     endif()
 
+    # Make the probes reject a flag the driver accepts but then does not implement.
+    #
+    # check_cxx_compiler_flag only proves the driver did not reject the spelling. Clang
+    # will accept a flag it has no implementation for on the current target and then
+    # report "argument unused during compilation: '-fstack-clash-protection'" on EVERY
+    # translation unit: the flag is requested, the mitigation is absent, and the build
+    # gains several hundred warnings saying so. OpenBSD/amd64 does exactly this with
+    # -fstack-clash-protection (316 warnings in a full build), and Darwin does the same.
+    #
+    # Promoting that diagnostic to an error for the duration of the probes turns
+    # "accepted but ignored" into a failed check, so the flag is simply not added. GCC
+    # has no such warning and errors on the option, so probe for it first -- without the
+    # guard, setting it unconditionally would make every hardening probe below fail on
+    # GCC and silently disable hardening on Linux.
+    #
+    # This does not catch a flag that is accepted AND honoured but semantically wrong for
+    # the target -- see -mbranch-protection on Mach-O above, which generates real code
+    # that breaks unwinding. No probe can see that; it stays platform-gated.
+    check_cxx_compiler_flag("-Werror=unused-command-line-argument" HARDENING_HAVE_WERROR_UNUSED_ARG)
+    set(_hardening_saved_required_flags "${CMAKE_REQUIRED_FLAGS}")
+    if(HARDENING_HAVE_WERROR_UNUSED_ARG)
+        string(APPEND CMAKE_REQUIRED_FLAGS " -Werror=unused-command-line-argument")
+    endif()
+
     foreach(flag ${hardening_flags})
         string(MAKE_C_IDENTIFIER "HARDENING_CXX${flag}" flag_var)
         check_cxx_compiler_flag("${flag}" ${flag_var})
         if(${flag_var})
             add_compile_options("${flag}")
+        else()
+            message(STATUS "Hardening: ${flag} not applied (compiler accepts no working "
+                           "implementation for this target)")
         endif()
     endforeach()
+
+    set(CMAKE_REQUIRED_FLAGS "${_hardening_saved_required_flags}")
+    unset(_hardening_saved_required_flags)
 
     # separate-code keeps executable and non-executable content on distinct pages,
     # which shrinks what a ROP search has to work with. GNU ld enables it by default

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -15,7 +15,7 @@ FreeBSD requires the FQDN in the configuration. If you are setting this OS up fr
 ```sh
 sudo sysrc hostname="hostname.domainname"
 sudo hostname "hostname.domainname"
-````
+```
 
 *Note: Ensure you add this hostname to `/etc/hosts` next to 127.0.0.1 and ::1 to prevent sudo delays.*
 

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -2,6 +2,11 @@
 
 This guide details how to build Gridcoin on FreeBSD (14.x+).
 
+Verified on **FreeBSD 15.0-RELEASE (amd64)** against Gridcoin 5.5.1.5: both the
+monolithic and the multiprocess builds compile, and the multiprocess GUI attaches to a
+separately started daemon over IPC. Toolchain used: clang 19.1.7, CMake 3.31.9,
+Boost 1.88, Qt6 6.9.3.
+
 ## 1. System Preparation (First Run Only)
 
 **Hostname Setup:**
@@ -47,7 +52,19 @@ sudo pkg install git cmake boost-all libzip curl pkgconf miniupnpc
 
 # Install Qt6 for the GUI Wallet
 sudo pkg install qt6
+
+# Multiprocess (GUI/node separation, -multiprocess) only:
+# Cap'n Proto supplies the code generator and the runtime the IPC layer is built on.
+# Not needed for a monolithic build.
+sudo pkg install capnproto
 ```
+
+> **Note on the Cap'n Proto package and FreeBSD 15.0-RELEASE.** `pkg` prints a warning
+> that a kernel bug may prevent the library working as intended on 15.0-RELEASE, with a
+> fix expected in 15.1. Gridcoin's IPC was exercised on 15.0-RELEASE regardless -- the
+> daemon serves on the socket and the GUI attaches and runs -- so the warning did not
+> prevent multiprocess from working here. It is reproduced so you know why `pkg` shows
+> it, not because it is known to break Gridcoin.
 
 ## 3\. Clone the Repository
 
@@ -73,8 +90,7 @@ cmake -B build \
 -DENABLE_TESTS=on \
 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 -DENABLE_PIE=on \
--DENABLE_UPNP=on \
--DBoost_USE_DEBUG_RUNTIME=OFF
+-DENABLE_UPNP=on
 
 cmake --build build -j$(sysctl -n hw.ncpu)
 
@@ -84,7 +100,34 @@ sudo cmake --install build
 ### Option B: GUI Wallet (Qt6) - Recommended
 
 **Configure:**
-*Note: `-DBoost_USE_DEBUG_RUNTIME=OFF` is critical on FreeBSD. It forces CMake to accept the system's "Release" version of Boost even when building Gridcoin with debug symbols. You can alternatively use "Release" instead of RelWithDebInfo if you don't need the debug symbols and omit the -DBoost_USE_DEBUG_RUNTIME=OFF flag.*
+
+> **`-DBoost_USE_DEBUG_RUNTIME=OFF` is no longer required.** Earlier revisions of this
+> guide told you to pass it, and described it as accepting the system's release Boost
+> "even when building with debug symbols" -- with `Release` offered as an alternative.
+> That description was wrong: the failure had nothing to do with the build type, and
+> `Release`, `RelWithDebInfo` and `Debug` all failed identically. CMake's FindBoost
+> defaults `Boost_USE_DEBUG_RUNTIME` to `TRUE` (an MSVC-only concept), and Boost's own
+> CMake config files honour it everywhere, so a distribution shipping only
+> release-runtime variants -- FreeBSD's -- had every variant rejected with "No suitable
+> build variant has been found". The tree now sets it `OFF` up front, so no flag is
+> needed. Passing it explicitly is still honoured if you have a reason to.
+
+```sh
+cmake -B build \
+-DENABLE_GUI=on \
+-DENABLE_TESTS=on \
+-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+-DUSE_QT6=on \
+-DENABLE_PIE=on \
+-DENABLE_UPNP=on
+```
+
+### Option C: Multiprocess (GUI/node separation)
+
+Add `-DENABLE_MULTIPROCESS=ON` to either configuration above; it requires the
+`capnproto` package. FreeBSD needs no other change -- its default per-process data limit
+is large (`ulimit -d` reports 32 GB), so the memory-hungry generated Cap'n Proto sources
+compile without adjustment.
 
 ```sh
 cmake -B build \
@@ -94,8 +137,20 @@ cmake -B build \
 -DUSE_QT6=on \
 -DENABLE_PIE=on \
 -DENABLE_UPNP=on \
--DBoost_USE_DEBUG_RUNTIME=OFF
+-DENABLE_MULTIPROCESS=ON
+
+cmake --build build -j$(sysctl -n hw.ncpu)
 ```
+
+To run it, start the daemon first and then attach the GUI; the GUI does not spawn a node:
+
+```sh
+./build/bin/gridcoinresearchd -multiprocess &
+./build/bin/gridcoinresearch -multiprocess
+```
+
+The daemon logs the peer-credential mechanism in force at startup; on FreeBSD it reads
+`getpeereid (connections from another OS user are refused)`.
 
 **Build:**
 Use `sysctl` to automatically detect core count for parallel compilation. Pay attention to memory usage. General 1 GB per core is required, so if you have a smaller amount of memory, you may want to substitute your RAM in GB - 1 GB as the number of CPUs.
@@ -123,7 +178,7 @@ gridcoinresearchd
 If you did not install, you can run directly from the build folder. Assuming you are still in the Gridcoin-Research repo directory,
 
 ```
-./build/src/gridcoinresearchd
+./build/bin/gridcoinresearchd
 ```
 
 ### If you followed option B (GUI)
@@ -137,5 +192,5 @@ gridcoinresearch
 If you did not install, you can run directly from the build folder. Assuming you are still in the Gridcoin-Research repo directory,
 
 ```
-./build/src/qt/gridcoinresearch
+./build/bin/gridcoinresearch
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,10 @@
 # OpenBSD build guide
 
-This guide details how to build Gridcoin on OpenBSD. While this is not checked in CI/CD, it has been verified to work as of the 5.5.0.0 release.
+This guide details how to build Gridcoin on OpenBSD. This is not checked in CI/CD.
+
+Verified on **OpenBSD 7.8 (amd64)** against Gridcoin 5.5.1.5: both the monolithic and the
+multiprocess builds compile, and the multiprocess GUI attaches to a separately started
+daemon over IPC. Toolchain used: clang 19.1.7, CMake 3.31.8, Boost 1.87, Qt6 6.8.3.
 
 ## 1. Install Dependencies
 
@@ -9,6 +13,11 @@ Run the following commands as root (or using `doas`) to install the necessary bu
 ```ksh
 # Basic build requirements and libraries
 pkg_add git cmake boost curl libzip miniupnpc
+
+# Multiprocess (GUI/node separation, -multiprocess) only:
+# Cap'n Proto supplies the code generator and the runtime the IPC layer is built on.
+# Not needed for a monolithic build.
+pkg_add capnproto
 
 # If you prefer sudo over the native doas (optional)
 pkg_add sudo
@@ -101,6 +110,58 @@ cmake --build build -j <# of cpus>
 doas cmake --install build
 ```
 
+### Option C: Multiprocess (GUI/node separation)
+
+Add `-DENABLE_MULTIPROCESS=ON` to either configuration above. This requires the
+`capnproto` package **and one OpenBSD-specific adjustment.**
+
+> **Raise `ulimit -d` before building with multiprocess.** OpenBSD caps a process's data
+> segment through `login.conf`; the `default` class sets `datasize-cur=1536M`. The
+> generated Cap'n Proto proxy sources are large (one preprocessed translation unit is
+> ~9 MB), and clang needs more than 1.5 GB of heap for them. Without the raise the build
+> dies part way through with:
+>
+> ```
+> LLVM ERROR: out of memory
+> c++: error: clang frontend command failed with exit code 134
+> ```
+>
+> This is not a Gridcoin error and not a shortage of RAM -- it is the per-process limit.
+> Users in the `staff` login class (`datasize-max=infinity`) can raise it in-shell; check
+> with `ulimit -d` and your class with `getent passwd $(id -un)`.
+
+```ksh
+# Raise the per-process data limit for this shell, then configure and build.
+ulimit -d 4194304
+
+cmake -B build -DENABLE_GUI=on -DENABLE_TESTS=on -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DUSE_QT6=on -DENABLE_PIE=on -DENABLE_UPNP=on -DENABLE_MULTIPROCESS=ON
+
+# Use FEWER jobs than cores for the multiprocess build. Several of the generated IPC
+# sources each need well over 1 GB; on a 4 GB machine -j4 will thrash or be killed.
+# -j2 completed reliably on a 4 vCPU / 4 GB VM.
+cmake --build build -j 2
+```
+
+To run it, start the daemon first and then attach the GUI; the GUI does not spawn a node:
+
+```ksh
+./build/bin/gridcoinresearchd -multiprocess &
+./build/bin/gridcoinresearch -multiprocess
+```
+
+The daemon logs the peer-credential mechanism in force at startup; on OpenBSD it reads
+`getpeereid (connections from another OS user are refused)`. OpenBSD does define
+`SO_PEERCRED`, but with a different payload than Linux, so Gridcoin uses `getpeereid(3)`
+here.
+
+## Notes on hardening flags
+
+OpenBSD's clang **accepts but ignores** `-fstack-clash-protection`; the build emits many
+`argument unused during compilation` warnings for it. They are harmless, but be aware
+that this particular mitigation is not actually applied on OpenBSD even though the build
+requests it. The other hardening flags are unaffected.
+
 ## 4\. Running Gridcoin
 
 ### If you followed option A (Daemon only)
@@ -114,7 +175,7 @@ gridcoinresearchd
 If you did not install, you can run directly from the build folder. Assuming you are still in the Gridcoin-Research repo directory,
 
 ```
-./build/src/gridcoinresearchd
+./build/bin/gridcoinresearchd
 ```
 
 ### If you followed option B (GUI)
@@ -128,6 +189,6 @@ gridcoinresearch
 If you did not install, you can run directly from the build folder. Assuming you are still in the Gridcoin-Research repo directory,
 
 ```
-./build/src/qt/gridcoinresearch
+./build/bin/gridcoinresearch
 ```
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -21,7 +21,7 @@ pkg_add capnproto
 
 # If you prefer sudo over the native doas (optional)
 pkg_add sudo
-````
+```
 
 ### Note on Sudo vs. Doas
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -157,10 +157,21 @@ here.
 
 ## Notes on hardening flags
 
-OpenBSD's clang **accepts but ignores** `-fstack-clash-protection`; the build emits many
-`argument unused during compilation` warnings for it. They are harmless, but be aware
-that this particular mitigation is not actually applied on OpenBSD even though the build
-requests it. The other hardening flags are unaffected.
+OpenBSD's clang **accepts but does not implement** `-fstack-clash-protection`: the driver
+takes the flag and the frontend then reports `argument unused during compilation` for it.
+
+The build detects this and does not apply the flag, so you will see it reported at
+configure time rather than as several hundred warnings during compilation:
+
+```
+-- Hardening: -fstack-clash-protection not applied (compiler accepts no working
+   implementation for this target)
+```
+
+Be aware that this particular mitigation is therefore **unavailable on OpenBSD** -- that
+is a property of the toolchain, not something the build can work around. Stack canaries
+(`-fstack-protector-all`) and control-flow protection (`-fcf-protection=full`) are applied
+normally.
 
 ## 4\. Running Gridcoin
 

--- a/src/ipc/peercred.cpp
+++ b/src/ipc/peercred.cpp
@@ -14,6 +14,18 @@
 #include <unistd.h>
 #endif
 
+//! Linux is the only target where SO_PEERCRED carries `struct ucred`. OpenBSD ALSO
+//! defines SO_PEERCRED (sys/socket.h), but its payload is `struct sockpeercred`, so
+//! keying off the option name alone fails to compile there with "variable has
+//! incomplete type 'struct ucred'". FreeBSD and macOS do not define SO_PEERCRED at
+//! all. Every non-Linux target we support provides getpeereid(3), so that is the
+//! portable branch. Defined once because CheckPeerCredentials() and
+//! PeerCredentialEnforcement() must never disagree: the latter is what the startup
+//! log advertises as the enforcement mechanism in force.
+#if defined(__linux__) && defined(SO_PEERCRED)
+#define GRIDCOIN_PEERCRED_SO_PEERCRED 1
+#endif
+
 namespace ipc {
 
 #ifndef WIN32
@@ -53,7 +65,7 @@ bool CheckPeerCredentials(int peer_fd, PeerCredPolicy policy)
     const uid_t self_uid = ::geteuid();
     uid_t peer_uid;
 
-#if defined(SO_PEERCRED)
+#ifdef GRIDCOIN_PEERCRED_SO_PEERCRED
     // Linux: struct ucred captured at connect time.
     struct ucred cred;
     socklen_t len = sizeof(cred);
@@ -65,7 +77,7 @@ bool CheckPeerCredentials(int peer_fd, PeerCredPolicy policy)
     }
     peer_uid = cred.uid;
 #else
-    // *BSD / macOS.
+    // OpenBSD / FreeBSD / macOS.
     gid_t peer_gid;
     if (::getpeereid(peer_fd, &peer_uid, &peer_gid) != 0) {
         return undetermined("getpeereid failed", errno);
@@ -85,7 +97,7 @@ const char* PeerCredentialEnforcement()
 #ifdef WIN32
     return "none (Windows AF_UNIX exposes no peer credentials; the owner-only DACL on node.sock "
            "and ipc.cookie is the guard)";
-#elif defined(SO_PEERCRED)
+#elif defined(GRIDCOIN_PEERCRED_SO_PEERCRED)
     return "SO_PEERCRED (connections from another OS user are refused)";
 #else
     return "getpeereid (connections from another OS user are refused)";

--- a/src/ipc/peercred.h
+++ b/src/ipc/peercred.h
@@ -45,7 +45,10 @@ bool PeerUidAllowed(uid_t peer_uid, uid_t self_uid);
 //! call failed and MP refuses to serve rather than silently degrading to
 //! cookie-only. Only a definite uid mismatch is logged via error().
 //!
-//! Platform coverage: Linux uses SO_PEERCRED; *BSD/macOS use getpeereid(). On
+//! Platform coverage: Linux uses SO_PEERCRED with struct ucred; every other POSIX
+//! target we support uses getpeereid(). Note OpenBSD ALSO defines SO_PEERCRED, but
+//! its payload is struct sockpeercred -- so the implementation gates on __linux__
+//! rather than on the option name, which would not compile on OpenBSD. On
 //! Windows AF_UNIX exposes no peer-credential API whatsoever, so this returns
 //! true and the explicit owner+SYSTEM PROTECTED DACL that ipc/process.cpp applies
 //! to node.sock and ipc.cookie (and verifies by read-back) is the guard. Call


### PR DESCRIPTION
Neither BSD could be built as documented. **FreeBSD failed to configure at all** without a workaround flag, and **OpenBSD could not compile the multiprocess build**. Both turned out to be portability bugs in this tree rather than packaging problems on those systems.

Verified on **OpenBSD 7.8 (amd64)** and **FreeBSD 15.0-RELEASE (amd64)**, 4 vCPU / 4 GB each.

## FreeBSD — Boost was not found

```
CMake Error at BoostConfig.cmake:141 (find_package):
  No suitable build variant has been found.
  * libboost_filesystem.so.1.88.0 (release runtime, Boost_USE_DEBUG_RUNTIME=TRUE)
  * libboost_filesystem.a (static, default is shared, ...)
```

CMake's FindBoost defaults `Boost_USE_DEBUG_RUNTIME` to `TRUE` when the caller has not set it (`FindBoost.cmake:1699`). That selects the MSVC `/MDd` runtime and means nothing elsewhere — but Boost's own CMake config files honour it on **every** platform; each variant file opens with:

```cmake
if(Boost_USE_DEBUG_RUNTIME)
  _BOOST_SKIPPED("libboost_foo.so" "release runtime, ...")
```

FreeBSD builds only release-runtime variants, so every variant was rejected. We reach that default because `CMP0167 OLD` routes the version probe through the FindBoost module.

Set `OFF` before the probe rather than cleared afterwards: FindBoost only assigns its default under `if(NOT DEFINED ...)`, so a value set here survives, it also covers the pre-1.70 module-mode branch, and it doesn't discard a value the user passed with `-D`.

This only bites where FindBoost runs its own module search — it returns early when a `BoostConfig.cmake` is found, which is why the failure doesn't reproduce everywhere.

## OpenBSD — multiprocess did not compile

```
src/ipc/peercred.cpp:58: error: variable has incomplete type 'struct ucred'
```

The peer-uid check selected the Linux path on `#if defined(SO_PEERCRED)`, assuming that option implies Linux's `struct ucred`. **OpenBSD also defines `SO_PEERCRED`** (`sys/socket.h:118`) but its payload is `struct sockpeercred` (line 306). FreeBSD and macOS don't define it at all, which is why only OpenBSD broke.

The condition now keys on `__linux__` and is defined **once** as `GRIDCOIN_PEERCRED_SO_PEERCRED`, because `CheckPeerCredentials()` and `PeerCredentialEnforcement()` must agree — the latter is what the startup log advertises as the enforcement mechanism in force, and a silent disagreement there would misstate a security property. Every non-Linux target we support provides `getpeereid(3)`.

## Documentation

Both guides claimed verification against **5.5.0.0**, neither mentioned multiprocess or Cap'n Proto, and both pointed at the **wrong output directory** (`build/src/...` rather than `build/bin/...`). Beyond fixing those:

- **Cap'n Proto** recorded as the multiprocess-only dependency on both.
- **OpenBSD needs `ulimit -d` raised** before a multiprocess build. `login.conf`'s `default` class caps `datasize` at 1536M and clang needs more for the generated Cap'n Proto proxies (one preprocessed TU is ~9 MB), dying with `LLVM ERROR: out of memory`. That's the per-process limit, **not** a RAM shortage — worth stating because the message reads like one. Fewer jobs than cores is also recommended: `-j2` completed reliably on 4 vCPU / 4 GB, `-j4` did not.
- **OpenBSD's clang accepts but ignores `-fstack-clash-protection`** (many `argument unused` warnings), so that mitigation is not applied there despite being requested. Recorded so nobody assumes it is.
- **The FreeBSD guide's existing Boost workaround was wrong.** It required `-DBoost_USE_DEBUG_RUNTIME=OFF`, described it as accepting release Boost "even when building with debug symbols", and offered `Release` as an alternative that avoids it. I tested all three build types — `Release`, `RelWithDebInfo` and `Debug` **all failed identically**; the build type is irrelevant. The flag is no longer needed and the note now says what actually happened.
- **FreeBSD 15.0's capnproto package warns of a kernel bug** fixed in 15.1. Reproduced *with* the finding that Gridcoin's IPC worked anyway, so readers know why `pkg` shows it rather than assuming it blocks multiprocess.

## Verification

| | OpenBSD 7.8 | FreeBSD 15.0 |
|---|---|---|
| Monolithic build | ✅ | ✅ |
| Multiprocess build | ✅ | ✅ |
| Binaries run | ✅ | ✅ |
| MP GUI attaches over IPC | ✅ `GUI loaded.` | ✅ `GUI loaded.` |
| Peer-cred mechanism | `getpeereid` | `getpeereid` |

Linux reconfigured and rebuilt with these changes: **0 errors**, Boost found identically, core suite *No errors detected*, Qt suite 8/8. Lint clean with a populated `COMMIT_RANGE`.

## The hardening probe is fixed, not just documented

An earlier revision of this PR documented that OpenBSD's clang silently ignores
`-fstack-clash-protection` and left it at that. That was the weaker answer: the build was
still requesting a mitigation it did not get, and emitting **316 warnings** saying so.

`check_cxx_compiler_flag` only proves the driver did not reject a flag's *spelling*. The
probes now run with `-Werror=unused-command-line-argument`, so a flag the compiler accepts
and then ignores fails the check and is not applied — reported once at configure time
instead of once per translation unit:

```
-- Hardening: -fstack-clash-protection not applied (compiler accepts no working
   implementation for this target)
```

GCC has no such warning and errors on the option, so it is probed for first. Setting it
unconditionally would make every hardening probe fail on GCC and **silently disable
hardening on Linux** — the exact opposite of the intent, and the thing most worth getting
wrong here.

This does **not** replace the Mach-O platform gate. `-mbranch-protection=standard` on
macOS arm64 is accepted *and honoured and wrong* — it emits real pointer-authentication
code that defeats libunwind. No probe can see that, so it stays gated by platform.

### Verified on three toolchains

| Toolchain | probe | stack-protector | cf-protection | stack-clash |
|---|---|---|---|---|
| Linux GCC 15.3 | Failed (required) | ✅ | ✅ | ✅ |
| Linux clang 19.1.7 | Success | ✅ | ✅ | ✅ |
| OpenBSD 7.8 clang 19.1.7 | Success | ✅ | ✅ | **correctly withheld** |

On OpenBSD a 208-object build produced **0** "argument unused" warnings (down from 316
across a full build) with 0 errors, and the compile options carry only the two flags that
actually work there. Linux is unchanged on both compilers.

## Not addressed

Neither BSD is in CI, so nothing here is regression-protected — the guides still say so. The `-fstack-clash-protection` gap is now fixed rather than documented (see above), but the mitigation itself remains **unavailable on OpenBSD** — that is a toolchain property the build cannot work around.