### PR TITLE
refactor: repoint wallet/wallet.h off main.h (#3269 U1)

### DIFF
--- a/src/gridcoin/contract/message.cpp
+++ b/src/gridcoin/contract/message.cpp
@@ -10,6 +10,7 @@
 #include "wallet/wallet.h"
 
 #include "wallet/coincontrol.h"
+#include "txmempool.h"
 
 using namespace GRC;
 

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -27,6 +27,7 @@
 #include <util/string.h>
 #include <set>
 #include <univalue.h>
+#include "txmempool.h"
 
 using namespace GRC;
 

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -14,6 +14,7 @@
 #include <boost/exception/exception.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <iostream>
+#include "node/blockstorage.h"
 
 using namespace GRC;
 

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/signals2/signal.hpp>
 #include <boost/test/unit_test.hpp>
+#include "consensus/consensus.h"
 
 extern CWallet* pwalletMain;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -14,10 +14,10 @@
 #include <stdlib.h>
 
 #include "amount.h"
+#include "chain.h"  // cs_main, mapBlockIndex
 #include "node/shutdown.h"
 #include "consensus/tx_verify.h"
 #include "gridcoin/staking/status.h"
-#include "main.h"
 #include "validationinterface.h"
 #include "key.h"
 #include "keystore.h"


### PR DESCRIPTION
Part of the U1 item of #3269.

`wallet/wallet.h` included the `main.h` umbrella. It needs one thing from it — `cs_main` and `mapBlockIndex`, both in `chain.h` — so it now includes `chain.h` instead.

This is the load-bearing include of the whole umbrella. 51 translation units include `wallet.h` directly, and many more reach it through `init.h` and `gridcoin/researcher.h`, so `wallet.h` put `main.h` back into most of the tree no matter what the individual `.cpp` files did.

Measured on the CMake `.o.d` dependency files, this drops the number of TUs that still preprocess `main.h` from **118 to 94** — 24 freed by this header alone, against 4 for the five leaf headers in #3277 and 1 for `kernel.h` in #3278.

Four translation units needed an include of their own afterwards:

| file | symbol | added |
|---|---|---|
| `gridcoin/contract/message.cpp` | `mempool` | `txmempool.h` |
| `gridcoin/researcher.cpp` | `mempool` | `txmempool.h` |
| `gridcoin/upgrade.cpp` | `LoadExternalBlockFile` | `node/blockstorage.h` |
| `test/interfaces_tests.cpp` | `MIN_TX_FEE` | `consensus/consensus.h` |

None of those four mentions `main.h` anywhere, so none appears in the list of files that include the umbrella. They were reaching those symbols through `wallet.h` → `main.h`. That is the general hazard with this header: **the set of files affected by repointing it is not the set of files that name `main.h`.**

### Verification

gcc build (GUI + tests) clean; clang 18.1.3 thread-safety gate with `ENABLE_MULTIPROCESS=ON WERROR_THREAD_SAFETY=ON` clean, zero diagnostics; `test_gridcoin` no errors; functional suite all passed; `lint-all.sh` clean.

Merge-order note: #3276 should land first. Without it, this and the sibling header changes are individually green but break the build in combination.

No behaviour change.
