### PR TITLE
wallet: write and notify once per transaction, not once per spent output

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -5,6 +5,7 @@
 #include "init.h"
 #include "main.h"
 #include "wallet/wallet.h"
+#include "wallet/walletdb.h"
 
 #include <algorithm>
 
@@ -634,6 +635,126 @@ BOOST_AUTO_TEST_CASE(getamounts_omits_coinstake_rollup_when_staked_input_is_unkn
                             "the whole staked principal was reported as a received amount");
     }
     BOOST_CHECK(listReceived.empty());
+}
+
+
+// WalletUpdateSpent must write and notify once per affected TRANSACTION, not
+// once per spent OUTPUT. Doing it per output made a consolidation quadratic:
+// 600 inputs drawn from three parents emitted 1152 notifications and 549
+// WriteToDisk calls, backlogging the GUI transaction queue badly enough to
+// leave the table sluggish and a confirmed transaction rendering as pending.
+// This also pins the calls OUT of the per-output loops, so moving them back
+// fails here rather than in the field.
+BOOST_AUTO_TEST_CASE(wallet_update_spent_notifies_once_per_parent)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CKey key;
+    key.MakeNewKey(true);
+    BOOST_REQUIRE(pwalletMain->AddKey(key));
+
+    // One parent carrying FOUR outputs to us -- the shape a consolidation
+    // draws from, and the shape that made the old code repeat itself.
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = COutPoint(
+        uint256S("0x4444444444444444444444444444444444444444444444444444444444444444"), 0);
+    parent.vout.resize(4);
+    for (unsigned int i = 0; i < 4; ++i) {
+        parent.vout[i].nValue = COIN;
+        parent.vout[i].scriptPubKey.SetDestination(CTxDestination(key.GetPubKey().GetID()));
+    }
+    const CTransaction parent_tx(parent);
+    const uint256 parent_hash = parent_tx.GetHash();
+
+    // Insert directly rather than through AddToWallet, which fires its own
+    // notification for the inserted transaction and would muddy the count.
+    CWalletTx parent_wtx(pwalletMain, parent_tx);
+    parent_wtx.SetTxState(TxStateInMempool{});
+    pwalletMain->mapWallet[parent_hash] = parent_wtx;
+
+    // A child spending THREE of that one parent's outputs.
+    CKey external_key;
+    external_key.MakeNewKey(true);
+    CMutableTransaction child;
+    child.vin.resize(3);
+    for (unsigned int i = 0; i < 3; ++i) {
+        child.vin[i].prevout = COutPoint(parent_hash, i);
+    }
+    child.vout.resize(1);
+    child.vout[0].nValue = 2 * COIN;
+    child.vout[0].scriptPubKey.SetDestination(CTxDestination(external_key.GetPubKey().GetID()));
+    const CTransaction child_tx(child);
+
+    std::map<uint256, int> notifies;
+    boost::signals2::scoped_connection conn(
+        pwalletMain->NotifyTransactionChanged.connect(
+            [&notifies](CWallet*, const uint256& h, ChangeType) { notifies[h] += 1; }));
+
+    CWalletDB walletdb(pwalletMain->strWalletFile);
+    pwalletMain->WalletUpdateSpent(child_tx, /*fBlock=*/false, &walletdb);
+
+    // Three outputs of ONE parent changed, so exactly one notification. The
+    // per-output form emitted three.
+    BOOST_CHECK_EQUAL(notifies[parent_hash], 1);
+
+    // ...and the coalescing did not cost correctness: every spent output is
+    // still marked, and the untouched fourth is not.
+    const auto it = pwalletMain->mapWallet.find(parent_hash);
+    BOOST_REQUIRE(it != pwalletMain->mapWallet.end());
+    BOOST_CHECK(it->second.IsSpent(0));
+    BOOST_CHECK(it->second.IsSpent(1));
+    BOOST_CHECK(it->second.IsSpent(2));
+    BOOST_CHECK(!it->second.IsSpent(3));
+
+    pwalletMain->EraseFromWallet(parent_hash);
+}
+
+// The fBlock branch must NOT notify the transaction being processed. The sole
+// caller, AddToWallet, unconditionally fires CT_NEW/CT_UPDATED for that same
+// hash on the next statement, so a notification here is a guaranteed duplicate
+// for every subscriber.
+BOOST_AUTO_TEST_CASE(wallet_update_spent_does_not_notify_the_transaction_itself)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CKey key;
+    key.MakeNewKey(true);
+    BOOST_REQUIRE(pwalletMain->AddKey(key));
+
+    CMutableTransaction mtx;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(
+        uint256S("0x5555555555555555555555555555555555555555555555555555555555555555"), 0);
+    mtx.vout.resize(2);
+    for (unsigned int i = 0; i < 2; ++i) {
+        mtx.vout[i].nValue = COIN;
+        mtx.vout[i].scriptPubKey.SetDestination(CTxDestination(key.GetPubKey().GetID()));
+    }
+    const CTransaction tx(mtx);
+    const uint256 hash = tx.GetHash();
+
+    CWalletTx wtx(pwalletMain, tx);
+    wtx.SetTxState(TxStateInMempool{});
+    pwalletMain->mapWallet[hash] = wtx;
+
+    std::map<uint256, int> notifies;
+    boost::signals2::scoped_connection conn(
+        pwalletMain->NotifyTransactionChanged.connect(
+            [&notifies](CWallet*, const uint256& h, ChangeType) { notifies[h] += 1; }));
+
+    CWalletDB walletdb(pwalletMain->strWalletFile);
+    pwalletMain->WalletUpdateSpent(tx, /*fBlock=*/true, &walletdb);
+
+    // Both owned outputs were marked unspent, and neither produced an event.
+    BOOST_CHECK_EQUAL(notifies[hash], 0);
+
+    const auto it = pwalletMain->mapWallet.find(hash);
+    BOOST_REQUIRE(it != pwalletMain->mapWallet.end());
+    BOOST_CHECK(!it->second.IsSpent(0));
+    BOOST_CHECK(!it->second.IsSpent(1));
+
+    pwalletMain->EraseFromWallet(hash);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -736,6 +736,14 @@ BOOST_AUTO_TEST_CASE(wallet_update_spent_does_not_notify_the_transaction_itself)
 
     CWalletTx wtx(pwalletMain, tx);
     wtx.SetTxState(TxStateInMempool{});
