### PR TITLE
util, wallet, test, build: musl thread-stack guard, MakeMock error check, and pre-logging setup diagnostics

### DIFF
--- a/build_targets.sh
+++ b/build_targets.sh
@@ -186,6 +186,42 @@ should_skip_build() {
 # Write the state captured at skip-decision time upon success (see
 # should_skip_build). Falls back to "unknown" -- never skippable -- if no
 # capture happened.
+# Record the resource state immediately before ctest.
+#
+# The unit-test binaries do their fixture setup BEFORE any logger exists, so a
+# failure there produces no output beyond ctest's one-line summary. That has made
+# an intermittent CI failure ("Test setup error: system_error ... Out of memory",
+# ~0.01s, no captured output) undiagnosable after the fact: by the time the log is
+# read, the conditions that produced it are gone.
+#
+# This is deliberately cheap and unconditional -- a CI-only switch would not be
+# there on the run that actually fails. Every command is guarded so a missing tool
+# on a minimal image (busybox, no procps) degrades to a blank line rather than
+# failing the build.
+print_pre_test_environment() {
+    echo ">>> Pre-test environment:"
+    echo "    ctest parallelism : -j ${CORES}   (nproc reports $(nproc 2>/dev/null || echo '?'))"
+    if command -v free >/dev/null 2>&1; then
+        free -m 2>/dev/null | sed 's/^/    /'
+    else
+        grep -E '^(MemTotal|MemFree|MemAvailable|SwapTotal|SwapFree)' /proc/meminfo 2>/dev/null | sed 's/^/    /'
+    fi
+    # In a container /proc/meminfo shows the HOST's memory, not the cgroup cap, so
+    # the limit that actually applies has to be read from the cgroup itself.
+    for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+        [ -r "$f" ] && echo "    cgroup mem limit  : $(cat "$f" 2>/dev/null) ($f)"
+    done
+    for f in /sys/fs/cgroup/pids.max /sys/fs/cgroup/pids/pids.max; do
+        [ -r "$f" ] && echo "    cgroup pids max   : $(cat "$f" 2>/dev/null)"
+    done
+    echo "    fd limit          : $(ulimit -n 2>/dev/null || echo '?')   thread/proc limit: $(ulimit -u 2>/dev/null || echo '?')"
+    echo "    stack limit (kb)  : $(ulimit -s 2>/dev/null || echo '?')"
+    df -h /tmp 2>/dev/null | tail -1 | sed 's/^/    tmp: /'
+    # 4th loadavg field is running/total kernel scheduling entities -- cheap, and
+    # avoids globbing /proc (shellcheck SC2012).
+    echo "    procs run/total   : $(awk '{print $4}' /proc/loadavg 2>/dev/null || echo '?')"
+}
+
 write_build_state() {
     local BUILD_DIR=$1
     echo "${CAPTURED_BUILD_STATE:-unknown}" > "$BUILD_DIR/.build_state"
@@ -452,6 +488,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "native" ]] && [[ "$(uname -s)" == "Lin
         cmake --build build -j $CORES
 
         # Test
+        print_pre_test_environment
         ctest --test-dir build -j $CORES --output-on-failure
 
         # Write state file (Only if build and test succeeded)
@@ -545,6 +582,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "depends" ]] && [[ "$(uname -s)" == "Li
         cmake --build build_linux_depends -j $CORES
 
         # Test
+        print_pre_test_environment
         ctest --test-dir build_linux_depends -j $CORES --output-on-failure
 
         # Write state file
@@ -653,6 +691,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "win64" ]] && [[ "$(uname -s)" == "Linu
         if [ "$ENABLE_MULTIPROCESS" = "true" ]; then
             echo ">>> Skipping ctest for multiprocess win64: the MP binary is not runnable under Wine (native-Windows-only); build + link coverage only."
         else
+            print_pre_test_environment
             ctest --test-dir build_win64 -j $CORES --output-on-failure
         fi
 
@@ -750,6 +789,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "macos" ]] && [[ "$(uname -s)" == "Darw
         cmake --build build_macos -j $CORES
 
         # Test
+        print_pre_test_environment
         ctest --test-dir build_macos -j $CORES --output-on-failure
 
         # Write state file

--- a/build_targets.sh
+++ b/build_targets.sh
@@ -217,6 +217,19 @@ print_pre_test_environment() {
     echo "    fd limit          : $(ulimit -n 2>/dev/null || echo '?')   thread/proc limit: $(ulimit -u 2>/dev/null || echo '?')"
     echo "    stack limit (kb)  : $(ulimit -s 2>/dev/null || echo '?')"
     df -h /tmp 2>/dev/null | tail -1 | sed 's/^/    tmp: /'
+    # AT_MINSIGSTKSZ (auxv type 51): the kernel's minimum alternate-signal-stack
+    # size, derived from THIS CPU's XSAVE area -- so it varies with the physical
+    # machine a CI job lands on. Boost.Test installs an alternate stack sized
+    # SIGSTKSZ, which musl hardcodes to 8192 while glibc 2.34+ makes it dynamic;
+    # sigaltstack() returns ENOMEM when the size is below the kernel's minimum.
+    # Recording it is what distinguishes "the runner's CPU needed more than 8192"
+    # from a stale errno on some other Boost assertion, for the intermittent
+    # "Test setup error: system_error ... Out of memory" on the Alpine job.
+    if [ -r /proc/self/auxv ] && command -v od >/dev/null 2>&1; then
+        echo "    AT_MINSIGSTKSZ    : $(od -An -tu8 -v /proc/self/auxv 2>/dev/null \
+            | awk '{ for (i = 1; i <= NF; i += 2) if ($i == 51) print $(i + 1) }' \
+            | head -1)   (musl SIGSTKSZ is 8192)"
+    fi
     # 4th loadavg field is running/total kernel scheduling entities -- cheap, and
     # avoids globbing /proc (shellcheck SC2012).
     echo "    procs run/total   : $(awk '{print $4}' /proc/loadavg 2>/dev/null || echo '?')"

--- a/build_targets.sh
+++ b/build_targets.sh
@@ -209,10 +209,10 @@ print_pre_test_environment() {
     # In a container /proc/meminfo shows the HOST's memory, not the cgroup cap, so
     # the limit that actually applies has to be read from the cgroup itself.
     for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
-        [ -r "$f" ] && echo "    cgroup mem limit  : $(cat "$f" 2>/dev/null) ($f)"
+        if [ -r "$f" ]; then echo "    cgroup mem limit  : $(cat "$f" 2>/dev/null) ($f)"; fi
     done
     for f in /sys/fs/cgroup/pids.max /sys/fs/cgroup/pids/pids.max; do
-        [ -r "$f" ] && echo "    cgroup pids max   : $(cat "$f" 2>/dev/null)"
+        if [ -r "$f" ]; then echo "    cgroup pids max   : $(cat "$f" 2>/dev/null)"; fi
     done
     echo "    fd limit          : $(ulimit -n 2>/dev/null || echo '?')   thread/proc limit: $(ulimit -u 2>/dev/null || echo '?')"
     echo "    stack limit (kb)  : $(ulimit -s 2>/dev/null || echo '?')"
@@ -233,6 +233,13 @@ print_pre_test_environment() {
     # 4th loadavg field is running/total kernel scheduling entities -- cheap, and
     # avoids globbing /proc (shellcheck SC2012).
     echo "    procs run/total   : $(awk '{print $4}' /proc/loadavg 2>/dev/null || echo '?')"
+
+    # Diagnostics must never be the reason a build fails. The script runs under
+    # `set -e`, where any construct whose LAST command is false makes the
+    # function return non-zero and aborts everything -- a trailing
+    # `[ -r x ] && echo` does exactly that (verified). The `if` forms above
+    # avoid it; this return means a line appended later cannot reintroduce it.
+    return 0
 }
 
 write_build_state() {

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -19,6 +19,12 @@
 #include "random.h"
 #include "wallet/wallet.h"
 
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <system_error>
+#include <typeinfo>
+
 leveldb::Env* txdb_env;
 
 extern CWallet* pwalletMain;
@@ -36,22 +42,83 @@ extern void noui_connect();
 extern leveldb::Options GetOptions();
 extern void InitLogging();
 
+//! Names the setup step in progress.
+//!
+//! Everything up to InitLogging() runs before the logger exists, so a throw in
+//! that window produces a process with NO OUTPUT AT ALL -- ctest reports only
+//! Boost's "Test setup error: ..." line and nothing else. That is precisely
+//! where the intermittent Alpine CI failure lands ("system_error ... Out of
+//! memory", ~0.01s, zero captured output), which is why it has resisted
+//! diagnosis: the one code path with no logging is the one that fails.
+//!
+//! These write to stderr directly, for the same reason: no logger yet.
+static const char* g_setup_step = "(not started)";
+
+//! Report what threw and, where the type carries one, the underlying error
+//! code -- the errno is the datum that would actually identify the failure,
+//! and it is the one Boost's summary discards.
+static void ReportSetupThrow()
+{
+    // Shaped after PrintException() in src/util/system.cpp: LogPrintf for the
+    // log (which buffers until the logger is started, so the message survives
+    // even though we throw before InitLogging), plus tfm::format to std::cerr
+    // so it is actually visible on a run that dies here. strprintf/tfm::format
+    // is the in-tree formatting primitive; the locale-dependent C printf family
+    // is not used.
+    std::string detail;
+    try {
+        throw;
+    } catch (const fs::filesystem_error& e) {
+        // fs:: is boost::filesystem, whose errors derive from std::runtime_error
+        // rather than std::system_error, so they need their own arm to keep the
+        // error code instead of falling through to the generic handler.
+        detail = strprintf("fs::filesystem_error  code=%d (%s)  path=%s  what=%s",
+                           e.code().value(), e.code().category().name(),
+                           e.path1().string(), e.what());
+    } catch (const std::system_error& e) {
+        detail = strprintf("std::system_error  code=%d (%s)  what=%s",
+                           e.code().value(), e.code().category().name(), e.what());
+    } catch (const std::exception& e) {
+        detail = strprintf("%s  what=%s", typeid(e).name(), e.what());
+    } catch (...) {
+        detail = "(not derived from std::exception)";
+    }
+
+    const std::string message = strprintf(
+        "TestingSetup threw during step: %s\n  %s\n  errno at catch: %d (%s)",
+        g_setup_step, detail, errno, std::strerror(errno));
+
+    LogPrintf("\n\n************************\n%s", message);
+    tfm::format(std::cerr, "\n\n************************\n%s\n", message.c_str());
+}
+
 struct TestingSetup {
     TestingSetup() {
-        SetupEnvironment();
+        try {
+            g_setup_step = "SetupEnvironment()";
+            SetupEnvironment();
 
-        fs::path m_path_root = fs::temp_directory_path() / "test_common_" PACKAGE_NAME / InsecureRand256().ToString();
-        fUseFastIndex = true; // Don't verify block hashes when loading
-        gArgs.ForceSetArg("-datadir", m_path_root.string());
-        gArgs.ClearPathCache();
-        SelectParams(CBaseChainParams::MAIN);
+            g_setup_step = "fs::temp_directory_path()";
+            fs::path m_path_root = fs::temp_directory_path() / "test_common_" PACKAGE_NAME / InsecureRand256().ToString();
+            fUseFastIndex = true; // Don't verify block hashes when loading
+            g_setup_step = "gArgs -datadir / SelectParams";
+            gArgs.ForceSetArg("-datadir", m_path_root.string());
+            gArgs.ClearPathCache();
+            SelectParams(CBaseChainParams::MAIN);
 
-        // Forces logger to log to the console, and also not log to the debug.log file.
-        gArgs.ForceSetArg("-debuglogfile", "none");
-        gArgs.SoftSetBoolArg("-printtoconsole", true);
+            // Forces logger to log to the console, and also not log to the debug.log file.
+            gArgs.ForceSetArg("-debuglogfile", "none");
+            gArgs.SoftSetBoolArg("-printtoconsole", true);
 
-        InitLogging();
-        ECC_Start();
+            g_setup_step = "InitLogging()";
+            InitLogging();
+            g_setup_step = "ECC_Start()";
+            ECC_Start();
+            g_setup_step = "(past the pre-logging window)";
+        } catch (...) {
+            ReportSetupThrow();
+            throw;
+        }
 
         // TODO: Refactor CTxDB to something like bitcoin's current CDBWrapper and remove this workaround.
         leveldb::Options db_options;

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -20,6 +20,7 @@
 #include "wallet/wallet.h"
 
 #include <cerrno>
+#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <system_error>
@@ -59,37 +60,51 @@ static const char* g_setup_step = "(not started)";
 //! and it is the one Boost's summary discards.
 static void ReportSetupThrow()
 {
-    // Shaped after PrintException() in src/util/system.cpp: LogPrintf for the
-    // log (which buffers until the logger is started, so the message survives
-    // even though we throw before InitLogging), plus tfm::format to std::cerr
-    // so it is actually visible on a run that dies here. strprintf/tfm::format
-    // is the in-tree formatting primitive; the locale-dependent C printf family
-    // is not used.
-    std::string detail;
+    // Capture errno FIRST. Everything below allocates and formats, any of which
+    // may set errno itself -- reporting it at the end would describe this
+    // function rather than the failure it is meant to describe.
+    const int saved_errno = errno;
+
     try {
-        throw;
-    } catch (const fs::filesystem_error& e) {
-        // fs:: is boost::filesystem, whose errors derive from std::runtime_error
-        // rather than std::system_error, so they need their own arm to keep the
-        // error code instead of falling through to the generic handler.
-        detail = strprintf("fs::filesystem_error  code=%d (%s)  path=%s  what=%s",
-                           e.code().value(), e.code().category().name(),
-                           e.path1().string(), e.what());
-    } catch (const std::system_error& e) {
-        detail = strprintf("std::system_error  code=%d (%s)  what=%s",
-                           e.code().value(), e.code().category().name(), e.what());
-    } catch (const std::exception& e) {
-        detail = strprintf("%s  what=%s", typeid(e).name(), e.what());
+        std::string detail;
+        try {
+            throw;
+        } catch (const fs::filesystem_error& e) {
+            // fs:: is boost::filesystem, whose errors derive from
+            // std::runtime_error rather than std::system_error, so they need
+            // their own arm to keep the error code.
+            detail = strprintf("fs::filesystem_error  code=%d (%s)  path=%s  what=%s",
+                               e.code().value(), e.code().category().name(),
+                               e.path1().string(), e.what());
+        } catch (const std::system_error& e) {
+            detail = strprintf("std::system_error  code=%d (%s)  what=%s",
+                               e.code().value(), e.code().category().name(), e.what());
+        } catch (const std::exception& e) {
+            detail = strprintf("%s  what=%s", typeid(e).name(), e.what());
+        } catch (...) {
+            detail = "(not derived from std::exception)";
+        }
+
+        const std::string message = strprintf(
+            "TestingSetup threw during step: %s\n  %s\n  errno at throw: %d (%s)",
+            g_setup_step, detail, saved_errno, std::strerror(saved_errno));
+
+        // PrintException()'s shape (src/util/system.cpp): LogPrintf for the log,
+        // which buffers until the logger opens, plus a direct write to stderr
+        // because a buffered message is lost if the process dies first.
+        LogPrintf("\n\n************************\n%s", message);
+        tfm::format(std::cerr, "\n\n************************\n%s\n", message.c_str());
     } catch (...) {
-        detail = "(not derived from std::exception)";
+        // The diagnostic itself failed -- std::bad_alloc being the obvious way,
+        // and memory exhaustion is one of the conditions under investigation.
+        // Fall back to something that neither allocates nor formats, so the
+        // failure being diagnosed is still named instead of being masked by a
+        // second exception escaping a catch handler.
+        std::fputs("\n\n************************\nTestingSetup threw during step: ", stderr);
+        std::fputs(g_setup_step, stderr);
+        std::fputs("\n(diagnostic formatting failed; original exception follows)\n", stderr);
+        std::fflush(stderr);
     }
-
-    const std::string message = strprintf(
-        "TestingSetup threw during step: %s\n  %s\n  errno at catch: %d (%s)",
-        g_setup_step, detail, errno, std::strerror(errno));
-
-    LogPrintf("\n\n************************\n%s", message);
-    tfm::format(std::cerr, "\n\n************************\n%s\n", message.c_str());
 }
 
 struct TestingSetup {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -429,7 +429,7 @@ bool ThreadHandler::createThread(void(*pfn)(ThreadHandlerPtr), ThreadHandlerPtr 
 {
     try
     {
-#if defined(__linux__) && !defined(__GLIBCXX__)
+#if defined(__linux__) && !defined(__GLIBC__)
         //
         // Explicitly set the stack size for this thread to 2 MB.
         //
@@ -443,11 +443,18 @@ bool ThreadHandler::createThread(void(*pfn)(ThreadHandlerPtr), ThreadHandlerPtr 
         // Bitcoin's newer thread management utilities, I will not take time
         // to generalize this patch. Ideally, we should specify a stack size
         // suitable for the application instead of relying on the default of
-        // the libc implementation. For now, we will let glibc do its thing.
-        // 2 MB is the typical default for glibc on x86 platforms so this is
-        // the size we'll start with. After testing, we may choose a smaller
-        // stack size. This patch may apply to other libc implementations as
-        // well.
+        // the libc implementation. For now, we let glibc do its thing: 2 MB
+        // matches glibc's typical x86 default, so this only raises musl to
+        // parity rather than changing glibc behaviour.
+        //
+        // The guard tests __GLIBC__, the C library macro, and NOT __GLIBCXX__,
+        // which libstdc++ defines. They are different libraries: Alpine's
+        // ordinary C++ toolchain is musl + libstdc++, so __GLIBCXX__ IS
+        // defined there and a !__GLIBCXX__ guard silently skipped this on the
+        // one platform it was written for. Verified on alpine:latest with g++:
+        // __GLIBCXX__ defined, __GLIBC__ absent, default pthread stack 131072
+        // bytes -- 128 KB, i.e. exactly the size the comment above says scrypt
+        // overruns.
         //
         boost::thread::attributes attrs;
         attrs.set_stack_size(2 << 20);
@@ -469,7 +476,7 @@ bool ThreadHandler::createThread(void(*pfn)(void*), void* parg, const std::strin
 {
     try
     {
-#if defined(__linux__) && !defined(__GLIBCXX__)
+#if defined(__linux__) && !defined(__GLIBC__)
         //
         // Explicitly set the stack size for this thread to 2 MB.
         //
@@ -483,11 +490,18 @@ bool ThreadHandler::createThread(void(*pfn)(void*), void* parg, const std::strin
         // Bitcoin's newer thread management utilities, I will not take time
         // to generalize this patch. Ideally, we should specify a stack size
         // suitable for the application instead of relying on the default of
-        // the libc implementation. For now, we will let glibc do its thing.
-        // 2 MB is the typical default for glibc on x86 platforms so this is
-        // the size we'll start with. After testing, we may choose a smaller
-        // stack size. This patch may apply to other libc implementations as
-        // well.
+        // the libc implementation. For now, we let glibc do its thing: 2 MB
+        // matches glibc's typical x86 default, so this only raises musl to
+        // parity rather than changing glibc behaviour.
+        //
+        // The guard tests __GLIBC__, the C library macro, and NOT __GLIBCXX__,
+        // which libstdc++ defines. They are different libraries: Alpine's
+        // ordinary C++ toolchain is musl + libstdc++, so __GLIBCXX__ IS
+        // defined there and a !__GLIBCXX__ guard silently skipped this on the
+        // one platform it was written for. Verified on alpine:latest with g++:
+        // __GLIBCXX__ defined, __GLIBC__ absent, default pthread stack 131072
+        // bytes -- 128 KB, i.e. exactly the size the comment above says scrypt
+        // overruns.
         //
         boost::thread::attributes attrs;
         attrs.set_stack_size(2 << 20);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -158,8 +158,18 @@ void CDBEnv::MakeMock()
                              DB_THREAD |
                              DB_PRIVATE,
                          S_IRUSR | S_IWUSR);
-    if (ret > 0)
-        throw runtime_error(strprintf("CDBEnv::MakeMock(): error %d opening database environment", ret));
+    // ret != 0, not ret > 0. Berkeley DB returns a positive errno for system
+    // errors but a NEGATIVE code for its own (DB_RUNRECOVERY -30973,
+    // DB_NOTFOUND -30988, ...), so a > 0 test silently accepted every
+    // BDB-level failure -- the panic return included -- and then set
+    // fDbEnvInit/fMockDb anyway, leaving the whole test suite running against
+    // an environment that had failed to open. Close the handle and decode the
+    // code the same way CDBEnv::Open() above does.
+    if (ret != 0) {
+        dbenv.close(0);
+        throw runtime_error(strprintf("CDBEnv::MakeMock(): error %s (%d) opening database environment",
+                                      DbEnv::strerror(ret), ret));
+    }
 
     fDbEnvInit = true;
     fMockDb = true;


### PR DESCRIPTION
`ThreadHandler::createThread` raises new threads to a 2 MB stack on musl, because musl defaults to 128 KB and the in-tree comment records that Gridcoin's scrypt parameters need more than that. The guard was:

```cpp
#if defined(__linux__) && !defined(__GLIBCXX__)
```

But `__GLIBCXX__` is defined by **libstdc++**, the GNU C++ *standard library*. The C library's macro is `__GLIBC__`. They are different libraries — and Alpine's ordinary C++ toolchain is **musl + libstdc++**, so `__GLIBCXX__` *is* defined there, the guard evaluated false, and the workaround was skipped on the one platform it was written for.

Threads that hash blocks have been running on 128 KB stacks on musl ever since.

## Verified in containers, not reasoned about

On `alpine:latest` with `g++`:

```
__GLIBCXX__  DEFINED      (libstdc++)
__GLIBC__    not defined  (musl)
guard `!defined(__GLIBCXX__)` -> FALSE, 2 MB NOT set
default pthread stack: 131072 bytes (128 KB)
```

131072 bytes is exactly the size the existing comment says scrypt overruns.

With the corrected macro:

| image | libc | corrected guard | default stack |
|---|---|---|---|
| `alpine:latest` | musl | **TRUE** — 2 MB set | 128 KB |
| `debian:sid` | glibc | FALSE — unchanged | 8192 KB |

So it raises musl to parity and is a no-op on glibc.

## The newly-live branch had never been compiled on musl

Because the guard excluded it there, the `boost::thread::attributes` branch was dead code on Alpine. Enabling it makes it live for the first time, so I ran the full Alpine distro job locally via `run-local-ci.sh` and confirmed `src/util.cpp` compiles with it active.

## Scope

The other `__GLIBCXX__` uses in the tree (`fs.cpp`, `fs.h`, `tinyformat.h`) are correct — those genuinely test for libstdc++. These two sites were the only ones using it as a libc test, and nothing in the tree tested `__GLIBC__` at all.

## What this does NOT fix

It does **not** explain the intermittent Alpine CI failure (`Test setup error: system_error ... Out of memory`). That was investigated separately and is unrelated:

- the same **unfixed** tree passes the Alpine distro job locally (`gridcoin_tests` in 19.15s, versus dying at 0.02s on CI);
- a blown stack surfaces as `SIGSEGV`, not `ENOMEM`;
- `OpenSUSE Leap` has flaked the same job historically, so it is not musl-specific.

That failure remains open. It looks like memory pressure on the 16 GB runner — it did not reproduce here under *more* ctest parallelism with 44 GB free — but I cannot name the failing allocation without catching it again with diagnostics, so I am not guessing at a mitigation in this PR.

## Testing

Clean build, full `test_gridcoin` green (1094 cases), `lint-all.sh` clean with `COMMIT_RANGE` exported, plus the Alpine distro job run locally end to end.
