### PR TITLE
doc: require a WSL-filesystem clone and fix stale executable paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ cmake --build build -j $(nproc)
 # Executables: build/bin/gridcoinresearchd, build/bin/gridcoinresearch
 ```
 
+On Windows, develop inside WSL with the clone in the WSL filesystem, not `/mnt/c`
+(see [doc/build-windows-wsl.md](doc/build-windows-wsl.md#1-get-the-source-code)); then
+run the Linux-native commands above unchanged. For Qt GUI iteration there is a tracked
+`gridcoin-gui-wsl` skill under `.claude/skills/` (GUI-only; it builds with
+`-DENABLE_TESTS=OFF`).
+
 ### Automated Build Script
 
 ```bash

--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -135,7 +135,7 @@ ctest --test-dir build_macos --output-on-failure
 You can run the application directly from the build folder:
 
 ```
-./build_macos/src/qt/gridcoinresearch
+./build_macos/bin/gridcoinresearch.app/Contents/MacOS/gridcoinresearch
 ```
 
 ### 7. Create the DMG Installer (Optional)

--- a/doc/build-windows-wsl.md
+++ b/doc/build-windows-wsl.md
@@ -18,6 +18,17 @@ It utilizes the `build_targets.sh` script to automate dependency installation (M
 
 Open your Linux terminal (e.g., "Ubuntu" from the Start Menu) and run the following commands to clone the repository:
 
+> **Clone inside the WSL filesystem** — use a path under your Linux home such as `~/Gridcoin-Research`,
+> not a Windows drive under `/mnt/c` and not a OneDrive-synced folder. A checkout made with Git for
+> Windows arrives with CRLF line endings: this repository's `.gitattributes` marks every path
+> `text=auto`, and for such a path the working-tree ending follows `core.eol`, whose default `native`
+> means CRLF on Windows — regardless of whether `core.autocrlf` is `true` or `false`, and there is no
+> per-path `eol=lf` override. CRLF breaks the repository's own POSIX shell scripts: `build_targets.sh`
+> fails immediately with `/usr/bin/env: 'bash\r': No such file or directory`, and the bundled BerkeleyDB
+> script `src/bdb53/dist/configure` fails with `Syntax error: newline unexpected` (the exact wording
+> varies by shell). Cloning from inside WSL avoids the conversion, but a build over `/mnt` is still
+> considerably slower than on ext4.
+
 ```bash
 # Update package lists and install git (if not already present)
 sudo apt update && sudo apt install -y git
@@ -116,13 +127,13 @@ The first time you run this, it will take a significant amount of time to compil
 Once the script completes successfully, your Windows executable is located here:
 
 ```bash
-./build_win64/src/gridcoinresearchd.exe
+./build_win64/bin/gridcoinresearchd.exe
 ```
 
 Because you are on WSL, you can run this directly from the Linux terminal to verify the version:
 
 ```bash
-./build_win64/src/gridcoinresearchd.exe --version
+./build_win64/bin/gridcoinresearchd.exe --version
 ```
 
 ## 4\. Create the Installer


### PR DESCRIPTION
Rewritten after @jamescowens' review. The earlier version added a `### Windows Contributors` section to `CLAUDE.md`; that framing implied a Windows-filesystem build was a supported configuration, which `doc/build.md`'s platform table does not offer. The substance now lives in the WSL guide instead.

### 1. `doc/build-windows-wsl.md` §1 — say where the clone must live

§1 tells the reader to open a Linux terminal and clone, but never says the clone must live *inside* the WSL filesystem. A contributor in a fully supported environment can still clone with Git for Windows, or work from a `/mnt/c` path, and land in a build failure the guide does not mention. A note next to the `git clone` covers it.

**Correction to the earlier description.** It blamed `core.autocrlf=true`. That is not the mechanism, and it is refutable in one command. `.gitattributes` marks every path `text=auto`, and for such a path the working-tree ending follows `core.eol`, whose default `native` is CRLF on Windows — with `core.autocrlf` `true` or `false` alike. Only `core.autocrlf=input`, or an explicit `eol=lf` attribute, yields LF:

```console
$ git ls-files --eol build_targets.sh src/bdb53/dist/configure
i/lf    w/crlf  attr/text=auto          build_targets.sh
i/lf    w/crlf  attr/text=auto          src/bdb53/dist/configure
```

**Also corrected: which script fails first.** The earlier description built its case on BerkeleyDB and `ExternalProject_Add`. That holds for the `CLAUDE.md` build, but this guide's reader never runs `cmake` — its only build command is `./build_targets.sh TARGET=win64` (line 88), and `build_targets.sh` is itself checked out CRLF, so it dies on its own shebang before anything is configured:

```console
$ head -1 build_targets.sh | od -c
0000000   #   !   /   u   s   r   /   b   i   n   /   e   n   v       b
0000020   a   s   h  \r  \n
```

The note leads with that failure and keeps BerkeleyDB as the second example.

A WSL-side clone into `/mnt/c` is *not* affected: WSL git leaves both `core.eol` and `core.autocrlf` unset, and `native` on Linux is LF. So the note gives `/mnt` build slowness as the reason to prefer `~` regardless of who cloned, rather than asserting `/mnt/c` always breaks.

### 2. `CLAUDE.md` — a pointer, not a section

The 17-line section becomes a short pointer that routes a Windows reader to WSL and then back to the Linux-native commands directly above it. It keeps the existing mention of the tracked `.claude/skills/gridcoin-gui-wsl` skill, since that was the file's only reference to it — happy to drop that clause if it is unwanted here.

### 3. Stale executable paths

Both the daemon and the GUI set `RUNTIME_OUTPUT_DIRECTORY` to `${CMAKE_BINARY_DIR}/bin` (`src/CMakeLists.txt:410`, `src/qt/CMakeLists.txt:321`), with no platform conditional.

- `doc/build-windows-wsl.md:119,125` → `build_win64/bin/gridcoinresearchd.exe`, as requested.
- `doc/build-macos.md:138` → `build_macos/bin/gridcoinresearch.app/Contents/MacOS/gridcoinresearch`, matching `TARGET4_GUI` at `build_targets.sh:729`.

The macOS line was not in the review. It turned up while checking whether anything remained: `CLAUDE.md:20` and `doc/developer-notes.md:363` were fixed by `0c6c50f2a` shortly after the review was posted, and the BSD guides by #3267, which left macOS as the last one. Glad to pull it into its own PR if this should stay single-purpose.

### Scope

Markdown only — 3 files, +20/−3. No source, CMake, test, workflow, or lint configuration is touched.
