### PR TITLE
refactor: give init.cpp and net_processing.cpp the includes they use (#3269)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,6 +35,7 @@
 #include <util/proc_hardening.h>
 #include <util/string.h>
 #include <util/syserror.h>
+#include "consensus/consensus.h"  // MAX_BLOCK_SIZE_GEN
 
 #include <openssl/crypto.h>
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -57,6 +57,7 @@
 #include <limits>
 #include <math.h>
 #include "wallet/wallet.h"
+#include "txmempool.h"
 
 using namespace std;
 


### PR DESCRIPTION
`init.cpp` uses `MAX_BLOCK_SIZE_GEN` at line 682 and includes neither `consensus/consensus.h`, where it is defined, nor `main.h`, which re-includes it. `net_processing.cpp` uses `mempool` in thirteen places and includes neither `txmempool.h` nor `main.h`. Both reach their symbol only through a chain of transitive includes ending at the `main.h` umbrella.

Correct on its own terms — a translation unit should include what it uses — but the reason to do it now is that it removes an ordering hazard from the #3269 header work.

Both files reach their symbol by **two independent umbrella paths**: one through `wallet/wallet.h`, one through `gridcoin/staking/kernel.h` or one of the leaf headers. Repointing any single one of those headers leaves the other path intact, so each of those changes builds clean on its own. Repointing the second one strands the translation unit.

The failure therefore appears in no individual change, only in their combination — whichever landed last would break the build, with nothing beforehand predicting it. I only found this by cherry-picking the header changes onto a common branch and building the result.

Landing this first makes those header changes safe in any merge order.

### Verification

Against `65aea214f`: gcc build (GUI + tests) clean; clang 18.1.3 thread-safety gate with `ENABLE_MULTIPROCESS=ON WERROR_THREAD_SAFETY=ON` clean, zero diagnostics; `test_gridcoin` no errors; functional suite all passed; `lint-all.sh` clean.

No behaviour change: two include directives, no code.
