### PR TITLE
test: run the Boost suites with --use_alt_stack=no (fixes the intermittent Alpine failure)

### DIFF
--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -19,27 +19,4 @@ ${RUNTIME_LIBS}
     gridcoin_util
     )
 
-# --use_alt_stack=no is not optional on musl.
-#
-# Boost.Test installs an alternate signal stack at framework startup, sized
-# BOOST_TEST_ALT_STACK_SIZE == SIGSTKSZ, and sigaltstack(2) returns ENOMEM when
-# that is below the kernel's minimum. The kernel derives its minimum from the
-# CPU's XSAVE area and publishes it as auxv AT_MINSIGSTKSZ. glibc 2.34+ made
-# SIGSTKSZ dynamic -- sysconf(_SC_SIGSTKSZ), i.e. that same value -- but musl
-# hardcodes 8192. On a CPU whose requirement exceeds 8192 the test binary
-# therefore dies before running a single test:
-#
-#   Test setup error: system_error produced by: exp: Out of memory
-#
-# measured on a CI runner reporting AT_MINSIGSTKSZ = 11952 with 14.5 GB of its
-# 16 GB free -- an undersized stack, never memory pressure. It presented as an
-# intermittent Alpine failure only because it depends on which physical CPU the
-# job lands on; hosts reporting ~3632 can never reproduce it.
-#
-# It cannot be fixed at compile time here: BOOST_TEST_DYN_LINK means
-# execution_monitor.ipp is compiled inside libboost_unit_test_framework, so
-# -DBOOST_TEST_DISABLE_ALT_STACK would be ignored. The runtime switch is the
-# supported control. The cost is that Boost can no longer report a
-# stack-overflow SIGSEGV from a separate stack, which is a small price for a
-# suite that starts at all.
-add_test(NAME gridcoin_qt_tests COMMAND test_gridcoin-qt --use_alt_stack=no)
+add_test(NAME gridcoin_qt_tests COMMAND test_gridcoin-qt)

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -19,4 +19,27 @@ ${RUNTIME_LIBS}
     gridcoin_util
     )
 
-add_test(NAME gridcoin_qt_tests COMMAND test_gridcoin-qt)
+# --use_alt_stack=no is not optional on musl.
+#
+# Boost.Test installs an alternate signal stack at framework startup, sized
+# BOOST_TEST_ALT_STACK_SIZE == SIGSTKSZ, and sigaltstack(2) returns ENOMEM when
+# that is below the kernel's minimum. The kernel derives its minimum from the
+# CPU's XSAVE area and publishes it as auxv AT_MINSIGSTKSZ. glibc 2.34+ made
+# SIGSTKSZ dynamic -- sysconf(_SC_SIGSTKSZ), i.e. that same value -- but musl
+# hardcodes 8192. On a CPU whose requirement exceeds 8192 the test binary
+# therefore dies before running a single test:
+#
+#   Test setup error: system_error produced by: exp: Out of memory
+#
+# measured on a CI runner reporting AT_MINSIGSTKSZ = 11952 with 14.5 GB of its
+# 16 GB free -- an undersized stack, never memory pressure. It presented as an
+# intermittent Alpine failure only because it depends on which physical CPU the
+# job lands on; hosts reporting ~3632 can never reproduce it.
+#
+# It cannot be fixed at compile time here: BOOST_TEST_DYN_LINK means
+# execution_monitor.ipp is compiled inside libboost_unit_test_framework, so
+# -DBOOST_TEST_DISABLE_ALT_STACK would be ignored. The runtime switch is the
+# supported control. The cost is that Boost can no longer report a
+# stack-overflow SIGSEGV from a separate stack, which is a small price for a
+# suite that starts at all.
+add_test(NAME gridcoin_qt_tests COMMAND test_gridcoin-qt --use_alt_stack=no)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -229,4 +229,9 @@ endif()
 # supported control. The cost is that Boost can no longer report a
 # stack-overflow SIGSEGV from a separate stack, which is a small price for a
 # suite that starts at all.
+#
+# Only THIS suite needs it. gridcoin_qt_tests is a QTest binary: it does not
+# link Boost::unit_test_framework, and its main() never forwards argc/argv to
+# QTest::qExec -- so it installs no alternate signal stack and would silently
+# ignore the option anyway.
 add_test(NAME gridcoin_tests COMMAND test_gridcoin --use_alt_stack=no)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -206,4 +206,27 @@ if(ENABLE_MULTIPROCESS AND NOT WIN32)
     target_link_libraries(test_gridcoin PRIVATE gridcoin_ipc)
 endif()
 
