### PR TITLE
wallet: coalesce SyncTransaction's spend marking per parent (follow-up to #3270)

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -2535,6 +2535,74 @@ BOOST_AUTO_TEST_CASE(incoming_tx_gets_order_position)
     pwalletMain->EraseFromWallet(tx2.GetHash());
 }
 
+// SyncTransaction must write and notify once per affected PARENT, not once per
+// consumed output. This is the second site of the amplification fixed in the
+// WalletUpdateSpent path: a consolidation consumes many outputs of the same
+// parent, and MarkSpent/MarkDirty are in-memory, so N consumed outputs need one
+// write and one notification -- not N of each. Measured on an isolated-testnet
+// consolidation of 427 inputs drawing 7 outputs from each of 61 parents: 427
+// notifications and 427 WriteToDisk calls where 61 of each is the whole content.
+BOOST_AUTO_TEST_CASE(sync_transaction_notifies_once_per_parent)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CKey key;
+    key.MakeNewKey(true);
+    BOOST_REQUIRE(pwalletMain->AddKey(key));
+
+    // One parent with FOUR outputs to us -- the shape a consolidation draws
+    // from, and the shape that made the per-output form repeat itself.
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = COutPoint(
+        uint256S("0x6666666666666666666666666666666666666666666666666666666666666666"), 0);
+    parent.vout.resize(4);
+    for (unsigned int i = 0; i < 4; ++i) {
+        parent.vout[i].nValue = COIN;
+        parent.vout[i].scriptPubKey.SetDestination(CTxDestination(key.GetPubKey().GetID()));
+    }
+    const CTransaction parent_tx(parent);
+    const uint256 parent_hash = parent_tx.GetHash();
+    BOOST_REQUIRE(pwalletMain->SyncTransaction(MakeTransactionRef(parent_tx), TxStateInMempool{}));
+
+    // A child consuming THREE of that one parent's outputs.
+    CKey external_key;
+    external_key.MakeNewKey(true);
+    CMutableTransaction child;
+    child.vin.resize(3);
+    for (unsigned int i = 0; i < 3; ++i) {
+        child.vin[i].prevout = COutPoint(parent_hash, i);
+    }
+    child.vout.resize(1);
+    child.vout[0].nValue = 2 * COIN;
+    child.vout[0].scriptPubKey.SetDestination(CTxDestination(external_key.GetPubKey().GetID()));
+    const CTransaction child_tx(child);
+
+    // Count only AFTER the parent is established, so its own sync is excluded.
+    std::map<uint256, int> notifies;
+    boost::signals2::scoped_connection conn(
+        pwalletMain->NotifyTransactionChanged.connect(
+            [&notifies](CWallet*, const uint256& h, ChangeType) { notifies[h] += 1; }));
+
+    BOOST_REQUIRE(pwalletMain->SyncTransaction(MakeTransactionRef(child_tx), TxStateInMempool{}));
+
+    // Three outputs of ONE parent were consumed, so exactly one notification for
+    // it. The per-output form emitted three.
+    BOOST_CHECK_EQUAL(notifies[parent_hash], 1);
+
+    // ...and the coalescing did not cost correctness: every consumed output is
+    // still marked, and the untouched fourth is not.
+    const auto it = pwalletMain->mapWallet.find(parent_hash);
+    BOOST_REQUIRE(it != pwalletMain->mapWallet.end());
+    BOOST_CHECK(it->second.IsSpent(0));
+    BOOST_CHECK(it->second.IsSpent(1));
+    BOOST_CHECK(it->second.IsSpent(2));
+    BOOST_CHECK(!it->second.IsSpent(3));
+
+    pwalletMain->EraseFromWallet(child_tx.GetHash());
+    pwalletMain->EraseFromWallet(parent_hash);
+}
+
 BOOST_AUTO_TEST_CASE(mempool_spend_marks_parent_output_spent)
 {
     // Legacy WalletUpdateSpent parity restored on the SyncTransaction path:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1081,6 +1081,13 @@ bool CWallet::SyncTransaction(const CTransactionRef& ptx,
 
     std::vector<CWalletTx*> txns_to_write;
 
+    // Parents whose spent flags this call actually changed, in first-touch
+    // order. A consolidation consumes many outputs of the same parent, and
+    // MarkSpent/MarkDirty are in-memory only -- so the parent needs ONE write
+    // and ONE notification however many of its outputs this transaction spends.
+    std::vector<uint256> spent_parents;
+    std::set<uint256> spent_parents_seen;
+
     // Mark consumed inputs as spent. Legacy parity: WalletUpdateSpent ran on
     // every AddToWallet sighting, so a spend already observed in the mempool
     // marks our parent outputs (repairing stale flags from wallet copies and
@@ -1109,11 +1116,17 @@ bool CWallet::SyncTransaction(const CTransactionRef& ptx,
 
                     parent_wtx.MarkSpent(txin.prevout.n);
                     parent_wtx.MarkDirty();
-                    txns_to_write.push_back(&parent_wtx);
 
-                    // Legacy WalletUpdateSpent parity: surface the parent's
-                    // changed spent state to the UI.
-                    NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
+                    // First touch of this parent only. Pushing it per input
+                    // wrote the same record once per consumed output, and
+                    // notifying per input emitted the same CT_UPDATED just as
+                    // often. Measured on a 427-input consolidation drawing 7
+                    // outputs from each of 61 parents: 427 writes and 427
+                    // notifications where 61 of each is the whole content.
+                    if (spent_parents_seen.insert(txin.prevout.hash).second) {
+                        spent_parents.push_back(txin.prevout.hash);
+                        txns_to_write.push_back(&parent_wtx);
+                    }
                 }
             }
         }