+    // Seed both outputs SPENT. Inserting with the default (unspent) flags would
+    // make the !IsSpent() assertions below pass even if the MarkUnspent loop were
+    // deleted outright -- they would be asserting the initial state, not the
+    // transition.
+    wtx.MarkSpent(0);
+    wtx.MarkSpent(1);
+    BOOST_REQUIRE(wtx.IsSpent(0));
+    BOOST_REQUIRE(wtx.IsSpent(1));
     pwalletMain->mapWallet[hash] = wtx;
 
     std::map<uint256, int> notifies;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -751,6 +751,31 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* 
     // restored from backup or the user making copies of wallet.dat.
     {
         LOCK(cs_wallet);
+
+        // Transactions whose spent flags this call actually changed, in
+        // first-touch order. The flag updates below are in-memory only
+        // (MarkSpent / MarkUnspent just flip vfSpent and drop the credit
+        // cache); the disk write and the UI notification are deferred to one
+        // per DISTINCT transaction at the end.
+        //
+        // Doing them per OUTPUT instead, as this did, is quadratic in exactly
+        // the case that matters. Every input spending the same parent rewrote
+        // that whole parent record and emitted another identical CT_UPDATED
+        // for it, and the fBlock loop below repeated both for a single hash
+        // once per owned output. Measured on an isolated-testnet consolidation
+        // of 600 inputs (issue #3183's coin control makes these a few clicks):
+        // 549 WriteToDisk calls and 1152 NotifyTransactionChanged for THREE
+        // distinct transactions -- a 384x notification amplification that
+        // backlogged the GUI transaction queue badly enough to leave the table
+        // sluggish and a just-sent transaction showing as unconfirmed long
+        // after it had confirmed.
+        std::vector<uint256> updated;
+        std::set<uint256> updated_seen;
+
+        auto mark_updated = [&updated, &updated_seen](const uint256& hash) {
+            if (updated_seen.insert(hash).second) updated.push_back(hash);
+        };
+
         for (auto const& txin : tx.vin)
         {
             auto mi = mapWallet.find(txin.prevout.hash);
@@ -762,8 +787,7 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* 
                 } else if (!wtx.IsSpent(txin.prevout.n) && (IsMine(wtx.vout[txin.prevout.n]) != ISMINE_NO)) {
                     LogPrint(BCLog::LogFlags::VERBOSE, "WalletUpdateSpent found spent coin %s gC %s", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
                     wtx.MarkSpent(txin.prevout.n);
-                    wtx.WriteToDisk(pwalletdb);
-                    NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
+                    mark_updated(txin.prevout.hash);
                 }
             }
         }
