### PR TITLE
refactor: repoint five leaf headers off main.h (#3269 U1)

### DIFF
--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_CHECKPOINTS_H
 #define BITCOIN_CHECKPOINTS_H
 
-#include "main.h"
+#include "chain.h"
 
 class uint256;
 class CBlockIndex;

--- a/src/miner.h
+++ b/src/miner.h
@@ -7,7 +7,7 @@
 #ifndef BITCOIN_MINER_H
 #define BITCOIN_MINER_H
 
-#include "main.h"
+#include "gridcoin/mrc.h"
 #include "gridcoin/sidestake.h"
 
 

--- a/src/node/coherence.h
+++ b/src/node/coherence.h
@@ -5,7 +5,7 @@
 #ifndef GRIDCOIN_NODE_COHERENCE_H
 #define GRIDCOIN_NODE_COHERENCE_H
 
-#include "main.h"  // cs_main (required for clang's EXCLUSIVE_LOCKS_REQUIRED thread-safety analyzer)
+#include "chain.h"  // cs_main (required for clang's EXCLUSIVE_LOCKS_REQUIRED thread-safety analyzer)
 #include "sync.h"
 
 #include <cstdint>

--- a/src/node/orphan_blocks.h
+++ b/src/node/orphan_blocks.h
@@ -5,7 +5,8 @@
 #ifndef GRIDCOIN_NODE_ORPHAN_BLOCKS_H
 #define GRIDCOIN_NODE_ORPHAN_BLOCKS_H
 
-#include "main.h"
+#include "chain.h"  // cs_main (required for clang's EXCLUSIVE_LOCKS_REQUIRED / GUARDED_BY analyzer)
+#include "primitives/block.h"  // BlockHasher
 #include "uint256.h"
 
 #include <functional>

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -6,7 +6,6 @@
 #define GRIDCOIN_NODE_PSGT_POOL_H
 
 #include <amount.h>
-#include <main.h>
 #include <psgt.h>
 #include <pubkey.h>
 #include <script/script.h>


### PR DESCRIPTION
Part of the U1 item of #3269.

`checkpoints.h`, `node/orphan_blocks.h`, `node/coherence.h`, `node/psgt_pool.h` and `miner.h` each included the `main.h` umbrella. None needs it. Each now includes the narrow set it actually uses:

| header | replacement | for |
|---|---|---|
| `checkpoints.h` | `chain.h` | `BlockMap` |
| `node/orphan_blocks.h` | `chain.h`, `primitives/block.h` | `cs_main`, `BlockHasher` |
| `node/coherence.h` | `chain.h` | `cs_main` |
| `node/psgt_pool.h` | *(none)* | `main.h` was unused |
| `miner.h` | `gridcoin/mrc.h` | `GRC::MRC` as a map value type |

No `.cpp` needed a new include: nothing was reaching `main.h` only through these five.

### Why the requirements were derived under clang, not gcc

`EXCLUSIVE_LOCKS_REQUIRED` and `GUARDED_BY` expand to nothing under gcc. Compiled with gcc, `node/coherence.h` is clean with **no `cs_main` declaration in scope at all** — its eight lock annotations and the `GUARDED_BY` on `g_orphan_blocks` would have become silently inert, building fine and passing both suites while quietly removing lock checking from the chain-coherence recovery path. Under clang it fails with `use of undeclared identifier 'cs_main'`.

Each header was therefore compiled standalone under clang with `-Wthread-safety -Werror=thread-safety-analysis`.

For the same reason `chain.h` carries an explanatory comment in both headers that include it only for `cs_main`: no code in either names `cs_main` outside an annotation, so the include reads as unused to a reader and to gcc, and removing it would disable lock checking rather than break the build. `node/coherence.h` already carried that warning on its `main.h` include; it is preserved and extended to `node/orphan_blocks.h`, where the same hazard now exists.

### Verification

gcc build (GUI + tests) clean; clang thread-safety gate with `ENABLE_MULTIPROCESS=ON WERROR_THREAD_SAFETY=ON` clean, zero diagnostics, established green on the unmodified baseline first; `test_gridcoin` no errors; functional suite all passed; `lint-all.sh` clean.

Merge-order note: #3276 should land first. Without it, this and the sibling header changes are individually green but break the build in combination.

No behaviour change.
