### PR TITLE
net, scraper, rpc, script: bounds, guards and ordering across the input paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,17 @@ if(ENABLE_TESTS)
     list(APPEND QT_COMPONENTS Test)
 endif()
 
-set(BOOST_MINIMUM_VERSION 1.63.0)
+# 1.66 is the oldest release this source can actually compile against, and has
+# been for some time: rpc/server.cpp uses boost::asio::ip::make_address_v6()
+# with no version guard, and that entered Boost in 1.66 along with the asio
+# rewrite. The 1.63 declared here was simply never revisited when that landed,
+# so it promised a floor no build has met in a while.
+#
+# 1.66 is the floor the source implies, not a version anyone exercises: CI
+# builds against the distribution Boost and depends pins 1.89. The io_context /
+# io_service shim in rpc/protocol.h still guards at 1.70, so 1.66-1.69 remains
+# intended to work.
+set(BOOST_MINIMUM_VERSION 1.66.0)
 set(BOOST_COMPONENTS filesystem iostreams thread serialization date_time)
 set(BOOST_HUNTER_COMPONENTS system atomic regex ${BOOST_COMPONENTS})
 if(ENABLE_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,7 +290,16 @@ target_link_libraries(gridcoin_util PUBLIC
     ${LIBBDB_CXX} ${LIBLEVELDB} ${LIBSECP256K1} ${LIBUNIVALUE}
     Boost::boost Boost::filesystem Boost::iostreams Boost::thread Boost::date_time Boost::serialization
     CURL::libcurl
-    OpenSSL::Crypto
+    # OpenSSL::SSL is linked for libcurl, NOT for the RPC server.
+    #
+    # -rpcssl is gone and no Gridcoin code calls into libssl any more, which
+    # made this look removable. It is not: the scraper fetches project
+    # statistics over HTTPS through libcurl, whose OpenSSL backend needs these
+    # symbols. A dynamic build hides that -- libcurl.so pulls libssl.so in
+    # transitively -- so removing it builds and links cleanly on the native
+    # target and fails only in the static depends build, with 54 undefined
+    # SSL_* references out of libcurl.a.
+    OpenSSL::Crypto OpenSSL::SSL
     Threads::Threads
     ZLIB::ZLIB
 )
@@ -383,7 +392,7 @@ if(ENABLE_DAEMON)
         ${LIBBDB_CXX} ${LIBLEVELDB} ${LIBSECP256K1} ${LIBUNIVALUE}
         Boost::boost Boost::filesystem Boost::iostreams Boost::thread Boost::date_time Boost::serialization
         CURL::libcurl
-        OpenSSL::Crypto
+        OpenSSL::Crypto OpenSSL::SSL
         Threads::Threads
         ZLIB::ZLIB
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,7 +290,7 @@ target_link_libraries(gridcoin_util PUBLIC
     ${LIBBDB_CXX} ${LIBLEVELDB} ${LIBSECP256K1} ${LIBUNIVALUE}
     Boost::boost Boost::filesystem Boost::iostreams Boost::thread Boost::date_time Boost::serialization
     CURL::libcurl
-    OpenSSL::Crypto OpenSSL::SSL
+    OpenSSL::Crypto
     Threads::Threads
     ZLIB::ZLIB
 )
@@ -383,7 +383,7 @@ if(ENABLE_DAEMON)
         ${LIBBDB_CXX} ${LIBLEVELDB} ${LIBSECP256K1} ${LIBUNIVALUE}
         Boost::boost Boost::filesystem Boost::iostreams Boost::thread Boost::date_time Boost::serialization
         CURL::libcurl
-        OpenSSL::Crypto OpenSSL::SSL
+        OpenSSL::Crypto
         Threads::Threads
         ZLIB::ZLIB
     )

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -115,8 +115,15 @@ protected:
     template<typename K, typename T>
     bool Write(const K& key, const T& value)
     {
-        if (fReadOnly)
+        if (fReadOnly) {
+            // The assert records an invariant the caller is expected to keep: a
+            // read-only handle is never opened for writing. The return is what
+            // makes the refusal operational. Without it the assert IS the guard,
+            // so compiling it out -- or simply deleting it during a sweep --
+            // silently converts a refused write into a performed one.
             assert(!"Write called on database in read-only mode");
+            return false;
+        }
 
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(1000);
@@ -142,8 +149,11 @@ protected:
     {
         if (!pdb)
             return false;
-        if (fReadOnly)
+        if (fReadOnly) {
+            // See Write() above: the return, not the assert, is the guard.
             assert(!"Erase called on database in read-only mode");
+            return false;
+        }
 
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(1000);

--- a/src/gridcoin/block_claims.cpp
+++ b/src/gridcoin/block_claims.cpp
@@ -21,7 +21,24 @@
 
 const GRC::Claim& CBlock::GetClaim() const
 {
-    if (nVersion >= 11 || !vtx[0].vContracts.empty()) {
+    // Take the contract only when there is actually a claim contract to take.
+    //
+    // The version used to be the whole of this test, which made the accessor
+    // partial: a v11+ block with no coinbase contracts indexed an empty vector,
+    // and one whose first contract was some other type reached
+    // SharePayloadAs<Claim>() over a payload that is not a Claim. Blocks are
+    // deserialized from untrusted input and this is reached from CheckBlock()
+    // before the coinbase shape has been established, so neither is a shape the
+    // caller can be assumed to have ruled out first.
+    //
+    // Testing the shape rather than the version keeps every input defined and
+    // decides nothing about validity: a block that lands in the fallback below
+    // is one the coinbase contract checks in CheckBlock() reject anyway. The
+    // blocks that satisfy those checks take the same branch they always did.
+    if (!vtx.empty()
+        && !vtx[0].vContracts.empty()
+        && vtx[0].vContracts[0].m_type == GRC::ContractType::CLAIM)
+    {
         return *vtx[0].vContracts[0].SharePayloadAs<GRC::Claim>();
     }
 
@@ -32,7 +49,7 @@ const GRC::Claim& CBlock::GetClaim() const
     if (m_claim_contract_cache.m_type == GRC::ContractType::UNKNOWN) {
         m_claim_contract_cache = GRC::MakeContract<GRC::Claim>(
             GRC::ContractAction::ADD,
-            GRC::Claim::Parse(vtx[0].hashBoinc, nVersion));
+            vtx.empty() ? GRC::Claim() : GRC::Claim::Parse(vtx[0].hashBoinc, nVersion));
     }
 
     return *m_claim_contract_cache.SharePayloadAs<GRC::Claim>();
@@ -40,10 +57,18 @@ const GRC::Claim& CBlock::GetClaim() const
 
 GRC::Claim CBlock::PullClaim()
 {
-    if (nVersion >= 11 || !vtx[0].vContracts.empty()) {
+    // Shape, not version -- see GetClaim() above for why.
+    if (!vtx.empty()
+        && !vtx[0].vContracts.empty()
+        && vtx[0].vContracts[0].m_type == GRC::ContractType::CLAIM)
+    {
         // PullPayloadAs operates on the shared_ptr within the Contract,
         // not on the vector element itself, so const vContracts is fine.
         return vtx[0].vContracts[0].CopyPayloadAs<GRC::Claim>();
+    }
+
+    if (vtx.empty()) {
+        return GRC::Claim();
     }
 
     // Before block version 11, the Gridcoin reward claim context is stored

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -155,8 +155,8 @@ struct MiningProject
     Cpid m_cpid;        //!< CPID of the BOINC account for the project.
     std::string m_team; //!< Name of the team joined for the project.
     std::string m_url;  //!< URL of the project website.
-    double m_rac;       //!< RAC of the project.
-    Error m_error;      //!< May describe why a project is ineligible.
+    double m_rac = 0.0;             //!< RAC of the project.
+    Error m_error = Error::NONE;    //!< May describe why a project is ineligible.
 
     //!
     //! \brief Determine whether the project is eligible for reward.
@@ -297,7 +297,7 @@ private:
     //!
     //! \brief Caches whether the map contains a project attached to a pool.
     //!
-    bool m_has_pool_project;
+    bool m_has_pool_project = false;
 }; // MiningProjectMap
 
 class Researcher; // forward for ResearcherPtr
@@ -697,8 +697,8 @@ public:
 private:
     MiningId m_mining_id;            //!< CPID or NONCRUNCHER variant.
     MiningProjectMap m_projects;     //!< Local projects loaded from BOINC.
-    GRC::BeaconError m_beacon_error; //!< Last beacon error that occurred, if any.
-    bool m_has_split_cpid;           //!< Flag that indicates project list has more than one CPID
+    GRC::BeaconError m_beacon_error = GRC::BeaconError::NONE; //!< Last beacon error that occurred, if any.
+    bool m_has_split_cpid = false;   //!< Flag that indicates project list has more than one CPID
 }; // Researcher
 }
 

--- a/src/gridcoin/scraper/http.cpp
+++ b/src/gridcoin/scraper/http.cpp
@@ -53,7 +53,23 @@ namespace
     }
 
     typedef std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> ScopedCurl;
-    typedef std::unique_ptr<FILE, decltype(&fclose)> ScopedFile;
+    //! \brief Deleter for ScopedFile.
+    //!
+    //! A functor rather than decltype(&fclose). glibc declares fclose with
+    //! attributes, and those are dropped when the function pointer type is used
+    //! as a template argument, which -Wignored-attributes reports. A functor
+    //! type carries no attributes, so the warning has nothing to discard, and it
+    //! also lets unique_ptr stay pointer-sized instead of storing a deleter
+    //! beside the handle. ScopedCurl above needs no equivalent:
+    //! curl_easy_cleanup carries no such attributes.
+    //!
+    //! unique_ptr only invokes the deleter for a non-null pointer, so fclose is
+    //! never handed one.
+    struct FileCloser {
+        void operator()(FILE* file) const { fclose(file); }
+    };
+
+    typedef std::unique_ptr<FILE, FileCloser> ScopedFile;
 
     ScopedCurl GetContext()
     {
@@ -132,7 +148,7 @@ void Http::Download(
         const fs::path &destination,
         const std::string &userpass)
 {
-    ScopedFile fp(fsbridge::fopen(destination, "wb"), &fclose);
+    ScopedFile fp(fsbridge::fopen(destination, "wb"));
     if (!fp)
         throw std::runtime_error(
                 tfm::strformat("Error opening target %s: %s (%d)", destination, strerror(errno), errno));

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -4859,7 +4859,17 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest, CScraperManifest::cs_mapM
 
         CDataStream part(std::move(vchData), SER_NETWORK, 1);
 
-        manifest->addPartData(std::move(part), true);
+        // The part index was reserved before the part existed, so a refused part
+        // would leave the manifest referencing something never created -- a
+        // manifest its own receipt check would then reject. Abandon the publish
+        // instead, and say which part was empty.
+        if (manifest->addPartData(std::move(part), true) < 0)
+        {
+            _log(logattribute::ERR, "ScraperSendFileManifestContents",
+                 "Empty beacon list part (" + inputfile.string() + "); manifest not published.");
+
+            return false;
+        }
 
         iPartNum++;
 
@@ -4892,7 +4902,14 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest, CScraperManifest::cs_mapM
 
                 part << ScraperVerifiedBeacons.mVerifiedMap;
 
-                manifest->addPartData(std::move(part), true);
+                // See the beacon list part above: the index is already committed.
+                if (manifest->addPartData(std::move(part), true) < 0)
+                {
+                    _log(logattribute::ERR, "ScraperSendFileManifestContents",
+                         "Empty VerifiedBeacons part; manifest not published.");
+
+                    return false;
+                }
 
                 iPartNum++;
             }
@@ -5003,7 +5020,14 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest, CScraperManifest::cs_mapM
 
             CDataStream part(vchData, SER_NETWORK, 1);
 
-            manifest->addPartData(std::move(part), true);
+            // See the beacon list part above: the index is already committed.
+            if (manifest->addPartData(std::move(part), true) < 0)
+            {
+                _log(logattribute::ERR, "ScraperSendFileManifestContents",
+                     "Empty part for project " + ProjectEntry.project + "; manifest not published.");
+
+                return false;
+            }
 
             iPartNum++;
         }
@@ -5030,7 +5054,14 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest, CScraperManifest::cs_mapM
 
             part << total_credit_map;
 
-            manifest->addPartData(std::move(part), true);
+            // See the beacon list part above: the index is already committed.
+            if (manifest->addPartData(std::move(part), true) < 0)
+            {
+                _log(logattribute::ERR, "ScraperSendFileManifestContents",
+                     "Empty ProjectsAllCpidTotalCredits part; manifest not published.");
+
+                return false;
+            }
 
             iPartNum++;
         }
@@ -5059,7 +5090,14 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest, CScraperManifest::cs_mapM
 
                 part << g_project_public_keys;
 
-                manifest->addPartData(std::move(part), true);
+                // See the beacon list part above: the index is already committed.
+                if (manifest->addPartData(std::move(part), true) < 0)
+                {
+                    _log(logattribute::ERR, "ScraperSendFileManifestContents",
+                         "Empty ProjectPublicKeys part; manifest not published.");
+
+                    return false;
+                }
 
                 iPartNum++;
             }

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -4292,11 +4292,6 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsByConvergedManifest(const
 
     ScraperStatsVerifiedBeaconsTotalCredits stats_verified_beacons_tc;
 
-    // Enumerate the count of active projects from the dummy converged manifest. One of the parts
-    // is the beacon list, is not a project, which is why that should not be included in the count.
-    // Populate the verified beacons map, and if it is don't count that either.
-    int exclude_parts_from_count = 1;
-
     auto iter = StructConvergedManifest.ConvergedManifestPartPtrsMap.find("VerifiedBeacons");
     if (iter != StructConvergedManifest.ConvergedManifestPartPtrsMap.end())
     {
@@ -4310,8 +4305,6 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsByConvergedManifest(const
         {
             _log(logattribute::WARNING, __func__, "failed to deserialize verified beacons part: " + std::string(e.what()));
         }
-
-        ++exclude_parts_from_count;
     }
 
     iter = StructConvergedManifest.ConvergedManifestPartPtrsMap.find("ProjectsAllCpidTotalCredits");
@@ -4327,16 +4320,28 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsByConvergedManifest(const
         {
             _log(logattribute::WARNING, __func__, "failed to deserialize ProjectsAllCpidTotalCredits part: " + std::string(e.what()));
         }
-
-        ++exclude_parts_from_count;
     }
 
-    iter = StructConvergedManifest.ConvergedManifestPartPtrsMap.find("ProjectPublicKeys");
-    if (iter != StructConvergedManifest.ConvergedManifestPartPtrsMap.end())
+    // Count the parts that are not projects, derived from the shared list rather
+    // than named here.
+    //
+    // These two things have to agree: what the loaders SKIP, and what this
+    // denominator EXCLUDES. Naming the pseudo-projects separately in each place
+    // let them disagree -- a name added to the list would be skipped as a source
+    // of statistics while still counting as an active project, which divides the
+    // network magnitude across a project that contributed none of it and quietly
+    // reduces every real project's share.
+    //
+    // The beacon list is the one that is not on the list, and is why this starts
+    // at one rather than zero.
+    int exclude_parts_from_count = 1;
+
+    for (const auto& part : StructConvergedManifest.ConvergedManifestPartPtrsMap)
     {
-        // ProjectPublicKeys is a non-project part; exclude from active project count.
-        // The data is available in the converged manifest for future use.
-        ++exclude_parts_from_count;
+        if (IsManifestPseudoProject(part.first))
+        {
+            ++exclude_parts_from_count;
+        }
     }
 
     unsigned int nActiveProjects = StructConvergedManifest.ConvergedManifestPartPtrsMap.size() - exclude_parts_from_count;
@@ -4405,12 +4410,7 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsFromSingleManifest(CScrap
 
     ScraperStatsVerifiedBeaconsTotalCredits stats_verified_beacons_tc {};
 
-    // Enumerate the count of active projects from the dummy converged manifest. One of the parts
-    // is the beacon list, is not a project, which is why that should not be included in the count.
-    // Populate the verified beacons map, and if it is don't count that either.
     ScraperPendingBeaconMap VerifiedBeaconMap;
-
-    int exclude_parts_from_count = 1;
 
     auto iter = StructDummyConvergedManifest.ConvergedManifestPartPtrsMap.find("VerifiedBeacons");
     if (iter != StructDummyConvergedManifest.ConvergedManifestPartPtrsMap.end())
@@ -4425,8 +4425,6 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsFromSingleManifest(CScrap
         {
             _log(logattribute::WARNING, __func__, "failed to deserialize verified beacons part: " + std::string(e.what()));
         }
-
-        ++exclude_parts_from_count;
     }
 
     stats_verified_beacons_tc.mVerifiedMap = VerifiedBeaconMap;
@@ -4446,16 +4444,30 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsFromSingleManifest(CScrap
         {
             _log(logattribute::WARNING, __func__, "failed to deserialize ProjectsAllCpidTotalCredits part: " + std::string(e.what()));
         }
-
-        ++exclude_parts_from_count;
     }
 
     stats_verified_beacons_tc.m_total_credit_map = projects_all_cpid_total_credits_map;
 
-    iter = StructDummyConvergedManifest.ConvergedManifestPartPtrsMap.find("ProjectPublicKeys");
-    if (iter != StructDummyConvergedManifest.ConvergedManifestPartPtrsMap.end())
+    // Count the parts that are not projects, derived from the shared list rather
+    // than named here.
+    //
+    // These two things have to agree: what the loaders SKIP, and what this
+    // denominator EXCLUDES. Naming the pseudo-projects separately in each place
+    // let them disagree -- a name added to the list would be skipped as a source
+    // of statistics while still counting as an active project, which divides the
+    // network magnitude across a project that contributed none of it and quietly
+    // reduces every real project's share.
+    //
+    // The beacon list is the one that is not on the list, and is why this starts
+    // at one rather than zero.
+    int exclude_parts_from_count = 1;
+
+    for (const auto& part : StructDummyConvergedManifest.ConvergedManifestPartPtrsMap)
     {
-        ++exclude_parts_from_count;
+        if (IsManifestPseudoProject(part.first))
+        {
+            ++exclude_parts_from_count;
+        }
     }
 
     unsigned int nActiveProjects = StructDummyConvergedManifest.ConvergedManifestPartPtrsMap.size()

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -5833,8 +5833,7 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
                     continue;
                 }
 
-                if (iter.project == "VerifiedBeacons" || iter.project == "ProjectsAllCpidTotalCredits"
-                        || iter.project == "ProjectPublicKeys") {
+                if (IsManifestPseudoProject(iter.project)) {
                     StructConvergedManifest.ConvergedManifestPartPtrsMap.insert(std::make_pair(iter.project,
                                                                                                manifest->vParts[iter.part1]));
                 }
@@ -5888,10 +5887,7 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
                 for (iter = StructConvergedManifest.ConvergedManifestPartPtrsMap.begin();
                      iter != StructConvergedManifest.ConvergedManifestPartPtrsMap.end(); ++iter)
                 {
-                    if (iter->first != "BeaconList"
-                            && iter->first != "VerifiedBeacons"
-                            && iter->first != "ProjectsAllCpidTotalCredits"
-                            && iter->first != "ProjectPublicKeys")
+                    if (iter->first != "BeaconList" && !IsManifestPseudoProject(iter->first))
                     {
                         StructConvergedManifest.CScraperConvergedManifest_ptr->addPart(iter->second->hash);
                     }
@@ -6799,10 +6795,7 @@ UniValue convergencereport(const UniValue& params)
 
         for (const auto& entry : ConvergedScraperStatsCache.Convergence.ConvergedManifestPartPtrsMap)
         {
-            if (entry.first == "BeaconList"
-                || entry.first == "VerifiedBeacons"
-                || entry.first == "ProjectsAllCpidTotalCredits"
-                || entry.first == "ProjectPublicKeys") {
+            if (entry.first == "BeaconList" || IsManifestPseudoProject(entry.first)) {
                 continue;
             }
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3933,6 +3933,15 @@ bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::fi
             _log(logattribute::ERR, __func__, "Project " + project + " part exceeds the maximum of "
                  + ToString(MAX_PART_RECORDS) + " records; rejecting.");
 
+            // Discard what was parsed so far. Every caller merges this map into
+            // the overall stats and none of them looks at the return value, so
+            // returning false alone did not reject anything -- it stopped
+            // parsing and handed back a truncated PREFIX of the project's
+            // statistics, which is worse than the unbounded parse it replaced.
+            // Emptied here, the project contributes nothing, which is what
+            // rejecting the part has to mean.
+            mScraperStats.clear();
+
             return false;
         }
 
@@ -4014,6 +4023,11 @@ bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::fi
     if (overlong) {
         _log(logattribute::ERR, __func__, "Project " + project + " part contains a record longer than "
              + ToString(MAX_PART_LINE_BYTES) + " bytes; rejecting.");
+
+        // Same reason as the record-count path above: callers merge this map
+        // regardless of the return value, so it has to be emptied for the
+        // rejection to mean anything.
+        mScraperStats.clear();
 
         return false;
     }

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3843,6 +3843,69 @@ bool LoadProjectObjectToStatsByCPID(const std::string& project, const SerializeD
     return bResult;
 }
 
+//! \brief Maximum number of CPID records a project part may contain.
+//!
+//! Back-solved from the superblock, which is what actually limits how many CPIDs
+//! can carry a magnitude: a superblock is at most Superblock::MAX_SIZE and its
+//! minimum serialized entry is sizeof(Cpid) + 1 byte of magnitude -- the same
+//! bound superblock.h uses to size its own reserve. Assuming a single project
+//! consumed an entire superblock gives the ceiling on records any one part could
+//! legitimately carry.
+//!
+//! Derived rather than hardcoded so it cannot silently disagree with
+//! Superblock::MAX_SIZE. That is convenience, NOT a guarantee: if that basis
+//! changes, re-derive rather than assume this still holds -- the per-record width
+//! below and the compression assumptions behind the wire limit were measured
+//! against today's format and do not follow automatically.
+static constexpr size_t MAX_PART_RECORDS = GRC::Superblock::MAX_SIZE / (sizeof(GRC::Cpid) + 1);
+
+//! \brief Maximum length of one record in a project part.
+//!
+//! A record is "TC,RAT,RAC,cpid": three doubles at six significant digits (widest
+//! observed on live data is 11 characters, e.g. 1.01799e+07), three separators
+//! and a 32-character CPID -- about 72 bytes. 512 is generous headroom while
+//! still bounding what a single line can cost.
+//!
+//! Together with MAX_PART_RECORDS this is what stops a decompression bomb, and it
+//! is why parsing stays STREAMING. A part arrives gzipped, so any wire limit
+//! bounds the compressed bytes only and DEFLATE reaches roughly 1032:1: a part
+//! well inside the wire limit can still expand to gigabytes. Bounding the line
+//! keeps peak memory at one record no matter what the stream produces, and
+//! bounding the record count stops the expansion continuing.
+//!
+//! std::getline cannot do this -- it grows its string until a delimiter or EOF,
+//! so an expansion with no newlines is buffered whole before any check can run.
+//! istream::getline(buf, n) bounds the length but sets failbit on a zero-length
+//! extraction, which is exactly what a blank line produces, so it would silently
+//! truncate parsing at the first empty line. Hence ReadBoundedLine below.
+static constexpr size_t MAX_PART_LINE_BYTES = 512;
+
+//! \brief Reads one newline-terminated record, refusing to buffer past \p max_len.
+//!
+//! Returns false at end of input or when the line is over-long, with \p overlong
+//! distinguishing the two. Handles empty lines, which istream::getline does not.
+static bool ReadBoundedLine(std::istream& in, std::string& out, const size_t max_len, bool& overlong)
+{
+    out.clear();
+    overlong = false;
+
+    char c;
+
+    while (in.get(c)) {
+        if (c == '\n') return true;
+
+        if (out.size() >= max_len) {
+            overlong = true;
+            return false;
+        }
+
+        out.push_back(c);
+    }
+
+    // A final record without a trailing newline is still a record.
+    return !out.empty();
+}
+
 bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::filtering_istream& sUncompressedIn,
                                          const double& projectmag, ScraperStats& mScraperStats)
 {
@@ -3851,8 +3914,22 @@ bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::fi
     // Lets vector the user blocks
     std::string line;
     double dProjectRAC = 0.0;
-    while (std::getline(sUncompressedIn, line))
+    size_t records = 0;
+    bool overlong = false;
+    while (ReadBoundedLine(sUncompressedIn, line, MAX_PART_LINE_BYTES, overlong))
     {
+        // Counts EVERY line, including blanks and comments, and does so before
+        // they are filtered below. That is deliberate: this is a bound on WORK,
+        // not on the size of the stats map. Counting only records that parse
+        // would let an expansion made entirely of blank lines run unbounded,
+        // since none of them would ever increment the counter.
+        if (++records > MAX_PART_RECORDS) {
+            _log(logattribute::ERR, __func__, "Project " + project + " part exceeds the maximum of "
+                 + ToString(MAX_PART_RECORDS) + " records; rejecting.");
+
+            return false;
+        }
+
         if (line[0] == '#')
             continue;
 
@@ -3922,6 +3999,17 @@ bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::fi
 
         // Increment project
         dProjectRAC += statsentry.statsvalue.dRAC;
+    }
+
+    // ReadBoundedLine stops rather than buffering an over-long record, so this is
+    // the decompression-bomb case: an expansion with no newlines, or a record far
+    // wider than the format allows. Refuse the part rather than accept a
+    // truncated view of it.
+    if (overlong) {
+        _log(logattribute::ERR, __func__, "Project " + project + " part contains a record longer than "
+             + ToString(MAX_PART_LINE_BYTES) + " bytes; rejecting.");
+
+        return false;
     }
 
     _log(logattribute::INFO, "LoadProjectObjectToStatsByCPID",

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3883,6 +3883,18 @@ bool LoadProjectObjectToStatsByCPID(const std::string& project, const SerializeD
 //! consumed an entire superblock gives the ceiling on records any one part could
 //! legitimately carry.
 //!
+//! Note this is the ceiling ITSELF, not the ceiling plus a margin. A part
+//! carrying the largest record count the superblock format admits sits exactly
+//! at this limit rather than comfortably under it. That is deliberate -- the
+//! figure means something precise, and padding it would make it mean nothing in
+//! particular -- and it is tolerable because the live count is smaller by orders
+//! of magnitude: the bound is on what the FORMAT permits, not on what the
+//! network produces. Anything approaching it is already anomalous.
+//!
+//! The corollary matters when reading a rejection: tripping this is not "a
+//! slightly oversized part", it is a part claiming more CPIDs than a whole
+//! superblock could ever represent.
+//!
 //! Derived rather than hardcoded so it cannot silently disagree with
 //! Superblock::MAX_SIZE. That is convenience, NOT a guarantee: if that basis
 //! changes, re-derive rather than assume this still holds -- the per-record width

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3877,34 +3877,9 @@ static constexpr size_t MAX_PART_RECORDS = GRC::Superblock::MAX_SIZE / (sizeof(G
 //! so an expansion with no newlines is buffered whole before any check can run.
 //! istream::getline(buf, n) bounds the length but sets failbit on a zero-length
 //! extraction, which is exactly what a blank line produces, so it would silently
-//! truncate parsing at the first empty line. Hence ReadBoundedLine below.
+//! truncate parsing at the first empty line. Hence ReadLineBounded (util/string.h).
 static constexpr size_t MAX_PART_LINE_BYTES = 512;
 
-//! \brief Reads one newline-terminated record, refusing to buffer past \p max_len.
-//!
-//! Returns false at end of input or when the line is over-long, with \p overlong
-//! distinguishing the two. Handles empty lines, which istream::getline does not.
-static bool ReadBoundedLine(std::istream& in, std::string& out, const size_t max_len, bool& overlong)
-{
-    out.clear();
-    overlong = false;
-
-    char c;
-
-    while (in.get(c)) {
-        if (c == '\n') return true;
-
-        if (out.size() >= max_len) {
-            overlong = true;
-            return false;
-        }
-
-        out.push_back(c);
-    }
-
-    // A final record without a trailing newline is still a record.
-    return !out.empty();
-}
 
 bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::filtering_istream& sUncompressedIn,
                                          const double& projectmag, ScraperStats& mScraperStats)
@@ -3916,7 +3891,7 @@ bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::fi
     double dProjectRAC = 0.0;
     size_t records = 0;
     bool overlong = false;
-    while (ReadBoundedLine(sUncompressedIn, line, MAX_PART_LINE_BYTES, overlong))
+    while (ReadLineBounded(sUncompressedIn, line, MAX_PART_LINE_BYTES, overlong))
     {
         // Counts EVERY line, including blanks and comments, and does so before
         // they are filtered below. That is deliberate: this is a bound on WORK,
@@ -4001,7 +3976,7 @@ bool ProcessProjectStatsFromStreamByCPID(const std::string& project, boostio::fi
         dProjectRAC += statsentry.statsvalue.dRAC;
     }
 
-    // ReadBoundedLine stops rather than buffering an over-long record, so this is
+    // ReadLineBounded stops rather than buffering an over-long record, so this is
     // the decompression-bomb case: an expansion with no newlines, or a record far
     // wider than the format allows. Refuse the part rather than accept a
     // truncated view of it.

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -5233,6 +5233,20 @@ bool ScraperConstructConvergedManifest(ConvergedManifest& StructConvergedManifes
     std::multimap<uint256, std::pair<ScraperID, uint256>> mManifestsBinnedbyContent;
     std::multimap<uint256, std::pair<ScraperID, uint256>>::iterator convergence;
 
+    // The denominator for the supermajority is the LOCALLY OBSERVED scraper
+    // count -- how many scrapers this node actually holds manifests from -- and
+    // that is correct by design, not an approximation to be tightened.
+    //
+    // Using the on-chain authorized scraper count instead would stall superblock
+    // production network wide whenever an authorized scraper is merely offline,
+    // which is routine: deauthorization is a manual governance action, so an
+    // idle or failed scraper stays authorized indefinitely. Measuring who is
+    // actually publishing is what keeps convergence possible in that state.
+    //
+    // This is also why manifest ingest must not be gated on sync state (see the
+    // OutOfSyncByAge branch in CScraperManifest::UnserializeCheck): a partial
+    // manifest set reaching housekeeping would shrink this denominator and let a
+    // minority view self-converge.
     unsigned int nScraperCount = mMapCSManifestsBinnedByScraper.size();
 
     _log(logattribute::INFO, "ScraperConstructConvergedManifest",

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -4352,8 +4352,7 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsByConvergedManifest(const
 
         // Do not process the BeaconList, VerifiedBeacons, ProjectsAllCpidTotalCredits, or ProjectPublicKeys
         // as a project stats file.
-        if (project != "BeaconList" && project != "VerifiedBeacons" && project != "ProjectsAllCpidTotalCredits"
-                && project != "ProjectPublicKeys")
+        if (project != "BeaconList" && !IsManifestPseudoProject(project))
         {
             _log(logattribute::INFO, "GetScraperStatsByConvergedManifest", "Processing stats for project: " + project);
 
@@ -4470,8 +4469,7 @@ ScraperStatsVerifiedBeaconsTotalCredits GetScraperStatsFromSingleManifest(CScrap
 
         // Do not process the BeaconList, VerifiedBeacons, ProjectsAllCpidTotalCredits, or ProjectPublicKeys
         // as a project stats file.
-        if (project != "BeaconList" && project != "VerifiedBeacons" && project != "ProjectsAllCpidTotalCredits"
-                && project != "ProjectPublicKeys")
+        if (project != "BeaconList" && !IsManifestPseudoProject(project))
         {
             _log(logattribute::INFO, "GetScraperStatsFromSingleManifest", "Processing stats for project: " + project);
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -580,6 +580,14 @@ void DownloadProjectPublicKeys(const WhitelistSnapshot& projectWhitelist);
  * @param all_cpid_total_credit
  * @return bool true if successful
  */
+//! Longest a single statistics field may be when a part is WRITTEN.
+//!
+//! total_credit, expavg_time and expavg_credit come straight out of the
+//! project's XML, so nothing upstream bounds them. All three are numbers; 64
+//! bytes is far past any real value and far under MAX_PART_LINE_BYTES, leaving
+//! room for the rest of the record.
+constexpr size_t MAX_RAC_FIELD_BYTES = 64;
+
 bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& file, const std::string& etag,
                                  BeaconConsensus& Consensus, ScraperVerifiedBeacons& GlobalVerifiedBeaconsCopy,
                                  ScraperVerifiedBeacons& IncomingVerifiedBeacons, double& all_cpid_total_credit)
@@ -3016,9 +3024,32 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
             }
 
             // User beacon verified. Append its statistics to the CSV output.
+            const std::string s_expavg_time = ExtractXML(data, "<expavg_time>", "</expavg_time>");
+            const std::string s_expavg_credit = ExtractXML(data, "<expavg_credit>", "</expavg_credit>");
+
+            // These three are lifted verbatim from the project's XML and nothing
+            // upstream bounds them. A single pathological value would produce a
+            // record that read-back refuses -- and refusing one record refuses
+            // the whole part, so one upstream oddity would drop this project out
+            // of convergence on every node that received it. Skip the record.
+            //
+            // No statistics are lost that were not lost already: all three are
+            // parsed as numbers on read-back, so a value this long has always
+            // failed there and been skipped. This only moves the skip to a place
+            // where it cannot take the part with it.
+            if (s_cpid_total_credit.size() > MAX_RAC_FIELD_BYTES
+                || s_expavg_time.size() > MAX_RAC_FIELD_BYTES
+                || s_expavg_credit.size() > MAX_RAC_FIELD_BYTES)
+            {
+                _log(logattribute::WARNING, "ProcessProjectRacFileByCPID",
+                     "Skipping CPID " + cpid + " in project " + project
+                     + ": a statistics field exceeds " + ToString(MAX_RAC_FIELD_BYTES) + " bytes.");
+                continue;
+            }
+
             out << s_cpid_total_credit << ","
-                << ExtractXML(data, "<expavg_time>", "</expavg_time>") << ","
-                << ExtractXML(data, "<expavg_credit>", "</expavg_credit>") << ","
+                << s_expavg_time << ","
+                << s_expavg_credit << ","
                 << cpid
                 << std::endl;
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -85,6 +85,16 @@ constexpr uint64_t MAX_MANIFEST_PART_HASHES = 1024;
 //! std::string plus scalars -- so the deserialization amplifies about 4.4x.
 constexpr uint64_t MAX_MANIFEST_PROJECTS = MAX_MANIFEST_PART_HASHES;
 
+//! Longest string field a manifest may carry: sCManifestName, and each dentry's
+//! project and ETag.
+//!
+//! All three deserialize as plain std::string, which sizes the string from a
+//! declared CompactSize before reading anything, so each is a 32 MiB allocation
+//! waiting to be asked for. Real values are short -- BOINC project names and
+//! HTTP entity tags -- so 1 KiB is an order of magnitude of headroom. At the
+//! dentry cap this bounds the string content of a manifest at about 2 MB.
+constexpr size_t MAX_MANIFEST_STRING_BYTES = 1024;
+
 //! \brief Maximum wire size of a single part.
 //!
 //! Deliberately coarse, and NOT the real bound. The precise limit is on the
@@ -421,8 +431,12 @@ void CScraperManifest::dentry::Serialize(CDataStream& ss) const
 
 void CScraperManifest::dentry::Unserialize(CDataStream& ss)
 {
-    ss >> project;
-    ss >> ETag;
+    // Bounded at the length prefix. Plain `ss >> project` reads a CompactSize
+    // and resizes the string to it before reading anything back, so a dentry
+    // declaring 32 MiB costs that allocation from a message a few bytes long.
+    // Capping the NUMBER of dentries does nothing about the size of each one.
+    ss >> LIMITED_STRING(project, MAX_MANIFEST_STRING_BYTES);
+    ss >> LIMITED_STRING(ETag, MAX_MANIFEST_STRING_BYTES);
     ss >> LastModified;
     ss >> part1 >> partc;
     ss >> GridcoinTeamID;
@@ -605,7 +619,8 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
     }
 
     ss >> pubkey;
-    ss >> sCManifestName;
+    // Same treatment, same reason.
+    ss >> LIMITED_STRING(sCManifestName, MAX_MANIFEST_STRING_BYTES);
     ss >> nTime;
 
     // This will set the bCheckAuthorized flag to false if a message

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -111,22 +111,17 @@ constexpr size_t MAX_MANIFEST_STRING_BYTES = 1024;
 //! compressed under pessimistic assumptions -- because tripping this rejects an
 //! honest scraper's part and breaks convergence. It is still half the 32 MiB
 //! wire ceiling it replaces for this message type.
-//! NOT an aggregate bound, and that gap is deliberate rather than overlooked.
-//! This caps one part. A manifest may reference MAX_MANIFEST_PART_HASHES of
-//! them, so a single accepted manifest can still retain 1024 * 16 MB of
-//! compressed part data in the process-global mapParts, and manifests are
-//! bounded by SCRAPER_CMANIFEST_RETENTION_TIME -- by age, not by count.
+//! This bounds one part, not the total held at once. The total is bounded
+//! elsewhere and by a different mechanism: manifests accepted before the wallet
+//! is in sync carry bCheckedAuthorized = false, and
+//! ScraperDeleteUnauthorizedCScraperManifests() removes those on the transition
+//! to in-sync, with ~CSplitBlob dropping each part's reference and erasing it
+//! from mapParts once the last one goes. Retention for that class is therefore
+//! scoped to the sync window rather than to this constant.
 //!
-//! Closing that needs a retention budget with an eviction policy, and eviction
-//! is the hard part: dropping a part breaks the manifest that references it, so
-//! the policy has to interact correctly with convergence rather than simply
-//! reclaiming the largest thing it can find. That is a design change, not a
-//! bound, and it is tracked separately.
-//!
-//! What is true here: an attacker must actually transmit every byte they want
-//! retained, this cap halves what each one buys them relative to the 32 MiB
-//! wire ceiling it replaces, and before it existed there was no per-part limit
-//! at all.
+//! Worth knowing before adding an aggregate cap here: the parts that a cap
+//! would evict are not the ones convergence reads, and the two classes should
+//! not be conflated. See the scraper notes in the maintainer documentation.
 constexpr size_t MAX_PART_WIRE_BYTES = 16 * 1024 * 1024;
 
 //! \brief The double-SHA256 of zero-length content.

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -666,6 +666,26 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
                       std::max(0.5, CONVERGENCE_BY_PROJECT_RATIO)) + 2);
     }
 
+    // KNOWN MISMATCH, not fixed here: the two sides of this comparison count
+    // different things. projects.size() counts every dentry, which includes the
+    // pseudo-projects the publisher injects -- VerifiedBeacons,
+    // ProjectsAllCpidTotalCredits and ProjectPublicKeys (scraper.cpp:4888, 5040,
+    // 5077) -- while nMaxProjects is derived from the whitelist alone, and none
+    // of the three is a whitelist entry.
+    //
+    // The +2 and the divisor exist to tolerate the whitelist SHRINKING between
+    // the publisher's snapshot and the receiver's without banning an honest
+    // scraper. The pseudo-projects spend that tolerance instead. Measured on
+    // mainnet: projects.size() = 19 against nMaxProjects = 24-25, so of a 5-6
+    // margin, 3 is consumed by dentries the formula never accounted for. Every
+    // pseudo-project added in future narrows it again, and the trip disposition
+    // here is an immediate ban at -banscore, not a soft rejection.
+    //
+    // Correcting it means either excluding the pseudo-projects from the count or
+    // widening nMaxProjects to admit them, and either changes when a node bans a
+    // peer. Nodes on different sides of that change would disagree about which
+    // manifests are acceptable, so it needs a version gate to roll over
+    // together; it is deliberately left alone in an ungated change.
     if (!OutOfSyncByAge() && projects.size() > nMaxProjects)
     {
         // Immediately ban the node from which the manifest was received.

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -408,6 +408,23 @@ EXCLUSIVE_LOCKS_REQUIRED(CSplitBlob::cs_manifest, CSplitBlob::cs_mapParts)
 
 // This is the complement to IsScraperAuthorizedToBroadcastManifests in the scraper.
 // It is used to determine whether received manifests are authorized.
+//
+// This check is SKIPPED while the receiving node is out of sync by age, at the
+// OutOfSyncByAge() branch in UnserializeCheck(). That is deliberate and is
+// documented there. It is safe because of a design property that is easy to miss
+// when reading this function alone:
+//
+//   An in-sync node TERMINATES a rogue manifest rather than passing it on.
+//   RecvManifest() emplaces speculatively, UnserializeCheck() rejects an
+//   unauthorized key here, and the caller then erases the entry and scores the
+//   sender. The MSG_SCRAPERINDEX relay runs from Complete(), which is reached
+//   only on success -- so an unauthorized manifest is not stored, not served and
+//   not relayed.
+//
+// Since the great majority of nodes on a working network are in sync, injection
+// cannot propagate through them: every victim needs a direct connection from the
+// attacker. The exposure is point to point, not network wide, which is why the
+// skip is tolerable rather than alarming.
 bool CScraperManifest::IsManifestAuthorized(int64_t& nTime, CPubKey& PubKey, unsigned int& banscore_out)
 EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest)
 {
@@ -533,9 +550,42 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
     // the manifest is authorized, then set the checked flag to true,
     // otherwise terminate the unserializecheck and return false,
     // which will also result in an increase in banscore, if past the grace period.
+    //
+    // THE SKIP BELOW IS DELIBERATE AND LOAD-BEARING. Do not "fix" it by gating
+    // manifest ingest on sync state, and do not add a getmanifests message. Two
+    // separate reasons, both of which cost more than the skip does:
+    //
+    //   1. Authorization is evaluated against the appcache, which is not usable
+    //      while out of sync. Checking anyway would ban a NEWLY AUTHORIZED
+    //      scraper, because this node cannot yet see the authorization.
+    //
+    //   2. Refill precedes housekeeping, and that ORDERING is the safety
+    //      property. PushInvTo() fires at the version handshake and is not gated
+    //      on our own sync state, so a syncing node fills to a complete manifest
+    //      set within seconds of connecting, while housekeeping stays blocked
+    //      until in sync. Housekeeping's first pass therefore always sees a
+    //      COMPLETE set. Gating ingest here inverts that: refill would begin
+    //      after sync, concurrent with housekeeping, so the first pass could run
+    //      on a PARTIAL set. Because the supermajority denominator is the
+    //      locally observed scraper count, a partial set can self-converge on a
+    //      minority view, permanently latch bMinHousekeepingComplete, and
+    //      thereafter return INVALID for legitimate superblocks -- a stall, and
+    //      honest peers banned. Scrapers are also quiescent roughly 20 hours in
+    //      24, so a node syncing in the quiet window would hold no manifests at
+    //      all for hours under such a gate.
+    //
+    // What makes the skip acceptable is documented above IsManifestAuthorized():
+    // an in-sync node terminates a rogue manifest instead of relaying it, so the
+    // exposure is point to point rather than network wide. The bounds checks in
+    // this function are what actually limit what an unauthenticated sender can
+    // cost us.
     if (OutOfSyncByAge())
     {
         bCheckedAuthorized = false;
+
+        LogPrint(BCLog::LogFlags::MANIFEST, "CScraperManifest::UnserializeCheck: accepting manifest "
+                 "\"%s\" without an authorization check: this node is out of sync by age. See the "
+                 "comment above for why this is deliberate.", sCManifestName);
     }
     else if (IsManifestAuthorized(nTime, pubkey, banscore_out))
     {

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -57,6 +57,34 @@ namespace {
 //! to hold.
 constexpr uint64_t MAX_MANIFEST_PART_HASHES = 1024;
 
+//! \brief Maximum number of project entries a manifest may declare.
+//!
+//! The companion to MAX_MANIFEST_PART_HASHES, and deliberately the same value
+//! rather than a second magic number: a manifest cannot carry more dentries than
+//! it carries parts. The publisher emits exactly one part per dentry plus one for
+//! the beacon list (partc and BeaconList_c are hardcoded 0), so parts =
+//! dentries + 1.
+//!
+//! Which means the effective headroom is a little under the constant, and that
+//! is the number worth remembering when judging whether this is generous:
+//!
+//!     1024 parts  ->  1023 dentries  ->  ~1020 real projects
+//!
+//! because three of the dentries are the injected pseudo-projects --
+//! VerifiedBeacons, ProjectsAllCpidTotalCredits and ProjectPublicKeys -- which
+//! ride in this vector without being whitelist entries. Against a current
+//! whitelist of 17-18, that is roughly sixty times over.
+//!
+//! Bounds the ALLOCATION, and has to be a flat constant for the same reason the
+//! part-hash cap is: nMaxProjects below is derived from the whitelist and gated
+//! on !OutOfSyncByAge(), so it is not in force during initial sync, which is
+//! when this needs to hold.
+//!
+//! Without it a dentry vector is bounded only by the message ceiling, and a
+//! dentry costs about 20 bytes on the wire against roughly 88 resident -- two
+//! std::string plus scalars -- so the deserialization amplifies about 4.4x.
+constexpr uint64_t MAX_MANIFEST_PROJECTS = MAX_MANIFEST_PART_HASHES;
+
 //! \brief Maximum wire size of a single part.
 //!
 //! Deliberately coarse, and NOT the real bound. The precise limit is on the
@@ -638,7 +666,29 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
 
     ss >> ConsensusBlock;
     ss >> BeaconList >> BeaconList_c;
-    ss >> projects;
+    {
+        // Read by hand for the same reason as the part-hash vector above: the
+        // default vector deserializer allocates against the declared count
+        // before reading what backs it, so only a check on the CompactSize
+        // prefix prevents the allocation.
+        const uint64_t project_count = ReadCompactSize(ss);
+
+        if (project_count > MAX_MANIFEST_PROJECTS) {
+            // banscore_out is deliberately NOT set here, unlike the part-hash
+            // cap. That one runs before anything has written it;
+            // IsManifestAuthorized() has already run by this point and may have
+            // recorded a verdict, so assigning would override a decision
+            // already made.
+            return error("CScraperManifest::UnserializeCheck: manifest declares %u projects, "
+                         "maximum is %u", project_count, MAX_MANIFEST_PROJECTS);
+        }
+
+        projects.resize(project_count);
+
+        for (dentry& project_entry : projects) {
+            ss >> project_entry;
+        }
+    }
 
     // Reference validity. The comparison is >= rather than >: the ranges are
     // inclusive, so partc == 0 names exactly one part and a reference ending at

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -97,10 +97,12 @@ constexpr size_t MAX_MANIFEST_STRING_BYTES = 1024;
 
 //! \brief Maximum wire size of a single part.
 //!
-//! Deliberately coarse, and NOT the real bound. The precise limit is on the
-//! DECOMPRESSED content, applied where the part is parsed
-//! (MAX_PART_DECOMPRESSED_BYTES in scraper.cpp), because a part arrives gzipped
-//! and its compressed size says little about what it expands to.
+//! Deliberately coarse, and NOT the real bound. A part arrives gzipped, so its
+//! compressed size says little about what it expands to; what limits the
+//! expansion is applied where the part is parsed, as a cap on the number of
+//! records (MAX_PART_RECORDS) and on the length of any one of them
+//! (MAX_PART_LINE_BYTES), both in scraper.cpp. There is no ceiling on total
+//! decompressed bytes, and parsing stays streaming so none is needed.
 //!
 //! This exists only to stop the compressed bytes being STORED. mapParts is
 //! process-global and a manifest may declare up to MAX_MANIFEST_PART_HASHES

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -13,6 +13,7 @@
 #include "rpc/server.h"
 #include "rpc/protocol.h"
 #include "rpc/util.h"
+#include "serialize.h"
 #ifdef SCRAPER_NET_PK_AS_ADDRESS
 #include <key_io.h>
 #endif
@@ -37,6 +38,25 @@ extern AppCacheSectionExt GetExtendedScrapersCache();
 extern bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
 
 namespace {
+//! \brief Maximum number of part hashes a manifest may declare.
+//!
+//! A COUNT of uint256, matching what the CompactSize prefix denotes for a
+//! vector<T> -- not a byte size. 1024 hashes is 32 KiB of vector storage,
+//! against a measured worst case of 20 (640 bytes) across 164 mainnet manifests
+//! spanning the full retention window. Our publisher emits exactly one part per
+//! project dentry plus one for the beacon list (partc and BeaconList_c are
+//! hardcoded 0), so this accommodates 1023 dentries against a current 19.
+//!
+//! This bounds the ALLOCATION only, and exists solely because vph is the first
+//! field on the wire, read before `projects`: at this point there is nothing to
+//! validate the count against.
+//!
+//! Deliberately a flat constant rather than a limit derived from the whitelist.
+//! The derived limit is nMaxProjects below, which is gated on !OutOfSyncByAge()
+//! and so is not in force during initial sync -- which is exactly when this has
+//! to hold.
+constexpr uint64_t MAX_MANIFEST_PART_HASHES = 1024;
+
 //! \brief The double-SHA256 of zero-length content.
 //!
 //! A manifest that declares a part with this hash is malformed: RecvPart
@@ -473,7 +493,37 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
     const auto pbegin = ss.begin();
 
     std::vector<uint256> vph;
-    ss >> vph;
+
+    {
+        // Read the part-hash vector by hand rather than with `ss >> vph`. The
+        // vector deserializer grows in 5,000,000/sizeof(T) element steps and
+        // allocates against the declared count before reading the data behind
+        // it, so a short message declaring a large count costs a multi-megabyte
+        // allocate-and-memset before the stream runs dry and throws. Checking
+        // the CompactSize prefix is the only point at which that is preventable.
+        const uint64_t part_count = ReadCompactSize(ss);
+
+        if (part_count > MAX_MANIFEST_PART_HASHES) {
+            // Reject the manifest without penalising the peer, and say so
+            // explicitly rather than leaning on RecvManifest's zero
+            // initialisation: a ceiling this far above any legitimate manifest
+            // must not ban if it ever turns out to be wrong. Nothing in this
+            // function has written banscore_out yet -- IsManifestAuthorized()
+            // below is the first -- so this cannot override a decision already
+            // made.
+            banscore_out = 0;
+
+            return error("CScraperManifest::UnserializeCheck: manifest declares %u part hashes, "
+                         "maximum is %u", part_count, MAX_MANIFEST_PART_HASHES);
+        }
+
+        vph.resize(part_count);
+
+        for (uint256& ph : vph) {
+            ss >> ph;
+        }
+    }
+
     ss >> pubkey;
     ss >> sCManifestName;
     ss >> nTime;

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -265,12 +265,28 @@ int CSplitBlob::addPartData(CDataStream&& vData, const bool& publish_in_progress
 
     m_publish_in_progress = publish_in_progress;
 
-    // Our own publishing path: a zero-byte part file (a truncated write, a full
-    // disk, an interrupted gzip) must not be registered. RecvPart ignores its
-    // own return value here, so this is the only place the condition is caught.
+    // Our own publishing path. RecvPart's return value is discarded below, so
+    // anything RecvPart would refuse has to be refused HERE -- before mapParts
+    // and vParts are touched -- or the caller gets a valid index for a part
+    // that will never hold data, Complete() is still called, and the manifest
+    // is advertised with a part no peer can ever be served.
+    //
+    // A zero-byte part file: a truncated write, a full disk, an interrupted
+    // gzip.
     if (vData.empty())
     {
         LogPrintf("ERROR: %s: refusing to add an empty part to the manifest.", __func__);
+        return -1;
+    }
+
+    // And oversize, for the same reason in the other direction: a part this
+    // side accepts but every receiver rejects would leave the published
+    // manifest permanently incompletable, project-wide. The write side has to
+    // agree with the read side.
+    if (vData.size() > MAX_PART_WIRE_BYTES)
+    {
+        LogPrintf("ERROR: %s: refusing to add a %u byte part to the manifest; the maximum is %u.",
+                  __func__, vData.size(), MAX_PART_WIRE_BYTES);
         return -1;
     }
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -111,6 +111,22 @@ constexpr size_t MAX_MANIFEST_STRING_BYTES = 1024;
 //! compressed under pessimistic assumptions -- because tripping this rejects an
 //! honest scraper's part and breaks convergence. It is still half the 32 MiB
 //! wire ceiling it replaces for this message type.
+//! NOT an aggregate bound, and that gap is deliberate rather than overlooked.
+//! This caps one part. A manifest may reference MAX_MANIFEST_PART_HASHES of
+//! them, so a single accepted manifest can still retain 1024 * 16 MB of
+//! compressed part data in the process-global mapParts, and manifests are
+//! bounded by SCRAPER_CMANIFEST_RETENTION_TIME -- by age, not by count.
+//!
+//! Closing that needs a retention budget with an eviction policy, and eviction
+//! is the hard part: dropping a part breaks the manifest that references it, so
+//! the policy has to interact correctly with convergence rather than simply
+//! reclaiming the largest thing it can find. That is a design change, not a
+//! bound, and it is tracked separately.
+//!
+//! What is true here: an attacker must actually transmit every byte they want
+//! retained, this cap halves what each one buys them relative to the 32 MiB
+//! wire ceiling it replaces, and before it existed there was no per-part limit
+//! at all.
 constexpr size_t MAX_PART_WIRE_BYTES = 16 * 1024 * 1024;
 
 //! \brief The double-SHA256 of zero-length content.

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -36,6 +36,20 @@ extern CCriticalSection cs_ConvergedScraperStatsCache;
 extern AppCacheSectionExt GetExtendedScrapersCache();
 extern bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
 
+namespace {
+//! \brief The double-SHA256 of zero-length content.
+//!
+//! A manifest that declares a part with this hash is malformed: RecvPart
+//! discards empty parts, so no delivery can ever satisfy such an entry and the
+//! manifest could never complete. Computed rather than hardcoded so it cannot
+//! drift from the hash function actually in use.
+const uint256& EmptyPartHash()
+{
+    static const uint256 hash = Hash(std::vector<unsigned char>{});
+    return hash;
+}
+} // anonymous namespace
+
 bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
 {
    /* Part of larger hashed blob. Currently only used for scraper data sharing.
@@ -43,6 +57,24 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
     * notify object or ignore if no object found
     * erase from mapAlreadyAskedFor
     */
+    // An empty part carries no data and can never satisfy a manifest's part
+    // list. Receiving one is a peer or filesystem condition, not a programming
+    // error, so discard it rather than aborting: the caller reports the failure
+    // and a peer that sent it earns the same banscore as a spurious part.
+    if (vRecv.empty())
+    {
+        if (pfrom)
+        {
+            LOCK(cs_ScraperGlobals);
+
+            pfrom->Misbehaving(SCRAPER_MISBEHAVING_NODE_BANSCORE / 5);
+            LogPrintf("WARNING: CSplitBlob::RecvPart: Empty part received from %s. Adding %u banscore.",
+                      pfrom->addr.ToString(), SCRAPER_MISBEHAVING_NODE_BANSCORE / 5);
+        }
+
+        return error("Empty part received!");
+    }
+
     auto& ss = vRecv;
     uint256 hash(Hash(ss));
     {
@@ -57,7 +89,6 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
     if (ipart != mapParts.end())
     {
         CPart& part = ipart->second;
-        assert(vRecv.size() > 0);
 
         if (!part.present())
         {
@@ -108,8 +139,9 @@ void CSplitBlob::addPart(const uint256& ihash)
 {
     LOCK2(cs_mapParts, cs_manifest);
 
-    assert(ihash != Hash(MakeByteSpan(vParts)));
-
+    // No guard here: addPart() returns void and so cannot reject anything. The
+    // empty-part-hash check that used to sit here as an assert is enforced by
+    // CScraperManifest::UnserializeCheck(), which can refuse the whole manifest.
     unsigned n = vParts.size();
     auto rc = mapParts.emplace(ihash,CPart(ihash));
     CPart& part = rc.first->second;
@@ -128,6 +160,15 @@ int CSplitBlob::addPartData(CDataStream&& vData, const bool& publish_in_progress
     LOCK2(cs_mapParts, cs_manifest);
 
     m_publish_in_progress = publish_in_progress;
+
+    // Our own publishing path: a zero-byte part file (a truncated write, a full
+    // disk, an interrupted gzip) must not be registered. RecvPart ignores its
+    // own return value here, so this is the only place the condition is caught.
+    if (vData.empty())
+    {
+        LogPrintf("ERROR: %s: refusing to add an empty part to the manifest.", __func__);
+        return -1;
+    }
 
     uint256 hash(Hash(vData));
 
@@ -533,6 +574,16 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
              Hash(signature).GetHex());
 
     if (!pubkey.Verify(hash, signature)) return error("CScraperManifest: Invalid manifest signature");
+
+    // Validate the whole part list before registering any of it, so a rejected
+    // manifest never leaves half its parts in the shared mapParts.
+    for (const uint256& ph : vph)
+    {
+        if (ph == EmptyPartHash())
+        {
+            return error("CScraperManifest: manifest declares a part with the empty-content hash");
+        }
+    }
 
     for (const uint256& ph : vph)
     {

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -608,7 +608,8 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest)
     }
 }
 
-[[nodiscard]] bool CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_out)
+[[nodiscard]] bool CScraperManifest::UnserializeCheck(CDataStream& ss, unsigned int& banscore_out,
+                                                     const bool v15_project_cap)
 EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manifest)
 {
     const auto pbegin = ss.begin();
@@ -880,7 +881,17 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
     // -banscore, immediately. Nodes on either side of the change would disagree
     // about which manifests are acceptable and would score each other's honest
     // relays, so it has to roll over together rather than on upgrade.
-    const unsigned int max_projects = IsV15Enabled(nBestHeight)
+    // Taken from the caller rather than read here.
+    //
+    // This runs holding cs_mapManifest and cs_manifest, and nBestHeight is
+    // guarded by cs_main. Reaching for cs_main from inside those is the
+    // ordering net_processing.cpp warns about above its own manifest handling:
+    // the net thread takes cs_main and then cs_mapManifest, while the scraper
+    // thread takes cs_mapManifest first and reaches authorization from there.
+    // Holding both concatenated in the other order is what that comment exists
+    // to prevent, so the height is read in RecvManifest() before any of these
+    // locks are acquired.
+    const unsigned int max_projects = v15_project_cap
         ? nMaxProjects + MANIFEST_PSEUDO_PROJECTS.size()
         : nMaxProjects;
 
@@ -896,7 +907,19 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
 
     uint256 hash = Hash(Span<const std::byte>{(std::byte*)&pbegin[0], (std::byte*)&ss.begin()[0]});
 
-    ss >> signature;
+    // Bounded like every other wire-driven length in this function, and for the
+    // same reason: the default vector deserializer reserves against the declared
+    // count before reading what backs it, so a short message can declare a large
+    // signature and charge us the allocation on the way to failing.
+    //
+    // This is reached unauthenticated. The out-of-sync branch above sets
+    // bCheckedAuthorized = false and carries on, which is what makes the bounds
+    // in this function -- rather than the authorization check -- the thing that
+    // limits what an unknown sender can cost.
+    //
+    // CPubKey::SIGNATURE_SIZE is the largest DER signature CKey::Sign() can
+    // produce, so this cannot refuse a signature a scraper actually made.
+    ss >> LIMITED_VECTOR(signature, CPubKey::SIGNATURE_SIZE);
     LogPrint(BCLog::LogFlags::MANIFEST, "CScraperManifest::UnserializeCheck: hash of signature = %s",
              Hash(signature).GetHex());
 
@@ -1060,6 +1083,13 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
     // hash the object
     uint256 hash(Hash(vRecv));
 
+    // Read the chain height BEFORE taking any of the manifest locks, and let go
+    // of cs_main again immediately. UnserializeCheck() needs to know whether the
+    // v15 project-count rule applies, but it runs under cs_mapManifest and
+    // cs_manifest, and taking cs_main from there is the lock ordering
+    // net_processing.cpp explicitly avoids for this same pair.
+    const bool v15_project_cap = WITH_LOCK(cs_main, return IsV15Enabled(nBestHeight));
+
     LOCK(cs_mapManifest);
 
     // see if we do not already have it
@@ -1087,7 +1117,7 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
 
         try
         {
-            if (!manifest->UnserializeCheck(vRecv, banscore))
+            if (!manifest->UnserializeCheck(vRecv, banscore, v15_project_cap))
             {
                 mapManifest.erase(hash);
                 LogPrint(BCLog::LogFlags::MANIFEST, "invalid manifest %s received", hash.GetHex());

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -863,27 +863,28 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
                       std::max(0.5, CONVERGENCE_BY_PROJECT_RATIO)) + 2);
     }
 
-    // KNOWN MISMATCH, not fixed here: the two sides of this comparison count
-    // different things. projects.size() counts every dentry, which includes the
-    // pseudo-projects the publisher injects -- VerifiedBeacons,
-    // ProjectsAllCpidTotalCredits and ProjectPublicKeys (scraper.cpp:4888, 5040,
-    // 5077) -- while nMaxProjects is derived from the whitelist alone, and none
-    // of the three is a whitelist entry.
+    // The two sides of this comparison count different things, and at v15 they
+    // stop doing so.
     //
-    // The +2 and the divisor exist to tolerate the whitelist SHRINKING between
-    // the publisher's snapshot and the receiver's without banning an honest
-    // scraper. The pseudo-projects spend that tolerance instead. Measured on
-    // mainnet: projects.size() = 19 against nMaxProjects = 24-25, so of a 5-6
-    // margin, 3 is consumed by dentries the formula never accounted for. Every
-    // pseudo-project added in future narrows it again, and the trip disposition
-    // here is an immediate ban at -banscore, not a soft rejection.
+    // projects.size() counts every dentry, including the pseudo-projects the
+    // publisher injects (MANIFEST_PSEUDO_PROJECTS). nMaxProjects is derived from
+    // the whitelist alone, and none of those is a whitelist entry. The +2 and
+    // the divisor above exist to tolerate the whitelist SHRINKING between the
+    // publisher's snapshot and the receiver's without banning an honest scraper;
+    // the pseudo-projects were spending that tolerance instead. Measured on
+    // mainnet: 19 dentries against a limit of 24-25, so three of a five-to-six
+    // margin went to entries the formula never accounted for, and every
+    // pseudo-project added in future narrowed it again.
     //
-    // Correcting it means either excluding the pseudo-projects from the count or
-    // widening nMaxProjects to admit them, and either changes when a node bans a
-    // peer. Nodes on different sides of that change would disagree about which
-    // manifests are acceptable, so it needs a version gate to roll over
-    // together; it is deliberately left alone in an ungated change.
-    if (!OutOfSyncByAge() && projects.size() > nMaxProjects)
+    // Gated because correcting it changes when a node BANS a peer, at
+    // -banscore, immediately. Nodes on either side of the change would disagree
+    // about which manifests are acceptable and would score each other's honest
+    // relays, so it has to roll over together rather than on upgrade.
+    const unsigned int max_projects = IsV15Enabled(nBestHeight)
+        ? nMaxProjects + MANIFEST_PSEUDO_PROJECTS.size()
+        : nMaxProjects;
+
+    if (!OutOfSyncByAge() && projects.size() > max_projects)
     {
         // Immediately ban the node from which the manifest was received.
         banscore_out = gArgs.GetArg("-banscore", 100);

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -558,16 +558,75 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
     ss >> BeaconList >> BeaconList_c;
     ss >> projects;
 
-    if (BeaconList + BeaconList_c > vph.size())
+    // Reference validity. The comparison is >= rather than >: the ranges are
+    // inclusive, so partc == 0 names exactly one part and a reference ending at
+    // vph.size() names one PAST the end. quorum.cpp:1436 guards the index it
+    // reads, but scraper.cpp:5669 indexes vParts[part1] unguarded, so admitting
+    // that value here is not harmless. An empty vph is rejected by the same
+    // comparison, which is correct: a manifest with no parts carries nothing.
+    //
+    // Negative values are rejected too. BeaconList and part1 are int and default
+    // to -1; the int/unsigned comparison promotes them, so an unset index
+    // becomes a very large unsigned and trips the check.
+    if (BeaconList + BeaconList_c >= vph.size())
     {
         return error("CScraperManifest::UnserializeCheck: beacon part out of range");
     }
 
     for (const dentry& prj : projects)
     {
-        if (prj.part1 + prj.partc > vph.size())
+        if (prj.part1 + prj.partc >= vph.size())
         {
             return error("CScraperManifest::UnserializeCheck: project part out of range");
+        }
+    }
+
+    // Coverage. The checks above reject references pointing outside vph; this
+    // rejects the converse -- parts declared and then never referenced by the
+    // beacon list or any project. Without it a manifest may declare parts it
+    // never uses, and every one is registered in the process-global mapParts by
+    // addPart() below and held until the manifest ages out of the retention
+    // window. Reclamation is refcount-driven (~CSplitBlob) and therefore only
+    // happens after the fact, which is sufficient for housekeeping and not
+    // sufficient against a peer constructing manifests to sit in that window.
+    //
+    // This needs no whitelist, no registry and no sync state, so unlike the
+    // project-count cap below it behaves identically during initial sync. It is
+    // also purely intra-message: it reads only fields of this manifest and says
+    // nothing about whether the part DATA has arrived, so it is unaffected by
+    // the order in which parts or manifests are received.
+    //
+    // banscore_out is deliberately not touched, unlike the length-prefix cap
+    // above: IsManifestAuthorized() has already run by this point and may have
+    // set a score, so assigning here would override a decision already made.
+    {
+        std::vector<bool> referenced(vph.size(), false);
+
+        // The bounds test in each loop is belt-and-suspenders. The range checks
+        // above already reject any reference that reaches this far, so it cannot
+        // fire today -- but it is what stands between a weakened check up there
+        // and an out-of-bounds write down here, and an index that is skipped
+        // simply reads as uncovered and is rejected below.
+        for (unsigned int i = BeaconList; i <= BeaconList + BeaconList_c && i < referenced.size(); ++i)
+        {
+            referenced[i] = true;
+        }
+
+        for (const dentry& prj : projects)
+        {
+            for (unsigned int i = prj.part1; i <= prj.part1 + prj.partc && i < referenced.size(); ++i)
+            {
+                referenced[i] = true;
+            }
+        }
+
+        for (size_t i = 0; i < referenced.size(); ++i)
+        {
+            if (!referenced[i])
+            {
+                return error("CScraperManifest::UnserializeCheck: part %u is declared but never "
+                             "referenced by the beacon list or a project", i);
+            }
         }
     }
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -57,6 +57,24 @@ namespace {
 //! to hold.
 constexpr uint64_t MAX_MANIFEST_PART_HASHES = 1024;
 
+//! \brief Maximum wire size of a single part.
+//!
+//! Deliberately coarse, and NOT the real bound. The precise limit is on the
+//! DECOMPRESSED content, applied where the part is parsed
+//! (MAX_PART_DECOMPRESSED_BYTES in scraper.cpp), because a part arrives gzipped
+//! and its compressed size says little about what it expands to.
+//!
+//! This exists only to stop the compressed bytes being STORED. mapParts is
+//! process-global and a manifest may declare up to MAX_MANIFEST_PART_HASHES
+//! parts, so without it one peer could park a large multiple of that in memory
+//! before anything is ever decompressed.
+//!
+//! Set well clear of the largest part the derivation admits -- roughly 9 MB
+//! compressed under pessimistic assumptions -- because tripping this rejects an
+//! honest scraper's part and breaks convergence. It is still half the 32 MiB
+//! wire ceiling it replaces for this message type.
+constexpr size_t MAX_PART_WIRE_BYTES = 16 * 1024 * 1024;
+
 //! \brief The double-SHA256 of zero-length content.
 //!
 //! A manifest that declares a part with this hash is malformed: RecvPart
@@ -81,6 +99,20 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
     // list. Receiving one is a peer or filesystem condition, not a programming
     // error, so discard it rather than aborting: the caller reports the failure
     // and a peer that sent it earns the same banscore as a spurious part.
+    if (vRecv.size() > MAX_PART_WIRE_BYTES)
+    {
+        if (pfrom)
+        {
+            LOCK(cs_ScraperGlobals);
+
+            pfrom->Misbehaving(SCRAPER_MISBEHAVING_NODE_BANSCORE / 5);
+            LogPrintf("WARNING: CSplitBlob::RecvPart: Oversized part (%u bytes) received from %s. Adding %u banscore.",
+                      vRecv.size(), pfrom->addr.ToString(), SCRAPER_MISBEHAVING_NODE_BANSCORE / 5);
+        }
+
+        return error("Oversized part received!");
+    }
+
     if (vRecv.empty())
     {
         if (pfrom)

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -123,10 +123,9 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
     * notify object or ignore if no object found
     * erase from mapAlreadyAskedFor
     */
-    // An empty part carries no data and can never satisfy a manifest's part
-    // list. Receiving one is a peer or filesystem condition, not a programming
-    // error, so discard it rather than aborting: the caller reports the failure
-    // and a peer that sent it earns the same banscore as a spurious part.
+    // Bound the part before anything touches its contents. Hashing and storing
+    // are both proportional to size, and nothing upstream of here limits what a
+    // peer may send in a single part message.
     if (vRecv.size() > MAX_PART_WIRE_BYTES)
     {
         if (pfrom)
@@ -141,6 +140,10 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
         return error("Oversized part received!");
     }
 
+    // An empty part carries no data and can never satisfy a manifest's part
+    // list. Receiving one is a peer or filesystem condition, not a programming
+    // error, so discard it rather than aborting: the caller reports the failure
+    // and a peer that sent it earns the same banscore as a spurious part.
     if (vRecv.empty())
     {
         if (pfrom)
@@ -697,17 +700,30 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
     // that value here is not harmless. An empty vph is rejected by the same
     // comparison, which is correct: a manifest with no parts carries nothing.
     //
-    // Negative values are rejected too. BeaconList and part1 are int and default
-    // to -1; the int/unsigned comparison promotes them, so an unset index
-    // becomes a very large unsigned and trips the check.
-    if (BeaconList + BeaconList_c >= vph.size())
+    // Negative starts are rejected EXPLICITLY, and the range arithmetic is done
+    // in int64_t.
+    //
+    // BeaconList and part1 are int (default -1) while BeaconList_c and partc are
+    // unsigned. Writing this as `part1 + partc >= vph.size()` converts part1 to
+    // unsigned before the addition, so part1 = -1 with partc = 1 wraps to 0 and
+    // PASSES -- and the coverage loop below, iterating an unsigned i from
+    // 0xFFFFFFFF, contributes nothing, so the manifest can still be fully
+    // covered by its other references. The result is an accepted manifest whose
+    // dentry holds part1 = -1, and quorum.cpp guards only the upper bound while
+    // scraper.cpp does not guard at all: vParts[-1], dereferenced.
+    //
+    // int64_t holds every int and every unsigned, so no operand is converted and
+    // a negative start stays negative.
+    if (BeaconList < 0
+        || static_cast<int64_t>(BeaconList) + BeaconList_c >= static_cast<int64_t>(vph.size()))
     {
         return error("CScraperManifest::UnserializeCheck: beacon part out of range");
     }
 
     for (const dentry& prj : projects)
     {
-        if (prj.part1 + prj.partc >= vph.size())
+        if (prj.part1 < 0
+            || static_cast<int64_t>(prj.part1) + prj.partc >= static_cast<int64_t>(vph.size()))
         {
             return error("CScraperManifest::UnserializeCheck: project part out of range");
         }
@@ -739,16 +755,23 @@ EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest, CSplitBlob::cs_manife
         // fire today -- but it is what stands between a weakened check up there
         // and an out-of-bounds write down here, and an index that is skipped
         // simply reads as uncovered and is rejected below.
-        for (unsigned int i = BeaconList; i <= BeaconList + BeaconList_c && i < referenced.size(); ++i)
+        // int64_t for the same reason as the range checks above: an unsigned
+        // induction variable starting from a negative index begins at
+        // 0xFFFFFFFF, fails its own condition immediately, and silently marks
+        // nothing -- which reads as "covered by something else" rather than as
+        // the malformed reference it is.
+        for (int64_t i = BeaconList; i <= static_cast<int64_t>(BeaconList) + BeaconList_c
+                                     && i < static_cast<int64_t>(referenced.size()); ++i)
         {
-            referenced[i] = true;
+            if (i >= 0) referenced[i] = true;
         }
 
         for (const dentry& prj : projects)
         {
-            for (unsigned int i = prj.part1; i <= prj.part1 + prj.partc && i < referenced.size(); ++i)
+            for (int64_t i = prj.part1; i <= static_cast<int64_t>(prj.part1) + prj.partc
+                                        && i < static_cast<int64_t>(referenced.size()); ++i)
             {
-                referenced[i] = true;
+                if (i >= 0) referenced[i] = true;
             }
         }
 

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -263,7 +263,13 @@ public: /* public methods */
     /** A combination of unserialization and integrity checking, which includes hash checks, authorization checks, and
      *  signature checks.
      */
-    [[nodiscard]] bool UnserializeCheck(CDataStream& s, unsigned int& banscore_out);
+    //! \param v15_project_cap Whether the v15 project-count rule applies. Passed
+    //! in rather than derived here: this runs under cs_mapManifest and
+    //! cs_manifest, and the chain height is guarded by cs_main, which must not
+    //! be acquired from inside those (see RecvManifest). Defaults to false, the
+    //! pre-v15 rule.
+    [[nodiscard]] bool UnserializeCheck(CDataStream& s, unsigned int& banscore_out,
+                                        bool v15_project_cap = false);
 
     /** Checks to see whether manifest age is current according to the SCRAPER_CMANIFEST_RETENTION_TIME network setting. */
     bool IsManifestCurrent() const;

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -61,10 +61,19 @@ public:
     /** Use the node as download source for this Split object. */
     void UseAsSource(CNode* pnode);
 
-    /** Add a part reference to vParts. Creates a CPart if necessary. */
+    /** Add a part reference to vParts. Creates a CPart if necessary.
+     *
+     * Returns void and therefore cannot reject: callers must validate the hash
+     * first. CScraperManifest::UnserializeCheck() screens the whole part list
+     * before calling this.
+     */
     void addPart(const uint256& ihash);
 
-    /** Create a part from specified data and add reference to it into vParts. */
+    /** Create a part from specified data and add reference to it into vParts.
+     *
+     * Returns the index of the new part, or -1 if \p vData is empty, in which
+     * case nothing is registered.
+     */
     int addPartData(CDataStream&& vData, const bool &publish_in_progress = false);
 
     /** Unref all parts referenced by this. Removes parts with no references */

--- a/src/gridcoin/scraper/scraper_net.h
+++ b/src/gridcoin/scraper/scraper_net.h
@@ -5,6 +5,43 @@
 #ifndef GRIDCOIN_SCRAPER_SCRAPER_NET_H
 #define GRIDCOIN_SCRAPER_SCRAPER_NET_H
 
+#include <array>
+#include <string>
+#include <string_view>
+
+//! \brief The non-whitelist entries a published manifest carries.
+//!
+//! The publisher injects these alongside the real project dentries. They are
+//! not whitelist projects and never have been, which matters in two places that
+//! previously disagreed: the manifest project cap in UnserializeCheck(), which
+//! compares a dentry count against a whitelist-derived limit, and the stats
+//! loader in scraper.cpp, which skips them by name when walking parts.
+//!
+//! One list so those two cannot drift. Adding a pseudo-project here widens the
+//! cap by one automatically, which is what previously did not happen -- each new
+//! one silently ate a share of the margin reserved for whitelist shrinkage.
+//!
+//! BeaconList is deliberately absent: it is carried by its own index rather than
+//! as a dentry, so it does not count against the project cap.
+inline constexpr std::array<std::string_view, 3> MANIFEST_PSEUDO_PROJECTS{
+    "VerifiedBeacons",
+    "ProjectsAllCpidTotalCredits",
+    "ProjectPublicKeys",
+};
+
+//! \brief True if the name is one of the injected pseudo-projects.
+//!
+//! Note this does NOT cover BeaconList, which is carried by its own index and
+//! is excluded separately at the call sites that need to skip it.
+inline bool IsManifestPseudoProject(const std::string& project)
+{
+    for (const std::string_view name : MANIFEST_PSEUDO_PROJECTS) {
+        if (project == name) return true;
+    }
+
+    return false;
+}
+
 /* Maybe the parts system will be useful for other things so let's abstract
  * that to parent class. Since it will be all in one file there will not be any
  * polymorphism.

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -7,6 +7,7 @@
 #include "config/gridcoin-config.h"
 #endif
 
+#include "util/dir_permissions.h"
 #include "chainparams.h"
 #include "chainparamsbase.h"
 #include "util.h"
@@ -406,6 +407,12 @@ bool AppInit(int argc, char* argv[])
 extern void noui_connect();
 int main(int argc, char* argv[])
 {
+    // Before anything can create a file: debug.log, the read-write settings file
+    // and the block subdirectories are all created without an explicit mode, so
+    // without this they inherit a default desktop umask of 022 and land
+    // world-readable. Narrowing here rather than after the fact leaves no window.
+    util::SetOwnerOnlyUmask();
+
     // Reinit default timer to ensure it is zeroed out at the start of main.
     g_timer.InitTimer("default", false);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2454,6 +2454,14 @@ bool AppInit2(ThreadHandlerPtr threads)
         ResendUnbroadcastTransactions();
     }, std::chrono::minutes{12});
 
+    // Sweep expired orphan transactions. The pool's count limit only applies when
+    // something new is inserted, so without this a peer can fill it and go quiet,
+    // leaving it full until unrelated traffic happens to evict entries at random.
+    // Five minutes against a twenty-minute TTL, matching the PSGT pool sweep above.
+    g_scheduler->scheduleEvery([]{
+        ExpireOrphanTransactions(GetAdjustedTime());
+    }, std::chrono::minutes{5});
+
     // Periodically rebroadcast the wallet's own unconfirmed transactions. This
     // was previously driven per-pass from net_processing::SendMessages via the
     // setpwalletRegistered ResendWalletTransactions wrapper; it now self-

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -930,8 +930,10 @@ void SetupServerArgs()
                    "opens the RPC port on all interfaces",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcbind=<addr>[:port]", "Bind the JSON-RPC listener to the given address, "
-                   "optionally on a specific port. May be given more than once. When unset the "
-                   "listener uses loopback, or all interfaces if -rpcallowip is set",
+                   "optionally on a specific port. May be given more than once. Each entry binds "
+                   "exactly what it names, so an IPv6 entry does NOT also accept IPv4 -- pass both "
+                   "-rpcbind=:: and -rpcbind=0.0.0.0 to listen on each. When unset the listener "
+                   "uses loopback, or all interfaces (dual-stack) if -rpcallowip is set",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcconnect=<ip>", "Send commands to node running on <ip> (default: 127.0.0.1)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -937,14 +937,6 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcthreads=<n>", "Set the number of threads to service RPC calls (default: 4)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
-    argsman.AddArg("-rpcssl", "Use OpenSSL (https) for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
-    argsman.AddArg("-rpcsslcertificatechainfile=<file.cert>", "Server certificate file (default: server.cert)",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
-    argsman.AddArg("-rpcsslprivatekeyfile=<file.pem>", "Server private key (default: server.pem)",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
-    argsman.AddArg("-rpcsslciphers=<ciphers>",
-                   "Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
 #if HAVE_DECL_FORK
     argsman.AddArg("-daemon",
@@ -1029,6 +1021,14 @@ void SetupServerArgs()
     SetupChainParamsBaseOptions(argsman);
 
     // Add the hidden options
+    // Removed options, still accepted so that a node whose config or command
+    // line carries them starts instead of dying on "invalid parameter". The RPC
+    // server logs a warning for each one it finds set.
+    hidden_args.emplace_back("-rpcssl");
+    hidden_args.emplace_back("-rpcsslcertificatechainfile");
+    hidden_args.emplace_back("-rpcsslprivatekeyfile");
+    hidden_args.emplace_back("-rpcsslciphers");
+
     argsman.AddHiddenArgs(hidden_args);
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -924,7 +924,14 @@ void SetupServerArgs()
     argsman.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u, testnet: %u)",
                                                 defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort()),
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
-    argsman.AddArg("-rpcallowip=<ip>", "Allow JSON-RPC connections from specified IP address",
+    argsman.AddArg("-rpcallowip=<ip>", "Allow JSON-RPC connections from the specified IP address, "
+                   "subnet (1.2.3.4/24 or 1.2.3.4/255.255.255.0) or wildcard pattern (1.2.3.*). "
+                   "May be given more than once. Note that setting this without -rpcbind also "
+                   "opens the RPC port on all interfaces",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    argsman.AddArg("-rpcbind=<addr>[:port]", "Bind the JSON-RPC listener to the given address, "
+                   "optionally on a specific port. May be given more than once. When unset the "
+                   "listener uses loopback, or all interfaces if -rpcallowip is set",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcconnect=<ip>", "Send commands to node running on <ip> (default: 127.0.0.1)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1402,7 +1402,9 @@ bool AppInit2(ThreadHandlerPtr threads)
     HeapSetInformation(nullptr, HeapEnableTerminationOnCorruption, nullptr, 0);
 #endif
 #ifndef WIN32
-    umask(077);
+    // The process umask is set at the top of main() (util::SetOwnerOnlyUmask), so
+    // that debug.log and the settings file -- both created before this point -- are
+    // covered too. Setting it here would be too late for them.
 
     // Clean shutdown on SIGTERM
     registerSignalHandler(SIGTERM, HandleSIGTERM);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,6 +22,7 @@
 #include "node/ui_interface.h"
 #include "scheduler.h"
 #include "validationinterface.h"
+#include "script/interpreter.h"
 #include "gridcoin/gridcoin.h"
 #include "gridcoin/upgrade.h"
 #include "gridcoin/contract/registry.h"
@@ -821,7 +822,9 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-enableaccounts", "DEPRECATED: Enable accounting functionality (default: 0)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    argsman.AddArg("-maxsigcachesize=<n>", "Set maximum size for signature cache (default: 50000)",
+    argsman.AddArg("-maxsigcachesize=<n>", strprintf("Set maximum size for signature cache, in entries "
+                                                     "(default: %d, maximum: %d)",
+                                                     DEFAULT_MAX_SIG_CACHE_SIZE, MAX_SIG_CACHE_ENTRIES),
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-contractchangetoinputaddress", "Change from a contract transaction is returned to an input address "
                                                     "rather than creating a new change address (default: 0)",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -937,6 +937,9 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcthreads=<n>", "Set the number of threads to service RPC calls (default: 4)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    argsman.AddArg("-rpcservertimeout=<n>", strprintf("Close an RPC connection that has been idle "
+                   "for this many seconds; 0 disables (default: %d)", DEFAULT_RPC_SERVER_TIMEOUT),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
 #if HAVE_DECL_FORK
     argsman.AddArg("-daemon",

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_LIMITEDMAP_H
 #define BITCOIN_LIMITEDMAP_H

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2012-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_LIMITEDMAP_H
+#define BITCOIN_LIMITEDMAP_H
+
+#include <assert.h>
+#include <map>
+
+//! Ported verbatim from Bitcoin Core, which has since deleted it (86f50ed10f,
+//! "Delete limitedmap as it is unused now") after replacing the map it bounded
+//! with TxRequestTracker. Gridcoin still has mapAlreadyAskedFor and needs it
+//! bounded; adopting TxRequestTracker and its dependencies would be a far larger
+//! change than the problem warrants. Retired upstream is not the same as
+//! untested -- this container shipped for years.
+//!
+//! The two assert(0) reachability markers below are internal invariants of the
+//! container (map and rmap disagreeing), not checks on external input, so they
+//! are left as asserts. Note that asserts are live in release builds in this
+//! tree: CMakeLists.txt applies -UNDEBUG globally.
+
+/** STL-like map container that only keeps the N elements with the highest value. */
+template <typename K, typename V>
+class limitedmap
+{
+public:
+    typedef K key_type;
+    typedef V mapped_type;
+    typedef std::pair<const key_type, mapped_type> value_type;
+    typedef typename std::map<K, V>::const_iterator const_iterator;
+    typedef typename std::map<K, V>::size_type size_type;
+
+protected:
+    std::map<K, V> map;
+    typedef typename std::map<K, V>::iterator iterator;
+    std::multimap<V, iterator> rmap;
+    typedef typename std::multimap<V, iterator>::iterator rmap_iterator;
+    size_type nMaxSize;
+
+public:
+    explicit limitedmap(size_type nMaxSizeIn)
+    {
+        assert(nMaxSizeIn > 0);
+        nMaxSize = nMaxSizeIn;
+    }
+    const_iterator begin() const { return map.begin(); }
+    const_iterator end() const { return map.end(); }
+    size_type size() const { return map.size(); }
+    bool empty() const { return map.empty(); }
+    const_iterator find(const key_type& k) const { return map.find(k); }
+    size_type count(const key_type& k) const { return map.count(k); }
+    void insert(const value_type& x)
+    {
+        std::pair<iterator, bool> ret = map.insert(x);
+        if (ret.second) {
+            if (map.size() > nMaxSize) {
+                map.erase(rmap.begin()->second);
+                rmap.erase(rmap.begin());
+            }
+            rmap.insert(make_pair(x.second, ret.first));
+        }
+    }
+    void erase(const key_type& k)
+    {
+        iterator itTarget = map.find(k);
+        if (itTarget == map.end())
+            return;
+        std::pair<rmap_iterator, rmap_iterator> itPair = rmap.equal_range(itTarget->second);
+        for (rmap_iterator it = itPair.first; it != itPair.second; ++it)
+            if (it->second == itTarget) {
+                rmap.erase(it);
+                map.erase(itTarget);
+                return;
+            }
+        // Shouldn't ever get here
+        assert(0);
+    }
+    void update(const_iterator itIn, const mapped_type& v)
+    {
+        // Using map::erase() with empty range instead of map::find() to get a non-const iterator,
+        // since it is a constant time operation in C++11. For more details, see
+        // https://stackoverflow.com/questions/765148/how-to-remove-constness-of-const-iterator
+        iterator itTarget = map.erase(itIn, itIn);
+
+        if (itTarget == map.end())
+            return;
+        std::pair<rmap_iterator, rmap_iterator> itPair = rmap.equal_range(itTarget->second);
+        for (rmap_iterator it = itPair.first; it != itPair.second; ++it)
+            if (it->second == itTarget) {
+                rmap.erase(it);
+                itTarget->second = v;
+                rmap.insert(make_pair(v, itTarget));
+                return;
+            }
+        // Shouldn't ever get here
+        assert(0);
+    }
+    size_type max_size() const { return nMaxSize; }
+    size_type max_size(size_type s)
+    {
+        assert(s > 0);
+        while (map.size() > s) {
+            map.erase(rmap.begin()->second);
+            rmap.erase(rmap.begin());
+        }
+        nMaxSize = s;
+        return nMaxSize;
+    }
+};
+
+#endif // BITCOIN_LIMITEDMAP_H

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -20,7 +20,23 @@
 //! are left as asserts. Note that asserts are live in release builds in this
 //! tree: CMakeLists.txt applies -UNDEBUG globally.
 
-/** STL-like map container that only keeps the N elements with the highest value. */
+/** STL-like map container that keeps roughly the N elements with the highest value.
+ *
+ * "Roughly", and the imprecision is upstream's: insert() adds to `map` first and
+ * only indexes the new element in `rmap` AFTER evicting, so the eviction always
+ * picks the lowest-valued PRE-EXISTING element. Inserting a value lower than
+ * everything already held therefore evicts a higher-valued entry and keeps the
+ * new lower one, rather than declining the insert.
+ *
+ * Left as upstream wrote it. This container shipped for years with that
+ * behaviour and the only caller here is mapAlreadyAskedFor, where values are
+ * request times and inserts are almost always "now" -- the highest value, not
+ * the lowest. The one deliberate low insert (chainman.cpp uses 0 to defeat
+ * AskFor's two-minute backoff) raises the value immediately afterwards, so the
+ * entry it displaces is one pending request, bounded and transient. Diverging
+ * from a well-tested upstream container to satisfy its own docstring would buy
+ * less than it costs.
+ */
 template <typename K, typename V>
 class limitedmap
 {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -430,6 +430,35 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
                 continue;
             }
 
+            // A claim rides in the coinbase, so one here would make this block
+            // invalid under v15 rules. Contract dispatch does not screen it --
+            // CLAIM has no handler and falls to the permissive one -- so the
+            // check above passes it.
+            //
+            // The mempool refuses these once v15 is live, but this cannot rely
+            // on that: a transaction accepted before the activation height is
+            // still sitting there afterwards. Dropping it costs nothing; keeping
+            // it costs the whole block.
+            if (IsV15Enabled(nHeight)) {
+                bool claim_outside_coinbase = false;
+
+                for (const auto& contract : tx.GetContracts()) {
+                    if (contract.m_type == GRC::ContractType::CLAIM) {
+                        claim_outside_coinbase = true;
+                        break;
+                    }
+                }
+
+                if (claim_outside_coinbase) {
+                    LogPrint(BCLog::LogFlags::MINER,
+                        "%s: claim contract outside the coinbase. Skipped tx %s",
+                        __func__,
+                        tx.GetHash().ToString());
+
+                    continue;
+                }
+            }
+
             COrphan* porphan = nullptr;
             int64_t nTotalIn = 0;
             bool fMissingInputs = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -9,6 +9,7 @@
 
 #include "wallet/db.h"
 #include "banman.h"
+#include "consensus/consensus.h"
 #include "net.h"
 #include "node/shutdown.h"
 #include "net_processing.h"
@@ -86,7 +87,13 @@ CCriticalSection cs_vAddedNodes;
 vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
 
 CCriticalSection cs_mapAlreadyAskedFor;
-map<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor);
+// Bounded at MAX_INV_SZ, the same ceiling upstream used, and the same number a
+// single peer can announce in one inv message. The map is global, so without a
+// bound one peer announcing inventory it never serves grows state charged to
+// every peer: entries are only removed on receipt. limitedmap evicts the lowest
+// value first, and the value here is the request time, so the oldest unfulfilled
+// request is what goes.
+limitedmap<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor){MAX_INV_SZ};
 
 CCriticalSection cs_vOneShots;
 static deque<string> vOneShots GUARDED_BY(cs_vOneShots);

--- a/src/net.h
+++ b/src/net.h
@@ -15,6 +15,7 @@
 
 #include "netbase.h"
 #include "mruset.h"
+#include "limitedmap.h"
 #include "protocol.h"
 #include "streams.h"
 #include "addrman.h"
@@ -117,7 +118,7 @@ extern ServiceFlags nLocalServices;
 //! cs_main. A dedicated leaf-level mutex avoids hoisting cs_main into
 //! the PART path and keeps the lock as narrow as possible.
 extern CCriticalSection cs_mapAlreadyAskedFor;
-extern std::map<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor);
+extern limitedmap<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor);
 extern ThreadHandler* netThreads;
 
 
@@ -451,10 +452,16 @@ public:
         // logging / time-formatting / static-counter arithmetic below
         // does not touch mapAlreadyAskedFor and should not hold the
         // global mutex.
-        int64_t nRequestTime;
+        // Absent means never asked, which is a request time of zero. Reading
+        // through find() rather than operator[] also stops the lookup itself
+        // from creating an entry: the write below is what should create it, and
+        // always runs, so the old insert-on-read was redundant as well as
+        // unbounded.
+        int64_t nRequestTime = 0;
         {
             LOCK(cs_mapAlreadyAskedFor);
-            nRequestTime = mapAlreadyAskedFor[inv];
+            const auto it = mapAlreadyAskedFor.find(inv);
+            if (it != mapAlreadyAskedFor.end()) nRequestTime = it->second;
         }
 
         LogPrint(BCLog::LogFlags::NET, "askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
@@ -470,7 +477,13 @@ public:
         const int64_t nNewRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
         {
             LOCK(cs_mapAlreadyAskedFor);
-            mapAlreadyAskedFor[inv] = nNewRequestTime;
+            const auto it = mapAlreadyAskedFor.find(inv);
+
+            if (it != mapAlreadyAskedFor.end()) {
+                mapAlreadyAskedFor.update(it, nNewRequestTime);
+            } else {
+                mapAlreadyAskedFor.insert(std::make_pair(inv, nNewRequestTime));
+            }
         }
         mapAskFor.insert(std::make_pair(nNewRequestTime, inv));
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -148,11 +148,6 @@ void ResendUnbroadcastTransactions()
 //! erased when its parent turns up -- so an orphan whose parent never exists sits
 //! there indefinitely, and a peer that fills the pool and then goes SILENT leaves
 //! it full, because nothing else drives eviction.
-struct COrphanTx {
-    CTransaction tx;
-    int64_t time_received;
-};
-
 //! \brief How long an orphan transaction may sit before it is swept.
 //!
 //! 20 minutes, matching OrphanBlockManager::MAX_ORPHAN_AGE_SECONDS and
@@ -178,7 +173,6 @@ struct COrphanTx {
 //! promptly and is rebroadcast or mined regardless -- not a chain that cannot
 //! reorganise. Before extending expiry to any other orphan store, re-establish
 //! that property for that store; do not carry this conclusion across.
-static constexpr int64_t ORPHAN_TX_EXPIRE_SECONDS = 20 * 60;
 
 map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);
 map<uint256, set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);
@@ -1636,21 +1630,27 @@ static bool SendMessages(CNode* pto, bool fSendTrickle)
     {
         const CInv& inv = (*pto->mapAskFor.begin()).second;
 
-        // mapAlreadyAskedFor gains an entry when the node enqueues a request
-        // for the object from a peer, and the node removes the entry when it
-        // receives the object. If the request does not exist in this map, we
-        // don't need to ask for the object again:
+        // This used to skip the request entirely when inv was absent from
+        // mapAlreadyAskedFor, on the reasoning that the entry is removed when
+        // the object arrives, so absence means satisfied.
         //
-        bool already_asked_present;
-        {
-            LOCK(cs_mapAlreadyAskedFor);
-            already_asked_present = mapAlreadyAskedFor.find(inv) != mapAlreadyAskedFor.end();
-        }
-        if (!already_asked_present)
-        {
-            pto->mapAskFor.erase(pto->mapAskFor.begin());
-            continue;
-        }
+        // That inference was sound only while the map was unbounded. It is now
+        // a limitedmap capped at MAX_INV_SZ and evicts lowest-value-first,
+        // where the value is the request time -- so absence now means EITHER
+        // "received" OR "evicted because something newer arrived", and the two
+        // are indistinguishable here. One peer announcing MAX_INV_SZ unknown
+        // hashes in a single inv inserts a fresh, higher-valued entry for each,
+        // which is enough to evict every older pending request in the process.
+        // Skipping on absence would then silently cancel real requests that
+        // were never answered, and nothing re-issues them unless another peer
+        // re-announces.
+        //
+        // AlreadyHave() below already answers the real question -- do we still
+        // need this object -- so the check simply falls through to it. The cost
+        // is one AlreadyHave() call for objects we have already received, where
+        // this previously short-circuited; correctness is worth more than the
+        // lookup, and the mapAskFor entry is erased at the bottom of the loop
+        // either way.
 
         // cs_main is required for the AlreadyHave call (mapBlockIndex
         // lookup) and must be released before the cs_mapManifest scope

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1622,9 +1622,9 @@ static bool SendMessages(CNode* pto, bool fSendTrickle)
             // request is satisfied and we should not reinsert it.
             {
                 LOCK(cs_mapAlreadyAskedFor);
-                auto it = mapAlreadyAskedFor.find(inv);
+                const auto it = mapAlreadyAskedFor.find(inv);
                 if (it != mapAlreadyAskedFor.end()) {
-                    it->second = nNow;
+                    mapAlreadyAskedFor.update(it, nNow);
                 }
             }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -141,7 +141,46 @@ void ResendUnbroadcastTransactions()
 
 // Orphan transaction storage. All accesses occur under cs_main from
 // ProcessMessage / AddOrphanTx / EraseOrphanTx / LimitOrphanTxSize.
-map<uint256, CTransaction> mapOrphanTransactions GUARDED_BY(cs_main);
+//! \brief An orphan transaction plus when it arrived.
+//!
+//! The timestamp exists so the pool can be reclaimed on its own. The count limit
+//! below is enforced only when a new orphan is inserted, and an orphan is only
+//! erased when its parent turns up -- so an orphan whose parent never exists sits
+//! there indefinitely, and a peer that fills the pool and then goes SILENT leaves
+//! it full, because nothing else drives eviction.
+struct COrphanTx {
+    CTransaction tx;
+    int64_t time_received;
+};
+
+//! \brief How long an orphan transaction may sit before it is swept.
+//!
+//! 20 minutes, matching OrphanBlockManager::MAX_ORPHAN_AGE_SECONDS and
+//! PSGTPool::ORPHAN_EXPIRY_SECONDS -- the other two orphan pools in this tree --
+//! and upstream's ORPHAN_TX_EXPIRE_TIME.
+//!
+//! WHY SWEEPING THIS POOL IS SAFE, and why the same argument does NOT transfer to
+//! orphan BLOCKS. The obvious objection to any expiry here is that it trades a
+//! denial of service through orphan injection for an inability to converge, by
+//! discarding exactly the material a node needs while the network is forked.
+//! That objection is correct for orphan blocks -- a node reconnecting across a
+//! fork receives blocks out of order and must hold them until the parent arrives
+//! -- and OrphanBlockManager is where it applies. This is a different pool.
+//!
+//! mapOrphanTransactions is reachable only from net_processing: no part of
+//! validation consults it. It is a relay cache for transactions whose inputs we
+//! have not seen yet, not an input to consensus. A block containing a swept
+//! transaction validates identically, because ConnectBlock resolves inputs from
+//! the transaction database rather than from this map, and transactions from
+//! disconnected blocks return through the mempool, not through here.
+//!
+//! So the cost of sweeping too eagerly is a transaction that is not relayed
+//! promptly and is rebroadcast or mined regardless -- not a chain that cannot
+//! reorganise. Before extending expiry to any other orphan store, re-establish
+//! that property for that store; do not carry this conclusion across.
+static constexpr int64_t ORPHAN_TX_EXPIRE_SECONDS = 20 * 60;
+
+map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);
 map<uint256, set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);
 
 //////////////////////////////////////////////////////////////////////////////
@@ -160,8 +199,9 @@ bool AddOrphanTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     // large transaction with a missing parent then we assume
     // it will rebroadcast it later, after the parent transaction(s)
     // have been mined or received.
-    // 10,000 orphans, each of which is at most 5,000 bytes big is
-    // at most 500 megabytes of orphans:
+    // MAX_ORPHAN_TRANSACTIONS is MAX_BLOCK_SIZE/100 = 10,000, and each is at
+    // most 5,000 bytes, so the pool is bounded at ~50 MB -- not the 500 MB this
+    // comment claimed before, which was out by a factor of ten.
 
     size_t nSize = GetSerializeSize(tx, SER_NETWORK, CTransaction::CURRENT_VERSION);
 
@@ -171,7 +211,7 @@ bool AddOrphanTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         return false;
     }
 
-    mapOrphanTransactions[hash] = tx;
+    mapOrphanTransactions[hash] = COrphanTx { tx, GetAdjustedTime() };
     for (auto const& txin : tx.vin)
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
@@ -183,7 +223,7 @@ void static EraseOrphanTx(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!mapOrphanTransactions.count(hash))
         return;
-    const CTransaction& tx = mapOrphanTransactions[hash];
+    const CTransaction& tx = mapOrphanTransactions[hash].tx;
     for (auto const& txin : tx.vin)
     {
         mapOrphanTransactionsByPrev[txin.prevout.hash].erase(hash);
@@ -200,13 +240,40 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRE
     {
         // Evict a random orphan:
         uint256 randomhash = GetRandHash();
-        map<uint256, CTransaction>::iterator it = mapOrphanTransactions.lower_bound(randomhash);
+        map<uint256, COrphanTx>::iterator it = mapOrphanTransactions.lower_bound(randomhash);
         if (it == mapOrphanTransactions.end())
             it = mapOrphanTransactions.begin();
         EraseOrphanTx(it->first);
         ++nEvicted;
     }
     return nEvicted;
+}
+
+unsigned int ExpireOrphanTransactions(const int64_t now)
+{
+    LOCK(cs_main);
+
+    unsigned int expired = 0;
+
+    for (auto it = mapOrphanTransactions.begin(); it != mapOrphanTransactions.end(); ) {
+        if (now - it->second.time_received > ORPHAN_TX_EXPIRE_SECONDS) {
+            const uint256 hash = it->first;
+
+            // EraseOrphanTx invalidates the iterator, so advance past it first.
+            ++it;
+            EraseOrphanTx(hash);
+            ++expired;
+        } else {
+            ++it;
+        }
+    }
+
+    if (expired > 0) {
+        LogPrint(BCLog::LogFlags::MEMPOOL, "ExpireOrphanTransactions: swept %u orphans, %" PRIszu " remaining",
+                 expired, mapOrphanTransactions.size());
+    }
+
+    return expired;
 }
 
 bool static AlreadyHave(CTxDB& txdb, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -1028,7 +1095,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      ++mi)
                 {
                     const uint256& orphanTxHash = *mi;
-                    CTransaction& orphanTx = mapOrphanTransactions[orphanTxHash];
+                    CTransaction& orphanTx = mapOrphanTransactions[orphanTxHash].tx;
                     CValidationState orphan_state;
                     bool fMissingInputs2 = false;
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -41,6 +41,22 @@ void RemoveFromRelayMemory(const uint256& hash);
 //! see the definition for the lock-order rationale).
 void ResendUnbroadcastTransactions();
 
+//! \brief Sweep orphan transactions past ORPHAN_TX_EXPIRE_SECONDS.
+//!
+//! The orphan pool's count limit is applied only when a new orphan is inserted,
+//! and an orphan is otherwise erased only when its parent arrives. A peer that
+//! fills the pool and then stops sending therefore leaves it full indefinitely.
+//! This gives reclamation a driver that does not depend on further traffic.
+//!
+//! Takes cs_main. Safe from the scheduler thread, which holds no per-node locks.
+//!
+//! \return the number of orphans swept.
+//! \param now  Current adjusted time; taken as a parameter rather than read
+//!             internally, matching OrphanBlockManager::EraseExpired and
+//!             PSGTPool::EraseExpired, and so that it is testable without
+//!             mocking the clock for the sweep itself.
+unsigned int ExpireOrphanTransactions(const int64_t now);
+
 //! Relay a pooled PSGT revision (#2910) to peers on PSGT_PROTO_VERSION or
 //! later. The object itself is served from the PSGT pool by the getdata loop.
 void RelayPSGT(const uint256& revision_hash);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_NET_PROCESSING_H
 #define BITCOIN_NET_PROCESSING_H
 
+#include <primitives/transaction.h>
 #include "net.h"
 #include "sync.h"
 #include "validationinterface.h"
@@ -40,6 +41,23 @@ void RemoveFromRelayMemory(const uint256& hash);
 //! Intended to be driven periodically by the scheduler (never from SendMessages;
 //! see the definition for the lock-order rationale).
 void ResendUnbroadcastTransactions();
+
+//! \brief One entry in the orphan transaction pool.
+//!
+//! Declared here, rather than privately in net_processing.cpp, so that the tests
+//! that drive the pool name the same type. A private copy in a test satisfies
+//! ODR only for as long as the two stay token-identical, and the failure when
+//! they diverge is a silent type mismatch across translation units.
+struct COrphanTx {
+    CTransaction tx;
+    int64_t time_received;
+};
+
+//! \brief How long an orphan transaction may sit before it is swept.
+//!
+//! Published for the same reason as COrphanTx: a test asserting the boundary
+//! must assert against the value the implementation actually uses.
+static constexpr int64_t ORPHAN_TX_EXPIRE_SECONDS = 20 * 60;
 
 //! \brief Sweep orphan transactions past ORPHAN_TX_EXPIRE_SECONDS.
 //!

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -199,6 +199,52 @@ bool LookupSubNet(const char* pszName, CSubNet& ret)
     return false;
 }
 
+//! \brief Receive exactly len bytes, or give up at the deadline.
+//!
+//! Every recv() in the SOCKS5 negotiation below was a bare blocking call with
+//! no deadline, so a proxy that accepted the connection and then simply stopped
+//! responding held the connecting thread indefinitely. That is reachable
+//! whenever the configured proxy is unreachable, hung, or hostile, and nothing
+//! else in the negotiation bounds it.
+//!
+//! Bounded with select() and the existing connect timeout, matching the idiom
+//! ConnectSocketDirectly() already uses a few lines below. Chunked rather than
+//! one-shot because the deadline applies to the whole read: a peer that dribbles
+//! one byte per interval must not be able to extend it indefinitely.
+//!
+//! Returns false on timeout, on error, and on a short read -- callers treat all
+//! three the same way, by closing the socket and failing the negotiation.
+static bool InterruptibleRecv(SOCKET hSocket, void* data, size_t len, int timeout_ms)
+{
+    uint8_t* buf = static_cast<uint8_t*>(data);
+    const int64_t deadline = GetTimeMillis() + timeout_ms;
+    size_t have = 0;
+
+    while (have < len)
+    {
+        const int64_t remaining = deadline - GetTimeMillis();
+        if (remaining <= 0) return false;
+
+        struct timeval tv;
+        tv.tv_sec  = remaining / 1000;
+        tv.tv_usec = (remaining % 1000) * 1000;
+
+        fd_set fdset;
+        FD_ZERO(&fdset);
+        FD_SET(hSocket, &fdset);
+
+        const int nRet = select(hSocket + 1, &fdset, nullptr, nullptr, &tv);
+        if (nRet <= 0) return false;   // deadline reached, or select failed
+
+        const ssize_t n = recv(hSocket, (char*)(buf + have), len - have, 0);
+        if (n <= 0) return false;      // closed by peer, or error
+
+        have += static_cast<size_t>(n);
+    }
+
+    return true;
+}
+
 bool static Socks5(string strDest, int port, SOCKET& hSocket)
 {
     LogPrintf("SOCKS5 connecting %s", strDest);
@@ -218,7 +264,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         return error("Error sending to proxy");
     }
     char pchRet1[2];
-    if (recv(hSocket, pchRet1, 2, 0) != 2)
+    if (!InterruptibleRecv(hSocket, pchRet1, 2, nConnectTimeout))
     {
         closesocket(hSocket);
         return error("Error reading proxy response");
@@ -241,7 +287,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         return error("Error sending to proxy");
     }
     char pchRet2[4];
-    if (recv(hSocket, pchRet2, 4, 0) != 4)
+    if (!InterruptibleRecv(hSocket, pchRet2, 4, nConnectTimeout))
     {
         closesocket(hSocket);
         return error("Error reading proxy response");
@@ -294,17 +340,17 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
 
     switch (pchRet2[3])
     {
-        case 0x01: ret = recv(hSocket, (char*)pchRet3, 4, 0) != 4; break;
-        case 0x04: ret = recv(hSocket, (char*)pchRet3, 16, 0) != 16; break;
+        case 0x01: ret = !InterruptibleRecv(hSocket, pchRet3, 4, nConnectTimeout); break;
+        case 0x04: ret = !InterruptibleRecv(hSocket, pchRet3, 16, nConnectTimeout); break;
         case 0x03:
         {
-            ret = recv(hSocket, (char*)pchRet3, 1, 0) != 1;
+            ret = !InterruptibleRecv(hSocket, pchRet3, 1, nConnectTimeout);
             if (ret) {
                 closesocket(hSocket);
                 return error("Error reading from proxy");
             }
             int nRecv = pchRet3[0];
-            ret = recv(hSocket, (char*)pchRet3, nRecv, 0) != nRecv;
+            ret = !InterruptibleRecv(hSocket, pchRet3, nRecv, nConnectTimeout);
             break;
         }
         default: closesocket(hSocket); return error("Error: malformed proxy response");
@@ -314,7 +360,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         closesocket(hSocket);
         return error("Error reading from proxy");
     }
-    if (recv(hSocket, (char*)pchRet3, 2, 0) != 2)
+    if (!InterruptibleRecv(hSocket, pchRet3, 2, nConnectTimeout))
     {
         closesocket(hSocket);
         return error("Error reading from proxy");

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include <limits>
 #include "netbase.h"
 #include "util.h"
 #include "sync.h"
@@ -271,20 +272,39 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         closesocket(hSocket);
         return error("Error: malformed proxy response");
     }
-    char pchRet3[256];
+    // uint8_t, not char. For the 0x03 (domain name) reply the length is taken
+    // from the first byte below, and char is signed on the platforms this
+    // matters for: a proxy returning a length byte of 0x80 or above produced a
+    // NEGATIVE nRecv, which POSIX recv() takes as size_t and treats as enormous.
+    // Measured effect was 144 bytes written past this buffer, attacker-sized and
+    // attacker-controlled, with the process exiting 0 and no error returned.
+    // Windows escapes it only by accident: winsock's recv takes int, so a
+    // negative length returns WSAEFAULT and writes nothing.
+    //
+    // With uint8_t the byte is 0..255 and cannot exceed the buffer, which is what
+    // the static_assert below pins -- the safety is a property of the two
+    // declarations together, not of a range check somewhere else.
+    //
+    // The casts are needed because winsock declares recv as taking char*; POSIX
+    // takes void* and would not need them.
+    uint8_t pchRet3[256];
+    static_assert(sizeof(pchRet3) > std::numeric_limits<uint8_t>::max(),
+                  "the domain-name length is read from a single byte, so the buffer "
+                  "must be larger than any value that byte can hold");
+
     switch (pchRet2[3])
     {
-        case 0x01: ret = recv(hSocket, pchRet3, 4, 0) != 4; break;
-        case 0x04: ret = recv(hSocket, pchRet3, 16, 0) != 16; break;
+        case 0x01: ret = recv(hSocket, (char*)pchRet3, 4, 0) != 4; break;
+        case 0x04: ret = recv(hSocket, (char*)pchRet3, 16, 0) != 16; break;
         case 0x03:
         {
-            ret = recv(hSocket, pchRet3, 1, 0) != 1;
+            ret = recv(hSocket, (char*)pchRet3, 1, 0) != 1;
             if (ret) {
                 closesocket(hSocket);
                 return error("Error reading from proxy");
             }
             int nRecv = pchRet3[0];
-            ret = recv(hSocket, pchRet3, nRecv, 0) != nRecv;
+            ret = recv(hSocket, (char*)pchRet3, nRecv, 0) != nRecv;
             break;
         }
         default: closesocket(hSocket); return error("Error: malformed proxy response");
@@ -294,7 +314,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         closesocket(hSocket);
         return error("Error reading from proxy");
     }
-    if (recv(hSocket, pchRet3, 2, 0) != 2)
+    if (recv(hSocket, (char*)pchRet3, 2, 0) != 2)
     {
         closesocket(hSocket);
         return error("Error reading from proxy");

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -853,7 +853,21 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me, CValidatio
                 //
                 {
                     LOCK(cs_mapAlreadyAskedFor);
-                    mapAlreadyAskedFor[ancestor_request] = 0;
+
+                    // Zero is deliberate: AskFor() below takes
+                    // max(nRequestTime + 2 minutes, now), so a stale future
+                    // timestamp here would postpone the request. Note that a
+                    // zero-valued entry is also limitedmap's first eviction
+                    // candidate, which is harmless -- AskFor() raises it
+                    // immediately, and losing it in between simply means AskFor
+                    // inserts it fresh.
+                    const auto it = mapAlreadyAskedFor.find(ancestor_request);
+
+                    if (it != mapAlreadyAskedFor.end()) {
+                        mapAlreadyAskedFor.update(it, 0);
+                    } else {
+                        mapAlreadyAskedFor.insert(std::make_pair(ancestor_request, 0));
+                    }
                 }
                 pfrom->AskFor(ancestor_request);
             }

--- a/src/node/orphan_blocks.cpp
+++ b/src/node/orphan_blocks.cpp
@@ -17,21 +17,29 @@ bool OrphanBlockManager::Add(const uint256& hash, const CBlock& block, int64_t n
         return false;
     }
 
-    // Expire stale orphans first, then evict randomly if still full.
+    const size_t bytes = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+
+    // Expire stale orphans first, then evict randomly if still full -- on
+    // either bound. Guarded on emptiness rather than on the counters alone: a
+    // single block larger than the whole budget would otherwise spin here
+    // evicting nothing.
     EraseExpired(now);
 
-    while (m_orphans.size() >= MAX_ORPHAN_BLOCKS) {
+    while (!m_orphans.empty()
+           && (m_orphans.size() >= MAX_ORPHAN_BLOCKS || m_bytes + bytes > MAX_ORPHAN_BYTES)) {
         EvictRandom();
     }
 
     OrphanEntry entry;
     entry.block = std::make_unique<CBlock>(block);
     entry.time_received = now;
+    entry.bytes = bytes;
 
     const uint256 prev_hash = block.hashPrevBlock;
 
     m_orphans.emplace(hash, std::move(entry));
     m_by_prev.emplace(prev_hash, hash);
+    m_bytes += bytes;
 
     LogPrint(BCLog::LogFlags::VERBOSE, "OrphanBlockManager: added orphan %s (prev=%s, map size %u)",
              hash.ToString(), prev_hash.ToString(), m_orphans.size());
@@ -140,6 +148,11 @@ size_t OrphanBlockManager::Size() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     return m_orphans.size();
 }
 
+size_t OrphanBlockManager::Bytes() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    return m_bytes;
+}
+
 void OrphanBlockManager::Clear() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     for (auto& [hash, entry] : m_orphans) {
@@ -150,6 +163,7 @@ void OrphanBlockManager::Clear() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
     m_orphans.clear();
     m_by_prev.clear();
+    m_bytes = 0;
 }
 
 std::unique_ptr<CBlock> OrphanBlockManager::EraseInternal(const uint256& hash)
@@ -161,6 +175,9 @@ std::unique_ptr<CBlock> OrphanBlockManager::EraseInternal(const uint256& hash)
 
     const uint256 prev_hash = it->second.block->hashPrevBlock;
     std::unique_ptr<CBlock> block = std::move(it->second.block);
+
+    // Subtract what was added, not a fresh measurement of the block.
+    m_bytes -= it->second.bytes;
 
     m_orphans.erase(it);
 

--- a/src/node/orphan_blocks.h
+++ b/src/node/orphan_blocks.h
@@ -5,6 +5,7 @@
 #ifndef GRIDCOIN_NODE_ORPHAN_BLOCKS_H
 #define GRIDCOIN_NODE_ORPHAN_BLOCKS_H
 
+#include <consensus/consensus.h>
 #include "chain.h"  // cs_main (required for clang's EXCLUSIVE_LOCKS_REQUIRED / GUARDED_BY analyzer)
 #include "primitives/block.h"  // BlockHasher
 #include "uint256.h"
@@ -28,6 +29,21 @@ public:
     //! superblock interval (~960 blocks) to avoid evicting orphans from a
     //! legitimate missing-block chain before it can be resolved.
     static constexpr size_t MAX_ORPHAN_BLOCKS = 1000;
+
+    //! Maximum total serialized bytes of orphan blocks to hold in memory.
+    //!
+    //! The count above used to imply this on its own: every block was bounded
+    //! by MAX_BLOCK_SIZE, so a thousand of them could not exceed a thousand
+    //! times that. A block carrying a superblock is measured against a larger
+    //! envelope, and once the per-block bound and the count differ the product
+    //! stops being a bound on anything. Stating the byte budget keeps the
+    //! ceiling where the count already put it, rather than letting it grow with
+    //! whatever the largest permitted block happens to become.
+    //!
+    //! Orphans are held before a parent is known, so nothing about the block
+    //! has been established when it is stored -- the bound cannot rely on the
+    //! block being valid, or on its sender being honest.
+    static constexpr size_t MAX_ORPHAN_BYTES = MAX_ORPHAN_BLOCKS * MAX_BLOCK_SIZE;
 
     //! Maximum age in seconds before an orphan is eligible for eviction.
     static constexpr int64_t MAX_ORPHAN_AGE_SECONDS = 20 * 60;
@@ -62,6 +78,9 @@ public:
     //! Current number of stored orphans.
     size_t Size() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    //! Current total serialized bytes of stored orphans.
+    size_t Bytes() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     //! Remove all orphans and clean up associated SeenStakes entries.
     void Clear() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -70,6 +89,10 @@ private:
     {
         std::unique_ptr<CBlock> block;
         int64_t time_received;
+
+        //! Measured once, on the way in. Recomputing it on the way out would
+        //! let the running total drift if the block were ever altered in place.
+        size_t bytes;
     };
 
     //! Primary storage: orphan block hash -> entry.
@@ -78,6 +101,9 @@ private:
     //! Reverse index: parent block hash -> set of orphan block hashes that
     //! claim it as their previous block.
     std::unordered_multimap<uint256, uint256, BlockHasher> m_by_prev;
+
+    //! Running total of OrphanEntry::bytes, maintained by Add/EraseInternal.
+    size_t m_bytes{0};
 
     //! Remove an orphan from all internal indices. Returns the block
     //! (moved out) so the caller can inspect it if needed.

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -36,6 +36,27 @@ static constexpr unsigned int STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRIPT_VERI
                                                              SCRIPT_VERIFY_CHECKSEQUENCEVERIFY |
                                                              SCRIPT_VERIFY_LOW_S};
 
+/**
+ * Script verification flags that close signature malleability, activated as
+ * CONSENSUS at block version 15 by GetBlockScriptFlags().
+ *
+ * Named for what they are rather than where they are applied: v15 turns them on
+ * for relay and for block validity at the same height, so there is no window in
+ * which a staker assembles a block from its own mempool that its peers reject.
+ *
+ * These close what the crypto layer leaves open by design -- pubkey.cpp
+ * normalizes high-S on verification and documents that enforcement belongs to
+ * SCRIPT_VERIFY_LOW_S, which nothing was setting. Safe to require because
+ * CKey::Sign() produces low-S, canonical-DER signatures by construction, so no
+ * transaction this wallet has ever produced is affected.
+ */
+static constexpr unsigned int V15_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY_LOW_S |
+                                                      SCRIPT_VERIFY_DERSIG |
+                                                      SCRIPT_VERIFY_STRICTENC |
+                                                      SCRIPT_VERIFY_NULLDUMMY |
+                                                      SCRIPT_VERIFY_MINIMALDATA |
+                                                      SCRIPT_VERIFY_CLEANSTACK};
+
 /** For convenience, standard but not mandatory verify flags. */
 static constexpr unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS{STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS};
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -805,6 +805,32 @@ public:
  * other node doesn't have the same branch, it can find a recent common trunk.
  * The further back it is, the further before the fork it may be.
  */
+//! \brief Maximum number of hashes a received block locator may declare.
+//!
+//! Set() builds a locator by walking back ten blocks one at a time and then
+//! doubling the step, so its length grows with the LOGARITHM of the chain
+//! height, not the height. Computed against that walk:
+//!
+//!     height  1,000,000 -> 31 entries
+//!     height  3,989,800 -> 33 entries   (v13 activation)
+//!     height 10,000,000 -> 35 entries
+//!     height 2^31 - 1   -> 42 entries
+//!
+//! So 101 -- the same ceiling upstream uses -- is roughly 2.4x the largest
+//! locator this code can produce at any representable height. It cannot reject
+//! a locator an honest peer generates, which is the one property that had to
+//! hold before capping: a cap below the legitimate maximum would partition the
+//! network rather than protect it.
+//!
+//! Without it, a locator is bounded only by the 32 MiB message ceiling, or about
+//! a million hashes. Every entry costs a mapBlockIndex lookup in GetBlockIndex()
+//! and friends, all of which run under cs_main, so an oversized locator is an
+//! attacker-chosen stall of the whole node, repeatable at will. Upstream can
+//! enforce this at the message handler because MAX_PROTOCOL_MESSAGE_LENGTH
+//! already bounds the allocation; this tree has no such ceiling yet, so the
+//! check goes at the length prefix where it also bounds the allocation.
+static const unsigned int MAX_LOCATOR_SZ = 101;
+
 class CBlockLocator
 {
 public:
@@ -836,7 +862,7 @@ public:
             READWRITE(nVersion);
         }
 
-        READWRITE(vHave);
+        READWRITE(LIMITED_VECTOR(vHave, MAX_LOCATOR_SZ));
     }
 
     void SetNull()

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -41,6 +41,7 @@
 #include "qtipcserver.h"
 #include "txdb.h"
 #include "util.h"
+#include "util/dir_permissions.h"
 #include "util/strencodings.h"
 #include "util/threadnames.h"
 #include "winshutdownmonitor.h"
@@ -724,6 +725,11 @@ int main(int argc, char *argv[])
     util::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
+
+    // Before anything can create a file -- see the same call in
+    // gridcoinresearchd.cpp. The GUI reaches InitLogging() and the settings file
+    // by a different route but creates the same artifacts.
+    util::SetOwnerOnlyUmask();
 
     // Reinit default timer to ensure it is zeroed out at the start of main.
     g_timer.InitTimer("default", false);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -183,6 +183,13 @@ const std::set<std::string> SENSITIVE_ARG_COMMANDS = {
     "encryptwallet",
     "importprivkey",
     "restoreseedphrase",
+    // Both alert commands take the WIF-encoded alert master private key as an
+    // argument. The console echoes the line into the pane and the Up-arrow
+    // history, and writes it verbatim to debug.log when the call fails -- and a
+    // failed call is the common case here, since these are hand-typed by an
+    // operator under time pressure.
+    "sendalert",
+    "sendalert2",
     "sethdseed",
     "signrawtransaction",
     "signrawtransactionwithkey",

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -869,7 +869,7 @@ static const RPCHelpMan setmocktime_help{
     "Adjusts the time returned by GetTime()/GetAdjustedTime() for testing; this does\n"
     "NOT change the system clock.",
     {
-        {"timestamp", RPCArg::Type::NUM, RPCArg::Optional::NO, UNIX_EPOCH_TIME + "\n"
+        {"timestamp", RPCArg::Type::NUM, RPCArg::Optional::NO, std::string(UNIX_EPOCH_TIME) + "\n"
          "Pass 0 to go back to using the system time."},
     },
     RPCResult{RPCResult::Type::NONE, "", ""},

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -51,7 +51,11 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
     // Loopback only warns. Crossing a network refuses outright -- that is where
     // the credentials are actually exposed, and continuing silently would be a
     // downgrade the operator did not ask for and cannot see.
-    if (gArgs.IsArgSet("-rpcssl")) {
+    // GetBoolArg, not IsArgSet. IsArgSet is true for "rpcssl=0" and for
+    // "-norpcssl" -- configurations that explicitly turned TLS OFF -- and
+    // treating those as a request for encryption would refuse remote CLI calls
+    // from operators who never wanted it. Presence is not intent.
+    if (gArgs.GetBoolArg("-rpcssl", false)) {
         const std::string host = gArgs.GetArg("-rpcconnect", "127.0.0.1");
 
         // Resolve the way the connection itself will, with asio's resolver, and

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -54,9 +54,34 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
     if (gArgs.IsArgSet("-rpcssl")) {
         const std::string host = gArgs.GetArg("-rpcconnect", "127.0.0.1");
 
-        CNetAddr target;
-        const bool resolved = LookupHost(host.c_str(), target, false);
-        const bool loopback = resolved && target.IsLocal();
+        // Resolve the way the connection itself will, with asio's resolver, and
+        // treat the target as loopback only if EVERY endpoint it yields is.
+        //
+        // A numeric-only check (LookupHost with fAllowLookup=false) gets
+        // "127.0.0.1" right and "localhost" wrong: AI_NUMERICHOST refuses to
+        // resolve a name, so the common loopback spelling would fall through to
+        // the refusal below. Deciding on a different resolution than the one
+        // used to connect is also just wrong in principle -- the address that
+        // matters is the one the credentials actually go to.
+        bool loopback = false;
+        try {
+            ioContext probe_context;
+            asio::ip::tcp::resolver probe(probe_context);
+            const auto endpoints = probe.resolve(
+                host, gArgs.GetArg("-rpcport", ToString(GetDefaultRPCPort())));
+
+            loopback = endpoints.begin() != endpoints.end();
+            for (const auto& ep : endpoints) {
+                if (!ep.endpoint().address().is_loopback()) {
+                    loopback = false;
+                    break;
+                }
+            }
+        } catch (const std::exception&) {
+            // Unresolvable. Fall through to the refusal: we cannot show it is
+            // loopback, and the connection is about to fail anyway.
+            loopback = false;
+        }
 
         if (loopback) {
             LogPrintf("WARNING: -rpcssl is no longer supported and is being ignored. This "

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -22,7 +22,6 @@
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/asio/ssl.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
 #include <stdexcept>
@@ -45,13 +44,10 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
                                 GetConfigFile().string()));
 
     // Connect to localhost
-    bool fUseSSL = gArgs.GetBoolArg("-rpcssl");
     ioContext io_context;
-    ssl::context context(ssl::context::sslv23);
-    context.set_options(ssl::context::no_sslv2);
-    asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_context, context);
-    SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);
-    iostreams::stream< SSLIOStreamDevice<asio::ip::tcp> > stream(d);
+    asio::ip::tcp::socket socket(io_context);
+    SocketIOStreamDevice<asio::ip::tcp> d(socket);
+    iostreams::stream< SocketIOStreamDevice<asio::ip::tcp> > stream(d);
 
     bool fWait = gArgs.GetBoolArg("-rpcwait", false); // -rpcwait means try until server has started or timeout is reached
     int timeout = gArgs.GetArg("-rpcwaittimeout", DEFAULT_WAIT_CLIENT_TIMEOUT); // The max time to wait

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -51,54 +51,6 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
     // Loopback only warns. Crossing a network refuses outright -- that is where
     // the credentials are actually exposed, and continuing silently would be a
     // downgrade the operator did not ask for and cannot see.
-    // GetBoolArg, not IsArgSet. IsArgSet is true for "rpcssl=0" and for
-    // "-norpcssl" -- configurations that explicitly turned TLS OFF -- and
-    // treating those as a request for encryption would refuse remote CLI calls
-    // from operators who never wanted it. Presence is not intent.
-    if (gArgs.GetBoolArg("-rpcssl", false)) {
-        const std::string host = gArgs.GetArg("-rpcconnect", "127.0.0.1");
-
-        // Resolve the way the connection itself will, with asio's resolver, and
-        // treat the target as loopback only if EVERY endpoint it yields is.
-        //
-        // A numeric-only check (LookupHost with fAllowLookup=false) gets
-        // "127.0.0.1" right and "localhost" wrong: AI_NUMERICHOST refuses to
-        // resolve a name, so the common loopback spelling would fall through to
-        // the refusal below. Deciding on a different resolution than the one
-        // used to connect is also just wrong in principle -- the address that
-        // matters is the one the credentials actually go to.
-        bool loopback = false;
-        try {
-            ioContext probe_context;
-            asio::ip::tcp::resolver probe(probe_context);
-            const auto endpoints = probe.resolve(
-                host, gArgs.GetArg("-rpcport", ToString(GetDefaultRPCPort())));
-
-            loopback = endpoints.begin() != endpoints.end();
-            for (const auto& ep : endpoints) {
-                if (!ep.endpoint().address().is_loopback()) {
-                    loopback = false;
-                    break;
-                }
-            }
-        } catch (const std::exception&) {
-            // Unresolvable. Fall through to the refusal: we cannot show it is
-            // loopback, and the connection is about to fail anyway.
-            loopback = false;
-        }
-
-        if (loopback) {
-            LogPrintf("WARNING: -rpcssl is no longer supported and is being ignored. This "
-                      "connection to %s is NOT encrypted.\n", host);
-        } else {
-            throw std::runtime_error(strprintf(
-                _("-rpcssl is no longer supported, and -rpcconnect=%s is not a loopback address. "
-                  "Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl "
-                  "to proceed deliberately, and tunnel the connection (for example over SSH) if it "
-                  "crosses an untrusted network."), host));
-        }
-    }
-
     // Connect to localhost
     ioContext io_context;
     asio::ip::tcp::socket socket(io_context);
@@ -110,10 +62,57 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
 
     std::chrono::seconds deadline = GetTime<std::chrono::seconds>() + std::chrono::seconds{timeout};
 
+    const std::string rpc_host = gArgs.GetArg("-rpcconnect", "127.0.0.1");
+    const std::string rpc_port = gArgs.GetArg("-rpcport", ToString(GetDefaultRPCPort()));
+
+    // GetBoolArg, not IsArgSet: IsArgSet is true for "rpcssl=0" and for
+    // "-norpcssl", configurations that explicitly turned TLS OFF, and treating
+    // those as a request for encryption would refuse remote calls from
+    // operators who never wanted it. Presence is not intent.
+    const bool ssl_requested = gArgs.GetBoolArg("-rpcssl", false);
+
     do {
+        // Resolve ONCE per attempt, and connect to exactly what was resolved.
+        //
+        // -rpcssl is gone, and this path never reaches StartRPCThreads(), so the
+        // warning the daemon logs for it is never seen here. Someone running the
+        // CLI with it set believes this connection is encrypted while Basic-auth
+        // credentials go out in clear text. On loopback that warns; to anything
+        // else it refuses, since that is where the credentials cross a network.
+        //
+        // The endpoints are handed to connect() rather than re-resolved inside
+        // it. Checking one resolution and connecting on another leaves a window
+        // where rotation between the two lookups passes the check with loopback
+        // and then connects somewhere else.
+        boost::asio::ip::tcp::resolver::results_type endpoints;
+        try {
+            asio::ip::tcp::resolver res(io_context);
+            endpoints = res.resolve(rpc_host, rpc_port);
+        } catch (const std::exception&) {
+            endpoints = {};
+        }
+
+        if (ssl_requested) {
+            bool loopback = endpoints.begin() != endpoints.end();
+            for (const auto& ep : endpoints) {
+                if (!ep.endpoint().address().is_loopback()) { loopback = false; break; }
+            }
+
+            if (loopback) {
+                LogPrintf("WARNING: -rpcssl is no longer supported and is being ignored. This "
+                          "connection to %s is NOT encrypted.\n", rpc_host);
+            } else {
+                throw std::runtime_error(strprintf(
+                    _("-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a "
+                      "loopback address. Sending RPC credentials to it would transmit them "
+                      "unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the "
+                      "connection (for example over SSH) if it crosses an untrusted network."),
+                    rpc_host));
+            }
+        }
+
         // If connection succeeds, immediately break. No need to wait.
-        if (d.connect(gArgs.GetArg("-rpcconnect", "127.0.0.1"),
-                      gArgs.GetArg("-rpcport", ToString(GetDefaultRPCPort())))) {
+        if (d.connect(endpoints)) {
             break;
         }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -43,6 +43,33 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
                                   "If the file does not exist, create it with owner-readable-only file permissions."),
                                 GetConfigFile().string()));
 
+    // -rpcssl is gone, and this path never reaches StartRPCThreads(), so the
+    // warning the daemon logs for it is never seen by someone running the CLI.
+    // Say it here too: an operator who believes this connection is wrapped in
+    // TLS is about to send Basic-auth credentials in clear text.
+    //
+    // Loopback only warns. Crossing a network refuses outright -- that is where
+    // the credentials are actually exposed, and continuing silently would be a
+    // downgrade the operator did not ask for and cannot see.
+    if (gArgs.IsArgSet("-rpcssl")) {
+        const std::string host = gArgs.GetArg("-rpcconnect", "127.0.0.1");
+
+        CNetAddr target;
+        const bool resolved = LookupHost(host.c_str(), target, false);
+        const bool loopback = resolved && target.IsLocal();
+
+        if (loopback) {
+            LogPrintf("WARNING: -rpcssl is no longer supported and is being ignored. This "
+                      "connection to %s is NOT encrypted.\n", host);
+        } else {
+            throw std::runtime_error(strprintf(
+                _("-rpcssl is no longer supported, and -rpcconnect=%s is not a loopback address. "
+                  "Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl "
+                  "to proceed deliberately, and tunnel the connection (for example over SSH) if it "
+                  "crosses an untrusted network."), host));
+        }
+    }
+
     // Connect to localhost
     ioContext io_context;
     asio::ip::tcp::socket socket(io_context);
@@ -88,7 +115,7 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
     // Receive HTTP reply message headers and body
     map<string, string> mapHeaders;
     string strReply;
-    ReadHTTPMessage(stream, mapHeaders, strReply, nProto);
+    ReadHTTPMessage(stream, mapHeaders, strReply, nProto, MAX_RPC_RESPONSE_SIZE);
 
     if (nStatus == HTTP_UNAUTHORIZED)
         throw runtime_error("incorrect rpcuser or rpcpassword (authorization failed)");

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -728,7 +728,7 @@ UniValue sendalert(const UniValue& params)
     sMsg << (CUnsignedAlert)alert;
     alert.vchMsg = vector<unsigned char>((unsigned char*)&sMsg.begin()[0], (unsigned char*)&sMsg.end()[0]);
 
-    key = DecodeSecret(params[0].get_str());
+    key = DecodeSecret(params[1].get_str());
 
     if (!key.IsValid()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -17,7 +17,6 @@
 #include <boost/bind/bind.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/asio/ssl.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
 

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -96,15 +96,58 @@ std::string HTTPReply(int nStatus, const std::string& strMsg, bool keepalive)
         strMsg);
 }
 
+//! \brief Maximum number of header lines accepted from one request.
+//!
+//! A legitimate RPC request sends a handful -- host, connection, content-type,
+//! content-length, authorization, user-agent. 100 is far beyond that while
+//! bounding what an unauthenticated client can insert into mapHeadersRet.
+static constexpr size_t MAX_HTTP_HEADER_COUNT = 100;
+
+//! \brief Maximum length of a single header line.
+//!
+//! 8 KiB, the de facto limit Apache and nginx apply. Bounding the individual line
+//! matters as much as bounding the count: std::getline grows its string until a
+//! delimiter or EOF, so a client that opens a header and never sends a newline
+//! is buffered without limit.
+static constexpr size_t MAX_HTTP_HEADER_LINE_BYTES = 8192;
+
+//! \brief Maximum total bytes of header lines accepted from one request.
+//!
+//! Count times line length would allow 800 KiB, which is far more than the
+//! headers of any real request; 32 KiB is generous against a typical few hundred
+//! bytes and caps the aggregate independently of how it is divided up.
+static constexpr size_t MAX_HTTP_HEADER_TOTAL_BYTES = 32768;
+
 int ReadHTTPHeaders(std::basic_istream<char>& stream, std::map<std::string, std::string>& mapHeadersRet)
 {
     int nLen = 0;
+    size_t header_count = 0;
+    size_t header_bytes = 0;
+    bool overlong = false;
+
+    // All three bounds are reachable BEFORE any authentication check, which is
+    // what makes them worth having: nothing above this point has established who
+    // the client is.
     while (true)
     {
         std::string str;
-        std::getline(stream, str);
+
+        if (!ReadLineBounded(stream, str, MAX_HTTP_HEADER_LINE_BYTES, overlong)) {
+            // Negative, not a status code: this function returns a CONTENT LENGTH,
+            // and the caller rejects a negative one. Returning 400 here would be
+            // read as a body of 400 bytes.
+            if (overlong) return -1;
+
+            break;
+        }
+
         if (str.empty() || str == "\r")
             break;
+
+        if (++header_count > MAX_HTTP_HEADER_COUNT) return -1;
+
+        header_bytes += str.size();
+        if (header_bytes > MAX_HTTP_HEADER_TOTAL_BYTES) return -1;
         std::string::size_type nColon = str.find(":");
         if (nColon != std::string::npos)
         {
@@ -115,7 +158,12 @@ int ReadHTTPHeaders(std::basic_istream<char>& stream, std::map<std::string, std:
             strValue = TrimString(strValue);
             mapHeadersRet[strHeader] = strValue;
             if (strHeader == "content-length" && !ParseInt32(strValue, &nLen)) {
-                throw std::invalid_argument("Unable to parse content-length value.");
+                // Returning rather than throwing: ServiceConnection has no
+                // try/catch around this call, so an exception here escapes on a
+                // malformed header from an unauthenticated client. Negative
+                // because this returns a content length, which the caller
+                // rejects when negative.
+                return -1;
             }
         }
     }
@@ -150,7 +198,12 @@ bool ReadHTTPRequestLine(std::basic_istream<char>& stream, int &proto,
 
     std::string strProto = vWords[2];
 
-    // Strip the \r, which MUST be present according to the HTTP standard.
+    // Strip the \r, which MUST be present according to the HTTP standard. Guarded
+    // because the request line "GET / " splits into three words whose third is
+    // empty, and pop_back() on an empty string is undefined -- reachable before
+    // authentication.
+    if (strProto.empty()) return false;
+
     strProto.pop_back();
     size_t length = strProto.length();
 
@@ -204,8 +257,14 @@ int ReadHTTPMessage(std::basic_istream<char>& stream, std::map<std::string,
 
     // Read header
     int nLen = ReadHTTPHeaders(stream, mapHeadersRet);
-    if (nLen < 0 || nLen > (int)MAX_SIZE)
-        return HTTP_INTERNAL_SERVER_ERROR;
+    // MAX_SIZE is 32 MiB, so this accepted an unauthenticated header field that
+    // then drove a 32 MiB allocation below. The worst legitimate request is
+    // signrawtransaction fed by consolidatemsunspent output, where the prevtxs
+    // array dominates because every multisig input carries its own redeemScript;
+    // bounded by MAX_STANDARD_TX_SIZE at roughly 1.8x, that is 400-500 KB. 20x
+    // MAX_STANDARD_TX_SIZE leaves several times that.
+    if (nLen < 0 || nLen > (int)MAX_RPC_BODY_SIZE)
+        return HTTP_BAD_REQUEST;
 
     // Read message
     if (nLen > 0)

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -233,7 +233,17 @@ bool ReadHTTPRequestLine(std::basic_istream<char>& stream, int &proto,
 int ReadHTTPStatus(std::basic_istream<char>& stream, int &proto)
 {
     std::string str;
-    std::getline(stream, str);
+
+    // Bounded, for the same reason the request line is. This is the FIRST thing
+    // the CLI reads from an endpoint, ahead of the bounded headers and body, so
+    // an unbounded getline here means the response ceiling those enforce can be
+    // walked around entirely: a hostile or broken endpoint streams a status line
+    // and never sends a newline.
+    bool overlong = false;
+    if (!ReadLineBounded(stream, str, MAX_HTTP_HEADER_LINE_BYTES, overlong)) {
+        return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
     std::vector<std::string> vWords;
     vWords = SplitString(str, ' ');
     if (vWords.size() < 2)

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -173,8 +173,19 @@ bool ReadHTTPRequestLine(std::basic_istream<char>& stream, int &proto,
                          std::string& http_method, std::string& http_uri)
 {
     std::string str;
+
+    // Bounded. std::getline() here grows without limit, and this runs before
+    // anything has authenticated: a peer that streams a request line and never
+    // sends a newline grows this string as fast as it can write. The connection
+    // deadline bounds how LONG that lasts, not how many bytes arrive in the
+    // meantime. Same ceiling as a header line -- an RPC request line is "/" or
+    // a short wallet path, so 8 KiB is already far past anything real.
+    //
     // This strips the \n but does NOT strip any extra \r, such as the \r\n in the HTTP standard field line ending.
-    std::getline(stream, str);
+    bool overlong = false;
+    if (!ReadLineBounded(stream, str, MAX_HTTP_HEADER_LINE_BYTES, overlong)) {
+        return false;
+    }
 
     // HTTP request line is space-delimited
     std::vector<std::string> vWords;
@@ -249,20 +260,22 @@ int ReadHTTPStatus(std::basic_istream<char>& stream, int &proto)
 
 int ReadHTTPMessage(std::basic_istream<char>& stream, std::map<std::string,
                     std::string>& mapHeadersRet, std::string& strMessageRet,
-                    int nProto)
+                    int nProto, size_t max_body_size)
 {
     mapHeadersRet.clear();
     strMessageRet = "";
 
     // Read header
     int nLen = ReadHTTPHeaders(stream, mapHeadersRet);
-    // MAX_SIZE is 32 MiB, so this accepted an unauthenticated header field that
-    // then drove a 32 MiB allocation below. The worst legitimate request is
-    // signrawtransaction fed by consolidatemsunspent output, where the prevtxs
-    // array dominates because every multisig input carries its own redeemScript;
-    // bounded by MAX_STANDARD_TX_SIZE at roughly 1.8x, that is 400-500 KB. 20x
-    // MAX_STANDARD_TX_SIZE leaves several times that.
-    if (nLen < 0 || nLen > (int)MAX_RPC_BODY_SIZE)
+
+    // The ceiling is the CALLER's, because this function reads both directions.
+    // The server reads a request from an unauthenticated peer and wants the
+    // tight bound; the CLI reads a reply from the server it chose to talk to,
+    // and legitimate replies are routinely far larger than any request --
+    // listtransactions on a big wallet, verbose getblock, scraperreport. Using
+    // the request bound for both would have made the CLI report "no response
+    // from server" for exactly those calls.
+    if (nLen < 0 || nLen > (int)max_body_size)
         return HTTP_BAD_REQUEST;
 
     // Read message

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -14,7 +14,6 @@
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
 
 #include <univalue.h>
 
@@ -124,55 +123,31 @@ enum RPCErrorCode
 };
 
 //
-// IOStream device that speaks SSL but can also speak non-SSL
+// IOStream device over a plain socket.
+//
+// This was SSLIOStreamDevice, which held a boost::asio::ssl::stream and chose
+// per operation between the TLS layer and next_layer() according to -rpcssl.
+// That option is gone, so the indirection is gone with it: the device holds the
+// socket itself. Removing it also drops the OpenSSL::SSL link, which was linked
+// solely to serve an RPC transport that should not have been carrying TLS.
 //
 template <typename Protocol>
-class SSLIOStreamDevice : public boost::iostreams::device<boost::iostreams::bidirectional> {
+class SocketIOStreamDevice : public boost::iostreams::device<boost::iostreams::bidirectional> {
 public:
-    SSLIOStreamDevice(boost::asio::ssl::stream<typename Protocol::socket> &streamIn, bool fUseSSLIn) : stream(streamIn)
-    {
-        fUseSSL = fUseSSLIn;
-        fNeedHandshake = fUseSSLIn;
-    }
+    explicit SocketIOStreamDevice(typename Protocol::socket& streamIn) : stream(streamIn) {}
 
-    //! \return false if the TLS negotiation failed. Non-throwing for the same
-    //! reason read() and write() are: this runs on an RPC worker thread with no
-    //! handler above it, so an escaping exception terminates the process. An
-    //! earlier revision converted only the data-transfer overloads and left this
-    //! one throwing, which merely moved the abort earlier -- a client that
-    //! disconnects mid-negotiation reaches here, not read().
-    bool handshake(boost::asio::ssl::stream_base::handshake_type role)
-    {
-        if (!fNeedHandshake) return true;
-        fNeedHandshake = false;
-
-        boost::system::error_code ec;
-        stream.handshake(role, ec);
-        if (!ec) return true;
-
-        // The connection never became usable. Callers translate this into their own
-        // end-of-sequence result rather than throwing.
-        return false;
-    }
     std::streamsize read(char* s, std::streamsize n)
     {
-        // HTTPS servers read first. A failed negotiation is end of sequence: there
-        // is no usable connection to read from, and throwing here would abort the
-        // process from a thread that cannot catch.
-        if (!handshake(boost::asio::ssl::stream_base::server)) return -1;
-
         boost::system::error_code ec;
-        const std::size_t bytes = fUseSSL
-            ? stream.read_some(boost::asio::buffer(s, n), ec)
-            : stream.next_layer().read_some(boost::asio::buffer(s, n), ec);
+        const std::size_t bytes = stream.read_some(boost::asio::buffer(s, n), ec);
 
         if (!ec) return static_cast<std::streamsize>(bytes);
 
         // Boost.IOStreams signals end of sequence by RETURNING -1. The throwing
-        // read_some overload used here previously raised boost::system::system_error
-        // instead, and this device is driven from an RPC worker thread with no
-        // handler above it -- so a peer closing its connection terminated the
-        // process with "read_some: End of file".
+        // read_some overload raises boost::system::system_error instead, and this
+        // device is driven from an RPC worker thread with no handler above it --
+        // so a peer closing its connection terminated the process with
+        // "read_some: End of file".
         //
         // That is not an edge case. It is the normal end of every RPC call, and
         // AcceptedConnectionImpl::interrupt() deliberately shuts the socket down to
@@ -184,16 +159,11 @@ public:
         // distinguish: report end of sequence and let the worker close it.
         return -1;
     }
+
     std::streamsize write(const char* s, std::streamsize n)
     {
-        // HTTPS clients write first. Report the write as consumed on a failed
-        // negotiation, matching how the error path below treats a dead connection.
-        if (!handshake(boost::asio::ssl::stream_base::client)) return n;
-
         boost::system::error_code ec;
-        const std::size_t bytes = fUseSSL
-            ? boost::asio::write(stream, boost::asio::buffer(s, n), ec)
-            : boost::asio::write(stream.next_layer(), boost::asio::buffer(s, n), ec);
+        const std::size_t bytes = boost::asio::write(stream, boost::asio::buffer(s, n), ec);
 
         if (!ec) return static_cast<std::streamsize>(bytes);
 
@@ -204,14 +174,15 @@ public:
         // thread that cannot catch.
         return n;
     }
+
     bool connect(const std::string& server, const std::string& port)
     {
         boost::asio::ip::tcp::resolver resolver(GetIOService(stream));
         boost::system::error_code error;
 
         for (const auto& res : resolver.resolve(server, port)) {
-            stream.lowest_layer().close();
-            stream.lowest_layer().connect(res, error);
+            stream.close();
+            stream.connect(res, error);
 
             if (!error) {
                 return true;
@@ -222,9 +193,7 @@ public:
     }
 
 private:
-    bool fNeedHandshake;
-    bool fUseSSL;
-    boost::asio::ssl::stream<typename Protocol::socket>& stream;
+    typename Protocol::socket& stream;
 };
 
 class AcceptedConnection
@@ -247,12 +216,9 @@ template <typename Protocol>
 class AcceptedConnectionImpl : public AcceptedConnection
 {
 public:
-    AcceptedConnectionImpl(
-            ioContext& io_context,
-            boost::asio::ssl::context &context,
-            bool fUseSSL) :
-        sslStream(io_context, context),
-        _d(sslStream, fUseSSL),
+    explicit AcceptedConnectionImpl(ioContext& io_context) :
+        socket(io_context),
+        _d(socket),
         _stream(_d)
     {
     }
@@ -279,15 +245,15 @@ public:
         // recv without racing on file-descriptor reuse. The owning worker
         // still performs the actual close()/delete on its own thread.
         boost::system::error_code ec;
-        sslStream.lowest_layer().shutdown(boost::asio::socket_base::shutdown_both, ec);
+        socket.shutdown(boost::asio::socket_base::shutdown_both, ec);
     }
 
     typename Protocol::endpoint peer;
-    boost::asio::ssl::stream<typename Protocol::socket> sslStream;
+    typename Protocol::socket socket;
 
 private:
-    SSLIOStreamDevice<Protocol> _d;
-    boost::iostreams::stream< SSLIOStreamDevice<Protocol> > _stream;
+    SocketIOStreamDevice<Protocol> _d;
+    boost::iostreams::stream< SocketIOStreamDevice<Protocol> > _stream;
 };
 
 std::string HTTPPost(const std::string& strMsg, const std::map<std::string,std::string>& mapRequestHeaders);

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -12,6 +12,19 @@
 #include <stdint.h>
 #include <string>
 #include <compat.h>
+
+// MSG_NOSIGNAL does not exist on Darwin or the BSDs -- compat.h only defines a
+// zero fallback under WIN32 -- and those platforms use SO_NOSIGPIPE on the
+// socket instead, which connect() below sets. Without this the header does not
+// compile there at all.
+//
+// Guarded on the SYMBOL, not on HAVE_MSG_NOSIGNAL as net.cpp and netbase.cpp
+// do. Those are translation units and see the generated config first; a header
+// does not necessarily. Testing the config macro made this redefine the real
+// MSG_NOSIGNAL in any TU that reached <sys/socket.h> without the config.
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
 #include <cerrno>
 #include <util/system.h>
 #include <boost/iostreams/concepts.hpp>
@@ -244,12 +257,18 @@ public:
         return n;
     }
 
-    bool connect(const std::string& server, const std::string& port)
+    //! Connect to endpoints the caller has already resolved.
+    //!
+    //! Separate from resolution on purpose. CallRPC has to inspect the resolved
+    //! endpoints before connecting -- to refuse sending credentials in clear to
+    //! a non-loopback target -- and resolving a second time in here would mean
+    //! the addresses that were checked are not necessarily the ones connected
+    //! to. Rotation between the two lookups would walk straight past the check.
+    bool connect(const boost::asio::ip::tcp::resolver::results_type& endpoints)
     {
-        boost::asio::ip::tcp::resolver resolver(GetIOService(stream));
         boost::system::error_code error;
 
-        for (const auto& res : resolver.resolve(server, port)) {
+        for (const auto& res : endpoints) {
             stream.close();
             stream.connect(res, error);
 

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -12,6 +12,8 @@
 #include <stdint.h>
 #include <string>
 #include <compat.h>
+#include <cerrno>
+#include <util/system.h>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/asio.hpp>
@@ -153,9 +155,26 @@ public:
         // blocking mode (SetRPCSocketTimeouts forces it), so a timeout arrives
         // here as EAGAIN/EWOULDBLOCK and is handled below with every other
         // error: the connection is finished, report end of sequence.
-        const int bytes = ::recv(stream.native_handle(), s, static_cast<size_t>(n), 0);
+        for (;;) {
+#ifdef WIN32
+            const int bytes = ::recv(stream.native_handle(), s, static_cast<int>(n), 0);
+#else
+            // ssize_t, not int: recv(2) returns ssize_t on POSIX and narrowing
+            // it is the same class of sloppiness as reading a length into a
+            // signed char.
+            const ssize_t bytes = ::recv(stream.native_handle(), s, static_cast<size_t>(n), 0);
 
-        if (bytes > 0) return static_cast<std::streamsize>(bytes);
+            // EINTR is a signal arriving mid-call, not a connection failure.
+            // Asio's synchronous read retried on it; treating it as end of
+            // sequence here would disconnect a healthy client whenever a signal
+            // reached this worker thread.
+            if (bytes < 0 && errno == EINTR) continue;
+#endif
+
+            if (bytes > 0) return static_cast<std::streamsize>(bytes);
+
+            break;
+        }
 
         // Boost.IOStreams signals end of sequence by RETURNING -1. The throwing
         // read_some overload raises boost::system::system_error instead, and this
@@ -181,13 +200,30 @@ public:
         // single send may accept less than asked.
         std::streamsize sent = 0;
         while (sent < n) {
+#ifdef WIN32
             const int bytes = ::send(stream.native_handle(), s + sent,
-                                     static_cast<size_t>(n - sent), MSG_NOSIGNAL);
+                                     static_cast<int>(n - sent), MSG_NOSIGNAL);
+#else
+            const ssize_t bytes = ::send(stream.native_handle(), s + sent,
+                                         static_cast<size_t>(n - sent), MSG_NOSIGNAL);
+
+            // As in read(): a signal is not a failure. Breaking here would
+            // report the reply as fully written when it was not.
+            if (bytes < 0 && errno == EINTR) continue;
+#endif
             if (bytes <= 0) break;
             sent += bytes;
         }
 
         if (sent == n) return sent;
+
+        // A short write is reported as consumed, below, because there is no way
+        // to signal an error through this device without throwing from a thread
+        // that cannot catch. Say so in the log, since the client is receiving a
+        // truncated reply and nothing else records that. The send deadline makes
+        // this reachable for a slow-but-alive client, not just a dead one.
+        LogPrintf("RPC: WARNING - short write to client, %d of %d bytes; reply truncated",
+                  static_cast<int64_t>(sent), static_cast<int64_t>(n));
 
         // Same hazard in the other direction: a client that closes before reading
         // the reply gives a broken pipe here, and boost::asio::write's throwing
@@ -207,6 +243,16 @@ public:
             stream.connect(res, error);
 
             if (!error) {
+#ifdef SO_NOSIGPIPE
+                // Darwin/BSD have no MSG_NOSIGNAL -- compat.h defines it as 0 --
+                // and the RPC CLI path never reaches AppInit2, so it never
+                // installs the SIGPIPE handler the daemon relies on. Without
+                // this, a server closing the connection mid-write kills the
+                // client outright. Same call netbase.cpp makes for P2P sockets.
+                int set = 1;
+                setsockopt(stream.native_handle(), SOL_SOCKET, SO_NOSIGPIPE,
+                           (void*)&set, sizeof(int));
+#endif
                 return true;
             }
         }

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_RPC_PROTOCOL_H
 #define BITCOIN_RPC_PROTOCOL_H
 
+#include "consensus/consensus.h"
 #include <list>
 #include <map>
 #include <stdint.h>
@@ -30,6 +31,18 @@
 #endif
 
 // HTTP status codes
+//! \brief Maximum accepted Content-Length for an RPC request body.
+//!
+//! Derived, not guessed. The worst legitimate request is signrawtransaction fed
+//! by consolidatemsunspent output, where the prevtxs array dominates because
+//! every multisig input carries its own redeemScript. That is bounded by
+//! MAX_STANDARD_TX_SIZE at roughly 1.8x, so 400-500 KB worst case; 20x leaves
+//! several times the headroom.
+//!
+//! Before this, Content-Length was accepted up to MAX_SIZE (32 MiB) and then
+//! allocated outright -- an allocation driven by an unauthenticated header field.
+static const unsigned int MAX_RPC_BODY_SIZE = 20 * MAX_STANDARD_TX_SIZE;
+
 enum HTTPStatusCode
 {
     HTTP_OK                    = 200,

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -175,10 +175,14 @@ public:
         // Verified: with SO_RCVTIMEO set and read_some() in this position, an
         // idle connection was still open after 15s against a 3s deadline.
         //
-        // Going straight to recv(2) keeps the deadline. The socket is in
-        // blocking mode (SetRPCSocketTimeouts forces it), so a timeout arrives
-        // here as EAGAIN/EWOULDBLOCK and is handled below with every other
-        // error: the connection is finished, report end of sequence.
+        // Going straight to recv(2) keeps the deadline. This REQUIRES a blocking
+        // socket -- SetRPCSocketTimeouts forces one on every accepted connection,
+        // whether or not a deadline is configured -- because a timeout arrives
+        // here as EAGAIN/EWOULDBLOCK and is handled below with every other error:
+        // the connection is finished, report end of sequence. On a non-blocking
+        // socket that same EAGAIN means only "nothing has arrived yet", and
+        // treating it as end of sequence would drop the connection before the
+        // client's first request.
         for (;;) {
 #ifdef WIN32
             const int bytes = ::recv(stream.native_handle(), s, static_cast<int>(n), 0);

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <stdint.h>
 #include <string>
+#include <compat.h>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/asio.hpp>
@@ -138,10 +139,23 @@ public:
 
     std::streamsize read(char* s, std::streamsize n)
     {
-        boost::system::error_code ec;
-        const std::size_t bytes = stream.read_some(boost::asio::buffer(s, n), ec);
+        // recv(2) directly rather than stream.read_some().
+        //
+        // The server puts SO_RCVTIMEO on accepted sockets so a silent client
+        // cannot hold a worker thread forever. Asio's synchronous read does not
+        // honour it: on timeout the underlying recv returns EAGAIN, which asio
+        // cannot distinguish from "not ready yet", so it waits on the descriptor
+        // and retries -- the deadline is swallowed and the read blocks anyway.
+        // Verified: with SO_RCVTIMEO set and read_some() in this position, an
+        // idle connection was still open after 15s against a 3s deadline.
+        //
+        // Going straight to recv(2) keeps the deadline. The socket is in
+        // blocking mode (SetRPCSocketTimeouts forces it), so a timeout arrives
+        // here as EAGAIN/EWOULDBLOCK and is handled below with every other
+        // error: the connection is finished, report end of sequence.
+        const int bytes = ::recv(stream.native_handle(), s, static_cast<size_t>(n), 0);
 
-        if (!ec) return static_cast<std::streamsize>(bytes);
+        if (bytes > 0) return static_cast<std::streamsize>(bytes);
 
         // Boost.IOStreams signals end of sequence by RETURNING -1. The throwing
         // read_some overload raises boost::system::system_error instead, and this
@@ -162,10 +176,18 @@ public:
 
     std::streamsize write(const char* s, std::streamsize n)
     {
-        boost::system::error_code ec;
-        const std::size_t bytes = boost::asio::write(stream, boost::asio::buffer(s, n), ec);
+        // send(2) directly, for the same reason read() uses recv(2): so
+        // SO_SNDTIMEO is not swallowed by asio's retry loop. Looped because a
+        // single send may accept less than asked.
+        std::streamsize sent = 0;
+        while (sent < n) {
+            const int bytes = ::send(stream.native_handle(), s + sent,
+                                     static_cast<size_t>(n - sent), MSG_NOSIGNAL);
+            if (bytes <= 0) break;
+            sent += bytes;
+        }
 
-        if (!ec) return static_cast<std::streamsize>(bytes);
+        if (sent == n) return sent;
 
         // Same hazard in the other direction: a client that closes before reading
         // the reply gives a broken pipe here, and boost::asio::write's throwing

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -253,11 +253,26 @@ public:
         LogPrintf("RPC: WARNING - short write to client, %d of %d bytes; reply truncated",
                   static_cast<int64_t>(sent), static_cast<int64_t>(n));
 
-        // Same hazard in the other direction: a client that closes before reading
+        // End the connection, rather than assuming it has ended.
+        //
+        // ServiceConnection() runs a keep-alive loop. Reporting the write as
+        // consumed and leaving the socket open lets that loop read the next
+        // request off the same connection and answer it -- while the client is
+        // still waiting for the rest of a Content-Length body it will never
+        // receive. It would then take the head of the next reply as the tail of
+        // the previous one, and every message after that is misframed.
+        //
+        // shutdown() rather than close(): the same choice interrupt() makes
+        // below, and for the same reason. It breaks the worker out of its next
+        // read without disturbing the descriptor this device still refers to.
+        boost::system::error_code shutdown_error;
+        stream.shutdown(boost::asio::socket_base::shutdown_both, shutdown_error);
+
+        // Only now is the claim below true. A client that closes before reading
         // the reply gives a broken pipe here, and boost::asio::write's throwing
-        // overload would abort the process over it. Report the write as consumed --
-        // the connection is finished either way -- rather than throwing from a
-        // thread that cannot catch.
+        // overload would abort the process over it. Report the write as consumed
+        // -- the connection is finished -- rather than throwing from a thread
+        // that cannot catch.
         return n;
     }
 

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -45,6 +45,17 @@
 //! allocated outright -- an allocation driven by an unauthenticated header field.
 static const unsigned int MAX_RPC_BODY_SIZE = 20 * MAX_STANDARD_TX_SIZE;
 
+//! Ceiling on an RPC RESPONSE body read by the command-line client.
+//!
+//! Deliberately far larger than MAX_RPC_BODY_SIZE. A reply comes from the server
+//! the operator pointed the CLI at, not from an unauthenticated peer, and
+//! replies legitimately dwarf requests: listtransactions on a large wallet,
+//! getblock with transaction detail, scraperreport. This keeps a bound so a
+//! hostile or broken endpoint cannot make the CLI allocate without limit, but it
+//! is not the request bound -- applying the request bound in this direction made
+//! the CLI report "no response from server" for exactly those calls.
+static const size_t MAX_RPC_RESPONSE_SIZE = 32 * 1024 * 1024;   // matches MAX_SIZE, the prior behaviour
+
 enum HTTPStatusCode
 {
     HTTP_OK                    = 200,
@@ -330,8 +341,13 @@ bool ReadHTTPRequestLine(std::basic_istream<char>& stream, int &proto,
                          std::string& http_method, std::string& http_uri);
 int ReadHTTPStatus(std::basic_istream<char>& stream, int &proto);
 int ReadHTTPHeaders(std::basic_istream<char>& stream, std::map<std::string, std::string>& mapHeadersRet);
+//! Read an HTTP message body, bounded by max_body_size.
+//!
+//! Used in BOTH directions, which is why the bound is the caller's: the server
+//! reads an unauthenticated request and passes MAX_RPC_BODY_SIZE, the CLI reads
+//! a reply and passes MAX_RPC_RESPONSE_SIZE.
 int ReadHTTPMessage(std::basic_istream<char>& stream, std::map<std::string, std::string>& mapHeadersRet,
-                    std::string& strMessageRet, int nProto);
+                    std::string& strMessageRet, int nProto, size_t max_body_size);
 std::string JSONRPCRequest(const std::string& strMethod, const UniValue& params, const UniValue& id);
 UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const UniValue& id);
 std::string JSONRPCReply(const UniValue& result, const UniValue& error, const UniValue& id);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1055,6 +1055,37 @@ void StartRPCThreads()
                   "explicitly.\n", "0.0.0.0 / ::");
     }
 
+    // The mirror image, and the quieter failure of the two: binding somewhere
+    // reachable while the allow list is empty. Loopback is always permitted, so
+    // the socket comes up and local clients work, but every remote client is
+    // answered 403 -- the port is listening and refusing, which reads like a
+    // credential problem rather than a configuration one.
+    //
+    // Only warn if something non-loopback is actually being bound; -rpcbind
+    // pointed at 127.0.0.1 needs no allow list and should not be nagged about.
+    if (bind_specified && !gArgs.IsArgSet("-rpcallowip")) {
+        for (const std::string& spec : gArgs.GetArgs("-rpcbind")) {
+            int port = 0;
+            std::string host;
+            SplitHostPort(spec, port, host);
+            if (host.empty()) continue;
+
+            boost::system::error_code ec;
+            const boost::asio::ip::address addr = boost::asio::ip::make_address(host, ec);
+
+            // An unparseable entry is reported by StartRPCListenersOn; treating
+            // it as remote here would warn twice about one typo.
+            if (ec || addr.is_loopback()) continue;
+
+            LogPrintf("RPC: WARNING - -rpcbind is set to a non-loopback address (%s) but "
+                      "-rpcallowip is not set, so the allow list is empty and every remote "
+                      "client will be refused with 403 Forbidden. Only loopback can connect. "
+                      "Add -rpcallowip for the hosts or subnets that should reach this port.\n",
+                      host);
+            break;
+        }
+    }
+
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
     asio::ip::address bindAddress = loopback ? asio::ip::address_v6::loopback() : asio::ip::address_v6::any();
     ip::tcp::endpoint endpoint(bindAddress, gArgs.GetArg("-rpcport", GetDefaultRPCPort()));

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -106,15 +106,24 @@ static void UnregisterRPCConnection(AcceptedConnection* conn)
 //! moves on with no further plumbing.
 static void SetRPCSocketTimeouts(boost::asio::ip::tcp::socket& socket)
 {
-    const int seconds = gArgs.GetArg("-rpcservertimeout", DEFAULT_RPC_SERVER_TIMEOUT);
-    if (seconds <= 0) return;  // explicitly disabled
-
-    // Asio may have left the accepted descriptor non-blocking; a deadline only
-    // means anything on a blocking socket, and the stream device reads it with
-    // recv(2) directly.
+    // Blocking mode first, and unconditionally.
+    //
+    // Asio may have left the accepted descriptor non-blocking. The stream device
+    // reads with recv(2) directly and treats EAGAIN as end of sequence -- correct
+    // for a deadline expiring, fatal on a non-blocking socket, where EAGAIN just
+    // means the client has not sent yet. That would close every connection before
+    // its first request.
+    //
+    // So this is a requirement of the device, not part of the deadline, and it
+    // has to happen even when the deadline is switched off. Setting it before the
+    // early return below is the whole point: -rpcservertimeout=0 is documented as
+    // "no timeout", not "no RPC".
     boost::system::error_code ec;
     socket.non_blocking(false, ec);
     socket.native_non_blocking(false, ec);
+
+    const int seconds = gArgs.GetArg("-rpcservertimeout", DEFAULT_RPC_SERVER_TIMEOUT);
+    if (seconds <= 0) return;  // deadline explicitly disabled; socket stays blocking
 
     const auto fd = socket.native_handle();
 
@@ -832,6 +841,23 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
         // do this before starting client thread, to filter out
         // certain DoS and misbehaving clients.
         AcceptedConnectionImpl<ip::tcp>* tcp_conn = dynamic_cast< AcceptedConnectionImpl<ip::tcp>* >(conn);
+
+        // Before the allow-list test, so it covers the rejection path too.
+        //
+        // Two things happen here: the socket is forced into blocking mode, which
+        // the stream device requires to tell a deadline from "nothing yet", and
+        // the read/write deadline is applied. Without the deadline a client that
+        // opens a connection and then sends nothing keeps this worker blocked in
+        // read() for as long as it cares to, and there are only -rpcthreads of
+        // them.
+        //
+        // The rejection path needs it just as much. Writing the 403 below is a
+        // blocking send: a client that stops reading -- letting its receive
+        // window close -- parks this worker there indefinitely. That one costs
+        // an attacker nothing at all, since failing the allow-list means it
+        // never had to present a credential.
+        if (tcp_conn) SetRPCSocketTimeouts(tcp_conn->socket);
+
         if (tcp_conn && !ClientAllowed(tcp_conn->peer.address()))
         {
             // The 403 was previously suppressed when TLS was in use, to avoid
@@ -842,12 +868,6 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
         }
         else
         {
-            // Apply the read/write deadline before servicing. Without it a
-            // client that opens a connection and then sends nothing keeps this
-            // worker blocked in read() for as long as it cares to, and there
-            // are only -rpcthreads of them.
-            if (tcp_conn) SetRPCSocketTimeouts(tcp_conn->socket);
-
             // Register before servicing so a concurrent StopRPCThreads() can
             // wake us out of the blocking read loop. If the server is already
             // stopping we skip servicing entirely rather than park with no

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -907,7 +907,14 @@ static bool StartRPCListenersOn(const std::vector<std::string>& binds, std::stri
             acceptor->set_option(ip::tcp::acceptor::reuse_address(true));
 
             // One address per acceptor, so never dual-stack: a v6 entry binds v6
-            // only. Otherwise binding both "::" and "0.0.0.0" would collide.
+            // only. Otherwise listing both "::" and "0.0.0.0" -- the natural way
+            // to ask for both families explicitly -- would collide on the second
+            // bind.
+            //
+            // Note this differs from the implicit path below, which sets
+            // v6_only(loopback) and so gives a dual-stack socket for the
+            // wildcard. Moving from -rpcallowip alone to -rpcbind=:: therefore
+            // drops IPv4 unless 0.0.0.0 is listed too; the help text says so.
             if (addr.is_v6()) {
                 boost::system::error_code v6_ec;
                 acceptor->set_option(ip::v6_only(true), v6_ec);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -640,6 +640,61 @@ void ErrorReply(std::ostream& stream, const UniValue& objError, const UniValue& 
     stream << HTTPReply(nStatus, strReply, false) << std::flush;
 }
 
+//! -rpcallowip, parsed once at RPC start.
+//!
+//! Two forms are kept because two forms are in the field. Anything
+//! LookupSubNet() accepts -- a CIDR prefix, an address/netmask pair, or a bare
+//! address, v4 or v6 -- becomes a CSubNet and is matched numerically. Anything
+//! else stays a string and is matched with WildcardMatch(), which is what this
+//! function did for every entry before, and is what makes forms like
+//! "192.168.1.*" keep working.
+//!
+//! Parsing every entry on every connection would be wasteful, but that is not
+//! the reason this is hoisted: LookupSubNet() reaches LookupHost(), and doing
+//! name resolution on the request path of an ACL is not something to leave
+//! available even with lookups disabled.
+struct RPCAllowEntry
+{
+    CSubNet subnet;         //!< valid when is_subnet
+    std::string pattern;    //!< used when !is_subnet
+    bool is_subnet{false};
+};
+
+static std::vector<RPCAllowEntry> g_rpc_allow_list;
+static bool g_rpc_allow_list_parsed{false};
+
+//! Parse -rpcallowip. Logs what each entry resolved to, because the failure
+//! this replaces was silent: an entry that matched nothing produced a listener
+//! that rejected everything, with nothing in the log to say why.
+void InitRPCAllowList(const std::vector<std::string>& entries)
+{
+    g_rpc_allow_list.clear();
+
+    for (const std::string& strAllow : entries) {
+        RPCAllowEntry entry;
+
+        CSubNet subnet;
+        if (LookupSubNet(strAllow.c_str(), subnet) && subnet.IsValid()) {
+            entry.subnet = subnet;
+            entry.is_subnet = true;
+            LogPrintf("RPC: -rpcallowip %s allows %s\n", strAllow, subnet.ToString());
+        } else {
+            entry.pattern = strAllow;
+            LogPrintf("RPC: -rpcallowip %s is not an address or subnet; matching it as a "
+                      "wildcard pattern against the peer address text\n", strAllow);
+        }
+
+        g_rpc_allow_list.push_back(entry);
+    }
+
+    g_rpc_allow_list_parsed = true;
+}
+
+void InitRPCAllowList()
+{
+    InitRPCAllowList(gArgs.GetArgs("-rpcallowip"));
+}
+
 bool ClientAllowed(const boost::asio::ip::address& address)
 {
     // Make sure that IPv4-compatible and IPv4-mapped IPv6 addresses are treated as IPv4 addresses
@@ -660,11 +715,27 @@ bool ClientAllowed(const boost::asio::ip::address& address)
       && (address.to_v4().to_bytes()[0] == 127)))
         return true;
 
+    // Fail closed if the list was somehow never parsed, rather than falling
+    // back to an unparsed read that would allow nothing anyway but silently.
+    if (!g_rpc_allow_list_parsed) {
+        LogPrintf("RPC: WARNING - allow list consulted before it was parsed; denying %s\n",
+                  address.to_string());
+        return false;
+    }
+
     const string strAddress = address.to_string();
-    const vector<string>& vAllow = gArgs.GetArgs("-rpcallowip");
-    for (auto const& strAllow : vAllow)
-        if (WildcardMatch(strAddress, strAllow))
+
+    CNetAddr netaddr;
+    const bool have_netaddr = LookupHost(strAddress.c_str(), netaddr, false);
+
+    for (const RPCAllowEntry& entry : g_rpc_allow_list) {
+        if (entry.is_subnet) {
+            if (have_netaddr && entry.subnet.Match(netaddr)) return true;
+        } else if (WildcardMatch(strAddress, entry.pattern)) {
             return true;
+        }
+    }
+
     return false;
 }
 
@@ -743,12 +814,81 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
     delete conn;
 }
 
+//! Bind one acceptor per -rpcbind entry.
+//!
+//! Each entry is an address, optionally with a port ("10.0.0.5", "[::1]:1234").
+//! Unlike the implicit path this makes no wildcard decision of its own: the
+//! operator gets exactly the addresses they named. An entry that fails to bind
+//! is reported and skipped rather than aborting the rest, so one bad line in a
+//! config does not cost the node every other listener; the caller still treats
+//! "none bound at all" as fatal.
+static bool StartRPCListenersOn(const std::vector<std::string>& binds, bool fUseSSL, std::string& strerr)
+{
+    using namespace boost::asio;
+
+    const int default_port = gArgs.GetArg("-rpcport", GetDefaultRPCPort());
+    bool any = false;
+
+    for (const std::string& spec : binds) {
+        int port = default_port;
+        std::string host;
+        SplitHostPort(spec, port, host);
+
+        if (host.empty()) {
+            strerr = strprintf("-rpcbind entry '%s' has no address", spec);
+            LogPrintf("ERROR: StartRPCThreads: %s\n", strerr);
+            continue;
+        }
+
+        boost::system::error_code ec;
+        const ip::address addr = ip::make_address(host, ec);
+        if (ec) {
+            strerr = strprintf("-rpcbind entry '%s' is not a numeric address: %s", spec, ec.message());
+            LogPrintf("ERROR: StartRPCThreads: %s\n", strerr);
+            continue;
+        }
+
+        try {
+            ip::tcp::endpoint endpoint(addr, static_cast<unsigned short>(port));
+            boost::shared_ptr<ip::tcp::acceptor> acceptor(new ip::tcp::acceptor(*rpc_io_service));
+
+            acceptor->open(endpoint.protocol());
+            acceptor->set_option(ip::tcp::acceptor::reuse_address(true));
+
+            // One address per acceptor, so never dual-stack: a v6 entry binds v6
+            // only. Otherwise binding both "::" and "0.0.0.0" would collide.
+            if (addr.is_v6()) {
+                boost::system::error_code v6_ec;
+                acceptor->set_option(ip::v6_only(true), v6_ec);
+            }
+
+            acceptor->bind(endpoint);
+            acceptor->listen(socket_base::max_listen_connections);
+
+            RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
+            rpc_acceptors.push_back(acceptor);
+
+            LogPrintf("RPC: bound and listening on %s:%u (-rpcbind)\n",
+                      endpoint.address().to_string(), endpoint.port());
+            any = true;
+        } catch (boost::system::system_error& e) {
+            strerr = strprintf(_("An error occurred while setting up the RPC port %u for listening on %s: %s"),
+                               port, host, e.what());
+            LogPrintf("ERROR: StartRPCThreads: %s\n", strerr);
+        }
+    }
+
+    return any;
+}
+
 void StartRPCThreads()
 {
     // Logged unconditionally: the absence of this line in a node's debug.log
     // distinguishes "RPC server never started" from "started but not serving"
     // when diagnosing functional-test RPC-startup timeouts.
     LogPrintf("StartRPCThreads: entered\n");
+
+    InitRPCAllowList();
 
     strRPCUserColonPass = gArgs.GetArg("-rpcuser", "") + ":" + gArgs.GetArg("-rpcpassword", "");
 
@@ -817,8 +957,28 @@ void StartRPCThreads()
         SSL_CTX_set_cipher_list(rpc_ssl_context->native_handle(), strCiphers.c_str());
     }
 
+    // Where to listen.
+    //
+    // Historically this was implied by -rpcallowip: setting any allow entry at
+    // all moved the listener from loopback to the wildcard address, on every
+    // interface. That coupling is surprising in the dangerous direction -- an
+    // operator narrowing who may connect simultaneously widens where the socket
+    // is reachable -- and there was no way to say "listen here" independently.
+    //
+    // -rpcbind now says it explicitly. When it is not given the old behaviour is
+    // kept exactly, so no existing deployment changes on upgrade, but the
+    // implicit widening is logged as a warning rather than happening silently.
+    const bool bind_specified = gArgs.IsArgSet("-rpcbind");
+    const bool loopback = !bind_specified && !gArgs.IsArgSet("-rpcallowip");
+
+    if (!bind_specified && !loopback) {
+        LogPrintf("RPC: WARNING - -rpcallowip is set and -rpcbind is not, so the RPC port is "
+                  "being opened on ALL interfaces (%s), not just loopback. Only the allow list "
+                  "restricts who may connect. Set -rpcbind to choose the listening address "
+                  "explicitly.\n", "0.0.0.0 / ::");
+    }
+
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
-    const bool loopback = !gArgs.IsArgSet("-rpcallowip");
     asio::ip::address bindAddress = loopback ? asio::ip::address_v6::loopback() : asio::ip::address_v6::any();
     ip::tcp::endpoint endpoint(bindAddress, gArgs.GetArg("-rpcport", GetDefaultRPCPort()));
     boost::system::error_code v6_only_error;
@@ -826,6 +986,14 @@ void StartRPCThreads()
 
     bool fListening = false;
     std::string strerr;
+
+    // Explicit -rpcbind replaces the implicit loopback/wildcard choice entirely.
+    // Both paths fall through to the shared "did anything bind?" check and the
+    // worker-thread startup below -- returning early here would leave the
+    // acceptors armed with nothing running io_context::run().
+    if (bind_specified) {
+        fListening = StartRPCListenersOn(gArgs.GetArgs("-rpcbind"), fUseSSL, strerr);
+    } else {
     try
     {
         acceptor->open(endpoint.protocol());
@@ -873,6 +1041,7 @@ void StartRPCThreads()
     {
         strerr = strprintf(_("An error occurred while setting up the RPC port %u for listening on IPv4: %s"), endpoint.port(), e.what());
     }
+    } // !bind_specified
 
     if (!fListening)
     {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1251,8 +1251,20 @@ void ServiceConnection(AcceptedConnection *conn)
         if (!ReadHTTPRequestLine(conn->stream(), nProto, strMethod, strURI))
             break;
 
-        // Read HTTP message headers and body
-        ReadHTTPMessage(conn->stream(), mapHeaders, strRequest, nProto);
+        // Read HTTP message headers and body.
+        //
+        // The status matters. Discarding it made an over-long or malformed body
+        // fail only incidentally: the body was never read, strRequest stayed
+        // empty, and the JSON parse further down returned 500 -- so the bound
+        // above worked by accident and reported the wrong thing. Answer with the
+        // status the parser actually produced and close.
+        const int http_status = ReadHTTPMessage(conn->stream(), mapHeaders, strRequest, nProto,
+                                                MAX_RPC_BODY_SIZE);
+
+        if (http_status != HTTP_OK) {
+            conn->stream() << HTTPReply(http_status, "", false) << std::flush;
+            break;
+        }
 
         if (strURI != "/") {
             conn->stream() << HTTPReply(HTTP_NOT_FOUND, "", false) << std::flush;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -71,6 +71,15 @@ static bool g_rpc_connections_stopped = false;
 //! Returns false if the server is already shutting down, in which case the
 //! caller must not service the connection (there is no worker-drain left to
 //! wake it).
+//!
+//! Deliberately no connection ceiling here. It would be unreachable: this runs
+//! from RPCAcceptHandler, which is an asio completion handler dispatched by the
+//! workers' io_context::run() and which calls ServiceConnection() synchronously,
+//! so a worker is occupied from accept through service and the size of this set
+//! can never exceed -rpcthreads. A cap above that number can never be hit, and a
+//! cap below it is just a smaller thread count. What actually bounds a hostile
+//! client is the socket deadline applied before servicing; further connections
+//! wait in the kernel accept backlog, not here.
 static bool RegisterRPCConnection(AcceptedConnection* conn)
 {
     std::lock_guard<std::mutex> lock(g_rpc_connections_mutex);
@@ -85,6 +94,47 @@ static void UnregisterRPCConnection(AcceptedConnection* conn)
 {
     std::lock_guard<std::mutex> lock(g_rpc_connections_mutex);
     g_rpc_connections.erase(conn);
+}
+
+//! Put a receive and send deadline on an accepted RPC socket.
+//!
+//! The servicing model is one blocking read per worker thread, so the deadline
+//! has to live on the socket rather than in an asio timer: there is no event
+//! loop watching a worker that is parked inside read(). SO_RCVTIMEO makes that
+//! read return an error instead of waiting forever, which the stream device
+//! already reports as end of sequence, so the worker closes the connection and
+//! moves on with no further plumbing.
+static void SetRPCSocketTimeouts(boost::asio::ip::tcp::socket& socket)
+{
+    const int seconds = gArgs.GetArg("-rpcservertimeout", DEFAULT_RPC_SERVER_TIMEOUT);
+    if (seconds <= 0) return;  // explicitly disabled
+
+    // Asio may have left the accepted descriptor non-blocking; a deadline only
+    // means anything on a blocking socket, and the stream device reads it with
+    // recv(2) directly.
+    boost::system::error_code ec;
+    socket.non_blocking(false, ec);
+    socket.native_non_blocking(false, ec);
+
+    const auto fd = socket.native_handle();
+
+#ifdef WIN32
+    DWORD tv = static_cast<DWORD>(seconds) * 1000;
+    const char* val = reinterpret_cast<const char*>(&tv);
+    const int len = sizeof(tv);
+#else
+    struct timeval tv;
+    tv.tv_sec = seconds;
+    tv.tv_usec = 0;
+    const void* val = &tv;
+    const socklen_t len = sizeof(tv);
+#endif
+
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, val, len) != 0
+        || setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, val, len) != 0) {
+        // Not fatal: the connection still works, it just has no deadline.
+        LogPrintf("RPC: WARNING - could not set a %ds timeout on an accepted connection\n", seconds);
+    }
 }
 
 const UniValue emptyobj(UniValue::VOBJ);
@@ -790,14 +840,23 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
             // always told why rather than seeing an unexplained closed socket.
             conn->stream() << HTTPReply(HTTP_FORBIDDEN, "", false) << std::flush;
         }
-        // Register before servicing so a concurrent StopRPCThreads() can wake us
-        // out of the blocking read loop. If the server is already stopping,
-        // RegisterRPCConnection() returns false and we skip servicing entirely
-        // rather than park with no drain left to interrupt us (issue #3123).
-        else if (RegisterRPCConnection(conn))
+        else
         {
-            ServiceConnection(conn);
-            UnregisterRPCConnection(conn);
+            // Apply the read/write deadline before servicing. Without it a
+            // client that opens a connection and then sends nothing keeps this
+            // worker blocked in read() for as long as it cares to, and there
+            // are only -rpcthreads of them.
+            if (tcp_conn) SetRPCSocketTimeouts(tcp_conn->socket);
+
+            // Register before servicing so a concurrent StopRPCThreads() can
+            // wake us out of the blocking read loop. If the server is already
+            // stopping we skip servicing entirely rather than park with no
+            // drain left to interrupt us (issue #3123).
+            if (RegisterRPCConnection(conn))
+            {
+                ServiceConnection(conn);
+                UnregisterRPCConnection(conn);
+            }
         }
 
         conn->close();
@@ -1038,6 +1097,7 @@ void StartRPCThreads()
     }
 
     const int nRPCThreads = gArgs.GetArg("-rpcthreads", 4);
+
     rpc_worker_group = new boost::thread_group();
     for (int i = 0; i < nRPCThreads; i++)
         rpc_worker_group->create_thread(boost::bind(&ioContext::run, rpc_io_service));

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -26,7 +26,6 @@
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/asio/ssl.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
 #include <algorithm>
@@ -47,7 +46,6 @@ static std::string strRPCUserColonPass;
 
 // These are created by StartRPCThreads, destroyed in StopRPCThreads
 static ioContext* rpc_io_service = nullptr;
-static ssl::context* rpc_ssl_context = nullptr;
 static boost::thread_group* rpc_worker_group = nullptr;
 // Acceptors created by StartRPCThreads. Retained so (a) startup can log the
 // bound endpoints and (b) StopRPCThreads can close() them before tearing down
@@ -744,8 +742,6 @@ void ServiceConnection(AcceptedConnection *conn);
 // Forward declaration required for RPCListen
 template <typename Protocol>
 static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> > acceptor,
-                             ssl::context& context,
-                             bool fUseSSL,
                              AcceptedConnection* conn,
                              const boost::system::error_code& error);
 
@@ -753,20 +749,16 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
  * Sets up I/O resources to accept and handle a new connection.
  */
 template <typename Protocol>
-static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol> > acceptor,
-                      ssl::context& context,
-                      const bool fUseSSL)
+static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol> > acceptor)
 {
     // Accept connection
-    AcceptedConnectionImpl<Protocol>* conn = new AcceptedConnectionImpl<Protocol>(GetIOServiceFromPtr(acceptor), context, fUseSSL);
+    AcceptedConnectionImpl<Protocol>* conn = new AcceptedConnectionImpl<Protocol>(GetIOServiceFromPtr(acceptor));
 
     acceptor->async_accept(
-                conn->sslStream.lowest_layer(),
+                conn->socket,
                 conn->peer,
                 boost::bind(&RPCAcceptHandler<Protocol>,
                             acceptor,
-                            boost::ref(context),
-                            fUseSSL,
                             conn,
                             boost::asio::placeholders::error));
 }
@@ -776,14 +768,12 @@ static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol> > accep
  */
 template <typename Protocol>
 static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> > acceptor,
-                             ssl::context& context,
-                             const bool fUseSSL,
                              AcceptedConnection* conn,
                              const boost::system::error_code& error)
 {
     // Immediately start accepting new connections, except when we're cancelled or our socket is closed.
     if (error != asio::error::operation_aborted && acceptor->is_open())
-        RPCListen(acceptor, context, fUseSSL);
+        RPCListen(acceptor);
 
     // TODO : Actually handle errors
     if (!error)
@@ -794,9 +784,11 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
         AcceptedConnectionImpl<ip::tcp>* tcp_conn = dynamic_cast< AcceptedConnectionImpl<ip::tcp>* >(conn);
         if (tcp_conn && !ClientAllowed(tcp_conn->peer.address()))
         {
-            // Only send a 403 if we're not using SSL to prevent a DoS during the SSL handshake.
-            if (!fUseSSL)
-                conn->stream() << HTTPReply(HTTP_FORBIDDEN, "", false) << std::flush;
+            // The 403 was previously suppressed when TLS was in use, to avoid
+            // replying inside a handshake that had not completed. With -rpcssl
+            // gone there is no handshake to be inside, so a rejected client is
+            // always told why rather than seeing an unexplained closed socket.
+            conn->stream() << HTTPReply(HTTP_FORBIDDEN, "", false) << std::flush;
         }
         // Register before servicing so a concurrent StopRPCThreads() can wake us
         // out of the blocking read loop. If the server is already stopping,
@@ -822,7 +814,7 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
 //! is reported and skipped rather than aborting the rest, so one bad line in a
 //! config does not cost the node every other listener; the caller still treats
 //! "none bound at all" as fatal.
-static bool StartRPCListenersOn(const std::vector<std::string>& binds, bool fUseSSL, std::string& strerr)
+static bool StartRPCListenersOn(const std::vector<std::string>& binds, std::string& strerr)
 {
     using namespace boost::asio;
 
@@ -865,7 +857,7 @@ static bool StartRPCListenersOn(const std::vector<std::string>& binds, bool fUse
             acceptor->bind(endpoint);
             acceptor->listen(socket_base::max_listen_connections);
 
-            RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
+            RPCListen(acceptor);
             rpc_acceptors.push_back(acceptor);
 
             LogPrintf("RPC: bound and listening on %s:%u (-rpcbind)\n",
@@ -920,7 +912,17 @@ void StartRPCThreads()
         return;
     }
 
-    const bool fUseSSL = gArgs.GetBoolArg("-rpcssl");
+    // -rpcssl and its three companion options are gone. Warn rather than ignore:
+    // an operator who believed the RPC port was wrapped in TLS must find out
+    // from the log, not from a packet capture.
+    for (const char* removed : {"-rpcssl", "-rpcsslcertificatechainfile",
+                                "-rpcsslprivatekeyfile", "-rpcsslciphers"}) {
+        if (gArgs.IsArgSet(removed)) {
+            LogPrintf("RPC: WARNING - %s is no longer supported and is being ignored. The JSON-RPC "
+                      "port does not speak TLS. Restrict it with -rpcbind and -rpcallowip, and "
+                      "tunnel it if it must cross an untrusted network.\n", removed);
+        }
+    }
 
     assert(rpc_io_service == nullptr);
 
@@ -937,25 +939,6 @@ void StartRPCThreads()
     }
 
     rpc_io_service = new ioContext();
-    rpc_ssl_context = new ssl::context(ssl::context::sslv23);
-
-    if (fUseSSL)
-    {
-        rpc_ssl_context->set_options(ssl::context::no_sslv2);
-
-        fs::path pathCertFile(gArgs.GetArg("-rpcsslcertificatechainfile", "server.cert"));
-        if (!pathCertFile.is_absolute()) pathCertFile = fs::path(GetDataDir()) / pathCertFile;
-        if (fs::exists(pathCertFile)) rpc_ssl_context->use_certificate_chain_file(pathCertFile.string());
-        else LogPrintf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string());
-
-        fs::path pathPKFile(gArgs.GetArg("-rpcsslprivatekeyfile", "server.pem"));
-        if (!pathPKFile.is_absolute()) pathPKFile = fs::path(GetDataDir()) / pathPKFile;
-        if (fs::exists(pathPKFile)) rpc_ssl_context->use_private_key_file(pathPKFile.string(), ssl::context::pem);
-        else LogPrintf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string());
-
-        string strCiphers = gArgs.GetArg("-rpcsslciphers", "TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH");
-        SSL_CTX_set_cipher_list(rpc_ssl_context->native_handle(), strCiphers.c_str());
-    }
 
     // Where to listen.
     //
@@ -992,7 +975,7 @@ void StartRPCThreads()
     // worker-thread startup below -- returning early here would leave the
     // acceptors armed with nothing running io_context::run().
     if (bind_specified) {
-        fListening = StartRPCListenersOn(gArgs.GetArgs("-rpcbind"), fUseSSL, strerr);
+        fListening = StartRPCListenersOn(gArgs.GetArgs("-rpcbind"), strerr);
     } else {
     try
     {
@@ -1005,7 +988,7 @@ void StartRPCThreads()
         acceptor->bind(endpoint);
         acceptor->listen(socket_base::max_listen_connections);
 
-        RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
+        RPCListen(acceptor);
         rpc_acceptors.push_back(acceptor);
         LogPrintf("RPC: bound and listening on [%s]:%u\n", endpoint.address().to_string(), endpoint.port());
 
@@ -1030,7 +1013,7 @@ void StartRPCThreads()
             acceptor->bind(endpoint);
             acceptor->listen(socket_base::max_listen_connections);
 
-            RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
+            RPCListen(acceptor);
             rpc_acceptors.push_back(acceptor);
             LogPrintf("RPC: bound and listening on %s:%u\n", endpoint.address().to_string(), endpoint.port());
 
@@ -1109,8 +1092,6 @@ void StopRPCThreads()
 
     delete rpc_worker_group;
     rpc_worker_group = nullptr;
-    delete rpc_ssl_context;
-    rpc_ssl_context = nullptr;
     delete rpc_io_service;
     rpc_io_service = nullptr;
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -916,8 +916,16 @@ static bool StartRPCListenersOn(const std::vector<std::string>& binds, std::stri
             // wildcard. Moving from -rpcallowip alone to -rpcbind=:: therefore
             // drops IPv4 unless 0.0.0.0 is listed too; the help text says so.
             if (addr.is_v6()) {
-                boost::system::error_code v6_ec;
-                acceptor->set_option(ip::v6_only(true), v6_ec);
+                // Throwing overload on purpose: the help text promises an IPv6
+                // entry does NOT also accept IPv4, and on a platform where
+                // IPV6_V6ONLY cannot be set the socket may default to
+                // dual-stack. Swallowing that error would leave the listener
+                // quietly accepting IPv4 while the documentation says it does
+                // not -- worse than not binding, because the operator has no
+                // way to see it. Caught below and reported like any other bind
+                // failure, which skips this listener rather than misrepresenting
+                // it.
+                acceptor->set_option(ip::v6_only(true));
             }
 
             acceptor->bind(endpoint);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -31,6 +31,11 @@ class RPCHelpMan;
 //! Parse -rpcallowip into the RPC allow list. Called by StartRPCThreads().
 //! The overload taking entries does the parsing and is what tests drive; the
 //! no-argument form supplies them from gArgs.
+//! Idle deadline for a serviced RPC connection, in seconds. One connection
+//! pins one worker thread, so this is what bounds how long a silent client can
+//! hold one of only -rpcthreads of them.
+static constexpr int DEFAULT_RPC_SERVER_TIMEOUT = 30;
+
 void InitRPCAllowList(const std::vector<std::string>& entries);
 void InitRPCAllowList();
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -7,8 +7,10 @@
 #ifndef BITCOIN_RPC_SERVER_H
 #define BITCOIN_RPC_SERVER_H
 
+#include <boost/asio/ip/address.hpp>
 #include <cstdint>
 #include <string>
+#include <vector>
 #include <list>
 #include <map>
 
@@ -25,6 +27,16 @@ class uint256;
 class RPCHelpMan;
 
 #include <univalue.h>
+
+//! Parse -rpcallowip into the RPC allow list. Called by StartRPCThreads().
+//! The overload taking entries does the parsing and is what tests drive; the
+//! no-argument form supplies them from gArgs.
+void InitRPCAllowList(const std::vector<std::string>& entries);
+void InitRPCAllowList();
+
+//! True if the address may open a JSON-RPC connection. Loopback is always
+//! allowed; everything else must match the -rpcallowip list.
+bool ClientAllowed(const boost::asio::ip::address& address);
 
 void StartRPCThreads();
 void StopRPCThreads();

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -28,14 +28,14 @@ class RPCHelpMan;
 
 #include <univalue.h>
 
+//! Idle deadline for a serviced RPC connection, in seconds. One connection pins
+//! one worker thread, so this is what bounds how long a silent client can hold
+//! one of only -rpcthreads of them.
+static constexpr int DEFAULT_RPC_SERVER_TIMEOUT = 30;
+
 //! Parse -rpcallowip into the RPC allow list. Called by StartRPCThreads().
 //! The overload taking entries does the parsing and is what tests drive; the
 //! no-argument form supplies them from gArgs.
-//! Idle deadline for a serviced RPC connection, in seconds. One connection
-//! pins one worker thread, so this is what bounds how long a silent client can
-//! hold one of only -rpcthreads of them.
-static constexpr int DEFAULT_RPC_SERVER_TIMEOUT = 30;
-
 void InitRPCAllowList(const std::vector<std::string>& entries);
 void InitRPCAllowList();
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -21,7 +21,6 @@
 // (RPCHelpMan::HandleRequest, Arg<T>/MaybeArg<T>, GetArgMap, MatchesType) is
 // intentionally omitted — see src/rpc/util.h for rationale.
 
-const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
 // TODO(#2922): replace with real Gridcoin example addresses before the first
 // Tier 1 conversion PR that references EXAMPLE_ADDRESS lands.
 const std::string EXAMPLE_ADDRESS[2] = {

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -60,7 +61,19 @@ struct Sections;
  * String used to describe UNIX epoch time in documentation, factored out to a
  * constant for consistency.
  */
-extern const std::string UNIX_EPOCH_TIME;
+//! Constexpr, so it needs no dynamic initialization.
+//!
+//! This was a namespace-scope const std::string in util.cpp, read by a
+//! namespace-scope RPCHelpMan initializer in blockchain.cpp. Both need dynamic
+//! initialization, their relative order across translation units is decided by
+//! the link, and nothing guarantees util.cpp goes first -- so the help text was
+//! being built from a std::string that may not have been constructed yet.
+//! AddressSanitizer with check_initialization_order=1 reports it as an
+//! initialization-order-fiasco and the daemon dies at startup under that
+//! configuration.
+//!
+//! A constexpr string_view over a literal has no initializer to order.
+inline constexpr std::string_view UNIX_EPOCH_TIME{"UNIX epoch time"};
 
 /**
  * Example addresses for the RPCExamples help documentation. They are

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1235,6 +1235,14 @@ public:
 
         LOCK(cs_sigcache);
 
+        sigdata_type k(hash, vchSig, pubKey);
+        setValid.insert(k);
+
+        // Insert THEN evict. Evicting first, on `size > m_max_size`, left the
+        // set resting at m_max_size + 1: at the limit nothing was evicted, the
+        // insert took it one over, and the next call brought it back. One entry
+        // over a ceiling expressed as a memory budget is a small lie, but it is
+        // a lie the tests and the -maxsigcachesize help text both repeat.
         while (static_cast<int64_t>(setValid.size()) > m_max_size)
         {
             // Evict a random entry. Random because that helps
@@ -1252,9 +1260,6 @@ public:
             // the iterator already names, while holding the lock.
             setValid.erase(it);
         }
-
-        sigdata_type k(hash, vchSig, pubKey);
-        setValid.insert(k);
     }
 };
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -13,6 +13,8 @@
 #include "sync.h"
 #include "util.h"
 
+#include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 
 using namespace std;
@@ -1161,6 +1163,22 @@ uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int
 }
 
 
+int64_t ResolveMaxSigCacheSize()
+{
+    const int64_t requested = gArgs.GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE);
+
+    // Zero or negative disables the cache, as before.
+    if (requested <= 0) return 0;
+
+    // Clamp rather than trust. The value is operator-supplied and was
+    // previously unbounded above, so a typo (or a copied config with an extra
+    // digit) sized an unevictable in-memory set with no ceiling. Entries are
+    // roughly SIG_CACHE_ENTRY_BYTES each, so the clamp is expressed as a
+    // memory budget and converted, which keeps it honest if the entry shape
+    // changes.
+    return std::min<int64_t>(requested, MAX_SIG_CACHE_ENTRIES);
+}
+
 // Valid signature cache, to avoid doing expensive ECDSA signature checking
 // twice for every transaction (once when accepted into memory pool, and
 // again when accepted into the block chain)
@@ -1173,7 +1191,19 @@ private:
     std::set< sigdata_type> setValid;
     CCriticalSection cs_sigcache;
 
+    //! Resolved once, at construction, rather than on every insertion.
+    //!
+    //! -maxsigcachesize cannot change after startup, so re-reading it per
+    //! signature bought nothing and cost a gArgs lock plus a map lookup and a
+    //! string compare on the hottest path in validation: every cache-missing
+    //! signature in every transaction in every block. CheckSig is only
+    //! reachable once block validation is running, which is long after
+    //! ParseParameters, so first-use resolution sees the operator's value.
+    const int64_t m_max_size;
+
 public:
+    CSignatureCache() : m_max_size(ResolveMaxSigCacheSize()) {}
+
     bool
     Get(uint256 hash, const std::vector<unsigned char>& vchSig, const std::vector<unsigned char>& pubKey)
     {
@@ -1188,28 +1218,39 @@ public:
 
     void Set(uint256 hash, const std::vector<unsigned char>& vchSig, const std::vector<unsigned char>& pubKey)
     {
-        // DoS prevention: limit cache size to less than 10MB
-        // (~200 bytes per cache entry times 50,000 entries)
-        // Since there are a maximum of 20,000 signature operations per block
-        // 50,000 is a reasonable default.
-        int64_t nMaxCacheSize = gArgs.GetArg("-maxsigcachesize", 50000);
-        if (nMaxCacheSize <= 0) return;
+        if (m_max_size == 0) return;
+
+        // Drawn BEFORE the lock is taken. GetRandHash() reaches ProcRand(),
+        // which takes the process-global RNG mutex; drawing it inside
+        // cs_sigcache nested that global lock underneath this one, so every
+        // signature verification in the process serialized on the RNG.
+        //
+        // One draw is always enough. m_max_size is fixed at construction and
+        // this function inserts a single entry at a time, so the set can
+        // exceed the limit by at most one and the loop below runs at most
+        // once. In the steady state -- a full cache -- it does run each time,
+        // so this is the same number of draws as before, just outside the
+        // critical section.
+        const uint256 randomHash = GetRandHash();
 
         LOCK(cs_sigcache);
 
-        while (static_cast<int64_t>(setValid.size()) > nMaxCacheSize)
+        while (static_cast<int64_t>(setValid.size()) > m_max_size)
         {
             // Evict a random entry. Random because that helps
             // foil would-be DoS attackers who might try to pre-generate
             // and reuse a set of valid signatures just-slightly-greater
             // than our cache size.
-            uint256 randomHash = GetRandHash();
             std::vector<unsigned char> unused;
             std::set<sigdata_type>::iterator it =
                 setValid.lower_bound(sigdata_type(randomHash, unused, unused));
             if (it == setValid.end())
                 it = setValid.begin();
-            setValid.erase(*it);
+
+            // erase(it), not erase(*it): the latter copies the tuple -- and so
+            // heap-allocates both of its vectors -- purely to look up the entry
+            // the iterator already names, while holding the lock.
+            setValid.erase(it);
         }
 
         sigdata_type k(hash, vchSig, pubKey);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -8,7 +8,31 @@
 
 #include "script/script.h"
 
+#include <cstdint>
+
 class CTransaction;
+
+//! Default -maxsigcachesize, in entries. Historically 10 MB of cache at
+//! roughly SIG_CACHE_ENTRY_BYTES per entry. A block admits at most 20,000
+//! signature operations, so this holds well over a block's worth.
+static constexpr int64_t DEFAULT_MAX_SIG_CACHE_SIZE = 50000;
+
+//! Approximate resident cost of one cache entry: a 32-byte hash, a ~72-byte
+//! signature and a ~33-byte pubkey, plus the set node and the two vector
+//! allocations that carry them.
+static constexpr int64_t SIG_CACHE_ENTRY_BYTES = 200;
+
+//! Ceiling on what -maxsigcachesize may ask for. Not a tuning knob -- it is
+//! there so an operator typo cannot size an unbounded in-memory set. Well
+//! above any useful setting: 512 MB is 50x the default cache.
+static constexpr int64_t MAX_SIG_CACHE_BYTES = 512 * 1024 * 1024;
+static constexpr int64_t MAX_SIG_CACHE_ENTRIES = MAX_SIG_CACHE_BYTES / SIG_CACHE_ENTRY_BYTES;
+
+//! Resolve -maxsigcachesize into an entry count, clamped to
+//! MAX_SIG_CACHE_ENTRIES. Zero or negative disables the cache and yields 0.
+//! Declared here so the clamp can be tested directly; the cache itself is
+//! file-local to interpreter.cpp.
+int64_t ResolveMaxSigCacheSize();
 
 bool EvalScript(std::vector<std::vector<unsigned char>>& stack, const CScript& script, unsigned int flags, const CTransaction& txTo, unsigned int nIn);
 uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -503,6 +503,7 @@ static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&
 #define VARINT(obj, ...) WrapVarInt<__VA_ARGS__>(REF(obj))
 #define COMPACTSIZE(obj) CCompactSize(REF(obj))
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))
+#define LIMITED_VECTOR(obj,n) MakeLimitedVector< n >(REF(obj))
 
 template<VarIntMode Mode, typename I>
 class CVarInt
@@ -647,6 +648,58 @@ public:
             s.write(MakeByteSpan(string));
     }
 };
+
+/**
+ * Wrapper for a vector with a maximum element count, enforced at the length
+ * prefix.
+ *
+ * The mirror of LimitedString above, and for the same reason: the check has to
+ * happen on the CompactSize prefix, BEFORE the vector is sized. The default
+ * vector deserializer grows in 5,000,000/sizeof(T) element steps and allocates
+ * against the declared count before reading the data behind it, so a short
+ * message declaring a huge count already costs a multi-megabyte allocation by
+ * the time a post-hoc size test could run.
+ *
+ * Deliberately shaped like LimitedString rather than ported from upstream's
+ * LimitedVectorFormatter, which needs the DefaultFormatter / VectorFormatter
+ * chain that this tree does not carry.
+ */
+template<size_t Limit, typename V>
+class LimitedVector
+{
+protected:
+    V& vec;
+public:
+    explicit LimitedVector(V& _vec) : vec(_vec) {}
+
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        vec.clear();
+        const size_t size = ReadCompactSize(s);
+        if (size > Limit) {
+            throw std::ios_base::failure("Vector length limit exceeded");
+        }
+        vec.reserve(size);
+        for (size_t i = 0; i < size; ++i) {
+            vec.emplace_back();
+            s >> vec.back();
+        }
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
+        WriteCompactSize(s, vec.size());
+        for (const auto& element : vec) {
+            s << element;
+        }
+    }
+};
+
+//! Deduction helper so LIMITED_VECTOR need not name the container type.
+template<size_t Limit, typename V>
+LimitedVector<Limit, V> MakeLimitedVector(V& vec) { return LimitedVector<Limit, V>(vec); }
 
 template<VarIntMode Mode=VarIntMode::DEFAULT, typename I>
 CVarInt<Mode, I> WrapVarInt(I& n) { return CVarInt<Mode, I>{n}; }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -139,6 +139,7 @@ add_executable(test_gridcoin
     sanity_tests.cpp
     scheduler_tests.cpp
     script_p2sh_tests.cpp
+    rpc_allowlist_tests.cpp
     script_tests.cpp
     serialize_tests.cpp
     sigopcount_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(test_gridcoin
     gridcoin/protocol_tests.cpp
     gridcoin/researcher_tests.cpp
     gridcoin/rsaverify_tests.cpp
+    gridcoin/scraper_net_tests.cpp
     gridcoin/scraper_registry_tests.cpp
     gridcoin/sidestake_tests.cpp
     gridcoin/superblock_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -182,7 +182,7 @@ target_link_libraries(test_gridcoin PRIVATE
     ${LIBBDB_CXX} ${LIBLEVELDB} ${LIBSECP256K1} ${LIBUNIVALUE}
     Boost::boost Boost::filesystem Boost::iostreams Boost::thread Boost::date_time Boost::serialization Boost::unit_test_framework
     CURL::libcurl
-    OpenSSL::Crypto OpenSSL::SSL
+    OpenSSL::Crypto
     Threads::Threads
     ZLIB::ZLIB
 )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(test_gridcoin
     gridcoin/superblock_tests.cpp
     interfaces_tests.cpp
     key_tests.cpp
+    limitedmap_tests.cpp
     merkle_tests.cpp
     merkleblock_tests.cpp
     mruset_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -183,7 +183,7 @@ target_link_libraries(test_gridcoin PRIVATE
     ${LIBBDB_CXX} ${LIBLEVELDB} ${LIBSECP256K1} ${LIBUNIVALUE}
     Boost::boost Boost::filesystem Boost::iostreams Boost::thread Boost::date_time Boost::serialization Boost::unit_test_framework
     CURL::libcurl
-    OpenSSL::Crypto
+    OpenSSL::Crypto OpenSSL::SSL
     Threads::Threads
     ZLIB::ZLIB
 )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -139,6 +139,7 @@ add_executable(test_gridcoin
     sanity_tests.cpp
     scheduler_tests.cpp
     script_p2sh_tests.cpp
+    gridcoin/connectinputs_tests.cpp
     rpc_allowlist_tests.cpp
     script_tests.cpp
     serialize_tests.cpp

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -19,7 +19,10 @@
 // Tests this internal-to-main.cpp method:
 extern bool AddOrphanTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-extern std::map<uint256, CTransaction> mapOrphanTransactions GUARDED_BY(cs_main);
+struct COrphanTx { CTransaction tx; int64_t time_received; };
+extern std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);
+extern unsigned int ExpireOrphanTransactions(const int64_t now);
+static constexpr int64_t ORPHAN_TX_EXPIRE_SECONDS = 20 * 60;
 extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);
 
 // The orphan-tx tests below are single-threaded and drive
@@ -138,7 +141,7 @@ CTransaction RandomOrphan() NO_THREAD_SAFETY_ANALYSIS
     auto it = mapOrphanTransactions.lower_bound(InsecureRand256());
     if (it == mapOrphanTransactions.end())
         it = mapOrphanTransactions.begin();
-    return it->second;
+    return it->second.tx;
 }
 
 BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
@@ -210,6 +213,49 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     LimitOrphanTxSize(0);
     BOOST_CHECK(mapOrphanTransactions.empty());
     BOOST_CHECK(mapOrphanTransactionsByPrev.empty());
+}
+
+//! An orphan past ORPHAN_TX_EXPIRE_SECONDS is swept. The count limit alone does
+//! not reclaim it: LimitOrphanTxSize only runs when something new is inserted,
+//! and EraseOrphanTx only fires when a parent arrives, so a peer that fills the
+//! pool and then falls silent leaves it full. Boundary checked from both sides,
+//! matching the orphan-block and PSGT-pool expiry tests.
+BOOST_AUTO_TEST_CASE(DoS_orphan_tx_expiry) NO_THREAD_SAFETY_ANALYSIS
+{
+    LimitOrphanTxSize(0);
+    BOOST_REQUIRE(mapOrphanTransactions.empty());
+
+    constexpr int64_t received_at = 1700003000;
+
+    SetMockTime(received_at);
+
+    CKey key;
+    key.MakeNewKey(true);
+    CBasicKeyStore keystore;
+    keystore.AddKey(key);
+
+    CMutableTransaction mtx;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout.n = 0;
+    mtx.vin[0].prevout.hash = InsecureRand256();     // parent we will never see
+    mtx.vin[0].scriptSig << OP_1;
+    mtx.vout.resize(1);
+    mtx.vout[0].nValue = 1 * CENT;
+    mtx.vout[0].scriptPubKey.SetDestination(key.GetPubKey().GetID());
+
+    BOOST_REQUIRE(AddOrphanTx(CTransaction(mtx)));
+    BOOST_CHECK_EQUAL(mapOrphanTransactions.size(), 1u);
+
+    // Exactly at the TTL: kept.
+    BOOST_CHECK_EQUAL(ExpireOrphanTransactions(received_at + ORPHAN_TX_EXPIRE_SECONDS), 0u);
+    BOOST_CHECK_EQUAL(mapOrphanTransactions.size(), 1u);
+
+    // One second past: swept, and the by-prev index goes with it.
+    BOOST_CHECK_EQUAL(ExpireOrphanTransactions(received_at + ORPHAN_TX_EXPIRE_SECONDS + 1), 1u);
+    BOOST_CHECK(mapOrphanTransactions.empty());
+    BOOST_CHECK(mapOrphanTransactionsByPrev.empty());
+
+    SetMockTime(0);
 }
 
 BOOST_AUTO_TEST_CASE(DoS_validation_state)

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -14,15 +14,14 @@
 
 #include <test/test_gridcoin.h>
 
+#include <net_processing.h>
 #include <stdint.h>
 
 // Tests this internal-to-main.cpp method:
 extern bool AddOrphanTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-struct COrphanTx { CTransaction tx; int64_t time_received; };
 extern std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);
 extern unsigned int ExpireOrphanTransactions(const int64_t now);
-static constexpr int64_t ORPHAN_TX_EXPIRE_SECONDS = 20 * 60;
 extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);
 
 // The orphan-tx tests below are single-threaded and drive

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -8,6 +8,7 @@
 #include <gridcoin/superblock.h>
 #include <gridcoin/contract/contract.h>
 #include <gridcoin/claim.h>
+#include <gridcoin/tx_message.h>
 #include <consensus/consensus.h>
 #include <limits>
 #include <script/interpreter.h>
@@ -451,6 +452,75 @@ BOOST_AUTO_TEST_CASE(a_coinbase_with_no_contracts_is_refused_before_the_claim_is
     BOOST_REQUIRE(block.nVersion >= 11);
 
     BOOST_CHECK(!CheckBlockSizeOnly(block));
+}
+
+//!
+//! A coinbase whose first contract is not a claim.
+//!
+//! The same read as the case above, reached a different way. GetClaim() used to
+//! decide on the block version alone, so a coinbase carrying some other kind of
+//! contract took the claim branch and handed a payload of one type to a cast
+//! expecting another. The message payload here is genuinely not a Claim, which
+//! is what makes this discriminating: a version-keyed accessor casts it, a
+//! shape-keyed one does not.
+//!
+BOOST_AUTO_TEST_CASE(a_coinbase_carrying_another_contract_type_is_refused)
+{
+    LOCK(cs_main);
+
+    CMutableTransaction cb;
+    cb.nVersion = 2;
+    cb.nTime = 1000;
+    cb.vin.resize(1);
+    cb.vin[0].prevout.SetNull();
+    cb.vin[0].scriptSig = CScript() << OP_11 << OP_11;
+    cb.vout.resize(1);
+    cb.vout[0].nValue = 1;
+    cb.vContracts.emplace_back(
+        GRC::MakeContract<GRC::TxMessage>(GRC::ContractAction::ADD, "not a claim"));
+
+    CBlock block = BlockOf(14, {CTransaction(cb)});
+    BOOST_REQUIRE(block.vtx[0].vContracts[0].m_type != GRC::ContractType::CLAIM);
+
+    BOOST_CHECK(!CheckBlockSizeOnly(block));
+}
+
+//!
+//! The same shape below version 11, where the coinbase contract checks do not
+//! run at all.
+//!
+//! Nothing rejects this on the contract, so the block is measured and the claim
+//! is read. The accessor has to stay defined without a check in front of it --
+//! reaching the fallback and reporting no superblock, rather than casting.
+//!
+//! No verdict is asserted here. Whether a block this old is acceptable is not
+//! what is under test, and pinning it would invent a rule; what is under test is
+//! that asking the question is safe.
+//!
+BOOST_AUTO_TEST_CASE(a_pre_v11_coinbase_contract_is_read_without_casting_it)
+{
+    LOCK(cs_main);
+
+    CMutableTransaction cb;
+    cb.nVersion = 2;
+    cb.nTime = 1000;
+    cb.vin.resize(1);
+    cb.vin[0].prevout.SetNull();
+    cb.vin[0].scriptSig = CScript() << OP_11 << OP_11;
+    cb.vout.resize(1);
+    cb.vout[0].nValue = 1;
+    cb.vContracts.emplace_back(
+        GRC::MakeContract<GRC::TxMessage>(GRC::ContractAction::ADD, "not a claim"));
+
+    CBlock block = BlockOf(10, {CTransaction(cb)});
+    BOOST_REQUIRE(block.nVersion < 11);
+    BOOST_REQUIRE(!block.vtx[0].vContracts.empty());
+
+    // The read itself, which is the part that used to be undefined.
+    BOOST_CHECK(!block.GetSuperblock()->WellFormed());
+
+    CValidationState state;
+    (void)CheckBlock(block, state, 1000, false, false, false);
 }
 
 BOOST_AUTO_TEST_CASE(an_empty_block_is_refused_before_vtx_is_read)

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -6,6 +6,8 @@
 #include <chainparams.h>
 #include <policy/policy.h>
 #include <gridcoin/superblock.h>
+#include <gridcoin/contract/contract.h>
+#include <gridcoin/claim.h>
 #include <consensus/consensus.h>
 #include <limits>
 #include <script/interpreter.h>
@@ -212,6 +214,117 @@ BOOST_AUTO_TEST_CASE(v15_script_flags_close_malleability_at_activation)
 }
 
 
+namespace {
+//! A superblock whose serialized size is at least `target` bytes.
+GRC::Superblock SuperblockOfAtLeast(const size_t target)
+{
+    GRC::Superblock superblock;
+    superblock.m_version = GRC::Superblock::CURRENT_VERSION;
+    superblock.m_projects.Add("project", GRC::Superblock::ProjectStats());
+
+    std::vector<unsigned char> bytes(16, 0);
+
+    for (uint32_t i = 0; ; i++) {
+        // Distinct CPIDs; duplicates would collapse in the index and loop forever.
+        bytes[0] = i         & 0xff;
+        bytes[1] = (i >>  8) & 0xff;
+        bytes[2] = (i >> 16) & 0xff;
+        bytes[3] = (i >> 24) & 0xff;
+
+        superblock.m_cpids.Add(GRC::Cpid(bytes), GRC::Magnitude::RoundFrom(1));
+
+        // Checking every entry would dominate the runtime of this file.
+        if ((i & 0x3ff) == 0
+            && ::GetSerializeSize(superblock, SER_NETWORK, PROTOCOL_VERSION) >= target)
+        {
+            break;
+        }
+    }
+
+    return superblock;
+}
+
+//! A coinbase carrying a claim, optionally with a superblock attached.
+CTransaction CoinbaseWithClaim(const GRC::Superblock* const superblock)
+{
+    GRC::Claim claim;
+    claim.m_version = GRC::Claim::CURRENT_VERSION;
+    claim.m_client_version = "test";
+
+    // Enough for WellFormed(): a valid mining id and a subsidy. Noncruncher
+    // deliberately, so the claim needs no research subsidy or signature -- the
+    // rules under test are about size and position, not about rewards.
+    claim.m_mining_id = GRC::MiningId::ForNoncruncher();
+    claim.m_block_subsidy = 1;
+
+    if (superblock != nullptr) {
+        claim.m_superblock.Replace(GRC::Superblock(*superblock));
+        claim.m_quorum_hash = claim.m_superblock->GetHash();
+    }
+
+    CMutableTransaction tx;
+    tx.nVersion = 2;
+    tx.nTime = 1000;  // before the block time set in BlockOf()
+    tx.vin.resize(1);
+    tx.vin[0].prevout.SetNull();
+    tx.vin[0].scriptSig = CScript() << OP_11 << OP_11;  // within the 2..100 coinbase bound
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1;
+    tx.vContracts.emplace_back(GRC::MakeContract<GRC::Claim>(GRC::ContractAction::ADD, claim));
+
+    return CTransaction(tx);
+}
+
+//! An ordinary transaction, optionally carrying a claim of its own.
+CTransaction OrdinaryTx(const uint32_t nonce, const GRC::Superblock* const superblock)
+{
+    CMutableTransaction tx;
+    tx.nVersion = 2;
+    tx.nTime = 1000;  // before the block time set in BlockOf()
+    tx.vin.resize(1);
+    tx.vin[0].prevout = COutPoint(uint256{nonce + 1}, 0);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1;
+
+    if (superblock != nullptr) {
+        GRC::Claim claim;
+        claim.m_version = GRC::Claim::CURRENT_VERSION;
+        claim.m_client_version = "test";
+        claim.m_mining_id = GRC::MiningId::ForNoncruncher();
+        claim.m_block_subsidy = 1;
+        claim.m_superblock.Replace(GRC::Superblock(*superblock));
+        claim.m_quorum_hash = claim.m_superblock->GetHash();
+
+        tx.vContracts.emplace_back(GRC::MakeContract<GRC::Claim>(GRC::ContractAction::ADD, claim));
+    }
+
+    return CTransaction(tx);
+}
+
+CBlock BlockOf(const int32_t version, std::vector<CTransaction> vtx)
+{
+    CBlock block;
+    block.nVersion = version;
+    block.nTime = 2000;  // at or after every transaction's nTime
+    block.hashPrevBlock = uint256{1};  // not the genesis short-circuit
+    block.vtx = std::move(vtx);
+
+    return block;
+}
+
+//! CheckBlock with the expensive contextual checks off. Those are not what any
+//! of this is about, and leaving them on would mean forging a proof and a
+//! merkle root to reach the size accounting.
+bool CheckBlockSizeOnly(CBlock& block)
+{
+    CValidationState state;
+
+    // Height below nGrandfather, so the difficulty check does not fire; the
+    // rules under test key on the block's version, not on this.
+    return CheckBlock(block, state, 1000, false, false, false);
+}
+} // namespace
+
 //!
 //! Under v15 rules the block size bounds are additive and independent:
 //! block-excluding-superblock <= MAX_BLOCK_SIZE, and superblock <=
@@ -220,39 +333,91 @@ BOOST_AUTO_TEST_CASE(v15_script_flags_close_malleability_at_activation)
 //! Independent on purpose. A single combined ceiling would make each side's
 //! headroom depend on the other -- a large superblock eating the room for
 //! ordinary transactions, a full block capping the superblock -- and it also
-//! means the superblock's own limit finally binds: while the block measurement
-//! includes the superblock's bytes and the block ceiling is the smaller of the
-//! two, the Superblock::MAX_SIZE term can never be reached.
+//! means the superblock's own limit finally binds.
 //!
-//! Keyed on the block's own version rather than a height, because CheckBlock()
-//! is given the tip's next height and that is not this block's height for an
-//! orphan, an out-of-order arrival, or a node catching up -- and fChecked makes
-//! that first verdict stick. Misjudging it around an activation would reject a
-//! valid block and score the honest peer that relayed it.
+//! The pair below differs only in the block's version, which is what selects
+//! the rule, so it fails if the envelope is removed, keyed on the wrong
+//! version, or serialized with the wrong flags.
 //!
-BOOST_AUTO_TEST_CASE(the_superblock_size_envelope_keys_on_block_version)
+BOOST_AUTO_TEST_CASE(the_superblock_leaves_the_block_bound_only_under_v15_rules)
 {
+    LOCK(cs_main);
+
     // Inert until v15 is scheduled.
     BOOST_REQUIRE_EQUAL(GetBlockV15Height(), std::numeric_limits<int>::max());
 
-    // The flag that separates the two measurements. Combined with AND -- as a
-    // plain reading of the two constants might suggest -- it yields neither.
-    BOOST_CHECK_EQUAL(SER_NETWORK & SER_SKIPSUPERBLOCK, 0);
-    BOOST_CHECK(((SER_NETWORK | SER_SKIPSUPERBLOCK) & SER_SKIPSUPERBLOCK) != 0);
+    // Over the block bound on its own, but inside its own bound.
+    const GRC::Superblock superblock = SuperblockOfAtLeast(MAX_BLOCK_SIZE + 1);
+    BOOST_REQUIRE_GT(::GetSerializeSize(superblock, SER_NETWORK, PROTOCOL_VERSION), MAX_BLOCK_SIZE);
+    BOOST_REQUIRE_LT(::GetSerializeSize(superblock, SER_NETWORK, PROTOCOL_VERSION), GRC::Superblock::MAX_SIZE);
 
-    // The envelope the two bounds describe.
-    BOOST_CHECK_EQUAL(MAX_BLOCK_SIZE, 1000000u);
-    BOOST_CHECK_EQUAL(GRC::Superblock::MAX_SIZE, 4000000u);
+    // v15: measured without the superblock, so the block is small and passes.
+    CBlock v15 = BlockOf(15, {CoinbaseWithClaim(&superblock), OrdinaryTx(1, nullptr)});
+    BOOST_CHECK(CheckBlockSizeOnly(v15));
 
-    // A pre-v15 block does not get the v15 envelope whatever height it is
-    // checked at -- which is the property that keying on version buys.
-    CBlock pre;
-    pre.nVersion = 14;
-    BOOST_CHECK(pre.nVersion < 15);
+    // The same block one version earlier: the superblock counts against the
+    // block bound, and it alone is over.
+    CBlock v14 = BlockOf(14, {CoinbaseWithClaim(&superblock), OrdinaryTx(1, nullptr)});
+    BOOST_CHECK(!CheckBlockSizeOnly(v14));
+}
 
-    CBlock at;
-    at.nVersion = 15;
-    BOOST_CHECK(at.nVersion >= 15);
+//!
+//! The superblock's own bound still binds under v15 -- excluding it from the
+//! block measurement is not the same as leaving it unmeasured.
+//!
+BOOST_AUTO_TEST_CASE(a_superblock_over_its_own_bound_is_refused_under_v15_rules)
+{
+    LOCK(cs_main);
+
+    const GRC::Superblock oversize = SuperblockOfAtLeast(GRC::Superblock::MAX_SIZE + 1);
+    BOOST_REQUIRE_GT(::GetSerializeSize(oversize, SER_NETWORK, PROTOCOL_VERSION), GRC::Superblock::MAX_SIZE);
+
+    CBlock block = BlockOf(15, {CoinbaseWithClaim(&oversize), OrdinaryTx(1, nullptr)});
+    BOOST_CHECK(!CheckBlockSizeOnly(block));
+}
+
+//!
+//! A claim belongs in the coinbase and nowhere else.
+//!
+//! The accounting takes that as given: the block is measured with
+//! SER_SKIPSUPERBLOCK, which drops the superblock from every claim the
+//! serializer walks, while the separate superblock measurement resolves through
+//! CBlock::GetClaim() and reads vtx[0]. A claim carried anywhere else is
+//! subtracted by the first and invisible to the second, so nothing bounds it.
+//!
+//! Reaching that gap needs BOTH halves. The coinbase has to carry a well-formed
+//! superblock of its own, since that is what turns the skip flag on; without it
+//! the block is measured whole and refused on plain size, which would make this
+//! pass for a reason that has nothing to do with the rule under test.
+//!
+BOOST_AUTO_TEST_CASE(a_claim_outside_the_coinbase_is_refused_under_v15_rules)
+{
+    LOCK(cs_main);
+
+    const GRC::Superblock small = SuperblockOfAtLeast(1);
+    const GRC::Superblock large = SuperblockOfAtLeast(MAX_BLOCK_SIZE + 1);
+
+    CBlock stray = BlockOf(15, {CoinbaseWithClaim(&small), OrdinaryTx(1, &large)});
+
+    // Measured whole, the block is over the bound.
+    BOOST_CHECK_GT(::GetSerializeSize(stray, SER_NETWORK, PROTOCOL_VERSION), MAX_BLOCK_SIZE);
+
+    // Measured the way the v15 rule measures it, the bytes are gone.
+    BOOST_CHECK_LT(::GetSerializeSize(stray, SER_NETWORK | SER_SKIPSUPERBLOCK, PROTOCOL_VERSION),
+                   MAX_BLOCK_SIZE);
+
+    // And the superblock bound cannot see them either: GetSuperblock() reads
+    // vtx[0], which carries only the small one.
+    BOOST_CHECK_LT(::GetSerializeSize(stray.GetSuperblock(), SER_NETWORK, PROTOCOL_VERSION),
+                   GRC::Superblock::MAX_SIZE);
+
+    // Both bounds satisfied, so nothing but the position of the claim refuses it.
+    BOOST_CHECK(!CheckBlockSizeOnly(stray));
+
+    // The same block with the stray claim removed is accepted, which is what
+    // makes the case above discriminating rather than a block that fails anyway.
+    CBlock clean = BlockOf(15, {CoinbaseWithClaim(&small), OrdinaryTx(1, nullptr)});
+    BOOST_CHECK(CheckBlockSizeOnly(clean));
 }
 
 BOOST_AUTO_TEST_CASE(an_empty_block_is_refused_before_vtx_is_read)

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -213,53 +213,48 @@ BOOST_AUTO_TEST_CASE(v15_script_flags_close_malleability_at_activation)
 
 
 //!
-//! From v15 the block size bounds are additive and independent:
+//! Under v15 rules the block size bounds are additive and independent:
 //! block-excluding-superblock <= MAX_BLOCK_SIZE, and superblock <=
 //! Superblock::MAX_SIZE.
 //!
 //! Independent on purpose. A single combined ceiling would make each side's
 //! headroom depend on the other -- a large superblock eating the room for
-//! ordinary transactions, a full block capping the superblock. It also means
-//! the superblock's own limit finally binds: while the block measurement
+//! ordinary transactions, a full block capping the superblock -- and it also
+//! means the superblock's own limit finally binds: while the block measurement
 //! includes the superblock's bytes and the block ceiling is the smaller of the
 //! two, the Superblock::MAX_SIZE term can never be reached.
 //!
-//! Inert today: BlockV15Height is numeric_limits<int>::max(), so every
-//! reachable height keeps the combined measurement.
+//! Keyed on the block's own version rather than a height, because CheckBlock()
+//! is given the tip's next height and that is not this block's height for an
+//! orphan, an out-of-order arrival, or a node catching up -- and fChecked makes
+//! that first verdict stick. Misjudging it around an activation would reject a
+//! valid block and score the honest peer that relayed it.
 //!
-BOOST_AUTO_TEST_CASE(the_superblock_size_envelope_is_gated_and_additive)
+BOOST_AUTO_TEST_CASE(the_superblock_size_envelope_keys_on_block_version)
 {
+    // Inert until v15 is scheduled.
     BOOST_REQUIRE_EQUAL(GetBlockV15Height(), std::numeric_limits<int>::max());
 
-    // The gate is closed at every height reachable today.
-    for (const int h : {0, 1000000, 3989999, 3990000, 4000000, 100000000}) {
-        BOOST_CHECK_MESSAGE(!IsV15Enabled(h), "v15 gate open at height " << h);
-    }
-
-    // The flag that makes the two measurements separable. Combined with AND --
-    // as a plain reading of the two constants might suggest -- it yields
-    // neither flag, and the claim serializer would emit the superblock into a
-    // measurement meant to exclude it.
+    // The flag that separates the two measurements. Combined with AND -- as a
+    // plain reading of the two constants might suggest -- it yields neither.
     BOOST_CHECK_EQUAL(SER_NETWORK & SER_SKIPSUPERBLOCK, 0);
-    BOOST_CHECK((( SER_NETWORK | SER_SKIPSUPERBLOCK) & SER_SKIPSUPERBLOCK) != 0);
+    BOOST_CHECK(((SER_NETWORK | SER_SKIPSUPERBLOCK) & SER_SKIPSUPERBLOCK) != 0);
 
-    // And the envelope the two bounds describe once open.
+    // The envelope the two bounds describe.
     BOOST_CHECK_EQUAL(MAX_BLOCK_SIZE, 1000000u);
     BOOST_CHECK_EQUAL(GRC::Superblock::MAX_SIZE, 4000000u);
+
+    // A pre-v15 block does not get the v15 envelope whatever height it is
+    // checked at -- which is the property that keying on version buys.
+    CBlock pre;
+    pre.nVersion = 14;
+    BOOST_CHECK(pre.nVersion < 15);
+
+    CBlock at;
+    at.nVersion = 15;
+    BOOST_CHECK(at.nVersion >= 15);
 }
 
-
-//!
-//! A block with no transactions is refused before anything reads vtx[0].
-//!
-//! CheckBlock() receives blocks straight off the wire -- ProcessMessage
-//! deserializes a peer-supplied CBlock and ProcessBlock calls through to here
-//! with no emptiness check of its own -- so an empty vtx is attacker-supplied
-//! input. Everything in the size-limit block reaches GetSuperblock(), which
-//! goes through CBlock::GetClaim() and indexes vtx[0] unconditionally, so the
-//! emptiness test has to come first and has to stand alone rather than sit in
-//! a || chain that a later reordering could disturb.
-//!
 BOOST_AUTO_TEST_CASE(an_empty_block_is_refused_before_vtx_is_read)
 {
     LOCK(cs_main);

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -3,6 +3,9 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <validation.h>
+#include <chainparams.h>
+#include <script/interpreter.h>
+#include <script/script.h>
 #include <txdb.h>
 #include <primitives/transaction.h>
 
@@ -129,6 +132,38 @@ BOOST_AUTO_TEST_CASE(a_clean_input_set_reaches_the_signature_loop)
                         CDiskTxPos(1, 1, 1), &index, /*fBlock=*/false, /*fMiner=*/false);
 
     BOOST_CHECK_EQUAL(g_connectinputs_signature_checks.load() - before, 1u);
+}
+
+
+//!
+//! Script flags are evaluated at the height the transaction will be validated
+//! IN, which is not always the height of the index the caller happens to hold.
+//!
+//! Connecting a block, that index IS the block. On the mempool and miner paths
+//! it is the PREVIOUS block, and the transaction is bound for the next one --
+//! so both were a height low. Harmless while no activation boundary is nearby,
+//! and a lost stake at the next one: a staker computing pre-fork flags builds a
+//! block that validators, computing post-fork flags, reject.
+//!
+BOOST_AUTO_TEST_CASE(script_flags_follow_the_height_a_transaction_lands_at)
+{
+    const int v14 = Params().GetConsensus().BlockV14Height;
+
+    // Straddling the activation, the flag set differs by exactly one height.
+    const unsigned int before = GetBlockScriptFlags(v14 - 1);
+    const unsigned int at     = GetBlockScriptFlags(v14);
+
+    BOOST_CHECK((before & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY) == 0);
+    BOOST_CHECK((at & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY) != 0);
+    BOOST_CHECK((at & SCRIPT_VERIFY_CHECKSEQUENCEVERIFY) != 0);
+
+    // P2SH is unconditional on both sides.
+    BOOST_CHECK((before & SCRIPT_VERIFY_P2SH) != 0);
+    BOOST_CHECK((at & SCRIPT_VERIFY_P2SH) != 0);
+
+    // The distinction the fix turns on: a miner or mempool holding the index at
+    // v14 - 1 is building for v14, and must use v14's flags, not that index's.
+    BOOST_CHECK(before != at);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -5,6 +5,8 @@
 #include <validation.h>
 #include <chainparams.h>
 #include <policy/policy.h>
+#include <gridcoin/superblock.h>
+#include <consensus/consensus.h>
 #include <limits>
 #include <script/interpreter.h>
 #include <script/script.h>
@@ -207,6 +209,43 @@ BOOST_AUTO_TEST_CASE(v15_script_flags_close_malleability_at_activation)
     BOOST_CHECK((at & SCRIPT_VERIFY_P2SH) != 0);
     BOOST_CHECK((at & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY) != 0);
     BOOST_CHECK((at & SCRIPT_VERIFY_CHECKSEQUENCEVERIFY) != 0);
+}
+
+
+//!
+//! From v15 the block size bounds are additive and independent:
+//! block-excluding-superblock <= MAX_BLOCK_SIZE, and superblock <=
+//! Superblock::MAX_SIZE.
+//!
+//! Independent on purpose. A single combined ceiling would make each side's
+//! headroom depend on the other -- a large superblock eating the room for
+//! ordinary transactions, a full block capping the superblock. It also means
+//! the superblock's own limit finally binds: while the block measurement
+//! includes the superblock's bytes and the block ceiling is the smaller of the
+//! two, the Superblock::MAX_SIZE term can never be reached.
+//!
+//! Inert today: BlockV15Height is numeric_limits<int>::max(), so every
+//! reachable height keeps the combined measurement.
+//!
+BOOST_AUTO_TEST_CASE(the_superblock_size_envelope_is_gated_and_additive)
+{
+    BOOST_REQUIRE_EQUAL(GetBlockV15Height(), std::numeric_limits<int>::max());
+
+    // The gate is closed at every height reachable today.
+    for (const int h : {0, 1000000, 3989999, 3990000, 4000000, 100000000}) {
+        BOOST_CHECK_MESSAGE(!IsV15Enabled(h), "v15 gate open at height " << h);
+    }
+
+    // The flag that makes the two measurements separable. Combined with AND --
+    // as a plain reading of the two constants might suggest -- it yields
+    // neither flag, and the claim serializer would emit the superblock into a
+    // measurement meant to exclude it.
+    BOOST_CHECK_EQUAL(SER_NETWORK & SER_SKIPSUPERBLOCK, 0);
+    BOOST_CHECK((( SER_NETWORK | SER_SKIPSUPERBLOCK) & SER_SKIPSUPERBLOCK) != 0);
+
+    // And the envelope the two bounds describe once open.
+    BOOST_CHECK_EQUAL(MAX_BLOCK_SIZE, 1000000u);
+    BOOST_CHECK_EQUAL(GRC::Superblock::MAX_SIZE, 4000000u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -4,6 +4,8 @@
 
 #include <validation.h>
 #include <chainparams.h>
+#include <policy/policy.h>
+#include <limits>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <txdb.h>
@@ -164,6 +166,47 @@ BOOST_AUTO_TEST_CASE(script_flags_follow_the_height_a_transaction_lands_at)
     // The distinction the fix turns on: a miner or mempool holding the index at
     // v14 - 1 is building for v14, and must use v14's flags, not that index's.
     BOOST_CHECK(before != at);
+}
+
+
+//!
+//! The v15 malleability flags are gated, and inert until v15 is scheduled.
+//!
+//! Landing them early is only safe if they genuinely do nothing at present.
+//! BlockV15Height is numeric_limits<int>::max() until a release schedules it,
+//! so every reachable height must produce the pre-v15 flag set.
+//!
+BOOST_AUTO_TEST_CASE(v15_script_flags_are_inert_until_v15_is_scheduled)
+{
+    const int v15 = GetBlockV15Height();
+
+    // Unscheduled today. If this ever fails, v15 has been given a height and
+    // the assertions below need revisiting rather than deleting.
+    BOOST_REQUIRE_EQUAL(v15, std::numeric_limits<int>::max());
+
+    for (const int h : {0, 1, 1000000, 3989999, 3990000, 4000000, 100000000}) {
+        const unsigned int flags = GetBlockScriptFlags(h);
+        BOOST_CHECK_MESSAGE((flags & V15_SCRIPT_VERIFY_FLAGS) == 0,
+                            "v15 flags leaked at height " << h);
+    }
+}
+
+//!
+//! And that they are the right flags once it is.
+//!
+BOOST_AUTO_TEST_CASE(v15_script_flags_close_malleability_at_activation)
+{
+    // Below the gate: none of them. At and above: all of them, and the v14 set
+    // is still present, since v15 adds rather than replaces.
+    const unsigned int below = GetBlockScriptFlags(std::numeric_limits<int>::max() - 1);
+    BOOST_CHECK((below & SCRIPT_VERIFY_LOW_S) == 0);
+
+    const unsigned int at = GetBlockScriptFlags(std::numeric_limits<int>::max());
+    BOOST_CHECK((at & V15_SCRIPT_VERIFY_FLAGS) == V15_SCRIPT_VERIFY_FLAGS);
+    BOOST_CHECK((at & SCRIPT_VERIFY_LOW_S) != 0);
+    BOOST_CHECK((at & SCRIPT_VERIFY_P2SH) != 0);
+    BOOST_CHECK((at & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY) != 0);
+    BOOST_CHECK((at & SCRIPT_VERIFY_CHECKSEQUENCEVERIFY) != 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -248,4 +248,31 @@ BOOST_AUTO_TEST_CASE(the_superblock_size_envelope_is_gated_and_additive)
     BOOST_CHECK_EQUAL(GRC::Superblock::MAX_SIZE, 4000000u);
 }
 
+
+//!
+//! A block with no transactions is refused before anything reads vtx[0].
+//!
+//! CheckBlock() receives blocks straight off the wire -- ProcessMessage
+//! deserializes a peer-supplied CBlock and ProcessBlock calls through to here
+//! with no emptiness check of its own -- so an empty vtx is attacker-supplied
+//! input. Everything in the size-limit block reaches GetSuperblock(), which
+//! goes through CBlock::GetClaim() and indexes vtx[0] unconditionally, so the
+//! emptiness test has to come first and has to stand alone rather than sit in
+//! a || chain that a later reordering could disturb.
+//!
+BOOST_AUTO_TEST_CASE(an_empty_block_is_refused_before_vtx_is_read)
+{
+    LOCK(cs_main);
+
+    CBlock block;
+    block.nVersion = 11;
+    BOOST_REQUIRE(block.vtx.empty());
+
+    CValidationState state;
+
+    // Must return false rather than crash. Before the guard was hoisted this
+    // dereferenced vtx[0] on an empty vector.
+    BOOST_CHECK(!CheckBlock(block, state, 1, false, false, false, false));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <validation.h>
+#include <txdb.h>
+#include <primitives/transaction.h>
+
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_AUTO_TEST_SUITE(connectinputs_tests)
+
+//!
+//! A transaction carrying an already-spent outpoint costs no signature
+//! verifications, whatever position that outpoint occupies.
+//!
+//! This is the ordering guarantee, and it is invisible to a test that only
+//! checks the return value: the transaction is rejected either way. What the
+//! conflict pre-scan changes is the COST of rejecting it. With the conflict
+//! check interleaved in the signature loop, every input ahead of the
+//! conflicting one is verified first -- at MAX_STANDARD_TX_SIZE roughly 675
+//! ECDSA operations under cs_main, for a transaction that was never going to be
+//! accepted, and which earns the sender no misbehaviour score.
+//!
+//! The signatures here are deliberately junk. They are never reached, which is
+//! the entire assertion; if a regression reaches them the count moves and this
+//! fails regardless of whether they would have verified.
+//!
+BOOST_AUTO_TEST_CASE(a_conflicting_input_costs_no_signature_verifications)
+{
+    LOCK(cs_main);
+
+    CBlockIndex index;
+    index.nHeight = nGrandfather + 1;   // past the grandfathered accept path
+
+    CMutableTransaction spender;
+    MapPrevTx inputs;
+
+    // Three inputs; the LAST one is already spent. Ahead of it sit two that a
+    // pre-scan must stop us from verifying.
+    for (int i = 0; i < 3; ++i) {
+        CMutableTransaction prev;
+        prev.vout.resize(1);
+
+        // Distinct values so the three hash differently. Identical prevs
+        // collapse to ONE entry in the map, every input then references the
+        // same already-spent outpoint, and the conflict is found at index 0 --
+        // where the old code bails before verifying anything too, so the test
+        // would pass with or without the pre-scan and guard nothing.
+        prev.vout[0].nValue = (i + 1) * COIN;
+
+        const CTransaction prev_tx(prev);
+        const uint256 prev_hash = prev_tx.GetHash();
+
+        CTxIndex txindex;
+        txindex.vSpent.resize(1);
+        if (i == 2) txindex.vSpent[0] = CDiskTxPos(1, 1, 1);
+
+        inputs[prev_hash] = {txindex, prev_tx};
+
+        spender.vin.emplace_back();
+        spender.vin.back().prevout = COutPoint(prev_hash, 0);
+        spender.vin.back().scriptSig = CScript() << OP_1;   // junk, never reached
+    }
+
+    spender.vout.resize(1);
+    spender.vout[0].nValue = 1 * COIN;
+
+    BOOST_REQUIRE_EQUAL(inputs.size(), 3u);   // three DISTINCT prevouts
+
+    CTransaction tx(spender);
+    CValidationState state;
+    CTxDB txdb("r");
+    std::map<uint256, CTxIndex> test_pool;
+
+    const uint64_t before = g_connectinputs_signature_checks.load();
+
+    const bool accepted = ConnectInputs(tx, state, txdb, inputs, test_pool,
+                                        CDiskTxPos(1, 1, 1), &index,
+                                        /*fBlock=*/false, /*fMiner=*/false);
+
+    const uint64_t verifications = g_connectinputs_signature_checks.load() - before;
+
+    BOOST_CHECK(!accepted);
+    BOOST_CHECK_EQUAL(verifications, 0u);
+}
+
+//!
+//! The converse, so the test above cannot pass by never reaching the loop at
+//! all: with no conflict, the signature loop IS entered and does verify.
+//!
+BOOST_AUTO_TEST_CASE(a_clean_input_set_reaches_the_signature_loop)
+{
+    LOCK(cs_main);
+
+    CBlockIndex index;
+    index.nHeight = nGrandfather + 1;
+
+    CMutableTransaction spender;
+    MapPrevTx inputs;
+
+    CMutableTransaction prev;
+    prev.vout.resize(1);
+    prev.vout[0].nValue = 1 * COIN;
+
+    const CTransaction prev_tx(prev);
+    const uint256 prev_hash = prev_tx.GetHash();
+
+    CTxIndex txindex;
+    txindex.vSpent.resize(1);          // unspent
+    inputs[prev_hash] = {txindex, prev_tx};
+
+    spender.vin.emplace_back();
+    spender.vin.back().prevout = COutPoint(prev_hash, 0);
+    spender.vin.back().scriptSig = CScript() << OP_1;
+
+    spender.vout.resize(1);
+    spender.vout[0].nValue = 1 * COIN;
+
+    CTransaction tx(spender);
+    CValidationState state;
+    CTxDB txdb("r");
+    std::map<uint256, CTxIndex> test_pool;
+
+    const uint64_t before = g_connectinputs_signature_checks.load();
+
+    (void)ConnectInputs(tx, state, txdb, inputs, test_pool,
+                        CDiskTxPos(1, 1, 1), &index, /*fBlock=*/false, /*fMiner=*/false);
+
+    BOOST_CHECK_EQUAL(g_connectinputs_signature_checks.load() - before, 1u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -282,7 +282,7 @@ CTransaction OrdinaryTx(const uint32_t nonce, const GRC::Superblock* const super
     tx.nVersion = 2;
     tx.nTime = 1000;  // before the block time set in BlockOf()
     tx.vin.resize(1);
-    tx.vin[0].prevout = COutPoint(uint256{nonce + 1}, 0);
+    tx.vin[0].prevout = COutPoint(uint256(nonce + 1), 0);
     tx.vout.resize(1);
     tx.vout[0].nValue = 1;
 

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -420,6 +420,39 @@ BOOST_AUTO_TEST_CASE(a_claim_outside_the_coinbase_is_refused_under_v15_rules)
     BOOST_CHECK(CheckBlockSizeOnly(clean));
 }
 
+//!
+//! A coinbase carrying no contracts at all.
+//!
+//! CBlock::GetClaim() indexes vtx[0].vContracts[0] on the strength of the block
+//! version alone, and the size accounting reaches it through GetSuperblock()
+//! before anything has established that the vector holds a claim. Blocks are
+//! deserialized from untrusted input, so an empty vContracts is a shape that has
+//! to be handled rather than assumed away.
+//!
+//! Note this case does not fail by returning the wrong answer if the guard is
+//! removed -- it fails by faulting.
+//!
+BOOST_AUTO_TEST_CASE(a_coinbase_with_no_contracts_is_refused_before_the_claim_is_read)
+{
+    LOCK(cs_main);
+
+    CMutableTransaction cb;
+    cb.nVersion = 2;
+    cb.nTime = 1000;
+    cb.vin.resize(1);
+    cb.vin[0].prevout.SetNull();
+    cb.vin[0].scriptSig = CScript() << OP_11 << OP_11;
+    cb.vout.resize(1);
+    cb.vout[0].nValue = 1;
+    // vContracts deliberately left empty.
+
+    CBlock block = BlockOf(14, {CTransaction(cb)});
+    BOOST_REQUIRE(block.vtx[0].vContracts.empty());
+    BOOST_REQUIRE(block.nVersion >= 11);
+
+    BOOST_CHECK(!CheckBlockSizeOnly(block));
+}
+
 BOOST_AUTO_TEST_CASE(an_empty_block_is_refused_before_vtx_is_read)
 {
     LOCK(cs_main);

--- a/src/test/gridcoin/pool_tests.cpp
+++ b/src/test/gridcoin/pool_tests.cpp
@@ -76,6 +76,8 @@ void DispatchApply(const CTransaction& tx, const CBlockIndex* pindex)
 {
     GRC::RegistryBookmarks bookmarks;
     bool found_contract = false;
+
+    LOCK(cs_main);
     GRC::ApplyContracts(tx, pindex, bookmarks, found_contract);
 }
 

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -162,6 +162,38 @@ CDataStream ManifestPrefix(size_t part_count, int beacon_list,
 } // anonymous namespace
 
 //!
+//! A manifest string field is bounded at its length prefix.
+//!
+//! sCManifestName, and each dentry's project and ETag, deserialize as plain
+//! std::string, which sizes the string from a declared CompactSize BEFORE
+//! reading anything back. So a message a few bytes long can declare 32 MiB and
+//! cost that allocation. Capping the number of dentries does nothing about it --
+//! one dentry is enough.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_an_oversized_manifest_string)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+
+    std::vector<uint256> vph(1);
+    vph[0] = Hash(std::vector<unsigned char>{1});
+
+    ss << vph;
+    ss << CPubKey();
+
+    // sCManifestName: a declared length far past the cap, with no data behind
+    // it. Unbounded, this sizes a 32 MiB string before discovering the stream is
+    // empty.
+    WriteCompactSize(ss, 32 * 1024 * 1024);
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK_THROW((void)manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
+}
+
+//!
 //! A negative part reference is refused.
 //!
 //! dentry::part1 and BeaconList are int and default to -1; partc and
@@ -285,8 +317,11 @@ BOOST_AUTO_TEST_CASE(unserializecheck_refuses_too_many_projects)
 
 //!
 //! The boundary from the other side: exactly at the cap is admitted, and fails
-//! later on the truncated stream instead. That pins the ceiling at 1020 rather
-//! than 1023.
+//! later on the truncated stream instead. The cap is MAX_MANIFEST_PROJECTS,
+//! i.e. 1024 dentries, which is what this pins. (The often-quoted "~1020
+//! projects" is a downstream consequence of that ceiling, not the ceiling
+//! itself: 1024 parts allows 1023 dentries once the beacon list takes one, and
+//! roughly three of those are pseudo-projects.)
 //!
 BOOST_AUTO_TEST_CASE(unserializecheck_admits_projects_at_the_cap)
 {

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -130,7 +130,8 @@ namespace {
 //! and a chainless test process is out of sync by age, which skips
 //! authorization.
 CDataStream ManifestPrefix(size_t part_count, int beacon_list,
-                           const std::vector<int>& project_part1s)
+                           const std::vector<int>& project_part1s,
+                           const std::vector<unsigned>& project_partcs = {})
 {
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
 
@@ -140,11 +141,11 @@ CDataStream ManifestPrefix(size_t part_count, int beacon_list,
     }
 
     std::vector<CScraperManifest::dentry> projects;
-    for (const int p : project_part1s) {
+    for (size_t i = 0; i < project_part1s.size(); ++i) {
         CScraperManifest::dentry d;
         d.project = "project";
-        d.part1 = p;
-        d.partc = 0;
+        d.part1 = project_part1s[i];
+        d.partc = i < project_partcs.size() ? project_partcs[i] : 0;
         projects.push_back(d);
     }
 
@@ -159,6 +160,53 @@ CDataStream ManifestPrefix(size_t part_count, int beacon_list,
     return ss;
 }
 } // anonymous namespace
+
+//!
+//! A negative part reference is refused.
+//!
+//! dentry::part1 and BeaconList are int and default to -1; partc and
+//! BeaconList_c are unsigned. Written as `part1 + partc >= vph.size()` the
+//! addition converts part1 to unsigned first, so part1 = -1 with partc = 1
+//! wraps to 0 and passes. The coverage loop does not catch it either: an
+//! unsigned induction variable starting at -1 begins at 0xFFFFFFFF, fails its
+//! condition immediately and marks nothing, so the manifest still reads as
+//! fully covered when its other references cover every part.
+//!
+//! An accepted manifest then carries a dentry with part1 = -1, and
+//! quorum.cpp bounds that index only from above while scraper.cpp does not
+//! bound it at all -- vParts[-1], dereferenced.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_a_negative_part_reference)
+{
+    // Two parts, both covered legitimately: the beacon list takes 0 and the
+    // first project takes 1. The second project is the malformed one, and its
+    // wrapped range contributes no coverage, so coverage alone cannot reject it.
+    CDataStream ss = ManifestPrefix(2, 0, {1, -1}, {0, 1});
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    // Must be a clean refusal. Before the fix this got past the range check and
+    // the coverage rule and reached the truncated stream, throwing instead.
+    BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
+}
+
+//!
+//! The beacon list is int as well, and takes the same treatment.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_a_negative_beacon_reference)
+{
+    CDataStream ss = ManifestPrefix(2, -1, {0, 1});
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
+}
 
 //!
 //! A part declared but referenced by nothing is refused. Without this a manifest

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -216,4 +216,40 @@ BOOST_AUTO_TEST_CASE(unserializecheck_refuses_a_reference_one_past_the_end)
     BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
 }
 
+//!
+//! The dentry vector is bounded at its length prefix too. Without it a manifest
+//! is limited only by the message ceiling, and a dentry costs about 20 bytes on
+//! the wire against roughly 88 resident, so deserializing amplifies ~4.4x.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_too_many_projects)
+{
+    // One part, and one dentry too many -- all referencing part 0, so nothing
+    // but the project cap can be what rejects this.
+    CDataStream ss = ManifestPrefix(1, 0, std::vector<int>(1025, 0));
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
+}
+
+//!
+//! The boundary from the other side: exactly at the cap is admitted, and fails
+//! later on the truncated stream instead. That pins the ceiling at 1020 rather
+//! than 1023.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_admits_projects_at_the_cap)
+{
+    CDataStream ss = ManifestPrefix(1, 0, std::vector<int>(1024, 0));
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK_THROW((void)manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -5,8 +5,10 @@
 #include "gridcoin/scraper/scraper_net.h"
 
 #include "hash.h"
+#include "key.h"
 #include "serialize.h"
 #include "streams.h"
+#include "util.h"
 #include "version.h"
 
 #include <boost/test/unit_test.hpp>
@@ -118,6 +120,100 @@ BOOST_AUTO_TEST_CASE(unserializecheck_admits_a_part_hash_vector_at_the_cap)
     LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
 
     BOOST_CHECK_THROW(manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
+}
+
+namespace {
+//! Build a manifest stream as far as the structural checks read it. The part
+//! list, the beacon-list reference and the project dentries are all that those
+//! checks consult, and they run before signature verification, so no key and no
+//! valid signature are needed. nTime is current so IsManifestCurrent() passes,
+//! and a chainless test process is out of sync by age, which skips
+//! authorization.
+CDataStream ManifestPrefix(size_t part_count, int beacon_list,
+                           const std::vector<int>& project_part1s)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+
+    std::vector<uint256> vph(part_count);
+    for (size_t i = 0; i < part_count; ++i) {
+        vph[i] = Hash(std::vector<unsigned char>{static_cast<unsigned char>(i + 1)});
+    }
+
+    std::vector<CScraperManifest::dentry> projects;
+    for (const int p : project_part1s) {
+        CScraperManifest::dentry d;
+        d.project = "project";
+        d.part1 = p;
+        d.partc = 0;
+        projects.push_back(d);
+    }
+
+    ss << vph;
+    ss << CPubKey();
+    ss << std::string("test-manifest");
+    ss << static_cast<int64_t>(GetAdjustedTime());
+    ss << uint256();
+    ss << beacon_list << static_cast<unsigned int>(0);
+    ss << projects;
+
+    return ss;
+}
+} // anonymous namespace
+
+//!
+//! A part declared but referenced by nothing is refused. Without this a manifest
+//! can declare parts it never uses; each is registered in the process-global
+//! mapParts and held until the manifest ages out, and reclamation is
+//! refcount-driven and so only happens afterwards.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_an_unreferenced_part)
+{
+    // Three parts; the beacon list covers 0 and one project covers 1. Part 2 is
+    // declared and referenced by nothing.
+    CDataStream ss = ManifestPrefix(3, 0, {1});
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
+}
+
+//!
+//! The converse: a fully covered part list gets past the coverage rule and fails
+//! later on the truncated stream instead, which is what shows the rule admits
+//! the shape our own publisher emits (beacon list at 0, one part per dentry).
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_admits_a_fully_referenced_part_list)
+{
+    CDataStream ss = ManifestPrefix(3, 0, {1, 2});
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK_THROW(manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
+}
+
+//!
+//! A reference ending exactly at vph.size() names one part past the end. The
+//! ranges are inclusive, so this must be refused -- it passed the previous
+//! comparison, which rejected only strictly-greater, and scraper.cpp indexes
+//! vParts[part1] without a bounds guard.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_a_reference_one_past_the_end)
+{
+    // Two parts, so the only valid indices are 0 and 1. part1 == 2 is one past.
+    CDataStream ss = ManifestPrefix(2, 0, {2});
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -75,6 +75,38 @@ BOOST_AUTO_TEST_CASE(addpartdata_still_accepts_a_non_empty_part)
 constexpr size_t kPartWireCap = 16 * 1024 * 1024;
 
 //!
+//! The project cap accounts for the pseudo-projects, at v15.
+//!
+//! projects.size() counts every dentry including the injected pseudo-projects;
+//! nMaxProjects is derived from the whitelist alone and none of them is a
+//! whitelist entry. They were therefore consuming the margin the +2 reserves
+//! for the whitelist shrinking between publisher and receiver -- three of a
+//! five-to-six margin on mainnet -- and the trip disposition is an immediate
+//! ban, not a soft rejection.
+//!
+//! Gated: correcting it changes when a node bans a peer, so both sides have to
+//! roll over together.
+//!
+BOOST_AUTO_TEST_CASE(the_pseudo_project_list_is_the_one_the_cap_is_derived_from)
+{
+    // The cap widens by exactly the number of pseudo-projects, so adding one to
+    // the list cannot silently narrow the shrinkage margin again.
+    BOOST_CHECK_EQUAL(MANIFEST_PSEUDO_PROJECTS.size(), 3u);
+
+    for (const std::string_view name : MANIFEST_PSEUDO_PROJECTS) {
+        BOOST_CHECK(IsManifestPseudoProject(std::string(name)));
+    }
+
+    // BeaconList is carried by its own index, not as a dentry, so it must NOT
+    // be in this list -- counting it would widen the cap for something that
+    // never consumed it.
+    BOOST_CHECK(!IsManifestPseudoProject("BeaconList"));
+
+    // And a real whitelist project is not one either.
+    BOOST_CHECK(!IsManifestPseudoProject("World_Community_Grid"));
+}
+
+//!
 //! The publishing path refuses an oversize part, and refuses it BEFORE
 //! registering anything.
 //!

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "gridcoin/scraper/scraper_net.h"
+
+#include "hash.h"
+#include "streams.h"
+#include "version.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(scraper_net_tests)
+
+//!
+//! An empty part is a peer or filesystem condition, not a programming error.
+//! It must be discarded and reported, never asserted on: asserts are live in
+//! release builds here (CMakeLists.txt applies -UNDEBUG globally), so aborting
+//! would turn a malformed input into a process termination.
+//!
+BOOST_AUTO_TEST_CASE(recvpart_discards_an_empty_part)
+{
+    CDataStream empty(SER_NETWORK, PROTOCOL_VERSION);
+    BOOST_REQUIRE(empty.empty());
+
+    // nullptr peer: this is the self-publishing path, and must not dereference.
+    BOOST_CHECK(CSplitBlob::RecvPart(nullptr, empty) == false);
+}
+
+//!
+//! Our own publishing path. A zero-byte part file -- a truncated write, a full
+//! disk, an interrupted gzip -- must not be registered, and must not abort.
+//!
+BOOST_AUTO_TEST_CASE(addpartdata_refuses_empty_data_and_registers_nothing)
+{
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+
+    CDataStream empty(SER_NETWORK, PROTOCOL_VERSION);
+
+    BOOST_CHECK_EQUAL(manifest->addPartData(std::move(empty)), -1);
+
+    LOCK(manifest->cs_manifest);
+    BOOST_CHECK_EQUAL(manifest->vParts.size(), 0u);
+}
+
+//!
+//! Control: a non-empty part is still accepted and indexed from zero, so the
+//! guard above rejects only what it is meant to.
+//!
+BOOST_AUTO_TEST_CASE(addpartdata_still_accepts_a_non_empty_part)
+{
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+
+    CDataStream data(SER_NETWORK, PROTOCOL_VERSION);
+    data << std::string("a non-empty part");
+
+    BOOST_CHECK_EQUAL(manifest->addPartData(std::move(data)), 0);
+
+    LOCK(manifest->cs_manifest);
+    BOOST_CHECK_EQUAL(manifest->vParts.size(), 1u);
+}
+
+//!
+//! The constant UnserializeCheck() screens manifest part lists against. Pinned
+//! here so a change to the hash function cannot silently move it: a manifest
+//! declaring this hash can never be satisfied, because RecvPart discards the
+//! only content that would produce it.
+//!
+BOOST_AUTO_TEST_CASE(the_empty_content_hash_is_the_documented_constant)
+{
+    const uint256 empty_hash = Hash(std::vector<unsigned char>{});
+
+    BOOST_CHECK_EQUAL(
+        empty_hash.ToString(),
+        "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(unserializecheck_admits_a_part_hash_vector_at_the_cap)
 
     LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
 
-    BOOST_CHECK_THROW(manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
+    BOOST_CHECK_THROW((void)manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
 }
 
 namespace {
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(unserializecheck_admits_a_fully_referenced_part_list)
 
     LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
 
-    BOOST_CHECK_THROW(manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
+    BOOST_CHECK_THROW((void)manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
 }
 
 //!

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -5,11 +5,13 @@
 #include "gridcoin/scraper/scraper_net.h"
 
 #include "hash.h"
+#include "serialize.h"
 #include "streams.h"
 #include "version.h"
 
 #include <boost/test/unit_test.hpp>
 
+#include <ios>
 #include <memory>
 #include <vector>
 
@@ -76,6 +78,46 @@ BOOST_AUTO_TEST_CASE(the_empty_content_hash_is_the_documented_constant)
     BOOST_CHECK_EQUAL(
         empty_hash.ToString(),
         "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d");
+}
+
+//!
+//! The part-hash vector is the first field on the wire, so its length prefix is
+//! reachable with no signature and no valid manifest behind it. A count above
+//! the ceiling must be refused, and must NOT penalise the peer: the ceiling sits
+//! far above any legitimate manifest, so if it is ever wrong it must not ban.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_an_oversized_part_hash_vector)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    WriteCompactSize(ss, 1025);   // one over the cap, nothing behind it
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+
+    // Sentinel: the guard must actively zero this, not merely leave it alone.
+    unsigned int banscore = 12345;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
+    BOOST_CHECK_EQUAL(banscore, 0u);
+}
+
+//!
+//! The boundary, from the other side. A count exactly at the ceiling is admitted
+//! by the cap and then fails on the truncated stream instead -- a different
+//! failure mode, which is what pins the ceiling at 1024 rather than 1023.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_admits_a_part_hash_vector_at_the_cap)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    WriteCompactSize(ss, 1024);   // exactly at the cap, still nothing behind it
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK_THROW(manifest->UnserializeCheck(ss, banscore), std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -67,6 +67,57 @@ BOOST_AUTO_TEST_CASE(addpartdata_still_accepts_a_non_empty_part)
     BOOST_CHECK_EQUAL(manifest->vParts.size(), 1u);
 }
 
+//! Mirrors MAX_PART_WIRE_BYTES, which is file-local to scraper_net.cpp by
+//! design. Pinned here the same way the manifest caps are pinned below: if the
+//! implementation constant moves, the boundary cases stop straddling it and
+//! addpartdata_refuses_an_oversized_part_and_registers_nothing starts passing
+//! for the wrong reason. Keep them in step.
+constexpr size_t kPartWireCap = 16 * 1024 * 1024;
+
+//!
+//! The publishing path refuses an oversize part, and refuses it BEFORE
+//! registering anything.
+//!
+//! addPartData discards RecvPart's return value, so a part this side accepts
+//! but every receiver rejects would be handed back as a valid index, Complete()
+//! would still run, and the manifest would be advertised with a part no peer
+//! can be served -- permanently incompletable, for that project, network-wide.
+//! The write side has to agree with the read side.
+//!
+BOOST_AUTO_TEST_CASE(addpartdata_refuses_an_oversized_part_and_registers_nothing)
+{
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    const size_t before = CSplitBlob::mapParts.size();
+
+    CDataStream oversize(SER_NETWORK, PROTOCOL_VERSION);
+    oversize.resize(kPartWireCap + 1);
+
+    BOOST_CHECK_EQUAL(manifest->addPartData(std::move(oversize)), -1);
+
+    // Nothing registered: not in the global part map, and no part appended.
+    BOOST_CHECK_EQUAL(CSplitBlob::mapParts.size(), before);
+    BOOST_CHECK(manifest->vParts.empty());
+}
+
+//!
+//! And the boundary from the other side: exactly at the cap is accepted.
+//!
+BOOST_AUTO_TEST_CASE(addpartdata_accepts_a_part_at_the_cap)
+{
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    CDataStream at_cap(SER_NETWORK, PROTOCOL_VERSION);
+    at_cap.resize(kPartWireCap);
+
+    BOOST_CHECK_EQUAL(manifest->addPartData(std::move(at_cap)), 0);
+    BOOST_CHECK_EQUAL(manifest->vParts.size(), 1u);
+}
+
 //!
 //! The constant UnserializeCheck() screens manifest part lists against. Pinned
 //! here so a change to the hash function cannot silently move it: a manifest

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -344,6 +344,60 @@ BOOST_AUTO_TEST_CASE(unserializecheck_refuses_an_unreferenced_part)
 }
 
 //!
+//! The signature is a wire-driven length like any other, and it is read on the
+//! unauthenticated path: the out-of-sync branch sets bCheckedAuthorized = false
+//! and carries on, so the bounds in UnserializeCheck() -- not the authorization
+//! check -- are what limit what an unknown sender can cost.
+//!
+//! Both the bounded and unbounded forms throw on this input, so asserting the
+//! throw alone would prove nothing. The message is the discriminator: refused on
+//! the declared length, before the allocation, rather than after running off the
+//! end of a stream that was never that long.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_refuses_an_oversized_signature_on_its_prefix)
+{
+    CDataStream ss = ManifestPrefix(3, 0, {1, 2});
+
+    ss << uint256();  // nContentHash
+
+    // A signature far larger than any key could produce, and no bytes behind it.
+    WriteCompactSize(ss, 5000000);
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK_EXCEPTION(
+        (void)manifest->UnserializeCheck(ss, banscore),
+        std::ios_base::failure,
+        [](const std::ios_base::failure& e) {
+            return std::string(e.what()).find("Vector length limit exceeded") != std::string::npos;
+        });
+}
+
+//!
+//! The bound is set at the largest DER signature CKey::Sign() can produce, so a
+//! signature of that size has to get through it. This one is refused later, on
+//! verification against a default public key -- which is the point: it is past
+//! the length check, so the check cannot be rejecting real signatures.
+//!
+BOOST_AUTO_TEST_CASE(unserializecheck_admits_a_maximum_length_signature)
+{
+    CDataStream ss = ManifestPrefix(3, 0, {1, 2});
+
+    ss << uint256();  // nContentHash
+    ss << std::vector<unsigned char>(CPubKey::SIGNATURE_SIZE, 0x01);
+
+    auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
+    unsigned int banscore = 0;
+
+    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+
+    BOOST_CHECK(manifest->UnserializeCheck(ss, banscore) == false);
+}
+
+//!
 //! The converse: a fully covered part list gets past the coverage rule and fails
 //! later on the truncated stream instead, which is what shows the rule admits
 //! the shape our own publisher emits (beacon list at 0, one part per dentry).

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "limitedmap.h"
 

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2012-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "limitedmap.h"
+
+#include "consensus/consensus.h"
+#include "net.h"
+
+#include <boost/test/unit_test.hpp>
+
+//! Ported from Bitcoin Core alongside src/limitedmap.h, which upstream deleted in
+//! 86f50ed10f once TxRequestTracker replaced the map it bounded. The container is
+//! still load-bearing here (mapAlreadyAskedFor), so its tests come with it.
+//! Fixture dropped: this tree installs TestingSetup as a global fixture.
+BOOST_AUTO_TEST_SUITE(limitedmap_tests)
+
+BOOST_AUTO_TEST_CASE(limitedmap_test)
+{
+    // create a limitedmap capped at 10 items
+    limitedmap<int, int> map(10);
+
+    // check that the max size is 10
+    BOOST_CHECK(map.max_size() == 10);
+
+    // check that it's empty
+    BOOST_CHECK(map.size() == 0);
+
+    // insert (-1, -1)
+    map.insert(std::pair<int, int>(-1, -1));
+
+    // make sure that the size is updated
+    BOOST_CHECK(map.size() == 1);
+
+    // make sure that the new item is in the map
+    BOOST_CHECK(map.count(-1) == 1);
+
+    // insert 10 new items
+    for (int i = 0; i < 10; i++) {
+        map.insert(std::pair<int, int>(i, i + 1));
+    }
+
+    // make sure that the map now contains 10 items...
+    BOOST_CHECK(map.size() == 10);
+
+    // ...and that the first item has been discarded
+    BOOST_CHECK(map.count(-1) == 0);
+
+    // iterate over the map, both with an index and an iterator
+    limitedmap<int, int>::const_iterator it = map.begin();
+    for (int i = 0; i < 10; i++) {
+        // make sure the item is present
+        BOOST_CHECK(map.count(i) == 1);
+
+        // use the iterator to check for the expected key and value
+        BOOST_CHECK(it->first == i);
+        BOOST_CHECK(it->second == i + 1);
+
+        // use find to check for the value
+        BOOST_CHECK(map.find(i)->second == i + 1);
+
+        // update and recheck
+        map.update(it, i + 2);
+        BOOST_CHECK(map.find(i)->second == i + 2);
+
+        it++;
+    }
+
+    // check that we've exhausted the iterator
+    BOOST_CHECK(it == map.end());
+
+    // resize the map to 5 items
+    map.max_size(5);
+
+    // check that the max size and size are now 5
+    BOOST_CHECK(map.max_size() == 5);
+    BOOST_CHECK(map.size() == 5);
+
+    // check that items less than 5 have been discarded
+    // and items greater than 5 are retained
+    for (int i = 0; i < 10; i++) {
+        if (i < 5) {
+            BOOST_CHECK(map.count(i) == 0);
+        } else {
+            BOOST_CHECK(map.count(i) == 1);
+        }
+    }
+
+    // erase some items not in the map
+    for (int i = 100; i < 1000; i += 100) {
+        map.erase(i);
+    }
+
+    // check that the size is unaffected
+    BOOST_CHECK(map.size() == 5);
+
+    // erase the remaining elements
+    for (int i = 5; i < 10; i++) {
+        map.erase(i);
+    }
+
+    // check that the map is now empty
+    BOOST_CHECK(map.empty());
+}
+
+//!
+//! The deployment that motivated keeping this container: mapAlreadyAskedFor is
+//! global, entries are only removed when the object is received, and AskFor()
+//! used to create them through operator[] on a plain std::map. A peer announcing
+//! inventory it never serves therefore grew state charged to every peer. This
+//! asserts the global is constructed bounded, which is the property that was
+//! missing rather than anything about the container itself.
+//!
+BOOST_AUTO_TEST_CASE(map_already_asked_for_is_bounded)
+{
+    LOCK(cs_mapAlreadyAskedFor);
+
+    BOOST_CHECK_EQUAL(mapAlreadyAskedFor.max_size(), (size_t)MAX_INV_SZ);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/orphan_block_tests.cpp
+++ b/src/test/orphan_block_tests.cpp
@@ -278,6 +278,77 @@ BOOST_AUTO_TEST_CASE(size_cap_enforced)
 // Time-based expiry
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Byte accounting
+// ---------------------------------------------------------------------------
+
+// The running total has to match what was actually stored, through every path
+// that removes an entry. It is maintained incrementally, so a missed decrement
+// does not show up as a wrong answer anywhere -- it shows up much later as a
+// budget that evicts too eagerly, or never.
+//
+// The budget THRESHOLD is not exercised here: MAX_ORPHAN_BYTES is a thousand
+// times MAX_BLOCK_SIZE, and reaching it would mean allocating a gigabyte of
+// blocks in a unit test. What is checked is the arithmetic that decides when
+// the threshold is met.
+BOOST_AUTO_TEST_CASE(byte_accounting_follows_the_stored_blocks)
+{
+    OrphanBlockManager mgr;
+
+    BOOST_CHECK_EQUAL(mgr.Bytes(), 0u);
+
+    const CBlock a = MakeTestBlock(uint256(1), 1);
+    const CBlock b = MakeTestBlock(uint256(2), 2);
+
+    const size_t a_bytes = ::GetSerializeSize(a, SER_NETWORK, PROTOCOL_VERSION);
+    const size_t b_bytes = ::GetSerializeSize(b, SER_NETWORK, PROTOCOL_VERSION);
+
+    BOOST_REQUIRE(mgr.Add(a.GetHash(true), a, 1000));
+    BOOST_CHECK_EQUAL(mgr.Bytes(), a_bytes);
+
+    BOOST_REQUIRE(mgr.Add(b.GetHash(true), b, 1000));
+    BOOST_CHECK_EQUAL(mgr.Bytes(), a_bytes + b_bytes);
+
+    // A refused duplicate must not be counted twice.
+    BOOST_CHECK(!mgr.Add(a.GetHash(true), a, 1000));
+    BOOST_CHECK_EQUAL(mgr.Bytes(), a_bytes + b_bytes);
+
+    // Expiry is one of the removal paths.
+    BOOST_CHECK_EQUAL(mgr.EraseExpired(1000 + OrphanBlockManager::MAX_ORPHAN_AGE_SECONDS + 1), 2u);
+    BOOST_CHECK_EQUAL(mgr.Size(), 0u);
+    BOOST_CHECK_EQUAL(mgr.Bytes(), 0u);
+
+    // As is Clear().
+    BOOST_REQUIRE(mgr.Add(a.GetHash(true), a, 2000));
+    BOOST_CHECK_EQUAL(mgr.Bytes(), a_bytes);
+    mgr.Clear();
+    BOOST_CHECK_EQUAL(mgr.Bytes(), 0u);
+}
+
+// Eviction under the count cap must keep the byte total consistent with what
+// remains, or the two bounds drift apart.
+BOOST_AUTO_TEST_CASE(byte_accounting_survives_eviction)
+{
+    OrphanBlockManager mgr;
+
+    const size_t overshoot = OrphanBlockManager::MAX_ORPHAN_BLOCKS + 50;
+
+    for (uint32_t i = 0; i < overshoot; i++) {
+        const CBlock block = MakeTestBlock(uint256(i + 1), i);
+        mgr.Add(block.GetHash(true), block, 1000);
+    }
+
+    BOOST_CHECK_EQUAL(mgr.Size(), OrphanBlockManager::MAX_ORPHAN_BLOCKS);
+
+    // Every block here serializes to the same size, so the total is exact
+    // rather than approximate.
+    const CBlock sample = MakeTestBlock(uint256(1), 0);
+    const size_t each = ::GetSerializeSize(sample, SER_NETWORK, PROTOCOL_VERSION);
+
+    BOOST_CHECK_EQUAL(mgr.Bytes(), each * OrphanBlockManager::MAX_ORPHAN_BLOCKS);
+    BOOST_CHECK_LE(mgr.Bytes(), OrphanBlockManager::MAX_ORPHAN_BYTES);
+}
+
 BOOST_AUTO_TEST_CASE(expire_old_orphans)
 {
     OrphanBlockManager mgr;

--- a/src/test/psgt_pool_tests.cpp
+++ b/src/test/psgt_pool_tests.cpp
@@ -477,7 +477,10 @@ BOOST_AUTO_TEST_CASE(pool_utxo_conflict_eviction)
     spender.vin[0].scriptSig = CScript() << 0;
     spender.vout.push_back(CTxOut(10 * COIN - 1000000, P2PKH(MakeKey().GetPubKey().GetID())));
 
-    pool.TransactionAddedToMempool(MakeTransactionRef(CTransaction(spender)));
+    {
+        LOCK(cs_main);
+        pool.TransactionAddedToMempool(MakeTransactionRef(CTransaction(spender)));
+    }
 
     BOOST_CHECK_EQUAL(pool.Size(), 0u);
     BOOST_CHECK(!pool.Get(image).has_value());
@@ -495,7 +498,10 @@ BOOST_AUTO_TEST_CASE(pool_utxo_conflict_eviction)
 
     CBlock block;
     block.vtx.push_back(CTransaction(spender));
-    pool.BlockConnected(block, 100);
+    {
+        LOCK(cs_main);
+        pool.BlockConnected(block, 100);
+    }
 
     BOOST_CHECK_EQUAL(pool.Size(), 0u);
     BOOST_REQUIRE_EQUAL(events.size(), 4u);
@@ -509,7 +515,10 @@ BOOST_AUTO_TEST_CASE(pool_utxo_conflict_eviction)
 
     CMutableTransaction unrelated = spender;
     unrelated.vin[0].prevout = COutPoint(InsecureRand256(), 0);
-    pool.TransactionAddedToMempool(MakeTransactionRef(CTransaction(unrelated)));
+    {
+        LOCK(cs_main);
+        pool.TransactionAddedToMempool(MakeTransactionRef(CTransaction(unrelated)));
+    }
     BOOST_CHECK_EQUAL(pool.Size(), 1u);
 }
 

--- a/src/test/rpc_allowlist_tests.cpp
+++ b/src/test/rpc_allowlist_tests.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <rpc/server.h>
+#include <netbase.h>
+#include <netaddress.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+//! Rebuild the allow list from a fresh set of -rpcallowip values.
+void SetAllowList(const std::vector<std::string>& entries)
+{
+    InitRPCAllowList(entries);
+}
+
+bool Allowed(const std::string& addr)
+{
+    return ClientAllowed(boost::asio::ip::make_address(addr));
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(rpc_allowlist_tests)
+
+// A subnet in -rpcallowip used to match nothing at all: the entry was compared
+// as text against the peer's address string, so an operator who wrote a CIDR
+// prefix got a listener that refused every connection.
+BOOST_AUTO_TEST_CASE(cidr_entries_match_their_subnet)
+{
+    SetAllowList({"10.9.8.0/24"});
+
+    BOOST_CHECK(Allowed("10.9.8.1"));
+    BOOST_CHECK(Allowed("10.9.8.255"));
+    BOOST_CHECK(!Allowed("10.9.9.1"));
+    BOOST_CHECK(!Allowed("11.9.8.1"));
+}
+
+// The address/netmask spelling has to work too, since both are in the field.
+BOOST_AUTO_TEST_CASE(netmask_entries_match_their_subnet)
+{
+    SetAllowList({"172.16.0.0/255.255.0.0"});
+
+    BOOST_CHECK(Allowed("172.16.5.9"));
+    BOOST_CHECK(!Allowed("172.17.5.9"));
+}
+
+// A bare address is a host route, not a prefix.
+BOOST_AUTO_TEST_CASE(bare_address_entries_match_exactly_one_host)
+{
+    SetAllowList({"203.0.113.7"});
+
+    BOOST_CHECK(Allowed("203.0.113.7"));
+    BOOST_CHECK(!Allowed("203.0.113.8"));
+}
+
+// The wildcard spelling predates subnet support and must keep working, or
+// upgrading silently locks out operators who wrote it.
+BOOST_AUTO_TEST_CASE(wildcard_entries_still_match)
+{
+    SetAllowList({"192.168.44.*"});
+
+    BOOST_CHECK(Allowed("192.168.44.3"));
+    BOOST_CHECK(!Allowed("192.168.45.3"));
+}
+
+BOOST_AUTO_TEST_CASE(ipv6_subnets_match)
+{
+    SetAllowList({"2001:470::/32"});
+
+    BOOST_CHECK(Allowed("2001:470::1"));
+    BOOST_CHECK(Allowed("2001:470:ffff::9"));
+    BOOST_CHECK(!Allowed("2001:471::1"));
+}
+
+// Addresses CNetAddr rejects outright can never be allowed, whatever the list
+// says. 2001:db8::/32 is the RFC 3849 documentation prefix, which IsValid()
+// refuses, so Match() declines it even against a rule naming that exact
+// subnet. Pinned because it is surprising: the rule parses, logs as accepted,
+// and still matches nothing.
+BOOST_AUTO_TEST_CASE(documentation_addresses_are_never_allowed)
+{
+    SetAllowList({"2001:db8::/32"});
+
+    BOOST_CHECK(!Allowed("2001:db8::1"));
+}
+
+// Loopback bypasses the list entirely -- including when the list is empty,
+// which is the default configuration for every node.
+BOOST_AUTO_TEST_CASE(loopback_is_always_allowed)
+{
+    SetAllowList({});
+
+    BOOST_CHECK(Allowed("127.0.0.1"));
+    BOOST_CHECK(Allowed("127.0.0.5"));
+    BOOST_CHECK(Allowed("::1"));
+    BOOST_CHECK(!Allowed("10.9.8.1"));
+}
+
+// An IPv4-mapped v6 peer must be judged by its v4 address, or a v4 rule
+// silently fails to cover the same host arriving over a dual-stack socket --
+// which is exactly what the default wildcard bind produces.
+BOOST_AUTO_TEST_CASE(v4_mapped_v6_is_matched_as_v4)
+{
+    SetAllowList({"10.9.8.0/24"});
+
+    BOOST_CHECK(Allowed("::ffff:10.9.8.1"));
+    BOOST_CHECK(!Allowed("::ffff:10.9.9.1"));
+}
+
+// Several entries, mixed spellings, all live at once.
+BOOST_AUTO_TEST_CASE(entries_are_independent)
+{
+    SetAllowList({"10.9.8.0/24", "192.168.44.*", "203.0.113.7"});
+
+    BOOST_CHECK(Allowed("10.9.8.200"));
+    BOOST_CHECK(Allowed("192.168.44.1"));
+    BOOST_CHECK(Allowed("203.0.113.7"));
+    BOOST_CHECK(!Allowed("8.8.8.8"));
+}
+
+// An unparseable entry must not take the rest of the list down with it.
+BOOST_AUTO_TEST_CASE(unparseable_entries_do_not_disable_the_others)
+{
+    SetAllowList({"this-is-not-an-address", "10.9.8.0/24"});
+
+    BOOST_CHECK(Allowed("10.9.8.1"));
+    BOOST_CHECK(!Allowed("8.8.8.8"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_allowlist_tests.cpp
+++ b/src/test/rpc_allowlist_tests.cpp
@@ -123,6 +123,37 @@ BOOST_AUTO_TEST_CASE(entries_are_independent)
 }
 
 // An unparseable entry must not take the rest of the list down with it.
+// A link-local peer stringifies with its zone appended ("fe80::1%2"), which is
+// not a form an operator can put in an entry: the zone is a local interface
+// index, not a property of the peer. Matching has to survive it.
+//
+// It does, and without the allow list doing anything about it: LookupHost()
+// resolves through getaddrinfo(), which parses the zone and reports it
+// separately (see the sin6_scope_id read in netbase.cpp), so the conversion
+// succeeds and the subnet comparison runs on the address alone. Pinned here
+// because that is a property of a dependency rather than of this file, and
+// nothing else would notice if it changed.
+BOOST_AUTO_TEST_CASE(link_local_scope_suffix_does_not_defeat_matching)
+{
+    SetAllowList({"fe80::/10"});
+
+    BOOST_CHECK(Allowed("fe80::1"));
+
+    // The same address, carrying a scope id.
+    boost::system::error_code ec;
+    const auto scoped = boost::asio::ip::make_address("fe80::1%2", ec);
+    BOOST_REQUIRE(!ec);
+
+    // Guard the premise: if this ever stops carrying the zone, the case below
+    // is testing nothing.
+    BOOST_REQUIRE(scoped.to_string().find('%') != std::string::npos);
+
+    BOOST_CHECK(ClientAllowed(scoped));
+
+    // Still outside the prefix, zone or no zone.
+    BOOST_CHECK(!Allowed("fec0::1"));
+}
+
 BOOST_AUTO_TEST_CASE(unparseable_entries_do_not_disable_the_others)
 {
     SetAllowList({"this-is-not-an-address", "10.9.8.0/24"});

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -163,4 +163,62 @@ BOOST_AUTO_TEST_CASE(getaddednodeinfo_dns_true_returns_array)
     g_connman->RemoveAddedNode(node); // vAddedNodes is process-global; clean up
 }
 
+//! The HTTP header parse is reachable BEFORE any authentication check, so its
+//! bounds are what an unauthenticated client is limited to. Each returns a
+//! negative length, which ReadHTTPMessage rejects -- not a status code, which it
+//! would read as a body size.
+BOOST_AUTO_TEST_CASE(http_headers_bounded)
+{
+    std::map<std::string, std::string> headers;
+
+    // A normal request parses, and yields its content length.
+    {
+        std::istringstream in("content-length: 42\r\nconnection: close\r\n\r\n");
+        BOOST_CHECK_EQUAL(ReadHTTPHeaders(in, headers), 42);
+    }
+
+    // Too many headers.
+    {
+        std::string raw;
+        for (int i = 0; i < 101; ++i) raw += "x-pad-" + ToString(i) + ": v\r\n";
+        raw += "\r\n";
+        std::istringstream in(raw);
+        BOOST_CHECK(ReadHTTPHeaders(in, headers) < 0);
+    }
+
+    // One header longer than the per-line bound, with no newline to end it --
+    // the shape std::getline would have buffered without limit.
+    {
+        std::istringstream in("x-pad: " + std::string(9000, 'A'));
+        BOOST_CHECK(ReadHTTPHeaders(in, headers) < 0);
+    }
+
+    // Within the count and line bounds, but past the aggregate.
+    {
+        std::string raw;
+        for (int i = 0; i < 20; ++i) raw += "x-pad-" + ToString(i) + ": " + std::string(4000, 'A') + "\r\n";
+        raw += "\r\n";
+        std::istringstream in(raw);
+        BOOST_CHECK(ReadHTTPHeaders(in, headers) < 0);
+    }
+
+    // A malformed content-length returns rather than throwing: ServiceConnection
+    // has no try/catch around this call.
+    {
+        std::istringstream in("content-length: notanumber\r\n\r\n");
+        BOOST_CHECK_NO_THROW(BOOST_CHECK(ReadHTTPHeaders(in, headers) < 0));
+    }
+}
+
+//! "GET / " splits into three words whose third is empty, and pop_back() on an
+//! empty string is undefined. Reachable before authentication.
+BOOST_AUTO_TEST_CASE(http_request_line_empty_proto)
+{
+    std::istringstream in("GET / \r\n");
+    int proto = 0;
+    std::string method, uri;
+
+    BOOST_CHECK_NO_THROW((void)ReadHTTPRequestLine(in, proto, method, uri));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -630,7 +630,11 @@ BOOST_AUTO_TEST_CASE(script_FindAndDelete)
 // in-memory set with no other ceiling, so the clamp is the whole point.
 BOOST_AUTO_TEST_CASE(maxsigcachesize_is_resolved_and_clamped)
 {
-    const std::string saved = gArgs.GetArg("-maxsigcachesize", "");
+    // Capture whether it was set at all. Restoring "" would leave the arg SET to
+    // an empty string, which GetArg(name, int64_t) parses as 0 -- i.e. the cache
+    // disabled for the rest of this test binary.
+    const bool had_arg = gArgs.IsArgSet("-maxsigcachesize");
+    const std::string saved = had_arg ? gArgs.GetArg("-maxsigcachesize", "") : std::string();
 
     // A sane operator value passes through untouched.
     gArgs.ForceSetArg("-maxsigcachesize", "120000");
@@ -661,7 +665,13 @@ BOOST_AUTO_TEST_CASE(maxsigcachesize_is_resolved_and_clamped)
     // override the documented default for every node.
     BOOST_CHECK(DEFAULT_MAX_SIG_CACHE_SIZE < MAX_SIG_CACHE_ENTRIES);
 
-    gArgs.ForceSetArg("-maxsigcachesize", saved);
+    if (had_arg) {
+        gArgs.ForceSetArg("-maxsigcachesize", saved);
+    } else {
+        // No clear-arg API; restore the documented default explicitly rather
+        // than leaving the arg set to an empty string.
+        gArgs.ForceSetArg("-maxsigcachesize", ToString(DEFAULT_MAX_SIG_CACHE_SIZE));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -644,9 +644,9 @@ BOOST_AUTO_TEST_CASE(maxsigcachesize_is_resolved_and_clamped)
 
     // Exactly at the ceiling is allowed; one over is clamped, as is an
     // absurd value of the shape a mistyped config produces.
-    gArgs.ForceSetArg("-maxsigcachesize", std::to_string(MAX_SIG_CACHE_ENTRIES));
+    gArgs.ForceSetArg("-maxsigcachesize", ToString(MAX_SIG_CACHE_ENTRIES));
     BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), MAX_SIG_CACHE_ENTRIES);
-    gArgs.ForceSetArg("-maxsigcachesize", std::to_string(MAX_SIG_CACHE_ENTRIES + 1));
+    gArgs.ForceSetArg("-maxsigcachesize", ToString(MAX_SIG_CACHE_ENTRIES + 1));
     BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), MAX_SIG_CACHE_ENTRIES);
     gArgs.ForceSetArg("-maxsigcachesize", "500000000");
     BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), MAX_SIG_CACHE_ENTRIES);

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <sstream>
+#include <script/interpreter.h>
 #include <util/strencodings.h>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -623,6 +624,44 @@ BOOST_AUTO_TEST_CASE(script_FindAndDelete)
     expect = ScriptFromHex("03feed");
     BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
     BOOST_CHECK(s == expect);
+}
+
+// -maxsigcachesize resolution. The value is operator-supplied and feeds an
+// in-memory set with no other ceiling, so the clamp is the whole point.
+BOOST_AUTO_TEST_CASE(maxsigcachesize_is_resolved_and_clamped)
+{
+    const std::string saved = gArgs.GetArg("-maxsigcachesize", "");
+
+    // A sane operator value passes through untouched.
+    gArgs.ForceSetArg("-maxsigcachesize", "120000");
+    BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), 120000);
+
+    // Zero and negative disable the cache rather than clamping up.
+    gArgs.ForceSetArg("-maxsigcachesize", "0");
+    BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), 0);
+    gArgs.ForceSetArg("-maxsigcachesize", "-1");
+    BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), 0);
+
+    // Exactly at the ceiling is allowed; one over is clamped, as is an
+    // absurd value of the shape a mistyped config produces.
+    gArgs.ForceSetArg("-maxsigcachesize", std::to_string(MAX_SIG_CACHE_ENTRIES));
+    BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), MAX_SIG_CACHE_ENTRIES);
+    gArgs.ForceSetArg("-maxsigcachesize", std::to_string(MAX_SIG_CACHE_ENTRIES + 1));
+    BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), MAX_SIG_CACHE_ENTRIES);
+    gArgs.ForceSetArg("-maxsigcachesize", "500000000");
+    BOOST_CHECK_EQUAL(ResolveMaxSigCacheSize(), MAX_SIG_CACHE_ENTRIES);
+
+    // The ceiling must stay a memory budget, not a bare number: if the entry
+    // shape is re-estimated the entry count has to move with it. The division
+    // truncates, so the identity is "fits, and one more would not".
+    BOOST_CHECK(MAX_SIG_CACHE_ENTRIES * SIG_CACHE_ENTRY_BYTES <= MAX_SIG_CACHE_BYTES);
+    BOOST_CHECK((MAX_SIG_CACHE_ENTRIES + 1) * SIG_CACHE_ENTRY_BYTES > MAX_SIG_CACHE_BYTES);
+
+    // The default has to sit under the ceiling, or the clamp would silently
+    // override the documented default for every node.
+    BOOST_CHECK(DEFAULT_MAX_SIG_CACHE_SIZE < MAX_SIG_CACHE_ENTRIES);
+
+    gArgs.ForceSetArg("-maxsigcachesize", saved);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 
+#include "primitives/block.h"
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(serialize_tests)
@@ -360,6 +362,45 @@ BOOST_AUTO_TEST_CASE(variants)
     BOOST_CHECK(std::get<p_t>(v) == std::make_pair(14, 48));
     ss >> v;
     BOOST_CHECK(std::get<CSerializeMethodsTestSingle>(v) == csmts);
+}
+
+//!
+//! A locator at exactly the cap must round-trip. This is the property that had
+//! to hold before capping at all: Set() produces at most 42 entries even at the
+//! maximum representable chain height, so 101 cannot reject anything an honest
+//! peer generates. A cap below the legitimate maximum would partition the
+//! network rather than protect it.
+//!
+BOOST_AUTO_TEST_CASE(block_locator_round_trips_at_the_cap)
+{
+    CBlockLocator locator;
+    locator.vHave.assign(MAX_LOCATOR_SZ, uint256());
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << locator;
+
+    CBlockLocator out;
+    ss >> out;
+
+    BOOST_CHECK_EQUAL(out.vHave.size(), (size_t)MAX_LOCATOR_SZ);
+}
+
+//!
+//! One over the cap is refused at the length prefix, before the vector is
+//! sized -- so the allocation an oversized locator would force never happens,
+//! and neither does the per-entry mapBlockIndex lookup under cs_main that makes
+//! a large locator expensive to receive.
+//!
+BOOST_AUTO_TEST_CASE(block_locator_refuses_one_over_the_cap)
+{
+    CBlockLocator locator;
+    locator.vHave.assign(MAX_LOCATOR_SZ + 1, uint256());
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << locator;   // writing is unrestricted, matching LimitedString
+
+    CBlockLocator out;
+    BOOST_CHECK_THROW(ss >> out, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -68,6 +68,8 @@ int msb3(const int64_t& n_in)
 }
 } //anonymous namespace
 
+#include <sstream>
+
 BOOST_AUTO_TEST_SUITE(util_tests)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
@@ -1847,6 +1849,99 @@ BOOST_AUTO_TEST_CASE(util_ReplaceAll)
     std::string shrink("aaa");
     ReplaceAll(shrink, "a", "");     // empty substitute with consecutive matches terminates
     BOOST_CHECK_EQUAL(shrink, "");
+}
+
+
+//!
+//! ReadLineBounded: the scraper's part parser reads every record through this,
+//! so its edge cases decide whether a project's statistics survive the trip.
+//!
+BOOST_AUTO_TEST_CASE(readlinebounded_splits_on_newlines)
+{
+    std::istringstream in("alpha\nbeta\ngamma\n");
+    std::string line;
+    bool overlong = false;
+
+    BOOST_CHECK(ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK_EQUAL(line, "alpha");
+    BOOST_CHECK(!overlong);
+
+    BOOST_CHECK(ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK_EQUAL(line, "beta");
+
+    BOOST_CHECK(ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK_EQUAL(line, "gamma");
+
+    BOOST_CHECK(!ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK(!overlong);
+}
+
+//! A blank line is a line, not the end of the stream. istream::getline() would
+//! set failbit here and silently truncate everything after it, which is why
+//! this helper exists at all.
+BOOST_AUTO_TEST_CASE(readlinebounded_treats_a_blank_line_as_a_line)
+{
+    std::istringstream in("first\n\nthird\n");
+    std::string line;
+    bool overlong = false;
+
+    BOOST_CHECK(ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK_EQUAL(line, "first");
+
+    BOOST_CHECK(ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK_EQUAL(line, "");
+    BOOST_CHECK(!overlong);
+
+    BOOST_CHECK(ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK_EQUAL(line, "third");
+}
+
+//! A final line with no trailing newline is still a line.
+BOOST_AUTO_TEST_CASE(readlinebounded_returns_a_trailing_line_without_a_newline)
+{
+    std::istringstream in("no-newline-at-end");
+    std::string line;
+    bool overlong = false;
+
+    BOOST_CHECK(ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK_EQUAL(line, "no-newline-at-end");
+    BOOST_CHECK(!overlong);
+
+    BOOST_CHECK(!ReadLineBounded(in, line, 64, overlong));
+}
+
+//! At the bound exactly, and one over. The point of the helper is that the
+//! over-long case never buffers the rest of the line.
+BOOST_AUTO_TEST_CASE(readlinebounded_flags_an_overlong_line_without_buffering_it)
+{
+    {
+        std::istringstream in(std::string(8, 'x') + "\n");
+        std::string line;
+        bool overlong = false;
+        BOOST_CHECK(ReadLineBounded(in, line, 8, overlong));
+        BOOST_CHECK_EQUAL(line.size(), 8u);
+        BOOST_CHECK(!overlong);
+    }
+    {
+        std::istringstream in(std::string(9, 'x') + "\n");
+        std::string line;
+        bool overlong = false;
+        BOOST_CHECK(!ReadLineBounded(in, line, 8, overlong));
+        BOOST_CHECK(overlong);
+        BOOST_CHECK_EQUAL(line.size(), 8u);   // stopped at the bound
+    }
+}
+
+//! An empty stream yields nothing and is not flagged over-long.
+BOOST_AUTO_TEST_CASE(readlinebounded_handles_an_empty_stream)
+{
+    std::istringstream in("");
+    std::string line;
+    bool overlong = false;
+
+    BOOST_CHECK(!ReadLineBounded(in, line, 64, overlong));
+    BOOST_CHECK(!overlong);
+    BOOST_CHECK(line.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/dir_permissions.cpp
+++ b/src/util/dir_permissions.cpp
@@ -200,6 +200,13 @@ void VerifyOwnerOnlyDacl(const fs::path& path)
 }
 #endif // WIN32
 
+void SetOwnerOnlyUmask()
+{
+#ifndef WIN32
+    ::umask(077);
+#endif
+}
+
 bool CreateOwnerOnlyDirectory(const fs::path& path, std::string& error)
 {
     error.clear();

--- a/src/util/dir_permissions.h
+++ b/src/util/dir_permissions.h
@@ -55,6 +55,30 @@ namespace util {
 //! place and \p error says so explicitly.
 bool CreateOwnerOnlyDirectory(const fs::path& path, std::string& error);
 
+//! Restrict the process umask so that every file and directory this process
+//! creates afterwards is owner-only from the moment it exists.
+//!
+//! MUST be called before anything is created -- before logging is initialised and
+//! before settings are read or written. The ordering is the entire point. The
+//! alternative, a chmod after the fact, leaves a window in which the file sits at
+//! whatever the ambient umask allowed; CreateNewConfigFile() documents that same
+//! reasoning for the RPC credentials file, which is narrowed before the password
+//! is written rather than after.
+//!
+//! This governs the files a data directory accumulates that are not created
+//! through CreateOwnerOnlyDirectory(): debug.log, the read-write settings file,
+//! and the block index subdirectories. On a default desktop umask of 022 those
+//! land group- and world-readable, which matters most for debug.log.
+//!
+//! It is a deliberate blunt instrument: process-wide, set once, never restored.
+//! Code that needs a different mode for one file should say so explicitly at that
+//! call site, as ipc/process.cpp does when it creates the IPC socket.
+//!
+//! No-op on Windows, which has no umask. There the equivalent protection is the
+//! data directory's inheritable owner+SYSTEM DACL, applied by
+//! CreateOwnerOnlyDirectory() and inherited by everything created inside it.
+void SetOwnerOnlyUmask();
+
 #ifdef WIN32
 //! Apply an owner+SYSTEM PROTECTED DACL to an existing file or directory and verify
 //! it by reading it back. Throws std::system_error on failure — callers that hold

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -5,6 +5,9 @@
 
 #include <util/string.h>
 
+#include <istream>
+#include <streambuf>
+
 using namespace std;
 
 void ParseString(const string& str, char c, vector<string>& v)
@@ -39,9 +42,31 @@ bool ReadLineBounded(std::istream& in, std::string& out, const size_t max_len, b
     out.clear();
     overlong = false;
 
-    char c;
+    // Read through the streambuf rather than istream::get(char&).
+    //
+    // get() constructs a sentry per call -- once per BYTE -- and this runs over
+    // every project part on every convergence, tens of megabytes of decompressed
+    // text per pass. sbumpc() does the same work without the per-character
+    // sentry.
+    //
+    // istream::getline(buf, n) would take the bound directly, but it sets
+    // failbit on a zero-length extraction, i.e. on a blank line. Blank lines
+    // occur in these files, so that would silently truncate the parse.
+    std::istream::sentry sentry(in, true);   // true: do not skip leading whitespace
+    if (!sentry) return false;
 
-    while (in.get(c)) {
+    std::streambuf* sb = in.rdbuf();
+
+    for (;;) {
+        const int c = sb->sbumpc();
+
+        if (c == std::char_traits<char>::eof()) {
+            in.setstate(std::ios_base::eofbit);
+
+            // A final line without a trailing newline is still a line.
+            return !out.empty();
+        }
+
         if (c == '\n') return true;
 
         if (out.size() >= max_len) {
@@ -49,9 +74,6 @@ bool ReadLineBounded(std::istream& in, std::string& out, const size_t max_len, b
             return false;
         }
 
-        out.push_back(c);
+        out.push_back(static_cast<char>(c));
     }
-
-    // A final line without a trailing newline is still a line.
-    return !out.empty();
 }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -33,3 +33,25 @@ std::string FromDoubleToString(const double& t, const int& precision)
     oss << std::scientific << std::setprecision(precision) << t;
     return oss.str();
 }
+
+bool ReadLineBounded(std::istream& in, std::string& out, const size_t max_len, bool& overlong)
+{
+    out.clear();
+    overlong = false;
+
+    char c;
+
+    while (in.get(c)) {
+        if (c == '\n') return true;
+
+        if (out.size() >= max_len) {
+            overlong = true;
+            return false;
+        }
+
+        out.push_back(c);
+    }
+
+    // A final line without a trailing newline is still a line.
+    return !out.empty();
+}

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -20,10 +20,30 @@
 #include <locale>
 #include <sstream>
 #include <string>
+#include <istream>
 #include <string_view>
 #include <vector>
 
 void ParseString(const std::string& str, char c, std::vector<std::string>& v);
+
+/** Read one newline-terminated line, refusing to buffer more than \p max_len bytes.
+ *
+ * std::getline grows its string until it finds a delimiter or hits EOF, so input
+ * with no newline in it is buffered whole -- which is a decompression bomb on one
+ * path and an unauthenticated peer on another. istream::getline takes a bound but
+ * sets failbit on a zero-length extraction, which is exactly what a blank line
+ * produces, so it silently stops at the first one.
+ *
+ * This returns on the delimiter regardless of how much was accumulated, so blank
+ * lines behave as they do with std::getline, and stops rather than growing past
+ * the bound.
+ *
+ * \param out       Receives the line, without its terminator.
+ * \param max_len   Maximum bytes to accumulate.
+ * \param overlong  Set when the bound was hit; distinguishes that from end of input.
+ * \return true if a line was read.
+ */
+bool ReadLineBounded(std::istream& in, std::string& out, size_t max_len, bool& overlong);
 
 /** Split a string on any char found in separators, returning a vector.
  *

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -433,6 +433,30 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
         // would not save it, since the error is the height, not the software.
         const int script_flag_height = fBlock ? pindexBlock->nHeight : pindexBlock->nHeight + 1;
 
+        // Consensus flags decide validity and apply on every path.
+        const unsigned int consensus_flags = GetBlockScriptFlags(script_flag_height);
+
+        // Local policy flags, applied to mempool acceptance only. Zero today.
+        //
+        // This tier exists so that a flag can ever be tightened for RELAY
+        // without banning honest peers, and that is why it lands even while
+        // empty: until a node can tell "consensus-invalid" from "non-standard
+        // to me", every ConnectInputs failure is DoS(100) and any future
+        // tightening scores peers for relaying transactions that are perfectly
+        // valid. The split is the prerequisite; the flags are a separate
+        // decision each time.
+        //
+        // The v15 malleability flags are NOT here. They activate as consensus
+        // in GetBlockScriptFlags() above, which turns them on for relay and for
+        // block validity at the same height -- a coordinated change rather than
+        // a staggered one, and no window where a staker builds from its own
+        // mempool a block its peers reject.
+        // When a flag is added it belongs behind (!fBlock && !fMiner), i.e.
+        // mempool acceptance only -- never when connecting a block, where it
+        // would change which chain this node follows, and never for the miner,
+        // which is assembling a block and must judge by validity alone.
+        const unsigned int policy_flags = 0;
+
         int64_t nValueIn = 0;
         int64_t nFees = 0;
 
@@ -563,9 +587,36 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
                 // verification is not measurable.
                 g_connectinputs_signature_checks.fetch_add(1, std::memory_order_relaxed);
 
-                // Verify signature
-                if (!VerifySignature(txPrev, tx, GetBlockScriptFlags(script_flag_height), i, 0))
+                // Verify signature.
+                //
+                // Two tiers, and the distinction is the whole point. The
+                // consensus flags decide VALIDITY: failing them means the
+                // transaction could never be in a block, so the peer that
+                // relayed it is relaying garbage and earns a ban. The policy
+                // flags are this node's local standard, applied on the mempool
+                // path only. Failing those means the transaction is merely
+                // non-standard to US -- it may be perfectly valid, and other
+                // nodes may relay it quite legitimately -- so it is dropped
+                // quietly and the relayer is NOT scored.
+                //
+                // Before this, every failure was DoS(100) with no way to tell
+                // the two apart, which meant no mempool flag could be tightened
+                // without banning honest peers for relaying transactions that
+                // are consensus-valid. That is why the split has to land before
+                // the flags do, not alongside them.
+                if (!VerifySignature(txPrev, tx, consensus_flags | policy_flags, i, 0))
                 {
+                    // Re-verify with consensus flags alone to place the blame.
+                    // Only worth doing when policy actually added something.
+                    if (policy_flags != 0
+                        && VerifySignature(txPrev, tx, consensus_flags, i, 0))
+                    {
+                        return state.Invalid(
+                            error("ConnectInputs() : %s non-mandatory script verify failure",
+                                  tx.GetHash().ToString().substr(0,10).c_str()),
+                            "non-mandatory-script-verify-flag");
+                    }
+
                     return state.DoS(100,error("ConnectInputs() : %s VerifySignature failed", tx.GetHash().ToString().substr(0,10).c_str()));
                 }
             }
@@ -1028,6 +1079,30 @@ unsigned int GetBlockScriptFlags(int nHeight)
     if (IsV14Enabled(nHeight)) {
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
+    }
+
+    // Signature malleability closes at block version 15, the same shape v14
+    // used for CLTV/CSV.
+    //
+    // These are the flags MEMPOOL_POLICY_SCRIPT_VERIFY_FLAGS applies as local
+    // standardness once v15 is live; here they become binding. The progression
+    // is deliberate and is the usual one: a node stops RELAYING these
+    // transactions and stops ACCEPTING blocks that contain them at the same
+    // height, so there is no window in which a staker builds a block from its
+    // own mempool that its peers then reject.
+    //
+    // Inert until v15 is scheduled -- BlockV15Height is
+    // numeric_limits<int>::max() -- so landing this early costs nothing and
+    // means the activation itself is a chainparams change rather than a code
+    // change made under fork pressure.
+    //
+    // What this fixes: pubkey.cpp normalizes high-S on verification and
+    // documents that enforcement belongs to SCRIPT_VERIFY_LOW_S. Nothing set
+    // it, so the other half of that division of responsibility was never
+    // wired up and third-party malleation of an otherwise-canonical signature
+    // stayed possible.
+    if (IsV15Enabled(nHeight)) {
+        flags |= V15_SCRIPT_VERIFY_FLAGS;
     }
 
     return flags;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -404,6 +404,8 @@ bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const s
     return true;
 }
 
+std::atomic<uint64_t> g_connectinputs_signature_checks{0};
+
 bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
     const CBlockIndex* pindexBlock, bool fBlock, bool fMiner)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -536,6 +538,14 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
 
             if (!(fBlock && (nBestHeight < Params().Checkpoints().GetHeight())))
             {
+                // Counted so the ordering above can be asserted rather than
+                // just asserted about. The whole point of the conflict pre-scan
+                // is that this is not reached for a transaction that has an
+                // already-spent input, and nothing else makes that observable
+                // from outside. One relaxed atomic increment against an ECDSA
+                // verification is not measurable.
+                g_connectinputs_signature_checks.fetch_add(1, std::memory_order_relaxed);
+
                 // Verify signature
                 if (!VerifySignature(txPrev, tx, GetBlockScriptFlags(*pindexBlock), i, 0))
                 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1454,6 +1454,35 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     // this envelope and also be accepted at a height that does not permit it.
     const bool v15_rules = block.nVersion >= 15;
 
+    // A claim rides in the coinbase, and only there.
+    //
+    // The accounting below takes that as given. It measures the block with
+    // SER_SKIPSUPERBLOCK, which drops the superblock from every claim the
+    // serializer walks, and then measures the superblock separately through
+    // GetSuperblock() -- which resolves via CBlock::GetClaim() and reads vtx[0].
+    // The two line up only while vtx[0] holds the block's one claim: a claim
+    // anywhere else is subtracted by the first measurement and invisible to the
+    // second, so nothing bounds what it carries.
+    //
+    // Nothing legitimate produces one. The miner puts the claim in the coinbase,
+    // and the checks further down already require it to be there and to be the
+    // only contract in it. This says the rest of the block may not hold one, so
+    // the skip flag means what the accounting assumes it means.
+    if (v15_rules)
+    {
+        for (unsigned int i = 1; i < block.vtx.size(); i++)
+        {
+            for (const auto& contract : block.vtx[i].vContracts)
+            {
+                if (contract.m_type == GRC::ContractType::CLAIM)
+                {
+                    return state.DoS(100, error("%s: claim contract outside the coinbase (tx %u)",
+                                                __func__, i));
+                }
+            }
+        }
+    }
+
     const int block_size_type = (block.GetSuperblock()->WellFormed() && v15_rules)
         ? (SER_NETWORK | SER_SKIPSUPERBLOCK)
         : 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -143,20 +143,22 @@ bool ReadTxFromDisk(CTransaction& tx, COutPoint prevout)
     return ReadTxFromDisk(tx, txdb, prevout, txindex);
 }
 
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, int nHeight)
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool v15_rules)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
         return state.DoS(10, error("CheckTransaction() : vin empty"));
     if (tx.vout.empty())
         return state.DoS(10, error("CheckTransaction() : vout empty"));
-    // Size limits. From v15 a coinbase or coinstake carrying a superblock is
-    // measured without it: the block-level check bounds the whole block, and
+    // Size limits. Under v15 rules a coinbase or coinstake carrying a superblock
+    // is measured without it: the block-level check bounds the whole block, and
     // bounds the superblock separately.
     //
-    // nHeight defaults to 0, so callers with no block context are unaffected;
-    // only CheckBlock() passes a height.
-    const int serialize_type = IsV15Enabled(nHeight) ? (SER_NETWORK | SER_SKIPSUPERBLOCK) : 0;
+    // Takes the caller's determination rather than a height, for the reason
+    // spelled out in CheckBlock(): the height available there is the tip's next
+    // height, not necessarily this block's. Defaults to false, so the callers
+    // with no block context are unaffected -- only CheckBlock() passes it.
+    const int serialize_type = v15_rules ? (SER_NETWORK | SER_SKIPSUPERBLOCK) : 0;
 
     if (GetSerializeSize(tx, serialize_type, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
         return state.DoS(100, error("CheckTransaction() : size limits failed"));
@@ -1431,7 +1433,28 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
         return state.DoS(100, error("%s: block has no transactions", __func__));
     }
 
-    const int block_size_type = (block.GetSuperblock()->WellFormed() && IsV15Enabled(height1))
+    // Keyed on the BLOCK'S OWN VERSION, not on a height.
+    //
+    // CheckBlock() does not reliably know the height of the block in front of
+    // it: ProcessBlock() passes pindexBest->nHeight + 1, the tip's next height,
+    // which is not this block's height for an orphan, a block arriving out of
+    // order, or a node catching up. ConnectBlock() passes the real height, but
+    // fChecked short-circuits that second call, so the approximate verdict is
+    // the only one that ever runs.
+    //
+    // Getting that wrong around an activation is a consensus split, not a
+    // nuisance: a node whose tip sits below the activation height would judge a
+    // valid post-activation block by the older rule, reject it, and score the
+    // honest peer that relayed it.
+    //
+    // The block's version does not have that problem -- it travels with the
+    // block. AcceptBlock() enforces version against the authoritative height
+    // (pindexPrev->nHeight + 1) and rejects a v15 block below the activation
+    // height as well as a pre-v15 block at or above it, so a block cannot claim
+    // this envelope and also be accepted at a height that does not permit it.
+    const bool v15_rules = block.nVersion >= 15;
+
+    const int block_size_type = (block.GetSuperblock()->WellFormed() && v15_rules)
         ? (SER_NETWORK | SER_SKIPSUPERBLOCK)
         : 0;
 
@@ -1519,7 +1542,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     // Check transactions
     for (auto const& tx : block.vtx)
     {
-        if (!CheckTransaction(tx, state, height1))
+        if (!CheckTransaction(tx, state, v15_rules))
             return error("%s: CheckTransaction failed", __func__);
 
         // ppcoin: check transaction timestamp

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -416,6 +416,23 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
     // ... both are false when called from CTransaction::AcceptToMemoryPool
     if (!tx.IsCoinBase())
     {
+        // Height of the block these inputs will be validated IN, which is not
+        // always pindexBlock's own height.
+        //
+        // Connecting a block, pindexBlock IS that block. On the mempool and
+        // miner paths it is the PREVIOUS block -- pindexBest and pindexPrev
+        // respectively -- and the transaction is destined for the next one, so
+        // both were evaluating script flags one height low.
+        //
+        // No effect today: the only height at which the flag set differs from
+        // its successor is exactly BlockV14Height - 1, which is behind the tip
+        // and behind the checkpoints, and BlockV15Height is unscheduled. It
+        // matters at the NEXT activation, where a staker computing pre-fork
+        // flags for a block validators judge with post-fork flags would build a
+        // block the network rejects and lose the stake -- and being upgraded
+        // would not save it, since the error is the height, not the software.
+        const int script_flag_height = fBlock ? pindexBlock->nHeight : pindexBlock->nHeight + 1;
+
         int64_t nValueIn = 0;
         int64_t nFees = 0;
 
@@ -547,7 +564,7 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
                 g_connectinputs_signature_checks.fetch_add(1, std::memory_order_relaxed);
 
                 // Verify signature
-                if (!VerifySignature(txPrev, tx, GetBlockScriptFlags(*pindexBlock), i, 0))
+                if (!VerifySignature(txPrev, tx, GetBlockScriptFlags(script_flag_height), i, 0))
                 {
                     return state.DoS(100,error("ConnectInputs() : %s VerifySignature failed", tx.GetHash().ToString().substr(0,10).c_str()));
                 }
@@ -1003,12 +1020,12 @@ bool GridcoinConnectBlock(
 }
 } // Anonymous namespace
 
-unsigned int GetBlockScriptFlags(const CBlockIndex& block_index)
+unsigned int GetBlockScriptFlags(int nHeight)
 {
     unsigned int flags{SCRIPT_VERIFY_P2SH};
 
     // BIP65 (CLTV) and BIP112 (CSV) are enforced starting with block version 14.
-    if (IsV14Enabled(block_index.nHeight)) {
+    if (IsV14Enabled(nHeight)) {
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1452,23 +1452,50 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     // (pindexPrev->nHeight + 1) and rejects a v15 block below the activation
     // height as well as a pre-v15 block at or above it, so a block cannot claim
     // this envelope and also be accepted at a height that does not permit it.
-    const bool v15_rules = block.nVersion >= 15;
+    // The coinbase claim is established BEFORE anything reads it.
+    //
+    // These are the same checks that have always run, moved ahead of the size
+    // accounting below, which resolves the block's superblock through
+    // CBlock::GetClaim(). Running them first means the claim is known to be
+    // present, singular and of the right type by the time it is read, rather
+    // than after.
+    //
+    // A move, not a new rule: every one of these already refused these blocks,
+    // so the set of acceptable blocks is unchanged and only the order in which
+    // a bad one is reported differs. Deliberately kept that way -- a rule that
+    // does not exist on the current network cannot be added here without an
+    // activation to carry it.
+    //
+    // Version 11+ blocks store the Gridcoin claim context as a contract in the
+    // coinbase transaction instead of the hashBoinc field.
+    //
+    if (block.nVersion >= 11) {
+        if (block.vtx[0].vContracts.empty()) {
+            return state.DoS(100, error("%s: missing claim contract", __func__));
+        }
 
-    // The claim contract has to be present before anything asks for it.
-    //
-    // CBlock::GetClaim() reads vtx[0].vContracts[0] whenever nVersion >= 11 --
-    // the version alone satisfies its guard, with no test that the vector holds
-    // anything. The size accounting below resolves through it via
-    // GetSuperblock(), while the test for an empty vContracts sits further
-    // down, so the read currently happens first.
-    //
-    // Ordering only. A block like this is refused either way; this refuses it
-    // ahead of the read instead of after, so the set of acceptable blocks is
-    // unchanged.
-    if (block.nVersion >= 11 && block.vtx[0].vContracts.empty())
-    {
-        return state.DoS(100, error("%s: missing claim contract", __func__));
+        if (block.vtx[0].vContracts.size() > 1) {
+            return state.DoS(100, error("%s: too many coinbase contracts", __func__));
+        }
+
+        if (block.vtx[0].vContracts[0].m_type != GRC::ContractType::CLAIM) {
+            return state.DoS(100, error("%s: unexpected coinbase contract", __func__));
+        }
+
+        if (!block.vtx[0].vContracts[0].WellFormed()) {
+            return state.DoS(100, error("%s: malformed claim contract", __func__));
+        }
+
+        if (block.vtx[0].vContracts[0].m_version <= 1 || block.GetClaim().m_version <= 1) {
+            return state.DoS(100, error("%s: legacy claim", __func__));
+        }
+
+        if (!OnTestnet() && block.GetClaim().m_version == 2) {
+            return state.DoS(100, error("%s: testnet-only claim", __func__));
+        }
     }
+
+    const bool v15_rules = block.nVersion >= 15;
 
     // A claim rides in the coinbase, and only there.
     //
@@ -1527,35 +1554,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     for (unsigned int i = 1; i < block.vtx.size(); i++)
         if (block.vtx[i].IsCoinBase())
             return state.DoS(100, error("%s: more than one coinbase", __func__));
-
-    // Version 11+ blocks store the Gridcoin claim context as a contract in the
-    // coinbase transaction instead of the hashBoinc field.
-    //
-    if (block.nVersion >= 11) {
-        if (block.vtx[0].vContracts.empty()) {
-            return state.DoS(100, error("%s: missing claim contract", __func__));
-        }
-
-        if (block.vtx[0].vContracts.size() > 1) {
-            return state.DoS(100, error("%s: too many coinbase contracts", __func__));
-        }
-
-        if (block.vtx[0].vContracts[0].m_type != GRC::ContractType::CLAIM) {
-            return state.DoS(100, error("%s: unexpected coinbase contract", __func__));
-        }
-
-        if (!block.vtx[0].vContracts[0].WellFormed()) {
-            return state.DoS(100, error("%s: malformed claim contract", __func__));
-        }
-
-        if (block.vtx[0].vContracts[0].m_version <= 1 || block.GetClaim().m_version <= 1) {
-            return state.DoS(100, error("%s: legacy claim", __func__));
-        }
-
-        if (!OnTestnet() && block.GetClaim().m_version == 2) {
-            return state.DoS(100, error("%s: testnet-only claim", __func__));
-        }
-    }
 
     // End of Proof Of Research
     if (block.IsProofOfStake())

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1454,6 +1454,22 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     // this envelope and also be accepted at a height that does not permit it.
     const bool v15_rules = block.nVersion >= 15;
 
+    // The claim contract has to be present before anything asks for it.
+    //
+    // CBlock::GetClaim() reads vtx[0].vContracts[0] whenever nVersion >= 11 --
+    // the version alone satisfies its guard, with no test that the vector holds
+    // anything. The size accounting below resolves through it via
+    // GetSuperblock(), while the test for an empty vContracts sits further
+    // down, so the read currently happens first.
+    //
+    // Ordering only. A block like this is refused either way; this refuses it
+    // ahead of the read instead of after, so the set of acceptable blocks is
+    // unchanged.
+    if (block.nVersion >= 11 && block.vtx[0].vContracts.empty())
+    {
+        return state.DoS(100, error("%s: missing claim contract", __func__));
+    }
+
     // A claim rides in the coinbase, and only there.
     //
     // The accounting below takes that as given. It measures the block with

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1420,12 +1420,22 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     //
     // SER_SKIPSUPERBLOCK is what excludes the superblock's bytes from the first
     // measurement; the claim's serializer honours it (see claim.h).
+    // Emptiness FIRST, and on its own. Everything below reaches GetSuperblock(),
+    // which goes through CBlock::GetClaim() and indexes vtx[0] unconditionally,
+    // so it must not run against a block with no transactions. A peer supplies
+    // this object straight off the wire -- ProcessMessage deserializes it and
+    // ProcessBlock calls straight through to here -- so an empty vtx is
+    // attacker-supplied input, not an internal impossibility.
+    if (block.vtx.empty())
+    {
+        return state.DoS(100, error("%s: block has no transactions", __func__));
+    }
+
     const int block_size_type = (block.GetSuperblock()->WellFormed() && IsV15Enabled(height1))
         ? (SER_NETWORK | SER_SKIPSUPERBLOCK)
         : 0;
 
-    if (block.vtx.empty()
-        || block.vtx.size() > MAX_BLOCK_SIZE
+    if (block.vtx.size() > MAX_BLOCK_SIZE
         || ::GetSerializeSize(block, block_size_type, PROTOCOL_VERSION) > MAX_BLOCK_SIZE
         || ::GetSerializeSize(block.GetSuperblock(), SER_NETWORK, PROTOCOL_VERSION) > GRC::Superblock::MAX_SIZE)
     {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -416,6 +416,12 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
     {
         int64_t nValueIn = 0;
         int64_t nFees = 0;
+
+        // Index of the first input whose outpoint is already spent, or -1.
+        // Recorded here rather than acted on immediately so that every DoS(100)
+        // this loop can raise still wins, exactly as before.
+        int conflict_input = -1;
+
         for (unsigned int i = 0; i < tx.vin.size(); i++)
         {
             COutPoint prevout = tx.vin[i].prevout;
@@ -444,10 +450,52 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
             if (!MoneyRange(txPrev.vout[prevout.n].nValue) || !MoneyRange(nValueIn))
                 return state.DoS(100, error("ConnectInputs() : txin values out of range"));
 
+            // Cheap: one array lookup. See the rejection below for why the
+            // result is remembered rather than returned on.
+            if (conflict_input < 0 && !txindex.vSpent[prevout.n].IsNull())
+                conflict_input = static_cast<int>(i);
         }
-        // The first loop above does all the inexpensive checks.
-        // Only if ALL inputs pass do we perform expensive ECDSA signature checks.
-        // Helps prevent CPU exhaustion attacks.
+        // The first loop above does all the inexpensive per-input checks, and
+        // only if ALL inputs pass do we perform the expensive ECDSA signature
+        // checks below. That is what prevents CPU exhaustion, and until this
+        // was added it was not actually true: the conflict check lived in the
+        // loop below, interleaved with VerifySignature. A transaction whose
+        // only defect was an already-spent outpoint in its LAST input cost a
+        // full signature verification for every input before it, and was then
+        // rejected with no DoS score -- deliberately, see below -- so the
+        // sender was neither disconnected nor banned and could send the next
+        // one immediately. At MAX_STANDARD_TX_SIZE that is roughly 675
+        // verifications, held under cs_main, for free and on demand.
+        //
+        // Reject here, between the loops, rather than returning from the loop
+        // itself: letting it run to completion keeps every DoS(100) it can
+        // raise -- including the cumulative MoneyRange check, which depends on
+        // inputs after the conflicting one -- winning exactly as it did before.
+        //
+        // Below nGrandfather the conflict branch in the loop below returns TRUE
+        // for non-miners, i.e. it accepts the transaction. That era is left
+        // entirely to that branch so nothing changes for it.
+        //
+        // The one behavioural difference: a transaction carrying BOTH a bad
+        // signature and a conflict used to be rejected by the signature check
+        // with DoS(100) and is now rejected here without a score. That is peer
+        // scoring, not validity, so it cannot affect which chain a node
+        // follows, and it only ever fired on an attack shape strictly worse
+        // for the attacker than simply omitting the bad signature.
+        if (conflict_input >= 0 && pindexBlock->nHeight >= nGrandfather)
+        {
+            if (fMiner) return false;
+
+            const COutPoint prevout = tx.vin[conflict_input].prevout;
+            const CTxIndex& txindex = inputs[prevout.hash].first;
+
+            return LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)
+                ? error("ConnectInputs() : %s prev tx already used at %s",
+                        tx.GetHash().ToString().c_str(),
+                        txindex.vSpent[prevout.n].ToString().c_str())
+                : false;
+        }
+
         for (unsigned int i = 0; i < tx.vin.size(); i++)
         {
             COutPoint prevout = tx.vin[i].prevout;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1093,12 +1093,15 @@ unsigned int GetBlockScriptFlags(int nHeight)
     // Signature malleability closes at block version 15, the same shape v14
     // used for CLTV/CSV.
     //
-    // These are the flags MEMPOOL_POLICY_SCRIPT_VERIFY_FLAGS applies as local
-    // standardness once v15 is live; here they become binding. The progression
-    // is deliberate and is the usual one: a node stops RELAYING these
-    // transactions and stops ACCEPTING blocks that contain them at the same
-    // height, so there is no window in which a staker builds a block from its
-    // own mempool that its peers then reject.
+    // Consensus flags, and the only tier these use. There is no separate
+    // standardness constant applying them for relay first -- the policy tier in
+    // ConnectInputs() is empty, deliberately, and this is what both paths read.
+    //
+    // Which is the point: mempool acceptance asks for the flags at the tip's
+    // next height and block connection asks for the flags at the block's own
+    // height, so a node stops RELAYING these transactions and stops ACCEPTING
+    // blocks containing them at the same height. No window opens in which a
+    // staker builds a block from its own mempool that its peers then reject.
     //
     // Inert until v15 is scheduled -- BlockV15Height is
     // numeric_limits<int>::max() -- so landing this early costs nothing and
@@ -2129,6 +2132,27 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
     // Rather not work on nonstandard transactions
     if (!IsStandardTx(tx))
         return state.Invalid(error("AcceptToMemoryPool : nonstandard transaction type"), "tx-nonstandard");
+
+    // A claim belongs in a coinbase, so it can never belong in a loose one.
+    //
+    // Contract dispatch will not catch this: CLAIM has no handler and falls to
+    // the permissive one, which accepts anything. Without this the transaction
+    // sits in the mempool, gets selected into a block, and CheckBlock() then
+    // refuses the block -- costing the staker the block rather than the sender
+    // the transaction.
+    //
+    // Gated to activate with the block rule it mirrors, so a node stops
+    // RELAYING these and stops ACCEPTING blocks containing them at the same
+    // height. Judged at the height the transaction would be mined at, which is
+    // the next one, for the same reason the script flags are.
+    if (IsV15Enabled(nBestHeight + 1)) {
+        for (const auto& contract : tx.GetContracts()) {
+            if (contract.m_type == GRC::ContractType::CLAIM) {
+                return state.DoS(100, error("%s: claim contract in a non-coinbase transaction", __func__),
+                                 "claim-outside-coinbase");
+            }
+        }
+    }
 
     // Perform contextual validation for any contracts:
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -143,15 +143,22 @@ bool ReadTxFromDisk(CTransaction& tx, COutPoint prevout)
     return ReadTxFromDisk(tx, txdb, prevout, txindex);
 }
 
-bool CheckTransaction(const CTransaction& tx, CValidationState& state)
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, int nHeight)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
         return state.DoS(10, error("CheckTransaction() : vin empty"));
     if (tx.vout.empty())
         return state.DoS(10, error("CheckTransaction() : vout empty"));
-    // Size limits - don't count coinbase superblocks--we check this at the block level:
-    if (GetSerializeSize(tx, (SER_NETWORK & SER_SKIPSUPERBLOCK), PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    // Size limits. From v15 a coinbase or coinstake carrying a superblock is
+    // measured without it: the block-level check bounds the whole block, and
+    // bounds the superblock separately.
+    //
+    // nHeight defaults to 0, so callers with no block context are unaffected;
+    // only CheckBlock() passes a height.
+    const int serialize_type = IsV15Enabled(nHeight) ? (SER_NETWORK | SER_SKIPSUPERBLOCK) : 0;
+
+    if (GetSerializeSize(tx, serialize_type, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
         return state.DoS(100, error("CheckTransaction() : size limits failed"));
 
     // Check for negative or overflow output values (see CVE-2010-5139)
@@ -1399,10 +1406,27 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     // These are checks that are independent of context
     // that can be verified before saving an orphan block.
 
-    // Size limits
+    // Size limits. From v15 the two bounds are independent and both bind:
+    //
+    //   block excluding the superblock <= MAX_BLOCK_SIZE
+    //   the superblock itself          <= GRC::Superblock::MAX_SIZE
+    //
+    // Deliberately additive rather than one combined ceiling. A single total
+    // would make each side's headroom depend on the other: a large superblock
+    // would eat the space available to ordinary transactions, and a full block
+    // of transactions would cap the superblock. Measuring them separately means
+    // neither crowds the other out, and the superblock's limit no longer
+    // depends implicitly on how much else the block happens to carry.
+    //
+    // SER_SKIPSUPERBLOCK is what excludes the superblock's bytes from the first
+    // measurement; the claim's serializer honours it (see claim.h).
+    const int block_size_type = (block.GetSuperblock()->WellFormed() && IsV15Enabled(height1))
+        ? (SER_NETWORK | SER_SKIPSUPERBLOCK)
+        : 0;
+
     if (block.vtx.empty()
         || block.vtx.size() > MAX_BLOCK_SIZE
-        || ::GetSerializeSize(block, (SER_NETWORK & SER_SKIPSUPERBLOCK), PROTOCOL_VERSION) > MAX_BLOCK_SIZE
+        || ::GetSerializeSize(block, block_size_type, PROTOCOL_VERSION) > MAX_BLOCK_SIZE
         || ::GetSerializeSize(block.GetSuperblock(), SER_NETWORK, PROTOCOL_VERSION) > GRC::Superblock::MAX_SIZE)
     {
         return state.DoS(100, error("%s: size limits failed", __func__));
@@ -1485,7 +1509,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool 
     // Check transactions
     for (auto const& tx : block.vtx)
     {
-        if (!CheckTransaction(tx, state))
+        if (!CheckTransaction(tx, state, height1))
             return error("%s: CheckTransaction failed", __func__);
 
         // ppcoin: check transaction timestamp

--- a/src/validation.h
+++ b/src/validation.h
@@ -66,7 +66,7 @@ bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout, CTxIndex& 
 bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout);
 bool ReadTxFromDisk(CTransaction& tx, COutPoint prevout);
 
-bool CheckTransaction(const CTransaction& tx, CValidationState& state);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, int nHeight = 0);
 
 //! \brief Check the validity of any contracts contained in the transaction.
 //!

--- a/src/validation.h
+++ b/src/validation.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_VALIDATION_H
 #define BITCOIN_VALIDATION_H
 
+#include <atomic>
 #include "amount.h"
 #include "consensus/validation.h"
 #include "index/disktxpos.h"
@@ -135,6 +136,16 @@ bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const s
     @param[in] fMiner	true if called from CreateNewBlock
     @return Returns true if all checks succeed
     */
+//! Count of signature verifications performed inside ConnectInputs().
+//!
+//! Exists so the ordering guarantee is testable: the conflict pre-scan means a
+//! transaction with an already-spent input must cost ZERO verifications, and
+//! without a counter that is only observable by instrumenting a build. A
+//! regression that moved the conflict check back inside the signature loop
+//! would otherwise still pass every test, since the transaction is rejected
+//! either way -- only the cost differs.
+extern std::atomic<uint64_t> g_connectinputs_signature_checks;
+
 bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge) EXCLUSIVE_LOCKS_REQUIRED(cs_main); // ppcoin: get transaction coin age

--- a/src/validation.h
+++ b/src/validation.h
@@ -175,7 +175,16 @@ bool AcceptBlock(CBlock& block, CValidationState& state, bool generated_by_me) E
 bool CheckBlockSignature(const CBlock& block);
 
 // Returns the script flags which should be checked for a given block
-unsigned int GetBlockScriptFlags(const CBlockIndex& block_index);
+//! Script verification flags in force at a given block height.
+//!
+//! Takes a height rather than a CBlockIndex because callers disagree about
+//! which block they mean: connecting a block it is that block, but on the
+//! mempool and miner paths the index in hand is the PREVIOUS one and the
+//! transaction is bound for the next. Passing an index invited each caller to
+//! hand over whichever one it had, which is how two of the three came to be a
+//! height low. Mirrors ComputeBlockVersion, which takes a height for the same
+//! reason.
+unsigned int GetBlockScriptFlags(int nHeight);
 
 unsigned int GetCoinstakeOutputLimit(const int& block_version);
 unsigned int GetMandatorySideStakeOutputLimit(const int& block_version);

--- a/src/validation.h
+++ b/src/validation.h
@@ -66,7 +66,11 @@ bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout, CTxIndex& 
 bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout);
 bool ReadTxFromDisk(CTransaction& tx, COutPoint prevout);
 
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, int nHeight = 0);
+//! v15_rules is the CALLER's determination that block-version-15 rules apply,
+//! not a height: CheckBlock() derives it from the block's own nVersion because
+//! the height it is given is the tip's next height rather than the block's.
+//! Defaults to false, so callers with no block context are unaffected.
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool v15_rules = false);
 
 //! \brief Check the validity of any contracts contained in the transaction.
 //!

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -161,8 +161,14 @@ protected:
     {
         if (!pdb)
             return false;
-        if (fReadOnly)
+        if (fReadOnly) {
+            // The assert records an invariant the caller is expected to keep; the
+            // return is what makes the refusal operational. Without it the assert
+            // IS the guard, and removing it would let a write proceed on a handle
+            // opened read-only. Mirrors the !pdb refusal directly above.
             assert(!"Write called on database in read-only mode");
+            return false;
+        }
 
         // Key
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
@@ -190,8 +196,11 @@ protected:
     {
         if (!pdb)
             return false;
-        if (fReadOnly)
+        if (fReadOnly) {
+            // See Write() above: the return, not the assert, is the guard.
             assert(!"Erase called on database in read-only mode");
+            return false;
+        }
 
         // Key
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -281,7 +281,7 @@ public:
     // Generate a new key
     CPubKey GenerateNewKey();
     // Adds a key to the store, and saves it to disk.
-    bool AddKey(const CKey& key);
+    bool AddKey(const CKey& key) override;
     // Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key) { return CCryptoKeyStore::AddKey(key); }
     // Load metadata (used by LoadWallet)
@@ -295,10 +295,10 @@ public:
     }
 
     // Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret) override;
     // Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
     bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
-    bool AddCScript(const CScript& redeemScript);
+    bool AddCScript(const CScript& redeemScript) override;
     bool LoadCScript(const CScript& redeemScript);
 
     bool Unlock(const SecureString& strWalletPassphrase);

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -97,6 +97,12 @@ class MempoolAcceptTest(GridcoinTestFramework):
 
         # 3. spending an outpoint already consumed by a confirmed transaction.
         #
+        # Note this asserts REJECTION, not the ordering of the checks inside
+        # ConnectInputs. It cannot: this transaction has a single input, so the
+        # conflict is found at index 0 either way. The ordering guarantee -- that
+        # a conflicting input costs zero signature verifications -- is asserted
+        # in connectinputs_tests, which counts them.
+        #
         # Distinct from case 2: mapNextTx only knows about the mempool, so this
         # reaches ConnectInputs and is rejected against txindex.vSpent. That is
         # the check the signature loop depends on running first -- if it ever

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -109,15 +109,21 @@ class MempoolAcceptTest(GridcoinTestFramework):
         # regresses to being tested per-input alongside VerifySignature, a
         # transaction like this one costs a full signature verification for
         # every input ahead of the conflicting one before being dropped.
+        # Assertions, not skips. run_test() stakes ten blocks above, so a
+        # coinstake with a spendable input is a property of the setup rather than
+        # something that may or may not turn up. Warning and returning here would
+        # let the case that motivates this whole file stop running while the test
+        # still reported success -- the failure mode being guarded against
+        # everywhere else in it.
         spent = self._confirmed_spent_outpoint(node)
-        if spent is None:
-            self.log.warning("no confirmed coinstake input found; skipping case 3")
-            return
+        assert spent is not None, (
+            "no confirmed coinstake input found: the ten staked blocks in run_test() "
+            "should always provide one, so the setup no longer does what case 3 needs")
 
         prev_txid, prev_vout, prev_spk, prev_amt = spent
-        if prev_amt <= 1:
-            self.log.warning("coinstake input too small to build a spend; skipping case 3")
-            return
+        assert prev_amt > 1, (
+            "coinstake input of {} is too small to build a spend with the ~1 GRC fee; "
+            "the staking setup no longer produces an output case 3 can use".format(prev_amt))
 
         raw = node.createrawtransaction(
             [{"txid": prev_txid, "vout": prev_vout}],

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -9,7 +9,14 @@ this drives sendrawtransaction + getrawmempool directly against a staked
 coinstake output:
 
   - a valid raw tx is accepted into the mempool;
-  - a double-spend of the same in-mempool UTXO is rejected.
+  - a double-spend of the same in-mempool UTXO is rejected;
+  - a spend of an outpoint already spent by a CONFIRMED transaction is rejected.
+
+The third case is a different code path from the second. An in-mempool conflict
+is caught by AcceptToMemoryPool's mapNextTx scan; a conflict with a confirmed
+spend is not visible there and is only caught in ConnectInputs, against
+txindex.vSpent. A staked block gives us a confirmed spend for free: the coinstake
+consumes a wallet UTXO, so that outpoint is spent on-chain and can be replayed.
 
 assert_raises is used (not assert_raises_rpc_error) so the rejection check does
 not depend on Gridcoin's specific RPC error codes.
@@ -42,6 +49,30 @@ class MempoolAcceptTest(GridcoinTestFramework):
         assert signed.get("complete"), signed
         return signed["hex"]
 
+    def _confirmed_spent_outpoint(self, node):
+        """Find an outpoint a confirmed coinstake already spent.
+
+        Walks blocks from the tip looking for a coinstake (vout[0] empty by
+        Gridcoin convention) and returns its first real input along with the
+        scriptPubKey and amount needed to re-sign a spend of it.
+        """
+        for height in range(node.getblockcount(), 0, -1):
+            block = node.getblock(node.getblockhash(height), True)
+            for tx in block.get("tx", []):
+                vin = tx.get("vin", [])
+                vout = tx.get("vout", [])
+                # coinstake: first output is empty; skip coinbase (no prevout)
+                if not vout or vout[0].get("value") != 0:
+                    continue
+                for entry in vin:
+                    if "txid" not in entry:
+                        continue
+                    prev = node.getrawtransaction(entry["txid"], 1)
+                    out = prev["vout"][entry["vout"]]
+                    return (entry["txid"], entry["vout"],
+                            out["scriptPubKey"]["hex"], out["value"])
+        return None
+
     def run_test(self):
         node = self.nodes[0]
         assert_equal(len(node.listunspent(0)), 10)
@@ -62,7 +93,32 @@ class MempoolAcceptTest(GridcoinTestFramework):
         # 2. a double-spend of the same UTXO is rejected (any RPC error code)
         second = self._signed_spend(node, u, node.getnewaddress(), amt)
         assert_raises_rpc_error(None, None, node.sendrawtransaction, second)
-        self.log.info("double-spend correctly rejected")
+        self.log.info("in-mempool double-spend correctly rejected")
+
+        # 3. spending an outpoint already consumed by a confirmed transaction.
+        #
+        # Distinct from case 2: mapNextTx only knows about the mempool, so this
+        # reaches ConnectInputs and is rejected against txindex.vSpent. That is
+        # the check the signature loop depends on running first -- if it ever
+        # regresses to being tested per-input alongside VerifySignature, a
+        # transaction like this one costs a full signature verification for
+        # every input ahead of the conflicting one before being dropped.
+        spent = self._confirmed_spent_outpoint(node)
+        if spent is None:
+            self.log.warning("no confirmed coinstake input found; skipping case 3")
+            return
+
+        prev_txid, prev_vout, prev_spk, prev_amt = spent
+        raw = node.createrawtransaction(
+            [{"txid": prev_txid, "vout": prev_vout}],
+            {node.getnewaddress(): prev_amt - 1})
+        signed = node.signrawtransactionwithwallet(
+            raw,
+            [{"txid": prev_txid, "vout": prev_vout,
+              "scriptPubKey": prev_spk, "amount": prev_amt}])
+        assert_raises_rpc_error(None, None, node.sendrawtransaction, signed["hex"])
+        self.log.info("confirmed-spend replay correctly rejected (%s:%d)",
+                      prev_txid, prev_vout)
 
 
 if __name__ == "__main__":

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -109,6 +109,10 @@ class MempoolAcceptTest(GridcoinTestFramework):
             return
 
         prev_txid, prev_vout, prev_spk, prev_amt = spent
+        if prev_amt <= 1:
+            self.log.warning("coinstake input too small to build a spend; skipping case 3")
+            return
+
         raw = node.createrawtransaction(
             [{"txid": prev_txid, "vout": prev_vout}],
             {node.getnewaddress(): prev_amt - 1})
@@ -116,6 +120,12 @@ class MempoolAcceptTest(GridcoinTestFramework):
             raw,
             [{"txid": prev_txid, "vout": prev_vout,
               "scriptPubKey": prev_spk, "amount": prev_amt}])
+
+        # Without this the test passes vacuously: an unsigned transaction is
+        # rejected too, for an entirely different reason, so a regression in the
+        # conflict check would go unnoticed.
+        assert signed.get("complete"), signed
+
         assert_raises_rpc_error(None, None, node.sendrawtransaction, signed["hex"])
         self.log.info("confirmed-spend replay correctly rejected (%s:%d)",
                       prev_txid, prev_vout)

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -58,9 +58,9 @@ EXPECTED_BOOST_INCLUDES=(
     boost/algorithm/string/split.hpp
     boost/array.hpp
     boost/asio.hpp
+    boost/asio/ip/address.hpp
     boost/asio/ip/udp.hpp
     boost/asio/ip/v6_only.hpp
-    boost/asio/ssl.hpp
     boost/asio/system_timer.hpp
     boost/assert.hpp
     boost/assign/list_of.hpp


### PR DESCRIPTION
Robustness work across the P2P, scraper, RPC, script and database paths. Most of it is a bound, a guard, or an ordering fix, and changes nothing on well-formed input.

A minority is not, and is called out below: a handful of block-level rules that tighten what a block may contain. Those sit behind `IsV15Enabled()`. `BlockV15Height` is `INT_MAX` on every network, so none of them is reachable today -- but they are consensus rules, and scheduling v15 activates them with no further code change. They are listed under [Consensus, gated](#consensus-gated) so that scheduling v15 is a decision made with them in view rather than a surprise.

## The recurring defect

A length declared on the wire drives an allocation before anything validates it. `serialize.h` grows a vector in `5,000,000/sizeof(T)` element steps and allocates against the declared count *before* reading what backs it, so a post-hoc size check cannot prevent the allocation it is meant to stop. The fix each time is to check the CompactSize prefix first.

| what | before | after |
|---|---|---|
| manifest part-hash vector | unbounded | 1024 (32 KiB) |
| manifest project vector | unbounded | 1024 dentries (~148 MB → 90 KB) |
| block locator | 32 MiB ceiling | 101 entries |
| scraper part, wire | none | 16 MB |
| scraper part, records | none | 235,294 |
| scraper part, record length | none | 512 B |
| scraper statistics field, on write | none | 64 B |
| HTTP headers | unbounded count, length, total | 100 / 8 KiB / 32 KiB |
| RPC request body | 32 MiB, then allocated | 2 MB |
| `mapAlreadyAskedFor` | unbounded, global | `limitedmap` at `MAX_INV_SZ` |
| orphan transactions | count only, no expiry | 20-minute TTL |
| `-maxsigcachesize` | unbounded above | 512 MB budget, converted to entries |

Two bounds are derived rather than chosen. The **part record cap** is back-solved from the superblock, which is what limits how many CPIDs can carry a magnitude: `Superblock::MAX_SIZE / (sizeof(Cpid) + 1)`. The **RPC body cap** is `20 * MAX_STANDARD_TX_SIZE`, against a worst legitimate `signrawtransaction` fed by `consolidatemsunspent` output.

The **locator cap of 101** was checked against what `CBlockLocator::Set` can actually generate *before* being applied — it walks back ten blocks then doubles, so length grows with the logarithm of height: 33 entries at the v13 activation height, 42 at `2^31 - 1`. A cap below the legitimate maximum would partition the network rather than protect it, so that check had to come first.

## Signed/unsigned and ordering

- **Manifest part references.** `dentry::part1` is `int` (default `-1`) while `partc` is `unsigned`, so `part1 + partc >= vph.size()` converts `part1` to unsigned and `-1 + 1` wraps to `0`, passing the check. The coverage rule did not catch it either: an unsigned induction variable starting at `-1` begins at `0xFFFFFFFF` and marks nothing, which reads as "covered by something else". The index is then used to subscript `vParts`, bounded only from above in one caller and not at all in two others. Negative starts are now rejected explicitly and the arithmetic is done in `int64_t`.
- **SOCKS5** read a reply length into a signed `char`, so a proxy returning a byte ≥ 0x80 produced a negative length passed to `recv`. The buffer is now `uint8_t`, with a `static_assert` pinning the relationship between buffer size and the largest value that byte can hold.
- **`ConnectInputs`** claimed all cheap checks ran before any ECDSA work. They did not: the conflict check — one array lookup — sat inside the signature loop, so a transaction whose only defect was an already-spent outpoint in its *last* input cost a full verification for every input ahead of it, and was then rejected with no misbehaviour score. Measured on regtest: six verifications before, zero after.

## Asserts that were carrying operational decisions

An assert is a claim about what cannot happen, not a decision about what to do — and asserts are live in every build here, since `-UNDEBUG` is applied globally and `util/check.h` hard-errors on `NDEBUG`.

- `RecvPart` asserted a part was non-empty. That is a peer or filesystem condition; it is now discarded and reported.
- `addPart` asserted a hash was not the empty-content hash. Correct when written in 2018 — `Hash(vParts.end(), vParts.end())` hashed zero bytes — but the 2022 span migration rewrote it as `Hash(MakeByteSpan(vParts))`, which hashes the vector's pointer bytes. The invariant now lives in `UnserializeCheck`, which can actually refuse the manifest.
- `CTxDB::Write`/`Erase` and `CDB::Write`/`Erase` had `if (fReadOnly) assert(...)` with **no return**, so the assertion *was* the guard. Deleting it — the obvious move when tidying asserts — would turn a refused write into a performed one. They now return `false` as well; the asserts stay, because `fReadOnly` comes from the open mode and is never derived from input.

One assert was deliberately **kept**: `cntPartsRcvd <= vParts.size()` is a genuine internal postcondition no input can violate.

## RPC

`-rpcssl` and its three companion options are removed. The transport chose between a TLS layer and the raw socket on a bool for every read and write, ran its handshake lazily inside the first of them on a thread with no handler above it, and suppressed the 403 for a rejected peer whenever TLS was on. `SSLIOStreamDevice` becomes `SocketIOStreamDevice` and holds the socket directly. The options remain registered as hidden args so a node carrying them still starts, and each logs a warning naming it.

`-rpcallowip` compared entries as **text**, so a CIDR prefix matched no address, ever — a node configured with `10.0.0.0/8` silently refused all non-loopback RPC. Entries are now parsed once at startup with `LookupSubNet` and matched with `CSubNet::Match`; anything that does not parse as an address or subnet keeps the old wildcard behaviour, so existing configurations do not change.

`-rpcbind` is new. Where the socket listens was previously implied by `-rpcallowip` — setting any allow entry moved the listener to the wildcard address on every interface, which couples the two in the dangerous direction. When `-rpcbind` is absent the old behaviour is kept exactly, but the implicit widening is now logged.

`-rpcservertimeout` (default 30s) puts a deadline on serviced connections. One connection pins one worker for as long as it is open and keep-alive is on, so `-rpcthreads` silent clients took the RPC server down for everyone — four of them, at the default, before authentication. Setting `SO_RCVTIMEO` is not sufficient on its own: asio's synchronous read sees the timeout as `EAGAIN`, cannot distinguish it from "not ready", and retries, so the deadline is swallowed. Measured: with the option set and `read_some` in place, an idle connection was still open after 15s against a 3s deadline. The device therefore calls `recv`/`send` directly, retrying on `EINTR`, and forces the descriptor back to blocking mode first.

There is deliberately **no** connection ceiling. `RPCAcceptHandler` is dispatched by the workers themselves and calls `ServiceConnection` synchronously, so the registered set can never exceed `-rpcthreads`: a cap above that cannot be reached and a cap below it is only a smaller thread count. An earlier revision carried one; it was removed once a test with three connections against a cap of two logged no refusals.

## Correctness

- **`sendalert`** read `params[0]` twice — once as the message, once as the WIF key — while its `RPCHelpMan` declares the key at `params[1]`, which was never read. Neither alert command was in the Qt console's `SENSITIVE_ARG_COMMANDS` despite both taking the alert master private key; both are now.
- **`umask(077)`** ran in `AppInit2`, after `InitLogging()` opens `debug.log` and after the settings file is written, so both inherited the ambient umask. Moved to the top of both `main()` functions. Verified by A/B against fresh data directories: `debug.log` and `gridcoinsettings.json` go 0644 → 0600.
- **Manifest parts** were checked for running past the end of the part list, but nothing checked the converse — parts declared and never referenced. The range checks it builds on were also off by one, since the ranges are inclusive.
- **The publisher** reserved a part index and pushed its dentry *before* calling `addPartData`, and ignored the result, so a zero-byte part file produced a manifest referencing a part that was never created. All five call sites now check it.
- **`mapAlreadyAskedFor`** absence was treated as proof the object arrived. Sound while the map was unbounded; bounding it made absence mean *either* received *or* evicted, so one peer announcing `MAX_INV_SZ` hashes could silently cancel every older pending request. The check now falls through to `AlreadyHave`, which answers the real question.
- **Scraper statistics fields** come verbatim from project XML with nothing bounding them, so one pathological upstream value would produce a record the reader refuses — and refusing a record refuses the whole part, dropping that project out of convergence network-wide. Bounded on the write side instead; the read-side limit stays, because it is what stops a hostile part being an expansion with no newlines.
- **HTTP parsing** threw on a malformed `content-length` and `ServiceConnection` has no `try/catch`; it now returns. `strProto.pop_back()` ran without an emptiness check, reachable from the request line `"GET / "`.
- **`UNIX_EPOCH_TIME`** was a namespace-scope `const std::string` read by a namespace-scope `RPCHelpMan` initializer in another translation unit. Both need dynamic initialization and nothing orders them, so the help text could be built from an unconstructed string; under AddressSanitizer the daemon aborts during static init. Now `constexpr std::string_view`, which has no initializer to order.
- **`CWallet::AddKey`/`AddCryptedKey`/`AddCScript`** override keystore virtuals without saying so. If a base signature changed, three key-storage entry points would silently become new overloads while the vtable kept calling the base.

## Documentation, no behaviour change

The scraper skips its authorization check while out of sync. This has been read as a bug twice from outside, because the two properties that make it safe were written down nowhere. Both are now recorded at three sites: an in-sync node terminates a rogue manifest rather than relaying it, so injection cannot propagate; and refill precedes housekeeping, which is the ordering that keeps a partial manifest set from reaching convergence. **Do not gate manifest ingest on sync state.**

The manifest project-count cap compares `projects.size()` — which includes three injected pseudo-projects — against a whitelist-derived limit, so those consume margin intended for whitelist shrinkage. Correcting it changes when a node bans a peer, so it is gated with the rest (below) rather than applied on upgrade.

## Consensus, gated

Behind `IsV15Enabled()` and inert while `BlockV15Height` is `INT_MAX`. Each tightens what a block may contain, so each has to activate with a version, not on upgrade.

| change | effect once v15 activates |
|---|---|
| block size accounting | a block's superblock and its other content are bounded separately and additively, rather than sharing one ceiling that let neither bind as intended |
| claim position | a claim is accepted only in the coinbase, which is the only place anything creates one, and the only place the size accounting can see it. Enforced on all three paths that can put one in a block -- block validation, mempool acceptance, and block assembly -- so the rule cannot cost a staker the block instead of costing the sender the transaction |
| script verification flags | the flags applied to block script verification are extended |
| manifest project count | the cap stops charging the three injected pseudo-projects against margin meant for whitelist shrinkage |

These are selected by the **block's own version**, not by the height the caller supplied. `CheckBlock()` is reached with the tip's next height, which is not the block's height for an orphan, an out-of-order arrival, or a node catching up, and `fChecked` makes that first verdict final. A rule keyed on it would have nodes disagree around the activation boundary and score each other for relaying valid blocks. `AcceptBlock()` enforces version against the authoritative height, so the two cannot come apart.

A rule enforced only where blocks are checked is not enough on its own. Contract dispatch sends `CLAIM` to a permissive handler and `IsStandardTx()` does not look at contract types, so without the other two paths a transaction carrying a claim would be relayed, accepted, and selected into a block that its own author's node then refuses. The sender would lose nothing and the staker would lose the block.

Orphan block storage is now bounded in bytes as well as in count, since the count alone bounded memory only while every block was bounded by `MAX_BLOCK_SIZE`. That part is not gated -- it is local storage policy, not a rule about validity.

## Operator-visible changes

- `-rpcssl` and its companions no longer do anything. The RPC port does not speak TLS; use `-rpcbind` and a tunnel.
- **`-rpcallowip` now honours CIDR.** An entry like `10.0.0.0/8` previously matched nothing, so a node configured that way was silently refusing all non-loopback RPC. It now works as written, which means such a node begins accepting RPC from that subnet.
- `-rpcbind` and `-rpcservertimeout` are new.
- `-maxsigcachesize` is clamped.
- `sendalert` reads its key from the documented position, so an invocation relying on the old behaviour will change.

## Testing

`src/test/gridcoin/scraper_net_tests.cpp` and `rpc_allowlist_tests.cpp` are new; `limitedmap_tests` comes across with the container it tests; `mempool_accept.py` gains the confirmed-spend case; `util_tests` gains coverage for the shared line reader, which had none. `connectinputs_tests` covers the block size envelope and the claim-position rule against real serialized sizes, and `orphan_block_tests` covers the byte accounting through every path that removes an entry.

Every guard was verified to **fail without its fix** rather than merely pass with it, against a deliberately broken build in each case:

| revert | what fails |
|---|---|
| HTTP parser | four failures |
| old part assert | suite `SIGABRT`s |
| old allow-list text match | seven of ten cases |
| negative part references | both cases get past validation entirely |
| size envelope removed | the v15 half of the version pair |
| envelope keyed on version 14 | the v14 half of the same pair |
| claim-position rule removed | the block with the stray claim is accepted |
| orphan byte decrement dropped | three accounting cases |
| signature length bound removed | the oversize case, on the reason rather than the throw |
| claim-contract guard removed | faults rather than returning |

Two of those needed a second pass to become meaningful. The claim-position case originally passed with the rule removed, because without a well-formed superblock in the coinbase the block was refused on plain size instead and the case proved nothing; reaching the accounting gap needs both halves. The signature case throws either way -- an unbounded read of a truncated stream throws the same exception type -- so it asserts the message, not the throw.

Clean builds, GUI + Qt6 + multiprocess + tests: **zero warnings on both GCC and Clang**. Clang thread-safety analysis at `-Werror`: clean. AddressSanitizer/UBSan suite: green, zero findings. `lint-all.sh` passes with `COMMIT_RANGE` set.