@@ -1170,6 +1183,13 @@ bool CWallet::SyncTransaction(const CTransactionRef& ptx,
                     "SyncTransaction: Persisted %d transaction(s) for tx %s (state type %d)\n",
                     txns_to_write.size(), hash.ToString(), state.index());
         }
+    }
+
+    // Legacy WalletUpdateSpent parity: surface each affected parent's changed
+    // spent state to the UI -- once per parent, after the batch write above, so
+    // a consumer observes the completed state rather than an intermediate one.
+    for (const uint256& parent_hash : spent_parents) {
+        NotifyTransactionChanged(this, parent_hash, CT_UPDATED);
     }
 
     // Notify UI of transaction change


### PR DESCRIPTION
Follow-up to #3270, which fixed this amplification in `CWallet::WalletUpdateSpent`. **The same shape exists in `CWallet::SyncTransaction`, and that site is the larger half.**

```cpp
for (const auto& txin : ptx->vin) {
    ...
    parent_wtx.MarkSpent(txin.prevout.n);
    parent_wtx.MarkDirty();
    txns_to_write.push_back(&parent_wtx);                          // per INPUT
    NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED); // per INPUT
}
```

`txns_to_write` is a plain `std::vector<CWalletTx*>` written in a loop, so a parent pushed once per consumed output is **written** once per consumed output — and notified just as often. `MarkSpent`/`MarkDirty` are in-memory, so N consumed outputs of one parent need one write and one notification.

## Measured, not reasoned about

Found by running a real consolidation on the isolated testnet against a wallet with 553k unspent inputs — 427 inputs drawing 7 outputs from each of 61 parents:

```
SyncTransaction     61 × 7 = 427 notifications + 427 writes   <- this PR
WalletUpdateSpent   61 × 1 =  61 notifications +  61 writes   <- #3270
                             ---
                             488     (observed 490, incl. the tx itself)
```

The tell was that **every parent showed exactly 8 notifications while every parent had exactly 7 outputs consumed** — 7 from here, 1 from the already-fixed path. A count that tracks output count is per-output; a count that doesn't is coalesced.

With this change that transaction produces **122** notifications and **122** writes instead of 488.

## Why review missed it

Worth recording, because it generalises:

- **#3270's review was diff-scoped**, so the duplicate site was never in view. When fixing a *pattern* defect, grep for the pattern before calling it fixed — one `grep -n NotifyTransactionChanged src/wallet/wallet.cpp` would have shown it.
- **This site reads *safer* than the one that was fixed.** It already collects into `txns_to_write` and writes "in a single database session", which looks like batching was considered. The appearance of care in adjacent code is what stops a reviewer looking closer.
- **It is invisible below pathological scale.** At two or three inputs per parent the multiplier vanishes into the noise. It took a real wallet doing a real consolidation to turn it into a 7× multiplier on 427 disk writes.

## Notes

Notifications now fire **after** the batch write, so a consumer observes the completed state rather than an intermediate one — matching what #3270 did in the other path. Behaviour is otherwise unchanged: every consumed output is still marked, `txns_to_write` still carries every modified parent (once), and the legacy `WalletUpdateSpent` parity the comment describes is preserved — the parent's changed spent state still reaches the UI, once.

## Testing

`sync_transaction_notifies_once_per_parent` added — one parent with four outputs, a child consuming three, asserting a single notification. Confirmed to **fail against the previous behaviour** (`3 != 1`) on a tree that builds with zero errors, so only the test catches it. It also asserts the coalescing did not cost correctness: outputs 0–2 marked, the untouched fourth not.

Clean build, full `test_gridcoin` green (1095 cases), `lint-all.sh` clean with `COMMIT_RANGE` exported.
