### PR TITLE
lint, test: require and verify an init.capnp ordinal for every Init factory

### DIFF
--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -24,9 +24,17 @@ using SideStake = import "sidestake.capnp";
 
 # Per-process bootstrap interface (interfaces::Init). construct @0 is the
 # libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
-# hand out the other interface capabilities. Only the subset whose return types
-# are schema'd so far is exposed (grow-per-migration): the remaining factories
-# (makeWallet / makeMRC / ...) are added as their interfaces get schemas.
+# hand out the other interface capabilities.
+#
+# This is no longer a grow-per-migration subset: EVERY virtual on
+# interfaces::Init must appear here, and test/lint/lint-serve-init-complete.py
+# enforces it. A virtual with no ordinal is not "not migrated yet" -- mpgen
+# generates no override for it on ProxyClient<Init>, so the call resolves to the
+# base default, returns nullptr, and the capability silently does not exist over
+# IPC. The coin channel shipped exactly that way and the multiprocess GUI could
+# not start at all. isAuthenticated is the one deliberate omission (the local
+# listener asks it before authentication); it is recorded in that lint's UNSERVED
+# set with the reason.
 interface Init $Proxy.wrap("interfaces::Init") {
     construct @0 (threadMap :Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
     isCoreReady @1 (context :Proxy.Context) -> (result :Bool);

--- a/src/test/ipc_wire_handshake_tests.cpp
+++ b/src/test/ipc_wire_handshake_tests.cpp
@@ -23,7 +23,15 @@
 // pre-auth test destroys those unique_ptrs (they never get a value, but the
 // destructor is still instantiated).
 #include "interfaces/node.h"
+#include "interfaces/mrc.h"
+#include "interfaces/psgt.h"
+#include "interfaces/researcher.h"
+#include "interfaces/sidestake.h"
+#include "interfaces/staking.h"
+#include "interfaces/voting.h"
 #include "interfaces/wallet.h"
+#include "interfaces/wallet_coin_source.h"
+#include "interfaces/wallet_tx_source.h"
 #include "ipc/capnp/protocol.h"
 #include "ipc/handshake.h"
 #include "ipc/protocol.h"
@@ -119,6 +127,51 @@ struct UnixSocket {
 };
 
 //! Factory serving a fresh ServeInit (StubInner + the given cookie/identity) per
+//! Records which Init factory methods actually ARRIVED on the server. Every
+//! factory returns nullptr -- what is under test is whether the call crossed the
+//! wire at all, not what it produced, so no concrete interface implementations
+//! are needed.
+//!
+//! This is the runtime half of the guard whose static half is
+//! test/lint/lint-serve-init-complete.py. A virtual on interfaces::Init with no
+//! ordinal in init.capnp gets no override on ProxyClient<Init>, so the client
+//! call resolves to interfaces::Init's own default and returns nullptr WITHOUT
+//! dispatching. Nothing fails to compile, nothing logs, and the capability
+//! simply does not exist over IPC -- which is how the coin channel shipped
+//! unmarshalled and left the multiprocess GUI unable to start. Flags are atomic
+//! because the server answers on its own loop thread.
+struct RecordingInner : interfaces::Init {
+    struct Seen {
+        std::atomic<bool> node{false};
+        std::atomic<bool> staking{false};
+        std::atomic<bool> wallet{false};
+        std::atomic<bool> wallet_tx_source{false};
+        std::atomic<bool> wallet_coin_source{false};
+        std::atomic<bool> mrc{false};
+        std::atomic<bool> voting{false};
+        std::atomic<bool> researcher{false};
+        std::atomic<bool> psgt{false};
+        std::atomic<bool> sidestake{false};
+        std::atomic<bool> core_ready{false};
+    };
+
+    explicit RecordingInner(Seen& seen) : m_seen(seen) {}
+
+    bool isCoreReady() override { m_seen.core_ready = true; return true; }
+    std::unique_ptr<interfaces::Node> makeNode() override { m_seen.node = true; return nullptr; }
+    std::unique_ptr<interfaces::StakingStatus> makeStakingStatus() override { m_seen.staking = true; return nullptr; }
+    std::unique_ptr<interfaces::Wallet> makeWallet() override { m_seen.wallet = true; return nullptr; }
+    std::shared_ptr<interfaces::WalletTxSource> makeWalletTxSource() override { m_seen.wallet_tx_source = true; return nullptr; }
+    std::shared_ptr<interfaces::WalletCoinSource> makeWalletCoinSource() override { m_seen.wallet_coin_source = true; return nullptr; }
+    std::unique_ptr<interfaces::MRC> makeMRC() override { m_seen.mrc = true; return nullptr; }
+    std::unique_ptr<interfaces::VotingManager> makeVotingManager() override { m_seen.voting = true; return nullptr; }
+    std::unique_ptr<interfaces::ResearcherContext> makeResearcherContext() override { m_seen.researcher = true; return nullptr; }
+    std::unique_ptr<interfaces::PSGTPoolContext> makePSGTPoolContext() override { m_seen.psgt = true; return nullptr; }
+    std::unique_ptr<interfaces::SideStakeManager> makeSideStakeManager() override { m_seen.sidestake = true; return nullptr; }
+
+    Seen& m_seen;
+};
+
 //! connection, matching how the daemon serves.
 interfaces::MakeServeInitFn CookieServeFactory(std::string cookie, interfaces::NodeIdentity id)
 {
@@ -318,6 +371,66 @@ BOOST_AUTO_TEST_CASE(wire_handshake_rejects_network_mismatch)
     ipc::HandshakeResult r = ipc::ClientHandshake(*link.client, "cookie", "test");
     BOOST_CHECK(!r.ok);
     BOOST_CHECK(!r.error.empty());
+}
+
+// Every interfaces::Init factory must actually reach the server over the wire.
+//
+// This is the test that would have caught the coin channel shipping without a
+// Cap'n Proto schema. makeWalletCoinSource existed on interfaces::Init, had an
+// auth-gated ServeInit override, and its DTOs all carried
+// INTERFACES_ASSERT_MARSHALABLE -- but with no ordinal in init.capnp, mpgen
+// generated no override on ProxyClient<Init>. The client call resolved to the
+// base default, returned nullptr without dispatching, and the multiprocess GUI
+// threw at startup. Everything compiled and every existing lint passed.
+//
+// Asserting the SERVER saw each call is what makes this robust: a factory that
+// legitimately returns nullptr (no wallet attached, say) is indistinguishable
+// client-side from one that was never marshalled, so a client-side null check
+// would prove nothing.
+BOOST_AUTO_TEST_CASE(wire_every_init_factory_reaches_the_server)
+{
+    RecordingInner::Seen seen;
+
+    interfaces::NodeIdentity id;
+    id.network = "main";
+    id.identity_token = "tok";
+
+    WireLink link([&seen, &id](int) -> std::unique_ptr<interfaces::Init> {
+        return ipc::MakeServeInit(std::make_unique<RecordingInner>(seen), "the-cookie", id);
+    });
+
+    // ServeInit gates every factory behind RequireAuth(), so authenticate first.
+    ipc::HandshakeResult r = ipc::ClientHandshake(*link.client, "the-cookie", "main");
+    BOOST_REQUIRE(r.ok);
+
+    // Each call returns nullptr by construction; the return is deliberately
+    // ignored. What is asserted is that the invocation arrived server-side.
+    link.client->isCoreReady();
+    link.client->makeNode();
+    link.client->makeStakingStatus();
+    link.client->makeWallet();
+    link.client->makeWalletTxSource();
+    link.client->makeWalletCoinSource();
+    link.client->makeMRC();
+    link.client->makeVotingManager();
+    link.client->makeResearcherContext();
+    link.client->makePSGTPoolContext();
+    link.client->makeSideStakeManager();
+
+    BOOST_CHECK_MESSAGE(seen.core_ready.load(), "isCoreReady did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.node.load(), "makeNode did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.staking.load(), "makeStakingStatus did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.wallet.load(), "makeWallet did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.wallet_tx_source.load(), "makeWalletTxSource did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.wallet_coin_source.load(),
+                        "makeWalletCoinSource did not reach the server -- it is missing an ordinal "
+                        "in src/ipc/capnp/init.capnp, so ProxyClient<Init> has no override and the "
+                        "call never left the client process");
+    BOOST_CHECK_MESSAGE(seen.mrc.load(), "makeMRC did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.voting.load(), "makeVotingManager did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.researcher.load(), "makeResearcherContext did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.psgt.load(), "makePSGTPoolContext did not reach the server");
+    BOOST_CHECK_MESSAGE(seen.sidestake.load(), "makeSideStakeManager did not reach the server");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ipc_wire_handshake_tests.cpp
+++ b/src/test/ipc_wire_handshake_tests.cpp
@@ -126,7 +126,6 @@ struct UnixSocket {
     }
 };
 
-//! Factory serving a fresh ServeInit (StubInner + the given cookie/identity) per
 //! Records which Init factory methods actually ARRIVED on the server. Every
 //! factory returns nullptr -- what is under test is whether the call crossed the
 //! wire at all, not what it produced, so no concrete interface implementations
@@ -172,6 +171,7 @@ struct RecordingInner : interfaces::Init {
     Seen& m_seen;
 };
 
+//! Factory serving a fresh ServeInit (StubInner + the given cookie/identity) per
 //! connection, matching how the daemon serves.
 interfaces::MakeServeInitFn CookieServeFactory(std::string cookie, interfaces::NodeIdentity id)
 {

--- a/test/lint/lint-serve-init-complete.py
+++ b/test/lint/lint-serve-init-complete.py
@@ -33,6 +33,7 @@ import sys
 INIT_HEADER = "src/interfaces/init.h"
 SERVE_INIT = "src/ipc/serve_init.cpp"
 INIT_CAPNP = "src/ipc/capnp/init.capnp"
+WIRE_TEST = "src/test/ipc_wire_handshake_tests.cpp"
 
 # Methods that must NOT be gated, with the reason each is exempt.
 UNGATED = {
@@ -201,7 +202,8 @@ def main():
     header_text = read(INIT_HEADER)
     serve_text = read(SERVE_INIT)
     capnp_text = read(INIT_CAPNP)
-    if header_text is None or serve_text is None or capnp_text is None:
+    wire_text = read(WIRE_TEST)
+    if header_text is None or serve_text is None or capnp_text is None or wire_text is None:
         return 1
 
     expected = declared_virtuals(header_text)
@@ -334,6 +336,33 @@ def main():
             errors.append(
                 "interfaces::Init::{0}() is listed as unserved-by-design but has an ordinal in "
                 "{1}; update either the schema or UNSERVED in this lint.".format(name, INIT_CAPNP))
+
+    # --- Fourth gate: the runtime round-trip test must cover every factory ---
+    #
+    # wire_every_init_factory_reaches_the_server drives each factory over a real
+    # socket and asserts the SERVER saw the call, which is the only check that a
+    # declared ordinal actually round-trips. But it enumerates the factories by
+    # hand, so on its own it does NOT generalize: a factory added to Init,
+    # ServeInit and init.capnp but not to that list leaves the test passing while
+    # covering nothing. Tie the two together here, so the list cannot silently
+    # fall behind the interface.
+    #
+    # Scoped to make* -- the handshake methods (authenticate / getBuildInfo /
+    # getIdentity) are exercised by the ClientHandshake cases in the same file
+    # rather than by that enumeration.
+    wire_calls = set(re.findall(r"link\.client->(\w+)\s*\(", strip_noncode(wire_text)))
+    for name, _arity in expected:
+        if not name.startswith("make"):
+            continue
+        if name in UNSERVED:
+            continue
+        if name not in wire_calls:
+            errors.append(
+                "interfaces::Init::{0}() is not exercised by {1}. That test is what proves a "
+                "declared ordinal actually round-trips to the server, and it enumerates factories "
+                "by hand -- so a factory missing from it is untested however correct the schema "
+                "looks. Add `link.client->{0}();` and a matching Seen flag + BOOST_CHECK_MESSAGE "
+                "to wire_every_init_factory_reaches_the_server.".format(name, WIRE_TEST))
 
     # An UNGATED entry that calls RequireAuth() is a contradiction worth catching.
     for name in UNGATED:

--- a/test/lint/lint-serve-init-complete.py
+++ b/test/lint/lint-serve-init-complete.py
@@ -271,9 +271,41 @@ def main():
         fail("found no methods on `interface Init` in {}; the parser is probably broken".format(INIT_CAPNP))
         return 1
 
+    # Overloads are rejected outright, because Cap'n Proto cannot represent them:
+    # method names must be unique within an interface scope ("error: 'bar' is
+    # already defined in this scope"). An overloaded virtual on an IPC-served
+    # interface is therefore never fully wirable -- at most one of the overloads
+    # can have an ordinal, and the others are silently unreachable over IPC no
+    # matter what anyone intends. No interfaces:: class has one today.
+    #
+    # That structural fact is also why this gate matches by NAME and does not try
+    # to disambiguate by arity. It could not: a capnp method's input parameters do
+    # not correspond to the C++ parameter list, because out-parameters live in the
+    # RESULTS. interfaces::Wallet::getNewReceiveAddress(std::string&) is C++ arity
+    # 1 with ZERO capnp inputs besides context, and getAddressLabel(const
+    # std::string&, std::string&) is arity 2 with one. Deriving arity from the
+    # schema would reject correct code as soon as Init gained such a method.
+    #
+    # So the name match is safe precisely BECAUSE overloads are refused here.
+    seen_names = set()
+    overloaded = set()
+    for name, _arity in expected:
+        if name in seen_names:
+            overloaded.add(name)
+        seen_names.add(name)
+    for name in sorted(overloaded):
+        errors.append(
+            "interfaces::Init::{0}() is overloaded ({1}). Cap'n Proto requires method names to "
+            "be unique within an interface, so an overload cannot be represented in {2} at all: "
+            "at most one of them can hold an ordinal and the rest are unreachable over IPC "
+            "however they are declared. Give the overloads distinct names.".format(
+                name, INIT_HEADER, INIT_CAPNP))
+
     for name, _arity in expected:
         if name in UNSERVED:
             continue
+        if name in overloaded:
+            continue  # already reported above; the name check below cannot be trusted
         if name not in capnp_methods:
             errors.append(
                 "interfaces::Init::{0}() has no ordinal in {1}. mpgen therefore generates no "

--- a/test/lint/lint-serve-init-complete.py
+++ b/test/lint/lint-serve-init-complete.py
@@ -32,6 +32,7 @@ import sys
 
 INIT_HEADER = "src/interfaces/init.h"
 SERVE_INIT = "src/ipc/serve_init.cpp"
+INIT_CAPNP = "src/ipc/capnp/init.capnp"
 
 # Methods that must NOT be gated, with the reason each is exempt.
 UNGATED = {
@@ -41,6 +42,26 @@ UNGATED = {
     # that is the only time the listener asks. Not exposed over capnp, so no remote
     # peer can call it.
     "isAuthenticated",
+}
+
+# Virtuals deliberately absent from init.capnp, with the reason each is exempt.
+# Everything else on interfaces::Init MUST have an ordinal: without one, mpgen
+# generates no override on ProxyClient<Init>, the call falls through to the base
+# default (nullptr / an empty value), and the capability silently does not exist
+# over IPC. That is not hypothetical -- the coin channel shipped that way and the
+# multiprocess GUI could not start at all until wallet_coin_source.capnp was
+# added.
+UNSERVED = {
+    # The listener asks this locally, before authentication, to decide whether a
+    # connection beat the deadline. Serving it would let a peer probe the gate.
+    "isAuthenticated",
+}
+
+# Schema methods with no interfaces::Init counterpart, with the reason.
+NOT_A_VIRTUAL = {
+    # libmultiprocess lifecycle entry point (the ThreadMap exchange), generated
+    # by mpgen rather than declared on the C++ interface.
+    "construct",
 }
 
 # "virtual <return type> <name>(" -- the return type may contain spaces, ::, <>, &, *.
@@ -148,10 +169,39 @@ def overrides_with_bodies(serve_text):
     return out
 
 
+def capnp_init_methods(capnp_text):
+    """Return {name: ordinal} for the methods of `interface Init` in init.capnp.
+
+    Scoped to that interface's braces rather than the whole file: the nested
+    structs (BuildInfo, NodeIdentity) restart their own ordinal spaces, and a
+    file-wide scan would mix their FIELD names in with the interface's methods.
+    """
+    m = re.search(r"\binterface\s+Init\b[^{]*\{", capnp_text)
+    if not m:
+        return None
+    start = m.end()
+    depth = 1
+    i = start
+    while i < len(capnp_text) and depth:
+        if capnp_text[i] == "{":
+            depth += 1
+        elif capnp_text[i] == "}":
+            depth -= 1
+        i += 1
+    if depth:
+        return None
+    body = capnp_text[start:i - 1]
+    # Strip capnp comments so prose cannot introduce a phantom method.
+    body = re.sub(r"#[^\n]*", "", body)
+    return {mm.group(1): int(mm.group(2))
+            for mm in re.finditer(r"^\s*(\w+)\s*@(\d+)\s*\(", body, re.M)}
+
+
 def main():
     header_text = read(INIT_HEADER)
     serve_text = read(SERVE_INIT)
-    if header_text is None or serve_text is None:
+    capnp_text = read(INIT_CAPNP)
+    if header_text is None or serve_text is None or capnp_text is None:
         return 1
 
     expected = declared_virtuals(header_text)
@@ -199,6 +249,59 @@ def main():
                 "ServeInit::{0}() (the {1}-argument overload) overrides nothing declared on "
                 "interfaces::Init ({2}); it is dead code or a half-finished rename.".format(
                     key[0], key[1], INIT_HEADER))
+
+    # --- Third gate: the capnp schema ---
+    #
+    # An override in ServeInit only matters if the call can reach it. mpgen drives
+    # ProxyClient<Init> from init.capnp, so a virtual with no ordinal there is never
+    # overridden client-side: the call resolves to interfaces::Init's own default,
+    # returns nullptr, and never leaves the GUI process. Nothing else catches this.
+    # The compiler cannot -- overriding a defaulted virtual is optional.
+    # lint-capnp-schema-compat.py compares ordinals that EXIST against a released
+    # baseline, so it cannot miss one that was never added. The multiprocess CI jobs
+    # build; they do not run a GUI. And INTERFACES_ASSERT_MARSHALABLE asserts the
+    # DTOs are copyable value types, which says nothing about whether marshalling
+    # exists -- the coin channel carried fifteen of those assertions while having no
+    # schema at all.
+    capnp_methods = capnp_init_methods(capnp_text)
+    if capnp_methods is None:
+        fail("could not locate `interface Init` in {} -- the lint needs updating".format(INIT_CAPNP))
+        return 1
+    if not capnp_methods:
+        fail("found no methods on `interface Init` in {}; the parser is probably broken".format(INIT_CAPNP))
+        return 1
+
+    for name, _arity in expected:
+        if name in UNSERVED:
+            continue
+        if name not in capnp_methods:
+            errors.append(
+                "interfaces::Init::{0}() has no ordinal in {1}. mpgen therefore generates no "
+                "override on ProxyClient<Init>, so over IPC the call falls through to the base "
+                "default and the capability silently does not exist -- the multiprocess GUI sees "
+                "nullptr. Add `{0} @<next> (context :Proxy.Context) -> (result :...);` to "
+                "`interface Init`, with a schema for the returned interface if it has none yet. "
+                "If it is deliberately not served, add it to UNSERVED in this lint with the "
+                "reason.".format(name, INIT_CAPNP))
+
+    # The reverse: an ordinal with no virtual behind it. mpgen would fail to build,
+    # but naming it here reports the cause rather than a template error.
+    declared_names = {name for name, _ in expected}
+    for name in capnp_methods:
+        if name in NOT_A_VIRTUAL:
+            continue
+        if name not in declared_names:
+            errors.append(
+                "{0} declares `{1}` on `interface Init`, but interfaces::Init has no such virtual "
+                "({2}); it is a stale ordinal or a half-finished rename.".format(
+                    INIT_CAPNP, name, INIT_HEADER))
+
+    # An UNSERVED entry that IS in the schema is a contradiction worth catching.
+    for name in UNSERVED:
+        if name in capnp_methods:
+            errors.append(
+                "interfaces::Init::{0}() is listed as unserved-by-design but has an ordinal in "
+                "{1}; update either the schema or UNSERVED in this lint.".format(name, INIT_CAPNP))
 
     # An UNGATED entry that calls RequireAuth() is a contradiction worth catching.
     for name in UNGATED:


### PR DESCRIPTION
Closes the gap that let the coin channel ship without a Cap'n Proto schema and leave the multiprocess GUI unable to start (fixed in #3225). Two guards, static and runtime, because the failure is invisible to everything we already run.

## What happened

`interfaces::Init::makeWalletCoinSource` existed, had an auth-gated `ServeInit` override, and its DTOs all carried `INTERFACES_ASSERT_MARSHALABLE` — but with no ordinal in `init.capnp`, mpgen generated **no override** on `ProxyClient<Init>`. The client call resolved to `interfaces::Init`'s own default, returned `nullptr`, and never dispatched. `qt/bitcoin.cpp` threw at startup:

```
EXCEPTION: St13runtime_error
wallet coin source unavailable after init
```

Five gates, five different narrow reasons for silence:

| gate | why it stayed silent |
|---|---|
| the compiler | overriding a virtual that has a default is optional; mpgen simply omits it |
| `lint-serve-init-complete.py` | checked `init.h` ↔ `serve_init.cpp` only, nothing about capnp |
| `lint-capnp-schema-compat.py` | compares ordinals that **exist** against a released baseline; cannot miss one never added |
| multiprocess CI jobs | they build; nothing starts a GUI |
| `INTERFACES_ASSERT_MARSHALABLE` | see below |

That last one deserves emphasis because it reads like the check that should have caught this. It expands to `static_assert(is_copy_constructible && is_copy_assignable && is_move_constructible)` — it pins a DTO as a copyable value type and says nothing about whether marshalling exists. `wallet_coin_channel.h` carried **15** of them, more than the working tx channel's 9, while having zero wire implementation.

## 1. Static gate — `lint-serve-init-complete.py`

The lint already parses `interfaces::Init`'s virtuals for its `ServeInit` completeness check, so it is the natural home. Added: every virtual must have an ordinal on `interface Init` in `init.capnp`.

- `isAuthenticated` is the one recorded exemption (`UNSERVED`) — the local listener asks it before authentication, so serving it would let a peer probe the gate.
- The reverse is checked too: an ordinal with no virtual behind it is a stale name or a half-finished rename, which mpgen would otherwise fail on with a template error rather than a diagnosis. `construct` is exempt (`NOT_A_VIRTUAL`, an mp lifecycle method).
- The capnp parser is scoped to the `interface Init` braces: the nested `BuildInfo` and `NodeIdentity` structs restart their own ordinal spaces, and a file-wide scan would mix their field names in with the methods.

Also corrects `init.capnp`'s own comment, which described the schema as a "grow-per-migration subset" with factories "added as their interfaces get schemas". That is no longer true — every factory is present and now required to be. Left as it was, it makes a missing ordinal read as *not migrated yet* rather than as a defect, which is close to how this one was rationalized in review.

## 2. Runtime gate — `wire_every_init_factory_reaches_the_server`

Drives every `Init` factory over the existing real-socket `CapnpProtocol` harness and asserts the **server** saw each call.

Server-side is the point: a factory that legitimately returns `nullptr` — no wallet attached, say — is indistinguishable client-side from one that was never marshalled, so a client-side null check would prove nothing. The stub returns `nullptr` from every factory and merely records arrival, which also means no concrete implementations of the ten returned interfaces are needed.

Runs in the ordinary unit suite: no display, no chain, no second process, and it generalizes to any factory added later.

## Both were verified to fire, not merely to pass

Removing `makeWalletCoinSource @14` reproduces exactly the state that broke the multiprocess GUI. **The tree still builds with zero errors** — the compiler genuinely cannot see it — and:

```
lint-serve-init-complete: interfaces::Init::makeWalletCoinSource() has no ordinal in
src/ipc/capnp/init.capnp. mpgen therefore generates no override on ProxyClient<Init>,
so over IPC the call falls through to the base default and the capability silently
does not exist -- the multiprocess GUI sees nullptr. ...
```

```
error: in "ipc_wire_handshake_tests/wire_every_init_factory_reaches_the_server":
makeWalletCoinSource did not reach the server -- it is missing an ordinal in
src/ipc/capnp/init.capnp, so ProxyClient<Init> has no override and the call never
left the client process
```

Renaming the ordinal instead reports both the missing virtual and the stale schema entry. Restored, both are green.

## Checklist this enforces

Adding a new `Init` factory needs: the C++ virtual, the `ServeInit` override calling `RequireAuth()`, a capnp schema for the returned interface, its `-types.h`, the `init.capnp` ordinal, the `init-types.h` proxy-types include, and the CMake `target_capnp_sources` entry. Miss any of the last four and it fails closed and silent. The first two were already enforced; these guards cover the ordinal.

## Testing

Clean build (GUI + Qt6 + multiprocess + tests), full `test_gridcoin` green, `lint-all.sh` clean with `COMMIT_RANGE` exported.