@@ -772,19 +796,38 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* 
         {
             uint256 hash = tx.GetHash();
             auto mi = mapWallet.find(hash);
-            CWalletTx& wtx = mi->second;
 
-            for (auto const& txout : tx.vout)
+            // Guard the lookup. Callers reach this only for transactions
+            // already added to the wallet, so the miss is not known to be
+            // reachable -- but the previous code dereferenced the iterator
+            // unconditionally, which is undefined behaviour the moment that
+            // assumption stops holding.
+            if (mi != mapWallet.end())
             {
-                if (IsMine(txout) != ISMINE_NO)
+                CWalletTx& wtx = mi->second;
+
+                for (auto const& txout : tx.vout)
                 {
-                    wtx.MarkUnspent(&txout - &tx.vout[0]);
-                    wtx.WriteToDisk(pwalletdb);
-                    NotifyTransactionChanged(this, hash, CT_UPDATED);
+                    if (IsMine(txout) != ISMINE_NO)
+                    {
+                        wtx.MarkUnspent(&txout - &tx.vout[0]);
+                        mark_updated(hash);
+                    }
                 }
             }
         }
 
+        // One write and one notification per affected transaction. mapWallet is
+        // neither inserted into nor erased from above, so every hash collected
+        // is still present.
+        for (const uint256& hash : updated)
+        {
+            auto mi = mapWallet.find(hash);
+            if (mi == mapWallet.end()) continue;
+
+            mi->second.WriteToDisk(pwalletdb);
+            NotifyTransactionChanged(this, hash, CT_UPDATED);
+        }
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -776,6 +776,14 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* 
             if (updated_seen.insert(hash).second) updated.push_back(hash);
         };
 
+        // The fBlock branch below changes THIS transaction's own vfSpent, which
+        // must be persisted -- but it must not be notified here. The sole caller
+        // is AddToWallet, which unconditionally fires CT_NEW/CT_UPDATED for this
+        // same hash on the statement after the one that called us, and nothing
+        // can return in between. Notifying here too would hand every subscriber
+        // a duplicate for the transaction being added.
+        bool self_spent_changed = false;
+
         for (auto const& txin : tx.vin)
         {
             auto mi = mapWallet.find(txin.prevout.hash);
@@ -811,13 +819,20 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* 
                     if (IsMine(txout) != ISMINE_NO)
                     {
                         wtx.MarkUnspent(&txout - &tx.vout[0]);
-                        mark_updated(hash);
+                        self_spent_changed = true;
                     }
+                }
+
+                // Write once if anything moved; deliberately no notification
+                // (see self_spent_changed above).
+                if (self_spent_changed) {
+                    wtx.WriteToDisk(pwalletdb);
                 }
             }
         }
 