-add_test(NAME gridcoin_tests COMMAND test_gridcoin)
+# --use_alt_stack=no is not optional on musl.
+#
+# Boost.Test installs an alternate signal stack at framework startup, sized
+# BOOST_TEST_ALT_STACK_SIZE == SIGSTKSZ, and sigaltstack(2) returns ENOMEM when
+# that is below the kernel's minimum. The kernel derives its minimum from the
+# CPU's XSAVE area and publishes it as auxv AT_MINSIGSTKSZ. glibc 2.34+ made
+# SIGSTKSZ dynamic -- sysconf(_SC_SIGSTKSZ), i.e. that same value -- but musl
+# hardcodes 8192. On a CPU whose requirement exceeds 8192 the test binary
+# therefore dies before running a single test:
+#
+#   Test setup error: system_error produced by: exp: Out of memory
+#
+# measured on a CI runner reporting AT_MINSIGSTKSZ = 11952 with 14.5 GB of its
+# 16 GB free -- an undersized stack, never memory pressure. It presented as an
+# intermittent Alpine failure only because it depends on which physical CPU the
+# job lands on; hosts reporting ~3632 can never reproduce it.
+#
+# It cannot be fixed at compile time here: BOOST_TEST_DYN_LINK means
+# execution_monitor.ipp is compiled inside libboost_unit_test_framework, so
+# -DBOOST_TEST_DISABLE_ALT_STACK would be ignored. The runtime switch is the
+# supported control. The cost is that Boost can no longer report a
+# stack-overflow SIGSEGV from a separate stack, which is a small price for a
+# suite that starts at all.
+add_test(NAME gridcoin_tests COMMAND test_gridcoin --use_alt_stack=no)


### PR DESCRIPTION
Fixes the intermittent Alpine distro failure that has been recurring since at least 2026-07-14. **Root cause confirmed on the runner that produced it**, not inferred — the diagnostics from #3272 caught it on that PR's own merge commit.

## The evidence

```
>>> Pre-test environment:
    ctest parallelism : -j 4   (nproc reports 4)
    Mem:          15989        1119        6073          47        8796       14476
    cgroup mem limit  : max (/sys/fs/cgroup/memory.max)
    AT_MINSIGSTKSZ    : 11952   (musl SIGSTKSZ is 8192)
...
2/3 Test #3: gridcoin_tests ...................***Failed    0.02 sec
Test setup error: system_error produced by: exp: Out of memory
```

**11952 > 8192.**

## What is actually happening

Boost.Test installs an alternate signal stack at framework startup:

```cpp
sigstk.ss_size = BOOST_TEST_ALT_STACK_SIZE;          // == SIGSTKSZ
BOOST_TEST_SYS_ASSERT( ::sigaltstack( &sigstk, 0 ) != -1 );
```

`sigaltstack(2)` returns **`ENOMEM` when `ss_size` is below the kernel's minimum**. The kernel derives that minimum from the CPU's XSAVE area and publishes it as auxv `AT_MINSIGSTKSZ`. glibc 2.34+ redefined `SIGSTKSZ` as `sysconf(_SC_SIGSTKSZ)` — that same value — while **musl hardcodes 8192**. On a CPU needing more, the binary dies before running a single test case.

Note what the same log lines rule out: **14.5 GB of 16 GB available, and no cgroup cap.** The machine was 90% free. Despite the wording, this was never memory exhaustion — it is an undersized buffer being rejected.

The `exp:` in the message is Boost's own bug: `BOOST_STRINGIZE( exp )` stringises the literal token rather than the condition, so all six `BOOST_TEST_SYS_ASSERT` sites report the same uninformative name. That is a good part of why this survived a month of investigation.

## Why it looked random, and only on Alpine

It depends entirely on **which physical CPU the job lands on**. A host reporting ~3632 cannot reproduce it at any number of attempts; one reporting 11952 cannot avoid it. That explains every previously confusing observation:

| observation | explanation |
|---|---|
| the same commit passed and failed | different runner, different CPU |
| 60 local runs clean, two configurations | this machine reports 3632 |
| Alpine only | glibc's `SIGSTKSZ` is dynamic; musl's is not |
| `ENOMEM` with the box 90% free | `sigaltstack`'s error for an undersized stack |
| dies at 0.02s with no output | execution-monitor ctor, before any of our code |

## The fix

`--use_alt_stack=no` is the supported runtime control. It cannot be fixed at compile time here: `BOOST_TEST_DYN_LINK` means `execution_monitor.ipp` is compiled inside `libboost_unit_test_framework`, so `-DBOOST_TEST_DISABLE_ALT_STACK` would be ignored.

With `p_use_alt_stack` false, `execution_monitor` passes a **null** `alt_stack` to `signal_handler`, whose `if( alt_stack )` block — containing both `sigaltstack` calls — is skipped entirely:

```cpp
signal_handler local_signal_handler( ..., !p_use_alt_stack ? 0 : m_alt_stack.get() );
```

Confirmed under `strace`: `sigaltstack` calls drop from 21 to 9, the remainder being glibc's own.

**Tradeoff:** Boost can no longer report a stack-overflow `SIGSEGV` from a separate stack. That is a small price for a suite that starts at all, and it buys back a whole platform. Applied to the Boost suite only. `gridcoin_qt_tests` is a **QTest** binary — it links no `Boost::unit_test_framework` and its `main()` never forwards `argc`/`argv` to `QTest::qExec` — so it installs no alternate signal stack and would silently ignore the option. (An earlier revision of this PR applied it there too on the mistaken assumption both suites used the same framework; corrected in ec63ce6c8 after review.)

## Testing

Clean build, `ctest` green (all 3 suites), `lint-all.sh` clean with `COMMIT_RANGE` exported. Verified the flag actually reaches the binaries via `ctest -N -V`:

```
2: Test command: .../test_gridcoin-qt "--use_alt_stack=no"
3: Test command: .../test_gridcoin "--use_alt_stack=no"
```

