### PR TITLE
refactor: delete the main.h compatibility duplicates (#3269 U3)

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -70,19 +70,6 @@ typedef std::optional<Claim> ClaimOption;
 // directly (issue #3125 C9).
 // Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
 
-// -- Compatibility declarations: delete as the remaining main.h includers
-// -- are repointed (#3125 C9). Verbatim duplicates of the canonical
-// -- declarations in gridcoin/staking/kernel.h and wallet/wallet.h, which
-// -- are NOT part of this header's re-include set (both still include
-// -- main.h themselves).
-extern unsigned int nStakeMinAge;
-extern unsigned int nStakeMaxAge;
-extern int64_t nTransactionFee;
-extern int64_t nReserveBalance;
-extern int64_t nMinimumInputValue;
-extern unsigned int nDerivationMethodIndex;
-// -- End compatibility declarations.
-
 class CReserveKey;
 class CTxDB;
 class CTxIndex;
@@ -99,11 +86,6 @@ class CTxIndex;
 
 // AbandonChainTo / PurgeOrphanedBlockIndexEntries live in node/coherence.h
 // with the rest of the #2865 recovery logic (issue #3125, workstream C4).
-
-// -- Compatibility declaration (see the fenced block above): verbatim
-// -- duplicate of the canonical declaration in gridcoin/claim.h, which is
-// -- not part of this header's re-include set.
-GRC::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 // GetNumBlocksOfPeers, IsInitialBlockDownload, and OutOfSyncByAge live in
 // validation.h, included above (issue #3125 C9).


### PR DESCRIPTION
Closes the U3 item of #3269.

`main.h` carried seven declarations duplicating canonical ones elsewhere — the six fenced externs and `GetClaimByIndex`. This deletes them. Declaration-only: no definition, call site or lock annotation is touched, and no other file changes.

#3269 lists U3 as *"blocked on U1/U2"*. It doesn't appear to be. Every user of the six externs already includes `gridcoin/staking/kernel.h` or `wallet/wallet.h` directly, and all four users of `GetClaimByIndex` already include `gridcoin/claim.h`:

| symbol | canonical home | reached independently by |
|---|---|---|
| `nStakeMinAge`, `nStakeMaxAge` | `gridcoin/staking/kernel.h:14-15` | all users |
| `nTransactionFee`, `nReserveBalance`, `nMinimumInputValue`, `nDerivationMethodIndex` | `wallet/wallet.h:44-47` | all users |
| `GetClaimByIndex` | `gridcoin/claim.h:424` | `block_claims.cpp`, `tally.cpp`, `voting/registry.cpp`, `rpc/blockchain.cpp` (via `rpc/blockchain.h:17`) |

`GetClaimByIndex` is a slightly different case from the other six. `gridcoin/claim.h` doesn't include `main.h`, directly or transitively — it was kept out of the re-include set by choice rather than by cycle. My fence comment pointed at the block above without noting the reason differed, which is where the "same structural reason" reading came from; deleting both blocks retires that.

It also wasn't usable through the umbrella alone: `main.h` declares `ClaimOption` as `std::optional<Claim>` with `Claim` only forward-declared, so a TU holding just `main.h` cannot call it — the return type is incomplete. Any caller already needed `claim.h`.

### Verification

Against `65aea214f`:

- **gcc**, `ENABLE_GUI=ON USE_QT6=ON ENABLE_TESTS=ON`, RelWithDebInfo — clean. 118 TUs recompiled, which is exactly the set that still preprocesses `main.h` (counted from the CMake `.o.d` dependency files), so every affected TU was exercised.
- **clang 18.1.3 thread-safety gate**, `ENABLE_MULTIPROCESS=ON ENABLE_GUI=ON USE_QT6=ON WERROR_THREAD_SAFETY=ON` — clean, zero diagnostics; established green on the unmodified baseline first so the result is attributable. This configuration also compiles the `#ifdef ENABLE_MULTIPROCESS` regions in `gridcoinresearchd.cpp` and `qt/bitcoin.cpp` that the non-multiprocess build never sees.
- `test_gridcoin` — no errors detected.
- Functional suite — all passed.
- `test/lint/lint-all.sh` — clean.

The `GRC::ClaimOption` typedef and the `GRC` forward declarations stay for now: they sit in one block with `SuperblockPtr` and `MRC`, and the block goes when `main.h` does.