-        // One write and one notification per affected transaction. mapWallet is
+        // One write and one notification per affected PARENT transaction (the
+        // transaction being added is handled above, write-only). mapWallet is
         // neither inserted into nor erased from above, so every hash collected
         // is still present.
         for (const uint256& hash : updated)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -818,8 +818,18 @@ void CWallet::WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* 
                 {
                     if (IsMine(txout) != ISMINE_NO)
                     {
-                        wtx.MarkUnspent(&txout - &tx.vout[0]);
-                        self_spent_changed = true;
+                        // Only a real transition counts. MarkUnspent is a no-op on
+                        // an already-unspent output, so flagging every owned output
+                        // would force a redundant write on the common path -- and
+                        // AddToWallet has already persisted this transaction by the
+                        // time it calls us. Mirrors the !IsSpent() guard the input
+                        // loop above applies for the same reason.
+                        const unsigned int n = &txout - &tx.vout[0];
+                        if (wtx.IsSpent(n))
+                        {
+                            wtx.MarkUnspent(n);
+                            self_spent_changed = true;
+                        }
                     }
                 }
 


### PR DESCRIPTION
`CWallet::WalletUpdateSpent` calls `WriteToDisk` **and** `NotifyTransactionChanged` inside its per-input loop, so every input spending the same parent re-serializes that entire parent record to the wallet database and emits another identical `CT_UPDATED` for it. The `fBlock` loop below it is worse in kind: `hash` never varies inside that loop, so each owned output rewrites the same record and fires the same notification again.

The cost is quadratic in exactly the case the new windowed coin control (#3183) makes easy. Measured on an isolated-testnet consolidation of **600 inputs**:

| | count |
|---|---|
| `NotifyTransactionChanged` emitted | 1152 |
| distinct txids | 3 |
| amplification | **384x** |
| `WriteToDisk` calls (input loop alone) | 549 |

The GUI transaction queue backlogged badly enough that the table went sluggish and the just-sent transaction kept rendering as unconfirmed for a while after it had confirmed on chain. Both cleared once the queue drained, so it is a backlog symptom rather than a stuck cache.

A second consolidation of 122 inputs, drawn from ~61 distinct parents, produced 246 notifications — the *factor* depends on how many inputs share a parent, but the redundant disk writes are the larger cost in either shape.

## The fix

`MarkSpent` and `MarkUnspent` are in-memory only — they flip `vfSpent` and drop the credit cache — so collect the transactions actually changed and do one write plus one notification per distinct hash at the end. The final on-disk content is identical, and consumers key on txid and only ever needed one event. Notifying after all the marks also means a consumer observes the completed state rather than an intermediate one.

Deferring the write slightly widens the window between marking a flag and persisting it. Nothing on that path can realistically throw — `MarkSpent`'s only throw is an out-of-range index, which the existing `prevout.n` bounds check already skips, and the `fBlock` loop indexes `tx.vout` against the same transaction's `wtx.vout` — and a throw mid-loop in the previous code left a partially persisted state regardless.

## Also: an unguarded iterator dereference

The input loop checks its iterator; the `fBlock` branch did not:

```cpp
uint256 hash = tx.GetHash();
auto mi = mapWallet.find(hash);
CWalletTx& wtx = mi->second;     // no mi != mapWallet.end() check
```

Callers reach it only for transactions already in the wallet, so the miss is not known to be reachable — but it is undefined behaviour the moment that assumption stops holding. Guarded.

## Provenance

The function body last changed in **2021** (a formatting commit), so this long predates the #3183 series. That series is simply what makes 600-input consolidations a few clicks, which is how it surfaced.

Found while validating #3225 on the isolated testnet; recorded there in the testing comment so the amplification is not later mis-attributed to the windowed coin-control work.

## Testing

Clean build (GUI + Qt6 + multiprocess + tests), full `test_gridcoin` green (1091 test cases), `lint-all.sh` clean with `COMMIT_RANGE` exported.
