### PR TITLE
refactor: repoint gridcoin/staking/kernel.h off main.h (#3269 U1)

### DIFF
--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -7,7 +7,11 @@
 #define GRIDCOIN_STAKING_KERNEL_H
 
 #include "amount.h"
-#include "main.h"
+#include "chain.h"  // cs_main (required for clang's EXCLUSIVE_LOCKS_REQUIRED analyzer), CBlock, CBlockHeader, uint256
+
+class CTransaction;
+class CTxDB;
+class CValidationState;
 
 //! Gridcoin minimum/maximum stake age. Defined in
 //! gridcoin/staking/kernel.cpp (moved from main.cpp, issue #3125 C9).

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -5,6 +5,11 @@
 #ifndef BITCOIN_INDEX_TXINDEX_H
 #define BITCOIN_INDEX_TXINDEX_H
 
+#include "index/disktxpos.h"
+#include "serialize.h"
+
+#include <vector>
+
 /**  A txdb record that contains the disk location of a transaction and the
  * locations of transactions that spend its outputs.  vSpent is really only
  * used as a flag, but having the location is very helpful for debugging.


### PR DESCRIPTION
Part of the U1 item of #3269.

`gridcoin/staking/kernel.h` included the `main.h` umbrella. It now includes `chain.h` — for `cs_main` and, transitively, `uint256` and the `CBlock`/`CBlockHeader` definitions — plus forward declarations for `CTransaction`, `CTxDB` and `CValidationState`.

Forward declarations rather than includes because every one of those types is used only by reference or pointer in this header. Only `uint256` is passed and returned by value, so it is the only one needing a complete type. Pulling in `txdb.h`, `primitives/transaction.h` and `consensus/validation.h` would have moved the umbrella problem into a header that is itself widely included, rather than removing it.

Requirements were derived by compiling the header standalone under clang with `-Wthread-safety -Werror=thread-safety-analysis`. gcc cannot be used for this: `EXCLUSIVE_LOCKS_REQUIRED` expands to nothing there, so a header whose `cs_main` declaration has gone out of scope still compiles, with its annotations silently inert.

### Also: `src/index/txindex.h` was never self-contained

This change forces the fix, so it is included here.

`txindex.h` had **no `#include` lines at all**. It declares `CTxIndex` with a `CDiskTxPos pos` member and a `std::vector<CDiskTxPos> vSpent`, and uses `ADD_SERIALIZE_METHODS` — but obtained all three from being included by `main.h` at line 14, immediately after `main.h` includes `index/disktxpos.h` at line 13. It compiled only because of that ordering, and would have failed for any translation unit including it directly.

It now includes `index/disktxpos.h`, `serialize.h` and `<vector>`. Without that fix, dropping `main.h` from `kernel.h` breaks `dbwrapper.cpp` and `index/txindex.h`; with it, the tree builds clean.

### Verification

gcc build (GUI + tests) clean, 131 TUs recompiled; clang thread-safety gate with `ENABLE_MULTIPROCESS=ON WERROR_THREAD_SAFETY=ON` clean, zero diagnostics; `test_gridcoin` no errors; functional suite all passed; `lint-all.sh` clean.

Merge-order note: #3276 should land first. Without it, this and the sibling header changes are individually green but break the build in combination.

No behaviour change.
